### PR TITLE
send memory usage and cpu usage to telemetry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2680,6 +2680,7 @@ dependencies = [
  "substrate-runtime-primitives 0.1.0",
  "substrate-service 0.3.0",
  "substrate-telemetry 0.3.0",
+ "sysinfo 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3325,6 +3326,17 @@ dependencies = [
  "proc-macro2 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4221,6 +4233,7 @@ dependencies = [
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum subtle 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dc7f6353c2ee5407358d063a14cccc1630804527090a6fb5a9489ce4924280fb"
 "checksum syn 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6dfd71b2be5a58ee30a6f8ea355ba8290d397131c00dfa55c3d34e6e13db5101"
+"checksum sysinfo 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c65f4e5794c2dacca1b1f6462c7774017e1ba8564ee268df2c89e2f23a70c5ea"
 "checksum take 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b157868d8ac1f56b64604539990685fa7611d8fa9e5476cf0c02cf34d32917c5"
 "checksum take_mut 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 "checksum target_info 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c63f48baada5c52e65a29eef93ab4f8982681b67f9e8d29c7b05abcfec2b9ffe"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2680,7 +2680,7 @@ dependencies = [
  "substrate-runtime-primitives 0.1.0",
  "substrate-service 0.3.0",
  "substrate-telemetry 0.3.0",
- "sysinfo 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sysinfo 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3330,7 +3330,7 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4233,7 +4233,7 @@ dependencies = [
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum subtle 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dc7f6353c2ee5407358d063a14cccc1630804527090a6fb5a9489ce4924280fb"
 "checksum syn 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6dfd71b2be5a58ee30a6f8ea355ba8290d397131c00dfa55c3d34e6e13db5101"
-"checksum sysinfo 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c65f4e5794c2dacca1b1f6462c7774017e1ba8564ee268df2c89e2f23a70c5ea"
+"checksum sysinfo 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)" = "394abcf30852ac00878ab01642b13668db48d166d945f250c7bdbb9e12d75ad0"
 "checksum take 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b157868d8ac1f56b64604539990685fa7611d8fa9e5476cf0c02cf34d32917c5"
 "checksum take_mut 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 "checksum target_info 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c63f48baada5c52e65a29eef93ab4f8982681b67f9e8d29c7b05abcfec2b9ffe"

--- a/substrate/cli/Cargo.toml
+++ b/substrate/cli/Cargo.toml
@@ -22,7 +22,7 @@ tokio = "0.1.7"
 futures = "0.1.17"
 fdlimit = "0.1"
 exit-future = "0.1"
-sysinfo = "0.5.6"
+sysinfo = "0.5.7"
 substrate-client = { path = "../../substrate/client" }
 substrate-extrinsic-pool = { path = "../../substrate/extrinsic-pool" }
 substrate-network = { path = "../../substrate/network" }

--- a/substrate/cli/Cargo.toml
+++ b/substrate/cli/Cargo.toml
@@ -22,6 +22,7 @@ tokio = "0.1.7"
 futures = "0.1.17"
 fdlimit = "0.1"
 exit-future = "0.1"
+sysinfo = "0.5.6"
 substrate-client = { path = "../../substrate/client" }
 substrate-extrinsic-pool = { path = "../../substrate/extrinsic-pool" }
 substrate-network = { path = "../../substrate/network" }

--- a/substrate/cli/src/informant.rs
+++ b/substrate/cli/src/informant.rs
@@ -83,8 +83,8 @@ pub fn start<C>(service: &Service<C>, exit: ::exit_future::Exit, handle: TaskExe
 				"height" => best_number,
 				"best" => ?hash,
 				"txcount" => txpool_status.transaction_count,
-				"cpu" => format!("{}%", cpu_usage),
-				"memory" => format!("{}kB", memory)
+				"cpu" => cpu_usage,
+				"memory" => memory
 			);
 		} else {
 			warn!("Error getting best block information");

--- a/substrate/cli/src/lib.rs
+++ b/substrate/cli/src/lib.rs
@@ -30,6 +30,7 @@ extern crate futures;
 extern crate tokio;
 extern crate names;
 extern crate backtrace;
+extern crate sysinfo;
 
 extern crate substrate_client as client;
 extern crate substrate_network as network;

--- a/substrate/telemetry/src/lib.rs
+++ b/substrate/telemetry/src/lib.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
-//! Telemtetry utils.
+//! Telemetry utils.
 //! 
 //! `telemetry` macro be used from whereever in the Substrate codebase
 //! in order to send real-time logging information to the telemetry


### PR DESCRIPTION
Fixes #443, however, it doesn't send IO usage, as it's not available in
this `sysinfo` crate.

I believe we should provide a way to opt out this feature, how do you think?