### PR TITLE
Expose node public key to telemetry

### DIFF
--- a/substrate/service/src/lib.rs
+++ b/substrate/service/src/lib.rs
@@ -226,7 +226,6 @@ impl<Components> Service<Components>
 		// Telemetry
 		let telemetry = match config.telemetry_url {
 			Some(url) => {
-				println!("{:?}", keystore.contents().unwrap()[0]);
 				let mut pubkey = String::new();
 
 				for ch in public_key.as_slice() {

--- a/substrate/service/src/lib.rs
+++ b/substrate/service/src/lib.rs
@@ -230,7 +230,7 @@ impl<Components> Service<Components>
 				let mut pubkey = String::new();
 
 				for ch in public_key.as_slice() {
-					write!(pubkey, "{:x}", ch).expect("Cannot fail on u8 slices; qed");
+					write!(pubkey, "{:02x}", ch).expect("Cannot fail on u8 slices; qed");
 				}
 
 				let name = config.name.clone();

--- a/substrate/service/src/lib.rs
+++ b/substrate/service/src/lib.rs
@@ -230,7 +230,7 @@ impl<Components> Service<Components>
 				let mut pubkey = String::new();
 
 				for ch in public_key.as_slice() {
-					write!(pubkey, "{:x}", ch).unwrap();
+					write!(pubkey, "{:x}", ch).expect("Cannot fail on u8 slices; qed");
 				}
 
 				let name = config.name.clone();

--- a/substrate/service/src/lib.rs
+++ b/substrate/service/src/lib.rs
@@ -57,6 +57,7 @@ pub mod chain_ops;
 use std::io;
 use std::net::SocketAddr;
 use std::sync::Arc;
+use std::fmt::Write;
 use futures::prelude::*;
 use keystore::Store as Keystore;
 use client::BlockchainEvents;
@@ -125,10 +126,17 @@ impl<Components> Service<Components>
 			keystore.generate_from_seed(seed)?;
 		}
 
-		if keystore.contents()?.is_empty() {
-			let key = keystore.generate("")?;
-			info!("Generated a new keypair: {:?}", key.public());
-		}
+		// Keep the public key for telemetry
+		let public_key = match keystore.contents()?.get(0) {
+			Some(public_key) => public_key.clone(),
+			None => {
+				let key = keystore.generate("")?;
+				let public_key = key.public();
+				info!("Generated a new keypair: {:?}", public_key);
+
+				public_key
+			}
+		};
 
 		let (client, on_demand) = Components::build_client(&config, executor)?;
 		let best_header = client.best_block_header()?;
@@ -218,6 +226,13 @@ impl<Components> Service<Components>
 		// Telemetry
 		let telemetry = match config.telemetry_url {
 			Some(url) => {
+				println!("{:?}", keystore.contents().unwrap()[0]);
+				let mut pubkey = String::new();
+
+				for ch in public_key.as_slice() {
+					write!(pubkey, "{:x}", ch).unwrap();
+				}
+
 				let name = config.name.clone();
 				let impl_name = config.impl_name.to_owned();
 				let version = version.clone();
@@ -231,6 +246,7 @@ impl<Components> Service<Components>
 							"version" => version.clone(),
 							"config" => "",
 							"chain" => chain_name.clone(),
+							"pubkey" => &pubkey,
 						);
 					}),
 				}))


### PR DESCRIPTION
In order to have somewhat reliable way to keep track of / sticky specific nodes through reconnects.