### PR TITLE
More robust connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,17 +252,17 @@ dependencies = [
 [[package]]
 name = "cid"
 version = "0.2.3"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb#6b323d4a5239cf11d362e8b64b664260c1a28adb"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0#015186bbe92b0c935519fd1999c84fe0465b69a0"
 dependencies = [
  "integer-encoding 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "multibase 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
+ "multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
 ]
 
 [[package]]
 name = "circular-buffer"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb#6b323d4a5239cf11d362e8b64b664260c1a28adb"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0#015186bbe92b0c935519fd1999c84fe0465b69a0"
 dependencies = [
  "smallvec 0.6.0 (git+https://github.com/Vurich/rust-smallvec.git?branch=array-zero)",
 ]
@@ -409,7 +409,7 @@ dependencies = [
 [[package]]
 name = "datastore"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb#6b323d4a5239cf11d362e8b64b664260c1a28adb"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0#015186bbe92b0c935519fd1999c84fe0465b69a0"
 dependencies = [
  "base64 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chashmap 2.2.1 (git+https://github.com/redox-os/tfs)",
@@ -1148,26 +1148,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "libp2p"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb#6b323d4a5239cf11d362e8b64b664260c1a28adb"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0#015186bbe92b0c935519fd1999c84fe0465b69a0"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
- "libp2p-dns 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
- "libp2p-floodsub 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
- "libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
- "libp2p-kad 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
- "libp2p-mplex 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
- "libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
- "libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
- "libp2p-ratelimit 0.1.1 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
- "libp2p-relay 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
- "libp2p-secio 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
- "libp2p-tcp-transport 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
- "libp2p-transport-timeout 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
- "libp2p-websocket 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
- "libp2p-yamux 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
+ "libp2p-dns 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
+ "libp2p-floodsub 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
+ "libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
+ "libp2p-kad 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
+ "libp2p-mplex 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
+ "libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
+ "libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
+ "libp2p-ratelimit 0.1.1 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
+ "libp2p-relay 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
+ "libp2p-secio 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
+ "libp2p-tcp-transport 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
+ "libp2p-transport-timeout 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
+ "libp2p-websocket 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
+ "libp2p-yamux 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
  "stdweb 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1177,16 +1177,16 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb#6b323d4a5239cf11d362e8b64b664260c1a28adb"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0#015186bbe92b0c935519fd1999c84fe0465b69a0"
 dependencies = [
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
- "multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
- "multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
+ "multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
+ "multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1197,12 +1197,12 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb#6b323d4a5239cf11d362e8b64b664260c1a28adb"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0#015186bbe92b0c935519fd1999c84fe0465b69a0"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
  "tokio-dns-unofficial 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1210,98 +1210,98 @@ dependencies = [
 [[package]]
 name = "libp2p-floodsub"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb#6b323d4a5239cf11d362e8b64b664260c1a28adb"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0#015186bbe92b0c935519fd1999c84fe0465b69a0"
 dependencies = [
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
 ]
 
 [[package]]
 name = "libp2p-identify"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb#6b323d4a5239cf11d362e8b64b664260c1a28adb"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0#015186bbe92b0c935519fd1999c84fe0465b69a0"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf-codegen-pure 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
 ]
 
 [[package]]
 name = "libp2p-kad"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb#6b323d4a5239cf11d362e8b64b664260c1a28adb"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0#015186bbe92b0c935519fd1999c84fe0465b69a0"
 dependencies = [
  "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "bigint 4.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
+ "datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
- "libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
- "libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
+ "libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
+ "libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
 ]
 
 [[package]]
 name = "libp2p-mplex"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb#6b323d4a5239cf11d362e8b64b664260c1a28adb"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0#015186bbe92b0c935519fd1999c84fe0465b69a0"
 dependencies = [
  "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "circular-buffer 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
+ "circular-buffer 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
  "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-mutex 0.3.0 (git+https://github.com/paritytech/futures-mutex)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-bigint 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
 ]
 
 [[package]]
 name = "libp2p-peerstore"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb#6b323d4a5239cf11d362e8b64b664260c1a28adb"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0#015186bbe92b0c935519fd1999c84fe0465b69a0"
 dependencies = [
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
+ "datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
  "owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.64 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1310,14 +1310,14 @@ dependencies = [
 [[package]]
 name = "libp2p-ping"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb#6b323d4a5239cf11d362e8b64b664260c1a28adb"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0#015186bbe92b0c935519fd1999c84fe0465b69a0"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
- "multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
+ "multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1326,11 +1326,11 @@ dependencies = [
 [[package]]
 name = "libp2p-ratelimit"
 version = "0.1.1"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb#6b323d4a5239cf11d362e8b64b664260c1a28adb"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0#015186bbe92b0c935519fd1999c84fe0465b69a0"
 dependencies = [
  "aio-limited 0.1.0 (git+https://github.com/paritytech/aio-limited.git)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1339,37 +1339,37 @@ dependencies = [
 [[package]]
 name = "libp2p-relay"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb#6b323d4a5239cf11d362e8b64b664260c1a28adb"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0#015186bbe92b0c935519fd1999c84fe0465b69a0"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
- "libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
+ "libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
 ]
 
 [[package]]
 name = "libp2p-secio"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb#6b323d4a5239cf11d362e8b64b664260c1a28adb"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0#015186bbe92b0c935519fd1999c84fe0465b69a0"
 dependencies = [
  "asn1_der 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "eth-secp256k1 0.5.7 (git+https://github.com/paritytech/rust-secp256k1)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf-codegen-pure 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
+ "rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1377,12 +1377,12 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp-transport"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb#6b323d4a5239cf11d362e8b64b664260c1a28adb"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0#015186bbe92b0c935519fd1999c84fe0465b69a0"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1390,10 +1390,10 @@ dependencies = [
 [[package]]
 name = "libp2p-transport-timeout"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb#6b323d4a5239cf11d362e8b64b664260c1a28adb"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0#015186bbe92b0c935519fd1999c84fe0465b69a0"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1401,13 +1401,13 @@ dependencies = [
 [[package]]
 name = "libp2p-websocket"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb#6b323d4a5239cf11d362e8b64b664260c1a28adb"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0#015186bbe92b0c935519fd1999c84fe0465b69a0"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
- "rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
+ "rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
  "stdweb 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "websocket 0.20.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1416,11 +1416,11 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb#6b323d4a5239cf11d362e8b64b664260c1a28adb"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0#015186bbe92b0c935519fd1999c84fe0465b69a0"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "yamux 0.1.0 (git+https://github.com/paritytech/yamux)",
@@ -1556,10 +1556,10 @@ dependencies = [
 [[package]]
 name = "multiaddr"
 version = "0.3.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb#6b323d4a5239cf11d362e8b64b664260c1a28adb"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0#015186bbe92b0c935519fd1999c84fe0465b69a0"
 dependencies = [
  "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "cid 0.2.3 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
+ "cid 0.2.3 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
  "integer-encoding 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1574,7 +1574,7 @@ dependencies = [
 [[package]]
 name = "multihash"
 version = "0.8.1-pre"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb#6b323d4a5239cf11d362e8b64b664260c1a28adb"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0#015186bbe92b0c935519fd1999c84fe0465b69a0"
 dependencies = [
  "sha1 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1584,14 +1584,14 @@ dependencies = [
 [[package]]
 name = "multistream-select"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb#6b323d4a5239cf11d362e8b64b664260c1a28adb"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0#015186bbe92b0c935519fd1999c84fe0465b69a0"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
 ]
 
 [[package]]
@@ -2377,7 +2377,7 @@ dependencies = [
 [[package]]
 name = "rw-stream-sink"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb#6b323d4a5239cf11d362e8b64b664260c1a28adb"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0#015186bbe92b0c935519fd1999c84fe0465b69a0"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2805,7 +2805,7 @@ dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipnetwork 0.12.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
+ "libp2p 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3688,7 +3688,7 @@ dependencies = [
 [[package]]
 name = "varint"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb#6b323d4a5239cf11d362e8b64b664260c1a28adb"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0#015186bbe92b0c935519fd1999c84fe0465b69a0"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3892,8 +3892,8 @@ dependencies = [
 "checksum cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "405216fd8fe65f718daa7102ea808a946b6ce40c742998fbfd3463645552de18"
 "checksum chashmap 2.2.1 (git+https://github.com/redox-os/tfs)" = "<none>"
 "checksum chrono 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1cce36c92cb605414e9b824f866f5babe0a0368e39ea07393b9b63cf3844c0e6"
-"checksum cid 0.2.3 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)" = "<none>"
-"checksum circular-buffer 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)" = "<none>"
+"checksum cid 0.2.3 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)" = "<none>"
+"checksum circular-buffer 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)" = "<none>"
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum cmake 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "95470235c31c726d72bf2e1f421adc1e65b9d561bf5529612cbe1a72da1467b3"
@@ -3910,7 +3910,7 @@ dependencies = [
 "checksum crossbeam-utils 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d636a8b3bcc1b409d7ffd3facef8f21dcb4009626adbd0c5e6c4305c07253c7b"
 "checksum crunchy 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a2f4a431c5c9f662e1200b7c7f02c34e91361150e382089a8f2dec3ba680cbda"
 "checksum ctrlc 1.1.1 (git+https://github.com/paritytech/rust-ctrlc.git)" = "<none>"
-"checksum datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)" = "<none>"
+"checksum datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)" = "<none>"
 "checksum difference 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3304d19798a8e067e48d8e69b2c37f0b5e9b4e462504ad9e27e9f3fce02bba8"
 "checksum digest 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3cae2388d706b52f2f2f9afe280f9d768be36544bd71d1b8120cb34ea6450b55"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
@@ -3981,22 +3981,22 @@ dependencies = [
 "checksum lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e6412c5e2ad9584b0b8e979393122026cdd6d2a80b933f890dcd694ddbe73739"
 "checksum lazycell 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a6f08839bc70ef4a3fe1d566d5350f519c5912ea86be0df1740a7d247c7fc0ef"
 "checksum libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)" = "ac8ebf8343a981e2fa97042b14768f02ed3e1d602eac06cae6166df3c8ced206"
-"checksum libp2p 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)" = "<none>"
-"checksum libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)" = "<none>"
-"checksum libp2p-dns 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)" = "<none>"
-"checksum libp2p-floodsub 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)" = "<none>"
-"checksum libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)" = "<none>"
-"checksum libp2p-kad 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)" = "<none>"
-"checksum libp2p-mplex 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)" = "<none>"
-"checksum libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)" = "<none>"
-"checksum libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)" = "<none>"
-"checksum libp2p-ratelimit 0.1.1 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)" = "<none>"
-"checksum libp2p-relay 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)" = "<none>"
-"checksum libp2p-secio 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)" = "<none>"
-"checksum libp2p-tcp-transport 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)" = "<none>"
-"checksum libp2p-transport-timeout 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)" = "<none>"
-"checksum libp2p-websocket 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)" = "<none>"
-"checksum libp2p-yamux 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)" = "<none>"
+"checksum libp2p 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)" = "<none>"
+"checksum libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)" = "<none>"
+"checksum libp2p-dns 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)" = "<none>"
+"checksum libp2p-floodsub 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)" = "<none>"
+"checksum libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)" = "<none>"
+"checksum libp2p-kad 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)" = "<none>"
+"checksum libp2p-mplex 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)" = "<none>"
+"checksum libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)" = "<none>"
+"checksum libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)" = "<none>"
+"checksum libp2p-ratelimit 0.1.1 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)" = "<none>"
+"checksum libp2p-relay 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)" = "<none>"
+"checksum libp2p-secio 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)" = "<none>"
+"checksum libp2p-tcp-transport 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)" = "<none>"
+"checksum libp2p-transport-timeout 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)" = "<none>"
+"checksum libp2p-websocket 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)" = "<none>"
+"checksum libp2p-yamux 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)" = "<none>"
 "checksum linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "70fb39025bc7cdd76305867c4eccf2f2dcf6e9a57f5b21a93e1c2d86cd03ec9e"
 "checksum local-encoding 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e1ceb20f39ff7ae42f3ff9795f3986b1daad821caaa1e1732a0944103a5a1a66"
 "checksum lock_api 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "949826a5ccf18c1b3a7c3d57692778d21768b79e46eb9dd07bfc4c2160036c54"
@@ -4012,10 +4012,10 @@ dependencies = [
 "checksum mime 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0b28683d0b09bbc20be1c9b3f6f24854efb1356ffcffee08ea3f6e65596e85fa"
 "checksum mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)" = "6d771e3ef92d58a8da8df7d6976bfca9371ed1de6619d9d5a5ce5b1f29b85bfe"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
-"checksum multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)" = "<none>"
+"checksum multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)" = "<none>"
 "checksum multibase 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b9c35dac080fd6e16a99924c8dfdef0af89d797dd851adab25feaffacf7850d6"
-"checksum multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)" = "<none>"
-"checksum multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)" = "<none>"
+"checksum multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)" = "<none>"
+"checksum multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)" = "<none>"
 "checksum nan-preserving-float 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "34d4f00fcc2f4c9efa8cc971db0da9e28290e28e97af47585e48691ef10ff31f"
 "checksum native-tls 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f74dbadc8b43df7864539cedb7bc91345e532fdd913cfdc23ad94f4d2d40fbc0"
 "checksum net2 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)" = "9044faf1413a1057267be51b5afba8eb1090bd2231c693664aa1db716fe1eae0"
@@ -4077,7 +4077,7 @@ dependencies = [
 "checksum rustc-hex 2.0.0 (git+https://github.com/rphmeier/rustc-hex.git)" = "<none>"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustc_version 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a54aa04a10c68c1c4eacb4337fd883b435997ede17a9385784b990777686b09a"
-"checksum rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)" = "<none>"
+"checksum rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)" = "<none>"
 "checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
 "checksum schannel 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "85fd9df495640643ad2d00443b3d78aae69802ad488debab4f1dd52fc1806ade"
 "checksum scoped-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "332ffa32bf586782a3efaeb58f127980944bbc8c4d6913a86107ac2a5ab24b28"
@@ -4159,7 +4159,7 @@ dependencies = [
 "checksum url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f808aadd8cfec6ef90e4a14eb46f24511824d1ac596b9682703c87056c8678b7"
 "checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
 "checksum varint 0.1.0 (git+https://github.com/libp2p/rust-libp2p)" = "<none>"
-"checksum varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)" = "<none>"
+"checksum varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)" = "<none>"
 "checksum vcpkg 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7ed0f6789c8a85ca41bbc1c9d175422116a9869bd1cf31bb08e1493ecce60380"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6b772017e347561807c1aa192438c5fd74242a670a6cffacc40f2defd1dc069d"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,17 +252,17 @@ dependencies = [
 [[package]]
 name = "cid"
 version = "0.2.3"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0#015186bbe92b0c935519fd1999c84fe0465b69a0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2#f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2"
 dependencies = [
  "integer-encoding 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "multibase 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
+ "multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
 ]
 
 [[package]]
 name = "circular-buffer"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0#015186bbe92b0c935519fd1999c84fe0465b69a0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2#f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2"
 dependencies = [
  "smallvec 0.6.0 (git+https://github.com/Vurich/rust-smallvec.git?branch=array-zero)",
 ]
@@ -409,7 +409,7 @@ dependencies = [
 [[package]]
 name = "datastore"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0#015186bbe92b0c935519fd1999c84fe0465b69a0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2#f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2"
 dependencies = [
  "base64 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chashmap 2.2.1 (git+https://github.com/redox-os/tfs)",
@@ -1148,26 +1148,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "libp2p"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0#015186bbe92b0c935519fd1999c84fe0465b69a0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2#f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
- "libp2p-dns 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
- "libp2p-floodsub 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
- "libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
- "libp2p-kad 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
- "libp2p-mplex 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
- "libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
- "libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
- "libp2p-ratelimit 0.1.1 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
- "libp2p-relay 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
- "libp2p-secio 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
- "libp2p-tcp-transport 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
- "libp2p-transport-timeout 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
- "libp2p-websocket 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
- "libp2p-yamux 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
+ "libp2p-dns 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
+ "libp2p-floodsub 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
+ "libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
+ "libp2p-kad 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
+ "libp2p-mplex 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
+ "libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
+ "libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
+ "libp2p-ratelimit 0.1.1 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
+ "libp2p-relay 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
+ "libp2p-secio 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
+ "libp2p-tcp-transport 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
+ "libp2p-transport-timeout 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
+ "libp2p-websocket 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
+ "libp2p-yamux 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
  "stdweb 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1177,16 +1177,16 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0#015186bbe92b0c935519fd1999c84fe0465b69a0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2#f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2"
 dependencies = [
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
- "multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
- "multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
+ "multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
+ "multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1197,12 +1197,12 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0#015186bbe92b0c935519fd1999c84fe0465b69a0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2#f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
  "tokio-dns-unofficial 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1210,98 +1210,98 @@ dependencies = [
 [[package]]
 name = "libp2p-floodsub"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0#015186bbe92b0c935519fd1999c84fe0465b69a0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2#f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2"
 dependencies = [
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
 ]
 
 [[package]]
 name = "libp2p-identify"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0#015186bbe92b0c935519fd1999c84fe0465b69a0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2#f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf-codegen-pure 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
 ]
 
 [[package]]
 name = "libp2p-kad"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0#015186bbe92b0c935519fd1999c84fe0465b69a0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2#f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2"
 dependencies = [
  "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "bigint 4.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
+ "datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
- "libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
- "libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
+ "libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
+ "libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
 ]
 
 [[package]]
 name = "libp2p-mplex"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0#015186bbe92b0c935519fd1999c84fe0465b69a0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2#f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2"
 dependencies = [
  "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "circular-buffer 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
+ "circular-buffer 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
  "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-mutex 0.3.0 (git+https://github.com/paritytech/futures-mutex)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-bigint 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
 ]
 
 [[package]]
 name = "libp2p-peerstore"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0#015186bbe92b0c935519fd1999c84fe0465b69a0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2#f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2"
 dependencies = [
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
+ "datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
  "owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.64 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1310,14 +1310,14 @@ dependencies = [
 [[package]]
 name = "libp2p-ping"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0#015186bbe92b0c935519fd1999c84fe0465b69a0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2#f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
- "multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
+ "multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1326,11 +1326,11 @@ dependencies = [
 [[package]]
 name = "libp2p-ratelimit"
 version = "0.1.1"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0#015186bbe92b0c935519fd1999c84fe0465b69a0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2#f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2"
 dependencies = [
  "aio-limited 0.1.0 (git+https://github.com/paritytech/aio-limited.git)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1339,37 +1339,37 @@ dependencies = [
 [[package]]
 name = "libp2p-relay"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0#015186bbe92b0c935519fd1999c84fe0465b69a0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2#f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
- "libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
+ "libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
 ]
 
 [[package]]
 name = "libp2p-secio"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0#015186bbe92b0c935519fd1999c84fe0465b69a0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2#f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2"
 dependencies = [
  "asn1_der 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "eth-secp256k1 0.5.7 (git+https://github.com/paritytech/rust-secp256k1)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf-codegen-pure 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
+ "rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1377,12 +1377,12 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp-transport"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0#015186bbe92b0c935519fd1999c84fe0465b69a0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2#f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1390,10 +1390,10 @@ dependencies = [
 [[package]]
 name = "libp2p-transport-timeout"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0#015186bbe92b0c935519fd1999c84fe0465b69a0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2#f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1401,13 +1401,13 @@ dependencies = [
 [[package]]
 name = "libp2p-websocket"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0#015186bbe92b0c935519fd1999c84fe0465b69a0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2#f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
- "rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
+ "rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
  "stdweb 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "websocket 0.20.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1416,11 +1416,11 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0#015186bbe92b0c935519fd1999c84fe0465b69a0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2#f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "yamux 0.1.0 (git+https://github.com/paritytech/yamux)",
@@ -1556,10 +1556,10 @@ dependencies = [
 [[package]]
 name = "multiaddr"
 version = "0.3.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0#015186bbe92b0c935519fd1999c84fe0465b69a0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2#f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2"
 dependencies = [
  "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "cid 0.2.3 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
+ "cid 0.2.3 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
  "integer-encoding 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1574,7 +1574,7 @@ dependencies = [
 [[package]]
 name = "multihash"
 version = "0.8.1-pre"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0#015186bbe92b0c935519fd1999c84fe0465b69a0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2#f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2"
 dependencies = [
  "sha1 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1584,14 +1584,14 @@ dependencies = [
 [[package]]
 name = "multistream-select"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0#015186bbe92b0c935519fd1999c84fe0465b69a0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2#f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
 ]
 
 [[package]]
@@ -2377,7 +2377,7 @@ dependencies = [
 [[package]]
 name = "rw-stream-sink"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0#015186bbe92b0c935519fd1999c84fe0465b69a0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2#f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2805,7 +2805,7 @@ dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipnetwork 0.12.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)",
+ "libp2p 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3688,7 +3688,7 @@ dependencies = [
 [[package]]
 name = "varint"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0#015186bbe92b0c935519fd1999c84fe0465b69a0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2#f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3892,8 +3892,8 @@ dependencies = [
 "checksum cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "405216fd8fe65f718daa7102ea808a946b6ce40c742998fbfd3463645552de18"
 "checksum chashmap 2.2.1 (git+https://github.com/redox-os/tfs)" = "<none>"
 "checksum chrono 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1cce36c92cb605414e9b824f866f5babe0a0368e39ea07393b9b63cf3844c0e6"
-"checksum cid 0.2.3 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)" = "<none>"
-"checksum circular-buffer 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)" = "<none>"
+"checksum cid 0.2.3 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)" = "<none>"
+"checksum circular-buffer 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)" = "<none>"
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum cmake 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "95470235c31c726d72bf2e1f421adc1e65b9d561bf5529612cbe1a72da1467b3"
@@ -3910,7 +3910,7 @@ dependencies = [
 "checksum crossbeam-utils 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d636a8b3bcc1b409d7ffd3facef8f21dcb4009626adbd0c5e6c4305c07253c7b"
 "checksum crunchy 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a2f4a431c5c9f662e1200b7c7f02c34e91361150e382089a8f2dec3ba680cbda"
 "checksum ctrlc 1.1.1 (git+https://github.com/paritytech/rust-ctrlc.git)" = "<none>"
-"checksum datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)" = "<none>"
+"checksum datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)" = "<none>"
 "checksum difference 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3304d19798a8e067e48d8e69b2c37f0b5e9b4e462504ad9e27e9f3fce02bba8"
 "checksum digest 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3cae2388d706b52f2f2f9afe280f9d768be36544bd71d1b8120cb34ea6450b55"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
@@ -3981,22 +3981,22 @@ dependencies = [
 "checksum lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e6412c5e2ad9584b0b8e979393122026cdd6d2a80b933f890dcd694ddbe73739"
 "checksum lazycell 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a6f08839bc70ef4a3fe1d566d5350f519c5912ea86be0df1740a7d247c7fc0ef"
 "checksum libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)" = "ac8ebf8343a981e2fa97042b14768f02ed3e1d602eac06cae6166df3c8ced206"
-"checksum libp2p 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)" = "<none>"
-"checksum libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)" = "<none>"
-"checksum libp2p-dns 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)" = "<none>"
-"checksum libp2p-floodsub 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)" = "<none>"
-"checksum libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)" = "<none>"
-"checksum libp2p-kad 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)" = "<none>"
-"checksum libp2p-mplex 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)" = "<none>"
-"checksum libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)" = "<none>"
-"checksum libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)" = "<none>"
-"checksum libp2p-ratelimit 0.1.1 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)" = "<none>"
-"checksum libp2p-relay 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)" = "<none>"
-"checksum libp2p-secio 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)" = "<none>"
-"checksum libp2p-tcp-transport 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)" = "<none>"
-"checksum libp2p-transport-timeout 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)" = "<none>"
-"checksum libp2p-websocket 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)" = "<none>"
-"checksum libp2p-yamux 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)" = "<none>"
+"checksum libp2p 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)" = "<none>"
+"checksum libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)" = "<none>"
+"checksum libp2p-dns 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)" = "<none>"
+"checksum libp2p-floodsub 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)" = "<none>"
+"checksum libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)" = "<none>"
+"checksum libp2p-kad 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)" = "<none>"
+"checksum libp2p-mplex 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)" = "<none>"
+"checksum libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)" = "<none>"
+"checksum libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)" = "<none>"
+"checksum libp2p-ratelimit 0.1.1 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)" = "<none>"
+"checksum libp2p-relay 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)" = "<none>"
+"checksum libp2p-secio 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)" = "<none>"
+"checksum libp2p-tcp-transport 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)" = "<none>"
+"checksum libp2p-transport-timeout 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)" = "<none>"
+"checksum libp2p-websocket 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)" = "<none>"
+"checksum libp2p-yamux 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)" = "<none>"
 "checksum linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "70fb39025bc7cdd76305867c4eccf2f2dcf6e9a57f5b21a93e1c2d86cd03ec9e"
 "checksum local-encoding 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e1ceb20f39ff7ae42f3ff9795f3986b1daad821caaa1e1732a0944103a5a1a66"
 "checksum lock_api 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "949826a5ccf18c1b3a7c3d57692778d21768b79e46eb9dd07bfc4c2160036c54"
@@ -4012,10 +4012,10 @@ dependencies = [
 "checksum mime 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0b28683d0b09bbc20be1c9b3f6f24854efb1356ffcffee08ea3f6e65596e85fa"
 "checksum mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)" = "6d771e3ef92d58a8da8df7d6976bfca9371ed1de6619d9d5a5ce5b1f29b85bfe"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
-"checksum multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)" = "<none>"
+"checksum multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)" = "<none>"
 "checksum multibase 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b9c35dac080fd6e16a99924c8dfdef0af89d797dd851adab25feaffacf7850d6"
-"checksum multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)" = "<none>"
-"checksum multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)" = "<none>"
+"checksum multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)" = "<none>"
+"checksum multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)" = "<none>"
 "checksum nan-preserving-float 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "34d4f00fcc2f4c9efa8cc971db0da9e28290e28e97af47585e48691ef10ff31f"
 "checksum native-tls 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f74dbadc8b43df7864539cedb7bc91345e532fdd913cfdc23ad94f4d2d40fbc0"
 "checksum net2 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)" = "9044faf1413a1057267be51b5afba8eb1090bd2231c693664aa1db716fe1eae0"
@@ -4077,7 +4077,7 @@ dependencies = [
 "checksum rustc-hex 2.0.0 (git+https://github.com/rphmeier/rustc-hex.git)" = "<none>"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustc_version 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a54aa04a10c68c1c4eacb4337fd883b435997ede17a9385784b990777686b09a"
-"checksum rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)" = "<none>"
+"checksum rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)" = "<none>"
 "checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
 "checksum schannel 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "85fd9df495640643ad2d00443b3d78aae69802ad488debab4f1dd52fc1806ade"
 "checksum scoped-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "332ffa32bf586782a3efaeb58f127980944bbc8c4d6913a86107ac2a5ab24b28"
@@ -4159,7 +4159,7 @@ dependencies = [
 "checksum url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f808aadd8cfec6ef90e4a14eb46f24511824d1ac596b9682703c87056c8678b7"
 "checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
 "checksum varint 0.1.0 (git+https://github.com/libp2p/rust-libp2p)" = "<none>"
-"checksum varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=015186bbe92b0c935519fd1999c84fe0465b69a0)" = "<none>"
+"checksum varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)" = "<none>"
 "checksum vcpkg 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7ed0f6789c8a85ca41bbc1c9d175422116a9869bd1cf31bb08e1493ecce60380"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6b772017e347561807c1aa192438c5fd74242a670a6cffacc40f2defd1dc069d"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ dependencies = [
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -252,17 +252,17 @@ dependencies = [
 [[package]]
 name = "cid"
 version = "0.2.3"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc#77b1c445807e53b8c5e4e5e2da751222da15b8cc"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f#dada5f98071235adcfd2004952c94bd57ea0a71f"
 dependencies = [
  "integer-encoding 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "multibase 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)",
+ "multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
 ]
 
 [[package]]
 name = "circular-buffer"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc#77b1c445807e53b8c5e4e5e2da751222da15b8cc"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f#dada5f98071235adcfd2004952c94bd57ea0a71f"
 dependencies = [
  "smallvec 0.6.0 (git+https://github.com/Vurich/rust-smallvec.git?branch=array-zero)",
 ]
@@ -409,7 +409,7 @@ dependencies = [
 [[package]]
 name = "datastore"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc#77b1c445807e53b8c5e4e5e2da751222da15b8cc"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f#dada5f98071235adcfd2004952c94bd57ea0a71f"
 dependencies = [
  "base64 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chashmap 2.2.1 (git+https://github.com/redox-os/tfs)",
@@ -925,7 +925,7 @@ dependencies = [
  "relay 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-proto 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-service 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1039,7 +1039,7 @@ dependencies = [
  "jsonrpc-core 8.0.2 (git+https://github.com/paritytech/jsonrpc.git)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1148,158 +1148,160 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "libp2p"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc#77b1c445807e53b8c5e4e5e2da751222da15b8cc"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f#dada5f98071235adcfd2004952c94bd57ea0a71f"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)",
- "libp2p-dns 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)",
- "libp2p-floodsub 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)",
- "libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)",
- "libp2p-kad 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)",
- "libp2p-mplex 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)",
- "libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)",
- "libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)",
- "libp2p-ratelimit 0.1.1 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)",
- "libp2p-relay 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)",
- "libp2p-secio 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)",
- "libp2p-tcp-transport 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)",
- "libp2p-transport-timeout 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)",
- "libp2p-websocket 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
+ "libp2p-dns 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
+ "libp2p-floodsub 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
+ "libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
+ "libp2p-kad 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
+ "libp2p-mplex 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
+ "libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
+ "libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
+ "libp2p-ratelimit 0.1.1 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
+ "libp2p-relay 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
+ "libp2p-secio 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
+ "libp2p-tcp-transport 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
+ "libp2p-transport-timeout 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
+ "libp2p-websocket 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
+ "libp2p-yamux 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
  "stdweb 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libp2p-core"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc#77b1c445807e53b8c5e4e5e2da751222da15b8cc"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f#dada5f98071235adcfd2004952c94bd57ea0a71f"
 dependencies = [
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)",
- "multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)",
- "multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
+ "multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
+ "multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libp2p-dns"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc#77b1c445807e53b8c5e4e5e2da751222da15b8cc"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f#dada5f98071235adcfd2004952c94bd57ea0a71f"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
  "tokio-dns-unofficial 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libp2p-floodsub"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc#77b1c445807e53b8c5e4e5e2da751222da15b8cc"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f#dada5f98071235adcfd2004952c94bd57ea0a71f"
 dependencies = [
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)",
+ "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
 ]
 
 [[package]]
 name = "libp2p-identify"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc#77b1c445807e53b8c5e4e5e2da751222da15b8cc"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f#dada5f98071235adcfd2004952c94bd57ea0a71f"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf-codegen-pure 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)",
+ "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
 ]
 
 [[package]]
 name = "libp2p-kad"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc#77b1c445807e53b8c5e4e5e2da751222da15b8cc"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f#dada5f98071235adcfd2004952c94bd57ea0a71f"
 dependencies = [
  "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "bigint 4.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)",
+ "datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)",
- "libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)",
- "libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
+ "libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
+ "libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
 ]
 
 [[package]]
 name = "libp2p-mplex"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc#77b1c445807e53b8c5e4e5e2da751222da15b8cc"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f#dada5f98071235adcfd2004952c94bd57ea0a71f"
 dependencies = [
  "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "circular-buffer 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)",
+ "circular-buffer 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
  "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-mutex 0.3.0 (git+https://github.com/paritytech/futures-mutex)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-bigint 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)",
+ "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
 ]
 
 [[package]]
 name = "libp2p-peerstore"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc#77b1c445807e53b8c5e4e5e2da751222da15b8cc"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f#dada5f98071235adcfd2004952c94bd57ea0a71f"
 dependencies = [
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)",
+ "datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
  "owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.64 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1308,90 +1310,90 @@ dependencies = [
 [[package]]
 name = "libp2p-ping"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc#77b1c445807e53b8c5e4e5e2da751222da15b8cc"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f#dada5f98071235adcfd2004952c94bd57ea0a71f"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)",
- "multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
+ "multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libp2p-ratelimit"
 version = "0.1.1"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc#77b1c445807e53b8c5e4e5e2da751222da15b8cc"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f#dada5f98071235adcfd2004952c94bd57ea0a71f"
 dependencies = [
  "aio-limited 0.1.0 (git+https://github.com/paritytech/aio-limited.git)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libp2p-relay"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc#77b1c445807e53b8c5e4e5e2da751222da15b8cc"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f#dada5f98071235adcfd2004952c94bd57ea0a71f"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)",
- "libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
+ "libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)",
+ "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
 ]
 
 [[package]]
 name = "libp2p-secio"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc#77b1c445807e53b8c5e4e5e2da751222da15b8cc"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f#dada5f98071235adcfd2004952c94bd57ea0a71f"
 dependencies = [
  "asn1_der 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "eth-secp256k1 0.5.7 (git+https://github.com/paritytech/rust-secp256k1)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf-codegen-pure 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)",
- "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
+ "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libp2p-tcp-transport"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc#77b1c445807e53b8c5e4e5e2da751222da15b8cc"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f#dada5f98071235adcfd2004952c94bd57ea0a71f"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libp2p-transport-timeout"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc#77b1c445807e53b8c5e4e5e2da751222da15b8cc"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f#dada5f98071235adcfd2004952c94bd57ea0a71f"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1399,16 +1401,29 @@ dependencies = [
 [[package]]
 name = "libp2p-websocket"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc#77b1c445807e53b8c5e4e5e2da751222da15b8cc"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f#dada5f98071235adcfd2004952c94bd57ea0a71f"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)",
- "rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
+ "rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
  "stdweb 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "websocket 0.20.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "libp2p-yamux"
+version = "0.1.0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f#dada5f98071235adcfd2004952c94bd57ea0a71f"
+dependencies = [
+ "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
+ "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "yamux 0.1.0 (git+https://github.com/paritytech/yamux)",
 ]
 
 [[package]]
@@ -1541,10 +1556,10 @@ dependencies = [
 [[package]]
 name = "multiaddr"
 version = "0.3.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc#77b1c445807e53b8c5e4e5e2da751222da15b8cc"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f#dada5f98071235adcfd2004952c94bd57ea0a71f"
 dependencies = [
  "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "cid 0.2.3 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)",
+ "cid 0.2.3 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
  "integer-encoding 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1559,7 +1574,7 @@ dependencies = [
 [[package]]
 name = "multihash"
 version = "0.8.1-pre"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc#77b1c445807e53b8c5e4e5e2da751222da15b8cc"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f#dada5f98071235adcfd2004952c94bd57ea0a71f"
 dependencies = [
  "sha1 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1569,14 +1584,14 @@ dependencies = [
 [[package]]
 name = "multistream-select"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc#77b1c445807e53b8c5e4e5e2da751222da15b8cc"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f#dada5f98071235adcfd2004952c94bd57ea0a71f"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)",
+ "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
 ]
 
 [[package]]
@@ -2123,6 +2138,11 @@ dependencies = [
 
 [[package]]
 name = "quick-error"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "quick-error"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -2357,11 +2377,11 @@ dependencies = [
 [[package]]
 name = "rw-stream-sink"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc#77b1c445807e53b8c5e4e5e2da751222da15b8cc"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f#dada5f98071235adcfd2004952c94bd57ea0a71f"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2785,12 +2805,12 @@ dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipnetwork 0.12.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)",
+ "libp2p 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "varint 0.1.0 (git+https://github.com/libp2p/rust-libp2p)",
 ]
@@ -3318,12 +3338,22 @@ dependencies = [
  "mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-fs 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tcp 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-threadpool 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-udp 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-codec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3339,7 +3369,7 @@ dependencies = [
  "scoped-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3369,13 +3399,13 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-threadpool 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tokio-io"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3396,7 +3426,7 @@ dependencies = [
  "smallvec 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "take 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-service 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3410,7 +3440,7 @@ dependencies = [
  "mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3430,7 +3460,7 @@ dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3464,7 +3494,7 @@ dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3476,7 +3506,7 @@ dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3652,20 +3682,20 @@ dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-bigint 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "varint"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc#77b1c445807e53b8c5e4e5e2da751222da15b8cc"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f#dada5f98071235adcfd2004952c94bd57ea0a71f"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-bigint 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3744,7 +3774,7 @@ dependencies = [
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha1 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tls 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3814,6 +3844,20 @@ name = "yaml-rust"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
+[[package]]
+name = "yamux"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/yamux#b2104369a4f676e11d1fc86cfc33e9a68d21c4f3"
+dependencies = [
+ "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quick-error 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
 [metadata]
 "checksum aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d6531d44de723825aa81398a6415283229725a00fa30713812ab9323faa82fc4"
 "checksum aio-limited 0.1.0 (git+https://github.com/paritytech/aio-limited.git)" = "<none>"
@@ -3848,8 +3892,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "405216fd8fe65f718daa7102ea808a946b6ce40c742998fbfd3463645552de18"
 "checksum chashmap 2.2.1 (git+https://github.com/redox-os/tfs)" = "<none>"
 "checksum chrono 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1cce36c92cb605414e9b824f866f5babe0a0368e39ea07393b9b63cf3844c0e6"
-"checksum cid 0.2.3 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)" = "<none>"
-"checksum circular-buffer 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)" = "<none>"
+"checksum cid 0.2.3 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)" = "<none>"
+"checksum circular-buffer 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)" = "<none>"
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum cmake 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "95470235c31c726d72bf2e1f421adc1e65b9d561bf5529612cbe1a72da1467b3"
@@ -3866,7 +3910,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum crossbeam-utils 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d636a8b3bcc1b409d7ffd3facef8f21dcb4009626adbd0c5e6c4305c07253c7b"
 "checksum crunchy 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a2f4a431c5c9f662e1200b7c7f02c34e91361150e382089a8f2dec3ba680cbda"
 "checksum ctrlc 1.1.1 (git+https://github.com/paritytech/rust-ctrlc.git)" = "<none>"
-"checksum datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)" = "<none>"
+"checksum datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)" = "<none>"
 "checksum difference 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3304d19798a8e067e48d8e69b2c37f0b5e9b4e462504ad9e27e9f3fce02bba8"
 "checksum digest 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3cae2388d706b52f2f2f9afe280f9d768be36544bd71d1b8120cb34ea6450b55"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
@@ -3937,21 +3981,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e6412c5e2ad9584b0b8e979393122026cdd6d2a80b933f890dcd694ddbe73739"
 "checksum lazycell 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a6f08839bc70ef4a3fe1d566d5350f519c5912ea86be0df1740a7d247c7fc0ef"
 "checksum libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)" = "ac8ebf8343a981e2fa97042b14768f02ed3e1d602eac06cae6166df3c8ced206"
-"checksum libp2p 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)" = "<none>"
-"checksum libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)" = "<none>"
-"checksum libp2p-dns 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)" = "<none>"
-"checksum libp2p-floodsub 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)" = "<none>"
-"checksum libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)" = "<none>"
-"checksum libp2p-kad 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)" = "<none>"
-"checksum libp2p-mplex 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)" = "<none>"
-"checksum libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)" = "<none>"
-"checksum libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)" = "<none>"
-"checksum libp2p-ratelimit 0.1.1 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)" = "<none>"
-"checksum libp2p-relay 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)" = "<none>"
-"checksum libp2p-secio 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)" = "<none>"
-"checksum libp2p-tcp-transport 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)" = "<none>"
-"checksum libp2p-transport-timeout 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)" = "<none>"
-"checksum libp2p-websocket 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)" = "<none>"
+"checksum libp2p 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)" = "<none>"
+"checksum libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)" = "<none>"
+"checksum libp2p-dns 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)" = "<none>"
+"checksum libp2p-floodsub 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)" = "<none>"
+"checksum libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)" = "<none>"
+"checksum libp2p-kad 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)" = "<none>"
+"checksum libp2p-mplex 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)" = "<none>"
+"checksum libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)" = "<none>"
+"checksum libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)" = "<none>"
+"checksum libp2p-ratelimit 0.1.1 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)" = "<none>"
+"checksum libp2p-relay 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)" = "<none>"
+"checksum libp2p-secio 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)" = "<none>"
+"checksum libp2p-tcp-transport 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)" = "<none>"
+"checksum libp2p-transport-timeout 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)" = "<none>"
+"checksum libp2p-websocket 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)" = "<none>"
+"checksum libp2p-yamux 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)" = "<none>"
 "checksum linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "70fb39025bc7cdd76305867c4eccf2f2dcf6e9a57f5b21a93e1c2d86cd03ec9e"
 "checksum local-encoding 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e1ceb20f39ff7ae42f3ff9795f3986b1daad821caaa1e1732a0944103a5a1a66"
 "checksum lock_api 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "949826a5ccf18c1b3a7c3d57692778d21768b79e46eb9dd07bfc4c2160036c54"
@@ -3967,10 +4012,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum mime 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0b28683d0b09bbc20be1c9b3f6f24854efb1356ffcffee08ea3f6e65596e85fa"
 "checksum mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)" = "6d771e3ef92d58a8da8df7d6976bfca9371ed1de6619d9d5a5ce5b1f29b85bfe"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
-"checksum multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)" = "<none>"
+"checksum multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)" = "<none>"
 "checksum multibase 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b9c35dac080fd6e16a99924c8dfdef0af89d797dd851adab25feaffacf7850d6"
-"checksum multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)" = "<none>"
-"checksum multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)" = "<none>"
+"checksum multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)" = "<none>"
+"checksum multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)" = "<none>"
 "checksum nan-preserving-float 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "34d4f00fcc2f4c9efa8cc971db0da9e28290e28e97af47585e48691ef10ff31f"
 "checksum native-tls 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f74dbadc8b43df7864539cedb7bc91345e532fdd913cfdc23ad94f4d2d40fbc0"
 "checksum net2 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)" = "9044faf1413a1057267be51b5afba8eb1090bd2231c693664aa1db716fe1eae0"
@@ -4004,6 +4049,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum protobuf-codegen-pure 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7fcc3085b0644bcad72ea33f174f267c24e558e56a97115e3ef31a4483581a1b"
 "checksum pulldown-cmark 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8361e81576d2e02643b04950e487ec172b687180da65c731c03cf336784e6c07"
 "checksum pwasm-utils 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "efd695333cfae6e9dbe2703a6d040e252b57a6fc3b9a65c712615ac042b2e0c5"
+"checksum quick-error 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5fb6ccf8db7bbcb9c2eae558db5ab4f3da1c2a87e4e597ed394726bc8ea6ca1d"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e44651a0dc4cdd99f71c83b561e221f714912d11af1a4dff0631f923d53af035"
 "checksum rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "15a732abf9d20f0ad8eeb6f909bf6868722d9a06e1e50802b6a70351f40b4eb1"
@@ -4031,7 +4077,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rustc-hex 2.0.0 (git+https://github.com/rphmeier/rustc-hex.git)" = "<none>"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustc_version 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a54aa04a10c68c1c4eacb4337fd883b435997ede17a9385784b990777686b09a"
-"checksum rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)" = "<none>"
+"checksum rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)" = "<none>"
 "checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
 "checksum schannel 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "85fd9df495640643ad2d00443b3d78aae69802ad488debab4f1dd52fc1806ade"
 "checksum scoped-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "332ffa32bf586782a3efaeb58f127980944bbc8c4d6913a86107ac2a5ab24b28"
@@ -4076,11 +4122,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum timer 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "31d42176308937165701f50638db1c31586f183f1aab416268216577aec7306b"
 "checksum tiny-keccak 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e9175261fbdb60781fcd388a4d6cc7e14764a2b629a7ad94abb439aed223a44f"
 "checksum tokio 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8ee337e5f4e501fc32966fec6fe0ca0cc1c237b0b1b14a335f8bfe3c5f06e286"
+"checksum tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "881e9645b81c2ce95fcb799ded2c29ffb9f25ef5bef909089a420e5961dd8ccb"
 "checksum tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "aeeffbbb94209023feaef3c196a41cbcdafa06b4a6f893f68779bb5e53796f71"
 "checksum tokio-dns-unofficial 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "be509b88bef660929f3066a6ed30260f8c1f3035c5ac80a7c67bb39c9cf28376"
 "checksum tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8cac2a7883ff3567e9d66bb09100d09b33d90311feca0206c7ca034bc0c55113"
 "checksum tokio-fs 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "76766830bbf9a2d5bfb50c95350d56a2e79e2c80f675967fff448bc615899708"
-"checksum tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "6af9eb326f64b2d6b68438e1953341e00ab3cf54de7e35d92bfc73af8555313a"
+"checksum tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a5c9635ee806f26d302b8baa1e145689a280d8f5aa8d0552e7344808da54cc21"
 "checksum tokio-proto 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8fbb47ae81353c63c487030659494b295f6cb6576242f907f203473b191b0389"
 "checksum tokio-reactor 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3cedc8e5af5131dc3423ffa4f877cce78ad25259a9a62de0613735a13ebc64b"
 "checksum tokio-service 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "24da22d077e0f15f55162bdbdc661228c1581892f52074fb242678d015b45162"
@@ -4112,7 +4159,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f808aadd8cfec6ef90e4a14eb46f24511824d1ac596b9682703c87056c8678b7"
 "checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
 "checksum varint 0.1.0 (git+https://github.com/libp2p/rust-libp2p)" = "<none>"
-"checksum varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=77b1c445807e53b8c5e4e5e2da751222da15b8cc)" = "<none>"
+"checksum varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)" = "<none>"
 "checksum vcpkg 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7ed0f6789c8a85ca41bbc1c9d175422116a9869bd1cf31bb08e1493ecce60380"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6b772017e347561807c1aa192438c5fd74242a670a6cffacc40f2defd1dc069d"
@@ -4131,3 +4178,4 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 "checksum xdg 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a66b7c2281ebde13cf4391d70d4c7e5946c3c25e72a7b859ca8f677dcd0b0c61"
 "checksum yaml-rust 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e66366e18dc58b46801afbf2ca7661a9f59cc8c5962c29892b6039b4f86fa992"
+"checksum yamux 0.1.0 (git+https://github.com/paritytech/yamux)" = "<none>"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,17 +252,17 @@ dependencies = [
 [[package]]
 name = "cid"
 version = "0.2.3"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2#f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0#2fb5ef1d40f2565e592248abbd21b7ca2da992e0"
 dependencies = [
  "integer-encoding 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "multibase 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
+ "multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
 ]
 
 [[package]]
 name = "circular-buffer"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2#f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0#2fb5ef1d40f2565e592248abbd21b7ca2da992e0"
 dependencies = [
  "smallvec 0.6.0 (git+https://github.com/Vurich/rust-smallvec.git?branch=array-zero)",
 ]
@@ -409,7 +409,7 @@ dependencies = [
 [[package]]
 name = "datastore"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2#f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0#2fb5ef1d40f2565e592248abbd21b7ca2da992e0"
 dependencies = [
  "base64 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chashmap 2.2.1 (git+https://github.com/redox-os/tfs)",
@@ -1148,26 +1148,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "libp2p"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2#f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0#2fb5ef1d40f2565e592248abbd21b7ca2da992e0"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
- "libp2p-dns 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
- "libp2p-floodsub 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
- "libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
- "libp2p-kad 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
- "libp2p-mplex 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
- "libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
- "libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
- "libp2p-ratelimit 0.1.1 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
- "libp2p-relay 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
- "libp2p-secio 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
- "libp2p-tcp-transport 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
- "libp2p-transport-timeout 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
- "libp2p-websocket 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
- "libp2p-yamux 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
+ "libp2p-dns 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
+ "libp2p-floodsub 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
+ "libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
+ "libp2p-kad 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
+ "libp2p-mplex 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
+ "libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
+ "libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
+ "libp2p-ratelimit 0.1.1 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
+ "libp2p-relay 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
+ "libp2p-secio 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
+ "libp2p-tcp-transport 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
+ "libp2p-transport-timeout 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
+ "libp2p-websocket 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
+ "libp2p-yamux 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
  "stdweb 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1177,16 +1177,16 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2#f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0#2fb5ef1d40f2565e592248abbd21b7ca2da992e0"
 dependencies = [
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
- "multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
- "multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
+ "multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
+ "multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1197,12 +1197,12 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2#f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0#2fb5ef1d40f2565e592248abbd21b7ca2da992e0"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
  "tokio-dns-unofficial 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1210,98 +1210,98 @@ dependencies = [
 [[package]]
 name = "libp2p-floodsub"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2#f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0#2fb5ef1d40f2565e592248abbd21b7ca2da992e0"
 dependencies = [
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
 ]
 
 [[package]]
 name = "libp2p-identify"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2#f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0#2fb5ef1d40f2565e592248abbd21b7ca2da992e0"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf-codegen-pure 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
 ]
 
 [[package]]
 name = "libp2p-kad"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2#f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0#2fb5ef1d40f2565e592248abbd21b7ca2da992e0"
 dependencies = [
  "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "bigint 4.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
+ "datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
- "libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
- "libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
+ "libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
+ "libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
 ]
 
 [[package]]
 name = "libp2p-mplex"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2#f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0#2fb5ef1d40f2565e592248abbd21b7ca2da992e0"
 dependencies = [
  "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "circular-buffer 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
+ "circular-buffer 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
  "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-mutex 0.3.0 (git+https://github.com/paritytech/futures-mutex)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-bigint 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
 ]
 
 [[package]]
 name = "libp2p-peerstore"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2#f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0#2fb5ef1d40f2565e592248abbd21b7ca2da992e0"
 dependencies = [
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
+ "datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
  "owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.64 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1310,14 +1310,14 @@ dependencies = [
 [[package]]
 name = "libp2p-ping"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2#f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0#2fb5ef1d40f2565e592248abbd21b7ca2da992e0"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
- "multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
+ "multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1326,11 +1326,11 @@ dependencies = [
 [[package]]
 name = "libp2p-ratelimit"
 version = "0.1.1"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2#f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0#2fb5ef1d40f2565e592248abbd21b7ca2da992e0"
 dependencies = [
  "aio-limited 0.1.0 (git+https://github.com/paritytech/aio-limited.git)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1339,37 +1339,37 @@ dependencies = [
 [[package]]
 name = "libp2p-relay"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2#f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0#2fb5ef1d40f2565e592248abbd21b7ca2da992e0"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
- "libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
+ "libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
 ]
 
 [[package]]
 name = "libp2p-secio"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2#f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0#2fb5ef1d40f2565e592248abbd21b7ca2da992e0"
 dependencies = [
  "asn1_der 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "eth-secp256k1 0.5.7 (git+https://github.com/paritytech/rust-secp256k1)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf-codegen-pure 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
+ "rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1377,12 +1377,12 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp-transport"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2#f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0#2fb5ef1d40f2565e592248abbd21b7ca2da992e0"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1390,10 +1390,10 @@ dependencies = [
 [[package]]
 name = "libp2p-transport-timeout"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2#f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0#2fb5ef1d40f2565e592248abbd21b7ca2da992e0"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1401,13 +1401,13 @@ dependencies = [
 [[package]]
 name = "libp2p-websocket"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2#f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0#2fb5ef1d40f2565e592248abbd21b7ca2da992e0"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
- "rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
+ "rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
  "stdweb 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "websocket 0.20.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1416,11 +1416,11 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2#f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0#2fb5ef1d40f2565e592248abbd21b7ca2da992e0"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "yamux 0.1.0 (git+https://github.com/paritytech/yamux)",
@@ -1556,10 +1556,10 @@ dependencies = [
 [[package]]
 name = "multiaddr"
 version = "0.3.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2#f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0#2fb5ef1d40f2565e592248abbd21b7ca2da992e0"
 dependencies = [
  "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "cid 0.2.3 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
+ "cid 0.2.3 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
  "integer-encoding 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1574,7 +1574,7 @@ dependencies = [
 [[package]]
 name = "multihash"
 version = "0.8.1-pre"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2#f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0#2fb5ef1d40f2565e592248abbd21b7ca2da992e0"
 dependencies = [
  "sha1 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1584,14 +1584,14 @@ dependencies = [
 [[package]]
 name = "multistream-select"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2#f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0#2fb5ef1d40f2565e592248abbd21b7ca2da992e0"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
 ]
 
 [[package]]
@@ -2377,7 +2377,7 @@ dependencies = [
 [[package]]
 name = "rw-stream-sink"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2#f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0#2fb5ef1d40f2565e592248abbd21b7ca2da992e0"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2805,7 +2805,7 @@ dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipnetwork 0.12.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)",
+ "libp2p 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3688,7 +3688,7 @@ dependencies = [
 [[package]]
 name = "varint"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2#f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0#2fb5ef1d40f2565e592248abbd21b7ca2da992e0"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3892,8 +3892,8 @@ dependencies = [
 "checksum cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "405216fd8fe65f718daa7102ea808a946b6ce40c742998fbfd3463645552de18"
 "checksum chashmap 2.2.1 (git+https://github.com/redox-os/tfs)" = "<none>"
 "checksum chrono 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1cce36c92cb605414e9b824f866f5babe0a0368e39ea07393b9b63cf3844c0e6"
-"checksum cid 0.2.3 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)" = "<none>"
-"checksum circular-buffer 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)" = "<none>"
+"checksum cid 0.2.3 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)" = "<none>"
+"checksum circular-buffer 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)" = "<none>"
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum cmake 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "95470235c31c726d72bf2e1f421adc1e65b9d561bf5529612cbe1a72da1467b3"
@@ -3910,7 +3910,7 @@ dependencies = [
 "checksum crossbeam-utils 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d636a8b3bcc1b409d7ffd3facef8f21dcb4009626adbd0c5e6c4305c07253c7b"
 "checksum crunchy 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a2f4a431c5c9f662e1200b7c7f02c34e91361150e382089a8f2dec3ba680cbda"
 "checksum ctrlc 1.1.1 (git+https://github.com/paritytech/rust-ctrlc.git)" = "<none>"
-"checksum datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)" = "<none>"
+"checksum datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)" = "<none>"
 "checksum difference 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3304d19798a8e067e48d8e69b2c37f0b5e9b4e462504ad9e27e9f3fce02bba8"
 "checksum digest 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3cae2388d706b52f2f2f9afe280f9d768be36544bd71d1b8120cb34ea6450b55"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
@@ -3981,22 +3981,22 @@ dependencies = [
 "checksum lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e6412c5e2ad9584b0b8e979393122026cdd6d2a80b933f890dcd694ddbe73739"
 "checksum lazycell 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a6f08839bc70ef4a3fe1d566d5350f519c5912ea86be0df1740a7d247c7fc0ef"
 "checksum libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)" = "ac8ebf8343a981e2fa97042b14768f02ed3e1d602eac06cae6166df3c8ced206"
-"checksum libp2p 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)" = "<none>"
-"checksum libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)" = "<none>"
-"checksum libp2p-dns 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)" = "<none>"
-"checksum libp2p-floodsub 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)" = "<none>"
-"checksum libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)" = "<none>"
-"checksum libp2p-kad 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)" = "<none>"
-"checksum libp2p-mplex 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)" = "<none>"
-"checksum libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)" = "<none>"
-"checksum libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)" = "<none>"
-"checksum libp2p-ratelimit 0.1.1 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)" = "<none>"
-"checksum libp2p-relay 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)" = "<none>"
-"checksum libp2p-secio 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)" = "<none>"
-"checksum libp2p-tcp-transport 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)" = "<none>"
-"checksum libp2p-transport-timeout 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)" = "<none>"
-"checksum libp2p-websocket 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)" = "<none>"
-"checksum libp2p-yamux 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)" = "<none>"
+"checksum libp2p 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)" = "<none>"
+"checksum libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)" = "<none>"
+"checksum libp2p-dns 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)" = "<none>"
+"checksum libp2p-floodsub 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)" = "<none>"
+"checksum libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)" = "<none>"
+"checksum libp2p-kad 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)" = "<none>"
+"checksum libp2p-mplex 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)" = "<none>"
+"checksum libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)" = "<none>"
+"checksum libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)" = "<none>"
+"checksum libp2p-ratelimit 0.1.1 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)" = "<none>"
+"checksum libp2p-relay 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)" = "<none>"
+"checksum libp2p-secio 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)" = "<none>"
+"checksum libp2p-tcp-transport 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)" = "<none>"
+"checksum libp2p-transport-timeout 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)" = "<none>"
+"checksum libp2p-websocket 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)" = "<none>"
+"checksum libp2p-yamux 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)" = "<none>"
 "checksum linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "70fb39025bc7cdd76305867c4eccf2f2dcf6e9a57f5b21a93e1c2d86cd03ec9e"
 "checksum local-encoding 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e1ceb20f39ff7ae42f3ff9795f3986b1daad821caaa1e1732a0944103a5a1a66"
 "checksum lock_api 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "949826a5ccf18c1b3a7c3d57692778d21768b79e46eb9dd07bfc4c2160036c54"
@@ -4012,10 +4012,10 @@ dependencies = [
 "checksum mime 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0b28683d0b09bbc20be1c9b3f6f24854efb1356ffcffee08ea3f6e65596e85fa"
 "checksum mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)" = "6d771e3ef92d58a8da8df7d6976bfca9371ed1de6619d9d5a5ce5b1f29b85bfe"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
-"checksum multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)" = "<none>"
+"checksum multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)" = "<none>"
 "checksum multibase 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b9c35dac080fd6e16a99924c8dfdef0af89d797dd851adab25feaffacf7850d6"
-"checksum multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)" = "<none>"
-"checksum multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)" = "<none>"
+"checksum multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)" = "<none>"
+"checksum multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)" = "<none>"
 "checksum nan-preserving-float 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "34d4f00fcc2f4c9efa8cc971db0da9e28290e28e97af47585e48691ef10ff31f"
 "checksum native-tls 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f74dbadc8b43df7864539cedb7bc91345e532fdd913cfdc23ad94f4d2d40fbc0"
 "checksum net2 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)" = "9044faf1413a1057267be51b5afba8eb1090bd2231c693664aa1db716fe1eae0"
@@ -4077,7 +4077,7 @@ dependencies = [
 "checksum rustc-hex 2.0.0 (git+https://github.com/rphmeier/rustc-hex.git)" = "<none>"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustc_version 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a54aa04a10c68c1c4eacb4337fd883b435997ede17a9385784b990777686b09a"
-"checksum rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)" = "<none>"
+"checksum rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)" = "<none>"
 "checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
 "checksum schannel 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "85fd9df495640643ad2d00443b3d78aae69802ad488debab4f1dd52fc1806ade"
 "checksum scoped-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "332ffa32bf586782a3efaeb58f127980944bbc8c4d6913a86107ac2a5ab24b28"
@@ -4159,7 +4159,7 @@ dependencies = [
 "checksum url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f808aadd8cfec6ef90e4a14eb46f24511824d1ac596b9682703c87056c8678b7"
 "checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
 "checksum varint 0.1.0 (git+https://github.com/libp2p/rust-libp2p)" = "<none>"
-"checksum varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2)" = "<none>"
+"checksum varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)" = "<none>"
 "checksum vcpkg 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7ed0f6789c8a85ca41bbc1c9d175422116a9869bd1cf31bb08e1493ecce60380"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6b772017e347561807c1aa192438c5fd74242a670a6cffacc40f2defd1dc069d"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,17 +252,17 @@ dependencies = [
 [[package]]
 name = "cid"
 version = "0.2.3"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f#dada5f98071235adcfd2004952c94bd57ea0a71f"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb#6b323d4a5239cf11d362e8b64b664260c1a28adb"
 dependencies = [
  "integer-encoding 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "multibase 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
+ "multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
 ]
 
 [[package]]
 name = "circular-buffer"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f#dada5f98071235adcfd2004952c94bd57ea0a71f"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb#6b323d4a5239cf11d362e8b64b664260c1a28adb"
 dependencies = [
  "smallvec 0.6.0 (git+https://github.com/Vurich/rust-smallvec.git?branch=array-zero)",
 ]
@@ -409,7 +409,7 @@ dependencies = [
 [[package]]
 name = "datastore"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f#dada5f98071235adcfd2004952c94bd57ea0a71f"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb#6b323d4a5239cf11d362e8b64b664260c1a28adb"
 dependencies = [
  "base64 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chashmap 2.2.1 (git+https://github.com/redox-os/tfs)",
@@ -1148,26 +1148,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "libp2p"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f#dada5f98071235adcfd2004952c94bd57ea0a71f"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb#6b323d4a5239cf11d362e8b64b664260c1a28adb"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
- "libp2p-dns 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
- "libp2p-floodsub 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
- "libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
- "libp2p-kad 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
- "libp2p-mplex 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
- "libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
- "libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
- "libp2p-ratelimit 0.1.1 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
- "libp2p-relay 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
- "libp2p-secio 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
- "libp2p-tcp-transport 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
- "libp2p-transport-timeout 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
- "libp2p-websocket 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
- "libp2p-yamux 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
+ "libp2p-dns 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
+ "libp2p-floodsub 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
+ "libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
+ "libp2p-kad 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
+ "libp2p-mplex 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
+ "libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
+ "libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
+ "libp2p-ratelimit 0.1.1 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
+ "libp2p-relay 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
+ "libp2p-secio 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
+ "libp2p-tcp-transport 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
+ "libp2p-transport-timeout 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
+ "libp2p-websocket 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
+ "libp2p-yamux 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
  "stdweb 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1177,16 +1177,16 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f#dada5f98071235adcfd2004952c94bd57ea0a71f"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb#6b323d4a5239cf11d362e8b64b664260c1a28adb"
 dependencies = [
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
- "multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
- "multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
+ "multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
+ "multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1197,12 +1197,12 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f#dada5f98071235adcfd2004952c94bd57ea0a71f"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb#6b323d4a5239cf11d362e8b64b664260c1a28adb"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
  "tokio-dns-unofficial 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1210,98 +1210,98 @@ dependencies = [
 [[package]]
 name = "libp2p-floodsub"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f#dada5f98071235adcfd2004952c94bd57ea0a71f"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb#6b323d4a5239cf11d362e8b64b664260c1a28adb"
 dependencies = [
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
 ]
 
 [[package]]
 name = "libp2p-identify"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f#dada5f98071235adcfd2004952c94bd57ea0a71f"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb#6b323d4a5239cf11d362e8b64b664260c1a28adb"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf-codegen-pure 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
 ]
 
 [[package]]
 name = "libp2p-kad"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f#dada5f98071235adcfd2004952c94bd57ea0a71f"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb#6b323d4a5239cf11d362e8b64b664260c1a28adb"
 dependencies = [
  "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "bigint 4.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
+ "datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
- "libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
- "libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
+ "libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
+ "libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
 ]
 
 [[package]]
 name = "libp2p-mplex"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f#dada5f98071235adcfd2004952c94bd57ea0a71f"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb#6b323d4a5239cf11d362e8b64b664260c1a28adb"
 dependencies = [
  "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "circular-buffer 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
+ "circular-buffer 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
  "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-mutex 0.3.0 (git+https://github.com/paritytech/futures-mutex)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-bigint 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
 ]
 
 [[package]]
 name = "libp2p-peerstore"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f#dada5f98071235adcfd2004952c94bd57ea0a71f"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb#6b323d4a5239cf11d362e8b64b664260c1a28adb"
 dependencies = [
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
+ "datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
  "owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.64 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1310,14 +1310,14 @@ dependencies = [
 [[package]]
 name = "libp2p-ping"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f#dada5f98071235adcfd2004952c94bd57ea0a71f"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb#6b323d4a5239cf11d362e8b64b664260c1a28adb"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
- "multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
+ "multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1326,11 +1326,11 @@ dependencies = [
 [[package]]
 name = "libp2p-ratelimit"
 version = "0.1.1"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f#dada5f98071235adcfd2004952c94bd57ea0a71f"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb#6b323d4a5239cf11d362e8b64b664260c1a28adb"
 dependencies = [
  "aio-limited 0.1.0 (git+https://github.com/paritytech/aio-limited.git)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1339,37 +1339,37 @@ dependencies = [
 [[package]]
 name = "libp2p-relay"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f#dada5f98071235adcfd2004952c94bd57ea0a71f"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb#6b323d4a5239cf11d362e8b64b664260c1a28adb"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
- "libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
+ "libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
 ]
 
 [[package]]
 name = "libp2p-secio"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f#dada5f98071235adcfd2004952c94bd57ea0a71f"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb#6b323d4a5239cf11d362e8b64b664260c1a28adb"
 dependencies = [
  "asn1_der 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "eth-secp256k1 0.5.7 (git+https://github.com/paritytech/rust-secp256k1)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf-codegen-pure 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
+ "rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1377,12 +1377,12 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp-transport"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f#dada5f98071235adcfd2004952c94bd57ea0a71f"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb#6b323d4a5239cf11d362e8b64b664260c1a28adb"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1390,10 +1390,10 @@ dependencies = [
 [[package]]
 name = "libp2p-transport-timeout"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f#dada5f98071235adcfd2004952c94bd57ea0a71f"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb#6b323d4a5239cf11d362e8b64b664260c1a28adb"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1401,13 +1401,13 @@ dependencies = [
 [[package]]
 name = "libp2p-websocket"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f#dada5f98071235adcfd2004952c94bd57ea0a71f"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb#6b323d4a5239cf11d362e8b64b664260c1a28adb"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
- "rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
+ "rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
  "stdweb 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "websocket 0.20.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1416,11 +1416,11 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f#dada5f98071235adcfd2004952c94bd57ea0a71f"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb#6b323d4a5239cf11d362e8b64b664260c1a28adb"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "yamux 0.1.0 (git+https://github.com/paritytech/yamux)",
@@ -1556,10 +1556,10 @@ dependencies = [
 [[package]]
 name = "multiaddr"
 version = "0.3.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f#dada5f98071235adcfd2004952c94bd57ea0a71f"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb#6b323d4a5239cf11d362e8b64b664260c1a28adb"
 dependencies = [
  "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "cid 0.2.3 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
+ "cid 0.2.3 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
  "integer-encoding 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1574,7 +1574,7 @@ dependencies = [
 [[package]]
 name = "multihash"
 version = "0.8.1-pre"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f#dada5f98071235adcfd2004952c94bd57ea0a71f"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb#6b323d4a5239cf11d362e8b64b664260c1a28adb"
 dependencies = [
  "sha1 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1584,14 +1584,14 @@ dependencies = [
 [[package]]
 name = "multistream-select"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f#dada5f98071235adcfd2004952c94bd57ea0a71f"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb#6b323d4a5239cf11d362e8b64b664260c1a28adb"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
 ]
 
 [[package]]
@@ -2377,7 +2377,7 @@ dependencies = [
 [[package]]
 name = "rw-stream-sink"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f#dada5f98071235adcfd2004952c94bd57ea0a71f"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb#6b323d4a5239cf11d362e8b64b664260c1a28adb"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2805,7 +2805,7 @@ dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipnetwork 0.12.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)",
+ "libp2p 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3688,7 +3688,7 @@ dependencies = [
 [[package]]
 name = "varint"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f#dada5f98071235adcfd2004952c94bd57ea0a71f"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb#6b323d4a5239cf11d362e8b64b664260c1a28adb"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3892,8 +3892,8 @@ dependencies = [
 "checksum cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "405216fd8fe65f718daa7102ea808a946b6ce40c742998fbfd3463645552de18"
 "checksum chashmap 2.2.1 (git+https://github.com/redox-os/tfs)" = "<none>"
 "checksum chrono 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1cce36c92cb605414e9b824f866f5babe0a0368e39ea07393b9b63cf3844c0e6"
-"checksum cid 0.2.3 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)" = "<none>"
-"checksum circular-buffer 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)" = "<none>"
+"checksum cid 0.2.3 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)" = "<none>"
+"checksum circular-buffer 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)" = "<none>"
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum cmake 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "95470235c31c726d72bf2e1f421adc1e65b9d561bf5529612cbe1a72da1467b3"
@@ -3910,7 +3910,7 @@ dependencies = [
 "checksum crossbeam-utils 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d636a8b3bcc1b409d7ffd3facef8f21dcb4009626adbd0c5e6c4305c07253c7b"
 "checksum crunchy 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a2f4a431c5c9f662e1200b7c7f02c34e91361150e382089a8f2dec3ba680cbda"
 "checksum ctrlc 1.1.1 (git+https://github.com/paritytech/rust-ctrlc.git)" = "<none>"
-"checksum datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)" = "<none>"
+"checksum datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)" = "<none>"
 "checksum difference 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3304d19798a8e067e48d8e69b2c37f0b5e9b4e462504ad9e27e9f3fce02bba8"
 "checksum digest 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3cae2388d706b52f2f2f9afe280f9d768be36544bd71d1b8120cb34ea6450b55"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
@@ -3981,22 +3981,22 @@ dependencies = [
 "checksum lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e6412c5e2ad9584b0b8e979393122026cdd6d2a80b933f890dcd694ddbe73739"
 "checksum lazycell 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a6f08839bc70ef4a3fe1d566d5350f519c5912ea86be0df1740a7d247c7fc0ef"
 "checksum libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)" = "ac8ebf8343a981e2fa97042b14768f02ed3e1d602eac06cae6166df3c8ced206"
-"checksum libp2p 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)" = "<none>"
-"checksum libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)" = "<none>"
-"checksum libp2p-dns 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)" = "<none>"
-"checksum libp2p-floodsub 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)" = "<none>"
-"checksum libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)" = "<none>"
-"checksum libp2p-kad 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)" = "<none>"
-"checksum libp2p-mplex 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)" = "<none>"
-"checksum libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)" = "<none>"
-"checksum libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)" = "<none>"
-"checksum libp2p-ratelimit 0.1.1 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)" = "<none>"
-"checksum libp2p-relay 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)" = "<none>"
-"checksum libp2p-secio 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)" = "<none>"
-"checksum libp2p-tcp-transport 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)" = "<none>"
-"checksum libp2p-transport-timeout 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)" = "<none>"
-"checksum libp2p-websocket 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)" = "<none>"
-"checksum libp2p-yamux 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)" = "<none>"
+"checksum libp2p 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)" = "<none>"
+"checksum libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)" = "<none>"
+"checksum libp2p-dns 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)" = "<none>"
+"checksum libp2p-floodsub 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)" = "<none>"
+"checksum libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)" = "<none>"
+"checksum libp2p-kad 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)" = "<none>"
+"checksum libp2p-mplex 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)" = "<none>"
+"checksum libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)" = "<none>"
+"checksum libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)" = "<none>"
+"checksum libp2p-ratelimit 0.1.1 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)" = "<none>"
+"checksum libp2p-relay 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)" = "<none>"
+"checksum libp2p-secio 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)" = "<none>"
+"checksum libp2p-tcp-transport 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)" = "<none>"
+"checksum libp2p-transport-timeout 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)" = "<none>"
+"checksum libp2p-websocket 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)" = "<none>"
+"checksum libp2p-yamux 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)" = "<none>"
 "checksum linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "70fb39025bc7cdd76305867c4eccf2f2dcf6e9a57f5b21a93e1c2d86cd03ec9e"
 "checksum local-encoding 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e1ceb20f39ff7ae42f3ff9795f3986b1daad821caaa1e1732a0944103a5a1a66"
 "checksum lock_api 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "949826a5ccf18c1b3a7c3d57692778d21768b79e46eb9dd07bfc4c2160036c54"
@@ -4012,10 +4012,10 @@ dependencies = [
 "checksum mime 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0b28683d0b09bbc20be1c9b3f6f24854efb1356ffcffee08ea3f6e65596e85fa"
 "checksum mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)" = "6d771e3ef92d58a8da8df7d6976bfca9371ed1de6619d9d5a5ce5b1f29b85bfe"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
-"checksum multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)" = "<none>"
+"checksum multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)" = "<none>"
 "checksum multibase 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b9c35dac080fd6e16a99924c8dfdef0af89d797dd851adab25feaffacf7850d6"
-"checksum multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)" = "<none>"
-"checksum multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)" = "<none>"
+"checksum multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)" = "<none>"
+"checksum multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)" = "<none>"
 "checksum nan-preserving-float 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "34d4f00fcc2f4c9efa8cc971db0da9e28290e28e97af47585e48691ef10ff31f"
 "checksum native-tls 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f74dbadc8b43df7864539cedb7bc91345e532fdd913cfdc23ad94f4d2d40fbc0"
 "checksum net2 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)" = "9044faf1413a1057267be51b5afba8eb1090bd2231c693664aa1db716fe1eae0"
@@ -4077,7 +4077,7 @@ dependencies = [
 "checksum rustc-hex 2.0.0 (git+https://github.com/rphmeier/rustc-hex.git)" = "<none>"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustc_version 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a54aa04a10c68c1c4eacb4337fd883b435997ede17a9385784b990777686b09a"
-"checksum rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)" = "<none>"
+"checksum rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)" = "<none>"
 "checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
 "checksum schannel 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "85fd9df495640643ad2d00443b3d78aae69802ad488debab4f1dd52fc1806ade"
 "checksum scoped-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "332ffa32bf586782a3efaeb58f127980944bbc8c4d6913a86107ac2a5ab24b28"
@@ -4159,7 +4159,7 @@ dependencies = [
 "checksum url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f808aadd8cfec6ef90e4a14eb46f24511824d1ac596b9682703c87056c8678b7"
 "checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
 "checksum varint 0.1.0 (git+https://github.com/libp2p/rust-libp2p)" = "<none>"
-"checksum varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=dada5f98071235adcfd2004952c94bd57ea0a71f)" = "<none>"
+"checksum varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=6b323d4a5239cf11d362e8b64b664260c1a28adb)" = "<none>"
 "checksum vcpkg 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7ed0f6789c8a85ca41bbc1c9d175422116a9869bd1cf31bb08e1493ecce60380"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6b772017e347561807c1aa192438c5fd74242a670a6cffacc40f2defd1dc069d"

--- a/substrate/network-libp2p/Cargo.toml
+++ b/substrate/network-libp2p/Cargo.toml
@@ -11,7 +11,7 @@ bytes = "0.4"
 error-chain = { version = "0.12", default-features = false }
 fnv = "1.0"
 futures = "0.1"
-libp2p = { git = "https://github.com/tomaka/libp2p-rs", rev = "015186bbe92b0c935519fd1999c84fe0465b69a0", default-features = false, features = ["libp2p-secio", "libp2p-secio-secp256k1"] }
+libp2p = { git = "https://github.com/tomaka/libp2p-rs", rev = "f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2", default-features = false, features = ["libp2p-secio", "libp2p-secio-secp256k1"] }
 ethcore-io = { git = "https://github.com/paritytech/parity.git" }
 ethkey = { git = "https://github.com/paritytech/parity.git" }
 ethereum-types = "0.3"

--- a/substrate/network-libp2p/Cargo.toml
+++ b/substrate/network-libp2p/Cargo.toml
@@ -11,7 +11,7 @@ bytes = "0.4"
 error-chain = { version = "0.12", default-features = false }
 fnv = "1.0"
 futures = "0.1"
-libp2p = { git = "https://github.com/tomaka/libp2p-rs", rev = "dada5f98071235adcfd2004952c94bd57ea0a71f", default-features = false, features = ["libp2p-secio", "libp2p-secio-secp256k1"] }
+libp2p = { git = "https://github.com/tomaka/libp2p-rs", rev = "6b323d4a5239cf11d362e8b64b664260c1a28adb", default-features = false, features = ["libp2p-secio", "libp2p-secio-secp256k1"] }
 ethcore-io = { git = "https://github.com/paritytech/parity.git" }
 ethkey = { git = "https://github.com/paritytech/parity.git" }
 ethereum-types = "0.3"

--- a/substrate/network-libp2p/Cargo.toml
+++ b/substrate/network-libp2p/Cargo.toml
@@ -11,7 +11,7 @@ bytes = "0.4"
 error-chain = { version = "0.12", default-features = false }
 fnv = "1.0"
 futures = "0.1"
-libp2p = { git = "https://github.com/tomaka/libp2p-rs", rev = "77b1c445807e53b8c5e4e5e2da751222da15b8cc", default-features = false, features = ["libp2p-secio", "libp2p-secio-secp256k1"] }
+libp2p = { git = "https://github.com/tomaka/libp2p-rs", rev = "dada5f98071235adcfd2004952c94bd57ea0a71f", default-features = false, features = ["libp2p-secio", "libp2p-secio-secp256k1"] }
 ethcore-io = { git = "https://github.com/paritytech/parity.git" }
 ethkey = { git = "https://github.com/paritytech/parity.git" }
 ethereum-types = "0.3"

--- a/substrate/network-libp2p/Cargo.toml
+++ b/substrate/network-libp2p/Cargo.toml
@@ -11,7 +11,7 @@ bytes = "0.4"
 error-chain = { version = "0.12", default-features = false }
 fnv = "1.0"
 futures = "0.1"
-libp2p = { git = "https://github.com/tomaka/libp2p-rs", rev = "f8abc6c6866ab9cc7e10b6fd6d4a0d08ca7cfee2", default-features = false, features = ["libp2p-secio", "libp2p-secio-secp256k1"] }
+libp2p = { git = "https://github.com/tomaka/libp2p-rs", rev = "2fb5ef1d40f2565e592248abbd21b7ca2da992e0", default-features = false, features = ["libp2p-secio", "libp2p-secio-secp256k1"] }
 ethcore-io = { git = "https://github.com/paritytech/parity.git" }
 ethkey = { git = "https://github.com/paritytech/parity.git" }
 ethereum-types = "0.3"

--- a/substrate/network-libp2p/Cargo.toml
+++ b/substrate/network-libp2p/Cargo.toml
@@ -11,7 +11,7 @@ bytes = "0.4"
 error-chain = { version = "0.12", default-features = false }
 fnv = "1.0"
 futures = "0.1"
-libp2p = { git = "https://github.com/tomaka/libp2p-rs", rev = "6b323d4a5239cf11d362e8b64b664260c1a28adb", default-features = false, features = ["libp2p-secio", "libp2p-secio-secp256k1"] }
+libp2p = { git = "https://github.com/tomaka/libp2p-rs", rev = "015186bbe92b0c935519fd1999c84fe0465b69a0", default-features = false, features = ["libp2p-secio", "libp2p-secio-secp256k1"] }
 ethcore-io = { git = "https://github.com/paritytech/parity.git" }
 ethkey = { git = "https://github.com/paritytech/parity.git" }
 ethereum-types = "0.3"

--- a/substrate/network-libp2p/src/custom_proto.rs
+++ b/substrate/network-libp2p/src/custom_proto.rs
@@ -55,8 +55,7 @@ pub struct RegisteredProtocolOutput<T> {
 	/// Version of the protocol that was negotiated.
 	pub protocol_version: u8,
 
-	/// Channel to sender outgoing messages to. Closing this channel closes the
-	/// connection.
+	/// Channel to sender outgoing messages to.
 	// TODO: consider assembling packet_id here
 	pub outgoing: mpsc::UnboundedSender<Bytes>,
 
@@ -156,7 +155,6 @@ where C: AsyncRead + AsyncWrite + 'static,		// TODO: 'static :-/
 		let (sink, stream) = {
 			let framed = AsyncRead::framed(socket, VarintCodec::default());
 			let msg_rx = msg_rx.map(Message::SendReq)
-				.chain(stream::once(Ok(Message::Finished)))
 				.map_err(|()| unreachable!("mpsc::UnboundedReceiver never errors"));
 			let (sink, stream) = framed.split();
 			let stream = stream.map(Message::RecvSocket)

--- a/substrate/network-libp2p/src/service.rs
+++ b/substrate/network-libp2p/src/service.rs
@@ -727,7 +727,7 @@ fn handle_custom_connection(
 			drop(dc_guard);
 			val
 		});
-	
+
 	debug!(target: "sub-libp2p", "Successfully connected to {:?} (peer id \
 		{}) with protocol {:?} version {}", node_id, peer_id, protocol_id,
 		custom_proto_out.protocol_version);


### PR DESCRIPTION
This replaces the Kademlia and custom protocols connections with [the `UniqueConnec` type](https://github.com/tomaka/libp2p-rs/blob/polkadot-tmp/core/src/unique.rs) which I've added to rust-libp2p.

There are several cases that are currently not handled properly: dialing a node that we already tried dialing earlier, handling connection failures, refusing an incoming connection to a peer when we already have one, etc.
This change delegates all this to the `UniqueConnec`.
