### PR TITLE
Update versions, docs.

### DIFF
--- a/demo/runtime/src/lib.rs
+++ b/demo/runtime/src/lib.rs
@@ -66,8 +66,8 @@ pub struct Concrete;
 pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: ver_str!("demo"),
 	impl_name: ver_str!("parity-demo"),
-	authoring_version: 0,
-	spec_version: 0,
+	authoring_version: 1,
+	spec_version: 1,
 	impl_version: 0,
 };
 

--- a/polkadot/runtime/src/lib.rs
+++ b/polkadot/runtime/src/lib.rs
@@ -109,8 +109,8 @@ pub struct Concrete;
 pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: ver_str!("polkadot"),
 	impl_name: ver_str!("parity-polkadot"),
-	authoring_version: 0,
-	spec_version: 0,
+	authoring_version: 1,
+	spec_version: 1,
 	impl_version: 0,
 };
 

--- a/substrate/runtime/version/src/lib.rs
+++ b/substrate/runtime/version/src/lib.rs
@@ -64,19 +64,33 @@ macro_rules! ver_str {
 #[derive(Clone)]
 #[cfg_attr(feature = "std", derive(Debug, Serialize, Deserialize))]
 pub struct RuntimeVersion {
-	/// Identifies the different Substrate runtimes. There'll be at least polkadot and demo. A different on-chain spec_name to that of the native runtime would normally result in node not attempting to sync further.
+	/// Identifies the different Substrate runtimes. There'll be at least polkadot and demo.
+	/// A different on-chain spec_name to that of the native runtime would normally result
+	/// in node not attempting to sync or author blocks.
 	pub spec_name: VersionString,
-	/// Name of the implementation of the spec. This is of little consequence for the node and serves only to differentiate code of different implementation teams. For this codebase, it will be parity-polkadot.
-	/// If there were a non-Rust implementation of the Polkadot runtime (e.g. C++), then it would identify itself with an accordingly different impl_name.
+	
+	/// Name of the implementation of the spec. This is of little consequence for the node
+	/// and serves only to differentiate code of different implementation teams. For this
+	/// codebase, it will be parity-polkadot. If there were a non-Rust implementation of the
+	/// Polkadot runtime (e.g. C++), then it would identify itself with an accordingly different
+	/// `impl_name`.
 	pub impl_name: VersionString,
-	/// `authoring_version` is the version of the authorship interface. An authoring node will not attempt to author blocks unless this is equal to its native runtime.
+	
+	/// `authoring_version` is the version of the authorship interface. An authoring node
+	/// will not attempt to author blocks unless this is equal to its native runtime.
 	pub authoring_version: u32,
-	/// Version of the runtime specification. A full-node will not attempt to use its native runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`, `spec_version` and `authoring_version`
-	/// are the same between Wasm and native.
+	
+	/// Version of the runtime specification. A full-node will not attempt to use its native
+	/// runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
+	/// `spec_version` and `authoring_version` are the same between Wasm and native.
 	pub spec_version: u32,
-	/// Version of the implementation of the specification. Nodes are free to ignore this; it serves only as an indication that the code is different;
-	/// as long as the other two versions are the same then while the code may be different, it is nonetheless required to do the same thing.
-	/// Non-consensus-breaking optimisations are about the only changes that could be made which would result in only the impl_version changing.
+
+	/// Version of the implementation of the specification. Nodes are free to ignore this; it
+	/// serves only as an indication that the code is different; as long as the other two versions
+	/// are the same then while the actual code may be different, it is nonetheless required to
+	/// do the same thing.
+	/// Non-consensus-breaking optimisations are about the only changes that could be made which
+	/// would result in only the `impl_version` changing.
 	pub impl_version: u32,
 }
 


### PR DESCRIPTION
The default (poc-1 era) runtime is `polkadot-0:0`; poc-2 version should be accordingly different `polkadot-1:1`.