### PR TITLE
Update log message for proposing blocks

### DIFF
--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -687,7 +687,7 @@ impl<C, TxApi> CreateProposal<C, TxApi> where
 
 		let new_block = block_builder.bake()?;
 
-		info!("Proposing block [number: {}; hash: {}; parent_hash: {}; extrinsics: [{}]]",
+		info!("Prepared block for proposing at {} [hash: {:?}; parent_hash: {}; extrinsics: [{}]]",
 			new_block.header.number,
 			Hash::from(new_block.header.hash()),
 			new_block.header.parent_hash,


### PR DESCRIPTION
Update the log messages to be less confusing when sealing proposed blocks.

See https://github.com/paritytech/substrate/pull/1397, fixes #74 