### PR TITLE
heap-size is a CLI arg, make it 512 by default [v0.2-devp2p]

### DIFF
--- a/demo/cli/src/lib.rs
+++ b/demo/cli/src/lib.rs
@@ -54,6 +54,7 @@ use demo_runtime::{Block, BlockId, UncheckedExtrinsic, GenesisConfig,
 	TimestampConfig};
 use futures::{Future, Sink, Stream};
 use tokio::runtime::Runtime;
+use demo_executor::NativeExecutor;
 
 struct DummyPool;
 impl extrinsic_pool::api::ExtrinsicPool<UncheckedExtrinsic, BlockId, Hash> for DummyPool {
@@ -107,7 +108,7 @@ pub fn run<I, T>(args: I) -> error::Result<()> where
 	init_logger(log_pattern);
 
 	// Create client
-	let executor = demo_executor::Executor::with_heap_pages(8);
+	let executor = NativeExecutor::with_heap_pages(8);
 
 	let god_key = hex!["3d866ec8a9190c8343c2fc593d21d8a6d0c5c4763aaab2349de3a6111d64d124"];
 	let genesis_config = GenesisConfig {
@@ -163,7 +164,7 @@ pub fn run<I, T>(args: I) -> error::Result<()> where
 		}),
 	};
 
-	let client = Arc::new(client::new_in_mem::<_, Block, _>(executor, genesis_config)?);
+	let client = Arc::new(client::new_in_mem::<NativeExecutor<demo_executor::Executor>, Block, _>(executor, genesis_config)?);
 	let mut runtime = Runtime::new()?;
 	let _rpc_servers = {
 		let handler = || {

--- a/demo/executor/src/lib.rs
+++ b/demo/executor/src/lib.rs
@@ -35,13 +35,14 @@ extern crate triehash;
 #[cfg(test)] extern crate substrate_runtime_consensus as consensus;
 #[cfg(test)] #[macro_use] extern crate hex_literal;
 
+pub use substrate_executor::NativeExecutor;
 native_executor_instance!(pub Executor, demo_runtime::api::dispatch, demo_runtime::VERSION, include_bytes!("../../runtime/wasm/target/wasm32-unknown-unknown/release/demo_runtime.compact.wasm"));
 
 #[cfg(test)]
 mod tests {
 	use runtime_io;
 	use super::Executor;
-	use substrate_executor::WasmExecutor;
+	use substrate_executor::{WasmExecutor, NativeExecutionDispatch};
 	use codec::{Slicable, Joiner};
 	use keyring::Keyring;
 	use runtime_support::{Hashable, StorageValue, StorageMap};
@@ -94,7 +95,7 @@ mod tests {
 	}
 
 	fn executor() -> ::substrate_executor::NativeExecutor<Executor> {
-		Executor::with_heap_pages(8)
+		::substrate_executor::NativeExecutor::with_heap_pages(8)
 	}
 
 	#[test]

--- a/polkadot/cli/src/cli.yml
+++ b/polkadot/cli/src/cli.yml
@@ -99,6 +99,10 @@ args:
       long: execution
       value_name: STRATEGY
       help: The means of execution used when calling into the runtime. Can be either wasm, native or both.
+  - heap-pages:
+      long: heap-pages
+      value_name: COUNT
+      help: The number of 64KB pages to allocate for Wasm execution. Don't alter this unless you know what you're doing.
 subcommands:
   - build-spec:
       about: Build a spec.json file, outputing to stdout
@@ -162,3 +166,11 @@ subcommands:
               value_name: PATH
               help: Specify custom base path.
               takes_value: true
+          - execution:
+              long: execution
+              value_name: STRATEGY
+              help: The means of execution used when calling into the runtime. Can be either wasm, native or both.
+          - heap-pages:
+              long: heap-pages
+              value_name: COUNT
+              help: The number of 64KB pages to allocate for Wasm execution. Don't alter this unless you know what you're doing.

--- a/substrate/client/src/genesis.rs
+++ b/substrate/client/src/genesis.rs
@@ -44,7 +44,7 @@ mod tests {
 	use super::*;
 	use codec::{Slicable, Joiner};
 	use keyring::Keyring;
-	use executor::WasmExecutor;
+	use executor::{WasmExecutor, NativeExecutionDispatch};
 	use state_machine::{execute, OverlayedChanges, ExecutionStrategy};
 	use state_machine::backend::InMemory;
 	use test_client;
@@ -55,7 +55,7 @@ mod tests {
 	native_executor_instance!(Executor, test_client::runtime::api::dispatch, test_client::runtime::VERSION, include_bytes!("../../test-runtime/wasm/target/wasm32-unknown-unknown/release/substrate_test_runtime.compact.wasm"));
 
 	fn executor() -> ::executor::NativeExecutor<Executor> {
-		Executor::with_heap_pages(8)
+		NativeExecutionDispatch::with_heap_pages(8)
 	}
 
 	fn construct_block(backend: &InMemory, number: BlockNumber, parent_hash: Hash, state_root: Hash, txs: Vec<Transfer>) -> (Vec<u8>, Hash) {

--- a/substrate/client/src/light/call_executor.rs
+++ b/substrate/client/src/light/call_executor.rs
@@ -140,6 +140,7 @@ fn do_check_execution_proof<Hash, E>(
 #[cfg(test)]
 mod tests {
 	use test_client;
+	use executor::NativeExecutionDispatch;
 	use super::*;
 
 	#[test]
@@ -152,9 +153,9 @@ mod tests {
 
 		// 'fetch' execution proof from remote node
 		let remote_execution_proof = remote_client.execution_proof(&remote_block_id, "authorities", &[]).unwrap().1;
-
+		
 		// check remote execution proof locally
-		let local_executor = test_client::NativeExecutor::with_heap_pages(8);
+		let local_executor = test_client::LocalExecutor::with_heap_pages(8);
 		do_check_execution_proof(remote_block_storage_root.into(), &local_executor, &RemoteCallRequest {
 			block: test_client::runtime::Hash::default(),
 			method: "authorities".into(),

--- a/substrate/service/src/config.rs
+++ b/substrate/service/src/config.rs
@@ -49,6 +49,8 @@ pub struct Configuration<G: Serialize + DeserializeOwned + BuildStorage> {
 	pub name: String,
 	/// Execution strategy.
 	pub execution_strategy: ExecutionStrategy,
+	/// Heap pages to allocate for Wasm execution.
+	pub heap_pages: usize,
 }
 
 impl<G: Serialize + DeserializeOwned + BuildStorage> Configuration<G> {
@@ -66,6 +68,7 @@ impl<G: Serialize + DeserializeOwned + BuildStorage> Configuration<G> {
 			telemetry: Default::default(),
 			pruning: PruningMode::ArchiveAll,
 			execution_strategy: ExecutionStrategy::Both,
+			heap_pages: 512,
 		};
 		configuration.network.boot_nodes = configuration.chain_spec.boot_nodes().to_vec();
 		configuration

--- a/substrate/service/src/lib.rs
+++ b/substrate/service/src/lib.rs
@@ -57,6 +57,7 @@ use network::ManageNetwork;
 use runtime_primitives::traits::{Header, As};
 use exit_future::Signal;
 use tokio::runtime::TaskExecutor;
+use substrate_executor::NativeExecutor;
 
 pub use self::error::{ErrorKind, Error};
 pub use config::{Configuration, Role, PruningMode};
@@ -83,7 +84,7 @@ pub struct Service<Components: components::Components> {
 pub fn new_client<Factory: components::ServiceFactory>(config: Configuration<Factory::Genesis>)
 	-> Result<Arc<ComponentClient<components::FullComponents<Factory>>>, error::Error>
 {
-	let executor = components::CodeExecutor::<Factory>::default();
+	let executor = NativeExecutor::with_heap_pages(config.heap_pages);
 	let (client, _) = components::FullComponents::<Factory>::build_client(
 		&config,
 		executor,
@@ -105,7 +106,7 @@ impl<Components> Service<Components>
 		let (signal, exit) = ::exit_future::signal();
 
 		// Create client
-		let executor = components::CodeExecutor::<Components::Factory>::default();
+		let executor = NativeExecutor::with_heap_pages(config.heap_pages);
 
 		let mut keystore = Keystore::open(config.keystore_path.as_str().into())?;
 		for seed in &config.keys {

--- a/substrate/test-client/src/client_ext.rs
+++ b/substrate/test-client/src/client_ext.rs
@@ -20,9 +20,10 @@ use client::{self, Client};
 use keyring::Keyring;
 use runtime_primitives::StorageMap;
 use runtime::genesismap::{GenesisConfig, additional_storage_with_genesis};
+use executor::NativeExecutor;
 use runtime;
 use bft;
-use {Backend, Executor, NativeExecutor};
+use {Backend, Executor};
 
 /// Extension trait for a test client.
 pub trait TestClient {

--- a/substrate/test-client/src/lib.rs
+++ b/substrate/test-client/src/lib.rs
@@ -34,21 +34,21 @@ mod client_ext;
 
 pub use client_ext::TestClient;
 
-mod native_executor {
+mod local_executor {
 	#![allow(missing_docs)]
 	use super::runtime;
 
-	native_executor_instance!(pub NativeExecutor, runtime::api::dispatch, runtime::VERSION, include_bytes!("../../test-runtime/wasm/target/wasm32-unknown-unknown/release/substrate_test_runtime.compact.wasm"));
+	native_executor_instance!(pub LocalExecutor, runtime::api::dispatch, runtime::VERSION, include_bytes!("../../test-runtime/wasm/target/wasm32-unknown-unknown/release/substrate_test_runtime.compact.wasm"));
 }
 
 /// Native executor used for tests.
-pub use self::native_executor::NativeExecutor;
+pub use local_executor::LocalExecutor;
 
 /// Test client database backend.
 pub type Backend = client::in_mem::Backend<runtime::Block>;
 
 /// Test client executor.
-pub type Executor = client::LocalCallExecutor<Backend, executor::NativeExecutor<NativeExecutor>>;
+pub type Executor = client::LocalCallExecutor<Backend, executor::NativeExecutor<LocalExecutor>>;
 
 /// Creates new client instance used for tests.
 pub fn new() -> client::Client<Backend, Executor, runtime::Block> {


### PR DESCRIPTION
128, in fact, wasn't enough. Also, there was no effective way of altering this within `substrate::service`. This is now fixed.