### PR TITLE
Added commit hash to --version

### DIFF
--- a/substrate/cli/src/lib.rs
+++ b/substrate/cli/src/lib.rs
@@ -44,7 +44,6 @@ extern crate exit_future;
 
 #[macro_use]
 extern crate lazy_static;
-#[macro_use]
 extern crate clap;
 #[macro_use]
 extern crate error_chain;
@@ -164,6 +163,9 @@ where
 {
 	panic_hook::set();
 
+	let full_version = service::Configuration::<<F>::Configuration, <F>::Genesis>
+		::full_version_from_strs(version.version, version.commit);
+
 	let yaml = format!(include_str!("./cli.yml"),
 		name = version.executable_name,
 		description = version.description,
@@ -171,7 +173,7 @@ where
 	);
 	let yaml = &clap::YamlLoader::load_from_str(&yaml).expect("Invalid yml file")[0];
 	let matches = match clap::App::from_yaml(yaml)
-		.version(&(crate_version!().to_owned() + "\n")[..])
+		.version(&(full_version + "\n")[..])
 		.get_matches_from_safe(args) {
 			Ok(m) => m,
 			Err(e) => e.exit(),

--- a/substrate/service/src/config.rs
+++ b/substrate/service/src/config.rs
@@ -105,10 +105,15 @@ impl<C: Default, G: Serialize + DeserializeOwned + BuildStorage> Configuration<C
 		format!("{}-{}{}{}", Target::arch(), Target::os(), env_dash, env)
 	}
 
-	/// Returns full version string.
+	/// Returns full version string of this configuration.
 	pub fn full_version(&self) -> String {
-		let commit_dash = if self.impl_commit.is_empty() { "" } else { "-" };
-		format!("{}{}{}-{}", self.impl_version, commit_dash, self.impl_commit, Self::platform())
+		Self::full_version_from_strs(self.impl_version, self.impl_commit)
+	}
+	
+	/// Returns full version string, using supplied version and commit.
+	pub fn full_version_from_strs(impl_version: &str, impl_commit: &str) -> String {
+		let commit_dash = if impl_commit.is_empty() { "" } else { "-" };
+		format!("{}{}{}-{}", impl_version, commit_dash, impl_commit, Self::platform())
 	}
 
 	/// Implementation id and version.


### PR DESCRIPTION
I have assumed that it is the full extended version name that is desired i.e. version, commit hash, platform as used in the telemetry and when starting Polkadot.

There is already a function in service::Configuration to produce this text string so it makes sense to call into it for consistency. I have made this logic available statically however, so that it can be called before there is an instance of Configuration (which can only be created after the --version string has been set because it requires return values of clap::App)

This function could be moved outside of Configuration if preferable.
