### PR TITLE
docs: Update README.md with variable chain spec CLI value dependant upon the Polkadot version installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,16 +33,18 @@ polkadot --chain=dev --validator --key Alice
 
 You can muck around by cloning and building the http://github.com/paritytech/polka-ui and http://github.com/paritytech/polkadot-ui or just heading to https://polkadot.js.org/apps.
 
-### PoC-1 Testnet
+### PoC-X Testnet
 
-You can also connect to the global PoC-1 testnet. To do this, just use:
+You can also connect to the global PoC-X testnet, where X is the Polkadot PoC version number. To do this, just use:
 
 ```
-polkadot --chain=poc-1
+polkadot --chain=CHAIN_SPEC
 ```
+
+Ensure you replace `CHAIN_SPEC` with an available chain specification from the list shown with `polkadot --help`.  
 
 If you want to do anything on it (not that there's much to do), then you'll need
-to get some PoC-1 testnet DOTs. Ask in the Polkadot watercooler.
+to get some PoC-X testnet DOTs. Ask in the Polkadot watercooler.
 
 ## Local Two-node Testnet
 


### PR DESCRIPTION
After installing the very latest version of Polkadot with `cargo install --git https://github.com/paritytech/polkadot.git polkadot`, I followed the instructions under the [PoC-1 Testnet](https://github.com/paritytech/polkadot#poc-1-testnet) of running `polkadot --chain=poc-1` to connect to the global PoC-1 Testnet, however it returned the following error since the latest version doesn't appear to support the `poc-1` CLI option value anymore. 

```bash
$ polkadot --chain=poc-1
thread 'main' panicked at 'Invalid chain name: poc-1', polkadot/cli/src/lib.rs:151:20
note: Run with `RUST_BACKTRACE=1` for a backtrace.
```

I found that other chain specifications were available including dev, local or poc-2 when I ran `polkadot --help`.
I was able to run PoC-2 Testnet when I ran `polkadot --chain=poc-2`

Propose to refer to the chain specification with `CHAIN_SPEC` instead of `poc-1` to encourage the user to use the Polkadot CLI help menu to view the available values depending on the version of Polkadot that they installed