### PR TITLE
Allow claim to be not signed by receiver account

### DIFF
--- a/runtime/src/claims.rs
+++ b/runtime/src/claims.rs
@@ -167,7 +167,7 @@ impl<T: Trait> ValidateUnsigned for Module<T> {
 				}
 
 				TransactionValidity::Valid {
-					priority: PRIORIY,
+					priority: PRIORITY,
 					requires: vec![],
 					provides: vec![],
 					longevity: TransactionLongevity::max_value(),

--- a/runtime/src/claims.rs
+++ b/runtime/src/claims.rs
@@ -143,7 +143,7 @@ decl_module! {
 }
 
 impl<T: Trait> ValidateUnsigned for Module<T> {
-	type Call=Call<T>;
+	type Call = Call<T>;
 
 	fn validate_unsigned(call: &Self::Call) -> TransactionValidity {
 		// Note errors > 0 are from ApplyError

--- a/runtime/src/claims.rs
+++ b/runtime/src/claims.rs
@@ -352,6 +352,10 @@ mod tests {
 				<Module<Test>>::validate_unsigned(&Call::claim(1, bob_sig(&1u64.encode()))),
 				TransactionValidity::Invalid(-20)
 			);
+			assert_eq!(
+				<Module<Test>>::validate_unsigned(&Call::claim(0, bob_sig(&1u64.encode()))),
+				TransactionValidity::Invalid(-20)
+			);
 		});
 	}
 }

--- a/runtime/src/claims.rs
+++ b/runtime/src/claims.rs
@@ -151,7 +151,7 @@ impl<T: Trait> ValidateUnsigned for Module<T> {
 		const SIGNER_HAS_NO_CLAIM: i8 = -20;
 		const INVALID_CALL: i8 = -30;
 
-		const PRIORIY: u64 = 100;
+		const PRIORITY: u64 = 100;
 
 		match call {
 			Call::claim(account, ethereum_signature) => {

--- a/runtime/src/claims.rs
+++ b/runtime/src/claims.rs
@@ -23,7 +23,8 @@ use srml_support::traits::Currency;
 use system::ensure_none;
 use codec::Encode;
 #[cfg(feature = "std")]
-use sr_primitives::traits::{Zero, ValidateUnsigned};
+use sr_primitives::traits::Zero;
+use sr_primitives::traits::ValidateUnsigned;
 use sr_primitives::transaction_validity::{TransactionLongevity, TransactionValidity};
 use system;
 

--- a/runtime/src/claims.rs
+++ b/runtime/src/claims.rs
@@ -122,9 +122,8 @@ decl_module! {
 		fn claim(origin, dest: T::AccountId, ethereum_signature: EcdsaSignature) {
 			ensure_none(origin)?;
 
-			let signer = dest.using_encoded(|data|
-					eth_recover(&ethereum_signature, data)
-				).ok_or("Invalid Ethereum signature")?;
+			let signer = dest.using_encoded(|data| eth_recover(&ethereum_signature, data))
+				.ok_or("Invalid Ethereum signature")?;
 
 			let balance_due = <Claims<T>>::take(&signer)
 				.ok_or("Ethereum address has no claim")?;


### PR DESCRIPTION
for now claim unsigned is only callable by the receiver of the claim.

Now claim can be done by anybody providing the ethereum_signature of message 'Pay dot to....'

a transaction is considered valid if ethereum signature is correct and signer has some claim.

NOTE:
* there is some double check in the call execution: we could provide signer as a parameter. then the call won't have to retrieve the signer he would be sure that it is correct as validate_unsigned will have checked that it match the actualy signer of ethereum_signature.
* before this PR, the account receiving the claim would pay transaction fees. This is no longer the case.
  But as a valid extrinsic is unsure to have some claim we could apply some fees on this claim if wanted. (but it seems we don't want that to me)
* maybe we want to introduce some mortal mecanism ?