### PR TITLE
Explicit stop of import queue thread

### DIFF
--- a/substrate/network/src/protocol.rs
+++ b/substrate/network/src/protocol.rs
@@ -536,6 +536,15 @@ impl<B: BlockT, S: Specialization<B>> Protocol<B, S> {
 		handshaking_peers.clear();
 	}
 
+	pub fn stop(&self) {
+		// stop processing import requests first (without holding a sync lock)
+		let import_queue = self.sync.read().import_queue();
+		import_queue.stop();
+
+		// and then clear all the sync data
+		self.abort();
+	}
+
 	pub fn on_block_announce(&self, io: &mut SyncIo, peer_id: PeerId, announce: message::BlockAnnounce<B::Header>) {
 		let header = announce.header;
 		let hash = header.hash();

--- a/substrate/network/src/service.rs
+++ b/substrate/network/src/service.rs
@@ -213,7 +213,7 @@ impl<B: BlockT + 'static, S: Specialization<B>> Service<B, S> {
 	}
 
 	fn stop(&self) {
-		self.handler.protocol.abort();
+		self.handler.protocol.stop();
 		self.network.stop();
 	}
 }

--- a/substrate/network/src/sync.rs
+++ b/substrate/network/src/sync.rs
@@ -100,7 +100,12 @@ impl<B: BlockT> ChainSync<B> {
 		self.peers.values().max_by_key(|p| p.best_number).map(|p| p.best_number)
 	}
 
-	/// Returns sync status
+	/// Returns import queue reference.
+	pub(crate) fn import_queue(&self) -> Arc<ImportQueue<B>> {
+		self.import_queue.clone()
+	}
+
+	/// Returns sync status.
 	pub(crate) fn status(&self) -> Status<B> {
 		let best_seen = self.best_seen_block();
 		let state = match &best_seen {


### PR DESCRIPTION
It must be stopped before the network service is stopped to make sure the thread doesn't holds the references to the network itself. This should fix the `resource deadlock avoided` error, reported by @tomaka (though I failed to reproduce it).