### PR TITLE
Add some logging if the timeouts stream ends

### DIFF
--- a/substrate/network-libp2p/src/service.rs
+++ b/substrate/network-libp2p/src/service.rs
@@ -546,6 +546,10 @@ fn init_thread(
 				}, timer_token);
 				Ok(())
 			}
+		})
+		.then(|val| {
+			warn!(target: "sub-libp2p", "Timeouts stream closed unexpectedly: {:?}", val);
+			val
 		});
 
 	// Start the process of periodically discovering nodes to connect to.


### PR DESCRIPTION
The timeouts stream is supposed to be infinite.
I don't think there's a bug in this, but it doesn't hurt to add a warning.