### PR TITLE
Moves polkadot/keystore to substrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1317,22 +1317,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "polkadot-keystore"
-version = "0.1.0"
-dependencies = [
- "ed25519 0.1.0",
- "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ethcore-crypto 0.1.0 (git+https://github.com/paritytech/parity.git)",
- "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.64 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.64 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "subtle 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "polkadot-parachain"
 version = "0.1.0"
 dependencies = [
@@ -1399,7 +1383,6 @@ dependencies = [
  "polkadot-api 0.1.0",
  "polkadot-consensus 0.1.0",
  "polkadot-executor 0.1.0",
- "polkadot-keystore 0.1.0",
  "polkadot-primitives 0.1.0",
  "polkadot-runtime 0.1.0",
  "polkadot-transaction-pool 0.1.0",
@@ -1407,6 +1390,7 @@ dependencies = [
  "substrate-client-db 0.1.0",
  "substrate-codec 0.1.0",
  "substrate-executor 0.1.0",
+ "substrate-keystore 0.1.0",
  "substrate-network 0.1.0",
  "substrate-primitives 0.1.0",
  "substrate-runtime-io 0.1.0",
@@ -1964,6 +1948,22 @@ dependencies = [
  "ed25519 0.1.0",
  "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "substrate-keystore"
+version = "0.1.0"
+dependencies = [
+ "ed25519 0.1.0",
+ "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethcore-crypto 0.1.0 (git+https://github.com/paritytech/parity.git)",
+ "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.64 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.64 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "subtle 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ members = [
 	"polkadot/collator",
 	"polkadot/consensus",
 	"polkadot/executor",
-	"polkadot/keystore",
 	"polkadot/parachain",
 	"polkadot/primitives",
 	"polkadot/runtime",
@@ -55,6 +54,7 @@ members = [
 	"substrate/serializer",
 	"substrate/state-machine",
 	"substrate/test-runtime",
+	"substrate/keystore",
 
 	"demo/cli",
 	"demo/executor",

--- a/polkadot/service/Cargo.toml
+++ b/polkadot/service/Cargo.toml
@@ -19,7 +19,7 @@ polkadot-consensus = { path = "../consensus" }
 polkadot-executor = { path = "../executor" }
 polkadot-api = { path = "../api" }
 polkadot-transaction-pool = { path = "../transaction-pool" }
-polkadot-keystore = { path = "../keystore" }
+substrate-keystore = { path = "../../substrate/keystore" }
 substrate-runtime-io = { path = "../../substrate/runtime-io" }
 substrate-primitives = { path = "../../substrate/primitives" }
 substrate-network = { path = "../../substrate/network" }

--- a/polkadot/service/src/lib.rs
+++ b/polkadot/service/src/lib.rs
@@ -28,7 +28,7 @@ extern crate polkadot_executor;
 extern crate polkadot_api;
 extern crate polkadot_consensus as consensus;
 extern crate polkadot_transaction_pool as transaction_pool;
-extern crate polkadot_keystore as keystore;
+extern crate substrate_keystore as keystore;
 extern crate substrate_runtime_io as runtime_io;
 extern crate substrate_primitives as primitives;
 extern crate substrate_network as network;

--- a/substrate/keystore/Cargo.toml
+++ b/substrate/keystore/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "substrate-keystore"
 version = "0.1.0"
-authors = ["Parity Technologies <robert@parity.io>"]
+authors = ["Parity Technologies <admin@parity.io>"]
 
 [dependencies]
 ethcore-crypto = { git = "https://github.com/paritytech/parity.git", default_features = false }

--- a/substrate/keystore/Cargo.toml
+++ b/substrate/keystore/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "polkadot-keystore"
+name = "substrate-keystore"
 version = "0.1.0"
 authors = ["Parity Technologies <robert@parity.io>"]
 
 [dependencies]
 ethcore-crypto = { git = "https://github.com/paritytech/parity.git", default_features = false }
-ed25519 = { path = "../../substrate/ed25519" }
+ed25519 = { path = "../ed25519" }
 error-chain = "0.11"
 hex = "0.3"
 rand = "0.4"

--- a/substrate/keystore/src/lib.rs
+++ b/substrate/keystore/src/lib.rs
@@ -1,18 +1,18 @@
-// Copyright 2017 Parity Technologies (UK) Ltd.
-// This file is part of Polkadot.
+// Copyright 2017-2018 Parity Technologies (UK) Ltd.
+// This file is part of Substrate.
 
-// Polkadot is free software: you can redistribute it and/or modify
+// Substrate is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 
-// Polkadot is distributed in the hope that it will be useful,
+// Substrate is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
 
 // You should have received a copy of the GNU General Public License
-// along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
+// along with Substrate. If not, see <http://www.gnu.org/licenses/>.
 
 //! Keystore (and session key management) for ed25519 based chains like Polkadot.
 

--- a/substrate/keystore/src/lib.rs
+++ b/substrate/keystore/src/lib.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
-//! Keystore (and session key management) for polkadot.
+//! Keystore (and session key management) for ed25519 based chains like Polkadot.
 
 extern crate ethcore_crypto as crypto;
 extern crate subtle;


### PR DESCRIPTION
Previously keystore crate was part of the Polkadot since it was the only chain using ed25519.
However, Blitz protocol also uses ed25519, so it is useful to move keystore library to the Substrate.