### PR TITLE
Rename Hashing Trait to Hash

### DIFF
--- a/polkadot/consensus/src/lib.rs
+++ b/polkadot/consensus/src/lib.rs
@@ -661,7 +661,7 @@ pub struct CreateProposal<C: PolkadotApi>  {
 impl<C> CreateProposal<C> where C: PolkadotApi {
 	fn propose_with(&self, candidates: Vec<CandidateReceipt>) -> Result<Block, Error> {
 		use polkadot_api::BlockBuilder;
-		use runtime_primitives::traits::{Hashing, BlakeTwo256};
+		use runtime_primitives::traits::{Hash as HashT, BlakeTwo256};
 
 		// TODO: handle case when current timestamp behind that in state.
 		let timestamp = current_timestamp();

--- a/polkadot/primitives/src/parachain.rs
+++ b/polkadot/primitives/src/parachain.rs
@@ -192,7 +192,7 @@ impl CandidateReceipt {
 	/// Get the blake2_256 hash
 	#[cfg(feature = "std")]
 	pub fn hash(&self) -> Hash {
-		use runtime_primitives::traits::{BlakeTwo256, Hashing};
+		use runtime_primitives::traits::{BlakeTwo256, Hash};
 		BlakeTwo256::hash_of(self)
 	}
 }
@@ -247,7 +247,7 @@ impl BlockData {
 	/// Compute hash of block data.
 	#[cfg(feature = "std")]
 	pub fn hash(&self) -> Hash {
-		use runtime_primitives::traits::{BlakeTwo256, Hashing};
+		use runtime_primitives::traits::{BlakeTwo256, Hash};
 		BlakeTwo256::hash(&self.0[..])
 	}
 }

--- a/polkadot/runtime/src/parachains.rs
+++ b/polkadot/runtime/src/parachains.rs
@@ -19,7 +19,7 @@
 use rstd::prelude::*;
 use codec::Slicable;
 
-use runtime_primitives::traits::{Hashing, BlakeTwo256, Executable, RefInto, MaybeEmpty};
+use runtime_primitives::traits::{Hash, BlakeTwo256, Executable, RefInto, MaybeEmpty};
 use primitives::parachain::{Id, Chain, DutyRoster, CandidateReceipt};
 use {system, session};
 

--- a/polkadot/transaction-pool/src/lib.rs
+++ b/polkadot/transaction-pool/src/lib.rs
@@ -49,7 +49,7 @@ use extrinsic_pool::api::ExtrinsicPool;
 use polkadot_api::PolkadotApi;
 use primitives::{AccountId, BlockId, Hash, Index, UncheckedExtrinsic as FutureProofUncheckedExtrinsic};
 use runtime::{Address, UncheckedExtrinsic};
-use substrate_runtime_primitives::traits::{Bounded, Checkable, Hashing, BlakeTwo256};
+use substrate_runtime_primitives::traits::{Bounded, Checkable, Hash as HashT, BlakeTwo256};
 
 pub use extrinsic_pool::txpool::{Options, Status, LightStatus, VerifiedTransaction as VerifiedTransactionOps};
 pub use error::{Error, ErrorKind, Result};

--- a/substrate/client/db/src/lib.rs
+++ b/substrate/client/db/src/lib.rs
@@ -50,7 +50,7 @@ use parking_lot::RwLock;
 use primitives::H256;
 use runtime_primitives::generic::BlockId;
 use runtime_primitives::bft::Justification;
-use runtime_primitives::traits::{Block as BlockT, Header as HeaderT, As, Hashing, HashingFor, Zero};
+use runtime_primitives::traits::{Block as BlockT, Header as HeaderT, As, Hash, HashFor, Zero};
 use runtime_primitives::BuildStorage;
 use state_machine::backend::Backend as StateBackend;
 use executor::RuntimeInfo;
@@ -180,7 +180,7 @@ impl<Block: BlockT> client::blockchain::HeaderBackend<Block> for BlockchainDb<Bl
 
 	fn hash(&self, number: <Block::Header as HeaderT>::Number) -> Result<Option<Block::Hash>, client::error::Error> {
 		read_db::<Block>(&*self.db, columns::BLOCK_INDEX, columns::HEADER, BlockId::Number(number)).map(|x|
-			x.map(|raw| HashingFor::<Block>::hash(&raw[..])).map(Into::into)
+			x.map(|raw| HashFor::<Block>::hash(&raw[..])).map(Into::into)
 		)
 	}
 }

--- a/substrate/client/db/src/light.rs
+++ b/substrate/client/db/src/light.rs
@@ -28,7 +28,7 @@ use client::light::blockchain::Storage as LightBlockchainStorage;
 use codec::Slicable;
 use primitives::AuthorityId;
 use runtime_primitives::generic::BlockId;
-use runtime_primitives::traits::{Block as BlockT, Header as HeaderT, As, Hashing, HashingFor, Zero};
+use runtime_primitives::traits::{Block as BlockT, Header as HeaderT, As, Hash, HashFor, Zero};
 use utils::{meta_keys, Meta, db_err, number_to_db_key, open_database, read_db, read_id, read_meta};
 use DatabaseSettings;
 
@@ -132,7 +132,7 @@ impl<Block> BlockchainHeaderBackend<Block> for LightStorage<Block>
 
 	fn hash(&self, number: <<Block as BlockT>::Header as HeaderT>::Number) -> ClientResult<Option<Block::Hash>> {
 		read_db::<Block>(&*self.db, columns::BLOCK_INDEX, columns::HEADER, BlockId::Number(number)).map(|x|
-			x.map(|raw| HashingFor::<Block>::hash(&raw[..])).map(Into::into)
+			x.map(|raw| HashFor::<Block>::hash(&raw[..])).map(Into::into)
 		)
 	}
 }

--- a/substrate/client/db/src/utils.rs
+++ b/substrate/client/db/src/utils.rs
@@ -26,7 +26,7 @@ use client;
 use codec::Slicable;
 use hashdb::DBValue;
 use runtime_primitives::generic::BlockId;
-use runtime_primitives::traits::{As, Block as BlockT, Header as HeaderT, Hashing, HashingFor, Zero};
+use runtime_primitives::traits::{As, Block as BlockT, Header as HeaderT, Hash, HashFor, Zero};
 use DatabaseSettings;
 
 /// Number of columns in the db. Must be the same for both full && light dbs.
@@ -155,7 +155,7 @@ pub fn read_meta<Block>(db: &KeyValueDB, col_header: Option<u32>) -> Result<Meta
 
 	let genesis_hash = db.get(col_header, &number_to_db_key(genesis_number))
 		.map_err(db_err)?
-		.map(|raw| HashingFor::<Block>::hash(&raw[..]))
+		.map(|raw| HashFor::<Block>::hash(&raw[..]))
 		.unwrap_or_default()
 		.into();
 

--- a/substrate/client/src/block_builder.rs
+++ b/substrate/client/src/block_builder.rs
@@ -19,7 +19,7 @@
 use std::vec::Vec;
 use codec::Slicable;
 use state_machine;
-use runtime_primitives::traits::{Header as HeaderT, Hashing as HashingT, Block as BlockT, One, HashingFor};
+use runtime_primitives::traits::{Header as HeaderT, Hash, Block as BlockT, One, HashFor};
 use runtime_primitives::generic::BlockId;
 use {backend, error, Client, CallExecutor};
 
@@ -109,7 +109,7 @@ impl<B, E, Block> BlockBuilder<B, E, Block> where
 
 		debug_assert_eq!(
 			self.header.extrinsics_root().clone(),
-			HashingFor::<Block>::ordered_trie_root(self.extrinsics.iter().map(Slicable::encode)),
+			HashFor::<Block>::ordered_trie_root(self.extrinsics.iter().map(Slicable::encode)),
 		);
 
 		Ok(<Block as BlockT>::new(self.header, self.extrinsics))

--- a/substrate/client/src/genesis.rs
+++ b/substrate/client/src/genesis.rs
@@ -16,7 +16,7 @@
 
 //! Tool for creating the genesis block.
 
-use runtime_primitives::traits::{Block as BlockT, Header as HeaderT, Hashing as HashingT, Zero};
+use runtime_primitives::traits::{Block as BlockT, Header as HeaderT, Hash as HashT, Zero};
 use runtime_primitives::StorageMap;
 
 /// Create a genesis block, given the initial storage.
@@ -25,8 +25,8 @@ pub fn construct_genesis_block<
 > (
 	storage: &StorageMap
 ) -> Block {
-	let state_root = <<<Block as BlockT>::Header as HeaderT>::Hashing as HashingT>::trie_root(storage.clone().into_iter());
-	let extrinsics_root = <<<Block as BlockT>::Header as HeaderT>::Hashing as HashingT>::trie_root(::std::iter::empty::<(&[u8], &[u8])>());
+	let state_root = <<<Block as BlockT>::Header as HeaderT>::Hashing as HashT>::trie_root(storage.clone().into_iter());
+	let extrinsics_root = <<<Block as BlockT>::Header as HeaderT>::Hashing as HashT>::trie_root(::std::iter::empty::<(&[u8], &[u8])>());
 	Block::new(
 		<<Block as BlockT>::Header as HeaderT>::new(
 			Zero::zero(),

--- a/substrate/network/src/protocol.rs
+++ b/substrate/network/src/protocol.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 use std::time;
 use parking_lot::RwLock;
 use serde_json;
-use runtime_primitives::traits::{Block as BlockT, Header as HeaderT, Hashing, HashingFor};
+use runtime_primitives::traits::{Block as BlockT, Header as HeaderT, Hash, HashFor};
 use runtime_primitives::generic::BlockId;
 use network::PeerId;
 
@@ -627,5 +627,5 @@ fn send_message<B: BlockT>(peers: &RwLock<HashMap<PeerId, Peer<B>>>, io: &mut Sy
 /// Hash a message.
 pub(crate) fn hash_message<B: BlockT>(message: &Message<B>) -> B::Hash {
 	let data = serde_json::to_vec(&message).expect("Serializer is infallible; qed");
-	HashingFor::<B>::hash(&data)
+	HashFor::<B>::hash(&data)
 }

--- a/substrate/rpc/src/state/mod.rs
+++ b/substrate/rpc/src/state/mod.rs
@@ -86,7 +86,7 @@ impl<B, E, Block> StateApi<Block::Hash> for Arc<Client<B, E, Block>> where
 	}
 
 	fn storage_hash_at(&self, key: StorageKey, block: Block::Hash) -> Result<Block::Hash> {
-		use runtime_primitives::traits::{Hashing, Header as HeaderT};
+		use runtime_primitives::traits::{Hash, Header as HeaderT};
 		self.storage_at(key, block).map(|x| <Block::Header as HeaderT>::Hashing::hash(&x.0))
 	}
 

--- a/substrate/runtime/council/src/voting.rs
+++ b/substrate/runtime/council/src/voting.rs
@@ -18,7 +18,7 @@
 
 use rstd::prelude::*;
 use rstd::borrow::Borrow;
-use primitives::traits::{Executable, RefInto, Hashing};
+use primitives::traits::{Executable, RefInto, Hash};
 use runtime_io::print;
 use substrate_runtime_support::dispatch::Result;
 use substrate_runtime_support::{StorageValue, StorageMap, IsSubType};

--- a/substrate/runtime/executive/src/lib.rs
+++ b/substrate/runtime/executive/src/lib.rs
@@ -54,7 +54,7 @@ use rstd::marker::PhantomData;
 use rstd::result;
 use runtime_support::StorageValue;
 use primitives::traits::{self, Header, Zero, One, Checkable, Applyable, CheckEqual, Executable,
-	MakePayment, Hashing, AuxLookup};
+	MakePayment, Hash, AuxLookup};
 use codec::Slicable;
 use system::extrinsics_root;
 use primitives::{ApplyOutcome, ApplyError};

--- a/substrate/runtime/primitives/src/generic.rs
+++ b/substrate/runtime/primitives/src/generic.rs
@@ -26,7 +26,7 @@ use rstd::prelude::*;
 use codec::{Slicable, Input};
 use runtime_support::AuxDispatchable;
 use traits::{self, Member, SimpleArithmetic, SimpleBitOps, MaybeDisplay, Block as BlockT,
-	Header as HeaderT, Hashing as HashingT};
+	Header as HeaderT, Hash as HashT};
 use rstd::ops;
 use bft::Justification;
 
@@ -262,15 +262,15 @@ impl<Item> traits::Digest for Digest<Item> where
 #[cfg_attr(feature = "std", derive(Debug, Serialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "std", serde(deny_unknown_fields))]
-pub struct Header<Number, Hashing: HashingT, DigestItem> {
+pub struct Header<Number, Hash: HashT, DigestItem> {
 	/// The parent hash.
-	pub parent_hash: <Hashing as HashingT>::Output,
+	pub parent_hash: <Hash as HashT>::Output,
 	/// The block number.
 	pub number: Number,
 	/// The state trie merkle root
-	pub state_root: <Hashing as HashingT>::Output,
+	pub state_root: <Hash as HashT>::Output,
 	/// The merkle root of the extrinsics.
-	pub extrinsics_root: <Hashing as HashingT>::Output,
+	pub extrinsics_root: <Hash as HashT>::Output,
 	/// A chain-specific digest of data useful for light clients or referencing auxiliary data.
 	pub digest: Digest<DigestItem>,
 }
@@ -291,8 +291,8 @@ struct DeserializeHeader<N, H, D> {
 }
 
 #[cfg(feature = "std")]
-impl<N, D, Hashing: HashingT> From<DeserializeHeader<N, Hashing::Output, D>> for Header<N, Hashing, D> {
-	fn from(other: DeserializeHeader<N, Hashing::Output, D>) -> Self {
+impl<N, D, Hash: HashT> From<DeserializeHeader<N, Hash::Output, D>> for Header<N, Hash, D> {
+	fn from(other: DeserializeHeader<N, Hash::Output, D>) -> Self {
 		Header {
 			parent_hash: other.parent_hash,
 			number: other.number,
@@ -304,21 +304,21 @@ impl<N, D, Hashing: HashingT> From<DeserializeHeader<N, Hashing::Output, D>> for
 }
 
 #[cfg(feature = "std")]
-impl<'a, Number: 'a, Hashing: 'a + HashingT, DigestItem: 'a> Deserialize<'a> for Header<Number, Hashing, DigestItem> where
+impl<'a, Number: 'a, Hash: 'a + HashT, DigestItem: 'a> Deserialize<'a> for Header<Number, Hash, DigestItem> where
 	Number: Deserialize<'a>,
-	Hashing::Output: Deserialize<'a>,
+	Hash::Output: Deserialize<'a>,
 	DigestItem: Deserialize<'a>,
 {
 	fn deserialize<D: Deserializer<'a>>(de: D) -> Result<Self, D::Error> {
-		DeserializeHeader::<Number, Hashing::Output, DigestItem>::deserialize(de).map(Into::into)
+		DeserializeHeader::<Number, Hash::Output, DigestItem>::deserialize(de).map(Into::into)
 	}
 }
 
-impl<Number, Hashing, DigestItem> Slicable for Header<Number, Hashing, DigestItem> where
+impl<Number, Hash, DigestItem> Slicable for Header<Number, Hash, DigestItem> where
 	Number: Member + Slicable + MaybeDisplay + SimpleArithmetic + Slicable,
-	Hashing: HashingT,
+	Hash: HashT,
 	DigestItem: Member + Default + Slicable,
-	Hashing::Output: Default + Member + MaybeDisplay + SimpleBitOps + Slicable,
+	Hash::Output: Default + Member + MaybeDisplay + SimpleBitOps + Slicable,
 {
 	fn decode<I: Input>(input: &mut I) -> Option<Self> {
 		Some(Header {
@@ -341,15 +341,15 @@ impl<Number, Hashing, DigestItem> Slicable for Header<Number, Hashing, DigestIte
 	}
 }
 
-impl<Number, Hashing, DigestItem> traits::Header for Header<Number, Hashing, DigestItem> where
+impl<Number, Hash, DigestItem> traits::Header for Header<Number, Hash, DigestItem> where
 	Number: Member + ::rstd::hash::Hash + Copy + Slicable + MaybeDisplay + SimpleArithmetic + Slicable,
-	Hashing: HashingT,
+	Hash: HashT,
 	DigestItem: Member + Default + Slicable,
-	Hashing::Output: Default + ::rstd::hash::Hash + Copy + Member + MaybeDisplay + SimpleBitOps + Slicable,
+	Hash::Output: Default + ::rstd::hash::Hash + Copy + Member + MaybeDisplay + SimpleBitOps + Slicable,
  {
 	type Number = Number;
-	type Hash = <Hashing as HashingT>::Output;
-	type Hashing = Hashing;
+	type Hash = <Hash as HashT>::Output;
+	type Hashing = Hash;
 	type Digest = Digest<DigestItem>;
 
 	fn number(&self) -> &Self::Number { &self.number }
@@ -380,16 +380,16 @@ impl<Number, Hashing, DigestItem> traits::Header for Header<Number, Hashing, Dig
 	}
 }
 
-impl<Number, Hashing, DigestItem> Header<Number, Hashing, DigestItem> where
+impl<Number, Hash, DigestItem> Header<Number, Hash, DigestItem> where
 	Number: Member + ::rstd::hash::Hash + Copy + Slicable + MaybeDisplay + SimpleArithmetic + Slicable,
-	Hashing: HashingT,
+	Hash: HashT,
 	DigestItem: Member + Default + Slicable,
-	Hashing::Output: Default + ::rstd::hash::Hash + Copy + Member + MaybeDisplay + SimpleBitOps + Slicable,
+	Hash::Output: Default + ::rstd::hash::Hash + Copy + Member + MaybeDisplay + SimpleBitOps + Slicable,
  {
 	/// Convenience helper for computing the hash of the header without having
 	/// to import the trait.
-	pub fn hash(&self) -> Hashing::Output {
-		Hashing::hash_of(self)
+	pub fn hash(&self) -> Hash::Output {
+		Hash::hash_of(self)
 	}
 }
 

--- a/substrate/runtime/primitives/src/traits.rs
+++ b/substrate/runtime/primitives/src/traits.rs
@@ -185,7 +185,7 @@ impl<A: Executable, B: Executable> Executable for (A, B) {
 }
 
 /// Abstraction around hashing
-pub trait Hashing: 'static + MaybeSerializeDebug + Clone + Eq + PartialEq {	// Stupid bug in the Rust compiler believes derived
+pub trait Hash: 'static + MaybeSerializeDebug + Clone + Eq + PartialEq {	// Stupid bug in the Rust compiler believes derived
 																	// traits must be fulfilled by all type parameters.
 	/// The hash type produced.
 	type Output: Member + AsRef<[u8]>;
@@ -218,12 +218,12 @@ pub trait Hashing: 'static + MaybeSerializeDebug + Clone + Eq + PartialEq {	// S
 	fn storage_root() -> Self::Output;
 }
 
-/// Blake2-256 Hashing implementation.
+/// Blake2-256 Hash implementation.
 #[derive(PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "std", derive(Debug, Serialize, Deserialize))]
 pub struct BlakeTwo256;
 
-impl Hashing for BlakeTwo256 {
+impl Hash for BlakeTwo256 {
 	type Output = substrate_primitives::H256;
 	fn hash(s: &[u8]) -> Self::Output {
 		runtime_io::blake2_256(s).into()
@@ -321,7 +321,7 @@ pub trait Digest {
 pub trait Header: Clone + Send + Sync + Slicable + Eq + MaybeSerializeDebug + 'static {
 	type Number: Member + ::rstd::hash::Hash + Copy + MaybeDisplay + SimpleArithmetic + Slicable;
 	type Hash: Member + ::rstd::hash::Hash + Copy + MaybeDisplay + Default + SimpleBitOps + Slicable + AsRef<[u8]>;
-	type Hashing: Hashing<Output = Self::Hash>;
+	type Hashing: Hash<Output = Self::Hash>;
 	type Digest: Member + Default;
 
 	fn new(
@@ -348,7 +348,7 @@ pub trait Header: Clone + Send + Sync + Slicable + Eq + MaybeSerializeDebug + 's
 	fn set_digest(&mut self, Self::Digest);
 
 	fn hash(&self) -> Self::Hash {
-		<Self::Hashing as Hashing>::hash_of(self)
+		<Self::Hashing as Hash>::hash_of(self)
 	}
 }
 
@@ -366,12 +366,12 @@ pub trait Block: Clone + Send + Sync + Slicable + Eq + MaybeSerializeDebug + 'st
 	fn deconstruct(self) -> (Self::Header, Vec<Self::Extrinsic>);
 	fn new(header: Self::Header, extrinsics: Vec<Self::Extrinsic>) -> Self;
 	fn hash(&self) -> Self::Hash {
-		<<Self::Header as Header>::Hashing as Hashing>::hash_of(self.header())
+		<<Self::Header as Header>::Hashing as Hash>::hash_of(self.header())
 	}
 }
 
 /// Extract the hashing type for a block.
-pub type HashingFor<B> = <<B as Block>::Header as Header>::Hashing;
+pub type HashFor<B> = <<B as Block>::Header as Header>::Hashing;
 
 /// A "checkable" piece of information, used by the standard Substrate Executive in order to
 /// check the validity of a piece of extrinsic information, usually by verifying the signature.

--- a/substrate/runtime/staking/src/lib.rs
+++ b/substrate/runtime/staking/src/lib.rs
@@ -55,7 +55,7 @@ use runtime_support::{StorageValue, StorageMap, Parameter};
 use runtime_support::dispatch::Result;
 use session::OnSessionChange;
 use primitives::traits::{Zero, One, Bounded, RefInto, SimpleArithmetic, Executable, MakePayment,
-	As, AuxLookup, Hashing as HashingT, Member};
+	As, AuxLookup, Hash as HashT, Member};
 use address::Address as RawAddress;
 use double_map::StorageDoubleMap;
 
@@ -108,15 +108,15 @@ impl ContractAddressFor<u64> for DummyContractAddressFor {
 	}
 }
 
-impl<Hashing, AccountId> ContractAddressFor<AccountId> for Hashing where
-	Hashing: HashingT,
-	AccountId: Sized + Slicable + From<Hashing::Output>,
-	Hashing::Output: Slicable
+impl<Hash, AccountId> ContractAddressFor<AccountId> for Hash where
+	Hash: HashT,
+	AccountId: Sized + Slicable + From<Hash::Output>,
+	Hash::Output: Slicable
 {
 	fn contract_address_for(code: &[u8], origin: &AccountId) -> AccountId {
-		let mut dest_pre = Hashing::hash(code).encode();
+		let mut dest_pre = Hash::hash(code).encode();
 		origin.using_encoded(|s| dest_pre.extend(s));
-		AccountId::from(Hashing::hash(&dest_pre))
+		AccountId::from(Hash::hash(&dest_pre))
 	}
 }
 

--- a/substrate/runtime/system/src/lib.rs
+++ b/substrate/runtime/system/src/lib.rs
@@ -39,7 +39,7 @@ extern crate safe_mix;
 
 use rstd::prelude::*;
 use primitives::traits::{self, CheckEqual, SimpleArithmetic, SimpleBitOps, Zero, One, Bounded,
-	Hashing, Member, MaybeDisplay};
+	Hash, Member, MaybeDisplay};
 use runtime_support::{StorageValue, StorageMap, Parameter};
 use safe_mix::TripletMix;
 
@@ -52,12 +52,12 @@ use codec::Slicable;
 use runtime_io::{twox_128, TestExternalities};
 
 /// Compute the extrinsics root of a list of extrinsics.
-pub fn extrinsics_root<H: Hashing, E: codec::Slicable>(extrinsics: &[E]) -> H::Output {
+pub fn extrinsics_root<H: Hash, E: codec::Slicable>(extrinsics: &[E]) -> H::Output {
 	extrinsics_data_root::<H>(extrinsics.iter().map(codec::Slicable::encode).collect())
 }
 
 /// Compute the extrinsics root of a list of extrinsics.
-pub fn extrinsics_data_root<H: Hashing>(xts: Vec<Vec<u8>>) -> H::Output {
+pub fn extrinsics_data_root<H: Hash>(xts: Vec<Vec<u8>>) -> H::Output {
 	let xts = xts.iter().map(Vec::as_slice).collect::<Vec<_>>();
 	H::enumerated_trie_root(&xts)
 }
@@ -66,12 +66,12 @@ pub trait Trait: Eq + Clone {
 	type Index: Parameter + Member + Default + MaybeDisplay + SimpleArithmetic + Copy;
 	type BlockNumber: Parameter + Member + MaybeDisplay + SimpleArithmetic + Default + Bounded + Copy + rstd::hash::Hash;
 	type Hash: Parameter + Member + MaybeDisplay + SimpleBitOps + Default + Copy + CheckEqual + rstd::hash::Hash + AsRef<[u8]>;
-	type Hashing: Hashing<Output = Self::Hash>;
+	type Hashing: Hash<Output = Self::Hash>;
 	type Digest: Parameter + Member + Default + traits::Digest;
 	type AccountId: Parameter + Member + MaybeDisplay + Ord + Default;
 	type Header: Parameter + traits::Header<
 		Number = Self::BlockNumber,
-		Hashing = Self::Hashing,
+		Hash = Self::Hash,
 		Hash = Self::Hash,
 		Digest = Self::Digest
 	>;

--- a/substrate/test-runtime/src/system.rs
+++ b/substrate/test-runtime/src/system.rs
@@ -20,7 +20,7 @@
 use rstd::prelude::*;
 use runtime_io::{storage_root, enumerated_trie_root};
 use runtime_support::storage::{self, StorageValue, StorageMap};
-use runtime_primitives::traits::{Hashing, BlakeTwo256};
+use runtime_primitives::traits::{Hash as HashT, BlakeTwo256};
 use codec::{KeyedVec, Slicable};
 use super::{AccountId, BlockNumber, Extrinsic, H256 as Hash, Block, Header};
 


### PR DESCRIPTION
fixes #172 .

Rename `runtimes-primitives::traits::Hashing` to `Hash` to make it more idiomatic. Also replaces `HashingFor` with `HashFor` and all the dependent uses of any of them in our code base. The cases I opted for `Hash as HashT`-imports is because it would otherwise lead to conflicting/overwriting imports from other modules.

Note: there is still one occurrence of `Hashing` in the code base: as a type on `Header`, which has both `Hash` and `Hashing` types defined. I was thinking of renaming it `Hasher` or `Hashed` but it wasn't clear to me what this is really referring to.