### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY . /polkadot
 
 RUN apt-get update && \
 	apt-get upgrade -y && \
-	apt-get install -y cmake pkg-config libssl-dev git
+	apt-get install -y cmake pkg-config libssl-dev git clang
 
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y && \
 	export PATH=$PATH:$HOME/.cargo/bin && \


### PR DESCRIPTION
`clang` is a dependency to build `polkadot`.

If someone tries to run the docker build script it will currently fail (I tried). Adding `clang` fixes it.

I also want to bring up a point on how to handle docker builds. Will Parity set up automated docker builds based on commit hooks? This seems to be the easiest solution to having always up to date binaries. For instance, the [current binary](https://hub.docker.com/r/chevdor/polkadot) released by @chevdor on Docker Hub is slightly out-of-date and doesn't include a fix to testnet genesis file. For this reason I had to [build my own binary](https://hub.docker.com/r/lsaether/polkadot-bin) to use for example in a [docker-compose script](https://github.com/lsaether/polkadot-devnet/blob/master/docker-compose.yml#L10) that would launch a local testnet. 

If there was a commit hook that ran docker builds, I would not have needed to build my own. If the infrastructure is set up, we could even pull down specific binaries from Docker based on commit hash if we wanted.