### PR TITLE
More networking fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,17 +252,17 @@ dependencies = [
 [[package]]
 name = "cid"
 version = "0.2.3"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304#7ed56d90b4a306793795c0627e99b903deaf8304"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf#bab05e8c264f74011023c0fa042511768502f5cf"
 dependencies = [
  "integer-encoding 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "multibase 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
+ "multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
 ]
 
 [[package]]
 name = "circular-buffer"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304#7ed56d90b4a306793795c0627e99b903deaf8304"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf#bab05e8c264f74011023c0fa042511768502f5cf"
 dependencies = [
  "smallvec 0.6.0 (git+https://github.com/Vurich/rust-smallvec.git?branch=array-zero)",
 ]
@@ -409,7 +409,7 @@ dependencies = [
 [[package]]
 name = "datastore"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304#7ed56d90b4a306793795c0627e99b903deaf8304"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf#bab05e8c264f74011023c0fa042511768502f5cf"
 dependencies = [
  "base64 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chashmap 2.2.1 (git+https://github.com/redox-os/tfs)",
@@ -1148,26 +1148,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "libp2p"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304#7ed56d90b4a306793795c0627e99b903deaf8304"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf#bab05e8c264f74011023c0fa042511768502f5cf"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
- "libp2p-dns 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
- "libp2p-floodsub 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
- "libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
- "libp2p-kad 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
- "libp2p-mplex 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
- "libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
- "libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
- "libp2p-ratelimit 0.1.1 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
- "libp2p-relay 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
- "libp2p-secio 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
- "libp2p-tcp-transport 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
- "libp2p-transport-timeout 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
- "libp2p-websocket 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
- "libp2p-yamux 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
+ "libp2p-dns 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
+ "libp2p-floodsub 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
+ "libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
+ "libp2p-kad 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
+ "libp2p-mplex 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
+ "libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
+ "libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
+ "libp2p-ratelimit 0.1.1 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
+ "libp2p-relay 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
+ "libp2p-secio 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
+ "libp2p-tcp-transport 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
+ "libp2p-transport-timeout 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
+ "libp2p-websocket 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
+ "libp2p-yamux 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
  "stdweb 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1177,16 +1177,16 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304#7ed56d90b4a306793795c0627e99b903deaf8304"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf#bab05e8c264f74011023c0fa042511768502f5cf"
 dependencies = [
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
- "multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
- "multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
+ "multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
+ "multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1197,12 +1197,12 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304#7ed56d90b4a306793795c0627e99b903deaf8304"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf#bab05e8c264f74011023c0fa042511768502f5cf"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
  "tokio-dns-unofficial 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1210,98 +1210,98 @@ dependencies = [
 [[package]]
 name = "libp2p-floodsub"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304#7ed56d90b4a306793795c0627e99b903deaf8304"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf#bab05e8c264f74011023c0fa042511768502f5cf"
 dependencies = [
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
 ]
 
 [[package]]
 name = "libp2p-identify"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304#7ed56d90b4a306793795c0627e99b903deaf8304"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf#bab05e8c264f74011023c0fa042511768502f5cf"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf-codegen-pure 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
 ]
 
 [[package]]
 name = "libp2p-kad"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304#7ed56d90b4a306793795c0627e99b903deaf8304"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf#bab05e8c264f74011023c0fa042511768502f5cf"
 dependencies = [
  "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "bigint 4.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
+ "datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
- "libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
- "libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
+ "libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
+ "libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
 ]
 
 [[package]]
 name = "libp2p-mplex"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304#7ed56d90b4a306793795c0627e99b903deaf8304"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf#bab05e8c264f74011023c0fa042511768502f5cf"
 dependencies = [
  "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "circular-buffer 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
+ "circular-buffer 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
  "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-mutex 0.3.0 (git+https://github.com/paritytech/futures-mutex)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-bigint 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
 ]
 
 [[package]]
 name = "libp2p-peerstore"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304#7ed56d90b4a306793795c0627e99b903deaf8304"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf#bab05e8c264f74011023c0fa042511768502f5cf"
 dependencies = [
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
+ "datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
  "owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1310,14 +1310,14 @@ dependencies = [
 [[package]]
 name = "libp2p-ping"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304#7ed56d90b4a306793795c0627e99b903deaf8304"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf#bab05e8c264f74011023c0fa042511768502f5cf"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
- "multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
+ "multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1326,11 +1326,11 @@ dependencies = [
 [[package]]
 name = "libp2p-ratelimit"
 version = "0.1.1"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304#7ed56d90b4a306793795c0627e99b903deaf8304"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf#bab05e8c264f74011023c0fa042511768502f5cf"
 dependencies = [
  "aio-limited 0.1.0 (git+https://github.com/paritytech/aio-limited.git)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1339,37 +1339,37 @@ dependencies = [
 [[package]]
 name = "libp2p-relay"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304#7ed56d90b4a306793795c0627e99b903deaf8304"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf#bab05e8c264f74011023c0fa042511768502f5cf"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
- "libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
+ "libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
 ]
 
 [[package]]
 name = "libp2p-secio"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304#7ed56d90b4a306793795c0627e99b903deaf8304"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf#bab05e8c264f74011023c0fa042511768502f5cf"
 dependencies = [
  "asn1_der 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "eth-secp256k1 0.5.7 (git+https://github.com/paritytech/rust-secp256k1)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf-codegen-pure 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
+ "rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1377,12 +1377,12 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp-transport"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304#7ed56d90b4a306793795c0627e99b903deaf8304"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf#bab05e8c264f74011023c0fa042511768502f5cf"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1390,10 +1390,10 @@ dependencies = [
 [[package]]
 name = "libp2p-transport-timeout"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304#7ed56d90b4a306793795c0627e99b903deaf8304"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf#bab05e8c264f74011023c0fa042511768502f5cf"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1401,13 +1401,13 @@ dependencies = [
 [[package]]
 name = "libp2p-websocket"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304#7ed56d90b4a306793795c0627e99b903deaf8304"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf#bab05e8c264f74011023c0fa042511768502f5cf"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
- "rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
+ "rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
  "stdweb 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "websocket 0.20.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1416,11 +1416,11 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304#7ed56d90b4a306793795c0627e99b903deaf8304"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf#bab05e8c264f74011023c0fa042511768502f5cf"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "yamux 0.1.0 (git+https://github.com/paritytech/yamux)",
@@ -1556,10 +1556,10 @@ dependencies = [
 [[package]]
 name = "multiaddr"
 version = "0.3.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304#7ed56d90b4a306793795c0627e99b903deaf8304"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf#bab05e8c264f74011023c0fa042511768502f5cf"
 dependencies = [
  "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "cid 0.2.3 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
+ "cid 0.2.3 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
  "integer-encoding 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1574,7 +1574,7 @@ dependencies = [
 [[package]]
 name = "multihash"
 version = "0.8.1-pre"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304#7ed56d90b4a306793795c0627e99b903deaf8304"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf#bab05e8c264f74011023c0fa042511768502f5cf"
 dependencies = [
  "sha1 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1584,14 +1584,14 @@ dependencies = [
 [[package]]
 name = "multistream-select"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304#7ed56d90b4a306793795c0627e99b903deaf8304"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf#bab05e8c264f74011023c0fa042511768502f5cf"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
 ]
 
 [[package]]
@@ -2388,7 +2388,7 @@ dependencies = [
 [[package]]
 name = "rw-stream-sink"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304#7ed56d90b4a306793795c0627e99b903deaf8304"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf#bab05e8c264f74011023c0fa042511768502f5cf"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2818,7 +2818,7 @@ dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipnetwork 0.12.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
+ "libp2p 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3701,7 +3701,7 @@ dependencies = [
 [[package]]
 name = "varint"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304#7ed56d90b4a306793795c0627e99b903deaf8304"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf#bab05e8c264f74011023c0fa042511768502f5cf"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3905,8 +3905,8 @@ dependencies = [
 "checksum cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "405216fd8fe65f718daa7102ea808a946b6ce40c742998fbfd3463645552de18"
 "checksum chashmap 2.2.1 (git+https://github.com/redox-os/tfs)" = "<none>"
 "checksum chrono 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1cce36c92cb605414e9b824f866f5babe0a0368e39ea07393b9b63cf3844c0e6"
-"checksum cid 0.2.3 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)" = "<none>"
-"checksum circular-buffer 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)" = "<none>"
+"checksum cid 0.2.3 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)" = "<none>"
+"checksum circular-buffer 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)" = "<none>"
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum cmake 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "95470235c31c726d72bf2e1f421adc1e65b9d561bf5529612cbe1a72da1467b3"
@@ -3923,7 +3923,7 @@ dependencies = [
 "checksum crossbeam-utils 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d636a8b3bcc1b409d7ffd3facef8f21dcb4009626adbd0c5e6c4305c07253c7b"
 "checksum crunchy 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a2f4a431c5c9f662e1200b7c7f02c34e91361150e382089a8f2dec3ba680cbda"
 "checksum ctrlc 1.1.1 (git+https://github.com/paritytech/rust-ctrlc.git)" = "<none>"
-"checksum datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)" = "<none>"
+"checksum datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)" = "<none>"
 "checksum difference 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3304d19798a8e067e48d8e69b2c37f0b5e9b4e462504ad9e27e9f3fce02bba8"
 "checksum digest 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3cae2388d706b52f2f2f9afe280f9d768be36544bd71d1b8120cb34ea6450b55"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
@@ -3994,22 +3994,22 @@ dependencies = [
 "checksum lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e6412c5e2ad9584b0b8e979393122026cdd6d2a80b933f890dcd694ddbe73739"
 "checksum lazycell 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a6f08839bc70ef4a3fe1d566d5350f519c5912ea86be0df1740a7d247c7fc0ef"
 "checksum libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)" = "ac8ebf8343a981e2fa97042b14768f02ed3e1d602eac06cae6166df3c8ced206"
-"checksum libp2p 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)" = "<none>"
-"checksum libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)" = "<none>"
-"checksum libp2p-dns 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)" = "<none>"
-"checksum libp2p-floodsub 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)" = "<none>"
-"checksum libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)" = "<none>"
-"checksum libp2p-kad 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)" = "<none>"
-"checksum libp2p-mplex 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)" = "<none>"
-"checksum libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)" = "<none>"
-"checksum libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)" = "<none>"
-"checksum libp2p-ratelimit 0.1.1 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)" = "<none>"
-"checksum libp2p-relay 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)" = "<none>"
-"checksum libp2p-secio 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)" = "<none>"
-"checksum libp2p-tcp-transport 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)" = "<none>"
-"checksum libp2p-transport-timeout 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)" = "<none>"
-"checksum libp2p-websocket 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)" = "<none>"
-"checksum libp2p-yamux 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)" = "<none>"
+"checksum libp2p 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)" = "<none>"
+"checksum libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)" = "<none>"
+"checksum libp2p-dns 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)" = "<none>"
+"checksum libp2p-floodsub 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)" = "<none>"
+"checksum libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)" = "<none>"
+"checksum libp2p-kad 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)" = "<none>"
+"checksum libp2p-mplex 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)" = "<none>"
+"checksum libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)" = "<none>"
+"checksum libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)" = "<none>"
+"checksum libp2p-ratelimit 0.1.1 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)" = "<none>"
+"checksum libp2p-relay 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)" = "<none>"
+"checksum libp2p-secio 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)" = "<none>"
+"checksum libp2p-tcp-transport 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)" = "<none>"
+"checksum libp2p-transport-timeout 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)" = "<none>"
+"checksum libp2p-websocket 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)" = "<none>"
+"checksum libp2p-yamux 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)" = "<none>"
 "checksum linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "70fb39025bc7cdd76305867c4eccf2f2dcf6e9a57f5b21a93e1c2d86cd03ec9e"
 "checksum local-encoding 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e1ceb20f39ff7ae42f3ff9795f3986b1daad821caaa1e1732a0944103a5a1a66"
 "checksum lock_api 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "949826a5ccf18c1b3a7c3d57692778d21768b79e46eb9dd07bfc4c2160036c54"
@@ -4025,10 +4025,10 @@ dependencies = [
 "checksum mime 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0b28683d0b09bbc20be1c9b3f6f24854efb1356ffcffee08ea3f6e65596e85fa"
 "checksum mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)" = "6d771e3ef92d58a8da8df7d6976bfca9371ed1de6619d9d5a5ce5b1f29b85bfe"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
-"checksum multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)" = "<none>"
+"checksum multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)" = "<none>"
 "checksum multibase 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b9c35dac080fd6e16a99924c8dfdef0af89d797dd851adab25feaffacf7850d6"
-"checksum multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)" = "<none>"
-"checksum multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)" = "<none>"
+"checksum multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)" = "<none>"
+"checksum multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)" = "<none>"
 "checksum names 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef320dab323286b50fb5cdda23f61c796a72a89998ab565ca32525c5c556f2da"
 "checksum nan-preserving-float 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "34d4f00fcc2f4c9efa8cc971db0da9e28290e28e97af47585e48691ef10ff31f"
 "checksum native-tls 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f74dbadc8b43df7864539cedb7bc91345e532fdd913cfdc23ad94f4d2d40fbc0"
@@ -4091,7 +4091,7 @@ dependencies = [
 "checksum rustc-hex 2.0.0 (git+https://github.com/rphmeier/rustc-hex.git)" = "<none>"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustc_version 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a54aa04a10c68c1c4eacb4337fd883b435997ede17a9385784b990777686b09a"
-"checksum rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)" = "<none>"
+"checksum rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)" = "<none>"
 "checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
 "checksum schannel 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "85fd9df495640643ad2d00443b3d78aae69802ad488debab4f1dd52fc1806ade"
 "checksum scoped-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "332ffa32bf586782a3efaeb58f127980944bbc8c4d6913a86107ac2a5ab24b28"
@@ -4173,7 +4173,7 @@ dependencies = [
 "checksum url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f808aadd8cfec6ef90e4a14eb46f24511824d1ac596b9682703c87056c8678b7"
 "checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
 "checksum varint 0.1.0 (git+https://github.com/libp2p/rust-libp2p)" = "<none>"
-"checksum varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)" = "<none>"
+"checksum varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)" = "<none>"
 "checksum vcpkg 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7ed0f6789c8a85ca41bbc1c9d175422116a9869bd1cf31bb08e1493ecce60380"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6b772017e347561807c1aa192438c5fd74242a670a6cffacc40f2defd1dc069d"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,17 +252,17 @@ dependencies = [
 [[package]]
 name = "cid"
 version = "0.2.3"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf#bab05e8c264f74011023c0fa042511768502f5cf"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c#ccbb4361c299491b40e5ca95cfa6716ba31c485c"
 dependencies = [
  "integer-encoding 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "multibase 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
+ "multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)",
 ]
 
 [[package]]
 name = "circular-buffer"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf#bab05e8c264f74011023c0fa042511768502f5cf"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c#ccbb4361c299491b40e5ca95cfa6716ba31c485c"
 dependencies = [
  "smallvec 0.6.0 (git+https://github.com/Vurich/rust-smallvec.git?branch=array-zero)",
 ]
@@ -409,7 +409,7 @@ dependencies = [
 [[package]]
 name = "datastore"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf#bab05e8c264f74011023c0fa042511768502f5cf"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c#ccbb4361c299491b40e5ca95cfa6716ba31c485c"
 dependencies = [
  "base64 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chashmap 2.2.1 (git+https://github.com/redox-os/tfs)",
@@ -1148,26 +1148,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "libp2p"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf#bab05e8c264f74011023c0fa042511768502f5cf"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c#ccbb4361c299491b40e5ca95cfa6716ba31c485c"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
- "libp2p-dns 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
- "libp2p-floodsub 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
- "libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
- "libp2p-kad 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
- "libp2p-mplex 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
- "libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
- "libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
- "libp2p-ratelimit 0.1.1 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
- "libp2p-relay 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
- "libp2p-secio 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
- "libp2p-tcp-transport 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
- "libp2p-transport-timeout 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
- "libp2p-websocket 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
- "libp2p-yamux 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)",
+ "libp2p-dns 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)",
+ "libp2p-floodsub 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)",
+ "libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)",
+ "libp2p-kad 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)",
+ "libp2p-mplex 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)",
+ "libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)",
+ "libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)",
+ "libp2p-ratelimit 0.1.1 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)",
+ "libp2p-relay 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)",
+ "libp2p-secio 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)",
+ "libp2p-tcp-transport 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)",
+ "libp2p-transport-timeout 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)",
+ "libp2p-websocket 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)",
+ "libp2p-yamux 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)",
  "stdweb 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1177,16 +1177,16 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf#bab05e8c264f74011023c0fa042511768502f5cf"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c#ccbb4361c299491b40e5ca95cfa6716ba31c485c"
 dependencies = [
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
- "multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
- "multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)",
+ "multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)",
+ "multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1197,12 +1197,12 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf#bab05e8c264f74011023c0fa042511768502f5cf"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c#ccbb4361c299491b40e5ca95cfa6716ba31c485c"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)",
  "tokio-dns-unofficial 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1210,98 +1210,98 @@ dependencies = [
 [[package]]
 name = "libp2p-floodsub"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf#bab05e8c264f74011023c0fa042511768502f5cf"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c#ccbb4361c299491b40e5ca95cfa6716ba31c485c"
 dependencies = [
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)",
 ]
 
 [[package]]
 name = "libp2p-identify"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf#bab05e8c264f74011023c0fa042511768502f5cf"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c#ccbb4361c299491b40e5ca95cfa6716ba31c485c"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf-codegen-pure 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)",
 ]
 
 [[package]]
 name = "libp2p-kad"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf#bab05e8c264f74011023c0fa042511768502f5cf"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c#ccbb4361c299491b40e5ca95cfa6716ba31c485c"
 dependencies = [
  "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "bigint 4.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
+ "datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
- "libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
- "libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)",
+ "libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)",
+ "libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)",
 ]
 
 [[package]]
 name = "libp2p-mplex"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf#bab05e8c264f74011023c0fa042511768502f5cf"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c#ccbb4361c299491b40e5ca95cfa6716ba31c485c"
 dependencies = [
  "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "circular-buffer 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
+ "circular-buffer 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)",
  "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-mutex 0.3.0 (git+https://github.com/paritytech/futures-mutex)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-bigint 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)",
 ]
 
 [[package]]
 name = "libp2p-peerstore"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf#bab05e8c264f74011023c0fa042511768502f5cf"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c#ccbb4361c299491b40e5ca95cfa6716ba31c485c"
 dependencies = [
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
+ "datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)",
  "owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1310,14 +1310,14 @@ dependencies = [
 [[package]]
 name = "libp2p-ping"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf#bab05e8c264f74011023c0fa042511768502f5cf"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c#ccbb4361c299491b40e5ca95cfa6716ba31c485c"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
- "multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)",
+ "multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1326,11 +1326,11 @@ dependencies = [
 [[package]]
 name = "libp2p-ratelimit"
 version = "0.1.1"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf#bab05e8c264f74011023c0fa042511768502f5cf"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c#ccbb4361c299491b40e5ca95cfa6716ba31c485c"
 dependencies = [
  "aio-limited 0.1.0 (git+https://github.com/paritytech/aio-limited.git)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1339,37 +1339,37 @@ dependencies = [
 [[package]]
 name = "libp2p-relay"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf#bab05e8c264f74011023c0fa042511768502f5cf"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c#ccbb4361c299491b40e5ca95cfa6716ba31c485c"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
- "libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)",
+ "libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)",
 ]
 
 [[package]]
 name = "libp2p-secio"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf#bab05e8c264f74011023c0fa042511768502f5cf"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c#ccbb4361c299491b40e5ca95cfa6716ba31c485c"
 dependencies = [
  "asn1_der 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "eth-secp256k1 0.5.7 (git+https://github.com/paritytech/rust-secp256k1)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf-codegen-pure 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
+ "rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1377,12 +1377,12 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp-transport"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf#bab05e8c264f74011023c0fa042511768502f5cf"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c#ccbb4361c299491b40e5ca95cfa6716ba31c485c"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1390,10 +1390,10 @@ dependencies = [
 [[package]]
 name = "libp2p-transport-timeout"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf#bab05e8c264f74011023c0fa042511768502f5cf"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c#ccbb4361c299491b40e5ca95cfa6716ba31c485c"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1401,13 +1401,13 @@ dependencies = [
 [[package]]
 name = "libp2p-websocket"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf#bab05e8c264f74011023c0fa042511768502f5cf"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c#ccbb4361c299491b40e5ca95cfa6716ba31c485c"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
- "rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)",
+ "rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)",
  "stdweb 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "websocket 0.20.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1416,11 +1416,11 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf#bab05e8c264f74011023c0fa042511768502f5cf"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c#ccbb4361c299491b40e5ca95cfa6716ba31c485c"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "yamux 0.1.0 (git+https://github.com/paritytech/yamux)",
@@ -1556,10 +1556,10 @@ dependencies = [
 [[package]]
 name = "multiaddr"
 version = "0.3.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf#bab05e8c264f74011023c0fa042511768502f5cf"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c#ccbb4361c299491b40e5ca95cfa6716ba31c485c"
 dependencies = [
  "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "cid 0.2.3 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
+ "cid 0.2.3 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)",
  "integer-encoding 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1574,7 +1574,7 @@ dependencies = [
 [[package]]
 name = "multihash"
 version = "0.8.1-pre"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf#bab05e8c264f74011023c0fa042511768502f5cf"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c#ccbb4361c299491b40e5ca95cfa6716ba31c485c"
 dependencies = [
  "sha1 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1584,14 +1584,14 @@ dependencies = [
 [[package]]
 name = "multistream-select"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf#bab05e8c264f74011023c0fa042511768502f5cf"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c#ccbb4361c299491b40e5ca95cfa6716ba31c485c"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)",
 ]
 
 [[package]]
@@ -2388,7 +2388,7 @@ dependencies = [
 [[package]]
 name = "rw-stream-sink"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf#bab05e8c264f74011023c0fa042511768502f5cf"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c#ccbb4361c299491b40e5ca95cfa6716ba31c485c"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2818,7 +2818,7 @@ dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipnetwork 0.12.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)",
+ "libp2p 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3701,7 +3701,7 @@ dependencies = [
 [[package]]
 name = "varint"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf#bab05e8c264f74011023c0fa042511768502f5cf"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c#ccbb4361c299491b40e5ca95cfa6716ba31c485c"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3905,8 +3905,8 @@ dependencies = [
 "checksum cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "405216fd8fe65f718daa7102ea808a946b6ce40c742998fbfd3463645552de18"
 "checksum chashmap 2.2.1 (git+https://github.com/redox-os/tfs)" = "<none>"
 "checksum chrono 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1cce36c92cb605414e9b824f866f5babe0a0368e39ea07393b9b63cf3844c0e6"
-"checksum cid 0.2.3 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)" = "<none>"
-"checksum circular-buffer 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)" = "<none>"
+"checksum cid 0.2.3 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)" = "<none>"
+"checksum circular-buffer 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)" = "<none>"
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum cmake 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "95470235c31c726d72bf2e1f421adc1e65b9d561bf5529612cbe1a72da1467b3"
@@ -3923,7 +3923,7 @@ dependencies = [
 "checksum crossbeam-utils 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d636a8b3bcc1b409d7ffd3facef8f21dcb4009626adbd0c5e6c4305c07253c7b"
 "checksum crunchy 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a2f4a431c5c9f662e1200b7c7f02c34e91361150e382089a8f2dec3ba680cbda"
 "checksum ctrlc 1.1.1 (git+https://github.com/paritytech/rust-ctrlc.git)" = "<none>"
-"checksum datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)" = "<none>"
+"checksum datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)" = "<none>"
 "checksum difference 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3304d19798a8e067e48d8e69b2c37f0b5e9b4e462504ad9e27e9f3fce02bba8"
 "checksum digest 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3cae2388d706b52f2f2f9afe280f9d768be36544bd71d1b8120cb34ea6450b55"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
@@ -3994,22 +3994,22 @@ dependencies = [
 "checksum lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e6412c5e2ad9584b0b8e979393122026cdd6d2a80b933f890dcd694ddbe73739"
 "checksum lazycell 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a6f08839bc70ef4a3fe1d566d5350f519c5912ea86be0df1740a7d247c7fc0ef"
 "checksum libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)" = "ac8ebf8343a981e2fa97042b14768f02ed3e1d602eac06cae6166df3c8ced206"
-"checksum libp2p 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)" = "<none>"
-"checksum libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)" = "<none>"
-"checksum libp2p-dns 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)" = "<none>"
-"checksum libp2p-floodsub 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)" = "<none>"
-"checksum libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)" = "<none>"
-"checksum libp2p-kad 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)" = "<none>"
-"checksum libp2p-mplex 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)" = "<none>"
-"checksum libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)" = "<none>"
-"checksum libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)" = "<none>"
-"checksum libp2p-ratelimit 0.1.1 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)" = "<none>"
-"checksum libp2p-relay 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)" = "<none>"
-"checksum libp2p-secio 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)" = "<none>"
-"checksum libp2p-tcp-transport 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)" = "<none>"
-"checksum libp2p-transport-timeout 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)" = "<none>"
-"checksum libp2p-websocket 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)" = "<none>"
-"checksum libp2p-yamux 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)" = "<none>"
+"checksum libp2p 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)" = "<none>"
+"checksum libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)" = "<none>"
+"checksum libp2p-dns 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)" = "<none>"
+"checksum libp2p-floodsub 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)" = "<none>"
+"checksum libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)" = "<none>"
+"checksum libp2p-kad 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)" = "<none>"
+"checksum libp2p-mplex 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)" = "<none>"
+"checksum libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)" = "<none>"
+"checksum libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)" = "<none>"
+"checksum libp2p-ratelimit 0.1.1 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)" = "<none>"
+"checksum libp2p-relay 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)" = "<none>"
+"checksum libp2p-secio 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)" = "<none>"
+"checksum libp2p-tcp-transport 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)" = "<none>"
+"checksum libp2p-transport-timeout 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)" = "<none>"
+"checksum libp2p-websocket 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)" = "<none>"
+"checksum libp2p-yamux 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)" = "<none>"
 "checksum linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "70fb39025bc7cdd76305867c4eccf2f2dcf6e9a57f5b21a93e1c2d86cd03ec9e"
 "checksum local-encoding 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e1ceb20f39ff7ae42f3ff9795f3986b1daad821caaa1e1732a0944103a5a1a66"
 "checksum lock_api 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "949826a5ccf18c1b3a7c3d57692778d21768b79e46eb9dd07bfc4c2160036c54"
@@ -4025,10 +4025,10 @@ dependencies = [
 "checksum mime 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0b28683d0b09bbc20be1c9b3f6f24854efb1356ffcffee08ea3f6e65596e85fa"
 "checksum mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)" = "6d771e3ef92d58a8da8df7d6976bfca9371ed1de6619d9d5a5ce5b1f29b85bfe"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
-"checksum multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)" = "<none>"
+"checksum multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)" = "<none>"
 "checksum multibase 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b9c35dac080fd6e16a99924c8dfdef0af89d797dd851adab25feaffacf7850d6"
-"checksum multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)" = "<none>"
-"checksum multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)" = "<none>"
+"checksum multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)" = "<none>"
+"checksum multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)" = "<none>"
 "checksum names 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef320dab323286b50fb5cdda23f61c796a72a89998ab565ca32525c5c556f2da"
 "checksum nan-preserving-float 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "34d4f00fcc2f4c9efa8cc971db0da9e28290e28e97af47585e48691ef10ff31f"
 "checksum native-tls 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f74dbadc8b43df7864539cedb7bc91345e532fdd913cfdc23ad94f4d2d40fbc0"
@@ -4091,7 +4091,7 @@ dependencies = [
 "checksum rustc-hex 2.0.0 (git+https://github.com/rphmeier/rustc-hex.git)" = "<none>"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustc_version 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a54aa04a10c68c1c4eacb4337fd883b435997ede17a9385784b990777686b09a"
-"checksum rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)" = "<none>"
+"checksum rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)" = "<none>"
 "checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
 "checksum schannel 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "85fd9df495640643ad2d00443b3d78aae69802ad488debab4f1dd52fc1806ade"
 "checksum scoped-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "332ffa32bf586782a3efaeb58f127980944bbc8c4d6913a86107ac2a5ab24b28"
@@ -4173,7 +4173,7 @@ dependencies = [
 "checksum url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f808aadd8cfec6ef90e4a14eb46f24511824d1ac596b9682703c87056c8678b7"
 "checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
 "checksum varint 0.1.0 (git+https://github.com/libp2p/rust-libp2p)" = "<none>"
-"checksum varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=bab05e8c264f74011023c0fa042511768502f5cf)" = "<none>"
+"checksum varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=ccbb4361c299491b40e5ca95cfa6716ba31c485c)" = "<none>"
 "checksum vcpkg 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7ed0f6789c8a85ca41bbc1c9d175422116a9869bd1cf31bb08e1493ecce60380"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6b772017e347561807c1aa192438c5fd74242a670a6cffacc40f2defd1dc069d"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,17 +252,17 @@ dependencies = [
 [[package]]
 name = "cid"
 version = "0.2.3"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7#38c9238a74504a6149909eb80f73608f63ab46c7"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304#7ed56d90b4a306793795c0627e99b903deaf8304"
 dependencies = [
  "integer-encoding 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "multibase 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)",
+ "multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
 ]
 
 [[package]]
 name = "circular-buffer"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7#38c9238a74504a6149909eb80f73608f63ab46c7"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304#7ed56d90b4a306793795c0627e99b903deaf8304"
 dependencies = [
  "smallvec 0.6.0 (git+https://github.com/Vurich/rust-smallvec.git?branch=array-zero)",
 ]
@@ -409,7 +409,7 @@ dependencies = [
 [[package]]
 name = "datastore"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7#38c9238a74504a6149909eb80f73608f63ab46c7"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304#7ed56d90b4a306793795c0627e99b903deaf8304"
 dependencies = [
  "base64 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chashmap 2.2.1 (git+https://github.com/redox-os/tfs)",
@@ -1148,26 +1148,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "libp2p"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7#38c9238a74504a6149909eb80f73608f63ab46c7"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304#7ed56d90b4a306793795c0627e99b903deaf8304"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)",
- "libp2p-dns 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)",
- "libp2p-floodsub 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)",
- "libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)",
- "libp2p-kad 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)",
- "libp2p-mplex 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)",
- "libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)",
- "libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)",
- "libp2p-ratelimit 0.1.1 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)",
- "libp2p-relay 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)",
- "libp2p-secio 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)",
- "libp2p-tcp-transport 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)",
- "libp2p-transport-timeout 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)",
- "libp2p-websocket 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)",
- "libp2p-yamux 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
+ "libp2p-dns 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
+ "libp2p-floodsub 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
+ "libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
+ "libp2p-kad 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
+ "libp2p-mplex 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
+ "libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
+ "libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
+ "libp2p-ratelimit 0.1.1 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
+ "libp2p-relay 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
+ "libp2p-secio 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
+ "libp2p-tcp-transport 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
+ "libp2p-transport-timeout 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
+ "libp2p-websocket 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
+ "libp2p-yamux 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
  "stdweb 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1177,16 +1177,16 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7#38c9238a74504a6149909eb80f73608f63ab46c7"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304#7ed56d90b4a306793795c0627e99b903deaf8304"
 dependencies = [
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)",
- "multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)",
- "multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
+ "multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
+ "multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1197,12 +1197,12 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7#38c9238a74504a6149909eb80f73608f63ab46c7"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304#7ed56d90b4a306793795c0627e99b903deaf8304"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
  "tokio-dns-unofficial 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1210,98 +1210,98 @@ dependencies = [
 [[package]]
 name = "libp2p-floodsub"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7#38c9238a74504a6149909eb80f73608f63ab46c7"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304#7ed56d90b4a306793795c0627e99b903deaf8304"
 dependencies = [
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
 ]
 
 [[package]]
 name = "libp2p-identify"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7#38c9238a74504a6149909eb80f73608f63ab46c7"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304#7ed56d90b4a306793795c0627e99b903deaf8304"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf-codegen-pure 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
 ]
 
 [[package]]
 name = "libp2p-kad"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7#38c9238a74504a6149909eb80f73608f63ab46c7"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304#7ed56d90b4a306793795c0627e99b903deaf8304"
 dependencies = [
  "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "bigint 4.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)",
+ "datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)",
- "libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)",
- "libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
+ "libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
+ "libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
 ]
 
 [[package]]
 name = "libp2p-mplex"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7#38c9238a74504a6149909eb80f73608f63ab46c7"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304#7ed56d90b4a306793795c0627e99b903deaf8304"
 dependencies = [
  "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "circular-buffer 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)",
+ "circular-buffer 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
  "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-mutex 0.3.0 (git+https://github.com/paritytech/futures-mutex)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-bigint 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
 ]
 
 [[package]]
 name = "libp2p-peerstore"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7#38c9238a74504a6149909eb80f73608f63ab46c7"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304#7ed56d90b4a306793795c0627e99b903deaf8304"
 dependencies = [
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)",
+ "datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
  "owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1310,14 +1310,14 @@ dependencies = [
 [[package]]
 name = "libp2p-ping"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7#38c9238a74504a6149909eb80f73608f63ab46c7"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304#7ed56d90b4a306793795c0627e99b903deaf8304"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)",
- "multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
+ "multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1326,11 +1326,11 @@ dependencies = [
 [[package]]
 name = "libp2p-ratelimit"
 version = "0.1.1"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7#38c9238a74504a6149909eb80f73608f63ab46c7"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304#7ed56d90b4a306793795c0627e99b903deaf8304"
 dependencies = [
  "aio-limited 0.1.0 (git+https://github.com/paritytech/aio-limited.git)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1339,37 +1339,37 @@ dependencies = [
 [[package]]
 name = "libp2p-relay"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7#38c9238a74504a6149909eb80f73608f63ab46c7"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304#7ed56d90b4a306793795c0627e99b903deaf8304"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)",
- "libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
+ "libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
 ]
 
 [[package]]
 name = "libp2p-secio"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7#38c9238a74504a6149909eb80f73608f63ab46c7"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304#7ed56d90b4a306793795c0627e99b903deaf8304"
 dependencies = [
  "asn1_der 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "eth-secp256k1 0.5.7 (git+https://github.com/paritytech/rust-secp256k1)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf-codegen-pure 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)",
+ "rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1377,12 +1377,12 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp-transport"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7#38c9238a74504a6149909eb80f73608f63ab46c7"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304#7ed56d90b4a306793795c0627e99b903deaf8304"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1390,10 +1390,10 @@ dependencies = [
 [[package]]
 name = "libp2p-transport-timeout"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7#38c9238a74504a6149909eb80f73608f63ab46c7"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304#7ed56d90b4a306793795c0627e99b903deaf8304"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1401,13 +1401,13 @@ dependencies = [
 [[package]]
 name = "libp2p-websocket"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7#38c9238a74504a6149909eb80f73608f63ab46c7"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304#7ed56d90b4a306793795c0627e99b903deaf8304"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)",
- "rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
+ "rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
  "stdweb 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "websocket 0.20.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1416,11 +1416,11 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7#38c9238a74504a6149909eb80f73608f63ab46c7"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304#7ed56d90b4a306793795c0627e99b903deaf8304"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "yamux 0.1.0 (git+https://github.com/paritytech/yamux)",
@@ -1556,10 +1556,10 @@ dependencies = [
 [[package]]
 name = "multiaddr"
 version = "0.3.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7#38c9238a74504a6149909eb80f73608f63ab46c7"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304#7ed56d90b4a306793795c0627e99b903deaf8304"
 dependencies = [
  "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "cid 0.2.3 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)",
+ "cid 0.2.3 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
  "integer-encoding 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1574,7 +1574,7 @@ dependencies = [
 [[package]]
 name = "multihash"
 version = "0.8.1-pre"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7#38c9238a74504a6149909eb80f73608f63ab46c7"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304#7ed56d90b4a306793795c0627e99b903deaf8304"
 dependencies = [
  "sha1 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1584,14 +1584,14 @@ dependencies = [
 [[package]]
 name = "multistream-select"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7#38c9238a74504a6149909eb80f73608f63ab46c7"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304#7ed56d90b4a306793795c0627e99b903deaf8304"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
 ]
 
 [[package]]
@@ -2388,7 +2388,7 @@ dependencies = [
 [[package]]
 name = "rw-stream-sink"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7#38c9238a74504a6149909eb80f73608f63ab46c7"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304#7ed56d90b4a306793795c0627e99b903deaf8304"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2818,7 +2818,7 @@ dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipnetwork 0.12.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)",
+ "libp2p 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3701,7 +3701,7 @@ dependencies = [
 [[package]]
 name = "varint"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7#38c9238a74504a6149909eb80f73608f63ab46c7"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304#7ed56d90b4a306793795c0627e99b903deaf8304"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3905,8 +3905,8 @@ dependencies = [
 "checksum cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "405216fd8fe65f718daa7102ea808a946b6ce40c742998fbfd3463645552de18"
 "checksum chashmap 2.2.1 (git+https://github.com/redox-os/tfs)" = "<none>"
 "checksum chrono 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1cce36c92cb605414e9b824f866f5babe0a0368e39ea07393b9b63cf3844c0e6"
-"checksum cid 0.2.3 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)" = "<none>"
-"checksum circular-buffer 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)" = "<none>"
+"checksum cid 0.2.3 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)" = "<none>"
+"checksum circular-buffer 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)" = "<none>"
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum cmake 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "95470235c31c726d72bf2e1f421adc1e65b9d561bf5529612cbe1a72da1467b3"
@@ -3923,7 +3923,7 @@ dependencies = [
 "checksum crossbeam-utils 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d636a8b3bcc1b409d7ffd3facef8f21dcb4009626adbd0c5e6c4305c07253c7b"
 "checksum crunchy 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a2f4a431c5c9f662e1200b7c7f02c34e91361150e382089a8f2dec3ba680cbda"
 "checksum ctrlc 1.1.1 (git+https://github.com/paritytech/rust-ctrlc.git)" = "<none>"
-"checksum datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)" = "<none>"
+"checksum datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)" = "<none>"
 "checksum difference 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3304d19798a8e067e48d8e69b2c37f0b5e9b4e462504ad9e27e9f3fce02bba8"
 "checksum digest 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3cae2388d706b52f2f2f9afe280f9d768be36544bd71d1b8120cb34ea6450b55"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
@@ -3994,22 +3994,22 @@ dependencies = [
 "checksum lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e6412c5e2ad9584b0b8e979393122026cdd6d2a80b933f890dcd694ddbe73739"
 "checksum lazycell 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a6f08839bc70ef4a3fe1d566d5350f519c5912ea86be0df1740a7d247c7fc0ef"
 "checksum libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)" = "ac8ebf8343a981e2fa97042b14768f02ed3e1d602eac06cae6166df3c8ced206"
-"checksum libp2p 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)" = "<none>"
-"checksum libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)" = "<none>"
-"checksum libp2p-dns 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)" = "<none>"
-"checksum libp2p-floodsub 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)" = "<none>"
-"checksum libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)" = "<none>"
-"checksum libp2p-kad 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)" = "<none>"
-"checksum libp2p-mplex 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)" = "<none>"
-"checksum libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)" = "<none>"
-"checksum libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)" = "<none>"
-"checksum libp2p-ratelimit 0.1.1 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)" = "<none>"
-"checksum libp2p-relay 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)" = "<none>"
-"checksum libp2p-secio 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)" = "<none>"
-"checksum libp2p-tcp-transport 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)" = "<none>"
-"checksum libp2p-transport-timeout 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)" = "<none>"
-"checksum libp2p-websocket 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)" = "<none>"
-"checksum libp2p-yamux 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)" = "<none>"
+"checksum libp2p 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)" = "<none>"
+"checksum libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)" = "<none>"
+"checksum libp2p-dns 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)" = "<none>"
+"checksum libp2p-floodsub 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)" = "<none>"
+"checksum libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)" = "<none>"
+"checksum libp2p-kad 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)" = "<none>"
+"checksum libp2p-mplex 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)" = "<none>"
+"checksum libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)" = "<none>"
+"checksum libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)" = "<none>"
+"checksum libp2p-ratelimit 0.1.1 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)" = "<none>"
+"checksum libp2p-relay 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)" = "<none>"
+"checksum libp2p-secio 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)" = "<none>"
+"checksum libp2p-tcp-transport 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)" = "<none>"
+"checksum libp2p-transport-timeout 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)" = "<none>"
+"checksum libp2p-websocket 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)" = "<none>"
+"checksum libp2p-yamux 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)" = "<none>"
 "checksum linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "70fb39025bc7cdd76305867c4eccf2f2dcf6e9a57f5b21a93e1c2d86cd03ec9e"
 "checksum local-encoding 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e1ceb20f39ff7ae42f3ff9795f3986b1daad821caaa1e1732a0944103a5a1a66"
 "checksum lock_api 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "949826a5ccf18c1b3a7c3d57692778d21768b79e46eb9dd07bfc4c2160036c54"
@@ -4025,10 +4025,10 @@ dependencies = [
 "checksum mime 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0b28683d0b09bbc20be1c9b3f6f24854efb1356ffcffee08ea3f6e65596e85fa"
 "checksum mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)" = "6d771e3ef92d58a8da8df7d6976bfca9371ed1de6619d9d5a5ce5b1f29b85bfe"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
-"checksum multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)" = "<none>"
+"checksum multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)" = "<none>"
 "checksum multibase 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b9c35dac080fd6e16a99924c8dfdef0af89d797dd851adab25feaffacf7850d6"
-"checksum multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)" = "<none>"
-"checksum multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)" = "<none>"
+"checksum multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)" = "<none>"
+"checksum multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)" = "<none>"
 "checksum names 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef320dab323286b50fb5cdda23f61c796a72a89998ab565ca32525c5c556f2da"
 "checksum nan-preserving-float 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "34d4f00fcc2f4c9efa8cc971db0da9e28290e28e97af47585e48691ef10ff31f"
 "checksum native-tls 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f74dbadc8b43df7864539cedb7bc91345e532fdd913cfdc23ad94f4d2d40fbc0"
@@ -4091,7 +4091,7 @@ dependencies = [
 "checksum rustc-hex 2.0.0 (git+https://github.com/rphmeier/rustc-hex.git)" = "<none>"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustc_version 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a54aa04a10c68c1c4eacb4337fd883b435997ede17a9385784b990777686b09a"
-"checksum rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)" = "<none>"
+"checksum rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)" = "<none>"
 "checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
 "checksum schannel 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "85fd9df495640643ad2d00443b3d78aae69802ad488debab4f1dd52fc1806ade"
 "checksum scoped-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "332ffa32bf586782a3efaeb58f127980944bbc8c4d6913a86107ac2a5ab24b28"
@@ -4173,7 +4173,7 @@ dependencies = [
 "checksum url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f808aadd8cfec6ef90e4a14eb46f24511824d1ac596b9682703c87056c8678b7"
 "checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
 "checksum varint 0.1.0 (git+https://github.com/libp2p/rust-libp2p)" = "<none>"
-"checksum varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=38c9238a74504a6149909eb80f73608f63ab46c7)" = "<none>"
+"checksum varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=7ed56d90b4a306793795c0627e99b903deaf8304)" = "<none>"
 "checksum vcpkg 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7ed0f6789c8a85ca41bbc1c9d175422116a9869bd1cf31bb08e1493ecce60380"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6b772017e347561807c1aa192438c5fd74242a670a6cffacc40f2defd1dc069d"

--- a/substrate/network-libp2p/Cargo.toml
+++ b/substrate/network-libp2p/Cargo.toml
@@ -11,7 +11,7 @@ bytes = "0.4"
 error-chain = { version = "0.12", default-features = false }
 fnv = "1.0"
 futures = "0.1"
-libp2p = { git = "https://github.com/tomaka/libp2p-rs", rev = "bab05e8c264f74011023c0fa042511768502f5cf", default-features = false, features = ["libp2p-secio", "libp2p-secio-secp256k1"] }
+libp2p = { git = "https://github.com/tomaka/libp2p-rs", rev = "ccbb4361c299491b40e5ca95cfa6716ba31c485c", default-features = false, features = ["libp2p-secio", "libp2p-secio-secp256k1"] }
 ethcore-io = { git = "https://github.com/paritytech/parity.git" }
 ethkey = { git = "https://github.com/paritytech/parity.git" }
 ethereum-types = "0.3"

--- a/substrate/network-libp2p/Cargo.toml
+++ b/substrate/network-libp2p/Cargo.toml
@@ -11,7 +11,7 @@ bytes = "0.4"
 error-chain = { version = "0.12", default-features = false }
 fnv = "1.0"
 futures = "0.1"
-libp2p = { git = "https://github.com/tomaka/libp2p-rs", rev = "38c9238a74504a6149909eb80f73608f63ab46c7", default-features = false, features = ["libp2p-secio", "libp2p-secio-secp256k1"] }
+libp2p = { git = "https://github.com/tomaka/libp2p-rs", rev = "7ed56d90b4a306793795c0627e99b903deaf8304", default-features = false, features = ["libp2p-secio", "libp2p-secio-secp256k1"] }
 ethcore-io = { git = "https://github.com/paritytech/parity.git" }
 ethkey = { git = "https://github.com/paritytech/parity.git" }
 ethereum-types = "0.3"

--- a/substrate/network-libp2p/Cargo.toml
+++ b/substrate/network-libp2p/Cargo.toml
@@ -11,7 +11,7 @@ bytes = "0.4"
 error-chain = { version = "0.12", default-features = false }
 fnv = "1.0"
 futures = "0.1"
-libp2p = { git = "https://github.com/tomaka/libp2p-rs", rev = "7ed56d90b4a306793795c0627e99b903deaf8304", default-features = false, features = ["libp2p-secio", "libp2p-secio-secp256k1"] }
+libp2p = { git = "https://github.com/tomaka/libp2p-rs", rev = "bab05e8c264f74011023c0fa042511768502f5cf", default-features = false, features = ["libp2p-secio", "libp2p-secio-secp256k1"] }
 ethcore-io = { git = "https://github.com/paritytech/parity.git" }
 ethkey = { git = "https://github.com/paritytech/parity.git" }
 ethereum-types = "0.3"

--- a/substrate/network-libp2p/src/custom_proto.rs
+++ b/substrate/network-libp2p/src/custom_proto.rs
@@ -52,6 +52,9 @@ pub struct RegisteredProtocolOutput<T> {
 	/// Id of the protocol.
 	pub protocol_id: ProtocolId,
 
+	/// Endpoint of the connection.
+	pub endpoint: Endpoint,
+
 	/// Version of the protocol that was negotiated.
 	pub protocol_version: u8,
 
@@ -123,7 +126,7 @@ where C: AsyncRead + AsyncWrite + 'static,		// TODO: 'static :-/
 		self,
 		socket: C,
 		protocol_version: Self::UpgradeIdentifier,
-		_endpoint: Endpoint,
+		endpoint: Endpoint,
 		remote_addr: Maf
 	) -> Self::Future {
 		let packet_count = self.supported_versions
@@ -214,6 +217,7 @@ where C: AsyncRead + AsyncWrite + 'static,		// TODO: 'static :-/
 		let out = RegisteredProtocolOutput {
 			custom_data: self.custom_data,
 			protocol_id: self.id,
+			endpoint,
 			protocol_version: protocol_version,
 			outgoing: msg_tx,
 			incoming: Box::new(incoming),

--- a/substrate/network-libp2p/src/network_state.rs
+++ b/substrate/network-libp2p/src/network_state.rs
@@ -323,6 +323,8 @@ impl NetworkState {
 	/// Adds an address discovered by Kademlia.
 	/// Note that we don't have to be connected to a peer to add an address.
 	pub fn add_kad_discovered_addr(&self, node_id: &PeerstorePeerId, addr: Multiaddr) {
+		trace!(target: "sub-libp2p", "Peer store: adding address {} for {:?}",
+			addr, node_id);
 		match self.peerstore {
 			PeersStorage::Memory(ref mem) =>
 				mem.peer_or_create(node_id)
@@ -495,6 +497,8 @@ impl NetworkState {
 				!infos.protocols.iter().any(|(_, conn)| conn.is_alive())
 			{
 				peer_by_nodeid.remove(&infos.id);
+				trace!(target: "sub-libp2p", "Cleaning up expired peer \
+					#{:?} ({:?})", peer_id, infos.id);
 				return false;
 			}
 
@@ -593,6 +597,10 @@ impl NetworkState {
 	pub fn disconnect_peer(&self, peer_id: PeerId) {
 		let mut connections = self.connections.write();
 		if let Some(peer_info) = connections.info_by_peer.remove(&peer_id) {
+			trace!(target: "sub-libp2p", "Destroying peer #{} {:?} ; \
+				kademlia = {:?} ; num_protos = {:?}", peer_id, peer_info.id,
+				peer_info.kad_connec.is_alive(),
+				peer_info.protocols.iter().filter(|c| c.1.is_alive()).count());
 			let old = connections.peer_by_nodeid.remove(&peer_info.id);
 			debug_assert_eq!(old, Some(peer_id));
 		}
@@ -617,6 +625,7 @@ impl NetworkState {
 	/// of `custom_proto`).
 	pub fn disable_peer(&self, peer_id: PeerId, reason: &str) {
 		// TODO: what do we do if the peer is reserved?
+		// TODO: same logging as in disconnect_peer
 		let mut connections = self.connections.write();
 		let peer_info = if let Some(peer_info) = connections.info_by_peer.remove(&peer_id) {
 			if let (&Some(ref client_version), &Some(ref remote_address)) = (&peer_info.client_version, &peer_info.remote_address) {
@@ -686,6 +695,8 @@ fn accept_connection(
 
 	let peer_id = *peer_by_nodeid.entry(node_id.clone()).or_insert_with(|| {
 		let new_id = next_peer_id.fetch_add(1, atomic::Ordering::Relaxed);
+		trace!(target: "sub-libp2p", "Creating new peer #{:?} for {:?}",
+			new_id, node_id);
 
 		info_by_peer.insert(new_id, PeerConnectionInfo {
 			protocols: Vec::new(),    // TODO: Vec::with_capacity(num_registered_protocols),

--- a/substrate/network-libp2p/src/network_state.rs
+++ b/substrate/network-libp2p/src/network_state.rs
@@ -601,6 +601,10 @@ impl NetworkState {
 				kademlia = {:?} ; num_protos = {:?}", peer_id, peer_info.id,
 				peer_info.kad_connec.is_alive(),
 				peer_info.protocols.iter().filter(|c| c.1.is_alive()).count());
+			// TODO: we manually clear the connections as a work-around for
+			// networking bugs ; normally it should automatically drop
+			for c in peer_info.protocols.iter() { c.1.clear(); }
+			peer_info.kad_connec.clear();
 			let old = connections.peer_by_nodeid.remove(&peer_info.id);
 			debug_assert_eq!(old, Some(peer_id));
 		}

--- a/substrate/network-libp2p/src/service.rs
+++ b/substrate/network-libp2p/src/service.rs
@@ -854,7 +854,7 @@ fn start_kademlia_discovery<T, To, St, C>(shared: Arc<Shared>, transport: T,
 			)
 	});
 
-	let discovery = Interval::new(Instant::now(), Duration::from_secs(30))
+	let discovery = Interval::new(Instant::now(), Duration::from_secs(32))
 		// TODO: add a timeout to the lookups
 		.map_err(|err| IoError::new(IoErrorKind::Other, err))
 		.and_then({

--- a/substrate/network-libp2p/src/transport.rs
+++ b/substrate/network-libp2p/src/transport.rs
@@ -56,10 +56,6 @@ pub fn build_transport(
 		.into_connection_reuse();
 
 	TransportTimeout::new(base, Duration::from_secs(20))
-		.map_err(|err| {
-			debug!(target: "sub-libp2p", "Error in base transport layer: {:?}", err);
-			err
-		})
 }
 
 /// Specifies whether unencrypted communications are allowed or denied.


### PR DESCRIPTION
- Don't connect to our own node for Kademlia.
- Make the logs way more clear.
- Manually clear the open connections when we destroy a peer ; right now when a ping times out we destroy the peer, which is supposed to close all open futures, but this doesn't happen for an unknown reason so we do it manually
- Unsynchronize Kademlia and the connection cycles, so that logs are easier to read. The discovery cycle is now 32 seconds instead of 30.
- Should fix `assertion failed: self.remaining_mut() >= src.remaining()`.