### PR TITLE
Ensure VoteAdvance messages propagate

### DIFF
--- a/polkadot/consensus/src/lib.rs
+++ b/polkadot/consensus/src/lib.rs
@@ -635,7 +635,10 @@ impl<C: PolkadotApi, R: TableRouter> bft::Proposer for Proposer<C, R> {
 		let offset = U256::from_big_endian(&self.random_seed.0) % len;
 		let offset = offset.low_u64() as usize + round_number;
 
-		authorities[offset % authorities.len()].clone()
+		let proposer = authorities[offset % authorities.len()].clone();
+		trace!(target: "bft", "proposer for round {} is {}", round_number, Hash::from(proposer));
+
+		proposer
 	}
 
 	fn import_misbehavior(&self, misbehavior: Vec<(AuthorityId, bft::Misbehavior)>) {

--- a/polkadot/consensus/src/service.rs
+++ b/polkadot/consensus/src/service.rs
@@ -98,6 +98,8 @@ fn process_message(msg: net::LocalizedBftMessage, local_id: &AuthorityId, author
 					}
 				};
 				bft::check_proposal(authorities, &msg.parent_hash, &proposal)?;
+
+				trace!(target: "bft", "importing proposal message for round {} from {}", proposal.round_number, Hash::from(proposal.sender));
 				proposal
 			}),
 			net::SignedConsensusMessage::Vote(vote) => bft::generic::LocalizedMessage::Vote({
@@ -115,6 +117,8 @@ fn process_message(msg: net::LocalizedBftMessage, local_id: &AuthorityId, author
 					}
 				};
 				bft::check_vote(authorities, &msg.parent_hash, &vote)?;
+
+				trace!(target: "bft", "importing vote {:?} from {}", vote.vote, Hash::from(vote.sender));
 				vote
 			}),
 		}),

--- a/polkadot/consensus/src/service.rs
+++ b/polkadot/consensus/src/service.rs
@@ -49,6 +49,7 @@ struct BftSink<E> {
 
 struct Messages {
 	network_stream: net::BftMessageStream,
+	local_id: AuthorityId,
 	authorities: Vec<AuthorityId>,
 }
 
@@ -64,8 +65,9 @@ impl Stream for Messages {
 				Ok(Async::NotReady) => return Ok(Async::NotReady),
 				Ok(Async::Ready(None)) => return Ok(Async::NotReady), // the input stream for agreements is never meant to logically end.
 				Ok(Async::Ready(Some(message))) => {
-					match process_message(message, &self.authorities) {
-						Ok(message) => return Ok(Async::Ready(Some(message))),
+					match process_message(message, &self.local_id, &self.authorities) {
+						Ok(Some(message)) => return Ok(Async::Ready(Some(message))),
+						Ok(None) => {} // ignored local message.
 						Err(e) => {
 							debug!("Message validation failed: {:?}", e);
 						}
@@ -76,10 +78,11 @@ impl Stream for Messages {
 	}
 }
 
-fn process_message(msg: net::LocalizedBftMessage, authorities: &[AuthorityId]) -> Result<bft::Communication, bft::Error> {
-	Ok(match msg.message {
+fn process_message(msg: net::LocalizedBftMessage, local_id: &AuthorityId, authorities: &[AuthorityId]) -> Result<Option<bft::Communication>, bft::Error> {
+	Ok(Some(match msg.message {
 		net::BftMessage::Consensus(c) => bft::generic::Communication::Consensus(match c {
 			net::SignedConsensusMessage::Propose(proposal) => bft::generic::LocalizedMessage::Propose({
+				if &proposal.sender == local_id { return Ok(None) }
 				let proposal = bft::generic::LocalizedProposal {
 					round_number: proposal.round_number as usize,
 					proposal: proposal.proposal,
@@ -98,6 +101,7 @@ fn process_message(msg: net::LocalizedBftMessage, authorities: &[AuthorityId]) -
 				proposal
 			}),
 			net::SignedConsensusMessage::Vote(vote) => bft::generic::LocalizedMessage::Vote({
+				if &vote.sender == local_id { return Ok(None) }
 				let vote = bft::generic::LocalizedVote {
 					sender: vote.sender,
 					signature: ed25519::LocalizedSignature {
@@ -121,7 +125,7 @@ fn process_message(msg: net::LocalizedBftMessage, authorities: &[AuthorityId]) -
 				.map_err(|_| bft::ErrorKind::InvalidJustification.into());
 			bft::generic::Communication::Auxiliary(justification?)
 		},
-	})
+	}))
 }
 
 impl<E> Sink for BftSink<E> {
@@ -190,8 +194,10 @@ fn start_bft<F, C>(
 		}
 	};
 
+
 	let input = Messages {
 		network_stream: network.bft_messages(parent_hash),
+		local_id: bft_service.local_id(),
 		authorities,
 	};
 

--- a/substrate/bft/src/generic/mod.rs
+++ b/substrate/bft/src/generic/mod.rs
@@ -792,7 +792,6 @@ impl<C, I, O> Future for Agreement<C, I, O>
 				self.poll()
 			}
 			Async::NotReady => {
-
 				Ok(Async::NotReady)
 			}
 		}

--- a/substrate/bft/src/generic/mod.rs
+++ b/substrate/bft/src/generic/mod.rs
@@ -683,6 +683,7 @@ impl<C: Context> Strategy<C> {
 
 	fn advance_to_round(&mut self, context: &C, round: usize) {
 		assert!(round > self.current_accumulator.round_number());
+		trace!(target: "bft", "advancing to round {}", round);
 
 		let threshold = self.nodes - self.max_faulty;
 

--- a/substrate/bft/src/generic/mod.rs
+++ b/substrate/bft/src/generic/mod.rs
@@ -418,6 +418,7 @@ impl<C: Context> Strategy<C> {
 
 		// poll until either completion or state doesn't change.
 		loop {
+			trace!(target: "bft", "Polling BFT logic. State={:?}", last_watermark);
 			match self.poll_once(context, sending)? {
 				Async::Ready(x) => return Ok(Async::Ready(x)),
 				Async::NotReady => {

--- a/substrate/bft/src/lib.rs
+++ b/substrate/bft/src/lib.rs
@@ -329,6 +329,12 @@ impl<P, I> BftService<P, I>
 		}
 	}
 
+	/// Get the local Authority ID.
+	pub fn local_id(&self) -> AuthorityId {
+		// TODO: based on a header and some keystore.
+		self.key.public().0
+	}
+
 	/// Signal that a valid block with the given header has been imported.
 	///
 	/// If the local signing key is an authority, this will begin the consensus process to build a
@@ -350,7 +356,7 @@ impl<P, I> BftService<P, I>
 		let max_faulty = max_faulty_of(n);
 		trace!(target: "bft", "max_faulty_of({})={}", n, max_faulty);
 
-		let local_id = self.key.public().0;
+		let local_id = self.local_id();
 
 		if !authorities.contains(&local_id) {
 			// cancel current agreement

--- a/substrate/network/src/consensus.rs
+++ b/substrate/network/src/consensus.rs
@@ -139,7 +139,9 @@ impl Consensus {
 	pub fn on_bft_message(&mut self, io: &mut SyncIo, protocol: &Protocol, peer_id: PeerId, message: message::LocalizedBftMessage, hash: Hash) {
 		if self.messages.contains_key(&hash) {
 			trace!(target:"sync", "Ignored already known BFT message from {}", peer_id);
+			return;
 		}
+
 		if let Some(ref mut peer) = self.peers.get_mut(&peer_id) {
 			peer.known_messages.insert(hash);
 			// TODO: validate signature?


### PR DESCRIPTION
also makes sure accumulator state doesn't get clobbered when a late proposal message comes in.