### PR TITLE
node-key CLI option

### DIFF
--- a/polkadot/cli/src/cli.yml
+++ b/polkadot/cli/src/cli.yml
@@ -24,6 +24,11 @@ args:
       value_name: STRING
       help: Specify additional key seed
       takes_value: true
+  - node-key:
+      long: node-key
+      value_name: KEY
+      help: Specify node secret key (64-character hex string).
+      takes_value: true
   - collator:
       long: collator
       help: Enable collator mode

--- a/polkadot/cli/src/lib.rs
+++ b/polkadot/cli/src/lib.rs
@@ -153,6 +153,11 @@ pub fn run<I, T>(args: I) -> error::Result<()> where
 		config.network.listen_address = Some(SocketAddr::new("0.0.0.0".parse().unwrap(), port));
 		config.network.public_address = None;
 		config.network.client_version = format!("parity-polkadot/{}", crate_version!());
+		config.network.use_secret = match matches.value_of("node-key").map(|s| s.parse()) {
+			Some(Ok(secret)) => Some(secret),
+			Some(Err(err)) => return Err(format!("Error parsing node key: {}", err).into()),
+			None => None,
+		};
 	}
 
 	config.keys = matches.values_of("key").unwrap_or_default().map(str::to_owned).collect();


### PR DESCRIPTION
Similar to the same option from Parity (specifying enode from cli). This ease writing test scripts.