### PR TITLE
Refactor out disable/disconnect peer to make API more declarative

### DIFF
--- a/polkadot/network/src/tests.rs
+++ b/polkadot/network/src/tests.rs
@@ -41,9 +41,9 @@ impl Context<Block> for TestContext {
 		unimplemented!()
 	}
 
-	fn report_peer(&mut self, peer: PeerId, _reason: Severity) {
-		match severity {
-			Severity::Bad => self.disabled.push(peer),
+	fn report_peer(&mut self, peer: PeerId, reason: Severity) {
+		match reason {
+			Severity::Bad(_) => self.disabled.push(peer),
 			_ => self.disconnected.push(peer),
 		}
 	}

--- a/polkadot/network/src/tests.rs
+++ b/polkadot/network/src/tests.rs
@@ -24,7 +24,7 @@ use polkadot_primitives::{Block, Hash, SessionKey};
 use polkadot_primitives::parachain::{CandidateReceipt, HeadData, BlockData};
 use substrate_primitives::H512;
 use codec::Encode;
-use substrate_network::{PeerId, PeerInfo, ClientHandle, Context, Roles, message::Message as SubstrateMessage, specialization::Specialization, generic_message::Message as GenericMessage};
+use substrate_network::{Severity, PeerId, PeerInfo, ClientHandle, Context, Roles, message::Message as SubstrateMessage, specialization::Specialization, generic_message::Message as GenericMessage};
 
 use std::sync::Arc;
 use futures::Future;
@@ -41,12 +41,11 @@ impl Context<Block> for TestContext {
 		unimplemented!()
 	}
 
-	fn disable_peer(&mut self, peer: PeerId, _reason: &str) {
-		self.disabled.push(peer);
-	}
-
-	fn disconnect_peer(&mut self, peer: PeerId) {
-		self.disconnected.push(peer);
+	fn report_peer(&mut self, peer: PeerId, _reason: Severity) {
+		match severity {
+			Severity::Bad => self.disabled.push(peer),
+			_ => self.disconnected.push(peer),
+		}
 	}
 
 	fn peer_info(&self, _peer: PeerId) -> Option<PeerInfo<Block>> {

--- a/substrate/network-libp2p/src/connection_filter.rs
+++ b/substrate/network-libp2p/src/connection_filter.rs
@@ -1,18 +1,18 @@
 // Copyright 2015-2018 Parity Technologies (UK) Ltd.
-// This file is part of Parity.
+// This file is part of Substrate.
 
-// Parity is free software: you can redistribute it and/or modify
+// Substrate is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 
-// Parity is distributed in the hope that it will be useful,
+// Substrate is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
 
 // You should have received a copy of the GNU General Public License
-// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
 //! Connection filter trait.
 

--- a/substrate/network-libp2p/src/custom_proto.rs
+++ b/substrate/network-libp2p/src/custom_proto.rs
@@ -1,18 +1,18 @@
 // Copyright 2018 Parity Technologies (UK) Ltd.
-// This file is part of Polkadot.
+// This file is part of Substrate.
 
-// Polkadot is free software: you can redistribute it and/or modify
+// Substrate is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 
-// Polkadot is distributed in the hope that it will be useful,
+// Substrate is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
 
 // You should have received a copy of the GNU General Public License
-// along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.?
+// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.?
 
 use bytes::{Bytes, BytesMut};
 use ProtocolId;
@@ -122,6 +122,7 @@ where C: AsyncRead + AsyncWrite + 'static,		// TODO: 'static :-/
 	type MultiaddrFuture = Maf;
 	type Future = future::FutureResult<(Self::Output, Self::MultiaddrFuture), IoError>;
 
+	#[allow(deprecated)]
 	fn upgrade(
 		self,
 		socket: C,

--- a/substrate/network-libp2p/src/error.rs
+++ b/substrate/network-libp2p/src/error.rs
@@ -1,18 +1,18 @@
 // Copyright 2015-2018 Parity Technologies (UK) Ltd.
-// This file is part of Parity.
+// This file is part of Substrate.
 
-// Parity is free software: you can redistribute it and/or modify
+// Substrate is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 
-// Parity is distributed in the hope that it will be useful,
+// Substrate is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
 
 // You should have received a copy of the GNU General Public License
-// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::{io, net, fmt};
 use libc::{ENFILE, EMFILE};

--- a/substrate/network-libp2p/src/lib.rs
+++ b/substrate/network-libp2p/src/lib.rs
@@ -1,18 +1,18 @@
 // Copyright 2018 Parity Technologies (UK) Ltd.
-// This file is part of Polkadot.
+// This file is part of Substrate.
 
-// Polkadot is free software: you can redistribute it and/or modify
+// Substrate is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 
-// Polkadot is distributed in the hope that it will be useful,
+// Substrate is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
 
 // You should have received a copy of the GNU General Public License
-// along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.?
+// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.?
 
 #![recursion_limit="128"]
 #![type_length_limit = "268435456"]

--- a/substrate/network-libp2p/src/network_state.rs
+++ b/substrate/network-libp2p/src/network_state.rs
@@ -1,18 +1,18 @@
 // Copyright 2018 Parity Technologies (UK) Ltd.
-// This file is part of Polkadot.
+// This file is part of Substrate.
 
-// Polkadot is free software: you can redistribute it and/or modify
+// Substrate is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 
-// Polkadot is distributed in the hope that it will be useful,
+// Substrate is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
 
 // You should have received a copy of the GNU General Public License
-// along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.?
+// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.?
 
 use bytes::Bytes;
 use fnv::{FnvHashMap, FnvHashSet};
@@ -581,14 +581,14 @@ impl NetworkState {
 			} else {
 				// We are connected to this peer, but not with the current
 				// protocol.
-				debug!(target: "sub-libp2p", "Tried to send message to peer {} \
-					for which we aren't connected with the requested protocol",
-					peer_id);
+				debug!(target: "sub-libp2p",
+					"Tried to send message to peer {} for which we aren't connected with the requested protocol",
+					peer_id
+				);
 				return Err(ErrorKind::PeerNotFound.into())
 			}
 		} else {
-			debug!(target: "sub-libp2p", "Tried to send message to invalid \
-				peer ID {}", peer_id);
+			debug!(target: "sub-libp2p", "Tried to send message to invalid peer ID {}", peer_id);
 			return Err(ErrorKind::PeerNotFound.into())
 		}
 	}
@@ -596,9 +596,15 @@ impl NetworkState {
 	/// Disconnects a peer, if a connection exists (ie. drops the Kademlia
 	/// controller, and the senders that were stored in the `UniqueConnec` of
 	/// `custom_proto`).
-	pub fn disconnect_peer(&self, peer_id: PeerId) {
+	pub fn disconnect_peer(&self, peer_id: PeerId, reason: &str) {
 		let mut connections = self.connections.write();
 		if let Some(peer_info) = connections.info_by_peer.remove(&peer_id) {
+			if let (&Some(ref client_version), &Some(ref remote_address)) = (&peer_info.client_version, &peer_info.remote_address) {
+				info!(target: "network", "Disconnected peer {} (version: {}, address: {}). {}", peer_id, client_version, remote_address, reason);
+			} else {
+				info!(target: "network", "Disconnected peer {}. {}", peer_id, reason);
+			}
+
 			trace!(target: "sub-libp2p", "Destroying peer #{} {:?} ; \
 				kademlia = {:?} ; num_protos = {:?}", peer_id, peer_info.id,
 				peer_info.kad_connec.is_alive(),

--- a/substrate/network-libp2p/src/timeouts.rs
+++ b/substrate/network-libp2p/src/timeouts.rs
@@ -1,18 +1,18 @@
 // Copyright 2018 Parity Technologies (UK) Ltd.
-// This file is part of Polkadot.
+// This file is part of Substrate.
 
-// Polkadot is free software: you can redistribute it and/or modify
+// Substrate is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 
-// Polkadot is distributed in the hope that it will be useful,
+// Substrate is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
 
 // You should have received a copy of the GNU General Public License
-// along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.?
+// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.?
 
 use futures::{Async, future, Future, Poll, stream, Stream, sync::mpsc};
 use std::io::Error as IoError;

--- a/substrate/network-libp2p/src/transport.rs
+++ b/substrate/network-libp2p/src/transport.rs
@@ -1,18 +1,18 @@
 // Copyright 2018 Parity Technologies (UK) Ltd.
-// This file is part of Polkadot.
+// This file is part of Substrate.
 
-// Polkadot is free software: you can redistribute it and/or modify
+// Substrate is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 
-// Polkadot is distributed in the hope that it will be useful,
+// Substrate is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
 
 // You should have received a copy of the GNU General Public License
-// along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.?
+// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.?
 
 use libp2p::{self, Transport, mplex, secio, yamux};
 use libp2p::core::{MuxedTransport, either, upgrade};

--- a/substrate/network-libp2p/tests/tests.rs
+++ b/substrate/network-libp2p/tests/tests.rs
@@ -73,9 +73,9 @@ impl NetworkProtocolHandler for TestProtocol {
 
 	fn connected(&self, io: &NetworkContext, peer: &PeerId) {
 		if self.drop_session {
-			io.disconnect_peer(*peer)
+			io.report_peer(*peer, Severity::Bad("We are evil and just want to drop"))
 		} else {
-			io.respond(33, "hello".to_owned().into_bytes()).unwrap();
+			io.respond(33, "hello".to_owned().into_bytes());
 		}
 	}
 

--- a/substrate/network/src/import_queue.rs
+++ b/substrate/network/src/import_queue.rs
@@ -22,7 +22,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use parking_lot::{Condvar, Mutex, RwLock};
 
 use client::{BlockOrigin, BlockStatus, ImportResult};
-use network_libp2p::PeerId;
+use network_libp2p::{PeerId, Severity};
 use runtime_primitives::generic::BlockId;
 use runtime_primitives::traits::{Block as BlockT, Header as HeaderT, NumberFor, Zero};
 
@@ -202,9 +202,9 @@ trait SyncLinkApi<B: BlockT> {
 	/// Maintain sync.
 	fn maintain_sync(&mut self);
 	/// Disconnect from peer.
-	fn disconnect(&mut self, peer_id: PeerId);
+	fn useless_peer(&mut self, peer_id: PeerId, reason: &str);
 	/// Disconnect from peer and restart sync.
-	fn disconnect_and_restart(&mut self, peer_id: PeerId);
+	fn note_useless_and_restart_sync(&mut self, peer_id: PeerId, reason: &str);
 	/// Restart sync.
 	fn restart(&mut self);
 }
@@ -357,11 +357,15 @@ fn process_import_result<'a, B: BlockT>(
 			1
 		},
 		Err(BlockImportError::Disconnect(peer_id)) => {
-			link.disconnect(peer_id);
+			// TODO: FIXME: @arkpar BlockImport shouldn't be trying to manage the peer set.
+			// This should contain an actual reason.
+			link.useless_peer(peer_id, "Import result was stated Disconnect");
 			0
 		},
 		Err(BlockImportError::DisconnectAndRestart(peer_id)) => {
-			link.disconnect_and_restart(peer_id);
+			// TODO: FIXME: @arkpar BlockImport shouldn't be trying to manage the peer set.
+			// This should contain an actual reason.
+			link.note_useless_and_restart_sync(peer_id, "Import result was stated DisconnectAndRestart");
 			0
 		},
 		Err(BlockImportError::Restart) => {
@@ -404,13 +408,13 @@ impl<'a, B: 'static + BlockT, E: ExecuteInContext<B>> SyncLinkApi<B> for SyncLin
 		self.with_sync(|sync, protocol| sync.maintain_sync(protocol))
 	}
 
-	fn disconnect(&mut self, peer_id: PeerId) {
-		self.with_sync(|_, protocol| protocol.disconnect_peer(peer_id))
+	fn useless_peer(&mut self, peer_id: PeerId, reason: &str) {
+		self.with_sync(|_, protocol| protocol.report_peer(peer_id, Severity::Useless(reason)))
 	}
 
-	fn disconnect_and_restart(&mut self, peer_id: PeerId) {
+	fn note_useless_and_restart_sync(&mut self, peer_id: PeerId, reason: &str) {
 		self.with_sync(|sync, protocol| {
-			protocol.disconnect_peer(peer_id);
+			protocol.report_peer(peer_id, Severity::Useless(reason));	// is this actually malign or just useless?
 			sync.restart(protocol);
 		})
 	}
@@ -486,8 +490,8 @@ pub mod tests {
 		fn chain(&self) -> &Client<Block> { &*self.chain }
 		fn block_imported(&mut self, _hash: &Hash, _number: NumberFor<Block>) { self.imported += 1; }
 		fn maintain_sync(&mut self) { self.maintains += 1; }
-		fn disconnect(&mut self, _peer_id: PeerId) { self.disconnects += 1; }
-		fn disconnect_and_restart(&mut self, _peer_id: PeerId) { self.disconnects += 1; self.restarts += 1; }
+		fn useless_peer(&mut self, _: PeerId, _: &str) { self.disconnects += 1; }
+		fn note_useless_and_restart_sync(&mut self, _: PeerId, _: &str) { self.disconnects += 1; self.restarts += 1; }
 		fn restart(&mut self) { self.restarts += 1; }
 	}
 

--- a/substrate/network/src/io.rs
+++ b/substrate/network/src/io.rs
@@ -14,17 +14,15 @@
 // You should have received a copy of the GNU General Public License
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.?
 
-use network_libp2p::{NetworkContext, PeerId, Error as NetworkError, SessionInfo};
+use network_libp2p::{NetworkContext, Severity, PeerId, SessionInfo};
 
 /// IO interface for the syncing handler.
 /// Provides peer connection management and an interface to the blockchain client.
 pub trait SyncIo {
-	/// Disable a peer
-	fn disable_peer(&mut self, peer_id: PeerId, reason: &str);
-	/// Disconnect peer
-	fn disconnect_peer(&mut self, peer_id: PeerId);
+	/// Report a peer for misbehaviour.
+	fn report_peer(&mut self, peer_id: PeerId, reason: Severity);
 	/// Send a packet to a peer.
-	fn send(&mut self, peer_id: PeerId, data: Vec<u8>) -> Result<(), NetworkError>;
+	fn send(&mut self, peer_id: PeerId, data: Vec<u8>);
 	/// Returns peer identifier string
 	fn peer_info(&self, peer_id: PeerId) -> String {
 		peer_id.to_string()
@@ -50,15 +48,11 @@ impl<'s> NetSyncIo<'s> {
 }
 
 impl<'s> SyncIo for NetSyncIo<'s> {
-	fn disable_peer(&mut self, peer_id: PeerId, reason: &str) {
-		self.network.disable_peer(peer_id, reason);
+	fn report_peer(&mut self, peer_id: PeerId, reason: Severity) {
+		self.network.report_peer(peer_id, reason);
 	}
 
-	fn disconnect_peer(&mut self, peer_id: PeerId) {
-		self.network.disconnect_peer(peer_id);
-	}
-
-	fn send(&mut self, peer_id: PeerId, data: Vec<u8>) -> Result<(), NetworkError>{
+	fn send(&mut self, peer_id: PeerId, data: Vec<u8>) {
 		self.network.send(peer_id, 0, data)
 	}
 

--- a/substrate/network/src/lib.rs
+++ b/substrate/network/src/lib.rs
@@ -59,7 +59,7 @@ pub use service::{Service, FetchFuture, ConsensusService, BftMessageStream,
 	TransactionPool, Params, ManageNetwork, SyncProvider};
 pub use protocol::{ProtocolStatus, PeerInfo, Context};
 pub use sync::{Status as SyncStatus, SyncState};
-pub use network_libp2p::{NonReservedPeerMode, NetworkConfiguration, PeerId, ProtocolId, ConnectionFilter, ConnectionDirection};
+pub use network_libp2p::{NonReservedPeerMode, NetworkConfiguration, PeerId, ProtocolId, ConnectionFilter, ConnectionDirection, Severity};
 pub use message::{generic as generic_message, RequestId, BftMessage, LocalizedBftMessage, ConsensusVote, SignedConsensusVote, SignedConsensusMessage, SignedConsensusProposal, Status as StatusMessage};
 pub use error::Error;
 pub use config::{Roles, ProtocolConfig};

--- a/substrate/network/src/test/mod.rs
+++ b/substrate/network/src/test/mod.rs
@@ -28,7 +28,7 @@ use io::SyncIo;
 use protocol::{Context, Protocol};
 use config::ProtocolConfig;
 use service::TransactionPool;
-use network_libp2p::{PeerId, SessionInfo, Error as NetworkError};
+use network_libp2p::{PeerId, SessionInfo, Severity};
 use keyring::Keyring;
 use codec::Encode;
 use import_queue::tests::SyncImportQueue;
@@ -81,11 +81,7 @@ impl<'p> Drop for TestIo<'p> {
 }
 
 impl<'p> SyncIo for TestIo<'p> {
-	fn disable_peer(&mut self, peer_id: PeerId, _reason: &str) {
-		self.disconnect_peer(peer_id);
-	}
-
-	fn disconnect_peer(&mut self, peer_id: PeerId) {
+	fn report_peer(&mut self, peer_id: PeerId, _reason: Severity) {
 		self.to_disconnect.insert(peer_id);
 	}
 
@@ -93,12 +89,11 @@ impl<'p> SyncIo for TestIo<'p> {
 		false
 	}
 
-	fn send(&mut self, peer_id: PeerId, data: Vec<u8>) -> Result<(), NetworkError> {
+	fn send(&mut self, peer_id: PeerId, data: Vec<u8>) {
 		self.packets.push(TestPacket {
 			data: data,
 			recipient: peer_id,
 		});
-		Ok(())
 	}
 
 	fn peer_info(&self, peer_id: PeerId) -> String {


### PR DESCRIPTION
This changes the peer/`SyncIo`/`NetworkContext` API to make it more declarative and less instructive. There are no changes to logic (expect, I think in one instance), but semantics are tweaked to make it clear that it's not up the high-level (Substrate protocol) to manage the peer set first-hand. Rather the high-level can *inform* the libp2p about certain (non-)events that could only be knowable by the high-level API, such as invalid or non-existent responses, badly formatted queries or inconsistent data. The lower, libp2p, layer can then decide what course of action to take.

Rather than two separate functions (which is something of a pain), there is a single API for reporting high-level misbehaviour information on a peer: `report_peer`. There is always a `reason` given when calling reporting, and that reason implies a `Severity`, which semantically informs substrate-libp2p on what course of action to take in response (e.g. lowering a reputation score, simple disconnect, temporary ban or permanent ban).

I envisage that further information could be added to `Severity` down the line in order to express richer concepts of misbehaviour, but for now it's just three options (`Bad`, which bans the peer; `Useless` and `Timeout`, which currently both just disconnect the peer but don't attempt to prevent further connections).

One immediately useful point of this PR is to ensure that *all* explicit peer disconnections come with an information notice including a reason for why they have been disconnected.