### PR TITLE
Timeouts now repeat forever

### DIFF
--- a/substrate/network-libp2p/src/lib.rs
+++ b/substrate/network-libp2p/src/lib.rs
@@ -19,6 +19,7 @@
 
 extern crate parking_lot;
 extern crate fnv;
+#[macro_use]
 extern crate futures;
 extern crate tokio_core;
 extern crate tokio_io;


### PR DESCRIPTION
I misinterpreted the code of devp2p. Right now timeouts only fire once, while in reality they should continue to fire forever.

cc @arkpar 