### PR TITLE
[WIP] Styling with rustfmt

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,75 @@
+# SEE https://github.com/rust-lang-nursery/rustfmt/blob/master/Configurations.md
+# activate unstable features, so we can configure a few of them
+unstable_features = true
+
+
+# everything without a comment is at the default value, but we could
+# also always pin the rustfmt version with the following line
+# (at the time of writing):
+#
+# required_version = "0.8.2"
+#
+
+indent_style = "Block"
+use_small_heuristics = "Default"
+binop_separator = "Front"
+combine_control_expr = true
+comment_width = 100
+condense_wildcard_suffixes = false
+control_brace_style = "AlwaysSameLine"
+disable_all_formatting = false
+error_on_line_overflow = false
+error_on_unformatted = false
+fn_args_density = "Tall"
+brace_style = "SameLineWhere"
+empty_item_single_line = true
+fn_single_line = false
+where_single_line = false
+force_explicit_abi = true
+format_strings = false
+# use tabs not spaces
+hard_tabs = true
+imports_indent = "Block"
+imports_layout = "Mixed"
+# do keep imports as they were written
+merge_imports = false
+# put a trailing comma in match block
+match_block_trailing_comma = true
+max_width = 100
+merge_derives = true
+force_multiline_blocks = false
+newline_style = "Unix"
+normalize_comments = false
+remove_nested_parens = true
+reorder_imports = true
+# our module order is intentional
+reorder_modules = false
+reorder_impl_items =  false
+report_todo = "Never"
+report_fixme = "Never"
+skip_children = false
+space_after_colon = true
+space_before_colon = false
+struct_field_align_threshold = 0
+spaces_around_ranges = false
+struct_lit_single_line = true
+tab_spaces = 4
+trailing_comma = "Vertical"
+# do not leave unneeded semicolons around
+trailing_semicolon = false
+type_punctuation_density = "Wide"
+# we use field shorthands 
+use_field_init_shorthand = true
+# we prefer `?` over `try!`
+use_try_shorthand = true
+# we prefer to have a block over long lines
+# even in comments :D
+wrap_comments = true
+# do not create unnaccesary arm blocks
+match_arm_blocks = false
+blank_lines_upper_bound = 1
+blank_lines_lower_bound = 0
+hide_parse_errors = false
+color = "Auto"
+# license_template_path = ""
+ignore = []

--- a/demo/cli/src/error.rs
+++ b/demo/cli/src/error.rs
@@ -25,5 +25,5 @@ error_chain! {
 	}
 	links {
 		Client(client::error::Error, client::error::ErrorKind) #[doc="Client error"];
-    }
+	}
 }

--- a/demo/cli/src/lib.rs
+++ b/demo/cli/src/lib.rs
@@ -19,22 +19,22 @@
 #![warn(missing_docs)]
 
 extern crate ctrlc;
+extern crate demo_executor;
+extern crate demo_primitives;
+extern crate demo_runtime;
 extern crate ed25519;
 extern crate env_logger;
 extern crate futures;
-extern crate tokio_core;
-extern crate triehash;
 extern crate substrate_client as client;
 extern crate substrate_codec as codec;
+extern crate substrate_extrinsic_pool as extrinsic_pool;
 extern crate substrate_primitives as primitives;
 extern crate substrate_rpc;
 extern crate substrate_rpc_servers as rpc;
 extern crate substrate_runtime_io as runtime_io;
 extern crate substrate_state_machine as state_machine;
-extern crate substrate_extrinsic_pool as extrinsic_pool;
-extern crate demo_executor;
-extern crate demo_primitives;
-extern crate demo_runtime;
+extern crate tokio_core;
+extern crate triehash;
 
 #[macro_use]
 extern crate hex_literal;
@@ -47,20 +47,23 @@ extern crate log;
 
 pub mod error;
 
-use std::sync::Arc;
 use demo_primitives::Hash;
-use demo_runtime::{Block, BlockId, UncheckedExtrinsic, GenesisConfig,
-	ConsensusConfig, CouncilConfig, DemocracyConfig, SessionConfig, StakingConfig,
-	TimestampConfig};
+use demo_runtime::{
+	Block, BlockId, ConsensusConfig, CouncilConfig, DemocracyConfig, GenesisConfig, SessionConfig,
+	StakingConfig, TimestampConfig, UncheckedExtrinsic,
+};
 use futures::{Future, Sink, Stream};
+use std::sync::Arc;
 
 struct DummyPool;
 impl extrinsic_pool::api::ExtrinsicPool<UncheckedExtrinsic, BlockId, Hash> for DummyPool {
 	type Error = extrinsic_pool::txpool::Error;
 
-	fn submit(&self, _block: BlockId, _: Vec<UncheckedExtrinsic>)
-		-> Result<Vec<Hash>, Self::Error>
-	{
+	fn submit(
+		&self,
+		_block: BlockId,
+		_: Vec<UncheckedExtrinsic>,
+	) -> Result<Vec<Hash>, Self::Error> {
 		Err("unimplemented".into())
 	}
 }
@@ -86,12 +89,15 @@ impl substrate_rpc::system::SystemApi for DummySystem {
 /// 9556-9591		Unassigned
 /// 9803-9874		Unassigned
 /// 9926-9949		Unassigned
-pub fn run<I, T>(args: I) -> error::Result<()> where
+pub fn run<I, T>(args: I) -> error::Result<()>
+where
 	I: IntoIterator<Item = T>,
 	T: Into<std::ffi::OsString> + Clone,
 {
 	let yaml = load_yaml!("./cli.yml");
-	let matches = clap::App::from_yaml(yaml).version(crate_version!()).get_matches_from_safe(args)?;
+	let matches = clap::App::from_yaml(yaml)
+		.version(crate_version!())
+		.get_matches_from_safe(args)?;
 
 	// TODO [ToDr] Split parameters parsing from actual execution.
 	let log_pattern = matches.value_of("log").unwrap_or("");
@@ -103,13 +109,13 @@ pub fn run<I, T>(args: I) -> error::Result<()> where
 	let god_key = hex!["3d866ec8a9190c8343c2fc593d21d8a6d0c5c4763aaab2349de3a6111d64d124"];
 	let genesis_config = GenesisConfig {
 		consensus: Some(ConsensusConfig {
-			code: vec![],	// TODO
+			code: vec![], // TODO
 			authorities: vec![god_key.clone().into()],
 		}),
 		system: None,
 		session: Some(SessionConfig {
 			validators: vec![god_key.clone().into()],
-			session_length: 720,	// that's 1 hour per session.
+			session_length: 720, // that's 1 hour per session.
 			broken_percent_late: 30,
 		}),
 		staking: Some(StakingConfig {
@@ -122,35 +128,41 @@ pub fn run<I, T>(args: I) -> error::Result<()> where
 			contract_fee: 0,
 			reclaim_rebate: 0,
 			existential_deposit: 500,
-			balances: vec![(god_key.clone().into(), 1u64 << 63)].into_iter().collect(),
+			balances: vec![(god_key.clone().into(), 1u64 << 63)]
+				.into_iter()
+				.collect(),
 			validator_count: 12,
-			sessions_per_era: 24,	// 24 hours per era.
-			bonding_duration: 90,	// 90 days per bond.
+			sessions_per_era: 24, // 24 hours per era.
+			bonding_duration: 90, // 90 days per bond.
 			early_era_slash: 10000,
 			session_reward: 100,
 		}),
 		democracy: Some(DemocracyConfig {
-			launch_period: 120 * 24 * 14,	// 2 weeks per public referendum
-			voting_period: 120 * 24 * 28,	// 4 weeks to discuss & vote on an active referendum
-			minimum_deposit: 1000,	// 1000 as the minimum deposit for a referendum
+			launch_period: 120 * 24 * 14, // 2 weeks per public referendum
+			voting_period: 120 * 24 * 28, // 4 weeks to discuss & vote on an active referendum
+			minimum_deposit: 1000,        // 1000 as the minimum deposit for a referendum
 		}),
 		council: Some(CouncilConfig {
 			active_council: vec![],
-			candidacy_bond: 1000,	// 1000 to become a council candidate
-			voter_bond: 100,		// 100 down to vote for a candidate
-			present_slash_per_voter: 1,	// slash by 1 per voter for an invalid presentation.
-			carry_count: 24,		// carry over the 24 runners-up to the next council election
-			presentation_duration: 120 * 24,	// one day for presenting winners.
-			approval_voting_period: 7 * 120 * 24,	// one week period between possible council elections.
-			term_duration: 180 * 120 * 24,	// 180 day term duration for the council.
-			desired_seats: 0, // start with no council: we'll raise this once the stake has been dispersed a bit.
-			inactive_grace_period: 1,	// one addition vote should go by before an inactive voter can be reaped.
+			candidacy_bond: 1000, // 1000 to become a council candidate
+			voter_bond: 100,      // 100 down to vote for a candidate
+			present_slash_per_voter: 1, /* slash by 1 per voter for an invalid
+			                       * presentation. */
+			carry_count: 24, // carry over the 24 runners-up to the next council election
+			presentation_duration: 120 * 24, // one day for presenting winners.
+			approval_voting_period: 7 * 120 * 24, // one week period between possible council elections.
+			term_duration: 180 * 120 * 24, // 180 day term duration for the council.
+			desired_seats: 0, /* start with no council: we'll raise this once the stake has been
+			                  * dispersed a bit. */
+			inactive_grace_period: 1, /* one addition vote should go by before an inactive voter
+			                           * can be reaped. */
 
-			cooloff_period: 90 * 120 * 24, // 90 day cooling off period if council member vetoes a proposal.
+			cooloff_period: 90 * 120 * 24, /* 90 day cooling off period if council member vetoes
+			                                * a proposal. */
 			voting_period: 7 * 120 * 24, // 7 day voting period for council members.
 		}),
 		timestamp: Some(TimestampConfig {
-			period: 5,					// 5 second block time.
+			period: 5, // 5 second block time.
 		}),
 	};
 
@@ -168,7 +180,7 @@ pub fn run<I, T>(args: I) -> error::Result<()> where
 
 		(
 			rpc::start_http(&http_address, handler())?,
-			rpc::start_ws(&ws_address, handler())?
+			rpc::start_ws(&ws_address, handler())?,
 		)
 	};
 
@@ -176,9 +188,14 @@ pub fn run<I, T>(args: I) -> error::Result<()> where
 		info!("Starting validator.");
 		let (exit_send, exit) = futures::sync::mpsc::channel(1);
 		ctrlc::CtrlC::set_handler(move || {
-			exit_send.clone().send(()).wait().expect("Error sending exit notification");
+			exit_send
+				.clone()
+				.send(())
+				.wait()
+				.expect("Error sending exit notification");
 		});
-		core.run(exit.into_future()).expect("Error running informant event loop");
+		core.run(exit.into_future())
+			.expect("Error running informant event loop");
 		return Ok(())
 	}
 
@@ -200,7 +217,6 @@ fn init_logger(pattern: &str) {
 	}
 
 	builder.parse(pattern);
-
 
 	builder.init().expect("Logger initialized only once.");
 }

--- a/demo/primitives/src/lib.rs
+++ b/demo/primitives/src/lib.rs
@@ -17,16 +17,16 @@
 //! Low-level types used throughout the Substrate Demo code.
 
 #![warn(missing_docs)]
-
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(not(feature = "std"), feature(alloc))]
 
-#[cfg(feature = "std")] extern crate serde;
+#[cfg(feature = "std")]
+extern crate serde;
 
-extern crate substrate_runtime_std as rstd;
-extern crate substrate_runtime_primitives as runtime_primitives;
-extern crate substrate_primitives as primitives;
 extern crate substrate_codec as codec;
+extern crate substrate_primitives as primitives;
+extern crate substrate_runtime_primitives as runtime_primitives;
+extern crate substrate_runtime_std as rstd;
 
 /// An index to a block.
 pub type BlockNumber = u64;

--- a/demo/runtime/src/lib.rs
+++ b/demo/runtime/src/lib.rs
@@ -34,23 +34,25 @@ extern crate serde_derive;
 #[cfg(feature = "std")]
 extern crate serde;
 
-extern crate substrate_runtime_std as rstd;
 extern crate substrate_runtime_consensus as consensus;
 extern crate substrate_runtime_council as council;
 extern crate substrate_runtime_democracy as democracy;
 extern crate substrate_runtime_executive as executive;
 extern crate substrate_runtime_session as session;
 extern crate substrate_runtime_staking as staking;
+extern crate substrate_runtime_std as rstd;
 extern crate substrate_runtime_system as system;
 extern crate substrate_runtime_timestamp as timestamp;
 #[macro_use]
 extern crate substrate_runtime_version as version;
 extern crate demo_primitives;
 
+use demo_primitives::{
+	AccountId, AccountIndex, Balance, BlockNumber, Hash, Index, SessionKey, Signature,
+};
 use rstd::prelude::*;
-use demo_primitives::{AccountId, AccountIndex, Balance, BlockNumber, Hash, Index, SessionKey, Signature};
 use runtime_primitives::generic;
-use runtime_primitives::traits::{Convert, HasPublicAux, BlakeTwo256};
+use runtime_primitives::traits::{BlakeTwo256, Convert, HasPublicAux};
 use version::RuntimeVersion;
 
 #[cfg(any(feature = "std", test))]
@@ -191,8 +193,13 @@ pub type Extrinsic = generic::Extrinsic<Address, Index, Call>;
 /// Extrinsic type that is signed.
 pub type BareExtrinsic = generic::Extrinsic<AccountId, Index, Call>;
 /// Executive: handles dispatch to the various modules.
-pub type Executive = executive::Executive<Concrete, Block, Staking, Staking,
-	(((((), Council), Democracy), Staking), Session)>;
+pub type Executive = executive::Executive<
+	Concrete,
+	Block,
+	Staking,
+	Staking,
+	(((((), Council), Democracy), Staking), Session),
+>;
 
 impl_outer_config! {
 	pub struct GenesisConfig for Concrete {

--- a/polkadot/api/src/lib.rs
+++ b/polkadot/api/src/lib.rs
@@ -20,12 +20,12 @@
 extern crate polkadot_executor;
 extern crate polkadot_primitives as primitives;
 extern crate polkadot_runtime as runtime;
-extern crate substrate_codec as codec;
-extern crate substrate_runtime_io as runtime_io;
 extern crate substrate_client as client;
+extern crate substrate_codec as codec;
 extern crate substrate_executor as substrate_executor;
-extern crate substrate_runtime_executive;
 extern crate substrate_primitives;
+extern crate substrate_runtime_executive;
+extern crate substrate_runtime_io as runtime_io;
 extern crate substrate_runtime_primitives as runtime_primitives;
 extern crate substrate_state_machine as state_machine;
 
@@ -38,10 +38,11 @@ extern crate substrate_keyring as keyring;
 pub mod full;
 pub mod light;
 
-use primitives::{AccountId, Block, BlockId, Hash, Index, SessionKey, Timestamp,
-	UncheckedExtrinsic};
-use runtime::Address;
 use primitives::parachain::{CandidateReceipt, DutyRoster, Id as ParaId};
+use primitives::{
+	AccountId, Block, BlockId, Hash, Index, SessionKey, Timestamp, UncheckedExtrinsic,
+};
+use runtime::Address;
 
 error_chain! {
 	errors {
@@ -71,7 +72,8 @@ error_chain! {
 impl From<client::error::Error> for Error {
 	fn from(e: client::error::Error) -> Error {
 		match e {
-			client::error::Error(client::error::ErrorKind::UnknownBlock(b), _) => Error::from_kind(ErrorKind::UnknownBlock(b)),
+			client::error::Error(client::error::ErrorKind::UnknownBlock(b), _) =>
+				Error::from_kind(ErrorKind::UnknownBlock(b)),
 			other => Error::from_kind(ErrorKind::Other(Box::new(other) as Box<_>)),
 		}
 	}
@@ -117,10 +119,12 @@ pub trait PolkadotApi {
 	/// Get the active parachains at a block.
 	fn active_parachains(&self, at: &BlockId) -> Result<Vec<ParaId>>;
 
-	/// Get the validation code of a parachain at a block. If the parachain is active, this will always return `Some`.
+	/// Get the validation code of a parachain at a block. If the parachain is active, this will
+	/// always return `Some`.
 	fn parachain_code(&self, at: &BlockId, parachain: ParaId) -> Result<Option<Vec<u8>>>;
 
-	/// Get the chain head of a parachain. If the parachain is active, this will always return `Some`.
+	/// Get the chain head of a parachain. If the parachain is active, this will always return
+	/// `Some`.
 	fn parachain_head(&self, at: &BlockId, parachain: ParaId) -> Result<Option<Vec<u8>>>;
 
 	/// Evaluate a block. Returns true if the block is good, false if it is known to be bad,
@@ -128,15 +132,26 @@ pub trait PolkadotApi {
 	fn evaluate_block(&self, at: &BlockId, block: Block) -> Result<bool>;
 
 	/// Build a block on top of the given, with inherent extrinsics pre-pushed.
-	fn build_block(&self, at: &BlockId, timestamp: Timestamp, new_heads: Vec<CandidateReceipt>) -> Result<Self::BlockBuilder>;
+	fn build_block(
+		&self,
+		at: &BlockId,
+		timestamp: Timestamp,
+		new_heads: Vec<CandidateReceipt>,
+	) -> Result<Self::BlockBuilder>;
 
 	/// Attempt to produce the (encoded) inherent extrinsics for a block being built upon the given.
 	/// This may vary by runtime and will fail if a runtime doesn't follow the same API.
-	fn inherent_extrinsics(&self, at: &BlockId, timestamp: Timestamp, new_heads: Vec<CandidateReceipt>) -> Result<Vec<UncheckedExtrinsic>>;
+	fn inherent_extrinsics(
+		&self,
+		at: &BlockId,
+		timestamp: Timestamp,
+		new_heads: Vec<CandidateReceipt>,
+	) -> Result<Vec<UncheckedExtrinsic>>;
 }
 
 /// Mark for all Polkadot API implementations, that are making use of state data, stored locally.
 pub trait LocalPolkadotApi: PolkadotApi {}
 
-/// Mark for all Polkadot API implementations, that are fetching required state data from remote nodes.
+/// Mark for all Polkadot API implementations, that are fetching required state data from remote
+/// nodes.
 pub trait RemotePolkadotApi: PolkadotApi {}

--- a/polkadot/cli/src/error.rs
+++ b/polkadot/cli/src/error.rs
@@ -26,7 +26,7 @@ error_chain! {
 	}
 	links {
 		Client(client::error::Error, client::error::ErrorKind) #[doc="Client error"];
-    }
+	}
 	errors {
 		/// Input error.
 		Input(m: String) {

--- a/polkadot/cli/src/informant.rs
+++ b/polkadot/cli/src/informant.rs
@@ -16,49 +16,55 @@
 
 //! Console informant. Prints sync progress and block events. Runs on the calling thread.
 
-use std::time::{Duration, Instant};
-use futures::stream::Stream;
-use service::{Service, Components};
-use tokio_core::reactor;
-use network::{SyncState, SyncProvider};
-use polkadot_primitives::Block;
-use state_machine;
 use client::{self, BlockchainEvents};
+use futures::stream::Stream;
+use network::{SyncProvider, SyncState};
+use polkadot_primitives::Block;
+use service::{Components, Service};
+use state_machine;
+use std::time::{Duration, Instant};
+use tokio_core::reactor;
 
 const TIMER_INTERVAL_MS: u64 = 5000;
 
 /// Spawn informant on the event loop
 pub fn start<C>(service: &Service<C>, handle: reactor::Handle)
-	where
-		C: Components,
-		client::error::Error: From<<<<C as Components>::Backend as client::backend::Backend<Block>>::State as state_machine::Backend>::Error>,
+where
+	C: Components,
+	client::error::Error:
+		From<<<<C as Components>::Backend as client::backend::Backend<Block>>::State as state_machine::Backend>::Error>,
 {
-	let interval = reactor::Interval::new_at(Instant::now(), Duration::from_millis(TIMER_INTERVAL_MS), &handle)
-		.expect("Error creating informant timer");
+	let interval = reactor::Interval::new_at(
+		Instant::now(),
+		Duration::from_millis(TIMER_INTERVAL_MS),
+		&handle,
+	).expect("Error creating informant timer");
 
 	let network = service.network();
 	let client = service.client();
 	let txpool = service.transaction_pool();
 
-	let display_notifications = interval.map_err(|e| debug!("Timer error: {:?}", e)).for_each(move |_| {
-		let sync_status = network.status();
+	let display_notifications = interval
+		.map_err(|e| debug!("Timer error: {:?}", e))
+		.for_each(move |_| {
+			let sync_status = network.status();
 
-		if let Ok(best_block) = client.best_block_header() {
-			let hash = best_block.hash();
-			let num_peers = sync_status.num_peers;
-			let status = match (sync_status.sync.state, sync_status.sync.best_seen_block) {
-				(SyncState::Idle, _) => "Idle".into(),
-				(SyncState::Downloading, None) => "Syncing".into(),
-				(SyncState::Downloading, Some(n)) => format!("Syncing, target=#{}", n),
-			};
-			let txpool_status = txpool.light_status();
-			info!(target: "polkadot", "{} ({} peers), best: #{} ({})", status, sync_status.num_peers, best_block.number, hash);
-			telemetry!("system.interval"; "status" => status, "peers" => num_peers, "height" => best_block.number, "best" => ?hash, "txcount" => txpool_status.transaction_count);
-		} else {
-			warn!("Error getting best block information");
-		}
-		Ok(())
-	});
+			if let Ok(best_block) = client.best_block_header() {
+				let hash = best_block.hash();
+				let num_peers = sync_status.num_peers;
+				let status = match (sync_status.sync.state, sync_status.sync.best_seen_block) {
+					(SyncState::Idle, _) => "Idle".into(),
+					(SyncState::Downloading, None) => "Syncing".into(),
+					(SyncState::Downloading, Some(n)) => format!("Syncing, target=#{}", n),
+				};
+				let txpool_status = txpool.light_status();
+				info!(target: "polkadot", "{} ({} peers), best: #{} ({})", status, sync_status.num_peers, best_block.number, hash);
+				telemetry!("system.interval"; "status" => status, "peers" => num_peers, "height" => best_block.number, "best" => ?hash, "txcount" => txpool_status.transaction_count);
+			} else {
+				warn!("Error getting best block information");
+			}
+			Ok(())
+		});
 
 	let client = service.client();
 	let display_block_import = client.import_notification_stream().for_each(|n| {
@@ -77,4 +83,3 @@ pub fn start<C>(service: &Service<C>, handle: reactor::Handle)
 	handle.spawn(display_block_import);
 	handle.spawn(display_txpool_import);
 }
-

--- a/polkadot/consensus/src/dynamic_inclusion.rs
+++ b/polkadot/consensus/src/dynamic_inclusion.rs
@@ -50,11 +50,7 @@ impl DynamicInclusion {
 			(0, 0)
 		};
 
-		DynamicInclusion {
-			start,
-			y,
-			m,
-		}
+		DynamicInclusion { start, y, m }
 	}
 
 	/// Returns the duration from `now` after which the amount of included parachain candidates
@@ -83,42 +79,49 @@ mod tests {
 	fn full_immediately_allowed() {
 		let now = Instant::now();
 
-		let dynamic = DynamicInclusion::new(
-			10,
-			now,
-			Duration::from_millis(4000),
-		);
+		let dynamic = DynamicInclusion::new(10, now, Duration::from_millis(4000));
 
 		assert!(dynamic.acceptable_in(now, 10).is_none());
 		assert!(dynamic.acceptable_in(now, 11).is_none());
-		assert!(dynamic.acceptable_in(now + Duration::from_millis(2000), 10).is_none());
+		assert!(
+			dynamic
+				.acceptable_in(now + Duration::from_millis(2000), 10)
+				.is_none()
+		);
 	}
 
 	#[test]
 	fn half_allowed_halfway() {
 		let now = Instant::now();
 
-		let dynamic = DynamicInclusion::new(
-			10,
-			now,
-			Duration::from_millis(4000),
-		);
+		let dynamic = DynamicInclusion::new(10, now, Duration::from_millis(4000));
 
-		assert_eq!(dynamic.acceptable_in(now, 5), Some(Duration::from_millis(2000)));
-		assert!(dynamic.acceptable_in(now + Duration::from_millis(2000), 5).is_none());
-		assert!(dynamic.acceptable_in(now + Duration::from_millis(3000), 5).is_none());
-		assert!(dynamic.acceptable_in(now + Duration::from_millis(4000), 5).is_none());
+		assert_eq!(
+			dynamic.acceptable_in(now, 5),
+			Some(Duration::from_millis(2000))
+		);
+		assert!(
+			dynamic
+				.acceptable_in(now + Duration::from_millis(2000), 5)
+				.is_none()
+		);
+		assert!(
+			dynamic
+				.acceptable_in(now + Duration::from_millis(3000), 5)
+				.is_none()
+		);
+		assert!(
+			dynamic
+				.acceptable_in(now + Duration::from_millis(4000), 5)
+				.is_none()
+		);
 	}
 
 	#[test]
 	fn zero_initial_is_flat() {
 		let now = Instant::now();
 
-		let dynamic = DynamicInclusion::new(
-			0,
-			now,
-			Duration::from_secs(10_000),
-		);
+		let dynamic = DynamicInclusion::new(0, now, Duration::from_secs(10_000));
 
 		for i in 0..10_001 {
 			let now = now + Duration::from_secs(i);

--- a/polkadot/consensus/src/shared_table/includable.rs
+++ b/polkadot/consensus/src/shared_table/includable.rs
@@ -24,7 +24,9 @@ use futures::sync::oneshot;
 use polkadot_primitives::Hash;
 
 /// Track includability of a set of candidates,
-pub(super) fn track<I: IntoIterator<Item=(Hash, bool)>>(candidates: I) -> (IncludabilitySender, Includable) {
+pub(super) fn track<I: IntoIterator<Item = (Hash, bool)>>(
+	candidates: I,
+) -> (IncludabilitySender, Includable) {
 	let (tx, rx) = oneshot::channel();
 	let tracking: HashMap<_, _> = candidates.into_iter().collect();
 	let includable_count = tracking.values().filter(|x| **x).count();
@@ -37,10 +39,7 @@ pub(super) fn track<I: IntoIterator<Item=(Hash, bool)>>(candidates: I) -> (Inclu
 
 	sender.try_complete();
 
-	(
-		sender,
-		Includable(rx),
-	)
+	(sender, Includable(rx))
 }
 
 /// The sending end of the includability sender.
@@ -59,7 +58,7 @@ impl IncludabilitySender {
 		use std::collections::hash_map::Entry;
 
 		match self.tracking.entry(candidate) {
-			Entry::Vacant(_) => {}
+			Entry::Vacant(_) => {},
 			Entry::Occupied(mut entry) => {
 				let old = entry.insert(includable);
 				if !old && includable {
@@ -67,7 +66,7 @@ impl IncludabilitySender {
 				} else if old && !includable {
 					self.includable_count -= 1;
 				}
-			}
+			},
 		}
 
 		self.try_complete()
@@ -113,12 +112,15 @@ mod tests {
 		let hash2 = [2; 32].into();
 		let hash3 = [3; 32].into();
 
-		let (mut sender, recv) = track([
-			(hash1, true),
-			(hash2, true),
-			(hash2, false), // overwrite should favor latter.
-			(hash3, true),
-		].iter().cloned());
+		let (mut sender, recv) = track(
+			[
+				(hash1, true),
+				(hash2, true),
+				(hash2, false), // overwrite should favor latter.
+				(hash3, true),
+			].iter()
+				.cloned(),
+		);
 
 		assert!(!sender.is_complete());
 

--- a/polkadot/executor/src/lib.rs
+++ b/polkadot/executor/src/lib.rs
@@ -18,6 +18,7 @@
 //! executed is equivalent to the natively compiled code.
 
 extern crate polkadot_runtime;
-#[macro_use] extern crate substrate_executor;
+#[macro_use]
+extern crate substrate_executor;
 
 native_executor_instance!(pub Executor, polkadot_runtime::api::dispatch, polkadot_runtime::VERSION, include_bytes!("../../runtime/wasm/target/wasm32-unknown-unknown/release/polkadot_runtime.compact.wasm"));

--- a/polkadot/parachain/src/lib.rs
+++ b/polkadot/parachain/src/lib.rs
@@ -27,8 +27,9 @@
 //! `validate` accepts as input two `i32` values, representing a pointer/length pair
 //! respectively, that encodes `ValidationParams`.
 //!
-//! `validate` returns an `i32` which is a pointer to a little-endian 32-bit integer denoting a length.
-//! Subtracting the length from the initial pointer will give a new pointer to the actual return data,
+//! `validate` returns an `i32` which is a pointer to a little-endian 32-bit integer denoting a
+//! length. Subtracting the length from the initial pointer will give a new pointer to the actual
+//! return data,
 //!
 //! ASCII-diagram demonstrating the return data format:
 //!
@@ -101,7 +102,7 @@ impl Slicable for ValidationParams {
 #[cfg_attr(feature = "std", derive(Debug))]
 pub struct ValidationResult {
 	/// New head data that should be included in the relay chain state.
-	pub head_data: Vec<u8>
+	pub head_data: Vec<u8>,
 }
 
 impl Slicable for ValidationResult {
@@ -134,7 +135,10 @@ pub fn write_result(result: ValidationResult) -> usize {
 	let mut encoded = result.encode();
 	let len = encoded.len();
 
-	assert!(len <= u32::max_value() as usize, "Len too large for parachain-WASM abi");
+	assert!(
+		len <= u32::max_value() as usize,
+		"Len too large for parachain-WASM abi"
+	);
 	(len as u32).using_encoded(|s| encoded.extend(s));
 
 	// do not alter `encoded` beyond this point. may reallocate.

--- a/polkadot/parachain/tests/basic_add.rs
+++ b/polkadot/parachain/tests/basic_add.rs
@@ -19,8 +19,8 @@
 extern crate polkadot_parachain as parachain;
 extern crate tiny_keccak;
 
+use parachain::codec::{Input, Slicable};
 use parachain::ValidationParams;
-use parachain::codec::{Slicable, Input};
 
 // Head data for this parachain.
 #[derive(Default, Clone)]
@@ -98,15 +98,15 @@ fn execute_good_on_parent() {
 		post_state: hash_state(0),
 	};
 
-	let block_data = BlockData {
-		state: 0,
-		add: 512,
-	};
+	let block_data = BlockData { state: 0, add: 512 };
 
-	let ret = parachain::wasm::validate_candidate(TEST_CODE, ValidationParams {
-		parent_head: parent_head.encode(),
-		block_data: block_data.encode(),
-	}).unwrap();
+	let ret = parachain::wasm::validate_candidate(
+		TEST_CODE,
+		ValidationParams {
+			parent_head: parent_head.encode(),
+			block_data: block_data.encode(),
+		},
+	).unwrap();
 
 	let new_head = HeadData::decode(&mut &ret.head_data[..]).unwrap();
 
@@ -133,10 +133,13 @@ fn execute_good_chain_on_parent() {
 			add,
 		};
 
-		let ret = parachain::wasm::validate_candidate(TEST_CODE, ValidationParams {
-			parent_head: parent_head.encode(),
-			block_data: block_data.encode(),
-		}).unwrap();
+		let ret = parachain::wasm::validate_candidate(
+			TEST_CODE,
+			ValidationParams {
+				parent_head: parent_head.encode(),
+				block_data: block_data.encode(),
+			},
+		).unwrap();
 
 		let new_head = HeadData::decode(&mut &ret.head_data[..]).unwrap();
 
@@ -152,7 +155,7 @@ fn execute_good_chain_on_parent() {
 
 #[test]
 fn execute_bad_on_parent() {
-		let parent_head = HeadData {
+	let parent_head = HeadData {
 		number: 0,
 		parent_hash: [0; 32],
 		post_state: hash_state(0),
@@ -163,8 +166,11 @@ fn execute_bad_on_parent() {
 		add: 256,
 	};
 
-	let _ret = parachain::wasm::validate_candidate(TEST_CODE, ValidationParams {
-		parent_head: parent_head.encode(),
-		block_data: block_data.encode(),
-	}).unwrap_err();
+	let _ret = parachain::wasm::validate_candidate(
+		TEST_CODE,
+		ValidationParams {
+			parent_head: parent_head.encode(),
+			block_data: block_data.encode(),
+		},
+	).unwrap_err();
 }

--- a/polkadot/primitives/src/lib.rs
+++ b/polkadot/primitives/src/lib.rs
@@ -17,13 +17,12 @@
 //! Shareable Polkadot types.
 
 #![warn(missing_docs)]
-
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(not(feature = "std"), feature(alloc))]
 
-extern crate substrate_runtime_std as rstd;
 extern crate substrate_primitives as primitives;
 extern crate substrate_runtime_primitives as runtime_primitives;
+extern crate substrate_runtime_std as rstd;
 #[cfg(test)]
 extern crate substrate_serializer;
 
@@ -39,10 +38,10 @@ extern crate serde;
 #[cfg(feature = "std")]
 use primitives::bytes;
 
-use rstd::prelude::*;
-use runtime_primitives::traits::BlakeTwo256;
-use runtime_primitives::generic;
 use codec::{Input, Slicable};
+use rstd::prelude::*;
+use runtime_primitives::generic;
+use runtime_primitives::traits::BlakeTwo256;
 
 pub mod parachain;
 
@@ -107,7 +106,7 @@ pub type BlockId = generic::BlockId<Block>;
 /// A log entry in the block.
 #[derive(PartialEq, Eq, Clone, Default)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize, Debug))]
-pub struct Log(#[cfg_attr(feature = "std", serde(with="bytes"))] pub Vec<u8>);
+pub struct Log(#[cfg_attr(feature = "std", serde(with = "bytes"))] pub Vec<u8>);
 
 impl Slicable for Log {
 	fn decode<I: Input>(input: &mut I) -> Option<Self> {

--- a/polkadot/primitives/src/parachain.rs
+++ b/polkadot/primitives/src/parachain.rs
@@ -16,10 +16,10 @@
 
 //! Polkadot parachain types.
 
-use codec::{Slicable, Input};
-use rstd::prelude::*;
-use rstd::cmp::Ordering;
 use super::Hash;
+use codec::{Input, Slicable};
+use rstd::cmp::Ordering;
+use rstd::prelude::*;
 
 #[cfg(feature = "std")]
 use primitives::bytes;
@@ -33,11 +33,15 @@ pub type CandidateSignature = ::runtime_primitives::Ed25519Signature;
 pub struct Id(u32);
 
 impl From<Id> for u32 {
-	fn from(x: Id) -> Self { x.0 }
+	fn from(x: Id) -> Self {
+		x.0
+	}
 }
 
 impl From<u32> for Id {
-	fn from(x: u32) -> Self { Id(x) }
+	fn from(x: u32) -> Self {
+		Id(x)
+	}
 }
 
 impl Id {
@@ -80,11 +84,13 @@ impl Slicable for Chain {
 	fn encode(&self) -> Vec<u8> {
 		let mut v = Vec::new();
 		match *self {
-			Chain::Relay => { v.push(0); }
+			Chain::Relay => {
+				v.push(0);
+			},
 			Chain::Parachain(id) => {
 				v.push(1u8);
 				id.using_encoded(|s| v.extend(s));
-			}
+			},
 		}
 		v
 	}
@@ -218,7 +224,8 @@ impl PartialOrd for CandidateReceipt {
 impl Ord for CandidateReceipt {
 	fn cmp(&self, other: &Self) -> Ordering {
 		// TODO: compare signatures or something more sane
-		self.parachain_index.cmp(&other.parachain_index)
+		self.parachain_index
+			.cmp(&other.parachain_index)
 			.then_with(|| self.head_data.cmp(&other.head_data))
 	}
 }
@@ -226,7 +233,7 @@ impl Ord for CandidateReceipt {
 /// Parachain ingress queue message.
 #[derive(PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize, Debug))]
-pub struct Message(#[cfg_attr(feature = "std", serde(with="bytes"))] pub Vec<u8>);
+pub struct Message(#[cfg_attr(feature = "std", serde(with = "bytes"))] pub Vec<u8>);
 
 /// Consolidated ingress queue data.
 ///
@@ -241,27 +248,27 @@ pub struct ConsolidatedIngress(pub Vec<(Id, Vec<Message>)>);
 /// contains everything required to validate para-block, may contain block and witness data
 #[derive(PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize, Debug))]
-pub struct BlockData(#[cfg_attr(feature = "std", serde(with="bytes"))] pub Vec<u8>);
+pub struct BlockData(#[cfg_attr(feature = "std", serde(with = "bytes"))] pub Vec<u8>);
 
 /// Parachain header raw bytes wrapper type.
 #[derive(PartialEq, Eq)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize, Debug))]
-pub struct Header(#[cfg_attr(feature = "std", serde(with="bytes"))] pub Vec<u8>);
+pub struct Header(#[cfg_attr(feature = "std", serde(with = "bytes"))] pub Vec<u8>);
 
 /// Parachain head data included in the chain.
 #[derive(PartialEq, Eq, Clone, PartialOrd, Ord)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize, Debug))]
-pub struct HeadData(#[cfg_attr(feature = "std", serde(with="bytes"))] pub Vec<u8>);
+pub struct HeadData(#[cfg_attr(feature = "std", serde(with = "bytes"))] pub Vec<u8>);
 
 /// Parachain validation code.
 #[derive(PartialEq, Eq)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize, Debug))]
-pub struct ValidationCode(#[cfg_attr(feature = "std", serde(with="bytes"))] pub Vec<u8>);
+pub struct ValidationCode(#[cfg_attr(feature = "std", serde(with = "bytes"))] pub Vec<u8>);
 
 /// Activitiy bit field
 #[derive(PartialEq, Eq, Clone, Default)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize, Debug))]
-pub struct Activity(#[cfg_attr(feature = "std", serde(with="bytes"))] pub Vec<u8>);
+pub struct Activity(#[cfg_attr(feature = "std", serde(with = "bytes"))] pub Vec<u8>);
 
 impl Slicable for Activity {
 	fn decode<I: Input>(input: &mut I) -> Option<Self> {
@@ -304,19 +311,19 @@ impl Slicable for Statement {
 			Statement::Candidate(ref candidate) => {
 				v.push(StatementKind::Candidate as u8);
 				candidate.using_encoded(|s| v.extend(s));
-			}
+			},
 			Statement::Valid(ref hash) => {
 				v.push(StatementKind::Valid as u8);
 				hash.using_encoded(|s| v.extend(s));
-			}
+			},
 			Statement::Invalid(ref hash) => {
 				v.push(StatementKind::Invalid as u8);
 				hash.using_encoded(|s| v.extend(s));
-			}
+			},
 			Statement::Available(ref hash) => {
 				v.push(StatementKind::Available as u8);
 				hash.using_encoded(|s| v.extend(s));
-			}
+			},
 		}
 
 		v
@@ -324,18 +331,14 @@ impl Slicable for Statement {
 
 	fn decode<I: Input>(value: &mut I) -> Option<Self> {
 		match value.read_byte() {
-			Some(x) if x == StatementKind::Candidate as u8 => {
-				Slicable::decode(value).map(Statement::Candidate)
-			}
-			Some(x) if x == StatementKind::Valid as u8 => {
-				Slicable::decode(value).map(Statement::Valid)
-			}
-			Some(x) if x == StatementKind::Invalid as u8 => {
-				Slicable::decode(value).map(Statement::Invalid)
-			}
-			Some(x) if x == StatementKind::Available as u8 => {
-				Slicable::decode(value).map(Statement::Available)
-			}
+			Some(x) if x == StatementKind::Candidate as u8 =>
+				Slicable::decode(value).map(Statement::Candidate),
+			Some(x) if x == StatementKind::Valid as u8 =>
+				Slicable::decode(value).map(Statement::Valid),
+			Some(x) if x == StatementKind::Invalid as u8 =>
+				Slicable::decode(value).map(Statement::Invalid),
+			Some(x) if x == StatementKind::Available as u8 =>
+				Slicable::decode(value).map(Statement::Available),
 			_ => None,
 		}
 	}

--- a/polkadot/runtime/src/utils.rs
+++ b/polkadot/runtime/src/utils.rs
@@ -16,15 +16,18 @@
 
 //! Utils for block interaction.
 
-use rstd::prelude::*;
-use super::{Call, UncheckedExtrinsic, Extrinsic, Staking};
-use runtime_primitives::traits::{Checkable, AuxLookup};
-use primitives::parachain::CandidateReceipt;
-use timestamp::Call as TimestampCall;
+use super::{Call, Extrinsic, Staking, UncheckedExtrinsic};
 use parachains::Call as ParachainsCall;
+use primitives::parachain::CandidateReceipt;
+use rstd::prelude::*;
+use runtime_primitives::traits::{AuxLookup, Checkable};
+use timestamp::Call as TimestampCall;
 
 /// Produces the list of inherent extrinsics.
-pub fn inherent_extrinsics(timestamp: ::primitives::Timestamp, parachain_heads: Vec<CandidateReceipt>) -> Vec<UncheckedExtrinsic> {
+pub fn inherent_extrinsics(
+	timestamp: ::primitives::Timestamp,
+	parachain_heads: Vec<CandidateReceipt>,
+) -> Vec<UncheckedExtrinsic> {
 	vec![
 		UncheckedExtrinsic::new(
 			Extrinsic {
@@ -32,7 +35,7 @@ pub fn inherent_extrinsics(timestamp: ::primitives::Timestamp, parachain_heads: 
 				function: Call::Timestamp(TimestampCall::set(timestamp)),
 				index: 0,
 			},
-			Default::default()
+			Default::default(),
 		),
 		UncheckedExtrinsic::new(
 			Extrinsic {
@@ -40,8 +43,8 @@ pub fn inherent_extrinsics(timestamp: ::primitives::Timestamp, parachain_heads: 
 				function: Call::Parachains(ParachainsCall::set_heads(parachain_heads)),
 				index: 0,
 			},
-			Default::default()
-		)
+			Default::default(),
+		),
 	]
 }
 

--- a/polkadot/service/src/config.rs
+++ b/polkadot/service/src/config.rs
@@ -16,11 +16,11 @@
 
 //! Service configuration.
 
-use transaction_pool;
 use chain_spec::ChainSpec;
-pub use network::Role;
-pub use network::NetworkConfiguration;
 pub use client_db::PruningMode;
+pub use network::NetworkConfiguration;
+pub use network::Role;
+use transaction_pool;
 
 /// Service configuration.
 pub struct Configuration {

--- a/polkadot/service/src/error.rs
+++ b/polkadot/service/src/error.rs
@@ -17,8 +17,8 @@
 //! Errors that can occur during the service operation.
 
 use client;
-use network;
 use keystore;
+use network;
 
 error_chain! {
 	links {

--- a/polkadot/statement-table/src/lib.rs
+++ b/polkadot/statement-table/src/lib.rs
@@ -14,15 +14,15 @@
 //! propose and attest to validity of candidates, and those who can only attest
 //! to availability.
 
-extern crate substrate_primitives;
 extern crate polkadot_primitives as primitives;
+extern crate substrate_primitives;
 
 pub mod generic;
 
 pub use generic::Table;
 
-use primitives::parachain::{Id, CandidateReceipt, CandidateSignature as Signature};
-use primitives::{SessionKey, Hash};
+use primitives::parachain::{CandidateReceipt, CandidateSignature as Signature, Id};
+use primitives::{Hash, SessionKey};
 
 /// Statements about candidates on the network.
 pub type Statement = generic::Statement<CandidateReceipt, Hash>;
@@ -45,11 +45,7 @@ pub trait Context {
 	/// Whether a authority is an availability guarantor of a group.
 	/// Guarantors are meant to vote on availability for candidates submitted
 	/// in a group.
-	fn is_availability_guarantor_of(
-		&self,
-		authority: &SessionKey,
-		group: &Id,
-	) -> bool;
+	fn is_availability_guarantor_of(&self, authority: &SessionKey, group: &Id) -> bool;
 
 	// requisite number of votes for validity and availability respectively from a group.
 	fn requisite_votes(&self, group: &Id) -> (usize, usize);
@@ -100,8 +96,12 @@ pub trait StatementBatch {
 }
 
 impl<T: StatementBatch> generic::StatementBatch<SessionKey, SignedStatement> for T {
-	fn targets(&self) -> &[SessionKey] { StatementBatch::targets(self ) }
-	fn is_empty(&self) -> bool { StatementBatch::is_empty(self) }
+	fn targets(&self) -> &[SessionKey] {
+		StatementBatch::targets(self)
+	}
+	fn is_empty(&self) -> bool {
+		StatementBatch::is_empty(self)
+	}
 	fn push(&mut self, statement: SignedStatement) -> bool {
 		StatementBatch::push(self, statement)
 	}

--- a/safe-mix/src/lib.rs
+++ b/safe-mix/src/lib.rs
@@ -29,16 +29,18 @@ use core::ops::{BitAnd, BitOr};
 
 pub const MAX_DEPTH: usize = 17;
 
-fn sub_mix<T>(seeds: &[T]) -> T where
-	T: BitAnd<Output = T> + BitOr<Output = T> + Copy
+fn sub_mix<T>(seeds: &[T]) -> T
+where
+	T: BitAnd<Output = T> + BitOr<Output = T> + Copy,
 {
 	(seeds[0] & seeds[1]) | (seeds[1] & seeds[2]) | (seeds[0] & seeds[2])
 }
 
 /// Mix a slice.
-pub fn triplet_mix<T>(seeds: &[T]) -> Result<T, ()> where
+pub fn triplet_mix<T>(seeds: &[T]) -> Result<T, ()>
+where
 	T: BitAnd<Output = T> + BitOr<Output = T>,
-	T: Default + Copy
+	T: Default + Copy,
 {
 	Ok(seeds.iter().cloned().triplet_mix())
 }
@@ -53,9 +55,10 @@ pub trait TripletMix {
 	fn triplet_mix(self) -> Self::Item;
 }
 
-impl<I, T> TripletMix for I where
+impl<I, T> TripletMix for I
+where
 	I: Iterator<Item = T>,
-	T: BitAnd<Output = T> + BitOr<Output = T> + Default + Copy
+	T: BitAnd<Output = T> + BitOr<Output = T> + Default + Copy,
 {
 	type Item = T;
 	fn triplet_mix(self) -> Self::Item {
@@ -66,7 +69,7 @@ impl<I, T> TripletMix for I where
 			let mut index_at_depth = i;
 			for depth in 0..MAX_DEPTH {
 				if index_at_depth % 3 != 2 {
-					break;
+					break
 				}
 				index_at_depth /= 3;
 				result = sub_mix(&accum[depth]);
@@ -74,7 +77,7 @@ impl<I, T> TripletMix for I where
 				// end of the threesome at depth.
 				if depth == MAX_DEPTH - 1 {
 					// end of our stack - bail with result.
-					break;
+					break
 				} else {
 					// save in the stack for parent computation
 					accum[depth + 1][index_at_depth % 3] = result;
@@ -140,6 +143,12 @@ mod tests {
 
 	#[test]
 	fn triplet_mix_works_on_third_level() {
-		assert_eq!(triplet_mix(&[0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 1, 1, 1, 0, 0, 1, 0, 1, 1, 1, 0, 1, 1, 1, 0, 0, 0][..]).unwrap(), 1);
+		assert_eq!(
+			triplet_mix(
+				&[0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 1, 1, 1, 0, 0, 1, 0, 1, 1, 1, 0, 1, 1, 1, 0, 0, 0]
+					[..]
+			).unwrap(),
+			1
+		);
 	}
 }

--- a/subkey/src/main.rs
+++ b/subkey/src/main.rs
@@ -1,17 +1,17 @@
 extern crate ed25519;
-extern crate substrate_primitives;
 extern crate rand;
+extern crate substrate_primitives;
 
+use ed25519::Pair;
 use rand::{OsRng, Rng};
 use std::env::args;
-use ed25519::Pair;
 use substrate_primitives::hexdisplay::HexDisplay;
 
 fn good_waypoint(done: u64) -> u64 {
 	match done {
-		0 ... 1_000_000 => 100_000,
-		0 ... 10_000_000 => 1_000_000,
-		0 ... 100_000_000 => 10_000_000,
+		0...1_000_000 => 100_000,
+		0...10_000_000 => 1_000_000,
+		0...100_000_000 => 10_000_000,
 		_ => 100_000_000,
 	}
 }
@@ -19,17 +19,22 @@ fn good_waypoint(done: u64) -> u64 {
 fn next_seed(mut seed: [u8; 32]) -> [u8; 32] {
 	for i in 0..32 {
 		match seed[i] {
-			255 => { seed[i] = 0; }
-			_ => { seed[i] += 1; break; }
+			255 => {
+				seed[i] = 0;
+			},
+			_ => {
+				seed[i] += 1;
+				break
+			},
 		}
 	}
-	return seed;
+	return seed
 }
 
 fn main() {
 	if args().len() != 2 {
 		println!("Usage: subkey <search string>");
-		return;
+		return
 	}
 	let desired = args().last().unwrap();
 	let score = |s: &str| {
@@ -37,7 +42,7 @@ fn main() {
 			let snip_size = desired.len() - truncate;
 			let truncated = &desired[0..snip_size];
 			if let Some(pos) = s.find(truncated) {
-				return (31 - pos) + (snip_size * 32);
+				return (31 - pos) + (snip_size * 32)
 			}
 		}
 		0
@@ -56,10 +61,15 @@ fn main() {
 		let ss58 = p.public().to_ss58check();
 		let s = score(&ss58);
 		if s > best {
-			println!("{}: {} ({}% complete)", ss58, HexDisplay::from(&seed), s * 100 / top);
+			println!(
+				"{}: {} ({}% complete)",
+				ss58,
+				HexDisplay::from(&seed),
+				s * 100 / top
+			);
 			best = s;
 			if best == top {
-				break;
+				break
 			}
 		}
 		seed = next_seed(seed);

--- a/substrate/client/db/src/utils.rs
+++ b/substrate/client/db/src/utils.rs
@@ -19,14 +19,16 @@
 
 use std::sync::Arc;
 
-use kvdb::{self, KeyValueDB, DBTransaction};
+use kvdb::{self, DBTransaction, KeyValueDB};
 use kvdb_rocksdb::{Database, DatabaseConfig};
 
 use client;
 use codec::Slicable;
 use hashdb::DBValue;
 use runtime_primitives::generic::BlockId;
-use runtime_primitives::traits::{As, Block as BlockT, Header as HeaderT, Hashing, HashingFor, Zero};
+use runtime_primitives::traits::{
+	As, Block as BlockT, Hashing, HashingFor, Header as HeaderT, Zero,
+};
 use DatabaseSettings;
 
 /// Number of columns in the db. Must be the same for both full && light dbs.
@@ -57,14 +59,17 @@ pub struct Meta<N, H> {
 pub type BlockKey = [u8; 4];
 
 /// Convert block number into key (LE representation).
-pub fn number_to_db_key<N>(n: N) -> BlockKey where N: As<u32> {
+pub fn number_to_db_key<N>(n: N) -> BlockKey
+where
+	N: As<u32>,
+{
 	let n: u32 = n.as_();
 
 	[
 		(n >> 24) as u8,
 		((n >> 16) & 0xff) as u8,
 		((n >> 8) & 0xff) as u8,
-		(n & 0xff) as u8
+		(n & 0xff) as u8,
 	]
 }
 
@@ -72,27 +77,34 @@ pub fn number_to_db_key<N>(n: N) -> BlockKey where N: As<u32> {
 pub fn db_err(err: kvdb::Error) -> client::error::Error {
 	use std::error::Error;
 	match err.kind() {
-		&kvdb::ErrorKind::Io(ref err) => client::error::ErrorKind::Backend(err.description().into()).into(),
+		&kvdb::ErrorKind::Io(ref err) =>
+			client::error::ErrorKind::Backend(err.description().into()).into(),
 		&kvdb::ErrorKind::Msg(ref m) => client::error::ErrorKind::Backend(m.clone()).into(),
 		_ => client::error::ErrorKind::Backend("Unknown backend error".into()).into(),
 	}
 }
 
 /// Open RocksDB database.
-pub fn open_database(config: &DatabaseSettings, db_type: &str) -> client::error::Result<Arc<KeyValueDB>> {
+pub fn open_database(
+	config: &DatabaseSettings,
+	db_type: &str,
+) -> client::error::Result<Arc<KeyValueDB>> {
 	let mut db_config = DatabaseConfig::with_columns(Some(NUM_COLUMNS));
 	db_config.memory_budget = config.cache_size;
 	db_config.wal = true;
-	let path = config.path.to_str().ok_or_else(|| client::error::ErrorKind::Backend("Invalid database path".into()))?;
+	let path = config
+		.path
+		.to_str()
+		.ok_or_else(|| client::error::ErrorKind::Backend("Invalid database path".into()))?;
 	let db = Database::open(&db_config, &path).map_err(db_err)?;
 
 	// check database type
 	match db.get(COLUMN_META, meta_keys::TYPE).map_err(db_err)? {
-		Some(stored_type) => {
-			if db_type.as_bytes() != &*stored_type {
-				return Err(client::error::ErrorKind::Backend(
-					format!("Unexpected database type. Expected: {}", db_type)).into());
-			}
+		Some(stored_type) => if db_type.as_bytes() != &*stored_type {
+			return Err(client::error::ErrorKind::Backend(format!(
+				"Unexpected database type. Expected: {}",
+				db_type
+			)).into())
 		},
 		None => {
 			let mut transaction = DBTransaction::new();
@@ -105,27 +117,40 @@ pub fn open_database(config: &DatabaseSettings, db_type: &str) -> client::error:
 }
 
 /// Convert block id to block key, reading number from db if required.
-pub fn read_id<Block>(db: &KeyValueDB, col_index: Option<u32>, id: BlockId<Block>) -> Result<Option<BlockKey>, client::error::Error>
-	where
-		Block: BlockT,
-		<<Block as BlockT>::Header as HeaderT>::Number: As<u32>,
+pub fn read_id<Block>(
+	db: &KeyValueDB,
+	col_index: Option<u32>,
+	id: BlockId<Block>,
+) -> Result<Option<BlockKey>, client::error::Error>
+where
+	Block: BlockT,
+	<<Block as BlockT>::Header as HeaderT>::Number: As<u32>,
 {
 	match id {
-		BlockId::Hash(h) => db.get(col_index, h.as_ref())
-			.map(|v| v.map(|v| {
-				let mut key: [u8; 4] = [0; 4];
-				key.copy_from_slice(&v);
-				key
-			})).map_err(db_err),
+		BlockId::Hash(h) => db
+			.get(col_index, h.as_ref())
+			.map(|v| {
+				v.map(|v| {
+					let mut key: [u8; 4] = [0; 4];
+					key.copy_from_slice(&v);
+					key
+				})
+			})
+			.map_err(db_err),
 		BlockId::Number(n) => Ok(Some(number_to_db_key(n))),
 	}
 }
 
 /// Read database column entry for the given block.
-pub fn read_db<Block>(db: &KeyValueDB, col_index: Option<u32>, col: Option<u32>, id: BlockId<Block>) -> client::error::Result<Option<DBValue>>
-	where
-		Block: BlockT,
-		<<Block as BlockT>::Header as HeaderT>::Number: As<u32>,
+pub fn read_db<Block>(
+	db: &KeyValueDB,
+	col_index: Option<u32>,
+	col: Option<u32>,
+	id: BlockId<Block>,
+) -> client::error::Result<Option<DBValue>>
+where
+	Block: BlockT,
+	<<Block as BlockT>::Header as HeaderT>::Number: As<u32>,
 {
 	read_id(db, col_index, id).and_then(|key| match key {
 		Some(key) => db.get(col, &key).map_err(db_err),
@@ -134,26 +159,38 @@ pub fn read_db<Block>(db: &KeyValueDB, col_index: Option<u32>, col: Option<u32>,
 }
 
 /// Read meta from the database.
-pub fn read_meta<Block>(db: &KeyValueDB, col_header: Option<u32>) -> Result<Meta<<<Block as BlockT>::Header as HeaderT>::Number, Block::Hash>, client::error::Error>
-	where
-		Block: BlockT,
-		<<Block as BlockT>::Header as HeaderT>::Number: As<u32>,
+pub fn read_meta<Block>(
+	db: &KeyValueDB,
+	col_header: Option<u32>,
+) -> Result<Meta<<<Block as BlockT>::Header as HeaderT>::Number, Block::Hash>, client::error::Error>
+where
+	Block: BlockT,
+	<<Block as BlockT>::Header as HeaderT>::Number: As<u32>,
 {
 	let genesis_number = <<Block as BlockT>::Header as HeaderT>::Number::zero();
-	let (best_hash, best_number) = if let Some(Some(header)) = db.get(COLUMN_META, meta_keys::BEST_BLOCK).and_then(|id|
-		match id {
-			Some(id) => db.get(col_header, &id).map(|h| h.map(|b| Block::Header::decode(&mut &b[..]))),
+	let (best_hash, best_number) = if let Some(Some(header)) = db
+		.get(COLUMN_META, meta_keys::BEST_BLOCK)
+		.and_then(|id| match id {
+			Some(id) => db
+				.get(col_header, &id)
+				.map(|h| h.map(|b| Block::Header::decode(&mut &b[..]))),
 			None => Ok(None),
-		}).map_err(db_err)?
+		})
+		.map_err(db_err)?
 	{
 		let hash = header.hash();
-		debug!("DB Opened blockchain db, best {:?} ({})", hash, header.number());
+		debug!(
+			"DB Opened blockchain db, best {:?} ({})",
+			hash,
+			header.number()
+		);
 		(hash, *header.number())
 	} else {
 		(Default::default(), genesis_number)
 	};
 
-	let genesis_hash = db.get(col_header, &number_to_db_key(genesis_number))
+	let genesis_hash = db
+		.get(col_header, &number_to_db_key(genesis_number))
 		.map_err(db_err)?
 		.map(|raw| HashingFor::<Block>::hash(&raw[..]))
 		.unwrap_or_default()

--- a/substrate/client/src/backend.rs
+++ b/substrate/client/src/backend.rs
@@ -16,11 +16,11 @@
 
 //! Polkadot Client data backend
 
-use state_machine::backend::Backend as StateBackend;
 use error;
 use runtime_primitives::bft::Justification;
-use runtime_primitives::traits::Block as BlockT;
 use runtime_primitives::generic::BlockId;
+use runtime_primitives::traits::Block as BlockT;
+use state_machine::backend::Backend as StateBackend;
 
 /// Block insertion operation. Keeps hold if the inserted block state and data.
 pub trait BlockImportOperation<Block: BlockT> {
@@ -35,13 +35,19 @@ pub trait BlockImportOperation<Block: BlockT> {
 		header: Block::Header,
 		body: Option<Vec<Block::Extrinsic>>,
 		justification: Option<Justification<Block::Hash>>,
-		is_new_best: bool
+		is_new_best: bool,
 	) -> error::Result<()>;
 
 	/// Inject storage data into the database.
-	fn update_storage(&mut self, update: <Self::State as StateBackend>::Transaction) -> error::Result<()>;
+	fn update_storage(
+		&mut self,
+		update: <Self::State as StateBackend>::Transaction,
+	) -> error::Result<()>;
 	/// Inject storage data into the database replacing any existing data.
-	fn reset_storage<I: Iterator<Item=(Vec<u8>, Vec<u8>)>>(&mut self, iter: I) -> error::Result<()>;
+	fn reset_storage<I: Iterator<Item = (Vec<u8>, Vec<u8>)>>(
+		&mut self,
+		iter: I,
+	) -> error::Result<()>;
 }
 
 /// Client backend. Manages the data layer.
@@ -50,8 +56,8 @@ pub trait BlockImportOperation<Block: BlockT> {
 /// should not be pruned. The backend should internally reference-count
 /// its state objects.
 ///
-/// The same applies for live `BlockImportOperation`s: while an import operation building on a parent `P`
-/// is alive, the state for `P` should not be pruned.
+/// The same applies for live `BlockImportOperation`s: while an import operation building on a
+/// parent `P` is alive, the state for `P` should not be pruned.
 pub trait Backend<Block: BlockT>: Send + Sync {
 	/// Associated block insertion operation type.
 	type BlockImportOperation: BlockImportOperation<Block>;

--- a/substrate/client/src/blockchain.rs
+++ b/substrate/client/src/blockchain.rs
@@ -16,9 +16,9 @@
 
 //! Polkadot blockchain trait
 
-use runtime_primitives::traits::{Block as BlockT, Header as HeaderT};
-use runtime_primitives::generic::BlockId;
 use runtime_primitives::bft::Justification;
+use runtime_primitives::generic::BlockId;
+use runtime_primitives::traits::{Block as BlockT, Header as HeaderT};
 
 use error::Result;
 
@@ -31,7 +31,10 @@ pub trait HeaderBackend<Block: BlockT>: Send + Sync {
 	/// Get block status.
 	fn status(&self, id: BlockId<Block>) -> Result<BlockStatus>;
 	/// Get block hash by number. Returns `None` if the header is not in the chain.
-	fn hash(&self, number: <<Block as BlockT>::Header as HeaderT>::Number) -> Result<Option<<<Block as BlockT>::Header as HeaderT>::Hash>>;
+	fn hash(
+		&self,
+		number: <<Block as BlockT>::Header as HeaderT>::Number,
+	) -> Result<Option<<<Block as BlockT>::Header as HeaderT>::Hash>>;
 }
 
 /// Blockchain database backend. Does not perform any validation.

--- a/substrate/client/src/error.rs
+++ b/substrate/client/src/error.rs
@@ -16,9 +16,9 @@
 
 //! Polkadot client possible errors.
 
-use std;
-use state_machine;
 use primitives::hexdisplay::HexDisplay;
+use state_machine;
+use std;
 
 error_chain! {
 	errors {

--- a/substrate/client/src/lib.rs
+++ b/substrate/client/src/lib.rs
@@ -17,27 +17,34 @@
 //! Substrate Client and associated logic.
 
 #![warn(missing_docs)]
-#![recursion_limit="128"]
+#![recursion_limit = "128"]
 
 extern crate substrate_bft as bft;
 extern crate substrate_codec as codec;
+#[cfg(test)]
+extern crate substrate_keyring as keyring;
 extern crate substrate_primitives as primitives;
 extern crate substrate_runtime_io as runtime_io;
-extern crate substrate_runtime_support as runtime_support;
 extern crate substrate_runtime_primitives as runtime_primitives;
+extern crate substrate_runtime_support as runtime_support;
 extern crate substrate_state_machine as state_machine;
-#[cfg(test)] extern crate substrate_keyring as keyring;
-#[cfg(test)] extern crate substrate_test_client as test_client;
+#[cfg(test)]
+extern crate substrate_test_client as test_client;
 
 extern crate ed25519;
 extern crate futures;
 extern crate parking_lot;
 extern crate triehash;
 
-#[macro_use] extern crate error_chain;
-#[macro_use] extern crate log;
-#[cfg_attr(test, macro_use)] extern crate substrate_executor as executor;
-#[cfg(test)] #[macro_use] extern crate hex_literal;
+#[macro_use]
+extern crate error_chain;
+#[macro_use]
+extern crate log;
+#[cfg_attr(test, macro_use)]
+extern crate substrate_executor as executor;
+#[cfg(test)]
+#[macro_use]
+extern crate hex_literal;
 
 pub mod error;
 pub mod blockchain;
@@ -49,11 +56,9 @@ pub mod light;
 mod call_executor;
 mod client;
 
-pub use client::{
-	new_in_mem,
-	BlockStatus, BlockOrigin, BlockchainEventStream, BlockchainEvents,
-	Client, ClientInfo, ChainHead,
-	ImportResult, JustifiedHeader,
-};
 pub use blockchain::Info as ChainInfo;
-pub use call_executor::{CallResult, CallExecutor, LocalCallExecutor};
+pub use call_executor::{CallExecutor, CallResult, LocalCallExecutor};
+pub use client::{
+	new_in_mem, BlockOrigin, BlockStatus, BlockchainEventStream, BlockchainEvents, ChainHead,
+	Client, ClientInfo, ImportResult, JustifiedHeader,
+};

--- a/substrate/client/src/light/blockchain.rs
+++ b/substrate/client/src/light/blockchain.rs
@@ -17,14 +17,16 @@
 //! Light client blockchin backend. Only stores headers and justifications of recent
 //! blocks. CHT roots are stored for headers of ancient blocks.
 
-use std::sync::Weak;
 use parking_lot::Mutex;
+use std::sync::Weak;
 
-use runtime_primitives::{bft::Justification, generic::BlockId};
 use runtime_primitives::traits::{Block as BlockT, Header as HeaderT};
+use runtime_primitives::{bft::Justification, generic::BlockId};
 
-use blockchain::{Backend as BlockchainBackend, BlockStatus,
-	HeaderBackend as BlockchainHeaderBackend, Info as BlockchainInfo};
+use blockchain::{
+	Backend as BlockchainBackend, BlockStatus, HeaderBackend as BlockchainHeaderBackend,
+	Info as BlockchainInfo,
+};
 use error::Result as ClientResult;
 use light::fetcher::Fetcher;
 
@@ -65,7 +67,12 @@ impl<S, F> Blockchain<S, F> {
 	}
 }
 
-impl<S, F, Block> BlockchainHeaderBackend<Block> for Blockchain<S, F> where Block: BlockT, S: Storage<Block>, F: Fetcher<Block> {
+impl<S, F, Block> BlockchainHeaderBackend<Block> for Blockchain<S, F>
+where
+	Block: BlockT,
+	S: Storage<Block>,
+	F: Fetcher<Block>,
+{
 	fn header(&self, id: BlockId<Block>) -> ClientResult<Option<Block::Header>> {
 		self.storage.header(id)
 	}
@@ -78,18 +85,29 @@ impl<S, F, Block> BlockchainHeaderBackend<Block> for Blockchain<S, F> where Bloc
 		self.storage.status(id)
 	}
 
-	fn hash(&self, number: <<Block as BlockT>::Header as HeaderT>::Number) -> ClientResult<Option<Block::Hash>> {
+	fn hash(
+		&self,
+		number: <<Block as BlockT>::Header as HeaderT>::Number,
+	) -> ClientResult<Option<Block::Hash>> {
 		self.storage.hash(number)
 	}
 }
 
-impl<S, F, Block> BlockchainBackend<Block> for Blockchain<S, F> where Block: BlockT, S: Storage<Block>, F: Fetcher<Block> {
+impl<S, F, Block> BlockchainBackend<Block> for Blockchain<S, F>
+where
+	Block: BlockT,
+	S: Storage<Block>,
+	F: Fetcher<Block>,
+{
 	fn body(&self, _id: BlockId<Block>) -> ClientResult<Option<Vec<Block::Extrinsic>>> {
 		// TODO [light]: fetch from remote node
 		Ok(None)
 	}
 
-	fn justification(&self, _id: BlockId<Block>) -> ClientResult<Option<Justification<Block::Hash>>> {
+	fn justification(
+		&self,
+		_id: BlockId<Block>,
+	) -> ClientResult<Option<Justification<Block::Hash>>> {
 		Ok(None)
 	}
 }

--- a/substrate/client/src/light/call_executor.rs
+++ b/substrate/client/src/light/call_executor.rs
@@ -17,19 +17,21 @@
 //! Light client call exector. Executes methods on remote full nodes, fetching
 //! execution proof and checking it locally.
 
+use futures::{Future, IntoFuture};
 use std::sync::Arc;
-use futures::{IntoFuture, Future};
 
 use runtime_primitives::generic::BlockId;
 use runtime_primitives::traits::{Block as BlockT, Header as HeaderT};
-use state_machine::{Backend as StateBackend, CodeExecutor, OverlayedChanges, execution_proof_check};
+use state_machine::{
+	execution_proof_check, Backend as StateBackend, CodeExecutor, OverlayedChanges,
+};
 
 use blockchain::Backend as ChainBackend;
 use call_executor::{CallExecutor, CallResult};
-use error::{Error as ClientError, ErrorKind as ClientErrorKind, Result as ClientResult};
-use light::fetcher::{Fetcher, RemoteCallRequest};
-use executor::RuntimeVersion;
 use codec::Slicable;
+use error::{Error as ClientError, ErrorKind as ClientErrorKind, Result as ClientResult};
+use executor::RuntimeVersion;
+use light::fetcher::{Fetcher, RemoteCallRequest};
 
 /// Call executor that executes methods on remote node, querying execution proof
 /// and checking proof by re-executing locally.
@@ -41,30 +43,43 @@ pub struct RemoteCallExecutor<B, F> {
 impl<B, F> RemoteCallExecutor<B, F> {
 	/// Creates new instance of remote call executor.
 	pub fn new(blockchain: Arc<B>, fetcher: Arc<F>) -> Self {
-		RemoteCallExecutor { blockchain, fetcher }
+		RemoteCallExecutor {
+			blockchain,
+			fetcher,
+		}
 	}
 }
 
 impl<B, F, Block> CallExecutor<Block> for RemoteCallExecutor<B, F>
-	where
-		Block: BlockT,
-		B: ChainBackend<Block>,
-		F: Fetcher<Block>,
+where
+	Block: BlockT,
+	B: ChainBackend<Block>,
+	F: Fetcher<Block>,
 {
 	type Error = ClientError;
 
-	fn call(&self, id: &BlockId<Block>, method: &str, call_data: &[u8]) -> ClientResult<CallResult> {
+	fn call(
+		&self,
+		id: &BlockId<Block>,
+		method: &str,
+		call_data: &[u8],
+	) -> ClientResult<CallResult> {
 		let block_hash = match *id {
 			BlockId::Hash(hash) => hash,
-			BlockId::Number(number) => self.blockchain.hash(number)?
+			BlockId::Number(number) => self
+				.blockchain
+				.hash(number)?
 				.ok_or_else(|| ClientErrorKind::UnknownBlock(format!("{}", number)))?,
 		};
 
-		self.fetcher.remote_call(RemoteCallRequest {
-			block: block_hash.clone(),
-			method: method.into(),
-			call_data: call_data.to_vec(),
-		}).into_future().wait()
+		self.fetcher
+			.remote_call(RemoteCallRequest {
+				block: block_hash.clone(),
+				method: method.into(),
+				call_data: call_data.to_vec(),
+			})
+			.into_future()
+			.wait()
 	}
 
 	fn runtime_version(&self, id: &BlockId<Block>) -> ClientResult<RuntimeVersion> {
@@ -73,11 +88,23 @@ impl<B, F, Block> CallExecutor<Block> for RemoteCallExecutor<B, F>
 			.ok_or_else(|| ClientErrorKind::VersionInvalid.into())
 	}
 
-	fn call_at_state<S: StateBackend>(&self, _state: &S, _changes: &mut OverlayedChanges, _method: &str, _call_data: &[u8]) -> ClientResult<(Vec<u8>, S::Transaction)> {
+	fn call_at_state<S: StateBackend>(
+		&self,
+		_state: &S,
+		_changes: &mut OverlayedChanges,
+		_method: &str,
+		_call_data: &[u8],
+	) -> ClientResult<(Vec<u8>, S::Transaction)> {
 		Err(ClientErrorKind::NotAvailableOnLightClient.into())
 	}
 
-	fn prove_at_state<S: StateBackend>(&self, _state: S, _changes: &mut OverlayedChanges, _method: &str, _call_data: &[u8]) -> ClientResult<(Vec<u8>, Vec<Vec<u8>>)> {
+	fn prove_at_state<S: StateBackend>(
+		&self,
+		_state: S,
+		_changes: &mut OverlayedChanges,
+		_method: &str,
+		_call_data: &[u8],
+	) -> ClientResult<(Vec<u8>, Vec<Vec<u8>>)> {
 		Err(ClientErrorKind::NotAvailableOnLightClient.into())
 	}
 
@@ -91,16 +118,17 @@ pub fn check_execution_proof<Block, B, E>(
 	blockchain: &B,
 	executor: &E,
 	request: &RemoteCallRequest<Block::Hash>,
-	remote_proof: Vec<Vec<u8>>
+	remote_proof: Vec<Vec<u8>>,
 ) -> ClientResult<CallResult>
-	where
-		Block: BlockT,
-		<Block as BlockT>::Hash: Into<[u8; 32]>, // TODO: remove when patricia_trie generic.
-		B: ChainBackend<Block>,
-		E: CodeExecutor,
+where
+	Block: BlockT,
+	<Block as BlockT>::Hash: Into<[u8; 32]>, // TODO: remove when patricia_trie generic.
+	B: ChainBackend<Block>,
+	E: CodeExecutor,
 {
 	let local_header = blockchain.header(BlockId::Hash(request.block))?;
-	let local_header = local_header.ok_or_else(|| ClientErrorKind::UnknownBlock(format!("{}", request.block)))?;
+	let local_header =
+		local_header.ok_or_else(|| ClientErrorKind::UnknownBlock(format!("{}", request.block)))?;
 	let local_state_root = *local_header.state_root();
 	do_check_execution_proof(local_state_root.into(), executor, request, remote_proof)
 }
@@ -112,9 +140,9 @@ fn do_check_execution_proof<Hash, E>(
 	request: &RemoteCallRequest<Hash>,
 	remote_proof: Vec<Vec<u8>>,
 ) -> ClientResult<CallResult>
-	where
-		Hash: ::std::fmt::Display,
-		E: CodeExecutor,
+where
+	Hash: ::std::fmt::Display,
+	E: CodeExecutor,
 {
 	let mut changes = OverlayedChanges::default();
 	let (local_result, _) = execution_proof_check(
@@ -123,33 +151,48 @@ fn do_check_execution_proof<Hash, E>(
 		&mut changes,
 		executor,
 		&request.method,
-		&request.call_data)?;
+		&request.call_data,
+	)?;
 
-	Ok(CallResult { return_data: local_result, changes })
+	Ok(CallResult {
+		return_data: local_result,
+		changes,
+	})
 }
 
 #[cfg(test)]
 mod tests {
-	use test_client;
 	use super::*;
+	use test_client;
 
 	#[test]
 	fn execution_proof_is_generated_and_checked() {
 		// prepare remote client
 		let remote_client = test_client::new();
 		let remote_block_id = BlockId::Number(0);
-		let remote_block_storage_root = remote_client.state_at(&remote_block_id)
-			.unwrap().storage_root(::std::iter::empty()).0;
+		let remote_block_storage_root = remote_client
+			.state_at(&remote_block_id)
+			.unwrap()
+			.storage_root(::std::iter::empty())
+			.0;
 
 		// 'fetch' execution proof from remote node
-		let remote_execution_proof = remote_client.execution_proof(&remote_block_id, "authorities", &[]).unwrap().1;
+		let remote_execution_proof = remote_client
+			.execution_proof(&remote_block_id, "authorities", &[])
+			.unwrap()
+			.1;
 
 		// check remote execution proof locally
 		let local_executor = test_client::NativeExecutor::new();
-		do_check_execution_proof(remote_block_storage_root.into(), &local_executor, &RemoteCallRequest {
-			block: test_client::runtime::Hash::default(),
-			method: "authorities".into(),
-			call_data: vec![],
-		}, remote_execution_proof).unwrap();
+		do_check_execution_proof(
+			remote_block_storage_root.into(),
+			&local_executor,
+			&RemoteCallRequest {
+				block: test_client::runtime::Hash::default(),
+				method: "authorities".into(),
+				call_data: vec![],
+			},
+			remote_execution_proof,
+		).unwrap();
 	}
 }

--- a/substrate/client/src/light/fetcher.rs
+++ b/substrate/client/src/light/fetcher.rs
@@ -16,8 +16,8 @@
 
 //! Light client data fetcher. Fetches requested data from remote full nodes.
 
-use std::sync::Arc;
 use futures::IntoFuture;
+use std::sync::Arc;
 
 use runtime_primitives::traits::{As, Block as BlockT, Header as HeaderT};
 use state_machine::CodeExecutor;
@@ -42,7 +42,7 @@ pub struct RemoteCallRequest<Hash: ::std::fmt::Display> {
 /// is correct (see FetchedDataChecker) and return already checked data.
 pub trait Fetcher<Block: BlockT>: Send + Sync {
 	/// Remote call result future.
-	type RemoteCallResult: IntoFuture<Item=CallResult, Error=ClientError>;
+	type RemoteCallResult: IntoFuture<Item = CallResult, Error = ClientError>;
 
 	/// Fetch remote call result.
 	fn remote_call(&self, request: RemoteCallRequest<Block::Hash>) -> Self::RemoteCallResult;
@@ -51,7 +51,11 @@ pub trait Fetcher<Block: BlockT>: Send + Sync {
 /// Light client remote data checker.
 pub trait FetchChecker<Block: BlockT>: Send + Sync {
 	/// Check remote method execution proof.
-	fn check_execution_proof(&self, request: &RemoteCallRequest<Block::Hash>, remote_proof: Vec<Vec<u8>>) -> ClientResult<CallResult>;
+	fn check_execution_proof(
+		&self,
+		request: &RemoteCallRequest<Block::Hash>,
+		remote_proof: Vec<Vec<u8>>,
+	) -> ClientResult<CallResult>;
 }
 
 /// Remote data checker.
@@ -76,15 +80,20 @@ impl<S, E, F> LightDataChecker<S, E, F> {
 }
 
 impl<S, E, F, Block> FetchChecker<Block> for LightDataChecker<S, E, F>
-	where
-		Block: BlockT,
-		<Block as BlockT>::Hash: From<[u8; 32]> + Into<[u8; 32]>, // TODO: remove when patricia_trie generic.
-		<<Block as BlockT>::Header as HeaderT>::Number: As<u32>,
-		S: BlockchainStorage<Block>,
-		E: CodeExecutor,
-		F: Fetcher<Block>,
+where
+	Block: BlockT,
+	<Block as BlockT>::Hash: From<[u8; 32]> + Into<[u8; 32]>, /* TODO: remove when
+	                                                           * patricia_trie generic. */
+	<<Block as BlockT>::Header as HeaderT>::Number: As<u32>,
+	S: BlockchainStorage<Block>,
+	E: CodeExecutor,
+	F: Fetcher<Block>,
 {
-	fn check_execution_proof(&self, request: &RemoteCallRequest<Block::Hash>, remote_proof: Vec<Vec<u8>>) -> ClientResult<CallResult> {
+	fn check_execution_proof(
+		&self,
+		request: &RemoteCallRequest<Block::Hash>,
+		remote_proof: Vec<Vec<u8>>,
+	) -> ClientResult<CallResult> {
 		check_execution_proof(&*self.blockchain, &self.executor, request, remote_proof)
 	}
 }

--- a/substrate/client/src/light/mod.rs
+++ b/substrate/client/src/light/mod.rs
@@ -23,8 +23,8 @@ pub mod fetcher;
 
 use std::sync::Arc;
 
-use runtime_primitives::BuildStorage;
 use runtime_primitives::traits::Block as BlockT;
+use runtime_primitives::BuildStorage;
 use state_machine::CodeExecutor;
 
 use client::Client;
@@ -35,12 +35,17 @@ use light::call_executor::RemoteCallExecutor;
 use light::fetcher::{Fetcher, LightDataChecker};
 
 /// Create an instance of light client blockchain backend.
-pub fn new_light_blockchain<B: BlockT, S: BlockchainStorage<B>, F>(storage: S) -> Arc<Blockchain<S, F>> {
+pub fn new_light_blockchain<B: BlockT, S: BlockchainStorage<B>, F>(
+	storage: S,
+) -> Arc<Blockchain<S, F>> {
 	Arc::new(Blockchain::new(storage))
 }
 
 /// Create an instance of light client backend.
-pub fn new_light_backend<B: BlockT, S: BlockchainStorage<B>, F: Fetcher<B>>(blockchain: Arc<Blockchain<S, F>>, fetcher: Arc<F>) -> Arc<Backend<S, F>> {
+pub fn new_light_backend<B: BlockT, S: BlockchainStorage<B>, F: Fetcher<B>>(
+	blockchain: Arc<Blockchain<S, F>>,
+	fetcher: Arc<F>,
+) -> Arc<Backend<S, F>> {
 	blockchain.set_fetcher(Arc::downgrade(&fetcher));
 	Arc::new(Backend::new(blockchain))
 }
@@ -51,11 +56,11 @@ pub fn new_light<B, S, F, GS>(
 	fetcher: Arc<F>,
 	genesis_storage: GS,
 ) -> ClientResult<Client<Backend<S, F>, RemoteCallExecutor<Blockchain<S, F>, F>, B>>
-	where
-		B: BlockT,
-		S: BlockchainStorage<B>,
-		F: Fetcher<B>,
-		GS: BuildStorage,
+where
+	B: BlockT,
+	S: BlockchainStorage<B>,
+	F: Fetcher<B>,
+	GS: BuildStorage,
 {
 	let executor = RemoteCallExecutor::new(backend.blockchain().clone(), fetcher);
 	Client::new(backend, executor, genesis_storage)
@@ -66,10 +71,10 @@ pub fn new_fetch_checker<B, S, E, F>(
 	blockchain: Arc<Blockchain<S, F>>,
 	executor: E,
 ) -> LightDataChecker<S, E, F>
-	where
-		B: BlockT,
-		S: BlockchainStorage<B>,
-		E: CodeExecutor,
+where
+	B: BlockT,
+	S: BlockchainStorage<B>,
+	E: CodeExecutor,
 {
 	LightDataChecker::new(blockchain, executor)
 }

--- a/substrate/codec/src/joiner.rs
+++ b/substrate/codec/src/joiner.rs
@@ -16,8 +16,8 @@
 
 //! Trait
 
-use core::iter::Extend;
 use super::slicable::Slicable;
+use core::iter::Extend;
 
 /// Trait to allow itself to be serialised into a value which can be extended
 /// by bytes.
@@ -25,7 +25,10 @@ pub trait Joiner {
 	fn and<V: Slicable + Sized>(self, value: &V) -> Self;
 }
 
-impl<T> Joiner for T where T: for<'a> Extend<&'a u8> {
+impl<T> Joiner for T
+where
+	T: for<'a> Extend<&'a u8>,
+{
 	fn and<V: Slicable + Sized>(mut self, value: &V) -> Self {
 		value.using_encoded(|s| self.extend(s));
 		self

--- a/substrate/codec/src/keyedvec.rs
+++ b/substrate/codec/src/keyedvec.rs
@@ -16,9 +16,9 @@
 
 //! Serialiser and prepender.
 
-use slicable::Slicable;
-use core::iter::Extend;
 use alloc::vec::Vec;
+use core::iter::Extend;
+use slicable::Slicable;
 
 /// Trait to allow itselg to be serialised and prepended by a given slice.
 pub trait KeyedVec {

--- a/substrate/codec/src/lib.rs
+++ b/substrate/codec/src/lib.rs
@@ -38,6 +38,6 @@ mod slicable;
 mod joiner;
 mod keyedvec;
 
-pub use self::slicable::{Input, Slicable, encode_slice};
 pub use self::joiner::Joiner;
 pub use self::keyedvec::KeyedVec;
+pub use self::slicable::{encode_slice, Input, Slicable};

--- a/substrate/codec/src/slicable.rs
+++ b/substrate/codec/src/slicable.rs
@@ -16,11 +16,11 @@
 
 //! Serialisation.
 
-use alloc::vec::Vec;
-use alloc::boxed::Box;
-use core::{mem, slice};
 use super::joiner::Joiner;
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 use arrayvec::ArrayVec;
+use core::{mem, slice};
 
 /// Trait that allows reading of data into a slice.
 pub trait Input {
@@ -74,7 +74,10 @@ pub trait Slicable: Sized {
 /// Encode a bytes slice as `Slicable` that can be decoded into a vector.
 pub fn encode_slice(bytes: &[u8]) -> Vec<u8> {
 	let len = bytes.len();
-	assert!(len <= u32::max_value() as usize, "Attempted to serialize a collection with too many elements.");
+	assert!(
+		len <= u32::max_value() as usize,
+		"Attempted to serialize a collection with too many elements."
+	);
 
 	let mut r: Vec<u8> = Vec::new().and(&(len as u32));
 	r.extend_from_slice(bytes);
@@ -96,11 +99,11 @@ impl<T: Slicable, E: Slicable> Slicable for Result<T, E> {
 			Ok(ref t) => {
 				v.push(0);
 				t.using_encoded(|s| v.extend(s));
-			}
+			},
 			Err(ref e) => {
 				v.push(1);
 				e.using_encoded(|s| v.extend(s));
-			}
+			},
 		}
 		v
 	}
@@ -143,7 +146,7 @@ impl<T: Slicable> Slicable for Option<T> {
 			Some(ref t) => {
 				v.push(1);
 				t.using_encoded(|s| v.extend(s));
-			}
+			},
 			None => v.push(0),
 		}
 		v
@@ -219,7 +222,10 @@ impl<T: Slicable> Slicable for Vec<T> {
 		use core::iter::Extend;
 
 		let len = self.len();
-		assert!(len <= u32::max_value() as usize, "Attempted to serialize vec with too many elements.");
+		assert!(
+			len <= u32::max_value() as usize,
+			"Attempted to serialize vec with too many elements."
+		);
 
 		let mut r: Vec<u8> = Vec::new().and(&(len as u32));
 		for item in self {
@@ -311,12 +317,24 @@ mod inner_tuple_impl {
 // note: the copy bound and static lifetimes are necessary for safety of `Slicable` blanket
 // implementation.
 trait EndianSensitive: Copy + 'static {
-	fn to_le(self) -> Self { self }
-	fn to_be(self) -> Self { self }
-	fn from_le(self) -> Self { self }
-	fn from_be(self) -> Self { self }
-	fn as_be_then<T, F: FnOnce(&Self) -> T>(&self, f: F) -> T { f(&self) }
-	fn as_le_then<T, F: FnOnce(&Self) -> T>(&self, f: F) -> T { f(&self) }
+	fn to_le(self) -> Self {
+		self
+	}
+	fn to_be(self) -> Self {
+		self
+	}
+	fn from_le(self) -> Self {
+		self
+	}
+	fn from_be(self) -> Self {
+		self
+	}
+	fn as_be_then<T, F: FnOnce(&Self) -> T>(&self, f: F) -> T {
+		f(&self)
+	}
+	fn as_le_then<T, F: FnOnce(&Self) -> T>(&self, f: F) -> T {
+		f(&self)
+	}
 }
 
 macro_rules! impl_endians {
@@ -404,10 +422,11 @@ macro_rules! impl_non_endians {
 }
 
 impl_endians!(u16, u32, u64, u128, usize, i16, i32, i64, i128, isize);
-impl_non_endians!(i8, [u8; 1], [u8; 2], [u8; 3], [u8; 4], [u8; 5], [u8; 6], [u8; 7], [u8; 8],
-	[u8; 10], [u8; 12], [u8; 14], [u8; 16], [u8; 20], [u8; 24], [u8; 28], [u8; 32], [u8; 40],
-	[u8; 48], [u8; 56], [u8; 64], [u8; 80], [u8; 96], [u8; 112], [u8; 128], bool);
-
+impl_non_endians!(
+	i8, [u8; 1], [u8; 2], [u8; 3], [u8; 4], [u8; 5], [u8; 6], [u8; 7], [u8; 8], [u8; 10], [u8; 12],
+	[u8; 14], [u8; 16], [u8; 20], [u8; 24], [u8; 28], [u8; 32], [u8; 40], [u8; 48], [u8; 56],
+	[u8; 64], [u8; 80], [u8; 96], [u8; 112], [u8; 128], bool
+);
 
 #[cfg(test)]
 mod tests {
@@ -416,8 +435,6 @@ mod tests {
 	#[test]
 	fn vec_is_slicable() {
 		let v = b"Hello world".to_vec();
-		v.using_encoded(|ref slice|
-			assert_eq!(slice, &b"\x0b\0\0\0Hello world")
-		);
+		v.using_encoded(|ref slice| assert_eq!(slice, &b"\x0b\0\0\0Hello world"));
 	}
 }

--- a/substrate/environmental/src/lib.rs
+++ b/substrate/environmental/src/lib.rs
@@ -27,17 +27,17 @@
 //! // create a place for the global reference to exist.
 //! environmental!(counter: u32);
 //! fn stuff() {
-//!   // do some stuff, accessing the named reference as desired.
-//!   counter::with(|i| *i += 1);
-//! }
+//! 	// do some stuff, accessing the named reference as desired.
+//! 	counter::with(|i| *i += 1);
+//! 	}
 //! fn main() {
-//!   // declare a stack variable of the same type as our global declaration.
-//!   let mut counter_value = 41u32;
-//!   // call stuff, setting up our `counter` environment as a refrence to our counter_value var.
-//!   counter::using(&mut counter_value, stuff);
-//!   println!("The answer is {:?}", counter_value); // will print 42!
-//!   stuff();	// safe! doesn't do anything.
-//! }
+//! 	// declare a stack variable of the same type as our global declaration.
+//! 	let mut counter_value = 41u32;
+//! 	// call stuff, setting up our `counter` environment as a refrence to our counter_value var.
+//! 	counter::using(&mut counter_value, stuff);
+//! 	println!("The answer is {:?}", counter_value); // will print 42!
+//! 	stuff(); // safe! doesn't do anything.
+//! 	}
 //! ```
 
 #![cfg_attr(not(feature = "std"), no_std)]
@@ -53,7 +53,7 @@ include!("../without_std.rs");
 pub fn using<T: ?Sized, R, F: FnOnce() -> R>(
 	global: &'static imp::LocalKey<imp::RefCell<Option<*mut T>>>,
 	protected: &mut T,
-	f: F
+	f: F,
 ) -> R {
 	// store the `protected` reference as a pointer so we can provide it to logic running within
 	// `f`.
@@ -101,7 +101,7 @@ pub fn with<T: ?Sized, R, F: FnOnce(&mut T) -> R>(
 				// safe because it's only non-zero when it's being called from using, which
 				// is holding on to the underlying reference (and not using it itself) safely.
 				Some(mutator(&mut *ptr))
-			}
+			},
 			None => None,
 		}
 	})
@@ -127,19 +127,28 @@ pub fn with<T: ?Sized, R, F: FnOnce(&mut T) -> R>(
 /// #[macro_use] extern crate environmental;
 /// environmental!(counter: u32);
 /// fn main() {
-///   let mut counter_value = 41u32;
-///   counter::using(&mut counter_value, || {
-///     let odd = counter::with(|value|
-///       if *value % 2 == 1 {
-///         *value += 1; true
-///       } else {
-///         *value -= 3; false
-///       }).unwrap();	// safe because we're inside a counter::using
-///     println!("counter was {}", match odd { true => "odd", _ => "even" });
-///   });
+/// 	let mut counter_value = 41u32;
+/// 	counter::using(&mut counter_value, || {
+/// 		let odd = counter::with(|value| {
+/// 			if *value % 2 == 1 {
+/// 				*value += 1;
+/// 				true
+/// 			} else {
+/// 				*value -= 3;
+/// 				false
+/// 			}
+/// 		}).unwrap(); // safe because we're inside a counter::using
+/// 		println!(
+/// 			"counter was {}",
+/// 			match odd {
+/// 				true => "odd",
+/// 				_ => "even",
+/// 			}
+/// 		);
+/// 	});
 ///
-///   println!("The answer is {:?}", counter_value); // 42
-/// }
+/// 	println!("The answer is {:?}", counter_value); // 42
+/// 	}
 /// ```
 ///
 /// Roughly the same, but with a trait object:
@@ -150,18 +159,18 @@ pub fn with<T: ?Sized, R, F: FnOnce(&mut T) -> R>(
 /// trait Increment { fn increment(&mut self); }
 ///
 /// impl Increment for i32 {
-///	fn increment(&mut self) { *self += 1 }
+/// 	fn increment(&mut self) { *self += 1 }
 /// }
 ///
 /// environmental!(val: Increment + 'static);
 ///
 /// fn main() {
-///	let mut local = 0i32;
-///	val::using(&mut local, || {
-///		val::with(|v| for _ in 0..5 { v.increment() });
-///	});
+/// 	let mut local = 0i32;
+/// 	val::using(&mut local, || {
+/// 		val::with(|v| for _ in 0..5 { v.increment() });
+/// 	});
 ///
-///	assert_eq!(local, 5);
+/// 	assert_eq!(local, 5);
 /// }
 /// ```
 #[macro_export]
@@ -226,7 +235,9 @@ mod tests {
 	fn simple_works() {
 		environmental!(counter: u32);
 
-		fn stuff() { counter::with(|value| *value += 1); };
+		fn stuff() {
+			counter::with(|value| *value += 1);
+		};
 
 		// declare a stack variable of the same type as our global declaration.
 		let mut local = 41u32;
@@ -234,7 +245,7 @@ mod tests {
 		// call stuff, setting up our `counter` environment as a refrence to our local counter var.
 		counter::using(&mut local, stuff);
 		assert_eq!(local, 42);
-		stuff();	// safe! doesn't do anything.
+		stuff(); // safe! doesn't do anything.
 	}
 
 	#[test]
@@ -258,8 +269,12 @@ mod tests {
 		}
 
 		impl Foo for i32 {
-			fn get(&self) -> i32 { *self }
-			fn set(&mut self, x: i32) { *self = x }
+			fn get(&self) -> i32 {
+				*self
+			}
+			fn set(&mut self, x: i32) {
+				*self = x
+			}
 		}
 
 		environmental!(foo: Foo + 'static);
@@ -306,7 +321,9 @@ mod tests {
 
 	#[test]
 	fn use_non_static_trait() {
-		trait Sum { fn sum(&self) -> usize; }
+		trait Sum {
+			fn sum(&self) -> usize;
+		}
 		impl<'a> Sum for &'a [usize] {
 			fn sum(&self) -> usize {
 				self.iter().fold(0, |a, c| a + c)
@@ -316,9 +333,7 @@ mod tests {
 		environmental!(sum: trait Sum);
 		let numbers = vec![1, 2, 3, 4, 5];
 		let mut numbers = &numbers[..];
-		let got_sum = sum::using(&mut numbers, || {
-			sum::with(|x| x.sum())
-		}).unwrap();
+		let got_sum = sum::using(&mut numbers, || sum::with(|x| x.sum())).unwrap();
 
 		assert_eq!(got_sum, 15);
 	}

--- a/substrate/executor/src/lib.rs
+++ b/substrate/executor/src/lib.rs
@@ -26,24 +26,25 @@
 //! I leave it as is for now as it might be removed before this is ever done.
 
 #![warn(missing_docs)]
-#![recursion_limit="128"]
+#![recursion_limit = "128"]
 
+extern crate ed25519;
 extern crate substrate_codec as codec;
-extern crate substrate_runtime_io as runtime_io;
 extern crate substrate_primitives as primitives;
+extern crate substrate_runtime_io as runtime_io;
+extern crate substrate_runtime_version as runtime_version;
 extern crate substrate_serializer as serializer;
 extern crate substrate_state_machine as state_machine;
-extern crate substrate_runtime_version as runtime_version;
-extern crate ed25519;
 
-extern crate serde;
-extern crate wasmi;
 extern crate byteorder;
-extern crate rustc_hex;
-extern crate triehash;
 extern crate parking_lot;
+extern crate rustc_hex;
+extern crate serde;
+extern crate triehash;
 extern crate twox_hash;
-#[macro_use] extern crate log;
+extern crate wasmi;
+#[macro_use]
+extern crate log;
 
 #[macro_use]
 extern crate lazy_static;
@@ -65,11 +66,11 @@ mod native_executor;
 mod sandbox;
 
 pub mod error;
-pub use wasm_executor::WasmExecutor;
-pub use native_executor::{with_native_environment, NativeExecutor, NativeExecutionDispatch};
-pub use state_machine::Externalities;
-pub use runtime_version::RuntimeVersion;
 pub use codec::Slicable;
+pub use native_executor::{with_native_environment, NativeExecutionDispatch, NativeExecutor};
+pub use runtime_version::RuntimeVersion;
+pub use state_machine::Externalities;
+pub use wasm_executor::WasmExecutor;
 
 /// Provides runtime information.
 pub trait RuntimeInfo {
@@ -77,9 +78,6 @@ pub trait RuntimeInfo {
 	const NATIVE_VERSION: Option<RuntimeVersion>;
 
 	/// Extract RuntimeVersion of given :code block
-	fn runtime_version<E: Externalities> (
-		&self,
-		ext: &mut E,
-		code: &[u8]
-	) -> Option<RuntimeVersion>;
+	fn runtime_version<E: Externalities>(&self, ext: &mut E, code: &[u8])
+		-> Option<RuntimeVersion>;
 }

--- a/substrate/executor/src/wasm_utils.rs
+++ b/substrate/executor/src/wasm_utils.rs
@@ -16,9 +16,9 @@
 
 //! Rust implementation of Substrate contracts.
 
-use wasmi::{ValueType, RuntimeValue, HostError};
-use wasmi::nan_preserving_float::{F32, F64};
 use std::fmt;
+use wasmi::nan_preserving_float::{F32, F64};
+use wasmi::{HostError, RuntimeValue, ValueType};
 
 #[derive(Debug)]
 pub struct DummyUserError;
@@ -27,20 +27,83 @@ impl fmt::Display for DummyUserError {
 		write!(f, "DummyUserError")
 	}
 }
-impl HostError for DummyUserError {
-}
+impl HostError for DummyUserError {}
 
-pub trait ConvertibleToWasm { const VALUE_TYPE: ValueType; type NativeType; fn to_runtime_value(self) -> RuntimeValue; }
-impl ConvertibleToWasm for i32 { type NativeType = i32; const VALUE_TYPE: ValueType = ValueType::I32; fn to_runtime_value(self) -> RuntimeValue { RuntimeValue::I32(self) } }
-impl ConvertibleToWasm for u32 { type NativeType = u32; const VALUE_TYPE: ValueType = ValueType::I32; fn to_runtime_value(self) -> RuntimeValue { RuntimeValue::I32(self as i32) } }
-impl ConvertibleToWasm for i64 { type NativeType = i64; const VALUE_TYPE: ValueType = ValueType::I64; fn to_runtime_value(self) -> RuntimeValue { RuntimeValue::I64(self) } }
-impl ConvertibleToWasm for u64 { type NativeType = u64; const VALUE_TYPE: ValueType = ValueType::I64; fn to_runtime_value(self) -> RuntimeValue { RuntimeValue::I64(self as i64) } }
-impl ConvertibleToWasm for F32 { type NativeType = F32; const VALUE_TYPE: ValueType = ValueType::F32; fn to_runtime_value(self) -> RuntimeValue { RuntimeValue::F32(self) } }
-impl ConvertibleToWasm for F64 { type NativeType = F64; const VALUE_TYPE: ValueType = ValueType::F64; fn to_runtime_value(self) -> RuntimeValue { RuntimeValue::F64(self) } }
-impl ConvertibleToWasm for isize { type NativeType = i32; const VALUE_TYPE: ValueType = ValueType::I32; fn to_runtime_value(self) -> RuntimeValue { RuntimeValue::I32(self as i32) } }
-impl ConvertibleToWasm for usize { type NativeType = u32; const VALUE_TYPE: ValueType = ValueType::I32; fn to_runtime_value(self) -> RuntimeValue { RuntimeValue::I32(self as u32 as i32) } }
-impl<T> ConvertibleToWasm for *const T { type NativeType = u32; const VALUE_TYPE: ValueType = ValueType::I32; fn to_runtime_value(self) -> RuntimeValue { RuntimeValue::I32(self as isize as i32) } }
-impl<T> ConvertibleToWasm for *mut T { type NativeType = u32; const VALUE_TYPE: ValueType = ValueType::I32; fn to_runtime_value(self) -> RuntimeValue { RuntimeValue::I32(self as isize as i32) } }
+pub trait ConvertibleToWasm {
+	const VALUE_TYPE: ValueType;
+	type NativeType;
+	fn to_runtime_value(self) -> RuntimeValue;
+}
+impl ConvertibleToWasm for i32 {
+	type NativeType = i32;
+	const VALUE_TYPE: ValueType = ValueType::I32;
+	fn to_runtime_value(self) -> RuntimeValue {
+		RuntimeValue::I32(self)
+	}
+}
+impl ConvertibleToWasm for u32 {
+	type NativeType = u32;
+	const VALUE_TYPE: ValueType = ValueType::I32;
+	fn to_runtime_value(self) -> RuntimeValue {
+		RuntimeValue::I32(self as i32)
+	}
+}
+impl ConvertibleToWasm for i64 {
+	type NativeType = i64;
+	const VALUE_TYPE: ValueType = ValueType::I64;
+	fn to_runtime_value(self) -> RuntimeValue {
+		RuntimeValue::I64(self)
+	}
+}
+impl ConvertibleToWasm for u64 {
+	type NativeType = u64;
+	const VALUE_TYPE: ValueType = ValueType::I64;
+	fn to_runtime_value(self) -> RuntimeValue {
+		RuntimeValue::I64(self as i64)
+	}
+}
+impl ConvertibleToWasm for F32 {
+	type NativeType = F32;
+	const VALUE_TYPE: ValueType = ValueType::F32;
+	fn to_runtime_value(self) -> RuntimeValue {
+		RuntimeValue::F32(self)
+	}
+}
+impl ConvertibleToWasm for F64 {
+	type NativeType = F64;
+	const VALUE_TYPE: ValueType = ValueType::F64;
+	fn to_runtime_value(self) -> RuntimeValue {
+		RuntimeValue::F64(self)
+	}
+}
+impl ConvertibleToWasm for isize {
+	type NativeType = i32;
+	const VALUE_TYPE: ValueType = ValueType::I32;
+	fn to_runtime_value(self) -> RuntimeValue {
+		RuntimeValue::I32(self as i32)
+	}
+}
+impl ConvertibleToWasm for usize {
+	type NativeType = u32;
+	const VALUE_TYPE: ValueType = ValueType::I32;
+	fn to_runtime_value(self) -> RuntimeValue {
+		RuntimeValue::I32(self as u32 as i32)
+	}
+}
+impl<T> ConvertibleToWasm for *const T {
+	type NativeType = u32;
+	const VALUE_TYPE: ValueType = ValueType::I32;
+	fn to_runtime_value(self) -> RuntimeValue {
+		RuntimeValue::I32(self as isize as i32)
+	}
+}
+impl<T> ConvertibleToWasm for *mut T {
+	type NativeType = u32;
+	const VALUE_TYPE: ValueType = ValueType::I32;
+	fn to_runtime_value(self) -> RuntimeValue {
+		RuntimeValue::I32(self as isize as i32)
+	}
+}
 
 #[macro_export]
 macro_rules! convert_args {
@@ -115,7 +178,7 @@ macro_rules! unmarshall_args {
 #[inline(always)]
 pub fn constrain_closure<R, F>(f: F) -> F
 where
-	F: FnOnce() -> Result<R, ::wasmi::Trap>
+	F: FnOnce() -> Result<R, ::wasmi::Trap>,
 {
 	f
 }

--- a/substrate/extrinsic-pool/src/api.rs
+++ b/substrate/extrinsic-pool/src/api.rs
@@ -25,11 +25,15 @@ pub trait Error: ::std::error::Error + Send + Sized {
 	/// This implementation is optional and used only to
 	/// provide more descriptive error messages for end users
 	/// of RPC API.
-	fn into_pool_error(self) -> Result<txpool::Error, Self> { Err(self) }
+	fn into_pool_error(self) -> Result<txpool::Error, Self> {
+		Err(self)
+	}
 }
 
 impl Error for txpool::Error {
-	fn into_pool_error(self) -> Result<txpool::Error, Self> { Ok(self) }
+	fn into_pool_error(self) -> Result<txpool::Error, Self> {
+		Ok(self)
+	}
 }
 
 /// Extrinsic pool.

--- a/substrate/extrinsic-pool/src/listener.rs
+++ b/substrate/extrinsic-pool/src/listener.rs
@@ -14,11 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::{
-	sync::Arc,
-	fmt,
-	collections::HashMap,
-};
+use std::{collections::HashMap, fmt, sync::Arc};
 use txpool;
 
 use watcher;
@@ -26,15 +22,21 @@ use watcher;
 /// Extrinsic pool default listener.
 #[derive(Default)]
 pub struct Listener<H: ::std::hash::Hash + Eq> {
-	watchers: HashMap<H, watcher::Sender<H>>
+	watchers: HashMap<H, watcher::Sender<H>>,
 }
 
 impl<H: ::std::hash::Hash + Eq + Copy + fmt::Debug + fmt::LowerHex + Default> Listener<H> {
 	/// Creates a new watcher for given verified extrinsic.
 	///
 	/// The watcher can be used to subscribe to lifecycle events of that extrinsic.
-	pub fn create_watcher<T: txpool::VerifiedTransaction<Hash=H>>(&mut self, xt: Arc<T>) -> watcher::Watcher<H> {
-		let sender = self.watchers.entry(*xt.hash()).or_insert_with(watcher::Sender::default);
+	pub fn create_watcher<T: txpool::VerifiedTransaction<Hash = H>>(
+		&mut self,
+		xt: Arc<T>,
+	) -> watcher::Watcher<H> {
+		let sender = self
+			.watchers
+			.entry(*xt.hash())
+			.or_insert_with(watcher::Sender::default);
 		sender.new_watcher()
 	}
 
@@ -43,7 +45,10 @@ impl<H: ::std::hash::Hash + Eq + Copy + fmt::Debug + fmt::LowerHex + Default> Li
 		self.fire(hash, |watcher| watcher.broadcast(peers));
 	}
 
-	fn fire<F>(&mut self, hash: &H, fun: F) where F: FnOnce(&mut watcher::Sender<H>) {
+	fn fire<F>(&mut self, hash: &H, fun: F)
+	where
+		F: FnOnce(&mut watcher::Sender<H>),
+	{
 		let clean = if let Some(h) = self.watchers.get_mut(hash) {
 			fun(h);
 			h.is_done()
@@ -57,9 +62,10 @@ impl<H: ::std::hash::Hash + Eq + Copy + fmt::Debug + fmt::LowerHex + Default> Li
 	}
 }
 
-impl<H, T> txpool::Listener<T> for Listener<H> where
+impl<H, T> txpool::Listener<T> for Listener<H>
+where
 	H: ::std::hash::Hash + Eq + Copy + fmt::Debug + fmt::LowerHex + Default,
-	T: txpool::VerifiedTransaction<Hash=H>,
+	T: txpool::VerifiedTransaction<Hash = H>,
 {
 	fn added(&mut self, tx: &Arc<T>, old: Option<&Arc<T>>) {
 		if let Some(old) = old {

--- a/substrate/extrinsic-pool/src/watcher.rs
+++ b/substrate/extrinsic-pool/src/watcher.rs
@@ -48,9 +48,7 @@ impl<H: Clone> Sender<H> {
 	pub fn new_watcher(&mut self) -> Watcher<H> {
 		let (tx, receiver) = mpsc::unbounded();
 		self.receivers.push(tx);
-		Watcher {
-			receiver,
-		}
+		Watcher { receiver }
 	}
 
 	/// Some state change (perhaps another extrinsic was included) rendered this extrinsic invalid.
@@ -80,6 +78,7 @@ impl<H: Clone> Sender<H> {
 	}
 
 	fn send(&mut self, status: Status<H>) {
-		self.receivers.retain(|sender| sender.unbounded_send(status.clone()).is_ok())
+		self.receivers
+			.retain(|sender| sender.unbounded_send(status.clone()).is_ok())
 	}
 }

--- a/substrate/keyring/src/lib.rs
+++ b/substrate/keyring/src/lib.rs
@@ -16,13 +16,15 @@
 
 //! Support code for the runtime.
 
-#[macro_use] extern crate hex_literal;
-#[macro_use] extern crate lazy_static;
+#[macro_use]
+extern crate hex_literal;
+#[macro_use]
+extern crate lazy_static;
 pub extern crate ed25519;
 
+use ed25519::{Pair, Public, Signature};
 use std::collections::HashMap;
 use std::ops::Deref;
-use ed25519::{Pair, Public, Signature};
 
 /// Set of test accounts.
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
@@ -78,7 +80,9 @@ impl Keyring {
 			Keyring::Eve => Pair::from_seed(b"Eve                             "),
 			Keyring::Ferdie => Pair::from_seed(b"Ferdie                          "),
 			Keyring::One => Pair::from_seed(b"12345678901234567890123456789012"),
-			Keyring::Two => Pair::from_seed(&hex!("9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60")),
+			Keyring::Two => Pair::from_seed(&hex!(
+				"9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60"
+			)),
 		}
 	}
 }
@@ -109,11 +113,15 @@ lazy_static! {
 			Keyring::Ferdie,
 			Keyring::One,
 			Keyring::Two,
-		].iter().map(|&i| (i, i.pair())).collect()
+		].iter()
+			.map(|&i| (i, i.pair()))
+			.collect()
 	};
-
 	static ref PUBLIC_KEYS: HashMap<Keyring, Public> = {
-		PRIVATE_KEYS.iter().map(|(&name, pair)| (name, pair.public())).collect()
+		PRIVATE_KEYS
+			.iter()
+			.map(|(&name, pair)| (name, pair.public()))
+			.collect()
 	};
 }
 
@@ -167,8 +175,20 @@ mod tests {
 
 	#[test]
 	fn should_work() {
-		assert!(Keyring::Alice.sign(b"I am Alice!").verify(b"I am Alice!", Keyring::Alice));
-		assert!(!Keyring::Alice.sign(b"I am Alice!").verify(b"I am Bob!", Keyring::Alice));
-		assert!(!Keyring::Alice.sign(b"I am Alice!").verify(b"I am Alice!", Keyring::Bob));
+		assert!(
+			Keyring::Alice
+				.sign(b"I am Alice!")
+				.verify(b"I am Alice!", Keyring::Alice)
+		);
+		assert!(
+			!Keyring::Alice
+				.sign(b"I am Alice!")
+				.verify(b"I am Bob!", Keyring::Alice)
+		);
+		assert!(
+			!Keyring::Alice
+				.sign(b"I am Alice!")
+				.verify(b"I am Alice!", Keyring::Bob)
+		);
 	}
 }

--- a/substrate/network/src/blocks.rs
+++ b/substrate/network/src/blocks.rs
@@ -14,14 +14,14 @@
 // You should have received a copy of the GNU General Public License
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.?
 
-use std::mem;
-use std::cmp;
-use std::ops::Range;
-use std::collections::{HashMap, BTreeMap};
-use std::collections::hash_map::Entry;
+use message;
 use network::PeerId;
 use runtime_primitives::traits::{Block as BlockT, Header as HeaderT};
-use message;
+use std::cmp;
+use std::collections::hash_map::Entry;
+use std::collections::{BTreeMap, HashMap};
+use std::mem;
+use std::ops::Range;
 
 const MAX_PARALLEL_DOWNLOADS: u32 = 1;
 
@@ -34,14 +34,14 @@ pub struct BlockData<B: BlockT> {
 
 #[derive(Debug)]
 enum BlockRangeState<B: BlockT> {
-	Downloading {
-		len: u64,
-		downloading: u32,
-	},
+	Downloading { len: u64, downloading: u32 },
 	Complete(Vec<BlockData<B>>),
 }
 
-impl<B: BlockT> BlockRangeState<B> where B::Header: HeaderT<Number=u64> {
+impl<B: BlockT> BlockRangeState<B>
+where
+	B::Header: HeaderT<Number = u64>,
+{
 	pub fn len(&self) -> u64 {
 		match *self {
 			BlockRangeState::Downloading { len, .. } => len,
@@ -58,7 +58,10 @@ pub struct BlockCollection<B: BlockT> {
 	peer_requests: HashMap<PeerId, u64>,
 }
 
-impl<B: BlockT> BlockCollection<B> where B::Header: HeaderT<Number=u64> {
+impl<B: BlockT> BlockCollection<B>
+where
+	B::Header: HeaderT<Number = u64>,
+{
 	/// Create a new instance.
 	pub fn new() -> Self {
 		BlockCollection {
@@ -76,27 +79,45 @@ impl<B: BlockT> BlockCollection<B> where B::Header: HeaderT<Number=u64> {
 	/// Insert a set of blocks into collection.
 	pub fn insert(&mut self, start: u64, blocks: Vec<message::BlockData<B>>, peer_id: PeerId) {
 		if blocks.is_empty() {
-			return;
+			return
 		}
 
 		match self.blocks.get(&start) {
 			Some(&BlockRangeState::Downloading { .. }) => {
 				trace!(target: "sync", "Ignored block data still marked as being downloaded: {}", start);
 				debug_assert!(false);
-				return;
+				return
 			},
 			Some(&BlockRangeState::Complete(ref existing)) if existing.len() >= blocks.len() => {
 				trace!(target: "sync", "Ignored block data already downloaded: {}", start);
-				return;
+				return
 			},
 			_ => (),
 		}
 
-		self.blocks.insert(start, BlockRangeState::Complete(blocks.into_iter().map(|b| BlockData { origin: peer_id, block: b }).collect()));
+		self.blocks.insert(
+			start,
+			BlockRangeState::Complete(
+				blocks
+					.into_iter()
+					.map(|b| BlockData {
+						origin: peer_id,
+						block: b,
+					})
+					.collect(),
+			),
+		);
 	}
 
-	/// Returns a set of block hashes that require a header download. The returned set is marked as being downloaded.
-	pub fn needed_blocks(&mut self, peer_id: PeerId, count: usize, peer_best: u64, common: u64) -> Option<Range<u64>> {
+	/// Returns a set of block hashes that require a header download. The returned set is marked as
+	/// being downloaded.
+	pub fn needed_blocks(
+		&mut self,
+		peer_id: PeerId,
+		count: usize,
+		peer_best: u64,
+		common: u64,
+	) -> Option<Range<u64>> {
 		// First block number that we need to download
 		let first_different = common + 1;
 		let count = count as u64;
@@ -106,16 +127,28 @@ impl<B: BlockT> BlockCollection<B> where B::Header: HeaderT<Number=u64> {
 			loop {
 				let next = downloading_iter.next();
 				break match &(prev, next) {
-					&(Some((start, &BlockRangeState::Downloading { ref len, downloading })), _) if downloading < MAX_PARALLEL_DOWNLOADS  =>
-						(*start .. *start + *len, downloading),
+					&(
+						Some((
+							start,
+							&BlockRangeState::Downloading {
+								ref len,
+								downloading,
+							},
+						)),
+						_,
+					) if downloading < MAX_PARALLEL_DOWNLOADS =>
+						(*start..*start + *len, downloading),
 					&(Some((start, r)), Some((next_start, _))) if start + r.len() < *next_start =>
-						(*start + r.len() .. cmp::min(*next_start, *start + r.len() + count), 0), // gap
-					&(Some((start, r)), None) =>
-						(start + r.len() .. start + r.len() + count, 0), // last range
-					&(None, None) =>
-						(first_different .. first_different + count, 0), // empty
-					&(None, Some((start, _))) if *start > first_different =>
-						(first_different .. cmp::min(first_different + count, *start), 0), // gap at the start
+						(
+							*start + r.len()..cmp::min(*next_start, *start + r.len() + count),
+							0,
+						), // gap
+					&(Some((start, r)), None) => (start + r.len()..start + r.len() + count, 0), /* last range */
+					&(None, None) => (first_different..first_different + count, 0),             /* empty */
+					&(None, Some((start, _))) if *start > first_different => (
+						first_different..cmp::min(first_different + count, *start),
+						0,
+					), /* gap at the start */
 					_ => {
 						prev = next;
 						continue
@@ -126,18 +159,28 @@ impl<B: BlockT> BlockCollection<B> where B::Header: HeaderT<Number=u64> {
 		// crop to peers best
 		if range.start > peer_best {
 			trace!(target: "sync", "Out of range for peer {} ({} vs {})", peer_id, range.start, peer_best);
-			return None;
+			return None
 		}
 		range.end = cmp::min(peer_best + 1, range.end);
 		self.peer_requests.insert(peer_id, range.start);
-		self.blocks.insert(range.start, BlockRangeState::Downloading{ len: range.end - range.start, downloading: downloading + 1 });
+		self.blocks.insert(
+			range.start,
+			BlockRangeState::Downloading {
+				len: range.end - range.start,
+				downloading: downloading + 1,
+			},
+		);
 		if range.end <= range.start {
-			panic!("Empty range {:?}, count={}, peer_best={}, common={}, blocks={:?}", range, count, peer_best, common, self.blocks);
+			panic!(
+				"Empty range {:?}, count={}, peer_best={}, common={}, blocks={:?}",
+				range, count, peer_best, common, self.blocks
+			);
 		}
 		Some(range)
 	}
 
-	/// Get a valid chain of blocks ordered in descending order and ready for importing into blockchain.
+	/// Get a valid chain of blocks ordered in descending order and ready for importing into
+	/// blockchain.
 	pub fn drain(&mut self, from: u64) -> Vec<BlockData<B>> {
 		let mut drained = Vec::new();
 		let mut ranges = Vec::new();
@@ -146,10 +189,10 @@ impl<B: BlockT> BlockCollection<B> where B::Header: HeaderT<Number=u64> {
 			for (start, range_data) in &mut self.blocks {
 				match range_data {
 					&mut BlockRangeState::Complete(ref mut blocks) if *start <= prev => {
-							prev = *start + blocks.len() as u64;
-							let mut blocks = mem::replace(blocks, Vec::new());
-							drained.append(&mut blocks);
-							ranges.push(*start);
+						prev = *start + blocks.len() as u64;
+						let mut blocks = mem::replace(blocks, Vec::new());
+						drained.append(&mut blocks);
+						ranges.push(*start);
 					},
 					_ => break,
 				}
@@ -167,17 +210,19 @@ impl<B: BlockT> BlockCollection<B> where B::Header: HeaderT<Number=u64> {
 			Entry::Occupied(entry) => {
 				let start = entry.remove();
 				let remove = match self.blocks.get_mut(&start) {
-					Some(&mut BlockRangeState::Downloading { ref mut downloading, .. }) if *downloading > 1 => {
+					Some(&mut BlockRangeState::Downloading {
+						ref mut downloading,
+						..
+					}) if *downloading > 1 =>
+					{
 						*downloading = *downloading - 1;
 						false
-					},
-					Some(&mut BlockRangeState::Downloading { .. })  => {
-						true
-					},
+					}
+					Some(&mut BlockRangeState::Downloading { .. }) => true,
 					_ => {
 						debug_assert!(false);
 						false
-					}
+					},
 				};
 				if remove {
 					self.blocks.remove(&start);
@@ -192,32 +237,33 @@ impl<B: BlockT> BlockCollection<B> where B::Header: HeaderT<Number=u64> {
 mod test {
 	use super::{BlockCollection, BlockData, BlockRangeState};
 	use message;
-	use runtime_primitives::testing::Block as RawBlock;
 	use primitives::H256;
+	use runtime_primitives::testing::Block as RawBlock;
 
 	type Block = RawBlock<u64>;
 
 	fn is_empty(bc: &BlockCollection<Block>) -> bool {
-		bc.blocks.is_empty() &&
-		bc.peer_requests.is_empty()
+		bc.blocks.is_empty() && bc.peer_requests.is_empty()
 	}
 
 	fn generate_blocks(n: usize) -> Vec<message::BlockData<Block>> {
-		(0 .. n).map(|_| message::generic::BlockData {
-			hash: H256::random(),
-			header: None,
-			body: None,
-			message_queue: None,
-			receipt: None,
-			justification: None,
-		}).collect()
+		(0..n)
+			.map(|_| message::generic::BlockData {
+				hash: H256::random(),
+				header: None,
+				body: None,
+				message_queue: None,
+				receipt: None,
+				justification: None,
+			})
+			.collect()
 	}
 
 	#[test]
 	fn create_clear() {
 		let mut bc = BlockCollection::new();
 		assert!(is_empty(&bc));
-		bc.insert(1, generate_blocks(100),  0);
+		bc.insert(1, generate_blocks(100), 0);
 		assert!(!is_empty(&bc));
 		bc.clear();
 		assert!(is_empty(&bc));
@@ -232,29 +278,56 @@ mod test {
 		let peer2 = 2;
 
 		let blocks = generate_blocks(150);
-		assert_eq!(bc.needed_blocks(peer0, 40, 150, 0), Some(1 .. 41));
-		assert_eq!(bc.needed_blocks(peer1, 40, 150, 0), Some(41 .. 81));
-		assert_eq!(bc.needed_blocks(peer2, 40, 150, 0), Some(81 .. 121));
+		assert_eq!(bc.needed_blocks(peer0, 40, 150, 0), Some(1..41));
+		assert_eq!(bc.needed_blocks(peer1, 40, 150, 0), Some(41..81));
+		assert_eq!(bc.needed_blocks(peer2, 40, 150, 0), Some(81..121));
 
 		bc.clear_peer_download(peer1);
 		bc.insert(41, blocks[41..81].to_vec(), peer1);
 		assert_eq!(bc.drain(1), vec![]);
-		assert_eq!(bc.needed_blocks(peer1, 40, 150, 0), Some(121 .. 151));
+		assert_eq!(bc.needed_blocks(peer1, 40, 150, 0), Some(121..151));
 		bc.clear_peer_download(peer0);
 		bc.insert(1, blocks[1..11].to_vec(), peer0);
 
-		assert_eq!(bc.needed_blocks(peer0, 40, 150, 0), Some(11 .. 41));
-		assert_eq!(bc.drain(1), blocks[1..11].iter().map(|b| BlockData { block: b.clone(), origin: 0 }).collect::<Vec<_>>());
+		assert_eq!(bc.needed_blocks(peer0, 40, 150, 0), Some(11..41));
+		assert_eq!(
+			bc.drain(1),
+			blocks[1..11]
+				.iter()
+				.map(|b| BlockData {
+					block: b.clone(),
+					origin: 0
+				})
+				.collect::<Vec<_>>()
+		);
 
 		bc.clear_peer_download(peer0);
 		bc.insert(11, blocks[11..41].to_vec(), peer0);
 
 		let drained = bc.drain(12);
-		assert_eq!(drained[..30], blocks[11..41].iter().map(|b| BlockData { block: b.clone(), origin: 0 }).collect::<Vec<_>>()[..]);
-		assert_eq!(drained[30..], blocks[41..81].iter().map(|b| BlockData { block: b.clone(), origin: 1 }).collect::<Vec<_>>()[..]);
+		assert_eq!(
+			drained[..30],
+			blocks[11..41]
+				.iter()
+				.map(|b| BlockData {
+					block: b.clone(),
+					origin: 0
+				})
+				.collect::<Vec<_>>()[..]
+		);
+		assert_eq!(
+			drained[30..],
+			blocks[41..81]
+				.iter()
+				.map(|b| BlockData {
+					block: b.clone(),
+					origin: 1
+				})
+				.collect::<Vec<_>>()[..]
+		);
 
 		bc.clear_peer_download(peer2);
-		assert_eq!(bc.needed_blocks(peer2, 40, 150, 80), Some(81 .. 121));
+		assert_eq!(bc.needed_blocks(peer2, 40, 150, 80), Some(81..121));
 		bc.clear_peer_download(peer2);
 		bc.insert(81, blocks[81..121].to_vec(), peer2);
 		bc.clear_peer_download(peer1);
@@ -262,21 +335,51 @@ mod test {
 
 		assert_eq!(bc.drain(80), vec![]);
 		let drained = bc.drain(81);
-		assert_eq!(drained[..40], blocks[81..121].iter().map(|b| BlockData { block: b.clone(), origin: 2 }).collect::<Vec<_>>()[..]);
-		assert_eq!(drained[40..], blocks[121..150].iter().map(|b| BlockData { block: b.clone(), origin: 1 }).collect::<Vec<_>>()[..]);
+		assert_eq!(
+			drained[..40],
+			blocks[81..121]
+				.iter()
+				.map(|b| BlockData {
+					block: b.clone(),
+					origin: 2
+				})
+				.collect::<Vec<_>>()[..]
+		);
+		assert_eq!(
+			drained[40..],
+			blocks[121..150]
+				.iter()
+				.map(|b| BlockData {
+					block: b.clone(),
+					origin: 1
+				})
+				.collect::<Vec<_>>()[..]
+		);
 	}
 
 	#[test]
 	fn large_gap() {
 		let mut bc: BlockCollection<Block> = BlockCollection::new();
-		bc.blocks.insert(100, BlockRangeState::Downloading {
-			len: 128,
-			downloading: 1,
-		});
-		let blocks = generate_blocks(10).into_iter().map(|b| BlockData { block: b, origin: 0 }).collect();
+		bc.blocks.insert(
+			100,
+			BlockRangeState::Downloading {
+				len: 128,
+				downloading: 1,
+			},
+		);
+		let blocks = generate_blocks(10)
+			.into_iter()
+			.map(|b| BlockData {
+				block: b,
+				origin: 0,
+			})
+			.collect();
 		bc.blocks.insert(114305, BlockRangeState::Complete(blocks));
 
-		assert_eq!(bc.needed_blocks(0, 128, 10000, 000), Some(1 .. 100));
-		assert_eq!(bc.needed_blocks(0, 128, 10000, 600), Some(100 + 128 .. 100 + 128 + 128));
+		assert_eq!(bc.needed_blocks(0, 128, 10000, 000), Some(1..100));
+		assert_eq!(
+			bc.needed_blocks(0, 128, 10000, 600),
+			Some(100 + 128..100 + 128 + 128)
+		);
 	}
 }

--- a/substrate/network/src/config.rs
+++ b/substrate/network/src/config.rs
@@ -25,8 +25,6 @@ pub struct ProtocolConfig {
 
 impl Default for ProtocolConfig {
 	fn default() -> ProtocolConfig {
-		ProtocolConfig {
-			roles: Role::FULL,
-		}
+		ProtocolConfig { roles: Role::FULL }
 	}
 }

--- a/substrate/network/src/error.rs
+++ b/substrate/network/src/error.rs
@@ -16,8 +16,8 @@
 
 //! Polkadot service possible errors.
 
-use network::Error as NetworkError;
 use client;
+use network::Error as NetworkError;
 
 error_chain! {
 	foreign_links {

--- a/substrate/network/src/io.rs
+++ b/substrate/network/src/io.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.?
 
-use network::{NetworkContext, PeerId, Error as NetworkError, SessionInfo};
+use network::{Error as NetworkError, NetworkContext, PeerId, SessionInfo};
 
 /// IO interface for the syncing handler.
 /// Provides peer connection management and an interface to the blockchain client.
@@ -43,9 +43,7 @@ pub struct NetSyncIo<'s> {
 impl<'s> NetSyncIo<'s> {
 	/// Creates a new instance from the `NetworkContext` and the blockchain client reference.
 	pub fn new(network: &'s NetworkContext) -> NetSyncIo<'s> {
-		NetSyncIo {
-			network: network,
-		}
+		NetSyncIo { network }
 	}
 }
 
@@ -58,7 +56,7 @@ impl<'s> SyncIo for NetSyncIo<'s> {
 		self.network.disconnect_peer(peer_id);
 	}
 
-	fn send(&mut self, peer_id: PeerId, data: Vec<u8>) -> Result<(), NetworkError>{
+	fn send(&mut self, peer_id: PeerId, data: Vec<u8>) -> Result<(), NetworkError> {
 		self.network.send(peer_id, 0, data)
 	}
 
@@ -74,5 +72,3 @@ impl<'s> SyncIo for NetSyncIo<'s> {
 		self.network.peer_client_version(peer_id)
 	}
 }
-
-

--- a/substrate/network/src/lib.rs
+++ b/substrate/network/src/lib.rs
@@ -19,32 +19,39 @@
 //! Implements polkadot protocol version as specified here:
 //! https://github.com/paritytech/polkadot/wiki/Network-protocol
 
-extern crate ethcore_network_devp2p as network_devp2p;
-extern crate ethcore_network as network;
+extern crate ed25519;
 extern crate ethcore_io as core_io;
+extern crate ethcore_network as network;
+extern crate ethcore_network_devp2p as network_devp2p;
+extern crate futures;
 extern crate linked_hash_map;
-extern crate rand;
 extern crate parking_lot;
-extern crate substrate_primitives as primitives;
-extern crate substrate_state_machine as state_machine;
-extern crate substrate_serializer as ser;
-extern crate substrate_client as client;
-extern crate substrate_runtime_support as runtime_support;
-extern crate substrate_runtime_primitives as runtime_primitives;
-extern crate substrate_bft;
-extern crate substrate_codec as codec;
+extern crate rand;
 extern crate serde;
 extern crate serde_json;
-extern crate futures;
-extern crate ed25519;
-#[macro_use] extern crate serde_derive;
-#[macro_use] extern crate log;
-#[macro_use] extern crate bitflags;
-#[macro_use] extern crate error_chain;
+extern crate substrate_bft;
+extern crate substrate_client as client;
+extern crate substrate_codec as codec;
+extern crate substrate_primitives as primitives;
+extern crate substrate_runtime_primitives as runtime_primitives;
+extern crate substrate_runtime_support as runtime_support;
+extern crate substrate_serializer as ser;
+extern crate substrate_state_machine as state_machine;
+#[macro_use]
+extern crate serde_derive;
+#[macro_use]
+extern crate log;
+#[macro_use]
+extern crate bitflags;
+#[macro_use]
+extern crate error_chain;
 
-#[cfg(test)] extern crate env_logger;
-#[cfg(test)] extern crate substrate_keyring as keyring;
-#[cfg(test)] extern crate substrate_test_client as test_client;
+#[cfg(test)]
+extern crate env_logger;
+#[cfg(test)]
+extern crate substrate_keyring as keyring;
+#[cfg(test)]
+extern crate substrate_test_client as test_client;
 
 mod service;
 mod sync;
@@ -58,14 +65,22 @@ mod consensus;
 mod on_demand;
 pub mod error;
 
-#[cfg(test)] mod test;
+#[cfg(test)]
+mod test;
 
-pub use service::{Service, FetchFuture, ConsensusService, BftMessageStream,
-	TransactionPool, Params, ManageNetwork, SyncProvider};
-pub use protocol::{ProtocolStatus};
-pub use sync::{Status as SyncStatus, SyncState};
-pub use network::{NonReservedPeerMode, NetworkConfiguration, ConnectionFilter, ConnectionDirection};
-pub use message::{generic as generic_message, BftMessage, LocalizedBftMessage, ConsensusVote, SignedConsensusVote, SignedConsensusMessage, SignedConsensusProposal};
+pub use config::{ProtocolConfig, Role};
 pub use error::Error;
-pub use config::{Role, ProtocolConfig};
+pub use message::{
+	generic as generic_message, BftMessage, ConsensusVote, LocalizedBftMessage,
+	SignedConsensusMessage, SignedConsensusProposal, SignedConsensusVote,
+};
+pub use network::{
+	ConnectionDirection, ConnectionFilter, NetworkConfiguration, NonReservedPeerMode,
+};
 pub use on_demand::{OnDemand, OnDemandService, RemoteCallResponse};
+pub use protocol::ProtocolStatus;
+pub use service::{
+	BftMessageStream, ConsensusService, FetchFuture, ManageNetwork, Params, Service, SyncProvider,
+	TransactionPool,
+};
+pub use sync::{Status as SyncStatus, SyncState};

--- a/substrate/network/src/on_demand.rs
+++ b/substrate/network/src/on_demand.rs
@@ -16,21 +16,21 @@
 
 //! On-demand requests service.
 
-use std::collections::VecDeque;
-use std::sync::{Arc, Weak};
-use std::time::{Instant, Duration};
-use futures::{Async, Future, Poll};
-use futures::sync::oneshot::{channel, Receiver, Sender};
-use linked_hash_map::LinkedHashMap;
-use linked_hash_map::Entry;
-use parking_lot::Mutex;
 use client;
-use client::light::fetcher::{Fetcher, FetchChecker, RemoteCallRequest};
+use client::light::fetcher::{FetchChecker, Fetcher, RemoteCallRequest};
+use futures::sync::oneshot::{channel, Receiver, Sender};
+use futures::{Async, Future, Poll};
 use io::SyncIo;
+use linked_hash_map::Entry;
+use linked_hash_map::LinkedHashMap;
 use message;
 use network::PeerId;
-use service;
+use parking_lot::Mutex;
 use runtime_primitives::traits::{Block as BlockT, Header as HeaderT};
+use service;
+use std::collections::VecDeque;
+use std::sync::{Arc, Weak};
+use std::time::{Duration, Instant};
 
 /// Remote request timeout.
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(15);
@@ -47,7 +47,12 @@ pub trait OnDemandService<Block: BlockT>: Send + Sync {
 	fn maintain_peers(&self, io: &mut SyncIo);
 
 	/// When call response is received from remote node.
-	fn on_remote_call_response(&self, io: &mut SyncIo, peer: PeerId, response: message::RemoteCallResponse);
+	fn on_remote_call_response(
+		&self,
+		io: &mut SyncIo,
+		peer: PeerId,
+		response: message::RemoteCallResponse,
+	);
 }
 
 /// On-demand requests service. Dispatches requests to appropriate peers.
@@ -77,7 +82,10 @@ struct Request<Block: BlockT> {
 }
 
 enum RequestData<Block: BlockT> {
-	RemoteCall(RemoteCallRequest<Block::Hash>, Sender<Result<client::CallResult, client::error::Error>>),
+	RemoteCall(
+		RemoteCallRequest<Block::Hash>,
+		Sender<Result<client::CallResult, client::error::Error>>,
+	),
 }
 
 enum Accept<Block: BlockT> {
@@ -90,7 +98,8 @@ impl Future for RemoteCallResponse {
 	type Error = client::error::Error;
 
 	fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-		self.receiver.poll()
+		self.receiver
+			.poll()
 			.map_err(|_| client::error::ErrorKind::RemoteFetchCancelled.into())
 			.and_then(|r| match r {
 				Async::Ready(Ok(ready)) => Ok(Async::Ready(ready)),
@@ -100,9 +109,10 @@ impl Future for RemoteCallResponse {
 	}
 }
 
-impl<B: BlockT, E> OnDemand<B, E> where
+impl<B: BlockT, E> OnDemand<B, E>
+where
 	E: service::ExecuteInContext<B>,
-	B::Header: HeaderT<Number=u64>,
+	B::Header: HeaderT<Number = u64>,
 {
 	/// Creates new on-demand service.
 	pub fn new(checker: Arc<FetchChecker<B>>) -> Self {
@@ -114,7 +124,7 @@ impl<B: BlockT, E> OnDemand<B, E> where
 				pending_requests: VecDeque::new(),
 				active_peers: LinkedHashMap::new(),
 				idle_peers: VecDeque::new(),
-			})
+			}),
 		}
 	}
 
@@ -132,7 +142,14 @@ impl<B: BlockT, E> OnDemand<B, E> where
 	}
 
 	/// Try to accept response from given peer.
-	fn accept_response<F: FnOnce(Request<B>) -> Accept<B>>(&self, rtype: &str, io: &mut SyncIo, peer: PeerId, request_id: u64, try_accept: F) {
+	fn accept_response<F: FnOnce(Request<B>) -> Accept<B>>(
+		&self,
+		rtype: &str,
+		io: &mut SyncIo,
+		peer: PeerId,
+		request_id: u64,
+		try_accept: F,
+	) {
 		let mut core = self.core.lock();
 		let request = match core.remove(peer, request_id) {
 			Some(request) => request,
@@ -140,7 +157,7 @@ impl<B: BlockT, E> OnDemand<B, E> where
 				trace!(target: "sync", "Invalid remote {} response from peer {}", rtype, peer);
 				io.disconnect_peer(peer);
 				core.remove_peer(peer);
-				return;
+				return
 			},
 		};
 
@@ -163,14 +180,18 @@ impl<B: BlockT, E> OnDemand<B, E> where
 	}
 }
 
-impl<B, E> OnDemandService<B> for OnDemand<B, E> where
+impl<B, E> OnDemandService<B> for OnDemand<B, E>
+where
 	B: BlockT,
 	E: service::ExecuteInContext<B>,
-	B::Header: HeaderT<Number=u64>,
+	B::Header: HeaderT<Number = u64>,
 {
 	fn on_connect(&self, peer: PeerId, role: service::Role) {
-		if !role.intersects(service::Role::FULL | service::Role::COLLATOR | service::Role::VALIDATOR) { // TODO: correct?
-			return;
+		if !role
+			.intersects(service::Role::FULL | service::Role::COLLATOR | service::Role::VALIDATOR)
+		{
+			// TODO: correct?
+			return
 		}
 
 		let mut core = self.core.lock();
@@ -193,38 +214,51 @@ impl<B, E> OnDemandService<B> for OnDemand<B, E> where
 		core.dispatch();
 	}
 
-	fn on_remote_call_response(&self, io: &mut SyncIo, peer: PeerId, response: message::RemoteCallResponse) {
-		self.accept_response("call", io, peer, response.id, |request| match request.data {
-			RequestData::RemoteCall(request, sender) => match self.checker.check_execution_proof(&request, response.proof) {
-				Ok(response) => {
-					// we do not bother if receiver has been dropped already
-					let _ = sender.send(Ok(response));
-					Accept::Ok
-				},
-				Err(error) => Accept::CheckFailed(error, RequestData::RemoteCall(request, sender)),
-			},
+	fn on_remote_call_response(
+		&self,
+		io: &mut SyncIo,
+		peer: PeerId,
+		response: message::RemoteCallResponse,
+	) {
+		self.accept_response("call", io, peer, response.id, |request| {
+			match request.data {
+				RequestData::RemoteCall(request, sender) =>
+					match self.checker.check_execution_proof(&request, response.proof) {
+						Ok(response) => {
+							// we do not bother if receiver has been dropped already
+							let _ = sender.send(Ok(response));
+							Accept::Ok
+						},
+						Err(error) =>
+							Accept::CheckFailed(error, RequestData::RemoteCall(request, sender)),
+					},
+			}
 		})
 	}
 }
 
-impl<B, E> Fetcher<B> for OnDemand<B, E> where
+impl<B, E> Fetcher<B> for OnDemand<B, E>
+where
 	B: BlockT,
 	E: service::ExecuteInContext<B>,
-	B::Header: HeaderT<Number=u64>,
+	B::Header: HeaderT<Number = u64>,
 {
 	type RemoteCallResult = RemoteCallResponse;
 
 	fn remote_call(&self, request: RemoteCallRequest<B::Hash>) -> Self::RemoteCallResult {
 		let (sender, receiver) = channel();
-		self.schedule_request(RequestData::RemoteCall(request, sender),
-			RemoteCallResponse { receiver })
+		self.schedule_request(
+			RequestData::RemoteCall(request, sender),
+			RemoteCallResponse { receiver },
+		)
 	}
 }
 
-impl<B, E> OnDemandCore<B, E> where
+impl<B, E> OnDemandCore<B, E>
+where
 	B: BlockT,
-	E: service::ExecuteInContext<B> ,
-	B::Header: HeaderT<Number=u64>
+	E: service::ExecuteInContext<B>,
+	B::Header: HeaderT<Number = u64>,
 {
 	pub fn add_peer(&mut self, peer: PeerId) {
 		self.idle_peers.push_back(peer);
@@ -233,7 +267,7 @@ impl<B, E> OnDemandCore<B, E> where
 	pub fn remove_peer(&mut self, peer: PeerId) {
 		if let Some(request) = self.active_peers.remove(&peer) {
 			self.pending_requests.push_front(request);
-			return;
+			return
 		}
 
 		if let Some(idle_index) = self.idle_peers.iter().position(|i| *i == peer) {
@@ -250,7 +284,10 @@ impl<B, E> OnDemandCore<B, E> where
 				_ => return bad_peers,
 			}
 
-			let (bad_peer, request) = self.active_peers.pop_front().expect("front() is Some as checked above");
+			let (bad_peer, request) = self
+				.active_peers
+				.pop_front()
+				.expect("front() is Some as checked above");
 			self.pending_requests.push_front(request);
 			bad_peers.push(bad_peer);
 		}
@@ -292,7 +329,10 @@ impl<B, E> OnDemandCore<B, E> where
 				None => return,
 			};
 
-			let mut request = self.pending_requests.pop_front().expect("checked in loop condition; qed");
+			let mut request = self
+				.pending_requests
+				.pop_front()
+				.expect("checked in loop condition; qed");
 			request.timestamp = Instant::now();
 			trace!(target: "sync", "Dispatching remote request {} to peer {}", request.id, peer);
 
@@ -307,43 +347,50 @@ impl<B, E> OnDemandCore<B, E> where
 impl<Block: BlockT> Request<Block> {
 	pub fn message(&self) -> message::Message<Block> {
 		match self.data {
-			RequestData::RemoteCall(ref data, _) => message::generic::Message::RemoteCallRequest(message::RemoteCallRequest {
-				id: self.id,
-				block: data.block,
-				method: data.method.clone(),
-				data: data.call_data.clone(),
-			}),
+			RequestData::RemoteCall(ref data, _) =>
+				message::generic::Message::RemoteCallRequest(message::RemoteCallRequest {
+					id: self.id,
+					block: data.block,
+					method: data.method.clone(),
+					data: data.call_data.clone(),
+				}),
 		}
 	}
 }
 
 #[cfg(test)]
 mod tests {
-	use std::collections::VecDeque;
-	use std::sync::Arc;
-	use std::time::Instant;
-	use futures::Future;
-	use parking_lot::RwLock;
+	use super::{OnDemand, OnDemandService, REQUEST_TIMEOUT};
 	use client;
-	use client::light::fetcher::{Fetcher, FetchChecker, RemoteCallRequest};
+	use client::light::fetcher::{FetchChecker, Fetcher, RemoteCallRequest};
+	use futures::Future;
 	use io::NetSyncIo;
 	use message;
 	use network::PeerId;
+	use parking_lot::RwLock;
 	use protocol::Protocol;
-	use service::{Role, ExecuteInContext};
+	use service::{ExecuteInContext, Role};
+	use std::collections::VecDeque;
+	use std::sync::Arc;
+	use std::time::Instant;
 	use test::TestIo;
-	use super::{REQUEST_TIMEOUT, OnDemand, OnDemandService};
 	use test_client::runtime::{Block, Hash};
 
 	struct DummyExecutor;
-	struct DummyFetchChecker { ok: bool }
+	struct DummyFetchChecker {
+		ok: bool,
+	}
 
 	impl ExecuteInContext<Block> for DummyExecutor {
 		fn execute_in_context<F: Fn(&mut NetSyncIo, &Protocol<Block>)>(&self, _closure: F) {}
 	}
 
 	impl FetchChecker<Block> for DummyFetchChecker {
-		fn check_execution_proof(&self, _request: &RemoteCallRequest<Hash>, _remote_proof: Vec<Vec<u8>>) -> client::error::Result<client::CallResult> {
+		fn check_execution_proof(
+			&self,
+			_request: &RemoteCallRequest<Hash>,
+			_remote_proof: Vec<Vec<u8>>,
+		) -> client::error::Result<client::CallResult> {
 			match self.ok {
 				true => Ok(client::CallResult {
 					return_data: vec![42],
@@ -366,11 +413,20 @@ mod tests {
 		core.idle_peers.len() + core.active_peers.len()
 	}
 
-	fn receive_call_response(on_demand: &OnDemand<Block, DummyExecutor>, network: &mut TestIo, peer: PeerId, id: message::RequestId) {
-		on_demand.on_remote_call_response(network, peer, message::RemoteCallResponse {
-			id: id,
-			proof: vec![vec![2]],
-		});
+	fn receive_call_response(
+		on_demand: &OnDemand<Block, DummyExecutor>,
+		network: &mut TestIo,
+		peer: PeerId,
+		id: message::RequestId,
+	) {
+		on_demand.on_remote_call_response(
+			network,
+			peer,
+			message::RemoteCallResponse {
+				id,
+				proof: vec![vec![2]],
+			},
+		);
 	}
 
 	#[test]
@@ -380,7 +436,16 @@ mod tests {
 		on_demand.on_connect(1, Role::FULL);
 		on_demand.on_connect(2, Role::COLLATOR);
 		on_demand.on_connect(3, Role::VALIDATOR);
-		assert_eq!(vec![1, 2, 3], on_demand.core.lock().idle_peers.iter().cloned().collect::<Vec<_>>());
+		assert_eq!(
+			vec![1, 2, 3],
+			on_demand
+				.core
+				.lock()
+				.idle_peers
+				.iter()
+				.cloned()
+				.collect::<Vec<_>>()
+		);
 	}
 
 	#[test]
@@ -400,17 +465,58 @@ mod tests {
 
 		on_demand.on_connect(0, Role::FULL);
 		on_demand.on_connect(1, Role::FULL);
-		assert_eq!(vec![0, 1], on_demand.core.lock().idle_peers.iter().cloned().collect::<Vec<_>>());
+		assert_eq!(
+			vec![0, 1],
+			on_demand
+				.core
+				.lock()
+				.idle_peers
+				.iter()
+				.cloned()
+				.collect::<Vec<_>>()
+		);
 		assert!(on_demand.core.lock().active_peers.is_empty());
 
-		on_demand.remote_call(RemoteCallRequest { block: Default::default(), method: "test".into(), call_data: vec![] });
-		assert_eq!(vec![1], on_demand.core.lock().idle_peers.iter().cloned().collect::<Vec<_>>());
-		assert_eq!(vec![0], on_demand.core.lock().active_peers.keys().cloned().collect::<Vec<_>>());
+		on_demand.remote_call(RemoteCallRequest {
+			block: Default::default(),
+			method: "test".into(),
+			call_data: vec![],
+		});
+		assert_eq!(
+			vec![1],
+			on_demand
+				.core
+				.lock()
+				.idle_peers
+				.iter()
+				.cloned()
+				.collect::<Vec<_>>()
+		);
+		assert_eq!(
+			vec![0],
+			on_demand
+				.core
+				.lock()
+				.active_peers
+				.keys()
+				.cloned()
+				.collect::<Vec<_>>()
+		);
 
-		on_demand.core.lock().active_peers[&0].timestamp = Instant::now() - REQUEST_TIMEOUT - REQUEST_TIMEOUT;
+		on_demand.core.lock().active_peers[&0].timestamp =
+			Instant::now() - REQUEST_TIMEOUT - REQUEST_TIMEOUT;
 		on_demand.maintain_peers(&mut network);
 		assert!(on_demand.core.lock().idle_peers.is_empty());
-		assert_eq!(vec![1], on_demand.core.lock().active_peers.keys().cloned().collect::<Vec<_>>());
+		assert_eq!(
+			vec![1],
+			on_demand
+				.core
+				.lock()
+				.active_peers
+				.keys()
+				.cloned()
+				.collect::<Vec<_>>()
+		);
 		assert!(network.to_disconnect.contains(&0));
 	}
 
@@ -421,7 +527,11 @@ mod tests {
 		let mut network = TestIo::new(&queue, None);
 		on_demand.on_connect(0, Role::FULL);
 
-		on_demand.remote_call(RemoteCallRequest { block: Default::default(), method: "test".into(), call_data: vec![] });
+		on_demand.remote_call(RemoteCallRequest {
+			block: Default::default(),
+			method: "test".into(),
+			call_data: vec![],
+		});
 		receive_call_response(&*on_demand, &mut network, 0, 1);
 		assert!(network.to_disconnect.contains(&0));
 		assert_eq!(on_demand.core.lock().pending_requests.len(), 1);
@@ -432,7 +542,11 @@ mod tests {
 		let (_x, on_demand) = dummy(false);
 		let queue = RwLock::new(VecDeque::new());
 		let mut network = TestIo::new(&queue, None);
-		on_demand.remote_call(RemoteCallRequest { block: Default::default(), method: "test".into(), call_data: vec![] });
+		on_demand.remote_call(RemoteCallRequest {
+			block: Default::default(),
+			method: "test".into(),
+			call_data: vec![],
+		});
 
 		on_demand.on_connect(0, Role::FULL);
 		receive_call_response(&*on_demand, &mut network, 0, 0);
@@ -458,7 +572,11 @@ mod tests {
 		let mut network = TestIo::new(&queue, None);
 		on_demand.on_connect(0, Role::FULL);
 
-		let response = on_demand.remote_call(RemoteCallRequest { block: Default::default(), method: "test".into(), call_data: vec![] });
+		let response = on_demand.remote_call(RemoteCallRequest {
+			block: Default::default(),
+			method: "test".into(),
+			call_data: vec![],
+		});
 		let thread = ::std::thread::spawn(move || {
 			let result = response.wait().unwrap();
 			assert_eq!(result.return_data, vec![42]);

--- a/substrate/network/src/test/consensus.rs
+++ b/substrate/network/src/test/consensus.rs
@@ -15,8 +15,8 @@
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
 use super::*;
-use message::{Message, generic};
 use futures::Stream;
+use message::{generic, Message};
 use test_client::runtime::Block;
 
 #[test]
@@ -29,17 +29,19 @@ fn bft_messages_include_those_sent_before_asking_for_stream() {
 
 	let peer = net.peer(0);
 	let mut io = TestIo::new(&peer.queue, None);
-	let bft_message = generic::BftMessage::Consensus(generic::SignedConsensusMessage::Vote(generic::SignedConsensusVote {
-		vote: generic::ConsensusVote::AdvanceRound(0),
-		sender: Default::default(),
-		signature: Default::default(),
-	}));
+	let bft_message = generic::BftMessage::Consensus(generic::SignedConsensusMessage::Vote(
+		generic::SignedConsensusVote {
+			vote: generic::ConsensusVote::AdvanceRound(0),
+			sender: Default::default(),
+			signature: Default::default(),
+		},
+	));
 
 	let parent_hash = peer.genesis_hash();
 
 	let localized = ::message::LocalizedBftMessage::<Block> {
 		message: bft_message,
-		parent_hash: parent_hash,
+		parent_hash,
 	};
 
 	let message: Message<Block> = generic::Message::BftMessage(localized.clone());

--- a/substrate/network/src/test/sync.rs
+++ b/substrate/network/src/test/sync.rs
@@ -14,11 +14,11 @@
 // You should have received a copy of the GNU General Public License
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
+use super::*;
 use client::backend::Backend;
 use client::blockchain::HeaderBackend as BlockchainHeaderBackend;
 use sync::SyncState;
-use {Role};
-use super::*;
+use Role;
 
 #[test]
 #[ignore]
@@ -28,7 +28,13 @@ fn sync_from_two_peers_works() {
 	net.peer(1).push_blocks(100, false);
 	net.peer(2).push_blocks(100, false);
 	net.sync();
-	assert!(net.peer(0).client.backend().blockchain().equals_to(net.peer(1).client.backend().blockchain()));
+	assert!(
+		net.peer(0)
+			.client
+			.backend()
+			.blockchain()
+			.equals_to(net.peer(1).client.backend().blockchain())
+	);
 	let status = net.peer(0).sync.status();
 	assert_eq!(status.sync.state, SyncState::Idle);
 }
@@ -43,7 +49,13 @@ fn sync_from_two_peers_with_ancestry_search_works() {
 	net.peer(2).push_blocks(100, false);
 	net.restart_peer(0);
 	net.sync();
-	assert!(net.peer(0).client.backend().blockchain().canon_equals_to(net.peer(1).client.backend().blockchain()));
+	assert!(
+		net.peer(0)
+			.client
+			.backend()
+			.blockchain()
+			.canon_equals_to(net.peer(1).client.backend().blockchain())
+	);
 }
 
 #[test]
@@ -54,7 +66,13 @@ fn sync_long_chain_works() {
 	net.sync_steps(3);
 	assert_eq!(net.peer(0).sync.status().sync.state, SyncState::Downloading);
 	net.sync();
-	assert!(net.peer(0).client.backend().blockchain().equals_to(net.peer(1).client.backend().blockchain()));
+	assert!(
+		net.peer(0)
+			.client
+			.backend()
+			.blockchain()
+			.equals_to(net.peer(1).client.backend().blockchain())
+	);
 }
 
 #[test]
@@ -64,7 +82,13 @@ fn sync_no_common_longer_chain_fails() {
 	net.peer(0).push_blocks(20, true);
 	net.peer(1).push_blocks(20, false);
 	net.sync();
-	assert!(!net.peer(0).client.backend().blockchain().canon_equals_to(net.peer(1).client.backend().blockchain()));
+	assert!(
+		!net.peer(0)
+			.client
+			.backend()
+			.blockchain()
+			.canon_equals_to(net.peer(1).client.backend().blockchain())
+	);
 }
 
 #[test]
@@ -86,9 +110,27 @@ fn sync_after_fork_works() {
 	// peer 1 has the best chain
 	let peer1_chain = net.peer(1).client.backend().blockchain().clone();
 	net.sync();
-	assert!(net.peer(0).client.backend().blockchain().canon_equals_to(&peer1_chain));
-	assert!(net.peer(1).client.backend().blockchain().canon_equals_to(&peer1_chain));
-	assert!(net.peer(2).client.backend().blockchain().canon_equals_to(&peer1_chain));
+	assert!(
+		net.peer(0)
+			.client
+			.backend()
+			.blockchain()
+			.canon_equals_to(&peer1_chain)
+	);
+	assert!(
+		net.peer(1)
+			.client
+			.backend()
+			.blockchain()
+			.canon_equals_to(&peer1_chain)
+	);
+	assert!(
+		net.peer(2)
+			.client
+			.backend()
+			.blockchain()
+			.canon_equals_to(&peer1_chain)
+	);
 }
 
 #[test]
@@ -119,7 +161,34 @@ fn blocks_are_not_announced_by_light_nodes() {
 	// peer 0 has the best chain
 	// peer 1 has the best chain
 	// peer 2 has genesis-chain only
-	assert_eq!(net.peer(0).client.backend().blockchain().info().unwrap().best_number, 1);
-	assert_eq!(net.peer(1).client.backend().blockchain().info().unwrap().best_number, 1);
-	assert_eq!(net.peer(2).client.backend().blockchain().info().unwrap().best_number, 0);
+	assert_eq!(
+		net.peer(0)
+			.client
+			.backend()
+			.blockchain()
+			.info()
+			.unwrap()
+			.best_number,
+		1
+	);
+	assert_eq!(
+		net.peer(1)
+			.client
+			.backend()
+			.blockchain()
+			.info()
+			.unwrap()
+			.best_number,
+		1
+	);
+	assert_eq!(
+		net.peer(2)
+			.client
+			.backend()
+			.blockchain()
+			.info()
+			.unwrap()
+			.best_number,
+		0
+	);
 }

--- a/substrate/primitives/src/authority_id.rs
+++ b/substrate/primitives/src/authority_id.rs
@@ -14,10 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
-
-#[cfg(feature = "std")]
-use serde::{Serialize, Serializer, Deserialize, Deserializer};
 use codec::Slicable;
+#[cfg(feature = "std")]
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use H256;
 
 /// An identifier for an authority in the consensus algorithm. The same size as ed25519::Public.
@@ -92,14 +91,20 @@ impl Into<H256> for AuthorityId {
 
 #[cfg(feature = "std")]
 impl Serialize for AuthorityId {
-	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: Serializer,
+	{
 		::bytes::serialize(&self.0, serializer)
 	}
 }
 
 #[cfg(feature = "std")]
 impl<'de> Deserialize<'de> for AuthorityId {
-	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: Deserializer<'de> {
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+	where
+		D: Deserializer<'de>,
+	{
 		::bytes::deserialize_check_len(deserializer, ::bytes::ExpectedLen::Exact(32))
 			.map(|x| AuthorityId::from_slice(&x))
 	}

--- a/substrate/primitives/src/hash.rs
+++ b/substrate/primitives/src/hash.rs
@@ -17,23 +17,29 @@
 //! A fixed hash type.
 
 #[cfg(feature = "std")]
-use serde::{Serialize, Serializer, Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 #[cfg(feature = "std")]
 use bytes;
 
 macro_rules! impl_rest {
-	($name: ident, $len: expr) => {
+	($name:ident, $len:expr) => {
 		#[cfg(feature = "std")]
 		impl Serialize for $name {
-			fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
+			fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+			where
+				S: Serializer,
+			{
 				bytes::serialize(&self.0, serializer)
 			}
 		}
 
 		#[cfg(feature = "std")]
 		impl<'de> Deserialize<'de> for $name {
-			fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: Deserializer<'de> {
+			fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+			where
+				D: Deserializer<'de>,
+			{
 				bytes::deserialize_check_len(deserializer, bytes::ExpectedLen::Exact($len))
 					.map(|x| (&*x).into())
 			}
@@ -48,7 +54,7 @@ macro_rules! impl_rest {
 				self.0.using_encoded(f)
 			}
 		}
-	}
+	};
 }
 
 construct_hash!(H160, 20);
@@ -66,13 +72,25 @@ mod tests {
 	#[test]
 	fn test_h160() {
 		let tests = vec![
-			(Default::default(), "0x0000000000000000000000000000000000000000"),
+			(
+				Default::default(),
+				"0x0000000000000000000000000000000000000000",
+			),
 			(H160::from(2), "0x0000000000000000000000000000000000000002"),
 			(H160::from(15), "0x000000000000000000000000000000000000000f"),
 			(H160::from(16), "0x0000000000000000000000000000000000000010"),
-			(H160::from(1_000), "0x00000000000000000000000000000000000003e8"),
-			(H160::from(100_000), "0x00000000000000000000000000000000000186a0"),
-			(H160::from(u64::max_value()), "0x000000000000000000000000ffffffffffffffff"),
+			(
+				H160::from(1_000),
+				"0x00000000000000000000000000000000000003e8",
+			),
+			(
+				H160::from(100_000),
+				"0x00000000000000000000000000000000000186a0",
+			),
+			(
+				H160::from(u64::max_value()),
+				"0x000000000000000000000000ffffffffffffffff",
+			),
 		];
 
 		for (number, expected) in tests {
@@ -84,13 +102,34 @@ mod tests {
 	#[test]
 	fn test_h256() {
 		let tests = vec![
-			(Default::default(), "0x0000000000000000000000000000000000000000000000000000000000000000"),
-			(H256::from(2), "0x0000000000000000000000000000000000000000000000000000000000000002"),
-			(H256::from(15), "0x000000000000000000000000000000000000000000000000000000000000000f"),
-			(H256::from(16), "0x0000000000000000000000000000000000000000000000000000000000000010"),
-			(H256::from(1_000), "0x00000000000000000000000000000000000000000000000000000000000003e8"),
-			(H256::from(100_000), "0x00000000000000000000000000000000000000000000000000000000000186a0"),
-			(H256::from(u64::max_value()), "0x000000000000000000000000000000000000000000000000ffffffffffffffff"),
+			(
+				Default::default(),
+				"0x0000000000000000000000000000000000000000000000000000000000000000",
+			),
+			(
+				H256::from(2),
+				"0x0000000000000000000000000000000000000000000000000000000000000002",
+			),
+			(
+				H256::from(15),
+				"0x000000000000000000000000000000000000000000000000000000000000000f",
+			),
+			(
+				H256::from(16),
+				"0x0000000000000000000000000000000000000000000000000000000000000010",
+			),
+			(
+				H256::from(1_000),
+				"0x00000000000000000000000000000000000000000000000000000000000003e8",
+			),
+			(
+				H256::from(100_000),
+				"0x00000000000000000000000000000000000000000000000000000000000186a0",
+			),
+			(
+				H256::from(u64::max_value()),
+				"0x000000000000000000000000000000000000000000000000ffffffffffffffff",
+			),
 		];
 
 		for (number, expected) in tests {
@@ -101,9 +140,24 @@ mod tests {
 
 	#[test]
 	fn test_invalid() {
-		assert!(ser::from_str::<H256>("\"0x000000000000000000000000000000000000000000000000000000000000000\"").unwrap_err().is_data());
-		assert!(ser::from_str::<H256>("\"0x000000000000000000000000000000000000000000000000000000000000000g\"").unwrap_err().is_data());
-		assert!(ser::from_str::<H256>("\"0x00000000000000000000000000000000000000000000000000000000000000000\"").unwrap_err().is_data());
+		assert!(
+			ser::from_str::<H256>(
+				"\"0x000000000000000000000000000000000000000000000000000000000000000\""
+			).unwrap_err()
+				.is_data()
+		);
+		assert!(
+			ser::from_str::<H256>(
+				"\"0x000000000000000000000000000000000000000000000000000000000000000g\""
+			).unwrap_err()
+				.is_data()
+		);
+		assert!(
+			ser::from_str::<H256>(
+				"\"0x00000000000000000000000000000000000000000000000000000000000000000\""
+			).unwrap_err()
+				.is_data()
+		);
 		assert!(ser::from_str::<H256>("\"\"").unwrap_err().is_data());
 		assert!(ser::from_str::<H256>("\"0\"").unwrap_err().is_data());
 		assert!(ser::from_str::<H256>("\"10\"").unwrap_err().is_data());

--- a/substrate/primitives/src/hashing.rs
+++ b/substrate/primitives/src/hashing.rs
@@ -57,7 +57,7 @@ pub fn blake2_128(data: &[u8]) -> [u8; 16] {
 
 /// Do a XX 128-bit hash and place result in `dest`.
 pub fn twox_128_into(data: &[u8], dest: &mut [u8; 16]) {
-	use ::core::hash::Hasher;
+	use core::hash::Hasher;
 	let mut h0 = twox_hash::XxHash::with_seed(0);
 	let mut h1 = twox_hash::XxHash::with_seed(1);
 	h0.write(data);
@@ -78,8 +78,8 @@ pub fn twox_128(data: &[u8]) -> [u8; 16] {
 
 /// Do a XX 256-bit hash and place result in `dest`.
 pub fn twox_256_into(data: &[u8], dest: &mut [u8; 32]) {
-	use ::core::hash::Hasher;
 	use byteorder::{ByteOrder, LittleEndian};
+	use core::hash::Hasher;
 	let mut h0 = twox_hash::XxHash::with_seed(0);
 	let mut h1 = twox_hash::XxHash::with_seed(1);
 	let mut h2 = twox_hash::XxHash::with_seed(2);

--- a/substrate/primitives/src/hexdisplay.rs
+++ b/substrate/primitives/src/hexdisplay.rs
@@ -21,13 +21,15 @@ pub struct HexDisplay<'a>(&'a [u8]);
 
 impl<'a> HexDisplay<'a> {
 	/// Create new instance that will display `d` as a hex string when displayed.
-	pub fn from(d: &'a AsBytesRef) -> Self { HexDisplay(d.as_bytes_ref()) }
+	pub fn from(d: &'a AsBytesRef) -> Self {
+		HexDisplay(d.as_bytes_ref())
+	}
 }
 
 impl<'a> ::core::fmt::Display for HexDisplay<'a> {
 	fn fmt(&self, fmtr: &mut ::core::fmt::Formatter) -> Result<(), ::core::fmt::Error> {
 		for byte in self.0 {
-			try!( fmtr.write_fmt(format_args!("{:02x}", byte)));
+			fmtr.write_fmt(format_args!("{:02x}", byte))?;
 		}
 		Ok(())
 	}
@@ -40,15 +42,21 @@ pub trait AsBytesRef {
 }
 
 impl<'a> AsBytesRef for &'a [u8] {
-	fn as_bytes_ref(&self) -> &[u8] { self }
+	fn as_bytes_ref(&self) -> &[u8] {
+		self
+	}
 }
 
 impl AsBytesRef for [u8] {
-	fn as_bytes_ref(&self) -> &[u8] { &self }
+	fn as_bytes_ref(&self) -> &[u8] {
+		&self
+	}
 }
 
 impl AsBytesRef for ::bytes::Vec<u8> {
-	fn as_bytes_ref(&self) -> &[u8] { &self }
+	fn as_bytes_ref(&self) -> &[u8] {
+		&self
+	}
 }
 
 macro_rules! impl_non_endians {
@@ -59,6 +67,8 @@ macro_rules! impl_non_endians {
 	)* }
 }
 
-impl_non_endians!([u8; 1], [u8; 2], [u8; 3], [u8; 4], [u8; 5], [u8; 6], [u8; 7], [u8; 8],
-	[u8; 10], [u8; 12], [u8; 14], [u8; 16], [u8; 20], [u8; 24], [u8; 28], [u8; 32], [u8; 40],
-	[u8; 48], [u8; 56], [u8; 64], [u8; 80], [u8; 96], [u8; 112], [u8; 128]);
+impl_non_endians!(
+	[u8; 1], [u8; 2], [u8; 3], [u8; 4], [u8; 5], [u8; 6], [u8; 7], [u8; 8], [u8; 10], [u8; 12],
+	[u8; 14], [u8; 16], [u8; 20], [u8; 24], [u8; 28], [u8; 32], [u8; 40], [u8; 48], [u8; 56],
+	[u8; 64], [u8; 80], [u8; 96], [u8; 112], [u8; 128]
+);

--- a/substrate/primitives/src/lib.rs
+++ b/substrate/primitives/src/lib.rs
@@ -17,12 +17,11 @@
 //! Shareable Polkadot types.
 
 #![warn(missing_docs)]
-
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(not(feature = "std"), feature(alloc))]
 
-extern crate rustc_hex;
 extern crate byteorder;
+extern crate rustc_hex;
 #[macro_use]
 extern crate crunchy;
 #[macro_use]
@@ -32,11 +31,11 @@ extern crate uint as uint_crate;
 extern crate substrate_codec as codec;
 
 #[cfg(feature = "std")]
+extern crate blake2_rfc;
+#[cfg(feature = "std")]
 extern crate serde;
 #[cfg(feature = "std")]
 extern crate twox_hash;
-#[cfg(feature = "std")]
-extern crate blake2_rfc;
 #[cfg(feature = "std")]
 #[macro_use]
 extern crate serde_derive;
@@ -61,8 +60,8 @@ macro_rules! map {
 	)
 }
 
-use rstd::prelude::*;
 use rstd::ops::Deref;
+use rstd::prelude::*;
 
 #[cfg(feature = "std")]
 pub mod bytes;
@@ -92,13 +91,17 @@ pub type Signature = hash::H512;
 /// Hex-serialised shim for `Vec<u8>`.
 #[derive(PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize, Debug, Hash, PartialOrd, Ord))]
-pub struct Bytes(#[cfg_attr(feature = "std", serde(with="bytes"))] pub Vec<u8>);
+pub struct Bytes(#[cfg_attr(feature = "std", serde(with = "bytes"))] pub Vec<u8>);
 
 impl From<Vec<u8>> for Bytes {
-	fn from(s: Vec<u8>) -> Self { Bytes(s) }
+	fn from(s: Vec<u8>) -> Self {
+		Bytes(s)
+	}
 }
 
 impl Deref for Bytes {
 	type Target = [u8];
-	fn deref(&self) -> &[u8] { &self.0[..] }
+	fn deref(&self) -> &[u8] {
+		&self.0[..]
+	}
 }

--- a/substrate/primitives/src/sandbox.rs
+++ b/substrate/primitives/src/sandbox.rs
@@ -16,7 +16,7 @@
 
 //! Definition of a sandbox environment.
 
-use codec::{Slicable, Input};
+use codec::{Input, Slicable};
 use rstd::vec::Vec;
 
 /// Error error that can be returned from host function.
@@ -77,7 +77,7 @@ impl TypedValue {
 #[cfg(feature = "std")]
 impl From<::wasmi::RuntimeValue> for TypedValue {
 	fn from(val: ::wasmi::RuntimeValue) -> TypedValue {
-		use ::wasmi::RuntimeValue;
+		use wasmi::RuntimeValue;
 		match val {
 			RuntimeValue::I32(v) => TypedValue::I32(v),
 			RuntimeValue::I64(v) => TypedValue::I64(v),
@@ -90,8 +90,8 @@ impl From<::wasmi::RuntimeValue> for TypedValue {
 #[cfg(feature = "std")]
 impl From<TypedValue> for ::wasmi::RuntimeValue {
 	fn from(val: TypedValue) -> ::wasmi::RuntimeValue {
-		use ::wasmi::RuntimeValue;
-		use ::wasmi::nan_preserving_float::{F32, F64};
+		use wasmi::nan_preserving_float::{F32, F64};
+		use wasmi::RuntimeValue;
 		match val {
 			TypedValue::I32(v) => RuntimeValue::I32(v),
 			TypedValue::I64(v) => RuntimeValue::I64(v),
@@ -108,19 +108,19 @@ impl Slicable for TypedValue {
 			TypedValue::I32(i) => {
 				v.push(ValueType::I32 as u8);
 				i.using_encoded(|s| v.extend(s));
-			}
+			},
 			TypedValue::I64(i) => {
 				v.push(ValueType::I64 as u8);
 				i.using_encoded(|s| v.extend(s));
-			}
+			},
 			TypedValue::F32(f_bits) => {
 				v.push(ValueType::F32 as u8);
 				f_bits.using_encoded(|s| v.extend(s));
-			}
+			},
 			TypedValue::F64(f_bits) => {
 				v.push(ValueType::F64 as u8);
 				f_bits.using_encoded(|s| v.extend(s));
-			}
+			},
 		}
 
 		v
@@ -163,11 +163,11 @@ impl Slicable for ReturnValue {
 		match *self {
 			ReturnValue::Unit => {
 				v.push(0);
-			}
+			},
 			ReturnValue::Value(ref val) => {
 				v.push(1);
 				val.using_encoded(|s| v.extend(s));
-			}
+			},
 		}
 		v
 	}
@@ -226,11 +226,11 @@ impl Slicable for ExternEntity {
 			ExternEntity::Function(ref index) => {
 				v.push(ExternEntityKind::Function as u8);
 				index.using_encoded(|s| v.extend(s));
-			}
+			},
 			ExternEntity::Memory(ref mem_id) => {
 				v.push(ExternEntityKind::Memory as u8);
 				mem_id.using_encoded(|s| v.extend(s));
-			}
+			},
 		}
 
 		v
@@ -241,11 +241,11 @@ impl Slicable for ExternEntity {
 			Some(x) if x == ExternEntityKind::Function as i8 => {
 				let idx = u32::decode(value)?;
 				Some(ExternEntity::Function(idx))
-			}
+			},
 			Some(x) if x == ExternEntityKind::Memory as i8 => {
 				let mem_id = u32::decode(value)?;
 				Some(ExternEntity::Memory(mem_id))
-			}
+			},
 			_ => None,
 		}
 	}
@@ -305,9 +305,7 @@ impl Slicable for EnvironmentDefinition {
 	fn decode<I: Input>(value: &mut I) -> Option<Self> {
 		let entries = Vec::decode(value)?;
 
-		Some(EnvironmentDefinition {
-			entries,
-		})
+		Some(EnvironmentDefinition { entries })
 	}
 }
 
@@ -348,28 +346,22 @@ mod tests {
 
 	#[test]
 	fn env_def_roundtrip() {
+		roundtrip(EnvironmentDefinition { entries: vec![] });
+
 		roundtrip(EnvironmentDefinition {
-			entries: vec![],
+			entries: vec![Entry {
+				module_name: b"kernel"[..].into(),
+				field_name: b"memory"[..].into(),
+				entity: ExternEntity::Memory(1337),
+			}],
 		});
 
 		roundtrip(EnvironmentDefinition {
-			entries: vec![
-				Entry {
-					module_name: b"kernel"[..].into(),
-					field_name: b"memory"[..].into(),
-					entity: ExternEntity::Memory(1337),
-				},
-			],
-		});
-
-		roundtrip(EnvironmentDefinition {
-			entries: vec![
-				Entry {
-					module_name: b"env"[..].into(),
-					field_name: b"abort"[..].into(),
-					entity: ExternEntity::Function(228),
-				},
-			],
+			entries: vec![Entry {
+				module_name: b"env"[..].into(),
+				field_name: b"abort"[..].into(),
+				entity: ExternEntity::Function(228),
+			}],
 		});
 	}
 }

--- a/substrate/primitives/src/storage.rs
+++ b/substrate/primitives/src/storage.rs
@@ -23,9 +23,9 @@ use rstd::vec::Vec;
 /// Contract storage key.
 #[derive(PartialEq, Eq)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize, Debug, Hash, PartialOrd, Ord))]
-pub struct StorageKey(#[cfg_attr(feature = "std", serde(with="bytes"))] pub Vec<u8>);
+pub struct StorageKey(#[cfg_attr(feature = "std", serde(with = "bytes"))] pub Vec<u8>);
 
 /// Contract storage entry data.
 #[derive(PartialEq, Eq)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize, Debug, Hash, PartialOrd, Ord))]
-pub struct StorageData(#[cfg_attr(feature = "std", serde(with="bytes"))] pub Vec<u8>);
+pub struct StorageData(#[cfg_attr(feature = "std", serde(with = "bytes"))] pub Vec<u8>);

--- a/substrate/rpc-servers/src/lib.rs
+++ b/substrate/rpc-servers/src/lib.rs
@@ -17,7 +17,6 @@
 //! Substrate RPC servers.
 
 #[warn(missing_docs)]
-
 pub extern crate substrate_rpc as apis;
 
 extern crate jsonrpc_core as rpc;
@@ -41,10 +40,11 @@ pub fn rpc_handler<Block: BlockT, S, C, A, Y>(
 	chain: C,
 	author: A,
 	system: Y,
-) -> RpcHandler where
+) -> RpcHandler
+where
 	Block: 'static,
 	S: apis::state::StateApi<Block::Hash>,
-	C: apis::chain::ChainApi<Block::Hash, Block::Header, Metadata=Metadata>,
+	C: apis::chain::ChainApi<Block::Hash, Block::Header, Metadata = Metadata>,
 	A: apis::author::AuthorApi<Block::Hash, Block::Extrinsic>,
 	Y: apis::system::SystemApi,
 {
@@ -57,10 +57,7 @@ pub fn rpc_handler<Block: BlockT, S, C, A, Y>(
 }
 
 /// Start HTTP server listening on given address.
-pub fn start_http(
-	addr: &std::net::SocketAddr,
-	io: RpcHandler,
-) -> io::Result<http::Server> {
+pub fn start_http(addr: &std::net::SocketAddr, io: RpcHandler) -> io::Result<http::Server> {
 	http::ServerBuilder::new(io)
 		.threads(4)
 		.rest_api(http::RestApi::Unsecure)
@@ -69,18 +66,16 @@ pub fn start_http(
 }
 
 /// Start WS server listening on given address.
-pub fn start_ws(
-	addr: &std::net::SocketAddr,
-	io: RpcHandler,
-) -> io::Result<ws::Server> {
-	ws::ServerBuilder::with_meta_extractor(io, |context: &ws::RequestContext| Metadata::new(context.sender()))
-		.start(addr)
+pub fn start_ws(addr: &std::net::SocketAddr, io: RpcHandler) -> io::Result<ws::Server> {
+	ws::ServerBuilder::with_meta_extractor(io, |context: &ws::RequestContext| {
+		Metadata::new(context.sender())
+	}).start(addr)
 		.map_err(|err| match err {
 			ws::Error(ws::ErrorKind::Io(io), _) => io,
 			ws::Error(ws::ErrorKind::ConnectionClosed, _) => io::ErrorKind::BrokenPipe.into(),
 			ws::Error(e, _) => {
 				error!("{}", e);
 				io::ErrorKind::Other.into()
-			}
+			},
 		})
 }

--- a/substrate/rpc/src/author/tests.rs
+++ b/substrate/rpc/src/author/tests.rs
@@ -16,10 +16,10 @@
 
 use super::*;
 
-use std::{fmt, sync::Arc};
 use extrinsic_pool::api;
-use test_client;
 use parking_lot::Mutex;
+use std::{fmt, sync::Arc};
+use test_client;
 
 type Extrinsic = u64;
 type Hash = u64;
@@ -33,7 +33,9 @@ struct DummyTxPool {
 struct Error;
 impl api::Error for Error {}
 impl ::std::error::Error for Error {
-	fn description(&self) -> &str { "Error" }
+	fn description(&self) -> &str {
+		"Error"
+	}
 }
 impl fmt::Display for Error {
 	fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
@@ -45,7 +47,11 @@ impl<BlockHash> api::ExtrinsicPool<Extrinsic, BlockHash, u64> for DummyTxPool {
 	type Error = Error;
 
 	/// Submit extrinsic for inclusion in block.
-	fn submit(&self, _block: BlockHash, xt: Vec<Extrinsic>) -> ::std::result::Result<Vec<Hash>, Self::Error> {
+	fn submit(
+		&self,
+		_block: BlockHash,
+		xt: Vec<Extrinsic>,
+	) -> ::std::result::Result<Vec<Hash>, Self::Error> {
 		let mut submitted = self.submitted.lock();
 		if submitted.len() < 1 {
 			let hashes = xt.iter().map(|_xt| 1).collect();
@@ -68,9 +74,7 @@ fn submit_transaction_should_not_cause_error() {
 		AuthorApi::submit_extrinsic(&p, u64::encode(&5).into()),
 		Ok(1)
 	);
-	assert!(
-		AuthorApi::submit_extrinsic(&p, u64::encode(&5).into()).is_err()
-	);
+	assert!(AuthorApi::submit_extrinsic(&p, u64::encode(&5).into()).is_err());
 }
 
 #[test]
@@ -80,11 +84,6 @@ fn submit_rich_transaction_should_not_cause_error() {
 		pool: Arc::new(DummyTxPool::default()),
 	};
 
-	assert_matches!(
-		AuthorApi::submit_rich_extrinsic(&p, 5),
-		Ok(1)
-	);
-	assert!(
-		AuthorApi::submit_rich_extrinsic(&p, 5).is_err()
-	);
+	assert_matches!(AuthorApi::submit_rich_extrinsic(&p, 5), Ok(1));
+	assert!(AuthorApi::submit_rich_extrinsic(&p, 5).is_err());
 }

--- a/substrate/rpc/src/chain/tests.rs
+++ b/substrate/rpc/src/chain/tests.rs
@@ -15,10 +15,10 @@
 // along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
 use super::*;
-use jsonrpc_macros::pubsub;
 use client::BlockOrigin;
-use test_client::{self, TestClient};
+use jsonrpc_macros::pubsub;
 use test_client::runtime::Header;
+use test_client::{self, TestClient};
 
 #[test]
 fn should_return_header() {
@@ -40,10 +40,7 @@ fn should_return_header() {
 		}
 	);
 
-	assert_matches!(
-		client.header(5.into()),
-		Ok(None)
-	);
+	assert_matches!(client.header(5.into()), Ok(None));
 }
 
 #[test]
@@ -64,7 +61,9 @@ fn should_notify_about_latest_block() {
 		assert_eq!(core.run(id), Ok(Ok(SubscriptionId::Number(0))));
 
 		let builder = api.client.new_block().unwrap();
-		api.client.justify_and_import(BlockOrigin::Own, builder.bake().unwrap()).unwrap();
+		api.client
+			.justify_and_import(BlockOrigin::Own, builder.bake().unwrap())
+			.unwrap();
 	}
 
 	// assert notification send to transport

--- a/substrate/rpc/src/lib.rs
+++ b/substrate/rpc/src/lib.rs
@@ -21,8 +21,8 @@
 extern crate jsonrpc_core as rpc;
 extern crate jsonrpc_pubsub;
 extern crate parking_lot;
-extern crate substrate_codec as codec;
 extern crate substrate_client as client;
+extern crate substrate_codec as codec;
 extern crate substrate_extrinsic_pool as extrinsic_pool;
 extern crate substrate_primitives as primitives;
 extern crate substrate_runtime_primitives as runtime_primitives;

--- a/substrate/rpc/src/metadata.rs
+++ b/substrate/rpc/src/metadata.rs
@@ -17,7 +17,7 @@
 //! RPC Metadata
 use std::sync::Arc;
 
-use jsonrpc_pubsub::{Session, PubSubMetadata};
+use jsonrpc_pubsub::{PubSubMetadata, Session};
 
 /// RPC Metadata.
 ///

--- a/substrate/rpc/src/state/tests.rs
+++ b/substrate/rpc/src/state/tests.rs
@@ -14,8 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
-use super::*;
 use self::error::{Error, ErrorKind};
+use super::*;
 use test_client::{self, TestClient};
 
 #[test]
@@ -35,7 +35,7 @@ fn should_call_contract() {
 	let genesis_hash = client.genesis_hash();
 
 	assert_matches!(
-		StateApi::call_at(&client, "balanceOf".into(), vec![1,2,3], genesis_hash),
+		StateApi::call_at(&client, "balanceOf".into(), vec![1, 2, 3], genesis_hash),
 		Err(Error(ErrorKind::Client(client::error::ErrorKind::Execution(_)), _))
 	)
 }

--- a/substrate/rpc/src/subscriptions.rs
+++ b/substrate/rpc/src/subscriptions.rs
@@ -21,7 +21,7 @@ use jsonrpc_macros::pubsub;
 use jsonrpc_pubsub::SubscriptionId;
 use parking_lot::Mutex;
 use rpc::futures::sync::oneshot;
-use rpc::futures::{Future, future};
+use rpc::futures::{future, Future};
 use tokio_core::reactor::Remote;
 
 type Id = u64;
@@ -52,10 +52,11 @@ impl Subscriptions {
 	/// Second parameter is a function that converts Subscriber sink into a future.
 	/// This future will be driven to completion bu underlying event loop
 	/// or will be cancelled in case #cancel is invoked.
-	pub fn add<T, E, G, R, F>(&self, subscriber: pubsub::Subscriber<T, E>, into_future: G) where
+	pub fn add<T, E, G, R, F>(&self, subscriber: pubsub::Subscriber<T, E>, into_future: G)
+	where
 		G: FnOnce(pubsub::Sink<T, E>) -> R,
-		R: future::IntoFuture<Future=F, Item=(), Error=()>,
-		F: future::Future<Item=(), Error=()> + Send + 'static,
+		R: future::IntoFuture<Future = F, Item = (), Error = ()>,
+		F: future::Future<Item = (), Error = ()> + Send + 'static,
 	{
 		let id = self.next_id.fetch_add(1, atomic::Ordering::AcqRel) as u64;
 		if let Ok(sink) = subscriber.assign_id(id.into()) {
@@ -78,7 +79,7 @@ impl Subscriptions {
 		if let SubscriptionId::Number(id) = id {
 			if let Some(tx) = self.active_subscriptions.lock().remove(&id) {
 				let _ = tx.send(());
-				return true;
+				return true
 			}
 		}
 		false

--- a/substrate/rpc/src/system/tests.rs
+++ b/substrate/rpc/src/system/tests.rs
@@ -14,8 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
-use super::*;
 use super::error::*;
+use super::*;
 
 impl SystemApi for () {
 	fn system_name(&self) -> Result<String> {
@@ -39,10 +39,7 @@ fn system_name_works() {
 
 #[test]
 fn system_version_works() {
-	assert_eq!(
-		SystemApi::system_version(&()).unwrap(),
-		"0.2.0".to_owned()
-	);
+	assert_eq!(SystemApi::system_version(&()).unwrap(), "0.2.0".to_owned());
 }
 
 #[test]

--- a/substrate/runtime-io/build.rs
+++ b/substrate/runtime-io/build.rs
@@ -4,11 +4,11 @@ extern crate rustc_version;
 use rustc_version::{version, version_meta, Channel};
 
 fn main() {
-    // Assert we haven't travelled back in time
-    assert!(version().unwrap().major >= 1);
+	// Assert we haven't travelled back in time
+	assert!(version().unwrap().major >= 1);
 
-    // Set cfg flags depending on release channel
-    if let Channel::Nightly = version_meta().unwrap().channel {
-        println!("cargo:rustc-cfg=feature=\"nightly\"");
-    }
+	// Set cfg flags depending on release channel
+	if let Channel::Nightly = version_meta().unwrap().channel {
+		println!("cargo:rustc-cfg=feature=\"nightly\"");
+	}
 }

--- a/substrate/runtime-io/src/lib.rs
+++ b/substrate/runtime-io/src/lib.rs
@@ -21,9 +21,14 @@
 #![cfg_attr(not(feature = "std"), feature(panic_implementation))]
 #![cfg_attr(not(feature = "std"), feature(core_intrinsics))]
 #![cfg_attr(not(feature = "std"), feature(alloc))]
-
-#![cfg_attr(feature = "std", doc = "Substrate runtime standard library as compiled when linked with Rust's standard library.")]
-#![cfg_attr(not(feature = "std"), doc = "Substrate's runtime standard library as compiled without Rust's standard library.")]
+#![cfg_attr(
+	feature = "std",
+	doc = "Substrate runtime standard library as compiled when linked with Rust's standard library."
+)]
+#![cfg_attr(
+	not(feature = "std"),
+	doc = "Substrate's runtime standard library as compiled without Rust's standard library."
+)]
 
 #[cfg(feature = "std")]
 include!("../with_std.rs");

--- a/substrate/runtime-sandbox/build.rs
+++ b/substrate/runtime-sandbox/build.rs
@@ -4,11 +4,11 @@ extern crate rustc_version;
 use rustc_version::{version, version_meta, Channel};
 
 fn main() {
-    // Assert we haven't travelled back in time
-    assert!(version().unwrap().major >= 1);
+	// Assert we haven't travelled back in time
+	assert!(version().unwrap().major >= 1);
 
-    // Set cfg flags depending on release channel
-    if let Channel::Nightly = version_meta().unwrap().channel {
-        println!("cargo:rustc-cfg=feature=\"nightly\"");
-    }
+	// Set cfg flags depending on release channel
+	if let Channel::Nightly = version_meta().unwrap().channel {
+		println!("cargo:rustc-cfg=feature=\"nightly\"");
+	}
 }

--- a/substrate/runtime-sandbox/src/lib.rs
+++ b/substrate/runtime-sandbox/src/lib.rs
@@ -39,17 +39,17 @@
 #![cfg_attr(not(feature = "std"), feature(alloc))]
 
 extern crate substrate_codec as codec;
+extern crate substrate_primitives as primitives;
 extern crate substrate_runtime_io as runtime_io;
 #[cfg_attr(not(feature = "std"), macro_use)]
 extern crate substrate_runtime_std as rstd;
-extern crate substrate_primitives as primitives;
 
 #[cfg(test)]
 extern crate wabt;
 
 use rstd::prelude::*;
 
-pub use primitives::sandbox::{TypedValue, ReturnValue, HostError};
+pub use primitives::sandbox::{HostError, ReturnValue, TypedValue};
 
 mod imp {
 	#[cfg(feature = "std")]
@@ -172,14 +172,17 @@ impl<T> EnvironmentDefinitionBuilder<T> {
 /// This instance can be used for invoking exported functions.
 pub struct Instance<T> {
 	inner: imp::Instance<T>,
-
 }
 
 impl<T> Instance<T> {
 	/// Instantiate a module with the given [`EnvironmentDefinitionBuilder`].
 	///
 	/// [`EnvironmentDefinitionBuilder`]: struct.EnvironmentDefinitionBuilder.html
-	pub fn new(code: &[u8], env_def_builder: &EnvironmentDefinitionBuilder<T>, state: &mut T) -> Result<Instance<T>, Error> {
+	pub fn new(
+		code: &[u8],
+		env_def_builder: &EnvironmentDefinitionBuilder<T>,
+		state: &mut T,
+	) -> Result<Instance<T>, Error> {
 		Ok(Instance {
 			inner: imp::Instance::new(code, &env_def_builder.inner, state)?,
 		})

--- a/substrate/runtime-std/src/lib.rs
+++ b/substrate/runtime-std/src/lib.rs
@@ -22,9 +22,14 @@
 #![cfg_attr(not(feature = "std"), feature(core_intrinsics))]
 #![cfg_attr(not(feature = "std"), feature(alloc))]
 #![cfg_attr(not(feature = "std"), feature(use_extern_macros))]
-
-#![cfg_attr(feature = "std", doc = "Polkadot runtime standard library as compiled when linked with Rust's standard library.")]
-#![cfg_attr(not(feature = "std"), doc = "Polkadot's runtime standard library as compiled without Rust's standard library.")]
+#![cfg_attr(
+	feature = "std",
+	doc = "Polkadot runtime standard library as compiled when linked with Rust's standard library."
+)]
+#![cfg_attr(
+	not(feature = "std"),
+	doc = "Polkadot's runtime standard library as compiled without Rust's standard library."
+)]
 
 #[macro_export]
 macro_rules! map {
@@ -43,8 +48,8 @@ include!("../without_std.rs");
 ///
 /// This should include only things which are in the normal std prelude.
 pub mod prelude {
-	pub use ::vec::Vec;
-	pub use ::boxed::Box;
-	pub use ::cmp::{Eq, PartialEq};
-	pub use ::clone::Clone;
+	pub use boxed::Box;
+	pub use clone::Clone;
+	pub use cmp::{Eq, PartialEq};
+	pub use vec::Vec;
 }

--- a/substrate/runtime-support/src/dispatch.rs
+++ b/substrate/runtime-support/src/dispatch.rs
@@ -16,13 +16,13 @@
 
 //! Dispatch system. Just dispatches calls.
 
-pub use rstd::prelude::{Vec, Clone, Eq, PartialEq};
-#[cfg(feature = "std")]
-pub use std::fmt;
+pub use codec::{Input, Slicable};
+pub use rstd::prelude::{Clone, Eq, PartialEq, Vec};
 pub use rstd::result;
 #[cfg(feature = "std")]
 use serde;
-pub use codec::{Slicable, Input};
+#[cfg(feature = "std")]
+pub use std::fmt;
 
 pub type Result = result::Result<(), &'static str>;
 

--- a/substrate/runtime-support/src/lib.rs
+++ b/substrate/runtime-support/src/lib.rs
@@ -21,9 +21,9 @@
 #[cfg(feature = "std")]
 extern crate serde;
 
-extern crate substrate_runtime_std as rstd;
-extern crate substrate_runtime_io as runtime_io;
 extern crate substrate_primitives as primitives;
+extern crate substrate_runtime_io as runtime_io;
+extern crate substrate_runtime_std as rstd;
 
 #[doc(hidden)]
 pub extern crate substrate_codec as codec;
@@ -33,53 +33,54 @@ pub mod dispatch;
 pub mod storage;
 mod hashable;
 
-pub use self::storage::{StorageVec, StorageList, StorageValue, StorageMap};
+pub use self::dispatch::{
+	AuxCallable, AuxDispatchable, Callable, Dispatchable, IsAuxSubType, IsSubType, Parameter,
+};
 pub use self::hashable::Hashable;
-pub use self::dispatch::{Parameter, Dispatchable, Callable, AuxDispatchable, AuxCallable, IsSubType, IsAuxSubType};
+pub use self::storage::{StorageList, StorageMap, StorageValue, StorageVec};
 pub use runtime_io::print;
-
 
 #[macro_export]
 macro_rules! fail {
-	( $y:expr ) => {{
-		return Err($y);
-	}}
+	($y:expr) => {{
+		return Err($y)
+		}};
 }
 
 #[macro_export]
 macro_rules! ensure {
-	( $x:expr, $y:expr ) => {{
+	($x:expr, $y:expr) => {{
 		if !$x {
 			fail!($y);
-		}
-	}}
+			}
+		}};
 }
 
 #[macro_export]
 #[cfg(feature = "std")]
 macro_rules! assert_noop {
-	( $x:expr , $y:expr ) => {
+	($x:expr, $y:expr) => {
 		let h = runtime_io::storage_root();
 		assert_err!($x, $y);
 		assert_eq!(h, runtime_io::storage_root());
-	}
+	};
 }
 
 #[macro_export]
 #[cfg(feature = "std")]
 macro_rules! assert_err {
-	( $x:expr , $y:expr ) => {
+	($x:expr, $y:expr) => {
 		assert_eq!($x, Err($y));
-	}
+	};
 }
 
 #[macro_export]
 #[cfg(feature = "std")]
 macro_rules! assert_ok {
-	( $x:expr ) => {
+	($x:expr) => {
 		assert_eq!($x, Ok(()));
 	};
-	( $x:expr, $y:expr ) => {
+	($x:expr, $y:expr) => {
 		assert_eq!($x, Ok($y));
-	}
+	};
 }

--- a/substrate/runtime/democracy/src/vote_threshold.rs
+++ b/substrate/runtime/democracy/src/vote_threshold.rs
@@ -16,9 +16,9 @@
 
 //! Voting thresholds.
 
-use primitives::traits::{Zero, IntegerSquareRoot};
 use codec::{Input, Slicable};
-use rstd::ops::{Add, Mul, Div, Rem};
+use primitives::traits::{IntegerSquareRoot, Zero};
+use rstd::ops::{Add, Div, Mul, Rem};
 
 /// A means of determining if a vote is past pass threshold.
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -59,25 +59,32 @@ pub trait Approved<Balance> {
 }
 
 /// Return `true` iff `n1 / d1 < n2 / d2`. `d1` and `d2` may not be zero.
-fn compare_rationals<T: Zero + Mul<T, Output = T> + Div<T, Output = T> + Rem<T, Output = T> + Ord + Copy>(mut n1: T, mut d1: T, mut n2: T, mut d2: T) -> bool {
+fn compare_rationals<
+	T: Zero + Mul<T, Output = T> + Div<T, Output = T> + Rem<T, Output = T> + Ord + Copy,
+>(
+	mut n1: T,
+	mut d1: T,
+	mut n2: T,
+	mut d2: T,
+) -> bool {
 	// Uses a continued fractional representation for a non-overflowing compare.
 	// Detailed at https://janmr.com/blog/2014/05/comparing-rational-numbers-without-overflow/.
 	loop {
 		let q1 = n1 / d1;
 		let q2 = n2 / d2;
 		if q1 < q2 {
-			return true;
+			return true
 		}
 		if q2 < q1 {
-			return false;
+			return false
 		}
 		let r1 = n1 % d1;
 		let r2 = n2 % d2;
 		if r2.is_zero() {
-			return false;
+			return false
 		}
 		if r1.is_zero() {
-			return true;
+			return true
 		}
 		n1 = d2;
 		n2 = d1;
@@ -86,7 +93,17 @@ fn compare_rationals<T: Zero + Mul<T, Output = T> + Div<T, Output = T> + Rem<T, 
 	}
 }
 
-impl<Balance: IntegerSquareRoot + Zero + Ord + Add<Balance, Output = Balance> + Mul<Balance, Output = Balance> + Div<Balance, Output = Balance> + Rem<Balance, Output = Balance> + Copy> Approved<Balance> for VoteThreshold {
+impl<
+		Balance: IntegerSquareRoot
+			+ Zero
+			+ Ord
+			+ Add<Balance, Output = Balance>
+			+ Mul<Balance, Output = Balance>
+			+ Div<Balance, Output = Balance>
+			+ Rem<Balance, Output = Balance>
+			+ Copy,
+	> Approved<Balance> for VoteThreshold
+{
 	/// Given `approve` votes for and `against` votes against from a total electorate size of
 	/// `electorate` (`electorate - (approve + against)` are abstainers), then returns true if the
 	/// overall outcome is in favour of approval.
@@ -94,7 +111,9 @@ impl<Balance: IntegerSquareRoot + Zero + Ord + Add<Balance, Output = Balance> + 
 		let voters = approve + against;
 		let sqrt_voters = voters.integer_sqrt();
 		let sqrt_electorate = electorate.integer_sqrt();
-		if sqrt_voters.is_zero() { return false; }
+		if sqrt_voters.is_zero() {
+			return false
+		}
 		match *self {
 			VoteThreshold::SuperMajorityApprove =>
 				compare_rationals(against, sqrt_voters, approve, sqrt_electorate),
@@ -111,7 +130,13 @@ mod tests {
 
 	#[test]
 	fn should_work() {
-		assert_eq!(VoteThreshold::SuperMajorityApprove.approved(60, 50, 210), false);
-		assert_eq!(VoteThreshold::SuperMajorityApprove.approved(100, 50, 210), true);
+		assert_eq!(
+			VoteThreshold::SuperMajorityApprove.approved(60, 50, 210),
+			false
+		);
+		assert_eq!(
+			VoteThreshold::SuperMajorityApprove.approved(100, 50, 210),
+			true
+		);
 	}
 }

--- a/substrate/runtime/primitives/src/generic.rs
+++ b/substrate/runtime/primitives/src/generic.rs
@@ -22,13 +22,15 @@ use std::fmt;
 #[cfg(feature = "std")]
 use serde::{Deserialize, Deserializer};
 
-use rstd::prelude::*;
-use codec::{Slicable, Input};
-use runtime_support::AuxDispatchable;
-use traits::{self, Member, SimpleArithmetic, SimpleBitOps, MaybeDisplay, Block as BlockT,
-	Header as HeaderT, Hashing as HashingT};
-use rstd::ops;
 use bft::Justification;
+use codec::{Input, Slicable};
+use rstd::ops;
+use rstd::prelude::*;
+use runtime_support::AuxDispatchable;
+use traits::{
+	self, Block as BlockT, Hashing as HashingT, Header as HeaderT, MaybeDisplay, Member,
+	SimpleArithmetic, SimpleBitOps,
+};
 
 /// Definition of something that the external world might want to say.
 #[derive(PartialEq, Eq, Clone)]
@@ -42,10 +44,11 @@ pub struct Extrinsic<Address, Index, Call> {
 	pub function: Call,
 }
 
-impl<Address, Index, Call> Slicable for Extrinsic<Address, Index, Call> where
+impl<Address, Index, Call> Slicable for Extrinsic<Address, Index, Call>
+where
 	Address: Member + Slicable + MaybeDisplay,
 	Index: Member + Slicable + MaybeDisplay + SimpleArithmetic,
-	Call: Member + Slicable
+	Call: Member + Slicable,
 {
 	fn decode<I: Input>(input: &mut I) -> Option<Self> {
 		Some(Extrinsic {
@@ -86,8 +89,10 @@ impl<Address, Index, Call, Signature> UncheckedExtrinsic<Address, Index, Call, S
 	}
 }
 
-impl<Address, AccountId, Index, Call, Signature> UncheckedExtrinsic<Address, Index, Call, ::MaybeUnsigned<Signature>> where
-	Signature: traits::Verify<Signer=AccountId> + Default + Eq,
+impl<Address, AccountId, Index, Call, Signature>
+	UncheckedExtrinsic<Address, Index, Call, ::MaybeUnsigned<Signature>>
+where
+	Signature: traits::Verify<Signer = AccountId> + Default + Eq,
 	AccountId: Default + Eq,
 {
 	/// `true` if this extrinsic is signed.
@@ -102,7 +107,7 @@ where
 	Address: Member + Default + MaybeDisplay,
 	Index: Member + MaybeDisplay + SimpleArithmetic,
 	Call: Member,
-	Signature: traits::Verify<Signer=AccountId> + Eq + Default,
+	Signature: traits::Verify<Signer = AccountId> + Eq + Default,
 	AccountId: Member + Default + MaybeDisplay,
 	::MaybeUnsigned<Signature>: Member,
 	Extrinsic<AccountId, Index, Call>: Slicable,
@@ -115,7 +120,8 @@ where
 		&self.extrinsic.signed
 	}
 
-	fn check<ThisLookup>(self, lookup: ThisLookup) -> Result<Self::Checked, &'static str> where
+	fn check<ThisLookup>(self, lookup: ThisLookup) -> Result<Self::Checked, &'static str>
+	where
 		ThisLookup: FnOnce(Address) -> Result<AccountId, &'static str>,
 	{
 		if !self.is_signed() {
@@ -125,12 +131,11 @@ where
 				function: self.extrinsic.function,
 			}))
 		} else {
-			let extrinsic: Extrinsic<AccountId, Index, Call>
-				= Extrinsic {
-					signed: lookup(self.extrinsic.signed)?,
-					index: self.extrinsic.index,
-					function: self.extrinsic.function,
-				};
+			let extrinsic: Extrinsic<AccountId, Index, Call> = Extrinsic {
+				signed: lookup(self.extrinsic.signed)?,
+				index: self.extrinsic.index,
+				function: self.extrinsic.function,
+			};
 			if ::verify_encoded_lazy(&self.signature, &extrinsic, &extrinsic.signed) {
 				Ok(CheckedExtrinsic(extrinsic))
 			} else {
@@ -140,7 +145,9 @@ where
 	}
 }
 
-impl<Address, Index, Call, Signature> Slicable for UncheckedExtrinsic<Address, Index, Call, Signature> where
+impl<Address, Index, Call, Signature> Slicable
+	for UncheckedExtrinsic<Address, Index, Call, Signature>
+where
 	Signature: Slicable,
 	Extrinsic<Address, Index, Call>: Slicable,
 {
@@ -153,7 +160,7 @@ impl<Address, Index, Call, Signature> Slicable for UncheckedExtrinsic<Address, I
 
 		Some(UncheckedExtrinsic::new(
 			Slicable::decode(input)?,
-			Slicable::decode(input)?
+			Slicable::decode(input)?,
 		))
 	}
 
@@ -177,7 +184,9 @@ impl<Address, Index, Call, Signature> Slicable for UncheckedExtrinsic<Address, I
 
 /// TODO: use derive when possible.
 #[cfg(feature = "std")]
-impl<Address, Index, Call, Signature> fmt::Debug for UncheckedExtrinsic<Address, Index, Call, Signature> where
+impl<Address, Index, Call, Signature> fmt::Debug
+	for UncheckedExtrinsic<Address, Index, Call, Signature>
+where
 	Address: fmt::Debug,
 	Index: fmt::Debug,
 	Call: fmt::Debug,
@@ -190,11 +199,9 @@ impl<Address, Index, Call, Signature> fmt::Debug for UncheckedExtrinsic<Address,
 /// A type-safe indicator that a extrinsic has been checked.
 #[derive(PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize, Debug))]
-pub struct CheckedExtrinsic<AccountId, Index, Call>
-	(Extrinsic<AccountId, Index, Call>);
+pub struct CheckedExtrinsic<AccountId, Index, Call>(Extrinsic<AccountId, Index, Call>);
 
-impl<AccountId, Index, Call> ops::Deref
-	for CheckedExtrinsic<AccountId, Index, Call>
+impl<AccountId, Index, Call> ops::Deref for CheckedExtrinsic<AccountId, Index, Call>
 where
 	AccountId: Member + MaybeDisplay,
 	Index: Member + MaybeDisplay + SimpleArithmetic,
@@ -207,8 +214,7 @@ where
 	}
 }
 
-impl<AccountId, Index, Call> traits::Applyable
-	for CheckedExtrinsic<AccountId, Index, Call>
+impl<AccountId, Index, Call> traits::Applyable for CheckedExtrinsic<AccountId, Index, Call>
 where
 	AccountId: Member + MaybeDisplay,
 	Index: Member + MaybeDisplay + SimpleArithmetic,
@@ -237,25 +243,28 @@ pub struct Digest<Item> {
 	pub logs: Vec<Item>,
 }
 
-impl<Item> Slicable for Digest<Item> where
-	Item: Member + Default + Slicable
+impl<Item> Slicable for Digest<Item>
+where
+	Item: Member + Default + Slicable,
 {
 	fn decode<I: Input>(input: &mut I) -> Option<Self> {
-		Some(Digest { logs: Slicable::decode(input)? })
+		Some(Digest {
+			logs: Slicable::decode(input)?,
+		})
 	}
 	fn using_encoded<R, F: FnOnce(&[u8]) -> R>(&self, f: F) -> R {
 		self.logs.using_encoded(f)
 	}
 }
-impl<Item> traits::Digest for Digest<Item> where
-	Item: Member + Default + Slicable
+impl<Item> traits::Digest for Digest<Item>
+where
+	Item: Member + Default + Slicable,
 {
 	type Item = Item;
 	fn push(&mut self, item: Self::Item) {
 		self.logs.push(item);
 	}
 }
-
 
 /// Abstraction over a block header for a substrate chain.
 #[derive(PartialEq, Eq, Clone)]
@@ -291,7 +300,9 @@ struct DeserializeHeader<N, H, D> {
 }
 
 #[cfg(feature = "std")]
-impl<N, D, Hashing: HashingT> From<DeserializeHeader<N, Hashing::Output, D>> for Header<N, Hashing, D> {
+impl<N, D, Hashing: HashingT> From<DeserializeHeader<N, Hashing::Output, D>>
+	for Header<N, Hashing, D>
+{
 	fn from(other: DeserializeHeader<N, Hashing::Output, D>) -> Self {
 		Header {
 			parent_hash: other.parent_hash,
@@ -304,7 +315,9 @@ impl<N, D, Hashing: HashingT> From<DeserializeHeader<N, Hashing::Output, D>> for
 }
 
 #[cfg(feature = "std")]
-impl<'a, Number: 'a, Hashing: 'a + HashingT, DigestItem: 'a> Deserialize<'a> for Header<Number, Hashing, DigestItem> where
+impl<'a, Number: 'a, Hashing: 'a + HashingT, DigestItem: 'a> Deserialize<'a>
+	for Header<Number, Hashing, DigestItem>
+where
 	Number: Deserialize<'a>,
 	Hashing::Output: Deserialize<'a>,
 	DigestItem: Deserialize<'a>,
@@ -314,7 +327,8 @@ impl<'a, Number: 'a, Hashing: 'a + HashingT, DigestItem: 'a> Deserialize<'a> for
 	}
 }
 
-impl<Number, Hashing, DigestItem> Slicable for Header<Number, Hashing, DigestItem> where
+impl<Number, Hashing, DigestItem> Slicable for Header<Number, Hashing, DigestItem>
+where
 	Number: Member + Slicable + MaybeDisplay + SimpleArithmetic + Slicable,
 	Hashing: HashingT,
 	DigestItem: Member + Default + Slicable,
@@ -341,51 +355,81 @@ impl<Number, Hashing, DigestItem> Slicable for Header<Number, Hashing, DigestIte
 	}
 }
 
-impl<Number, Hashing, DigestItem> traits::Header for Header<Number, Hashing, DigestItem> where
-	Number: Member + ::rstd::hash::Hash + Copy + Slicable + MaybeDisplay + SimpleArithmetic + Slicable,
+impl<Number, Hashing, DigestItem> traits::Header for Header<Number, Hashing, DigestItem>
+where
+	Number:
+		Member + ::rstd::hash::Hash + Copy + Slicable + MaybeDisplay + SimpleArithmetic + Slicable,
 	Hashing: HashingT,
 	DigestItem: Member + Default + Slicable,
-	Hashing::Output: Default + ::rstd::hash::Hash + Copy + Member + MaybeDisplay + SimpleBitOps + Slicable,
- {
+	Hashing::Output:
+		Default + ::rstd::hash::Hash + Copy + Member + MaybeDisplay + SimpleBitOps + Slicable,
+{
 	type Number = Number;
 	type Hash = <Hashing as HashingT>::Output;
 	type Hashing = Hashing;
 	type Digest = Digest<DigestItem>;
 
-	fn number(&self) -> &Self::Number { &self.number }
-	fn set_number(&mut self, num: Self::Number) { self.number = num }
+	fn number(&self) -> &Self::Number {
+		&self.number
+	}
+	fn set_number(&mut self, num: Self::Number) {
+		self.number = num
+	}
 
-	fn extrinsics_root(&self) -> &Self::Hash { &self.extrinsics_root }
-	fn set_extrinsics_root(&mut self, root: Self::Hash) { self.extrinsics_root = root }
+	fn extrinsics_root(&self) -> &Self::Hash {
+		&self.extrinsics_root
+	}
+	fn set_extrinsics_root(&mut self, root: Self::Hash) {
+		self.extrinsics_root = root
+	}
 
-	fn state_root(&self) -> &Self::Hash { &self.state_root }
-	fn set_state_root(&mut self, root: Self::Hash) { self.state_root = root }
+	fn state_root(&self) -> &Self::Hash {
+		&self.state_root
+	}
+	fn set_state_root(&mut self, root: Self::Hash) {
+		self.state_root = root
+	}
 
-	fn parent_hash(&self) -> &Self::Hash { &self.parent_hash }
-	fn set_parent_hash(&mut self, hash: Self::Hash) { self.parent_hash = hash }
+	fn parent_hash(&self) -> &Self::Hash {
+		&self.parent_hash
+	}
+	fn set_parent_hash(&mut self, hash: Self::Hash) {
+		self.parent_hash = hash
+	}
 
-	fn digest(&self) -> &Self::Digest { &self.digest }
-	fn set_digest(&mut self, digest: Self::Digest) { self.digest = digest }
+	fn digest(&self) -> &Self::Digest {
+		&self.digest
+	}
+	fn set_digest(&mut self, digest: Self::Digest) {
+		self.digest = digest
+	}
 
 	fn new(
 		number: Self::Number,
 		extrinsics_root: Self::Hash,
 		state_root: Self::Hash,
 		parent_hash: Self::Hash,
-		digest: Self::Digest
+		digest: Self::Digest,
 	) -> Self {
 		Header {
-			number, extrinsics_root: extrinsics_root, state_root, parent_hash, digest
+			number,
+			extrinsics_root,
+			state_root,
+			parent_hash,
+			digest,
 		}
 	}
 }
 
-impl<Number, Hashing, DigestItem> Header<Number, Hashing, DigestItem> where
-	Number: Member + ::rstd::hash::Hash + Copy + Slicable + MaybeDisplay + SimpleArithmetic + Slicable,
+impl<Number, Hashing, DigestItem> Header<Number, Hashing, DigestItem>
+where
+	Number:
+		Member + ::rstd::hash::Hash + Copy + Slicable + MaybeDisplay + SimpleArithmetic + Slicable,
 	Hashing: HashingT,
 	DigestItem: Member + Default + Slicable,
-	Hashing::Output: Default + ::rstd::hash::Hash + Copy + Member + MaybeDisplay + SimpleBitOps + Slicable,
- {
+	Hashing::Output:
+		Default + ::rstd::hash::Hash + Copy + Member + MaybeDisplay + SimpleBitOps + Slicable,
+{
 	/// Convenience helper for computing the hash of the header without having
 	/// to import the trait.
 	pub fn hash(&self) -> Hashing::Output {
@@ -489,7 +533,9 @@ pub struct SignedBlock<Header, Extrinsic, Hash> {
 	pub justification: Justification<Hash>,
 }
 
-impl<Header: Slicable, Extrinsic: Slicable, Hash: Slicable> Slicable for SignedBlock<Header, Extrinsic, Hash> {
+impl<Header: Slicable, Extrinsic: Slicable, Hash: Slicable> Slicable
+	for SignedBlock<Header, Extrinsic, Hash>
+{
 	fn decode<I: Input>(input: &mut I) -> Option<Self> {
 		Some(SignedBlock {
 			block: Slicable::decode(input)?,
@@ -507,9 +553,9 @@ impl<Header: Slicable, Extrinsic: Slicable, Hash: Slicable> Slicable for SignedB
 
 #[cfg(test)]
 mod tests {
+	use super::{Digest, Extrinsic, Header, UncheckedExtrinsic};
 	use codec::Slicable;
 	use substrate_primitives::{H256, H512};
-	use super::{Digest, Header, UncheckedExtrinsic, Extrinsic};
 
 	type Block = super::Block<
 		Header<u64, ::traits::BlakeTwo256, Vec<u8>>,
@@ -524,7 +570,9 @@ mod tests {
 				number: 100_000,
 				state_root: [1u8; 32].into(),
 				extrinsics_root: [2u8; 32].into(),
-				digest: Digest { logs: vec![vec![1, 2, 3], vec![4, 5, 6]] },
+				digest: Digest {
+					logs: vec![vec![1, 2, 3], vec![4, 5, 6]],
+				},
 			},
 			extrinsics: vec![
 				UncheckedExtrinsic::new(
@@ -533,7 +581,7 @@ mod tests {
 						index: 0,
 						function: 100,
 					},
-					H512::from([0u8; 64]).into()
+					H512::from([0u8; 64]).into(),
 				),
 				UncheckedExtrinsic::new(
 					Extrinsic {
@@ -541,9 +589,9 @@ mod tests {
 						index: 100,
 						function: 99,
 					},
-					H512::from([255u8; 64]).into()
-				)
-			]
+					H512::from([255u8; 64]).into(),
+				),
+			],
 		};
 
 		{

--- a/substrate/runtime/primitives/src/lib.rs
+++ b/substrate/runtime/primitives/src/lib.rs
@@ -26,13 +26,13 @@ extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 
-extern crate num_traits;
 extern crate integer_sqrt;
-extern crate substrate_runtime_std as rstd;
-extern crate substrate_runtime_io as runtime_io;
-extern crate substrate_runtime_support as runtime_support;
+extern crate num_traits;
 extern crate substrate_codec as codec;
 extern crate substrate_primitives;
+extern crate substrate_runtime_io as runtime_io;
+extern crate substrate_runtime_std as rstd;
+extern crate substrate_runtime_support as runtime_support;
 
 #[cfg(test)]
 extern crate serde_json;
@@ -50,7 +50,7 @@ pub mod traits;
 pub mod generic;
 pub mod bft;
 
-use traits::{Verify, Lazy};
+use traits::{Lazy, Verify};
 
 /// A set of key value pairs for storage.
 #[cfg(feature = "std")]
@@ -82,8 +82,12 @@ impl Verify for Ed25519Signature {
 }
 
 impl codec::Slicable for Ed25519Signature {
-	fn decode<I: codec::Input>(input: &mut I) -> Option<Self> { Some(Ed25519Signature(codec::Slicable::decode(input)?,)) }
-	fn using_encoded<R, F: FnOnce(&[u8]) -> R>(&self, f: F) -> R { self.0.using_encoded(f) }
+	fn decode<I: codec::Input>(input: &mut I) -> Option<Self> {
+		Some(Ed25519Signature(codec::Slicable::decode(input)?))
+	}
+	fn using_encoded<R, F: FnOnce(&[u8]) -> R>(&self, f: F) -> R {
+		self.0.using_encoded(f)
+	}
 }
 
 impl From<H512> for Ed25519Signature {
@@ -152,7 +156,8 @@ pub type ApplyResult = Result<ApplyOutcome, ApplyError>;
 #[cfg_attr(feature = "std", derive(Debug, Serialize, Deserialize))]
 pub struct MaybeUnsigned<T>(pub T);
 
-impl<T: Verify> MaybeUnsigned<T> where
+impl<T: Verify> MaybeUnsigned<T>
+where
 	T: Default + Eq,
 	<T as Verify>::Signer: Default + Eq,
 {
@@ -165,7 +170,8 @@ impl<T: Verify> MaybeUnsigned<T> where
 	}
 }
 
-impl<T: Verify> Verify for MaybeUnsigned<T> where
+impl<T: Verify> Verify for MaybeUnsigned<T>
+where
 	T: Default + Eq,
 	<T as Verify>::Signer: Default + Eq,
 {
@@ -180,8 +186,12 @@ impl<T: Verify> Verify for MaybeUnsigned<T> where
 }
 
 impl<T: codec::Slicable> codec::Slicable for MaybeUnsigned<T> {
-	fn decode<I: codec::Input>(input: &mut I) -> Option<Self> { Some(MaybeUnsigned(codec::Slicable::decode(input)?)) }
-	fn using_encoded<R, F: FnOnce(&[u8]) -> R>(&self, f: F) -> R { self.0.using_encoded(f) }
+	fn decode<I: codec::Input>(input: &mut I) -> Option<Self> {
+		Some(MaybeUnsigned(codec::Slicable::decode(input)?))
+	}
+	fn using_encoded<R, F: FnOnce(&[u8]) -> R>(&self, f: F) -> R {
+		self.0.using_encoded(f)
+	}
 }
 
 impl<T> From<T> for MaybeUnsigned<T> {
@@ -192,7 +202,11 @@ impl<T> From<T> for MaybeUnsigned<T> {
 
 /// Verify a signature on an encoded value in a lazy manner. This can be
 /// an optimization if the signature scheme has an "unsigned" escape hash.
-pub fn verify_encoded_lazy<V: Verify, T: codec::Slicable>(sig: &V, item: &T, signer: &V::Signer) -> bool {
+pub fn verify_encoded_lazy<V: Verify, T: codec::Slicable>(
+	sig: &V,
+	item: &T,
+	signer: &V::Signer,
+) -> bool {
 	// The `Lazy<T>` trait expresses something like `X: FnMut<Output = for<'a> &'a T>`.
 	// unfortunately this is a lifetime relationship that can't
 	// be expressed without generic associated types, better unification of HRTBs in type position,
@@ -209,7 +223,10 @@ pub fn verify_encoded_lazy<V: Verify, T: codec::Slicable>(sig: &V, item: &T, sig
 	}
 
 	sig.verify(
-		LazyEncode { inner: || item.encode(), encoded: None },
+		LazyEncode {
+			inner: || item.encode(),
+			encoded: None,
+		},
 		signer,
 	)
 }

--- a/substrate/runtime/primitives/src/testing.rs
+++ b/substrate/runtime/primitives/src/testing.rs
@@ -16,11 +16,11 @@
 
 //! Testing utilities.
 
-use serde::{Serialize, de::DeserializeOwned};
-use std::fmt::Debug;
-use codec::{Slicable, Input};
+use codec::{Input, Slicable};
 use runtime_support::AuxDispatchable;
-use traits::{self, Checkable, Applyable, BlakeTwo256};
+use serde::{de::DeserializeOwned, Serialize};
+use std::fmt::Debug;
+use traits::{self, Applyable, BlakeTwo256, Checkable};
 
 pub use substrate_primitives::H256;
 
@@ -80,30 +80,54 @@ impl traits::Header for Header {
 	type Hash = H256;
 	type Digest = Digest;
 
-	fn number(&self) -> &Self::Number { &self.number }
-	fn set_number(&mut self, num: Self::Number) { self.number = num }
+	fn number(&self) -> &Self::Number {
+		&self.number
+	}
+	fn set_number(&mut self, num: Self::Number) {
+		self.number = num
+	}
 
-	fn extrinsics_root(&self) -> &Self::Hash { &self.extrinsics_root }
-	fn set_extrinsics_root(&mut self, root: Self::Hash) { self.extrinsics_root = root }
+	fn extrinsics_root(&self) -> &Self::Hash {
+		&self.extrinsics_root
+	}
+	fn set_extrinsics_root(&mut self, root: Self::Hash) {
+		self.extrinsics_root = root
+	}
 
-	fn state_root(&self) -> &Self::Hash { &self.state_root }
-	fn set_state_root(&mut self, root: Self::Hash) { self.state_root = root }
+	fn state_root(&self) -> &Self::Hash {
+		&self.state_root
+	}
+	fn set_state_root(&mut self, root: Self::Hash) {
+		self.state_root = root
+	}
 
-	fn parent_hash(&self) -> &Self::Hash { &self.parent_hash }
-	fn set_parent_hash(&mut self, hash: Self::Hash) { self.parent_hash = hash }
+	fn parent_hash(&self) -> &Self::Hash {
+		&self.parent_hash
+	}
+	fn set_parent_hash(&mut self, hash: Self::Hash) {
+		self.parent_hash = hash
+	}
 
-	fn digest(&self) -> &Self::Digest { &self.digest }
-	fn set_digest(&mut self, digest: Self::Digest) { self.digest = digest }
+	fn digest(&self) -> &Self::Digest {
+		&self.digest
+	}
+	fn set_digest(&mut self, digest: Self::Digest) {
+		self.digest = digest
+	}
 
 	fn new(
 		number: Self::Number,
 		extrinsics_root: Self::Hash,
 		state_root: Self::Hash,
 		parent_hash: Self::Hash,
-		digest: Self::Digest
+		digest: Self::Digest,
 	) -> Self {
 		Header {
-			number, extrinsics_root: extrinsics_root, state_root, parent_hash, digest
+			number,
+			extrinsics_root,
+			state_root,
+			parent_hash,
+			digest,
 		}
 	}
 }
@@ -113,7 +137,9 @@ pub struct Block<Xt: Slicable + Sized + Send + Sync + Serialize + Clone + Eq + D
 	pub header: Header,
 	pub extrinsics: Vec<Xt>,
 }
-impl<Xt: Slicable + Sized + Send + Sync + Serialize + DeserializeOwned + Clone + Eq + Debug> Slicable for Block<Xt> {
+impl<Xt: Slicable + Sized + Send + Sync + Serialize + DeserializeOwned + Clone + Eq + Debug>
+	Slicable for Block<Xt>
+{
 	fn decode<I: Input>(input: &mut I) -> Option<Self> {
 		Some(Block {
 			header: Slicable::decode(input)?,
@@ -127,7 +153,19 @@ impl<Xt: Slicable + Sized + Send + Sync + Serialize + DeserializeOwned + Clone +
 		v
 	}
 }
-impl<Xt: 'static + Slicable + Sized + Send + Sync + Serialize + DeserializeOwned + Clone + Eq + Debug> traits::Block for Block<Xt> {
+impl<
+		Xt: 'static
+			+ Slicable
+			+ Sized
+			+ Send
+			+ Sync
+			+ Serialize
+			+ DeserializeOwned
+			+ Clone
+			+ Eq
+			+ Debug,
+	> traits::Block for Block<Xt>
+{
 	type Extrinsic = Xt;
 	type Header = Header;
 	type Hash = <Header as traits::Header>::Hash;
@@ -147,9 +185,23 @@ impl<Xt: 'static + Slicable + Sized + Send + Sync + Serialize + DeserializeOwned
 }
 
 #[derive(PartialEq, Eq, Clone, Serialize, Deserialize, Debug)]
-pub struct TestXt<Call: AuxDispatchable + Slicable + Sized + Send + Sync + Serialize>(pub (u64, u64, Call));
+pub struct TestXt<Call: AuxDispatchable + Slicable + Sized + Send + Sync + Serialize>(
+	pub (u64, u64, Call),
+);
 
-impl<Call: AuxDispatchable + Slicable + Sized + Send + Sync + Serialize + DeserializeOwned + Clone + Eq + Debug> Slicable for TestXt<Call> {
+impl<
+		Call: AuxDispatchable
+			+ Slicable
+			+ Sized
+			+ Send
+			+ Sync
+			+ Serialize
+			+ DeserializeOwned
+			+ Clone
+			+ Eq
+			+ Debug,
+	> Slicable for TestXt<Call>
+{
 	fn decode<I: Input>(input: &mut I) -> Option<Self> {
 		Some(TestXt(Slicable::decode(input)?))
 	}
@@ -157,17 +209,55 @@ impl<Call: AuxDispatchable + Slicable + Sized + Send + Sync + Serialize + Deseri
 		self.0.encode()
 	}
 }
-impl<Call: 'static + AuxDispatchable + Slicable + Sized + Send + Sync + Serialize + DeserializeOwned + Clone + Eq + Debug> Checkable for TestXt<Call> {
+impl<
+		Call: 'static
+			+ AuxDispatchable
+			+ Slicable
+			+ Sized
+			+ Send
+			+ Sync
+			+ Serialize
+			+ DeserializeOwned
+			+ Clone
+			+ Eq
+			+ Debug,
+	> Checkable for TestXt<Call>
+{
 	type Checked = Self;
 	type Address = u64;
 	type AccountId = u64;
-	fn sender(&self) -> &u64 { &(self.0).0 }
-	fn check<ThisLookup: FnOnce(Self::Address) -> Result<Self::AccountId, &'static str>>(self, _lookup: ThisLookup) -> Result<Self::Checked, &'static str> { Ok(self) }
+	fn sender(&self) -> &u64 {
+		&(self.0).0
+	}
+	fn check<ThisLookup: FnOnce(Self::Address) -> Result<Self::AccountId, &'static str>>(
+		self,
+		_lookup: ThisLookup,
+	) -> Result<Self::Checked, &'static str> {
+		Ok(self)
+	}
 }
-impl<Call: AuxDispatchable<Aux = u64> + Slicable + Sized + Send + Sync + Serialize + DeserializeOwned + Clone + Eq + Debug> Applyable for TestXt<Call> {
+impl<
+		Call: AuxDispatchable<Aux = u64>
+			+ Slicable
+			+ Sized
+			+ Send
+			+ Sync
+			+ Serialize
+			+ DeserializeOwned
+			+ Clone
+			+ Eq
+			+ Debug,
+	> Applyable for TestXt<Call>
+{
 	type AccountId = u64;
 	type Index = u64;
-	fn sender(&self) -> &u64 { &(self.0).0 }
-	fn index(&self) -> &u64 { &(self.0).1 }
-	fn apply(self) -> Result<(), &'static str> { (self.0).2.dispatch(&(self.0).0) }
+	fn sender(&self) -> &u64 {
+		&(self.0).0
+	}
+	fn index(&self) -> &u64 {
+		&(self.0).1
+	}
+	fn apply(self) -> Result<(), &'static str> {
+		(self.0).2.dispatch(&(self.0).0)
+	}
 }

--- a/substrate/runtime/staking/src/account_db.rs
+++ b/substrate/runtime/staking/src/account_db.rs
@@ -16,12 +16,12 @@
 
 //! Auxilliaries to help with managing partial changes to accounts state.
 
-use rstd::prelude::*;
+use super::*;
+use double_map::StorageDoubleMap;
 use rstd::cell::RefCell;
 use rstd::collections::btree_map::{BTreeMap, Entry};
+use rstd::prelude::*;
 use runtime_support::StorageMap;
-use double_map::StorageDoubleMap;
-use super::*;
 
 pub struct ChangeEntry<T: Trait> {
 	balance: Option<T::Balance>,
@@ -42,10 +42,18 @@ impl<T: Trait> Default for ChangeEntry<T> {
 
 impl<T: Trait> ChangeEntry<T> {
 	pub fn contract_created(b: T::Balance, c: Vec<u8>) -> Self {
-		ChangeEntry { balance: Some(b), code: Some(c), storage: Default::default() }
+		ChangeEntry {
+			balance: Some(b),
+			code: Some(c),
+			storage: Default::default(),
+		}
 	}
 	pub fn balance_changed(b: T::Balance) -> Self {
-		ChangeEntry { balance: Some(b), code: None, storage: Default::default() }
+		ChangeEntry {
+			balance: Some(b),
+			code: None,
+			storage: Default::default(),
+		}
 	}
 }
 
@@ -87,7 +95,7 @@ impl<T: Trait> AccountDb<T> for DirectAccountDb {
 				// TODO: enforce this for the other balance-altering functions.
 				if balance < ed {
 					<Module<T>>::on_free_too_low(&address);
-					continue;
+					continue
 				} else {
 					if !<FreeBalance<T>>::exists(&address) {
 						let outcome = <Module<T>>::new_account(&address, balance);
@@ -185,10 +193,10 @@ impl<'a, T: Trait> AccountDb<T> for OverlayAccountDb<'a, T> {
 						value.code = changed.code;
 					}
 					value.storage.extend(changed.storage.into_iter());
-				}
+				},
 				Entry::Vacant(e) => {
 					e.insert(changed);
-				}
+				},
 			}
 		}
 	}
@@ -206,7 +214,8 @@ impl<'a, 'b: 'a, T: Trait> contract::Ext for StakingExt<'a, 'b, T> {
 		self.account_db.get_storage(&self.account, key)
 	}
 	fn set_storage(&mut self, key: &[u8], value: Option<Vec<u8>>) {
-		self.account_db.set_storage(&self.account, key.to_vec(), value);
+		self.account_db
+			.set_storage(&self.account, key.to_vec(), value);
 	}
 	fn create(&mut self, code: &[u8], value: Self::Balance) {
 		if let Ok(Some(commit_state)) =

--- a/substrate/runtime/staking/src/address.rs
+++ b/substrate/runtime/staking/src/address.rs
@@ -16,28 +16,30 @@
 
 //! Address type that is union of index and id for an account.
 
+use super::{As, Input, Member, Slicable};
 use rstd::prelude::*;
 #[cfg(feature = "std")]
 use std::fmt;
-use super::{Member, Slicable, As, Input};
 
 /// A vetted and verified extrinsic from the external world.
 #[derive(PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize, Debug, Hash))]
-pub enum Address<AccountId, AccountIndex> where
+pub enum Address<AccountId, AccountIndex>
+where
 	AccountId: Member,
 	AccountIndex: Member,
 {
 	/// It's an account ID (pubkey).
-	#[cfg_attr(feature = "std", serde(deserialize_with="AccountId::deserialize"))]
+	#[cfg_attr(feature = "std", serde(deserialize_with = "AccountId::deserialize"))]
 	Id(AccountId),
 	/// It's an account index.
-	#[cfg_attr(feature = "std", serde(deserialize_with="AccountIndex::deserialize"))]
+	#[cfg_attr(feature = "std", serde(deserialize_with = "AccountIndex::deserialize"))]
 	Index(AccountIndex),
 }
 
 #[cfg(feature = "std")]
-impl<AccountId, AccountIndex> fmt::Display for Address<AccountId, AccountIndex> where
+impl<AccountId, AccountIndex> fmt::Display for Address<AccountId, AccountIndex>
+where
 	AccountId: Member,
 	AccountIndex: Member,
 {
@@ -46,7 +48,8 @@ impl<AccountId, AccountIndex> fmt::Display for Address<AccountId, AccountIndex> 
 	}
 }
 
-impl<AccountId, AccountIndex> From<AccountId> for Address<AccountId, AccountIndex> where
+impl<AccountId, AccountIndex> From<AccountId> for Address<AccountId, AccountIndex>
+where
 	AccountId: Member,
 	AccountIndex: Member,
 {
@@ -56,19 +59,28 @@ impl<AccountId, AccountIndex> From<AccountId> for Address<AccountId, AccountInde
 }
 
 fn need_more_than<T: PartialOrd>(a: T, b: T) -> Option<T> {
-	if a < b { Some(a) } else { None }
+	if a < b {
+		Some(a)
+	} else {
+		None
+	}
 }
 
-impl<AccountId, AccountIndex> Slicable for Address<AccountId, AccountIndex> where
+impl<AccountId, AccountIndex> Slicable for Address<AccountId, AccountIndex>
+where
 	AccountId: Member + Slicable,
-	AccountIndex: Member + Slicable + PartialOrd<AccountIndex> + Ord + As<u32> + As<u16> + As<u8> + Copy,
+	AccountIndex:
+		Member + Slicable + PartialOrd<AccountIndex> + Ord + As<u32> + As<u16> + As<u8> + Copy,
 {
 	fn decode<I: Input>(input: &mut I) -> Option<Self> {
 		Some(match input.read_byte()? {
 			x @ 0x00...0xef => Address::Index(As::sa(x)),
 			0xfc => Address::Index(As::sa(need_more_than(0xef, u16::decode(input)?)?)),
 			0xfd => Address::Index(As::sa(need_more_than(0xffff, u32::decode(input)?)?)),
-			0xfe => Address::Index(need_more_than(As::sa(0xffffffffu32), Slicable::decode(input)?)?),
+			0xfe => Address::Index(need_more_than(
+				As::sa(0xffffffffu32),
+				Slicable::decode(input)?,
+			)?),
 			0xff => Address::Id(Slicable::decode(input)?),
 			_ => return None,
 		})
@@ -81,19 +93,19 @@ impl<AccountId, AccountIndex> Slicable for Address<AccountId, AccountIndex> wher
 			Address::Id(ref i) => {
 				v.push(255);
 				i.using_encoded(|s| v.extend(s));
-			}
+			},
 			Address::Index(i) if i > As::sa(0xffffffffu32) => {
 				v.push(254);
 				i.using_encoded(|s| v.extend(s));
-			}
+			},
 			Address::Index(i) if i > As::sa(0xffffu32) => {
 				v.push(253);
 				As::<u32>::as_(i).using_encoded(|s| v.extend(s));
-			}
+			},
 			Address::Index(i) if i >= As::sa(0xf0u32) => {
 				v.push(252);
 				As::<u16>::as_(i).using_encoded(|s| v.extend(s));
-			}
+			},
 			Address::Index(i) => v.push(As::<u8>::as_(i)),
 		}
 
@@ -101,7 +113,8 @@ impl<AccountId, AccountIndex> Slicable for Address<AccountId, AccountIndex> wher
 	}
 }
 
-impl<AccountId, AccountIndex> Default for Address<AccountId, AccountIndex> where
+impl<AccountId, AccountIndex> Default for Address<AccountId, AccountIndex>
+where
 	AccountId: Member + Default,
 	AccountIndex: Member,
 {

--- a/substrate/runtime/staking/src/double_map.rs
+++ b/substrate/runtime/staking/src/double_map.rs
@@ -18,10 +18,10 @@
 //!
 //! This implementation is somewhat specialized to the tracking of the storage of accounts.
 
-use rstd::prelude::*;
 use codec::Slicable;
-use runtime_support::storage::unhashed;
+use rstd::prelude::*;
 use runtime_io::{blake2_256, twox_128};
+use runtime_support::storage::unhashed;
 
 /// Returns only a first part of the storage key.
 ///

--- a/substrate/runtime/staking/src/mock.rs
+++ b/substrate/runtime/staking/src/mock.rs
@@ -18,13 +18,13 @@
 
 #![cfg(test)]
 
-use primitives::BuildStorage;
-use primitives::traits::{HasPublicAux, Identity};
-use primitives::testing::{Digest, Header};
-use substrate_primitives::H256;
-use runtime_io;
-use {GenesisConfig, Module, Trait, consensus, session, system, timestamp};
 use super::DummyContractAddressFor;
+use primitives::testing::{Digest, Header};
+use primitives::traits::{HasPublicAux, Identity};
+use primitives::BuildStorage;
+use runtime_io;
+use substrate_primitives::H256;
+use {consensus, session, system, timestamp, GenesisConfig, Module, Trait};
 
 // Workaround for https://github.com/rust-lang/rust/issues/26925 . Remove when sorted.
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
@@ -59,50 +59,78 @@ impl Trait for Test {
 	type AccountIndex = u64;
 }
 
-pub fn new_test_ext(ext_deposit: u64, session_length: u64, sessions_per_era: u64, current_era: u64, monied: bool, reward: u64) -> runtime_io::TestExternalities {
-	let mut t = system::GenesisConfig::<Test>::default().build_storage().unwrap();
-	let balance_factor = if ext_deposit > 0 {
-		256
-	} else {
-		1
-	};
-	t.extend(consensus::GenesisConfig::<Test>{
-		code: vec![],
-		authorities: vec![],
-	}.build_storage().unwrap());
-	t.extend(session::GenesisConfig::<Test>{
-		session_length,
-		validators: vec![10, 20],
-		broken_percent_late: 30,
-	}.build_storage().unwrap());
-	t.extend(GenesisConfig::<Test>{
-		sessions_per_era,
-		current_era,
-		balances: if monied {
-			if reward > 0 {
-				vec![(1, 10 * balance_factor), (2, 20 * balance_factor), (3, 30 * balance_factor), (4, 40 * balance_factor), (10, balance_factor), (20, balance_factor)]
+pub fn new_test_ext(
+	ext_deposit: u64,
+	session_length: u64,
+	sessions_per_era: u64,
+	current_era: u64,
+	monied: bool,
+	reward: u64,
+) -> runtime_io::TestExternalities {
+	let mut t = system::GenesisConfig::<Test>::default()
+		.build_storage()
+		.unwrap();
+	let balance_factor = if ext_deposit > 0 { 256 } else { 1 };
+	t.extend(
+		consensus::GenesisConfig::<Test> {
+			code: vec![],
+			authorities: vec![],
+		}.build_storage()
+			.unwrap(),
+	);
+	t.extend(
+		session::GenesisConfig::<Test> {
+			session_length,
+			validators: vec![10, 20],
+			broken_percent_late: 30,
+		}.build_storage()
+			.unwrap(),
+	);
+	t.extend(
+		GenesisConfig::<Test> {
+			sessions_per_era,
+			current_era,
+			balances: if monied {
+				if reward > 0 {
+					vec![
+						(1, 10 * balance_factor),
+						(2, 20 * balance_factor),
+						(3, 30 * balance_factor),
+						(4, 40 * balance_factor),
+						(10, balance_factor),
+						(20, balance_factor),
+					]
+				} else {
+					vec![
+						(1, 10 * balance_factor),
+						(2, 20 * balance_factor),
+						(3, 30 * balance_factor),
+						(4, 40 * balance_factor),
+					]
+				}
 			} else {
-				vec![(1, 10 * balance_factor), (2, 20 * balance_factor), (3, 30 * balance_factor), (4, 40 * balance_factor)]
-			}
-		} else {
-			vec![(10, balance_factor), (20, balance_factor)]
-		},
-		intentions: vec![],
-		validator_count: 2,
-		bonding_duration: 3,
-		transaction_base_fee: 0,
-		transaction_byte_fee: 0,
-		existential_deposit: ext_deposit,
-		transfer_fee: 0,
-		creation_fee: 0,
-		contract_fee: 0,
-		reclaim_rebate: 0,
-		session_reward: reward,
-		early_era_slash: if monied { 20 } else { 0 },
-	}.build_storage().unwrap());
-	t.extend(timestamp::GenesisConfig::<Test>{
-		period: 5
-	}.build_storage().unwrap());
+				vec![(10, balance_factor), (20, balance_factor)]
+			},
+			intentions: vec![],
+			validator_count: 2,
+			bonding_duration: 3,
+			transaction_base_fee: 0,
+			transaction_byte_fee: 0,
+			existential_deposit: ext_deposit,
+			transfer_fee: 0,
+			creation_fee: 0,
+			contract_fee: 0,
+			reclaim_rebate: 0,
+			session_reward: reward,
+			early_era_slash: if monied { 20 } else { 0 },
+		}.build_storage()
+			.unwrap(),
+	);
+	t.extend(
+		timestamp::GenesisConfig::<Test> { period: 5 }
+			.build_storage()
+			.unwrap(),
+	);
 	t
 }
 

--- a/substrate/runtime/staking/src/tests.rs
+++ b/substrate/runtime/staking/src/tests.rs
@@ -19,8 +19,8 @@
 #![cfg(test)]
 
 use super::*;
+use mock::{new_test_ext, Session, Staking, System, Test, Timestamp};
 use runtime_io::with_externalities;
-use mock::{Session, Staking, System, Timestamp, Test, new_test_ext};
 
 #[test]
 fn reward_should_work() {
@@ -42,23 +42,23 @@ fn rewards_should_work() {
 		assert_eq!(Staking::voting_balance(&10), 1);
 
 		System::set_block_number(3);
-		Timestamp::set_timestamp(15);	// on time.
+		Timestamp::set_timestamp(15); // on time.
 		Session::check_rotate_session();
 		assert_eq!(Staking::current_era(), 0);
 		assert_eq!(Session::current_index(), 1);
 		assert_eq!(Staking::voting_balance(&10), 11);
 		System::set_block_number(6);
-		Timestamp::set_timestamp(31);	// a little late
+		Timestamp::set_timestamp(31); // a little late
 		Session::check_rotate_session();
 		assert_eq!(Staking::current_era(), 0);
 		assert_eq!(Session::current_index(), 2);
-		assert_eq!(Staking::voting_balance(&10), 20);	// less reward
+		assert_eq!(Staking::voting_balance(&10), 20); // less reward
 		System::set_block_number(9);
-		Timestamp::set_timestamp(50);	// very late
+		Timestamp::set_timestamp(50); // very late
 		Session::check_rotate_session();
 		assert_eq!(Staking::current_era(), 1);
 		assert_eq!(Session::current_index(), 3);
-		assert_eq!(Staking::voting_balance(&10), 27);	// much less reward
+		assert_eq!(Staking::voting_balance(&10), 27); // much less reward
 	});
 }
 
@@ -73,21 +73,21 @@ fn slashing_should_work() {
 		assert_eq!(Staking::voting_balance(&10), 1);
 
 		System::set_block_number(3);
-		Timestamp::set_timestamp(15);	// on time.
+		Timestamp::set_timestamp(15); // on time.
 		Session::check_rotate_session();
 		assert_eq!(Staking::current_era(), 0);
 		assert_eq!(Session::current_index(), 1);
 		assert_eq!(Staking::voting_balance(&10), 11);
 
 		System::set_block_number(6);
-		Timestamp::set_timestamp(30);	// on time.
+		Timestamp::set_timestamp(30); // on time.
 		Session::check_rotate_session();
 		assert_eq!(Staking::current_era(), 0);
 		assert_eq!(Session::current_index(), 2);
 		assert_eq!(Staking::voting_balance(&10), 21);
 
 		System::set_block_number(7);
-		Timestamp::set_timestamp(100);	// way too late - early exit.
+		Timestamp::set_timestamp(100); // way too late - early exit.
 		Session::check_rotate_session();
 		assert_eq!(Staking::current_era(), 1);
 		assert_eq!(Session::current_index(), 3);
@@ -122,7 +122,7 @@ fn dust_account_removal_should_work() {
 		assert_eq!(System::account_nonce(&2), 1);
 		assert_eq!(Staking::voting_balance(&2), 256 * 20);
 
-		assert_ok!(Staking::transfer(&2, 5.into(), 256 * 10 + 1));	// index 1 (account 2) becomes zombie
+		assert_ok!(Staking::transfer(&2, 5.into(), 256 * 10 + 1)); // index 1 (account 2) becomes zombie
 		assert_eq!(Staking::voting_balance(&2), 0);
 		assert_eq!(Staking::voting_balance(&5), 256 * 10 + 1);
 		assert_eq!(System::account_nonce(&2), 0);
@@ -136,10 +136,10 @@ fn reclaim_indexing_on_new_accounts_should_work() {
 		assert_eq!(Staking::lookup_index(4), None);
 		assert_eq!(Staking::voting_balance(&2), 256 * 20);
 
-		assert_ok!(Staking::transfer(&2, 5.into(), 256 * 20));	// account 2 becomes zombie freeing index 1 for reclaim)
+		assert_ok!(Staking::transfer(&2, 5.into(), 256 * 20)); // account 2 becomes zombie freeing index 1 for reclaim)
 		assert_eq!(Staking::voting_balance(&2), 0);
 
-		assert_ok!(Staking::transfer(&5, 6.into(), 256 * 1 + 0x69));	// account 6 takes index 1.
+		assert_ok!(Staking::transfer(&5, 6.into(), 256 * 1 + 0x69)); // account 6 takes index 1.
 		assert_eq!(Staking::voting_balance(&6), 256 * 1 + 0x69);
 		assert_eq!(Staking::lookup_index(1), Some(6));
 	});
@@ -153,23 +153,23 @@ fn reserved_balance_should_prevent_reclaim_count() {
 		assert_eq!(Staking::lookup_index(4), None);
 		assert_eq!(Staking::voting_balance(&2), 256 * 20);
 
-		assert_ok!(Staking::reserve(&2, 256 * 19 + 1));					// account 2 becomes mostly reserved
-		assert_eq!(Staking::free_balance(&2), 0);						// "free" account deleted."
-		assert_eq!(Staking::voting_balance(&2), 256 * 19 + 1);			// reserve still exists.
+		assert_ok!(Staking::reserve(&2, 256 * 19 + 1)); // account 2 becomes mostly reserved
+		assert_eq!(Staking::free_balance(&2), 0); // "free" account deleted."
+		assert_eq!(Staking::voting_balance(&2), 256 * 19 + 1); // reserve still exists.
 		assert_eq!(System::account_nonce(&2), 1);
 
-		assert_ok!(Staking::transfer(&4, 5.into(), 256 * 1 + 0x69));	// account 4 tries to take index 1 for account 5.
+		assert_ok!(Staking::transfer(&4, 5.into(), 256 * 1 + 0x69)); // account 4 tries to take index 1 for account 5.
 		assert_eq!(Staking::voting_balance(&5), 256 * 1 + 0x69);
-		assert_eq!(Staking::lookup_index(1), Some(2));					// but fails.
+		assert_eq!(Staking::lookup_index(1), Some(2)); // but fails.
 		assert_eq!(System::account_nonce(&2), 1);
 
-		assert_eq!(Staking::slash(&2, 256 * 18 + 2), None);				// account 2 gets slashed
-		assert_eq!(Staking::voting_balance(&2), 0);						// "free" account deleted."
+		assert_eq!(Staking::slash(&2, 256 * 18 + 2), None); // account 2 gets slashed
+		assert_eq!(Staking::voting_balance(&2), 0); // "free" account deleted."
 		assert_eq!(System::account_nonce(&2), 0);
 
-		assert_ok!(Staking::transfer(&4, 6.into(), 256 * 1 + 0x69));	// account 4 tries to take index 1 again for account 6.
+		assert_ok!(Staking::transfer(&4, 6.into(), 256 * 1 + 0x69)); // account 4 tries to take index 1 again for account 6.
 		assert_eq!(Staking::voting_balance(&6), 256 * 1 + 0x69);
-		assert_eq!(Staking::lookup_index(1), Some(6));					// and succeeds.
+		assert_eq!(Staking::lookup_index(1), Some(6)); // and succeeds.
 	});
 }
 
@@ -199,7 +199,10 @@ fn staking_should_work() {
 		// Block 3: Unstake highest, introduce another staker. No change yet.
 		System::set_block_number(3);
 		assert_ok!(Staking::stake(&3));
-		assert_ok!(Staking::unstake(&4, Staking::intentions().iter().position(|&x| x == 4).unwrap() as u32));
+		assert_ok!(Staking::unstake(
+			&4,
+			Staking::intentions().iter().position(|&x| x == 4).unwrap() as u32
+		));
 		assert_eq!(Staking::current_era(), 1);
 		Session::check_rotate_session();
 
@@ -221,7 +224,10 @@ fn staking_should_work() {
 
 		// Block 7: Unstake three. No change yet.
 		System::set_block_number(7);
-		assert_ok!(Staking::unstake(&3, Staking::intentions().iter().position(|&x| x == 3).unwrap() as u32));
+		assert_ok!(Staking::unstake(
+			&3,
+			Staking::intentions().iter().position(|&x| x == 3).unwrap() as u32
+		));
 		Session::check_rotate_session();
 		assert_eq!(Session::validators(), vec![1, 3]);
 
@@ -247,7 +253,7 @@ fn nominating_and_rewards_should_work() {
 		assert_ok!(Staking::nominate(&4, 1.into()));
 		Session::check_rotate_session();
 		assert_eq!(Staking::current_era(), 1);
-		assert_eq!(Session::validators(), vec![1, 3]);	// 4 + 1, 3
+		assert_eq!(Session::validators(), vec![1, 3]); // 4 + 1, 3
 		assert_eq!(Staking::voting_balance(&1), 10);
 		assert_eq!(Staking::voting_balance(&2), 20);
 		assert_eq!(Staking::voting_balance(&3), 30);
@@ -265,7 +271,10 @@ fn nominating_and_rewards_should_work() {
 
 		System::set_block_number(3);
 		assert_ok!(Staking::stake(&4));
-		assert_ok!(Staking::unstake(&3, Staking::intentions().iter().position(|&x| x == 3).unwrap() as u32));
+		assert_ok!(Staking::unstake(
+			&3,
+			Staking::intentions().iter().position(|&x| x == 3).unwrap() as u32
+		));
 		assert_ok!(Staking::nominate(&3, 1.into()));
 		Session::check_rotate_session();
 		assert_eq!(Session::validators(), vec![1, 4]);
@@ -303,14 +312,14 @@ fn nominating_slashes_should_work() {
 		Session::check_rotate_session();
 
 		assert_eq!(Staking::current_era(), 1);
-		assert_eq!(Session::validators(), vec![1, 3]);	// 1 + 4, 3 + 2
+		assert_eq!(Session::validators(), vec![1, 3]); // 1 + 4, 3 + 2
 		assert_eq!(Staking::voting_balance(&1), 10);
 		assert_eq!(Staking::voting_balance(&2), 20);
 		assert_eq!(Staking::voting_balance(&3), 30);
 		assert_eq!(Staking::voting_balance(&4), 40);
 
 		System::set_block_number(5);
-		Timestamp::set_timestamp(100);	// late
+		Timestamp::set_timestamp(100); // late
 		assert_eq!(Session::blocks_remaining(), 1);
 		assert!(Session::broken_validation());
 		Session::check_rotate_session();
@@ -329,10 +338,16 @@ fn double_staking_should_fail() {
 		System::set_block_number(1);
 		assert_ok!(Staking::stake(&1));
 		assert_noop!(Staking::stake(&1), "Cannot stake if already staked.");
-		assert_noop!(Staking::nominate(&1, 1.into()), "Cannot nominate if already staked.");
+		assert_noop!(
+			Staking::nominate(&1, 1.into()),
+			"Cannot nominate if already staked."
+		);
 		assert_ok!(Staking::nominate(&2, 1.into()));
 		assert_noop!(Staking::stake(&2), "Cannot stake if already nominating.");
-		assert_noop!(Staking::nominate(&2, 1.into()), "Cannot nominate if already nominating.");
+		assert_noop!(
+			Staking::nominate(&2, 1.into()),
+			"Cannot nominate if already nominating."
+		);
 	});
 }
 
@@ -433,7 +448,10 @@ fn staking_balance_transfer_when_bonded_should_not_work() {
 	with_externalities(&mut new_test_ext(0, 1, 3, 1, false, 0), || {
 		<FreeBalance<Test>>::insert(1, 111);
 		assert_ok!(Staking::stake(&1));
-		assert_noop!(Staking::transfer(&1, 2.into(), 69), "bondage too high to send value");
+		assert_noop!(
+			Staking::transfer(&1, 2.into(), 69),
+			"bondage too high to send value"
+		);
 	});
 }
 
@@ -459,7 +477,10 @@ fn staking_balance_transfer_when_reserved_should_not_work() {
 	with_externalities(&mut new_test_ext(0, 1, 3, 1, false, 0), || {
 		<FreeBalance<Test>>::insert(1, 111);
 		assert_ok!(Staking::reserve(&1, 69));
-		assert_noop!(Staking::transfer(&1, 2.into(), 69), "balance too low to send value");
+		assert_noop!(
+			Staking::transfer(&1, 2.into(), 69),
+			"balance too low to send value"
+		);
 	});
 }
 
@@ -568,7 +589,10 @@ fn transferring_reserved_balance_to_nonexistent_should_fail() {
 	with_externalities(&mut new_test_ext(0, 1, 3, 1, false, 0), || {
 		<FreeBalance<Test>>::insert(1, 111);
 		assert_ok!(Staking::reserve(&1, 111));
-		assert_noop!(Staking::transfer_reserved(&1, &2, 42), "beneficiary account must pre-exist");
+		assert_noop!(
+			Staking::transfer_reserved(&1, &2, 42),
+			"beneficiary account must pre-exist"
+		);
 	});
 }
 
@@ -612,8 +636,14 @@ fn account_removal_removes_storage() {
 			assert_eq!(<StorageOf<Test>>::get(1, b"foo".to_vec()), None);
 			assert_eq!(<StorageOf<Test>>::get(1, b"bar".to_vec()), None);
 
-			assert_eq!(<StorageOf<Test>>::get(2, b"hello".to_vec()), Some(b"3".to_vec()));
-			assert_eq!(<StorageOf<Test>>::get(2, b"world".to_vec()), Some(b"4".to_vec()));
+			assert_eq!(
+				<StorageOf<Test>>::get(2, b"hello".to_vec()),
+				Some(b"3".to_vec())
+			);
+			assert_eq!(
+				<StorageOf<Test>>::get(2, b"world".to_vec()),
+				Some(b"4".to_vec())
+			);
 		}
 	});
 }

--- a/substrate/runtime/version/src/lib.rs
+++ b/substrate/runtime/version/src/lib.rs
@@ -34,8 +34,8 @@ extern crate substrate_runtime_support as runtime_support;
 
 extern crate substrate_codec as codec;
 
-use rstd::prelude::*;
 use codec::Slicable;
+use rstd::prelude::*;
 #[cfg(feature = "std")]
 use std::borrow::Cow;
 
@@ -47,20 +47,25 @@ pub type VersionString = &'static str;
 #[cfg(feature = "std")]
 #[macro_export]
 macro_rules! ver_str {
-	( $y:expr ) => {{ ::std::borrow::Cow::Borrowed($y) }}
+	($y:expr) => {{
+		::std::borrow::Cow::Borrowed($y)
+		}};
 }
 
 #[cfg(not(feature = "std"))]
 #[macro_export]
 macro_rules! ver_str {
-	( $y:expr ) => {{ $y }}
+	($y:expr) => {{
+			$y
+		}};
 }
 
 /// Runtime version.
 /// This should not be thought of as classic Semver (major/minor/tiny).
 /// This triplet have different semantics and mis-interpretation could cause problems.
-/// In particular: bug fixes should result in an increment of `spec_version` and possibly `authoring_version`,
-/// absolutely not `impl_version` since they change the semantics of the runtime.
+/// In particular: bug fixes should result in an increment of `spec_version` and possibly
+/// `authoring_version`, absolutely not `impl_version` since they change the semantics of the
+/// runtime.
 #[derive(Clone)]
 #[cfg_attr(feature = "std", derive(Debug, Serialize, Deserialize))]
 pub struct RuntimeVersion {
@@ -68,18 +73,18 @@ pub struct RuntimeVersion {
 	/// A different on-chain spec_name to that of the native runtime would normally result
 	/// in node not attempting to sync or author blocks.
 	pub spec_name: VersionString,
-	
+
 	/// Name of the implementation of the spec. This is of little consequence for the node
 	/// and serves only to differentiate code of different implementation teams. For this
 	/// codebase, it will be parity-polkadot. If there were a non-Rust implementation of the
 	/// Polkadot runtime (e.g. C++), then it would identify itself with an accordingly different
 	/// `impl_name`.
 	pub impl_name: VersionString,
-	
+
 	/// `authoring_version` is the version of the authorship interface. An authoring node
 	/// will not attempt to author blocks unless this is equal to its native runtime.
 	pub authoring_version: u32,
-	
+
 	/// Version of the runtime specification. A full-node will not attempt to use its native
 	/// runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
 	/// `spec_version` and `authoring_version` are the same between Wasm and native.
@@ -112,15 +117,14 @@ impl Default for RuntimeVersion {
 impl RuntimeVersion {
 	/// Check if this version matches other version for calling into runtime.
 	pub fn can_call_with(&self, other: &RuntimeVersion) -> bool {
-		self.spec_version == other.spec_version &&
-		self.spec_name == other.spec_name &&
-		self.authoring_version == other.authoring_version
+		self.spec_version == other.spec_version
+			&& self.spec_name == other.spec_name
+			&& self.authoring_version == other.authoring_version
 	}
 
 	/// Check if this version matches other version for authoring blocks.
 	pub fn can_author_with(&self, other: &RuntimeVersion) -> bool {
-		self.authoring_version == other.authoring_version &&
-		self.spec_name == other.spec_name
+		self.authoring_version == other.authoring_version && self.spec_name == other.spec_name
 	}
 }
 

--- a/substrate/serializer/src/lib.rs
+++ b/substrate/serializer/src/lib.rs
@@ -24,7 +24,7 @@
 extern crate serde;
 extern crate serde_json;
 
-pub use serde_json::{from_str, from_slice, from_reader, Result, Error};
+pub use serde_json::{from_reader, from_slice, from_str, Error, Result};
 
 const PROOF: &str = "Serializers are infallible; qed";
 
@@ -39,6 +39,9 @@ pub fn encode<T: serde::Serialize + ?Sized>(value: &T) -> Vec<u8> {
 }
 
 /// Serialize the given data structure as JSON into the IO stream.
-pub fn to_writer<W: ::std::io::Write, T: serde::Serialize + ?Sized>(writer: W, value: &T) -> Result<()> {
+pub fn to_writer<W: ::std::io::Write, T: serde::Serialize + ?Sized>(
+	writer: W,
+	value: &T,
+) -> Result<()> {
 	serde_json::to_writer(writer, value)
 }

--- a/substrate/state-db/src/test.rs
+++ b/substrate/state-db/src/test.rs
@@ -16,9 +16,9 @@
 
 //! Test utils
 
-use std::collections::HashMap;
 use primitives::H256;
-use {DBValue, ChangeSet, CommitSet, MetaDb, HashDb};
+use std::collections::HashMap;
+use {ChangeSet, CommitSet, DBValue, HashDb, MetaDb};
 
 #[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct TestDb {
@@ -62,7 +62,10 @@ impl TestDb {
 
 pub fn make_changeset(inserted: &[u64], deleted: &[u64]) -> ChangeSet<H256> {
 	ChangeSet {
-		inserted: inserted.iter().map(|v| (H256::from(*v), H256::from(*v).to_vec())).collect(),
+		inserted: inserted
+			.iter()
+			.map(|v| (H256::from(*v), H256::from(*v).to_vec()))
+			.collect(),
 		deleted: deleted.iter().map(|v| H256::from(*v)).collect(),
 	}
 }
@@ -76,8 +79,10 @@ pub fn make_commit(inserted: &[u64], deleted: &[u64]) -> CommitSet<H256> {
 
 pub fn make_db(inserted: &[u64]) -> TestDb {
 	TestDb {
-		data: inserted.iter().map(|v| (H256::from(*v), H256::from(*v).to_vec())).collect(),
+		data: inserted
+			.iter()
+			.map(|v| (H256::from(*v), H256::from(*v).to_vec()))
+			.collect(),
 		meta: Default::default(),
 	}
 }
-

--- a/substrate/state-machine/src/ext.rs
+++ b/substrate/state-machine/src/ext.rs
@@ -16,8 +16,8 @@
 
 //! Conrete externalities implementation.
 
-use std::{error, fmt};
 use backend::Backend;
+use std::{error, fmt};
 use {Externalities, OverlayedChanges};
 
 /// Errors that can occur when interacting with the externalities.
@@ -72,7 +72,9 @@ impl<'a, B: 'a + Backend> Ext<'a, B> {
 	/// Get the transaction necessary to update the backend.
 	pub fn transaction(mut self) -> B::Transaction {
 		let _ = self.storage_root();
-		self.transaction.expect("transaction always set after calling storage root; qed").0
+		self.transaction
+			.expect("transaction always set after calling storage root; qed")
+			.0
 	}
 
 	/// Invalidates the currently cached storage root and the db transaction.
@@ -88,7 +90,9 @@ impl<'a, B: 'a + Backend> Ext<'a, B> {
 	pub fn storage_pairs(&self) -> Vec<(Vec<u8>, Vec<u8>)> {
 		use std::collections::HashMap;
 
-		self.backend.pairs().iter()
+		self.backend
+			.pairs()
+			.iter()
 			.map(|&(ref k, ref v)| (k.to_vec(), Some(v.to_vec())))
 			.chain(self.overlay.committed.clone().into_iter())
 			.chain(self.overlay.prospective.clone().into_iter())
@@ -100,11 +104,18 @@ impl<'a, B: 'a + Backend> Ext<'a, B> {
 }
 
 impl<'a, B: 'a> Externalities for Ext<'a, B>
-	where B: Backend
+where
+	B: Backend,
 {
 	fn storage(&self, key: &[u8]) -> Option<Vec<u8>> {
-		self.overlay.storage(key).map(|x| x.map(|x| x.to_vec())).unwrap_or_else(||
-			self.backend.storage(key).expect("Externalities not allowed to fail within runtime"))
+		self.overlay
+			.storage(key)
+			.map(|x| x.map(|x| x.to_vec()))
+			.unwrap_or_else(|| {
+				self.backend
+					.storage(key)
+					.expect("Externalities not allowed to fail within runtime")
+			})
 	}
 
 	fn place_storage(&mut self, key: Vec<u8>, value: Option<Vec<u8>>) {
@@ -124,12 +135,15 @@ impl<'a, B: 'a> Externalities for Ext<'a, B>
 	}
 
 	fn storage_root(&mut self) -> [u8; 32] {
-		if let Some((_, ref root)) =  self.transaction {
-			return root.clone();
+		if let Some((_, ref root)) = self.transaction {
+			return root.clone()
 		}
 
 		// compute and memoize
-		let delta = self.overlay.committed.iter()
+		let delta = self
+			.overlay
+			.committed
+			.iter()
 			.chain(self.overlay.prospective.iter())
 			.map(|(k, v)| (k.clone(), v.clone()));
 

--- a/substrate/state-machine/src/testing.rs
+++ b/substrate/state-machine/src/testing.rs
@@ -16,8 +16,8 @@
 
 //! Test implementation for Externalities.
 
-use std::collections::HashMap;
 use super::Externalities;
+use std::collections::HashMap;
 use triehash::trie_root;
 
 /// Simple HashMap based Externalities impl.
@@ -30,18 +30,22 @@ impl Externalities for TestExternalities {
 
 	fn place_storage(&mut self, key: Vec<u8>, maybe_value: Option<Vec<u8>>) {
 		match maybe_value {
-			Some(value) => { self.insert(key, value); }
-			None => { self.remove(&key); }
+			Some(value) => {
+				self.insert(key, value);
+			},
+			None => {
+				self.remove(&key);
+			},
 		}
 	}
 
 	fn clear_prefix(&mut self, prefix: &[u8]) {
-		self.retain(|key, _|
-			!key.starts_with(prefix)
-		)
+		self.retain(|key, _| !key.starts_with(prefix))
 	}
 
-	fn chain_id(&self) -> u64 { 42 }
+	fn chain_id(&self) -> u64 {
+		42
+	}
 
 	fn storage_root(&mut self) -> [u8; 32] {
 		trie_root(self.clone()).0
@@ -58,7 +62,8 @@ mod tests {
 		ext.set_storage(b"doe".to_vec(), b"reindeer".to_vec());
 		ext.set_storage(b"dog".to_vec(), b"puppy".to_vec());
 		ext.set_storage(b"dogglesworth".to_vec(), b"cat".to_vec());
-		const ROOT: [u8; 32] = hex!("8aad789dff2f538bca5d8ea56e8abe10f4c7ba3a5dea95fea4cd6e7c3a1168d3");
+		const ROOT: [u8; 32] =
+			hex!("8aad789dff2f538bca5d8ea56e8abe10f4c7ba3a5dea95fea4cd6e7c3a1168d3");
 		assert_eq!(ext.storage_root(), ROOT);
 	}
 }

--- a/substrate/test-client/src/lib.rs
+++ b/substrate/test-client/src/lib.rs
@@ -22,12 +22,13 @@ extern crate substrate_bft as bft;
 extern crate substrate_codec as codec;
 extern crate substrate_keyring as keyring;
 extern crate substrate_primitives as primitives;
-extern crate substrate_runtime_support as runtime_support;
 extern crate substrate_runtime_primitives as runtime_primitives;
-#[macro_use] extern crate substrate_executor as executor;
+extern crate substrate_runtime_support as runtime_support;
+#[macro_use]
+extern crate substrate_executor as executor;
 
-pub extern crate substrate_test_runtime as runtime;
 pub extern crate substrate_client as client;
+pub extern crate substrate_test_runtime as runtime;
 
 mod client_ext;
 

--- a/substrate/test-runtime/src/genesismap.rs
+++ b/substrate/test-runtime/src/genesismap.rs
@@ -16,11 +16,11 @@
 
 //! Tool for creating the genesis block.
 
-use std::collections::HashMap;
-use runtime_io::twox_128;
-use codec::{KeyedVec, Joiner};
+use codec::{Joiner, KeyedVec};
 use primitives::AuthorityId;
+use runtime_io::twox_128;
 use runtime_primitives::traits::Block;
+use std::collections::HashMap;
 
 /// Configuration of a general Substrate test genesis block.
 pub struct GenesisConfig {
@@ -38,16 +38,24 @@ impl GenesisConfig {
 
 	pub fn genesis_map(&self) -> HashMap<Vec<u8>, Vec<u8>> {
 		let wasm_runtime = include_bytes!("../wasm/genesis.wasm").to_vec();
-		self.balances.iter()
+		self.balances
+			.iter()
 			.map(|&(account, balance)| (account.to_keyed_vec(b"balance:"), vec![].and(&balance)))
 			.map(|(k, v)| (twox_128(&k[..])[..].to_vec(), v.to_vec()))
-			.chain(vec![
-				(b":code"[..].into(), wasm_runtime),
-				(b":auth:len"[..].into(), vec![].and(&(self.authorities.len() as u32))),
-			].into_iter())
-			.chain(self.authorities.iter()
-				.enumerate()
-				.map(|(i, account)| ((i as u32).to_keyed_vec(b":auth:"), vec![].and(account)))
+			.chain(
+				vec![
+					(b":code"[..].into(), wasm_runtime),
+					(
+						b":auth:len"[..].into(),
+						vec![].and(&(self.authorities.len() as u32)),
+					),
+				].into_iter(),
+			)
+			.chain(
+				self.authorities
+					.iter()
+					.enumerate()
+					.map(|(i, account)| ((i as u32).to_keyed_vec(b":auth:"), vec![].and(account))),
 			)
 			.collect()
 	}

--- a/substrate/test-runtime/src/lib.rs
+++ b/substrate/test-runtime/src/lib.rs
@@ -18,9 +18,9 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-extern crate substrate_runtime_std as rstd;
 extern crate substrate_codec as codec;
 extern crate substrate_runtime_primitives as runtime_primitives;
+extern crate substrate_runtime_std as rstd;
 
 #[cfg(feature = "std")]
 extern crate serde;
@@ -46,17 +46,17 @@ extern crate substrate_runtime_io as runtime_io;
 #[macro_use]
 extern crate substrate_runtime_version as runtime_version;
 
-
-#[cfg(feature = "std")] pub mod genesismap;
+#[cfg(feature = "std")]
+pub mod genesismap;
 pub mod system;
 
-use rstd::prelude::*;
 use codec::Slicable;
+use rstd::prelude::*;
 
-use runtime_primitives::traits::{BlindCheckable, BlakeTwo256};
+pub use primitives::hash::H256;
+use runtime_primitives::traits::{BlakeTwo256, BlindCheckable};
 use runtime_primitives::Ed25519Signature;
 use runtime_version::RuntimeVersion;
-pub use primitives::hash::H256;
 
 /// Test runtime version.
 pub const VERSION: RuntimeVersion = RuntimeVersion {
@@ -92,7 +92,12 @@ impl Slicable for Transfer {
 	}
 
 	fn decode<I: ::codec::Input>(input: &mut I) -> Option<Self> {
-		Slicable::decode(input).map(|(from, to, amount, nonce)| Transfer { from, to, amount, nonce })
+		Slicable::decode(input).map(|(from, to, amount, nonce)| Transfer {
+			from,
+			to,
+			amount,
+			nonce,
+		})
 	}
 }
 
@@ -113,7 +118,10 @@ impl Slicable for Extrinsic {
 	}
 
 	fn decode<I: ::codec::Input>(input: &mut I) -> Option<Self> {
-		Slicable::decode(input).map(|(transfer, signature)| Extrinsic { transfer, signature })
+		Slicable::decode(input).map(|(transfer, signature)| Extrinsic {
+			transfer,
+			signature,
+		})
 	}
 }
 
@@ -125,7 +133,11 @@ impl BlindCheckable for Extrinsic {
 		&self.transfer.from
 	}
 	fn check(self) -> Result<Self, &'static str> {
-		if ::runtime_primitives::verify_encoded_lazy(&self.signature, &self.transfer, &self.transfer.from) {
+		if ::runtime_primitives::verify_encoded_lazy(
+			&self.signature,
+			&self.transfer,
+			&self.transfer.from,
+		) {
 			Ok(self)
 		} else {
 			Err("bad signature")
@@ -155,7 +167,11 @@ pub fn run_tests(mut input: &[u8]) -> Vec<u8> {
 	print("run_tests...");
 	let block = Block::decode(&mut input).unwrap();
 	print("deserialised block.");
-	let stxs = block.extrinsics.iter().map(Slicable::encode).collect::<Vec<_>>();
+	let stxs = block
+		.extrinsics
+		.iter()
+		.map(Slicable::encode)
+		.collect::<Vec<_>>();
 	print("reserialised transactions.");
 	[stxs.len() as u8].encode()
 }


### PR DESCRIPTION
This is an example, how our code base would be reformatted if we applied `rustfmt`, [with a configuration](https://github.com/paritytech/polkadot/commit/f0b945c3a42f966721b223ef59bcd243069c9506) as close to [the new styleguide](https://github.com/paritytech/polkadot/wiki/Style-Guide) as possible.

I'd also like to address to following, when taking into consideration whether we want to move forward with this:

> Every time rustfmt gets updated the CI will break
While that used to be true, there are a few things that have changed recently, which make me believe this isn't going to be as much of a problem in the future:
1. [fmt has moved into an RFC process](https://github.com/rust-lang-nursery/fmt-rfcs) and released new-features behind a flag first as with the proper release process, which I believe to go much slower, too
2. as we need that flag set though, we have a rather complete configuration file with all options set to their current default, thus changing defaults would not effect us
3. you can now _pin_ to a specific fmt version, thus if this really becomes an issue, we could pin to the current version and make intended formatting upgrades only when we want to

Comparing this to the styleguide:

> Indent levels should be greater than 5 only in exceptional circumstances and certainly no greater than 8. If they are greater than 5, then consider using let or auxiliary functions in order to strip out complex inline expressions. _(from the styleguide)
Can't be addressed with rustfmt, but maybe with clippy? I am very fond of this and would really like to have a tool ensuring we adhere to it!

> Lines should be longer than 80 characters long only in exceptional circumstances and certainly no longer than 120. For this purpose, tabs are considered 4 characters wide.
This goes for a max_width of 100 with tabs and tabs considered 4 chars. Intentionally longer lines could be [marked for rustfmt to ignore](https://github.com/rust-lang-nursery/rustfmt#tips) but that hasn't been done.

> `where` is indented, and its items are indented one further
This isn't a configuration option at the moment, however the indentation-rules around `where` provided within the current version are coming pretty close imho

> Blocks should not be used unnecessarily.
This has been deactivated here, however the "unnecessary" is another thing for clippy I guess....