### PR TITLE
Format published wasm binaries package version with semver

### DIFF
--- a/publish-wasm.sh
+++ b/publish-wasm.sh
@@ -7,7 +7,7 @@ REPO_AUTH="${GH_TOKEN}:@${REPO}"
 SRCS=( "polkadot/runtime/wasm" "substrate/executor/wasm" "substrate/test-runtime/wasm" )
 DST=".wasm-binaries"
 TARGET="wasm32-unknown-unknown"
-UTCDATE=`date -u "+%Y%m%d.%H%M%S"`
+UTCDATE=`date -u "+%Y%m%d.%H%M%S.0"`
 
 pushd .
 


### PR DESCRIPTION
Small bugfix to the WASM binary publish scripts, latest versions of yarn & npm don't like non-semver (<major>.<minor>.<patch>) versions, making the https://github.com/paritytech/polkadot-wasm-bin currently uninstallable.