### PR TITLE
use write_all instead of write

### DIFF
--- a/substrate/codec/src/codec.rs
+++ b/substrate/codec/src/codec.rs
@@ -80,7 +80,7 @@ impl Output for Vec<u8> {
 #[cfg(feature = "std")]
 impl<W: ::std::io::Write> Output for W {
 	fn write(&mut self, bytes: &[u8]) {
-		(self as &mut ::std::io::Write).write(bytes).expect("Codec outputs are infallible");
+		(self as &mut ::std::io::Write).write_all(bytes).expect("Codec outputs are infallible");
 	}
 }
 


### PR DESCRIPTION
io::Write::write is not guaranteed to process the entire buffer. it return how many bytes were processed, which might be smaller than a given buffer’s length. use write_all instead.