### PR TITLE
move version out of yaml and let it populate dynamically from package info

### DIFF
--- a/cli/src/cli.yml
+++ b/cli/src/cli.yml
@@ -1,5 +1,4 @@
 name: polkadot
-version: "1.0.0"
 author: "Parity Team <admin@polkadot.io>"
 about: Polkadot Node Rust Implementation
 args:

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -46,7 +46,7 @@ pub fn run<I, T>(args: I) -> error::Result<()> where
 	T: Into<std::ffi::OsString> + Clone,
 {
 	let yaml = load_yaml!("./cli.yml");
-	let matches = clap::App::from_yaml(yaml).get_matches_from_safe(args)?;
+	let matches = clap::App::from_yaml(yaml).version(crate_version!()).get_matches_from_safe(args)?;
 
 	// TODO [ToDr] Split paremeters parsing from actual execution.
 	let log_pattern = matches.value_of("log").unwrap_or("");


### PR DESCRIPTION
So we don't need to update the version in `Cargo.toml` and this yaml file at the same time, the version will be automatically be picked up.

My first contribution to polkadot. :) 