### PR TITLE
Bump wabt-rs to 0.4.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1713,7 +1713,7 @@ dependencies = [
  "lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2165,7 +2165,7 @@ dependencies = [
  "substrate-serializer 0.1.0",
  "substrate-state-machine 0.1.0",
  "triehash 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "wabt 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wabt 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmi 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2329,7 +2329,7 @@ dependencies = [
  "substrate-codec 0.1.0",
  "substrate-runtime-sandbox 0.1.0",
  "substrate-runtime-std 0.1.0",
- "wabt 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wabt 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2436,7 +2436,7 @@ dependencies = [
  "substrate-primitives 0.1.0",
  "substrate-runtime-io 0.1.0",
  "substrate-runtime-std 0.1.0",
- "wabt 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wabt 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmi 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2481,7 +2481,7 @@ dependencies = [
  "substrate-runtime-support 0.1.0",
  "substrate-runtime-system 0.1.0",
  "substrate-runtime-timestamp 0.1.0",
- "wabt 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wabt 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3068,19 +3068,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "wabt"
-version = "0.1.8"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "serde 1.0.64 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.64 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "wabt-sys 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wabt-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wabt-sys"
-version = "0.1.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3458,8 +3457,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6b772017e347561807c1aa192438c5fd74242a670a6cffacc40f2defd1dc069d"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
-"checksum wabt 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "e902997144209c90311321b90dd658d964dd8e58b23a5919e66a1d068a0050e5"
-"checksum wabt-sys 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "fc67b1d96cd7839be6996edf94be66351d83f614e9cc7c6edc33accd9f5e6529"
+"checksum wabt 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "182ae543249ccf2705f324d233891c1176fca142e137b55ba43d9dbfe93f18a2"
+"checksum wabt-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ca77c6b934a2b32618941b2f565aac43b8cb7141378c3b4fba4d8fcdcd57da3"
 "checksum want 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a05d9d966753fa4b5c8db73fcab5eed4549cfe0e1e4e66911e5564a0085c35d1"
 "checksum wasmi 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d19da510b59247935ad5f598357b3cc739912666d75d3d28318026478d95bbdb"
 "checksum websocket 0.20.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eb277e7f4c23dc49176f74ae200e77651764efb2c25f56ad2d22623b63826369"

--- a/substrate/executor/Cargo.toml
+++ b/substrate/executor/Cargo.toml
@@ -22,4 +22,4 @@ log = "0.3"
 
 [dev-dependencies]
 assert_matches = "1.1"
-wabt = "0.1.7"
+wabt = "0.4"

--- a/substrate/runtime-sandbox/Cargo.toml
+++ b/substrate/runtime-sandbox/Cargo.toml
@@ -15,7 +15,7 @@ substrate-runtime-io = { path = "../runtime-io", default_features = false }
 substrate-codec = { path = "../codec", default_features = false }
 
 [dev-dependencies]
-wabt = "0.1.7"
+wabt = "0.4"
 
 [features]
 default = ["std"]

--- a/substrate/runtime/contract/Cargo.toml
+++ b/substrate/runtime/contract/Cargo.toml
@@ -11,7 +11,7 @@ parity-wasm = { version = "0.30", default_features = false }
 pwasm-utils = { version = "0.2", default_features = false }
 
 [dev-dependencies]
-wabt = "0.1.7"
+wabt = "0.4"
 assert_matches = "1.1"
 
 [features]

--- a/substrate/runtime/staking/Cargo.toml
+++ b/substrate/runtime/staking/Cargo.toml
@@ -23,7 +23,7 @@ substrate-runtime-session = { path = "../session", default_features = false }
 substrate-runtime-timestamp = { path = "../timestamp", default_features = false }
 
 [dev-dependencies]
-wabt = "0.1.7"
+wabt = "0.4"
 
 [features]
 default = ["std"]


### PR DESCRIPTION
Upgrade wabt to 0.4.

Current version of wabt-rs builds pinned revision of [wabt](https://github.com/WebAssembly/wabt). Recently released GCC 8 added some new warnings, which are triggered on wabt. And in turn, warnings generated by the project treated as errors in cmake, which prevents building of wabt-rs.

This warnings were fixed in recent version of wabt, and wabt-rs 4.0 incorporates this fixes.