### PR TITLE
Fix the networking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,17 +252,17 @@ dependencies = [
 [[package]]
 name = "cid"
 version = "0.2.3"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0#2fb5ef1d40f2565e592248abbd21b7ca2da992e0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331#7043d6ae5849605b6f9fe26ce89e0c72c5252331"
 dependencies = [
  "integer-encoding 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "multibase 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
+ "multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
 ]
 
 [[package]]
 name = "circular-buffer"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0#2fb5ef1d40f2565e592248abbd21b7ca2da992e0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331#7043d6ae5849605b6f9fe26ce89e0c72c5252331"
 dependencies = [
  "smallvec 0.6.0 (git+https://github.com/Vurich/rust-smallvec.git?branch=array-zero)",
 ]
@@ -409,7 +409,7 @@ dependencies = [
 [[package]]
 name = "datastore"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0#2fb5ef1d40f2565e592248abbd21b7ca2da992e0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331#7043d6ae5849605b6f9fe26ce89e0c72c5252331"
 dependencies = [
  "base64 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chashmap 2.2.1 (git+https://github.com/redox-os/tfs)",
@@ -1148,26 +1148,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "libp2p"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0#2fb5ef1d40f2565e592248abbd21b7ca2da992e0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331#7043d6ae5849605b6f9fe26ce89e0c72c5252331"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
- "libp2p-dns 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
- "libp2p-floodsub 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
- "libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
- "libp2p-kad 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
- "libp2p-mplex 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
- "libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
- "libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
- "libp2p-ratelimit 0.1.1 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
- "libp2p-relay 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
- "libp2p-secio 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
- "libp2p-tcp-transport 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
- "libp2p-transport-timeout 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
- "libp2p-websocket 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
- "libp2p-yamux 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
+ "libp2p-dns 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
+ "libp2p-floodsub 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
+ "libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
+ "libp2p-kad 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
+ "libp2p-mplex 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
+ "libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
+ "libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
+ "libp2p-ratelimit 0.1.1 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
+ "libp2p-relay 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
+ "libp2p-secio 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
+ "libp2p-tcp-transport 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
+ "libp2p-transport-timeout 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
+ "libp2p-websocket 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
+ "libp2p-yamux 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
  "stdweb 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1177,16 +1177,16 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0#2fb5ef1d40f2565e592248abbd21b7ca2da992e0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331#7043d6ae5849605b6f9fe26ce89e0c72c5252331"
 dependencies = [
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
- "multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
- "multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
+ "multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
+ "multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1197,12 +1197,12 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0#2fb5ef1d40f2565e592248abbd21b7ca2da992e0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331#7043d6ae5849605b6f9fe26ce89e0c72c5252331"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
  "tokio-dns-unofficial 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1210,98 +1210,98 @@ dependencies = [
 [[package]]
 name = "libp2p-floodsub"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0#2fb5ef1d40f2565e592248abbd21b7ca2da992e0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331#7043d6ae5849605b6f9fe26ce89e0c72c5252331"
 dependencies = [
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
 ]
 
 [[package]]
 name = "libp2p-identify"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0#2fb5ef1d40f2565e592248abbd21b7ca2da992e0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331#7043d6ae5849605b6f9fe26ce89e0c72c5252331"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf-codegen-pure 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
 ]
 
 [[package]]
 name = "libp2p-kad"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0#2fb5ef1d40f2565e592248abbd21b7ca2da992e0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331#7043d6ae5849605b6f9fe26ce89e0c72c5252331"
 dependencies = [
  "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "bigint 4.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
+ "datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
- "libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
- "libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
+ "libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
+ "libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
 ]
 
 [[package]]
 name = "libp2p-mplex"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0#2fb5ef1d40f2565e592248abbd21b7ca2da992e0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331#7043d6ae5849605b6f9fe26ce89e0c72c5252331"
 dependencies = [
  "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "circular-buffer 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
+ "circular-buffer 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
  "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-mutex 0.3.0 (git+https://github.com/paritytech/futures-mutex)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-bigint 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
 ]
 
 [[package]]
 name = "libp2p-peerstore"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0#2fb5ef1d40f2565e592248abbd21b7ca2da992e0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331#7043d6ae5849605b6f9fe26ce89e0c72c5252331"
 dependencies = [
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
+ "datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
  "owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.64 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1310,14 +1310,14 @@ dependencies = [
 [[package]]
 name = "libp2p-ping"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0#2fb5ef1d40f2565e592248abbd21b7ca2da992e0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331#7043d6ae5849605b6f9fe26ce89e0c72c5252331"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
- "multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
+ "multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1326,11 +1326,11 @@ dependencies = [
 [[package]]
 name = "libp2p-ratelimit"
 version = "0.1.1"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0#2fb5ef1d40f2565e592248abbd21b7ca2da992e0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331#7043d6ae5849605b6f9fe26ce89e0c72c5252331"
 dependencies = [
  "aio-limited 0.1.0 (git+https://github.com/paritytech/aio-limited.git)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1339,37 +1339,37 @@ dependencies = [
 [[package]]
 name = "libp2p-relay"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0#2fb5ef1d40f2565e592248abbd21b7ca2da992e0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331#7043d6ae5849605b6f9fe26ce89e0c72c5252331"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
- "libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
+ "libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
 ]
 
 [[package]]
 name = "libp2p-secio"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0#2fb5ef1d40f2565e592248abbd21b7ca2da992e0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331#7043d6ae5849605b6f9fe26ce89e0c72c5252331"
 dependencies = [
  "asn1_der 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "eth-secp256k1 0.5.7 (git+https://github.com/paritytech/rust-secp256k1)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf-codegen-pure 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
+ "rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1377,12 +1377,12 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp-transport"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0#2fb5ef1d40f2565e592248abbd21b7ca2da992e0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331#7043d6ae5849605b6f9fe26ce89e0c72c5252331"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1390,10 +1390,10 @@ dependencies = [
 [[package]]
 name = "libp2p-transport-timeout"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0#2fb5ef1d40f2565e592248abbd21b7ca2da992e0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331#7043d6ae5849605b6f9fe26ce89e0c72c5252331"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1401,13 +1401,13 @@ dependencies = [
 [[package]]
 name = "libp2p-websocket"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0#2fb5ef1d40f2565e592248abbd21b7ca2da992e0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331#7043d6ae5849605b6f9fe26ce89e0c72c5252331"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
- "rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
+ "rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
  "stdweb 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "websocket 0.20.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1416,11 +1416,11 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0#2fb5ef1d40f2565e592248abbd21b7ca2da992e0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331#7043d6ae5849605b6f9fe26ce89e0c72c5252331"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "yamux 0.1.0 (git+https://github.com/paritytech/yamux)",
@@ -1556,10 +1556,10 @@ dependencies = [
 [[package]]
 name = "multiaddr"
 version = "0.3.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0#2fb5ef1d40f2565e592248abbd21b7ca2da992e0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331#7043d6ae5849605b6f9fe26ce89e0c72c5252331"
 dependencies = [
  "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "cid 0.2.3 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
+ "cid 0.2.3 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
  "integer-encoding 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1574,7 +1574,7 @@ dependencies = [
 [[package]]
 name = "multihash"
 version = "0.8.1-pre"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0#2fb5ef1d40f2565e592248abbd21b7ca2da992e0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331#7043d6ae5849605b6f9fe26ce89e0c72c5252331"
 dependencies = [
  "sha1 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1584,14 +1584,14 @@ dependencies = [
 [[package]]
 name = "multistream-select"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0#2fb5ef1d40f2565e592248abbd21b7ca2da992e0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331#7043d6ae5849605b6f9fe26ce89e0c72c5252331"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
 ]
 
 [[package]]
@@ -2377,7 +2377,7 @@ dependencies = [
 [[package]]
 name = "rw-stream-sink"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0#2fb5ef1d40f2565e592248abbd21b7ca2da992e0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331#7043d6ae5849605b6f9fe26ce89e0c72c5252331"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2807,7 +2807,7 @@ dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipnetwork 0.12.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)",
+ "libp2p 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3690,7 +3690,7 @@ dependencies = [
 [[package]]
 name = "varint"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0#2fb5ef1d40f2565e592248abbd21b7ca2da992e0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331#7043d6ae5849605b6f9fe26ce89e0c72c5252331"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3894,8 +3894,8 @@ dependencies = [
 "checksum cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "405216fd8fe65f718daa7102ea808a946b6ce40c742998fbfd3463645552de18"
 "checksum chashmap 2.2.1 (git+https://github.com/redox-os/tfs)" = "<none>"
 "checksum chrono 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1cce36c92cb605414e9b824f866f5babe0a0368e39ea07393b9b63cf3844c0e6"
-"checksum cid 0.2.3 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)" = "<none>"
-"checksum circular-buffer 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)" = "<none>"
+"checksum cid 0.2.3 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)" = "<none>"
+"checksum circular-buffer 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)" = "<none>"
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum cmake 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "95470235c31c726d72bf2e1f421adc1e65b9d561bf5529612cbe1a72da1467b3"
@@ -3912,7 +3912,7 @@ dependencies = [
 "checksum crossbeam-utils 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d636a8b3bcc1b409d7ffd3facef8f21dcb4009626adbd0c5e6c4305c07253c7b"
 "checksum crunchy 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a2f4a431c5c9f662e1200b7c7f02c34e91361150e382089a8f2dec3ba680cbda"
 "checksum ctrlc 1.1.1 (git+https://github.com/paritytech/rust-ctrlc.git)" = "<none>"
-"checksum datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)" = "<none>"
+"checksum datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)" = "<none>"
 "checksum difference 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3304d19798a8e067e48d8e69b2c37f0b5e9b4e462504ad9e27e9f3fce02bba8"
 "checksum digest 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3cae2388d706b52f2f2f9afe280f9d768be36544bd71d1b8120cb34ea6450b55"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
@@ -3983,22 +3983,22 @@ dependencies = [
 "checksum lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e6412c5e2ad9584b0b8e979393122026cdd6d2a80b933f890dcd694ddbe73739"
 "checksum lazycell 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a6f08839bc70ef4a3fe1d566d5350f519c5912ea86be0df1740a7d247c7fc0ef"
 "checksum libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)" = "ac8ebf8343a981e2fa97042b14768f02ed3e1d602eac06cae6166df3c8ced206"
-"checksum libp2p 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)" = "<none>"
-"checksum libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)" = "<none>"
-"checksum libp2p-dns 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)" = "<none>"
-"checksum libp2p-floodsub 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)" = "<none>"
-"checksum libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)" = "<none>"
-"checksum libp2p-kad 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)" = "<none>"
-"checksum libp2p-mplex 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)" = "<none>"
-"checksum libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)" = "<none>"
-"checksum libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)" = "<none>"
-"checksum libp2p-ratelimit 0.1.1 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)" = "<none>"
-"checksum libp2p-relay 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)" = "<none>"
-"checksum libp2p-secio 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)" = "<none>"
-"checksum libp2p-tcp-transport 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)" = "<none>"
-"checksum libp2p-transport-timeout 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)" = "<none>"
-"checksum libp2p-websocket 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)" = "<none>"
-"checksum libp2p-yamux 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)" = "<none>"
+"checksum libp2p 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)" = "<none>"
+"checksum libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)" = "<none>"
+"checksum libp2p-dns 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)" = "<none>"
+"checksum libp2p-floodsub 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)" = "<none>"
+"checksum libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)" = "<none>"
+"checksum libp2p-kad 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)" = "<none>"
+"checksum libp2p-mplex 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)" = "<none>"
+"checksum libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)" = "<none>"
+"checksum libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)" = "<none>"
+"checksum libp2p-ratelimit 0.1.1 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)" = "<none>"
+"checksum libp2p-relay 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)" = "<none>"
+"checksum libp2p-secio 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)" = "<none>"
+"checksum libp2p-tcp-transport 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)" = "<none>"
+"checksum libp2p-transport-timeout 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)" = "<none>"
+"checksum libp2p-websocket 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)" = "<none>"
+"checksum libp2p-yamux 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)" = "<none>"
 "checksum linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "70fb39025bc7cdd76305867c4eccf2f2dcf6e9a57f5b21a93e1c2d86cd03ec9e"
 "checksum local-encoding 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e1ceb20f39ff7ae42f3ff9795f3986b1daad821caaa1e1732a0944103a5a1a66"
 "checksum lock_api 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "949826a5ccf18c1b3a7c3d57692778d21768b79e46eb9dd07bfc4c2160036c54"
@@ -4014,10 +4014,10 @@ dependencies = [
 "checksum mime 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0b28683d0b09bbc20be1c9b3f6f24854efb1356ffcffee08ea3f6e65596e85fa"
 "checksum mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)" = "6d771e3ef92d58a8da8df7d6976bfca9371ed1de6619d9d5a5ce5b1f29b85bfe"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
-"checksum multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)" = "<none>"
+"checksum multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)" = "<none>"
 "checksum multibase 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b9c35dac080fd6e16a99924c8dfdef0af89d797dd851adab25feaffacf7850d6"
-"checksum multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)" = "<none>"
-"checksum multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)" = "<none>"
+"checksum multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)" = "<none>"
+"checksum multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)" = "<none>"
 "checksum nan-preserving-float 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "34d4f00fcc2f4c9efa8cc971db0da9e28290e28e97af47585e48691ef10ff31f"
 "checksum native-tls 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f74dbadc8b43df7864539cedb7bc91345e532fdd913cfdc23ad94f4d2d40fbc0"
 "checksum net2 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)" = "9044faf1413a1057267be51b5afba8eb1090bd2231c693664aa1db716fe1eae0"
@@ -4079,7 +4079,7 @@ dependencies = [
 "checksum rustc-hex 2.0.0 (git+https://github.com/rphmeier/rustc-hex.git)" = "<none>"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustc_version 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a54aa04a10c68c1c4eacb4337fd883b435997ede17a9385784b990777686b09a"
-"checksum rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)" = "<none>"
+"checksum rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)" = "<none>"
 "checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
 "checksum schannel 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "85fd9df495640643ad2d00443b3d78aae69802ad488debab4f1dd52fc1806ade"
 "checksum scoped-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "332ffa32bf586782a3efaeb58f127980944bbc8c4d6913a86107ac2a5ab24b28"
@@ -4161,7 +4161,7 @@ dependencies = [
 "checksum url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f808aadd8cfec6ef90e4a14eb46f24511824d1ac596b9682703c87056c8678b7"
 "checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
 "checksum varint 0.1.0 (git+https://github.com/libp2p/rust-libp2p)" = "<none>"
-"checksum varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=2fb5ef1d40f2565e592248abbd21b7ca2da992e0)" = "<none>"
+"checksum varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)" = "<none>"
 "checksum vcpkg 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7ed0f6789c8a85ca41bbc1c9d175422116a9869bd1cf31bb08e1493ecce60380"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6b772017e347561807c1aa192438c5fd74242a670a6cffacc40f2defd1dc069d"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,17 +252,17 @@ dependencies = [
 [[package]]
 name = "cid"
 version = "0.2.3"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331#7043d6ae5849605b6f9fe26ce89e0c72c5252331"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7#727e0e099b53a4032a7e2330994c819fe866add7"
 dependencies = [
  "integer-encoding 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "multibase 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
+ "multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)",
 ]
 
 [[package]]
 name = "circular-buffer"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331#7043d6ae5849605b6f9fe26ce89e0c72c5252331"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7#727e0e099b53a4032a7e2330994c819fe866add7"
 dependencies = [
  "smallvec 0.6.0 (git+https://github.com/Vurich/rust-smallvec.git?branch=array-zero)",
 ]
@@ -409,7 +409,7 @@ dependencies = [
 [[package]]
 name = "datastore"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331#7043d6ae5849605b6f9fe26ce89e0c72c5252331"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7#727e0e099b53a4032a7e2330994c819fe866add7"
 dependencies = [
  "base64 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chashmap 2.2.1 (git+https://github.com/redox-os/tfs)",
@@ -1148,26 +1148,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "libp2p"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331#7043d6ae5849605b6f9fe26ce89e0c72c5252331"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7#727e0e099b53a4032a7e2330994c819fe866add7"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
- "libp2p-dns 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
- "libp2p-floodsub 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
- "libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
- "libp2p-kad 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
- "libp2p-mplex 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
- "libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
- "libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
- "libp2p-ratelimit 0.1.1 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
- "libp2p-relay 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
- "libp2p-secio 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
- "libp2p-tcp-transport 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
- "libp2p-transport-timeout 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
- "libp2p-websocket 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
- "libp2p-yamux 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)",
+ "libp2p-dns 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)",
+ "libp2p-floodsub 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)",
+ "libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)",
+ "libp2p-kad 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)",
+ "libp2p-mplex 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)",
+ "libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)",
+ "libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)",
+ "libp2p-ratelimit 0.1.1 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)",
+ "libp2p-relay 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)",
+ "libp2p-secio 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)",
+ "libp2p-tcp-transport 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)",
+ "libp2p-transport-timeout 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)",
+ "libp2p-websocket 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)",
+ "libp2p-yamux 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)",
  "stdweb 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1177,16 +1177,16 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331#7043d6ae5849605b6f9fe26ce89e0c72c5252331"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7#727e0e099b53a4032a7e2330994c819fe866add7"
 dependencies = [
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
- "multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
- "multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)",
+ "multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)",
+ "multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1197,12 +1197,12 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331#7043d6ae5849605b6f9fe26ce89e0c72c5252331"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7#727e0e099b53a4032a7e2330994c819fe866add7"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)",
  "tokio-dns-unofficial 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1210,98 +1210,98 @@ dependencies = [
 [[package]]
 name = "libp2p-floodsub"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331#7043d6ae5849605b6f9fe26ce89e0c72c5252331"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7#727e0e099b53a4032a7e2330994c819fe866add7"
 dependencies = [
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)",
 ]
 
 [[package]]
 name = "libp2p-identify"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331#7043d6ae5849605b6f9fe26ce89e0c72c5252331"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7#727e0e099b53a4032a7e2330994c819fe866add7"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf-codegen-pure 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)",
 ]
 
 [[package]]
 name = "libp2p-kad"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331#7043d6ae5849605b6f9fe26ce89e0c72c5252331"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7#727e0e099b53a4032a7e2330994c819fe866add7"
 dependencies = [
  "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "bigint 4.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
+ "datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
- "libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
- "libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)",
+ "libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)",
+ "libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)",
 ]
 
 [[package]]
 name = "libp2p-mplex"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331#7043d6ae5849605b6f9fe26ce89e0c72c5252331"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7#727e0e099b53a4032a7e2330994c819fe866add7"
 dependencies = [
  "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "circular-buffer 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
+ "circular-buffer 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)",
  "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-mutex 0.3.0 (git+https://github.com/paritytech/futures-mutex)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-bigint 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)",
 ]
 
 [[package]]
 name = "libp2p-peerstore"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331#7043d6ae5849605b6f9fe26ce89e0c72c5252331"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7#727e0e099b53a4032a7e2330994c819fe866add7"
 dependencies = [
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
+ "datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)",
  "owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.64 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1310,14 +1310,14 @@ dependencies = [
 [[package]]
 name = "libp2p-ping"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331#7043d6ae5849605b6f9fe26ce89e0c72c5252331"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7#727e0e099b53a4032a7e2330994c819fe866add7"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
- "multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)",
+ "multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1326,11 +1326,11 @@ dependencies = [
 [[package]]
 name = "libp2p-ratelimit"
 version = "0.1.1"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331#7043d6ae5849605b6f9fe26ce89e0c72c5252331"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7#727e0e099b53a4032a7e2330994c819fe866add7"
 dependencies = [
  "aio-limited 0.1.0 (git+https://github.com/paritytech/aio-limited.git)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1339,37 +1339,37 @@ dependencies = [
 [[package]]
 name = "libp2p-relay"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331#7043d6ae5849605b6f9fe26ce89e0c72c5252331"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7#727e0e099b53a4032a7e2330994c819fe866add7"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
- "libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)",
+ "libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)",
 ]
 
 [[package]]
 name = "libp2p-secio"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331#7043d6ae5849605b6f9fe26ce89e0c72c5252331"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7#727e0e099b53a4032a7e2330994c819fe866add7"
 dependencies = [
  "asn1_der 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "eth-secp256k1 0.5.7 (git+https://github.com/paritytech/rust-secp256k1)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf-codegen-pure 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
+ "rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1377,12 +1377,12 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp-transport"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331#7043d6ae5849605b6f9fe26ce89e0c72c5252331"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7#727e0e099b53a4032a7e2330994c819fe866add7"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1390,10 +1390,10 @@ dependencies = [
 [[package]]
 name = "libp2p-transport-timeout"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331#7043d6ae5849605b6f9fe26ce89e0c72c5252331"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7#727e0e099b53a4032a7e2330994c819fe866add7"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1401,13 +1401,13 @@ dependencies = [
 [[package]]
 name = "libp2p-websocket"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331#7043d6ae5849605b6f9fe26ce89e0c72c5252331"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7#727e0e099b53a4032a7e2330994c819fe866add7"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
- "rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)",
+ "rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)",
  "stdweb 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "websocket 0.20.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1416,11 +1416,11 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331#7043d6ae5849605b6f9fe26ce89e0c72c5252331"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7#727e0e099b53a4032a7e2330994c819fe866add7"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "yamux 0.1.0 (git+https://github.com/paritytech/yamux)",
@@ -1556,10 +1556,10 @@ dependencies = [
 [[package]]
 name = "multiaddr"
 version = "0.3.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331#7043d6ae5849605b6f9fe26ce89e0c72c5252331"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7#727e0e099b53a4032a7e2330994c819fe866add7"
 dependencies = [
  "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "cid 0.2.3 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
+ "cid 0.2.3 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)",
  "integer-encoding 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1574,7 +1574,7 @@ dependencies = [
 [[package]]
 name = "multihash"
 version = "0.8.1-pre"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331#7043d6ae5849605b6f9fe26ce89e0c72c5252331"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7#727e0e099b53a4032a7e2330994c819fe866add7"
 dependencies = [
  "sha1 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1584,14 +1584,14 @@ dependencies = [
 [[package]]
 name = "multistream-select"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331#7043d6ae5849605b6f9fe26ce89e0c72c5252331"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7#727e0e099b53a4032a7e2330994c819fe866add7"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)",
 ]
 
 [[package]]
@@ -2377,7 +2377,7 @@ dependencies = [
 [[package]]
 name = "rw-stream-sink"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331#7043d6ae5849605b6f9fe26ce89e0c72c5252331"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7#727e0e099b53a4032a7e2330994c819fe866add7"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2807,7 +2807,7 @@ dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipnetwork 0.12.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)",
+ "libp2p 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3690,7 +3690,7 @@ dependencies = [
 [[package]]
 name = "varint"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331#7043d6ae5849605b6f9fe26ce89e0c72c5252331"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7#727e0e099b53a4032a7e2330994c819fe866add7"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3894,8 +3894,8 @@ dependencies = [
 "checksum cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "405216fd8fe65f718daa7102ea808a946b6ce40c742998fbfd3463645552de18"
 "checksum chashmap 2.2.1 (git+https://github.com/redox-os/tfs)" = "<none>"
 "checksum chrono 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1cce36c92cb605414e9b824f866f5babe0a0368e39ea07393b9b63cf3844c0e6"
-"checksum cid 0.2.3 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)" = "<none>"
-"checksum circular-buffer 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)" = "<none>"
+"checksum cid 0.2.3 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)" = "<none>"
+"checksum circular-buffer 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)" = "<none>"
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum cmake 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "95470235c31c726d72bf2e1f421adc1e65b9d561bf5529612cbe1a72da1467b3"
@@ -3912,7 +3912,7 @@ dependencies = [
 "checksum crossbeam-utils 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d636a8b3bcc1b409d7ffd3facef8f21dcb4009626adbd0c5e6c4305c07253c7b"
 "checksum crunchy 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a2f4a431c5c9f662e1200b7c7f02c34e91361150e382089a8f2dec3ba680cbda"
 "checksum ctrlc 1.1.1 (git+https://github.com/paritytech/rust-ctrlc.git)" = "<none>"
-"checksum datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)" = "<none>"
+"checksum datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)" = "<none>"
 "checksum difference 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3304d19798a8e067e48d8e69b2c37f0b5e9b4e462504ad9e27e9f3fce02bba8"
 "checksum digest 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3cae2388d706b52f2f2f9afe280f9d768be36544bd71d1b8120cb34ea6450b55"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
@@ -3983,22 +3983,22 @@ dependencies = [
 "checksum lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e6412c5e2ad9584b0b8e979393122026cdd6d2a80b933f890dcd694ddbe73739"
 "checksum lazycell 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a6f08839bc70ef4a3fe1d566d5350f519c5912ea86be0df1740a7d247c7fc0ef"
 "checksum libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)" = "ac8ebf8343a981e2fa97042b14768f02ed3e1d602eac06cae6166df3c8ced206"
-"checksum libp2p 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)" = "<none>"
-"checksum libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)" = "<none>"
-"checksum libp2p-dns 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)" = "<none>"
-"checksum libp2p-floodsub 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)" = "<none>"
-"checksum libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)" = "<none>"
-"checksum libp2p-kad 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)" = "<none>"
-"checksum libp2p-mplex 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)" = "<none>"
-"checksum libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)" = "<none>"
-"checksum libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)" = "<none>"
-"checksum libp2p-ratelimit 0.1.1 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)" = "<none>"
-"checksum libp2p-relay 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)" = "<none>"
-"checksum libp2p-secio 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)" = "<none>"
-"checksum libp2p-tcp-transport 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)" = "<none>"
-"checksum libp2p-transport-timeout 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)" = "<none>"
-"checksum libp2p-websocket 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)" = "<none>"
-"checksum libp2p-yamux 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)" = "<none>"
+"checksum libp2p 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)" = "<none>"
+"checksum libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)" = "<none>"
+"checksum libp2p-dns 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)" = "<none>"
+"checksum libp2p-floodsub 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)" = "<none>"
+"checksum libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)" = "<none>"
+"checksum libp2p-kad 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)" = "<none>"
+"checksum libp2p-mplex 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)" = "<none>"
+"checksum libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)" = "<none>"
+"checksum libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)" = "<none>"
+"checksum libp2p-ratelimit 0.1.1 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)" = "<none>"
+"checksum libp2p-relay 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)" = "<none>"
+"checksum libp2p-secio 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)" = "<none>"
+"checksum libp2p-tcp-transport 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)" = "<none>"
+"checksum libp2p-transport-timeout 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)" = "<none>"
+"checksum libp2p-websocket 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)" = "<none>"
+"checksum libp2p-yamux 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)" = "<none>"
 "checksum linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "70fb39025bc7cdd76305867c4eccf2f2dcf6e9a57f5b21a93e1c2d86cd03ec9e"
 "checksum local-encoding 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e1ceb20f39ff7ae42f3ff9795f3986b1daad821caaa1e1732a0944103a5a1a66"
 "checksum lock_api 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "949826a5ccf18c1b3a7c3d57692778d21768b79e46eb9dd07bfc4c2160036c54"
@@ -4014,10 +4014,10 @@ dependencies = [
 "checksum mime 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0b28683d0b09bbc20be1c9b3f6f24854efb1356ffcffee08ea3f6e65596e85fa"
 "checksum mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)" = "6d771e3ef92d58a8da8df7d6976bfca9371ed1de6619d9d5a5ce5b1f29b85bfe"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
-"checksum multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)" = "<none>"
+"checksum multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)" = "<none>"
 "checksum multibase 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b9c35dac080fd6e16a99924c8dfdef0af89d797dd851adab25feaffacf7850d6"
-"checksum multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)" = "<none>"
-"checksum multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)" = "<none>"
+"checksum multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)" = "<none>"
+"checksum multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)" = "<none>"
 "checksum nan-preserving-float 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "34d4f00fcc2f4c9efa8cc971db0da9e28290e28e97af47585e48691ef10ff31f"
 "checksum native-tls 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f74dbadc8b43df7864539cedb7bc91345e532fdd913cfdc23ad94f4d2d40fbc0"
 "checksum net2 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)" = "9044faf1413a1057267be51b5afba8eb1090bd2231c693664aa1db716fe1eae0"
@@ -4079,7 +4079,7 @@ dependencies = [
 "checksum rustc-hex 2.0.0 (git+https://github.com/rphmeier/rustc-hex.git)" = "<none>"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustc_version 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a54aa04a10c68c1c4eacb4337fd883b435997ede17a9385784b990777686b09a"
-"checksum rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)" = "<none>"
+"checksum rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)" = "<none>"
 "checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
 "checksum schannel 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "85fd9df495640643ad2d00443b3d78aae69802ad488debab4f1dd52fc1806ade"
 "checksum scoped-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "332ffa32bf586782a3efaeb58f127980944bbc8c4d6913a86107ac2a5ab24b28"
@@ -4161,7 +4161,7 @@ dependencies = [
 "checksum url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f808aadd8cfec6ef90e4a14eb46f24511824d1ac596b9682703c87056c8678b7"
 "checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
 "checksum varint 0.1.0 (git+https://github.com/libp2p/rust-libp2p)" = "<none>"
-"checksum varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7043d6ae5849605b6f9fe26ce89e0c72c5252331)" = "<none>"
+"checksum varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=727e0e099b53a4032a7e2330994c819fe866add7)" = "<none>"
 "checksum vcpkg 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7ed0f6789c8a85ca41bbc1c9d175422116a9869bd1cf31bb08e1493ecce60380"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6b772017e347561807c1aa192438c5fd74242a670a6cffacc40f2defd1dc069d"

--- a/substrate/network-libp2p/Cargo.toml
+++ b/substrate/network-libp2p/Cargo.toml
@@ -11,7 +11,7 @@ bytes = "0.4"
 error-chain = { version = "0.12", default-features = false }
 fnv = "1.0"
 futures = "0.1"
-libp2p = { git = "https://github.com/tomaka/libp2p-rs", rev = "2fb5ef1d40f2565e592248abbd21b7ca2da992e0", default-features = false, features = ["libp2p-secio", "libp2p-secio-secp256k1"] }
+libp2p = { git = "https://github.com/tomaka/libp2p-rs", rev = "7043d6ae5849605b6f9fe26ce89e0c72c5252331", default-features = false, features = ["libp2p-secio", "libp2p-secio-secp256k1"] }
 ethcore-io = { git = "https://github.com/paritytech/parity.git" }
 ethkey = { git = "https://github.com/paritytech/parity.git" }
 ethereum-types = "0.3"

--- a/substrate/network-libp2p/Cargo.toml
+++ b/substrate/network-libp2p/Cargo.toml
@@ -11,7 +11,7 @@ bytes = "0.4"
 error-chain = { version = "0.12", default-features = false }
 fnv = "1.0"
 futures = "0.1"
-libp2p = { git = "https://github.com/tomaka/libp2p-rs", rev = "7043d6ae5849605b6f9fe26ce89e0c72c5252331", default-features = false, features = ["libp2p-secio", "libp2p-secio-secp256k1"] }
+libp2p = { git = "https://github.com/tomaka/libp2p-rs", rev = "727e0e099b53a4032a7e2330994c819fe866add7", default-features = false, features = ["libp2p-secio", "libp2p-secio-secp256k1"] }
 ethcore-io = { git = "https://github.com/paritytech/parity.git" }
 ethkey = { git = "https://github.com/paritytech/parity.git" }
 ethereum-types = "0.3"

--- a/substrate/network-libp2p/src/network_state.rs
+++ b/substrate/network-libp2p/src/network_state.rs
@@ -192,7 +192,28 @@ impl NetworkState {
 		&self.local_public_key
 	}
 
-	/// Returns all the IDs of the peer we have knowledge of.
+	/// Returns the ID of a random peer of the network.
+	///
+	/// Returns `None` if we don't know any peer.
+	pub fn random_peer(&self) -> Option<PeerstorePeerId> {
+		// TODO: optimize by putting the operation directly in the peerstore
+		// https://github.com/libp2p/rust-libp2p/issues/316
+		let peers = match self.peerstore {
+			PeersStorage::Memory(ref mem) =>
+				mem.peers().collect::<Vec<_>>(),
+			PeersStorage::Json(ref json) =>
+				json.peers().collect::<Vec<_>>(),
+		};
+
+		if peers.is_empty() {
+			return None
+		}
+
+		let nth = rand::random::<usize>() % peers.len();
+		Some(peers[nth].clone())
+	}
+
+	/// Returns all the IDs of the peers on the network we have knowledge of.
 	///
 	/// This includes peers we are not connected to.
 	pub fn known_peers(&self) -> impl Iterator<Item = PeerstorePeerId> {

--- a/substrate/network-libp2p/src/network_state.rs
+++ b/substrate/network-libp2p/src/network_state.rs
@@ -447,7 +447,7 @@ impl NetworkState {
 		if self.reserved_only.load(atomic::Ordering::Relaxed) {
 			0
 		} else {
-			self.min_peers - self.num_open_custom_connections()
+			self.min_peers.saturating_sub(self.num_open_custom_connections())
 		}
 	}
 

--- a/substrate/network-libp2p/src/network_state.rs
+++ b/substrate/network-libp2p/src/network_state.rs
@@ -16,7 +16,7 @@
 
 use bytes::Bytes;
 use fnv::{FnvHashMap, FnvHashSet};
-use futures::{future, sync::mpsc};
+use futures::sync::mpsc;
 use libp2p::core::{Multiaddr, AddrComponent, Endpoint, UniqueConnec};
 use libp2p::core::{PeerId as PeerstorePeerId, PublicKey};
 use libp2p::kad::KadConnecController;

--- a/substrate/network-libp2p/src/service.rs
+++ b/substrate/network-libp2p/src/service.rs
@@ -799,7 +799,7 @@ fn start_kademlia_discovery<T, To, St, C>(shared: Arc<Shared>, transport: T,
 				// that we don't need to run a timer just for flushing.
 				let _ = shared.network_state.flush_caches_to_disk();
 
-				if shared.network_state.should_open_outgoing_connections() {
+				if shared.network_state.should_open_outgoing_custom_connections() != 0 {
 					future::Either::A(perform_kademlia_query(shared.clone(),
 						transport.clone(), swarm_controller.clone()))
 				} else {
@@ -892,7 +892,7 @@ fn process_kad_results<T, To, St, C>(shared: Arc<Shared>, transport: T,
 		// Skip if we reach `min_peers`.
 		// Also skip nodes we are already connected to, in order to not connect twice.
 		// TODO: better API in network_state
-		if !shared.network_state.should_open_outgoing_connections() ||
+		if shared.network_state.should_open_outgoing_custom_connections() == 0 ||
 			discovered_peer == *local_peer_id ||
 			shared.network_state.is_peer_disabled(&discovered_peer)
 		{

--- a/substrate/network-libp2p/src/service.rs
+++ b/substrate/network-libp2p/src/service.rs
@@ -609,10 +609,11 @@ fn handle_kademlia_connection(
 
 /// When a remote performs a `FIND_NODE` Kademlia request for `searched`,
 /// this function builds the response to send back.
-fn build_kademlia_response(shared: &Arc<Shared>, searched: &PeerstorePeerId)
-	-> Vec<KadPeer> {
+fn build_kademlia_response(
+	shared: &Arc<Shared>,
+	searched: &PeerstorePeerId
+) -> Vec<KadPeer> {
 	shared.kad_system
-		// TODO the iter of `known_closest_peers` should be infinite
 		.known_closest_peers(searched)
 		.map(move |peer_id| {
 			if peer_id == *shared.kad_system.local_peer_id() {
@@ -638,6 +639,8 @@ fn build_kademlia_response(shared: &Arc<Shared>, searched: &PeerstorePeerId)
 				}
 			}
 		})
+		.filter(|p| !p.multiaddrs.is_empty())
+		.take(20)
 		.collect::<Vec<_>>()
 }
 

--- a/substrate/network-libp2p/src/service.rs
+++ b/substrate/network-libp2p/src/service.rs
@@ -646,8 +646,8 @@ fn build_kademlia_response(
 			}
 		})
 		// TODO: we really want to remove nodes with no multiaddress from
-		// the results, but a flew in the Kad protocol of libp2p makes it
-		// impossible to return no result at all ; therefore we must at least
+		// the results, but a flaw in the Kad protocol of libp2p makes it
+		// impossible to return empty results ; therefore we must at least
 		// return ourselves
 		.filter(|p| p.node_id == *shared.kad_system.local_peer_id() ||
 			!p.multiaddrs.is_empty())

--- a/substrate/network-libp2p/src/transport.rs
+++ b/substrate/network-libp2p/src/transport.rs
@@ -56,6 +56,11 @@ pub fn build_transport(
 		.into_connection_reuse();
 
 	TransportTimeout::new(base, Duration::from_secs(20))
+		.map_err(|err| {
+			debug!(target: "sub-libp2p", "Error in base transport \
+				layer: {:?}", err);
+			err
+		})
 }
 
 /// Specifies whether unencrypted communications are allowed or denied.

--- a/substrate/network-libp2p/src/transport.rs
+++ b/substrate/network-libp2p/src/transport.rs
@@ -16,6 +16,8 @@
 
 use libp2p::{self, Transport, secio};
 use libp2p::core::{MuxedTransport, either, upgrade};
+use libp2p::transport_timeout::TransportTimeout;
+use std::time::Duration;
 use tokio_core::reactor::Handle;
 use tokio_io::{AsyncRead, AsyncWrite};
 
@@ -25,7 +27,7 @@ pub fn build_transport(
 	unencrypted_allowed: UnencryptedAllowed,
 	local_private_key: secio::SecioKeyPair
 ) -> impl MuxedTransport<Output = impl AsyncRead + AsyncWrite> + Clone {
-	libp2p::CommonTransport::new(core)
+	let base = libp2p::CommonTransport::new(core)
 		.with_upgrade({
 			let secio = secio::SecioConfig {
 				key: local_private_key,
@@ -51,7 +53,9 @@ pub fn build_transport(
 		// TODO: check that the public key matches what is reported by identify
 		.map(|(socket, _key), _| socket)
 		.with_upgrade(libp2p::mplex::MultiplexConfig::new())
-		.into_connection_reuse()
+		.into_connection_reuse();
+
+	TransportTimeout::new(base, Duration::from_secs(20))
 }
 
 /// Specifies whether unencrypted communications are allowed or denied.


### PR DESCRIPTION
Fixes the most pressing issues with the networking:

- Fixes a panic in `IdentifyTransport`.
- Adds a 20 seconds timeout to connections. We try to dial nodes again later if an earlier connection fails.
- Do not take into account connections that only have a Kademlia substream (and not a substrate substream) for `min_peers`/`max_peers`.
- Print the error in the logs when a connection attempt fails.
- Instead of connecting to the results of the Kademlia queries, we just pick random nodes from the peer store.
- We immediately try to connect to random nodes from the peer store at startup. The first time a node is started, it will connect to the bootstrap nodes, but afterwards it will connect to nodes it learned about earlier.