### PR TITLE
Add docker resources

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+doc
+target

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -e
+
+pushd .
+
+# The following line ensure we run from the project root
+PROJECT_ROOT=`git rev-parse --show-toplevel`
+cd $PROJECT_ROOT
+
+# Find the current version from Cargo.toml
+VERSION=`grep "^version" ./Cargo.toml | egrep -o "([0-9\.]+)"`
+GITUSER=chevdor
+GITREPO=polkadot
+
+# Build the image
+echo "Building ${GITUSER}/${GITREPO}:latest docker image, hang on!"
+time docker build -f ./docker/Dockerfile --build-arg PROFILE=release -t ${GITUSER}/${GITREPO}:latest .
+
+# Show the list of available images for this repo
+echo "Image is ready"
+docker images | grep ${GITREPO}
+
+echo -e "\nIf you just built version ${VERSION}, you may want to update your tag:"
+echo " $ docker tag ${GITUSER}/${GITREPO}:$VERSION ${GITUSER}/${GITREPO}:${VERSION}"
+
+popd

--- a/docker/docker-compose-local.yml
+++ b/docker/docker-compose-local.yml
@@ -1,0 +1,44 @@
+version: '3'
+services:
+  node_alice:
+    build:
+      context: .
+    ports:
+      - "30333:30333"
+      - "9933:9933"
+      - "9944:9944"
+    image: chevdor/polkadot:latest
+    volumes:
+      - "polkadot-data-alice:/data"
+    command: polkadot --chain=local --validator --key Alice -d /data --node-key 0000000000000000000000000000000000000000000000000000000000000001
+    networks:
+      testing_net:
+        ipv4_address: 172.28.1.1
+
+  node_bob:
+    build:
+      context: .
+    ports:
+      - "30344:30344"
+      - "9935:9935"
+      - "9945:9945"
+    image: chevdor/polkadot:latest
+    volumes:
+      - "polkadot-data-bob:/data"
+    links:
+      - "node_alice:alice"
+    command: polkadot --chain=local --validator --key Bob -d /data --port 30344 --rpc-port 9935 --ws-port 9945 --bootnodes '/ip4/172.28.1.1/tcp/30333/p2p/QmQZ8TjTqeDj3ciwr93EJ95hxfDsb9pEYDizUAbWpigtQN'
+    networks:
+      testing_net:
+        ipv4_address: 172.28.1.2
+
+volumes:
+  polkadot-data-alice:
+  polkadot-data-bob:
+
+networks:
+  testing_net:
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.28.0.0/16

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3'
+services:
+  polkadot:
+    build:
+      context: .
+    ports:
+      - "127.0.0.1:30333:30333/tcp"
+      - "127.0.0.1:9933:9933/tcp"
+    image: chevdor/polkadot:latest
+    volumes:
+      - "polkadot-data:/data"
+    command: polkadot
+
+volumes:
+  polkadot-data:

--- a/docker/readme-docker.adoc
+++ b/docker/readme-docker.adoc
@@ -1,0 +1,16 @@
+
+== Polkadot Docker
+
+=== Start a Polkadot docker container
+
+Run the following command
+
+	docker run -d -P --name polkadot chevdor/polkadot:latest
+
+=== Building the image
+
+To build your own image from the source, you can run the following command:
+
+	./docker/build.sh
+
+NOTE: Building the image takes a while. Count at least 30min on a good machine.


### PR DESCRIPTION
This brings back Docker to the polkadot repo.
See PR for Substrate that removes Docker from Substrate: https://github.com/paritytech/substrate/pull/699