### PR TITLE
Reject too large transactions

### DIFF
--- a/polkadot/consensus/src/lib.rs
+++ b/polkadot/consensus/src/lib.rs
@@ -770,12 +770,6 @@ impl<C> CreateProposal<C> where C: PolkadotApi {
 			let result = self.transaction_pool.cull_and_get_pending(BlockId::hash(self.parent_hash), |pending_iterator| {
 				let mut pending_size = 0;
 				for pending in pending_iterator {
-					// skip and cull transactions which are too large.
-					if pending.encoded_size() > MAX_TRANSACTIONS_SIZE {
-						unqueue_invalid.push(pending.hash().clone());
-						continue
-					}
-
 					if pending_size + pending.encoded_size() >= MAX_TRANSACTIONS_SIZE { break }
 
 					match block_builder.push_extrinsic(pending.primitive_extrinsic()) {

--- a/polkadot/transaction-pool/src/error.rs
+++ b/polkadot/transaction-pool/src/error.rs
@@ -55,6 +55,11 @@ error_chain! {
 			description("Unrecognised address in extrinsic"),
 			display("Unrecognised address in extrinsic: {}", who),
 		}
+		/// Extrinsic too large
+		TooLarge(got: usize, max: usize) {
+			description("Extrinsic too large"),
+			display("Extrinsic is too large ({} > {})", got, max),
+		}
 	}
 }
 

--- a/polkadot/transaction-pool/src/lib.rs
+++ b/polkadot/transaction-pool/src/lib.rs
@@ -61,7 +61,7 @@ pub use error::{Error, ErrorKind, Result};
 
 /// Maximal size of a single encoded extrinsic.
 ///
-/// See also substrate-consensus::MAX_TRANSACTIONS_SIZE
+/// See also polkadot-consensus::MAX_TRANSACTIONS_SIZE
 const MAX_TRANSACTION_SIZE: usize = 4 * 1024 * 1024;
 
 /// Type alias for convenience.

--- a/polkadot/transaction-pool/src/lib.rs
+++ b/polkadot/transaction-pool/src/lib.rs
@@ -59,6 +59,11 @@ use substrate_runtime_primitives::traits::{Bounded, Checkable, Hash as HashT, Bl
 pub use extrinsic_pool::txpool::{Options, Status, LightStatus, VerifiedTransaction as VerifiedTransactionOps};
 pub use error::{Error, ErrorKind, Result};
 
+/// Maximal size of a single encoded extrinsic.
+///
+/// See also substrate-consensus::MAX_TRANSACTIONS_SIZE
+const MAX_TRANSACTION_SIZE: usize = 4 * 1024 * 1024;
+
 /// Type alias for convenience.
 pub type CheckedExtrinsic = <UncheckedExtrinsic as Checkable<fn(Address) -> std::result::Result<AccountId, &'static str>>>::Checked;
 
@@ -279,14 +284,18 @@ impl<'a, A> txpool::Verifier<UncheckedExtrinsic> for Verifier<'a, A> where
 	type Error = Error;
 
 	fn verify_transaction(&self, uxt: UncheckedExtrinsic) -> Result<Self::VerifiedTransaction> {
-
 		if !uxt.is_signed() {
 			bail!(ErrorKind::IsInherent(uxt))
 		}
 
 		let encoded = uxt.encode();
-		let (encoded_size, hash) = (encoded.len(), BlakeTwo256::hash(&encoded));
+		let encoded_size = encoded.len();
 
+		if encoded_size > MAX_TRANSACTION_SIZE {
+			bail!(ErrorKind::TooLarge(encoded_size, MAX_TRANSACTION_SIZE));
+		}
+
+		let hash = BlakeTwo256::hash(&encoded);
 		debug!(target: "transaction-pool", "Transaction submitted: {}", ::substrate_primitives::hexdisplay::HexDisplay::from(&encoded));
 
 		let inner = match uxt.clone().check_with(|a| self.lookup(a)) {

--- a/substrate/extrinsic-pool/src/listener.rs
+++ b/substrate/extrinsic-pool/src/listener.rs
@@ -80,7 +80,7 @@ impl<H, T> txpool::Listener<T> for Listener<H> where
 	}
 
 	fn invalid(&mut self, tx: &Arc<T>) {
-		warn!("Extrinsic invalid: {:?}", tx);
+		debug!("Extrinsic invalid: {:?}", tx);
 	}
 
 	fn canceled(&mut self, tx: &Arc<T>) {

--- a/substrate/extrinsic-pool/src/listener.rs
+++ b/substrate/extrinsic-pool/src/listener.rs
@@ -80,7 +80,7 @@ impl<H, T> txpool::Listener<T> for Listener<H> where
 	}
 
 	fn invalid(&mut self, tx: &Arc<T>) {
-		debug!("Extrinsic invalid: {:?}", tx);
+		warn!("Extrinsic invalid: {:?}", tx);
 	}
 
 	fn canceled(&mut self, tx: &Arc<T>) {

--- a/substrate/extrinsic-pool/src/pool.rs
+++ b/substrate/extrinsic-pool/src/pool.rs
@@ -111,7 +111,7 @@ impl<Hash, VEx, S, E> Pool<Hash, VEx, S, E> where
 		let mut pool = self.pool.write();
 		let mut results = Vec::with_capacity(hashes.len());
 		for hash in hashes {
-			results.push(pool.remove(hash, is_valid));
+			results.push(pool.remove(hash, !is_valid));
 		}
 		results
 	}


### PR DESCRIPTION
Move rejection from consensus to pool verifier, so that large transactions are not propagated around.