### PR TITLE
docs: Fixes #204. Update Readme. Add command to switch to Rust stable. Append binaries to installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Implementation of a https://polkadot.io node in Rust.
 ## To play
 
 If you'd like to play with Polkadot, you'll need to install a client like this
-one. First, get Rust (1.26.1 or 1.26.2 stable) and the support software if you don't already have it, and ensure you change the active toolchain to the stable version instead of the nightly version:
+one. First, get Rust (1.26.1 or later) and the support software if you don't already have it, and ensure you change the active toolchain to the stable version instead of the nightly version:
 
 ```
 curl https://sh.rustup.rs -sSf | sh

--- a/README.md
+++ b/README.md
@@ -5,11 +5,12 @@ Implementation of a https://polkadot.io node in Rust.
 ## To play
 
 If you'd like to play with Polkadot, you'll need to install a client like this
-one. First, get Rust (1.26.1 stable) and the support software if you don't already have it:
+one. First, get Rust (1.26.1 or 1.26.2 stable) and the support software if you don't already have it, and ensure you change the active toolchain to the stable version instead of the nightly version:
 
 ```
 curl https://sh.rustup.rs -sSf | sh
 sudo apt install make clang
+rustup default stable
 ```
 
 Then, install Polkadot PoC-1:
@@ -19,7 +20,7 @@ cargo install --git https://github.com/paritytech/polkadot.git --branch v0.1
 ```
 
 You'll now have a `polkadot` binary installed to your `PATH`. You can drop the
-`--branch v0.1` to get the very latest version of Polkadot, but these
+`--branch v0.1` or run `cargo install --git https://github.com/paritytech/polkadot.git polkadot subkey` to get the very latest version of Polkadot, but these
 instructions might not work in that case.
 
 ### Development


### PR DESCRIPTION
* Add command to switch to a stable version of Rust before installing Polkadot PoC-1 since error occurs when trying to install using Rust Nightly, which some users may have configured as their active toolchain
* Append ` polkadot subkey` to the command that installs the latest version of Polkadot PoC-1 to overcome error