### PR TITLE
Correct FIXME/TODO in service module

### DIFF
--- a/service/src/chain_spec.rs
+++ b/service/src/chain_spec.rs
@@ -54,7 +54,7 @@ fn staging_testnet_config_genesis() -> GenesisConfig {
 	const DAYS: u64 = HOURS * 24;
 	GenesisConfig {
 		consensus: Some(ConsensusConfig {
-			code: include_bytes!("../../runtime/wasm/target/wasm32-unknown-unknown/release/polkadot_runtime.compact.wasm").to_vec(),	// TODO change
+			code: include_bytes!("../../runtime/wasm/target/wasm32-unknown-unknown/release/polkadot_runtime.compact.wasm").to_vec(),
 			authorities: initial_authorities.clone(),
 		}),
 		system: None,

--- a/service/src/chain_spec.rs
+++ b/service/src/chain_spec.rs
@@ -54,6 +54,7 @@ fn staging_testnet_config_genesis() -> GenesisConfig {
 	const DAYS: u64 = HOURS * 24;
 	GenesisConfig {
 		consensus: Some(ConsensusConfig {
+			// TODO: Change after Substrate 1252 is fixed (https://github.com/paritytech/substrate/issues/1252)
 			code: include_bytes!("../../runtime/wasm/target/wasm32-unknown-unknown/release/polkadot_runtime.compact.wasm").to_vec(),
 			authorities: initial_authorities.clone(),
 		}),

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -179,7 +179,7 @@ construct_service_factory! {
 					let voter = grandpa::run_grandpa(
 						grandpa::Config {
 							// TODO: make gossip_duration available through chainspec
-							// https://github.com/paritytech/polkadot/issues/163
+							// https://github.com/paritytech/substrate/issues/1578
 							gossip_duration: Duration::new(4, 0),
 							local_key: key.clone(),
 							justification_period: 4096,

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -178,7 +178,9 @@ construct_service_factory! {
 				{
 					let voter = grandpa::run_grandpa(
 						grandpa::Config {
-							gossip_duration: Duration::new(4, 0), // FIXME: make this available through chainspec?
+							// TODO: make gossip_duration available through chainspec
+							// https://github.com/paritytech/polkadot/issues/163
+							gossip_duration: Duration::new(4, 0),
 							local_key: key.clone(),
 							justification_period: 4096,
 							name: Some(service.config.name.clone()),


### PR DESCRIPTION
This closes the `service` section of #139 

- chainspec.rs TODO was accidentally left after the change. Removed.
- One lib.rs FIXME already had an issue associated with it.
- Created issue #163 to lib.rs for GRANDPA config