### PR TITLE
Remove invalid value from chainspec

### DIFF
--- a/service/res/alexander.json
+++ b/service/res/alexander.json
@@ -11,7 +11,6 @@
   "protocolId": "dot",
   "consensusEngine": null,
   "properties": {
-    "networkId": 3,
 		"tokenDecimals": 15,
 		"tokenSymbol": "DOT"
   },


### PR DESCRIPTION
CC @jacogr 

note: UIs should use (42,43) for ss58 address encoding by default.