### PR TITLE
Add codec tests

### DIFF
--- a/substrate/primitives/src/block.rs
+++ b/substrate/primitives/src/block.rs
@@ -178,6 +178,30 @@ mod tests {
 	use substrate_serializer as ser;
 
 	#[test]
+	fn test_header_encoding() {
+		let header = Header {
+			parent_hash: 5.into(),
+			number: 67,
+			state_root: 3.into(),
+			transaction_root: 6.into(),
+			digest: Digest { logs: vec![Log(vec![1]), Log(vec![2])] },
+		};
+
+		assert_eq!(header.encode(), vec![
+			// parent_hash
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5,
+			// number
+			67, 0, 0, 0, 0, 0, 0, 0,
+			// state_root
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3,
+			// transaction_root
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 6,
+			// digest (length, log1, log2)
+			2, 0, 0, 0, 1, 0, 0, 0, 1, 1, 0, 0, 0, 2
+		]);
+	}
+
+	#[test]
 	fn test_header_serialization() {
 		let header = Header {
 			parent_hash: 5.into(),
@@ -201,5 +225,28 @@ mod tests {
 
 		let v = header.encode();
 		assert_eq!(Header::decode(&mut &v[..]).unwrap(), header);
+	}
+
+	#[test]
+	fn test_block_encoding() {
+		let block = Block {
+			header: Header::from_block_number(12),
+			transactions: vec![Transaction(vec!(4))],
+		};
+
+		assert_eq!(block.encode(), vec![
+			// parent_hash
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			// number
+			12, 0, 0, 0, 0, 0, 0, 0,
+			// state_root
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			// transaction_root
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			// digest
+			0, 0, 0, 0,
+			// transactions (length, tx...)
+			1, 0, 0, 0, 1, 0, 0, 0, 4
+		]);
 	}
 }

--- a/substrate/test-runtime/src/transaction.rs
+++ b/substrate/test-runtime/src/transaction.rs
@@ -54,3 +54,30 @@ impl Slicable for Transaction {
 }
 
 impl ::codec::NonTrivialSlicable for Transaction {}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use keyring::Keyring;
+
+	#[test]
+	fn test_tx_encoding() {
+		let tx = Transaction {
+			from: Keyring::Alice.to_raw_public(),
+			to: Keyring::Bob.to_raw_public(),
+			amount: 69,
+			nonce: 33,
+		};
+
+		assert_eq!(tx.encode(), vec![
+			// from
+			209, 114, 167, 76, 218, 76, 134, 89, 18, 195, 43, 160, 168, 10, 87, 174, 105, 171, 174, 65, 14, 92, 203, 89, 222, 232, 78, 47, 68, 50, 219, 79,
+			// to
+			215, 86, 142, 95, 10, 126, 218, 103, 168, 38, 145, 255, 55, 154, 196, 187, 164, 249, 201, 184, 89, 254, 119, 155, 93, 70, 54, 59, 97, 173, 45, 185,
+			// amount
+			69, 0, 0, 0, 0, 0, 0, 0,
+			// nonce
+			33, 0, 0, 0, 0, 0, 0, 0
+		]);
+	}
+}

--- a/substrate/test-runtime/src/unchecked_transaction.rs
+++ b/substrate/test-runtime/src/unchecked_transaction.rs
@@ -61,3 +61,37 @@ impl Slicable for UncheckedTransaction {
 }
 
 impl ::codec::NonTrivialSlicable for UncheckedTransaction {}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use keyring::Keyring;
+	use ::Transaction;
+
+	#[test]
+	fn test_unchecked_encoding() {
+		let tx = Transaction {
+			from: Keyring::Alice.to_raw_public(),
+			to: Keyring::Bob.to_raw_public(),
+			amount: 69,
+			nonce: 34,
+		};
+		let signature = Keyring::from_raw_public(tx.from).unwrap().sign(&tx.encode());
+		let signed = UncheckedTransaction { tx, signature };
+
+		assert_eq!(signed.encode(), vec![
+			// length
+			144, 0, 0, 0,
+			// from
+			209, 114, 167, 76, 218, 76, 134, 89, 18, 195, 43, 160, 168, 10, 87, 174, 105, 171, 174, 65, 14, 92, 203, 89, 222, 232, 78, 47, 68, 50, 219, 79,
+			// to
+			215, 86, 142, 95, 10, 126, 218, 103, 168, 38, 145, 255, 55, 154, 196, 187, 164, 249, 201, 184, 89, 254, 119, 155, 93, 70, 54, 59, 97, 173, 45, 185,
+			// amount
+			69, 0, 0, 0, 0, 0, 0, 0,
+			// nonce
+			34, 0, 0, 0, 0, 0, 0, 0,
+			// signature
+			207, 69, 156, 55, 7, 227, 202, 3, 114, 111, 43, 46, 227, 38, 39, 122, 245, 69, 195, 117, 190, 154, 89, 76, 134, 91, 251, 230, 31, 221, 1, 194, 144, 34, 33, 58, 220, 154, 205, 135, 224, 52, 248, 198, 12, 17, 96, 53, 110, 160, 194, 10, 9, 60, 40, 133, 57, 112, 151, 200, 105, 198, 245, 10
+		]);
+	}
+}


### PR DESCRIPTION
As part of doing the JS implementation and confirming it yields the same outputs, added some tests for the encoding done by https://github.com/paritytech/polkadot/tree/master/substrate/codec

- Basic block & header encoding tests
- Basic transaction & unchecked_transaction encoding tests

As a first pass kept the checks against a `vec` (commented with relevant sections), to ease cross-implementation checks.