### PR TITLE
Issue 279 - unique path for each chains db, network, keystore to prevent collisions

### DIFF
--- a/polkadot/cli/src/lib.rs
+++ b/polkadot/cli/src/lib.rs
@@ -207,7 +207,7 @@ pub fn run<I, T, W>(args: I, worker: W) -> error::Result<()> where
 		.to_string_lossy()
 		.into();
 
-	config.database_path = db_path(&base_path, config.chain_spec.name()).to_string_lossy().into();
+	config.database_path = db_path(&base_path, config.chain_spec.id()).to_string_lossy().into();
 
 	config.pruning = match matches.value_of("pruning") {
 		Some("archive") => PruningMode::ArchiveAll,
@@ -327,7 +327,7 @@ fn export_blocks<E>(matches: &clap::ArgMatches, exit: E) -> error::Result<()>
 	let base_path = base_path(matches);
 	let (spec, _) = load_spec(&matches)?;
 	let mut config = service::Configuration::default_with_spec(spec);
-	config.database_path = db_path(&base_path, config.chain_spec.name()).to_string_lossy().into();
+	config.database_path = db_path(&base_path, config.chain_spec.id()).to_string_lossy().into();
 	info!("DB path: {}", config.database_path);
 	let client = service::new_client(config)?;
 	let (exit_send, exit_recv) = std::sync::mpsc::channel();
@@ -392,7 +392,7 @@ fn import_blocks<E>(matches: &clap::ArgMatches, exit: E) -> error::Result<()>
 	let (spec, _) = load_spec(&matches)?;
 	let base_path = base_path(matches);
 	let mut config = service::Configuration::default_with_spec(spec);
-	config.database_path = db_path(&base_path, config.chain_spec.name()).to_string_lossy().into();
+	config.database_path = db_path(&base_path, config.chain_spec.id()).to_string_lossy().into();
 	let client = service::new_client(config)?;
 	let (exit_send, exit_recv) = std::sync::mpsc::channel();
 
@@ -506,10 +506,11 @@ fn keystore_path(base_path: &Path) -> PathBuf {
 	path
 }
 
-fn db_path(base_path: &Path, spec_name: &str) -> PathBuf {
+fn db_path(base_path: &Path, spec_id: &str) -> PathBuf {
 	let mut path = base_path.to_owned();
-	path.push("dbs");
-	path.push(spec_name);
+	path.push("chains");
+	path.push(spec_id);
+	path.push("db");
 	path
 }
 

--- a/polkadot/cli/src/lib.rs
+++ b/polkadot/cli/src/lib.rs
@@ -251,7 +251,7 @@ pub fn run<I, T, W>(args: I, worker: W) -> error::Result<()> where
 		config.network.boot_nodes.extend(matches
 			.values_of("bootnodes")
 			.map_or(Default::default(), |v| v.map(|n| n.to_owned()).collect::<Vec<_>>()));
-		config.network.config_path = Some(network_path(&base_path).to_string_lossy().into());
+		config.network.config_path = Some(network_path(&base_path, config.chain_spec.id()).to_string_lossy().into());
 		config.network.net_config_path = config.network.config_path.clone();
 
 		let port = match matches.value_of("port") {
@@ -516,8 +516,10 @@ fn db_path(base_path: &Path, spec_id: &str) -> PathBuf {
 	path
 }
 
-fn network_path(base_path: &Path) -> PathBuf {
+fn network_path(base_path: &Path, spec_id: &str) -> PathBuf {
 	let mut path = base_path.to_owned();
+	path.push("chains");
+	path.push(spec_id);
 	path.push("network");
 	path
 }

--- a/polkadot/cli/src/lib.rs
+++ b/polkadot/cli/src/lib.rs
@@ -206,7 +206,7 @@ pub fn run<I, T, W>(args: I, worker: W) -> error::Result<()> where
 		.to_string_lossy()
 		.into();
 
-	config.database_path = db_path(&base_path).to_string_lossy().into();
+	config.database_path = db_path(&base_path, config.chain_spec.name()).to_string_lossy().into();
 
 	config.pruning = match matches.value_of("pruning") {
 		Some("archive") => PruningMode::ArchiveAll,
@@ -326,7 +326,7 @@ fn export_blocks<E>(matches: &clap::ArgMatches, exit: E) -> error::Result<()>
 	let base_path = base_path(matches);
 	let (spec, _) = load_spec(&matches)?;
 	let mut config = service::Configuration::default_with_spec(spec);
-	config.database_path = db_path(&base_path).to_string_lossy().into();
+	config.database_path = db_path(&base_path, config.chain_spec.name()).to_string_lossy().into();
 	info!("DB path: {}", config.database_path);
 	let client = service::new_client(config)?;
 	let (exit_send, exit_recv) = std::sync::mpsc::channel();
@@ -391,7 +391,7 @@ fn import_blocks<E>(matches: &clap::ArgMatches, exit: E) -> error::Result<()>
 	let (spec, _) = load_spec(&matches)?;
 	let base_path = base_path(matches);
 	let mut config = service::Configuration::default_with_spec(spec);
-	config.database_path = db_path(&base_path).to_string_lossy().into();
+	config.database_path = db_path(&base_path, config.chain_spec.name()).to_string_lossy().into();
 	let client = service::new_client(config)?;
 	let (exit_send, exit_recv) = std::sync::mpsc::channel();
 
@@ -505,9 +505,10 @@ fn keystore_path(base_path: &Path) -> PathBuf {
 	path
 }
 
-fn db_path(base_path: &Path) -> PathBuf {
+fn db_path(base_path: &Path, spec_name: &str) -> PathBuf {
 	let mut path = base_path.to_owned();
-	path.push("db");
+	path.push("dbs");
+	path.push(spec_name);
 	path
 }
 

--- a/polkadot/cli/src/lib.rs
+++ b/polkadot/cli/src/lib.rs
@@ -203,7 +203,7 @@ pub fn run<I, T, W>(args: I, worker: W) -> error::Result<()> where
 
 	config.keystore_path = matches.value_of("keystore")
 		.map(|x| Path::new(x).to_owned())
-		.unwrap_or_else(|| keystore_path(&base_path))
+		.unwrap_or_else(|| keystore_path(&base_path, config.chain_spec.id()))
 		.to_string_lossy()
 		.into();
 
@@ -500,8 +500,10 @@ fn parse_address(default: &str, port_param: &str, matches: &clap::ArgMatches) ->
 	Ok(address)
 }
 
-fn keystore_path(base_path: &Path) -> PathBuf {
+fn keystore_path(base_path: &Path, spec_id: &str) -> PathBuf {
 	let mut path = base_path.to_owned();
+	path.push("chains");
+	path.push(spec_id);
 	path.push("keystore");
 	path
 }

--- a/polkadot/cli/src/lib.rs
+++ b/polkadot/cli/src/lib.rs
@@ -200,6 +200,7 @@ pub fn run<I, T, W>(args: I, worker: W) -> error::Result<()> where
 	}
 
 	let base_path = base_path(&matches);
+
 	config.keystore_path = matches.value_of("keystore")
 		.map(|x| Path::new(x).to_owned())
 		.unwrap_or_else(|| keystore_path(&base_path))

--- a/polkadot/cli/src/lib.rs
+++ b/polkadot/cli/src/lib.rs
@@ -500,26 +500,26 @@ fn parse_address(default: &str, port_param: &str, matches: &clap::ArgMatches) ->
 	Ok(address)
 }
 
-fn keystore_path(base_path: &Path, spec_id: &str) -> PathBuf {
+fn keystore_path(base_path: &Path, chain_id: &str) -> PathBuf {
 	let mut path = base_path.to_owned();
 	path.push("chains");
-	path.push(spec_id);
+	path.push(chain_id);
 	path.push("keystore");
 	path
 }
 
-fn db_path(base_path: &Path, spec_id: &str) -> PathBuf {
+fn db_path(base_path: &Path, chain_id: &str) -> PathBuf {
 	let mut path = base_path.to_owned();
 	path.push("chains");
-	path.push(spec_id);
+	path.push(chain_id);
 	path.push("db");
 	path
 }
 
-fn network_path(base_path: &Path, spec_id: &str) -> PathBuf {
+fn network_path(base_path: &Path, chain_id: &str) -> PathBuf {
 	let mut path = base_path.to_owned();
 	path.push("chains");
-	path.push(spec_id);
+	path.push(chain_id);
 	path.push("network");
 	path
 }

--- a/polkadot/service/res/poc-1.json
+++ b/polkadot/service/res/poc-1.json
@@ -1,5 +1,6 @@
 {
 "name": "PoC-1 Testnet",
+"id": "poc-1-testnet",
 "genesis": {"raw": {
 	"0x9768f3cbdd14c1a63474dfbdbe052f42": "0x80f4030000000000",
 	"0x3b700687fecdff5ec1c4a5b714521eb6": "0x0000000000000000",

--- a/polkadot/service/src/chain_spec.rs
+++ b/polkadot/service/src/chain_spec.rs
@@ -94,7 +94,7 @@ fn staging_testnet_config_genesis() -> GenesisConfig {
 /// Staging testnet config.
 pub fn staging_testnet_config() -> ChainSpec<GenesisConfig> {
 	let boot_nodes = vec![];
-	ChainSpec::from_genesis("Staging Testnet", staging_testnet_config_genesis, boot_nodes)
+	ChainSpec::from_genesis("Staging Testnet", "staging_testnet", staging_testnet_config_genesis, boot_nodes)
 }
 
 fn testnet_genesis(initial_authorities: Vec<AuthorityId>) -> GenesisConfig {
@@ -169,7 +169,7 @@ fn development_config_genesis() -> GenesisConfig {
 
 /// Development config (single validator Alice)
 pub fn development_config() -> ChainSpec<GenesisConfig> {
-	ChainSpec::from_genesis("Development", development_config_genesis, vec![])
+	ChainSpec::from_genesis("Development", "development", development_config_genesis, vec![])
 }
 
 fn local_testnet_genesis() -> GenesisConfig {
@@ -181,5 +181,5 @@ fn local_testnet_genesis() -> GenesisConfig {
 
 /// Local testnet config (multivalidator Alice + Bob)
 pub fn local_testnet_config() -> ChainSpec<GenesisConfig> {
-	ChainSpec::from_genesis("Local Testnet", local_testnet_genesis, vec![])
+	ChainSpec::from_genesis("Local Testnet", "local_testnet", local_testnet_genesis, vec![])
 }

--- a/substrate/service/src/chain_spec.rs
+++ b/substrate/service/src/chain_spec.rs
@@ -73,6 +73,7 @@ enum Genesis<G> {
 #[serde(rename_all = "camelCase")]
 struct ChainSpecFile {
 	pub name: String,
+	pub id: String,
 	pub boot_nodes: Vec<String>,
 }
 
@@ -89,6 +90,10 @@ impl<G: RuntimeGenesis> ChainSpec<G> {
 
 	pub fn name(&self) -> &str {
 		&self.spec.name
+	}
+
+	pub fn id(&self) -> &str {
+		&self.spec.id
 	}
 
 	/// Parse json content into a `ChainSpec`
@@ -111,9 +116,10 @@ impl<G: RuntimeGenesis> ChainSpec<G> {
 	}
 
 	/// Create hardcoded spec.
-	pub fn from_genesis(name: &str, constructor: fn() -> G, boot_nodes: Vec<String>) -> Self {
+	pub fn from_genesis(name: &str, id: &str, constructor: fn() -> G, boot_nodes: Vec<String>) -> Self {
 		let spec = ChainSpecFile {
 			name: name.to_owned(),
+			id: id.to_owned(),
 			boot_nodes: boot_nodes,
 		};
 		ChainSpec {


### PR DESCRIPTION
https://github.com/paritytech/polkadot/issues/279

TODO

- [ ] manual test
- [ ] possibly enforce/check that `ChainSpec.id` is `[a-z0-9]`, dashes, underscores only