### PR TITLE
 Reverts `wee_alloc` to a normal versioning scheme 

### DIFF
--- a/polkadot/parachain/test-chains/basic_add/Cargo.toml
+++ b/polkadot/parachain/test-chains/basic_add/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 polkadot-parachain = { path = "../../", default-features = false }
-wee_alloc = { git = "https://github.com/rustwasm/wee_alloc", rev = "4e9f23fff1f2474962085ca693f8884db666889f" }
+wee_alloc = "0.4.1"
 tiny-keccak = "1.4"
 pwasm-libc = "0.2"
 

--- a/polkadot/parachain/test-chains/basic_add/src/lib.rs
+++ b/polkadot/parachain/test-chains/basic_add/src/lib.rs
@@ -17,7 +17,7 @@
 //! Basic parachain that adds a number as part of its state.
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(not(feature = "std"), feature(alloc, core_intrinsics, global_allocator, lang_items, panic_implementation, core_panic_info))]
+#![cfg_attr(not(feature = "std"), feature(alloc, core_intrinsics, lang_items, panic_implementation, core_panic_info))]
 
 #[cfg(not(feature = "std"))]
 extern crate alloc;


### PR DESCRIPTION
Mainainers of `wee_alloc` crate included my fix in their latest version `0.4.1`. In order to prevent stagnation and take advantage of potential bugfixes, it would be better to revert back to a normal versioning scheme.

Also, `global_allocator` attribute was removed in `polkadot/parachain/test-chains/basic_add/src/lib.rs`, since it's now on by default.