### PR TITLE
README: fixed typo in docker run command

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -120,7 +120,7 @@ The easiest/faster option is to use the latest image.
 Let´s first check the version we have. The first time you run this command, the polkadot docker image will be downloaded. This takes a bit of time and bandwidth, be patient:
 
 [source, shell]
-docker run --rm -it chevdor/polkadot:latest pokadot --version
+docker run --rm -it chevdor/polkadot:latest polkadot --version
 
 
 .Polkadot arguments


### PR DESCRIPTION
Docker command with this typo just doesn't wok