### PR TITLE
update storage build

### DIFF
--- a/runtime/src/parachains.rs
+++ b/runtime/src/parachains.rs
@@ -25,7 +25,7 @@ use primitives::Hash;
 use primitives::parachain::{Id as ParaId, Chain, DutyRoster, AttestedCandidate, Statement};
 use {system, session};
 
-use srml_support::{StorageValue, StorageMap};
+use srml_support::{StorageValue, StorageMap, storage::hashed::generator};
 use srml_support::dispatch::Result;
 
 use inherents::{ProvideInherent, InherentData, RuntimeString, MakeFatalError, InherentIdentifier};
@@ -64,7 +64,7 @@ decl_storage! {
 		config(parachains): Vec<(ParaId, Vec<u8>, Vec<u8>)>;
 		config(_phdata): PhantomData<T>;
 		build(|storage: &mut StorageOverlay, _: &mut ChildrenStorageOverlay, config: &GenesisConfig<T>| {
-			use codec::Encode;
+			let storage = std::cell::RefCell::new(storage);
 
 			let mut p = config.parachains.clone();
 			p.sort_unstable_by_key(|&(ref id, _, _)| id.clone());
@@ -72,15 +72,12 @@ decl_storage! {
 
 			let only_ids: Vec<_> = p.iter().map(|&(ref id, _, _)| id).cloned().collect();
 
-			storage.insert(<Parachains<T>>::key().to_vec(), only_ids.encode());
+			<Parachains<T> as generator::StorageValue<_>>::put(&only_ids, &storage);
 
 			for (id, code, genesis) in p {
-				let code_key = <Code<T>>::key_for(&id);
-				let head_key = <Heads<T>>::key_for(&id);
 				// no ingress -- a chain cannot be routed to until it is live.
-
-				storage.insert(code_key, code.encode());
-				storage.insert(head_key, genesis.encode());
+				<Code<T> as generator::StorageMap<_, _>>::insert(&id, &code, &storage);
+				<Heads<T> as generator::StorageMap<_, _>>::insert(&id, &genesis, &storage);
 			}
 		});
 	}


### PR DESCRIPTION
indeed the use of RefCell is not very beautiful and storage traits should be implemented to inner type in srml-support.

But this ensure if the default hasher is changed for a map then the build code is still valid

EDIT: no the refcell is introduced to be able to implement the actual trait which requires to implement on &self