### PR TITLE
New flags to listen to all interfaces

### DIFF
--- a/substrate/cli/src/cli.yml
+++ b/substrate/cli/src/cli.yml
@@ -46,6 +46,14 @@ args:
       value_name: PORT
       help: Specify p2p protocol TCP port
       takes_value: true
+  - rpc-external:
+      long: rpc-external
+      help: Listen to all rpc interfaces (Default is local)
+      takes_value: false
+  - ws-external:
+      long: ws-external
+      help: Listen to all web socket interfaces (Default is local)
+      takes_value: false
   - rpc-port:
       long: rpc-port
       value_name: PORT

--- a/substrate/cli/src/cli.yml
+++ b/substrate/cli/src/cli.yml
@@ -48,11 +48,11 @@ args:
       takes_value: true
   - rpc-external:
       long: rpc-external
-      help: Listen to all rpc interfaces (Default is local)
+      help: Listen to all RPC interfaces (default is local)
       takes_value: false
   - ws-external:
       long: ws-external
-      help: Listen to all web socket interfaces (Default is local)
+      help: Listen to all Websocket interfaces (default is local)
       takes_value: false
   - rpc-port:
       long: rpc-port

--- a/substrate/cli/src/lib.rs
+++ b/substrate/cli/src/lib.rs
@@ -295,8 +295,11 @@ where
 		config.keys.push("Alice".into());
 	}
 
-	config.rpc_http = Some(parse_address("127.0.0.1:9933", "rpc-port", &matches)?);
-	config.rpc_ws = Some(parse_address("127.0.0.1:9944", "ws-port", &matches)?);
+	let rpc_interface: &str = if matches.is_present("rpc-external") { "0.0.0.0" } else { "127.0.0.1" };
+	let ws_interface: &str = if matches.is_present("ws-external") { "0.0.0.0" } else { "127.0.0.1" };
+
+	config.rpc_http = Some(parse_address(&format!("{}:{}", rpc_interface, 9933), "rpc-port", &matches)?);
+	config.rpc_ws = Some(parse_address(&format!("{}:{}", ws_interface, 9944), "ws-port", &matches)?);
 
 	// Override telemetry
 	if matches.is_present("no-telemetry") {

--- a/substrate/runtime/staking/src/lib.rs
+++ b/substrate/runtime/staking/src/lib.rs
@@ -438,7 +438,7 @@ impl<T: Trait> Module<T> {
 	/// Returns if the account was successfully updated or update has led to killing of the account.
 	pub fn set_free_balance(who: &T::AccountId, balance: T::Balance) -> UpdateBalanceOutcome {
 		// Commented out for no - but consider it instructive.
-//		assert!(!Self::voting_balance(who).is_zero());
+		// assert!(!Self::voting_balance(who).is_zero());
 		if balance < Self::existential_deposit() {
 			Self::on_free_too_low(who);
 			UpdateBalanceOutcome::AccountKilled


### PR DESCRIPTION
The current version listens *only* on 127.0.0.1. 

This change is required for containerised versions to run properly.

Adds:
- `--ws-external`
- `--rpc-external`

```
USAGE:
    polkadot [FLAGS] [OPTIONS] [SUBCOMMAND]

FLAGS:
        --dev             Run in development mode; implies --chain=dev --validator --key Alice
    -h, --help            Prints help information
        --light           Run in light client mode
        --no-telemetry    Should not connect to the Polkadot telemetry server (telemetry is on by default on global
                          chains)
⥤    --rpc-external    Listen to all rpc interfaces (Default is local)
    -t, --telemetry       Should connect to the Polkadot telemetry server (telemetry is off by default on local chains)
        --validator       Enable validator mode
    -V, --version         Prints version information
⥤    --ws-external     Listen to all web socket interfaces (Default is local)

<...>
```
