### PR TITLE
--version commit hash - style improvement

### DIFF
--- a/substrate/cli/src/lib.rs
+++ b/substrate/cli/src/lib.rs
@@ -163,8 +163,7 @@ where
 {
 	panic_hook::set();
 
-	let full_version = service::Configuration::<<F>::Configuration, <F>::Genesis>
-		::full_version_from_strs(version.version, version.commit);
+	let full_version = service::config::full_version_from_strs(version.version, version.commit);
 
 	let yaml = format!(include_str!("./cli.yml"),
 		name = version.executable_name,

--- a/substrate/cli/src/lib.rs
+++ b/substrate/cli/src/lib.rs
@@ -163,8 +163,10 @@ where
 {
 	panic_hook::set();
 
-	let full_version = service::config::full_version_from_strs(version.version, version.commit);
-
+	let full_version = service::config::full_version_from_strs(
+		version.version,
+		version.commit
+	);
 	let yaml = format!(include_str!("./cli.yml"),
 		name = version.executable_name,
 		description = version.description,

--- a/substrate/service/src/config.rs
+++ b/substrate/service/src/config.rs
@@ -98,26 +98,26 @@ impl<C: Default, G: Serialize + DeserializeOwned + BuildStorage> Configuration<C
 		configuration
 	}
 
-	/// Returns platform info
-	pub fn platform() -> String {
-		let env = Target::env();
-		let env_dash = if env.is_empty() { "" } else { "-" };
-		format!("{}-{}{}{}", Target::arch(), Target::os(), env_dash, env)
-	}
-
 	/// Returns full version string of this configuration.
 	pub fn full_version(&self) -> String {
-		Self::full_version_from_strs(self.impl_version, self.impl_commit)
-	}
-	
-	/// Returns full version string, using supplied version and commit.
-	pub fn full_version_from_strs(impl_version: &str, impl_commit: &str) -> String {
-		let commit_dash = if impl_commit.is_empty() { "" } else { "-" };
-		format!("{}{}{}-{}", impl_version, commit_dash, impl_commit, Self::platform())
+		full_version_from_strs(self.impl_version, self.impl_commit)
 	}
 
 	/// Implementation id and version.
 	pub fn client_id(&self) -> String {
 		format!("{}/v{}", self.impl_name, self.full_version())
 	}
+}
+
+/// Returns platform info
+pub fn platform() -> String {
+	let env = Target::env();
+	let env_dash = if env.is_empty() { "" } else { "-" };
+	format!("{}-{}{}{}", Target::arch(), Target::os(), env_dash, env)
+}
+	
+/// Returns full version string, using supplied version and commit.
+pub fn full_version_from_strs(impl_version: &str, impl_commit: &str) -> String {
+	let commit_dash = if impl_commit.is_empty() { "" } else { "-" };
+	format!("{}{}{}-{}", impl_version, commit_dash, impl_commit, platform())
 }

--- a/substrate/service/src/config.rs
+++ b/substrate/service/src/config.rs
@@ -121,3 +121,4 @@ pub fn full_version_from_strs(impl_version: &str, impl_commit: &str) -> String {
 	let commit_dash = if impl_commit.is_empty() { "" } else { "-" };
 	format!("{}{}{}-{}", impl_version, commit_dash, impl_commit, platform())
 }
+

--- a/substrate/service/src/lib.rs
+++ b/substrate/service/src/lib.rs
@@ -50,7 +50,7 @@ extern crate serde_derive;
 
 mod components;
 mod error;
-mod config;
+pub mod config;
 mod chain_spec;
 pub mod chain_ops;
 

--- a/substrate/service/src/lib.rs
+++ b/substrate/service/src/lib.rs
@@ -50,8 +50,8 @@ extern crate serde_derive;
 
 mod components;
 mod error;
-pub mod config;
 mod chain_spec;
+pub mod config;
 pub mod chain_ops;
 
 use std::io;


### PR DESCRIPTION
Moved static method `full_version_from_strs` out of the `Configuration` struct to be a free function within the same module. This has simplified calls to the function by avoiding the complicated type of `Configuration`.

The `platform` function has also made the same journey for the same reasons. Additionally it is called by `full_version_from_strs` so needs to be easily accessible from the new location.

Closes #468 