### PR TITLE
Locked Cargo.lock

### DIFF
--- a/ci/script.sh
+++ b/ci/script.sh
@@ -17,7 +17,7 @@ case $TARGET in
 		sudo apt-get -y update
 		sudo apt-get install -y cmake pkg-config libssl-dev
 
-		cargo test --all
+		cargo test --all --locked
 		;;
 
 	"wasm")


### PR DESCRIPTION
Imagine you have a clean repo, you run `cargo build`, and then you do `git status` and you notice that cargo has modified the `Cargo.lock`. That happens because the `Cargo.lock` wasn't in sync with the `Cargo.toml`.

The `--locked` flag means that Cargo will return an error when they are not in sync, instead of updating the Cargo.lock.
