### PR TITLE
Add link in README to referenced Polkadot watercooler

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -81,7 +81,7 @@ cargo install --git https://github.com/paritytech/substrate.git --tag v0.2.5 pol
 
 === Obtaining DOTs
 
-If you want to do anything on it (not that there's much to do), then you'll need to get an account and some Alexander or Krumme Lanke DOTs. Ask in the Polkadot watercooler.
+If you want to do anything on it (not that there's much to do), then you'll need to get an account and some Alexander or Krumme Lanke DOTs. Ask in the Polkadot watercooler ( https://riot.im/app/#/room/#polkadot-watercooler:matrix.org ).
 
 === Development
 


### PR DESCRIPTION
As I was reading through the README file, there was a reference to getting DOTs by asking in the watercooler, but it took me a bit of searching to find what it was referring to.  This PR simply adds a link to the watercooler at that reference.