### PR TITLE
Reset peers.json if the content is not loadable

### DIFF
--- a/substrate/network-libp2p/src/network_state.rs
+++ b/substrate/network-libp2p/src/network_state.rs
@@ -176,12 +176,10 @@ impl NetworkState {
 		let node_store = if let Some(ref path) = config.net_config_path {
 			let path = Path::new(path).join(NODES_FILE);
 			if let Ok(node_store) = JsonPeerstore::new(path.clone()) {
-				debug!(target: "sub-libp2p", "Initialized peer store for JSON \
-					file {:?}", path);
+				debug!(target: "sub-libp2p", "Initialized peer store for JSON file {:?}", path);
 				NodeStore::Json(node_store)
 			} else {
-				warn!(target: "sub-libp2p", "Failed to open peer storage {:?}\
-					; peers file will be reset", path);
+				warn!(target: "sub-libp2p", "Failed to open peer storage {:?}; peers file will be reset", path);
 				fs::remove_file(&path).expect("Failed deleting peers.json");
 
 				// we check for about 1s if the file was really deleted and move on
@@ -189,8 +187,7 @@ impl NetworkState {
 					if !Path::new(&path).exists() {
 						break;
 					} else {
-						debug!("Waiting for effective deletion of invalid/outdate \
-							peers.json");
+						debug!("Waiting for effective deletion of invalid/outdate peers.json");
 						thread::sleep(time::Duration::from_millis(5));
 					}
 				}
@@ -199,14 +196,15 @@ impl NetworkState {
 					debug!("peers.json reset");
 					NodeStore::Json(peerstore)
 				} else {
-					warn!(target: "sub-libp2p", "Failed to reset peer storage\
-						{:?}; peers change will not be saved", path);
+					warn!(target: "sub-libp2p",
+						"Failed to reset peer storage {:?}; peers change will not be saved",
+						path
+					);
 					NodeStore::Memory(MemoryPeerstore::empty())
 				}
 			}
 		} else {
-			debug!(target: "sub-libp2p", "No peers file configured ; peers \
-				won't be saved");
+			debug!(target: "sub-libp2p", "No peers file configured ; peers won't be saved");
 			NodeStore::Memory(MemoryPeerstore::empty())
 		};
 


### PR DESCRIPTION
Fix #404

Tested manually the following cases:
- no `peers.json`
- incorrect (old format) content in `peers.json`
- correct/current content 
- invalid json in `peers.json`
