### PR TITLE
Fix disconnect periodicity because of ping timeout

### DIFF
--- a/substrate/network-libp2p/src/service.rs
+++ b/substrate/network-libp2p/src/service.rs
@@ -1276,7 +1276,7 @@ fn start_pinger<T, To, St, C>(
 			})
 		});
 
-	let fut = Interval::new(Instant::now(), Duration::from_secs(30))
+	let fut = Interval::new(Instant::now(), Duration::from_secs(28))
 		.map_err(|err| IoError::new(IoErrorKind::Other, err))
 		.for_each(move |_|
 			ping_all(shared.clone(), transport.clone(), &swarm_controller))


### PR DESCRIPTION
Currently, the ping interval and ping timeout are both 30 seconds, which will cause connection disconnect periodicity. Make the ping interval little smaller than timeout will fix this.

The best solution, after a timeout reset, every received valid message(include ping message) will increment a message counter, if `counter > 0` we do not trigger `DeadlineError`, then set the counter to `0` again.