### PR TITLE
Fix cargo build on Mac OSX with latest rust nightly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2531,6 +2531,7 @@ name = "substrate-telemetry"
 version = "0.2.0"
 dependencies = [
  "lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-async 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/substrate/telemetry/Cargo.toml
+++ b/substrate/telemetry/Cargo.toml
@@ -7,6 +7,7 @@ description = "Telemetry utils"
 [dependencies]
 parking_lot = "0.4"
 lazy_static = "1.0"
+log = "0.3"
 slog = "^2"
 slog-json = "^2"
 slog-async = "^2"


### PR DESCRIPTION
:wave: Just checking out polkadot for the first time and ran into an error building with `cargo build` for the first time. With my version of rustc, `rustc 1.27.0 (3eda71b00 2018-06-19)`, on Mac OSX `10.13.5` I got the following error:

```
error[E0658]: use of unstable library feature 'rustc_private': this crate is being loaded from the sysroot, an unstable location; did you mean to load this crate from crates.io via `Cargo.toml` instead? (see issue #27812)
```

I followed the discussion in the [`rust-lang` repo](https://github.com/rust-lang/rust/issues/27812) and I updated the `Cargo.toml` in the `substrate/telemetry` directory to fix the error.


![image](https://user-images.githubusercontent.com/2637602/41815163-7073b96c-7717-11e8-8eff-dc607dde88df.png)
