### PR TITLE
Cache the RuntimeVersion for code blocks, too

### DIFF
--- a/substrate/client/src/client.rs
+++ b/substrate/client/src/client.rs
@@ -216,13 +216,10 @@ impl<B, E, Block> Client<B, E, Block> where
 				.ok_or(error::ErrorKind::AuthLenInvalid.into()))
 	}
 
-	/// Get the set of authorities at a given block.
+	/// Get the RuntimeVersion at a given block.
 	pub fn runtime_version_at(&self, id: &BlockId<Block>) -> error::Result<RuntimeVersion> {
 		// TODO: Post Poc-2 return an error if version is missing
-		Ok(self.executor.call(id, "version", &[])
-			.and_then(|r| RuntimeVersion::decode(&mut &r.return_data[..])
-				.ok_or(error::ErrorKind::VersionInvalid.into()))
-			.unwrap_or_default())
+		self.executor.runtime_version(id)
 	}
 
 	/// Get call executor reference.

--- a/substrate/executor/src/error.rs
+++ b/substrate/executor/src/error.rs
@@ -39,6 +39,12 @@ error_chain! {
 			display("Invalid Code: {:?}", c),
 		}
 
+		/// Cound not get runtime version.
+		VersionInvalid {
+			description("Runtime version error"),
+			display("On-chain runtime does not specify version"),
+		}
+
 		/// Externalities have failed.
 		Externalities {
 			description("externalities failure"),

--- a/substrate/executor/src/lib.rs
+++ b/substrate/executor/src/lib.rs
@@ -75,4 +75,11 @@ pub use codec::Slicable;
 pub trait RuntimeInfo {
 	/// Native runtime information if any.
 	const NATIVE_VERSION: Option<RuntimeVersion>;
+
+	/// Extract RuntimeVersion of given :code block
+	fn runtime_version<E: Externalities> (
+		&self,
+		ext: &mut E,
+		code: &[u8]
+	) -> Option<RuntimeVersion>;
 }

--- a/substrate/executor/src/native_executor.rs
+++ b/substrate/executor/src/native_executor.rs
@@ -23,17 +23,21 @@ use std::collections::HashMap;
 use codec::Slicable;
 use twox_hash::XxHash;
 use std::hash::Hasher;
-use parking_lot::Mutex;
+use parking_lot::{Mutex, MutexGuard};
 use RuntimeInfo;
 
-// For the internal Runtime Cache
+// For the internal Runtime Cache:
+// Do we run this natively or use the given WasmModule
 enum RunWith {
-	NativeRuntime,
-	WasmRuntime(WasmModule)
+	InvalidVersion(WasmModule),
+	NativeRuntime(RuntimeVersion),
+	WasmRuntime(RuntimeVersion, WasmModule)
 }
 
+type CacheType = HashMap<u64, RunWith>;
+
 lazy_static! {
-	static ref RUNTIMES_CACHE: Mutex<HashMap<u64, RunWith>> = Mutex::new(HashMap::new());
+	static ref RUNTIMES_CACHE: Mutex<CacheType> = Mutex::new(HashMap::new());
 }
 
 // helper function to generate low-over-head caching_keys
@@ -44,6 +48,34 @@ fn gen_cache_key(code: &[u8]) -> u64 {
 	let mut h = XxHash::with_seed(0);
 	h.write(code);
 	h.finish()
+}
+
+/// fetch a runtime version from the cache or if there is no cached version yet, create
+/// the runtime version entry for `code`, determines whether `RunWith::NativeRuntime`
+/// can be used by by comparing returned RuntimeVersion to `ref_version`
+fn fetch_cached_runtime_version<'a, E: Externalities>(
+	cache: &'a mut MutexGuard<CacheType>,
+	ext: &mut E,
+	code: &[u8],
+	ref_version: RuntimeVersion
+) -> &'a RunWith {
+	cache.entry(gen_cache_key(code))
+		.or_insert_with(||{
+			let module = WasmModule::from_buffer(code).expect("all modules compiled with rustc are valid wasm code; qed");
+			let version = WasmExecutor.call_in_wasm_module(ext, &module, "version", &[]).ok()
+				.and_then(|v| RuntimeVersion::decode(&mut v.as_slice()));
+
+
+			if let Some(v) = version {
+				if ref_version.can_call_with(&v) {
+					RunWith::NativeRuntime(v)
+				} else {
+					RunWith::WasmRuntime(v, module)
+				}
+			} else {
+				RunWith::InvalidVersion(module)
+			}
+	})
 }
 
 fn safe_call<F, U>(f: F) -> Result<U>
@@ -88,7 +120,7 @@ impl<D: NativeExecutionDispatch + Sync + Send> NativeExecutor<D> {
 		// FIXME: set this entry at compile time
 		RUNTIMES_CACHE.lock().insert(
 			gen_cache_key(D::native_equivalent()),
-			RunWith::NativeRuntime);
+			RunWith::NativeRuntime(D::VERSION));
 
 		NativeExecutor {
 			_dummy: Default::default(),
@@ -106,6 +138,18 @@ impl<D: NativeExecutionDispatch + Sync + Send> Clone for NativeExecutor<D> {
 
 impl<D: NativeExecutionDispatch + Sync + Send> RuntimeInfo for NativeExecutor<D> {
 	const NATIVE_VERSION: Option<RuntimeVersion> = Some(D::VERSION);
+
+	fn runtime_version<E: Externalities>(
+		&self,
+		ext: &mut E,
+		code: &[u8],
+	) -> Option<RuntimeVersion> {
+		let mut c = RUNTIMES_CACHE.lock();
+		match fetch_cached_runtime_version(&mut c, ext, code, D::VERSION) {
+			RunWith::NativeRuntime(v) | RunWith::WasmRuntime(v, _) => Some(v.clone()),
+			RunWith::InvalidVersion(_m) => None
+		}
+	}
 }
 
 impl<D: NativeExecutionDispatch + Sync + Send> CodeExecutor for NativeExecutor<D> {
@@ -118,26 +162,10 @@ impl<D: NativeExecutionDispatch + Sync + Send> CodeExecutor for NativeExecutor<D
 		method: &str,
 		data: &[u8],
 	) -> Result<Vec<u8>> {
-		let mut cache = RUNTIMES_CACHE.lock();
-		let r = cache.entry(gen_cache_key(code))
-			.or_insert_with(|| {
-				let wasm_module = WasmModule::from_buffer(code)
-					.expect("all modules compiled with rustc are valid wasm code; qed");
-
-				// Missing version export is allowed in Poc-2 for Poc-1 compatibility.
-				// TODO: return an error on missing version.
-				if WasmExecutor.call_in_wasm_module(ext, &wasm_module, "version", &[]).ok()
-					.and_then(|version| RuntimeVersion::decode(&mut version.as_slice()))
-					.map_or(false, |v| D::VERSION.can_call_with(&v))
-				{
-					RunWith::NativeRuntime
-				} else {
-					RunWith::WasmRuntime(wasm_module)
-				}
-			});
-		match r {
-			RunWith::NativeRuntime => D::dispatch(ext, method, data),
-			RunWith::WasmRuntime(module) => WasmExecutor.call_in_wasm_module(ext, &module, method, data)
+		let mut c = RUNTIMES_CACHE.lock();
+		match fetch_cached_runtime_version(&mut c, ext, code, D::VERSION) {
+			RunWith::NativeRuntime(_v) => D::dispatch(ext, method, data),
+			RunWith::WasmRuntime(_, m) | RunWith::InvalidVersion(m) => WasmExecutor.call_in_wasm_module(ext, m, method, data)
 		}
 	}
 }

--- a/substrate/executor/src/native_executor.rs
+++ b/substrate/executor/src/native_executor.rs
@@ -60,7 +60,7 @@ fn fetch_cached_runtime_version<'a, E: Externalities>(
 	ref_version: RuntimeVersion
 ) -> &'a RunWith {
 	cache.entry(gen_cache_key(code))
-		.or_insert_with(||{
+		.or_insert_with(|| {
 			let module = WasmModule::from_buffer(code).expect("all modules compiled with rustc are valid wasm code; qed");
 			let version = WasmExecutor.call_in_wasm_module(ext, &module, "version", &[]).ok()
 				.and_then(|v| RuntimeVersion::decode(&mut v.as_slice()));


### PR DESCRIPTION
This will:

1. expose a new `runtime_version` API to retrieve the (cached) `RuntimeVersion` for a code-block
2. refactor cache to keep both version and way in which it should be executed
3. replace code execution in clients with newly added `runtime_version` call

Notes:
This makes the cache value a bit more of a complex construct, keeping track of both the runtime to use and the version determined, rather than having separate caches for version and runtime which would be more costly in either parsing the wasm module more than once or running twox more than once. Through this slight increase in complexity we can prevent both of them.