### PR TITLE
service: use grandpa block import for locally sealed aura blocks

### DIFF
--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -227,7 +227,7 @@ construct_service_factory! {
 					SlotDuration::get_or_compute(&*client)?,
 					key,
 					client.clone(),
-					client,
+					block_import,
 					Arc::new(proposer_factory),
 					service.network(),
 					service.on_exit(),


### PR DESCRIPTION
Blocks authored locally by aura weren't going through the grandpa `BlockImport` handler which is required to track authority set changes.