### PR TITLE
Some PoC-3 GRANDPA tweaks

### DIFF
--- a/runtime/src/curated_grandpa.rs
+++ b/runtime/src/curated_grandpa.rs
@@ -75,7 +75,10 @@ decl_module! {
 					voters.swap(remaining - 1, voter_index);
 				}
 
+				// finalisation order is undefined, so grandpa's on_finalise might
+				// have already been called. calling it again is OK though.
 				let _ = grandpa::Module::<T>::schedule_change(voters, T::BlockNumber::zero(), None);
+				grandpa::Module::<T>::on_finalise(block_number);
 			}
 		}
 	}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -107,7 +107,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("polkadot"),
 	impl_name: create_runtime_str!("parity-polkadot"),
 	authoring_version: 1,
-	spec_version: 105,
+	spec_version: 106,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 };

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -172,7 +172,7 @@ construct_service_factory! {
 				{
 					let voter = grandpa::run_grandpa(
 						grandpa::Config {
-							gossip_duration: Duration::new(4, 0), // FIXME: make this available through chainspec?
+							gossip_duration: Duration::from_millis(500),
 							local_key: key.clone(),
 							justification_period: 4096,
 							name: Some(service.config.name.clone()),


### PR DESCRIPTION
Make sure that curated-grandpa changes happen before grandpa module's finalization.
Also tweaks the grandpa round timer to make things finalize faster.