### PR TITLE
Migrate to the 2018 edition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,6 @@ name = "adder"
 version = "0.1.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-codec-derive 3.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-parachain 0.1.0",
  "tiny-keccak 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -996,11 +995,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex-literal"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "hex-literal-impl 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro-hack 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "hex-literal-impl"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro-hack 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "hex-literal-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro-hack 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2305,7 +2321,6 @@ version = "0.1.0"
 dependencies = [
  "polkadot-runtime 0.1.0",
  "substrate-executor 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
 ]
 
 [[package]]
@@ -2317,7 +2332,6 @@ dependencies = [
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-codec-derive 3.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-availability-store 0.1.0",
  "polkadot-primitives 0.1.0",
@@ -2352,7 +2366,6 @@ dependencies = [
  "polkadot-parachain 0.1.0",
  "pretty_assertions 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
  "sr-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
  "sr-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
@@ -2366,11 +2379,10 @@ name = "polkadot-runtime"
 version = "0.1.0"
 dependencies = [
  "bitvec 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "hex-literal 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex-literal 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsecp256k1 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-codec-derive 3.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-primitives 0.1.0",
  "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2413,7 +2425,7 @@ name = "polkadot-service"
 version = "0.5.0"
 dependencies = [
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "hex-literal 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex-literal 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2444,7 +2456,6 @@ name = "polkadot-statement-table"
 version = "0.1.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-codec-derive 3.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-primitives 0.1.0",
  "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
 ]
@@ -5072,7 +5083,9 @@ dependencies = [
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
 "checksum hex-literal 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ddc2928beef125e519d69ae1baa8c37ea2e0d3848545217f6db0179c5eb1d639"
+"checksum hex-literal 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c3da68162fdd2147e66682e78e729bd77f93b4c99656db058c5782d8c6b6225a"
 "checksum hex-literal-impl 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "520870c3213943eb8d7803e80180d12a6c7ceb4ae74602544529d1643dc4ddda"
+"checksum hex-literal-impl 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "06095d08c7c05760f11a071b3e1d4c5b723761c01bd8d7201c30a9536668a612"
 "checksum hmac 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7a13f4163aa0c5ca1be584aace0e2212b2e41be5478218d4f657f5f778b2ae2a"
 "checksum hmac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f127a908633569f208325f86f71255d3363c79721d7f9fe31cd5569908819771"
 "checksum hmac-drbg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4fe727d41d2eec0a6574d887914347e5ff96a3b87177817e2a9820c5c87fecc2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,10 @@ name = "polkadot"
 version = "0.5.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 build = "build.rs"
+edition = "2018"
 
 [dependencies]
-polkadot-cli = { path = "cli" }
+cli = { package = "polkadot-cli", path = "cli" }
 futures = "0.1"
 ctrlc = { version = "3.0", features = ["termination"] }
 

--- a/availability-store/Cargo.toml
+++ b/availability-store/Cargo.toml
@@ -3,6 +3,7 @@ name = "polkadot-availability-store"
 description = "Persistent database for parachain data"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2018"
 
 [dependencies]
 polkadot-primitives = { path = "../primitives" }

--- a/availability-store/src/lib.rs
+++ b/availability-store/src/lib.rs
@@ -16,22 +16,12 @@
 
 //! Persistent database for parachain data.
 
-extern crate polkadot_primitives;
-extern crate parking_lot;
-extern crate parity_codec as codec;
-extern crate substrate_primitives;
-extern crate kvdb;
-extern crate kvdb_rocksdb;
-extern crate kvdb_memorydb;
-
-#[macro_use]
-extern crate log;
-
-use codec::{Encode, Decode};
+use parity_codec::{Encode, Decode};
 use kvdb::{KeyValueDB, DBTransaction};
 use kvdb_rocksdb::{Database, DatabaseConfig};
 use polkadot_primitives::Hash;
 use polkadot_primitives::parachain::{Id as ParaId, BlockData, Extrinsic};
+use log::warn;
 
 use std::collections::HashSet;
 use std::path::PathBuf;
@@ -101,7 +91,7 @@ impl Store {
 	/// Create a new `Store` in-memory. Useful for tests.
 	pub fn new_in_memory() -> Self {
 		Store {
-			inner: Arc::new(::kvdb_memorydb::create(::columns::NUM_COLUMNS)),
+			inner: Arc::new(::kvdb_memorydb::create(columns::NUM_COLUMNS)),
 		}
 	}
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -3,11 +3,12 @@ name = "polkadot-cli"
 version = "0.5.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Polkadot node implementation in Rust."
+edition = "2018"
 
 [dependencies]
 log = "0.4.6"
 tokio = "0.1.7"
 futures = "0.1.17"
 exit-future = "0.1"
-substrate-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-polkadot-service = { path = "../service" }
+cli = { package = "substrate-cli", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+service = { package = "polkadot-service", path = "../service" }

--- a/collator/Cargo.toml
+++ b/collator/Cargo.toml
@@ -3,14 +3,15 @@ name = "polkadot-collator"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Collator node implementation"
+edition = "2018"
 
 [dependencies]
 futures = "0.1.17"
-substrate-client = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+client = { package = "substrate-client", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
 parity-codec = "3.0"
-substrate-primitives = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-substrate-consensus-authorities = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-substrate-consensus-common= { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+primitives = { package = "substrate-primitives", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+consensus_authorities = { package = "substrate-consensus-authorities", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+consensus_common = { package = "substrate-consensus-common", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
 polkadot-runtime = { path = "../runtime", version = "0.1" }
 polkadot-primitives = { path = "../primitives", version = "0.1" }
 polkadot-cli = { path = "../cli" }
@@ -20,4 +21,4 @@ log = "0.4"
 tokio = "0.1.7"
 
 [dev-dependencies]
-substrate-keyring = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+keyring = { package = "substrate-keyring", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }

--- a/collator/src/lib.rs
+++ b/collator/src/lib.rs
@@ -44,32 +44,13 @@
 //! This crate defines traits which provide context necessary for collation logic
 //! to be performed, as the collation logic itself.
 
-extern crate futures;
-extern crate substrate_client as client;
-extern crate parity_codec as codec;
-extern crate substrate_primitives as primitives;
-extern crate substrate_consensus_authorities as consensus_authorities;
-extern crate substrate_consensus_common as consensus_common;
-extern crate tokio;
-
-extern crate polkadot_cli;
-extern crate polkadot_runtime;
-extern crate polkadot_primitives;
-extern crate polkadot_network;
-extern crate polkadot_validation;
-
-#[macro_use]
-extern crate log;
-
-#[cfg(test)]
-extern crate substrate_keyring as keyring;
-
 use std::collections::HashSet;
 use std::fmt;
 use std::sync::Arc;
 use std::time::Duration;
 
 use futures::{future, Stream, Future, IntoFuture};
+use log::{info, warn};
 use client::BlockchainEvents;
 use primitives::{ed25519, Pair};
 use polkadot_primitives::{BlockId, SessionKey, Hash, Block};

--- a/erasure-coding/Cargo.toml
+++ b/erasure-coding/Cargo.toml
@@ -5,8 +5,8 @@ authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 
 [dependencies]
-polkadot-primitives = { path = "../primitives" }
-reed-solomon-erasure = { git = "https://github.com/paritytech/reed-solomon-erasure" }
+primitives = { package = "polkadot-primitives", path = "../primitives" }
+reed_solomon = { package = "reed-solomon-erasure", git = "https://github.com/paritytech/reed-solomon-erasure" }
 parity-codec = "3.0"
 substrate-primitives = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-substrate-trie = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+trie = { package = "substrate-trie", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }

--- a/erasure-coding/src/lib.rs
+++ b/erasure-coding/src/lib.rs
@@ -24,13 +24,7 @@
 //! f is the maximum number of faulty vaildators in the system.
 //! The data is coded so any f+1 chunks can be used to reconstruct the full data.
 
-extern crate polkadot_primitives as primitives;
-extern crate reed_solomon_erasure as reed_solomon;
-extern crate parity_codec as codec;
-extern crate substrate_primitives;
-extern crate substrate_trie as trie;
-
-use codec::{Encode, Decode};
+use parity_codec::{Encode, Decode};
 use reed_solomon::galois_16::{self, ReedSolomon};
 use primitives::{Hash as H256, BlakeTwo256, HashT};
 use primitives::parachain::{BlockData, Extrinsic};
@@ -297,7 +291,7 @@ struct ShardInput<'a, I> {
 	cur_shard: Option<(&'a [u8], usize)>,
 }
 
-impl<'a, I: Iterator<Item=&'a [u8]>> codec::Input for ShardInput<'a, I> {
+impl<'a, I: Iterator<Item=&'a [u8]>> parity_codec::Input for ShardInput<'a, I> {
 	fn read(&mut self, into: &mut [u8]) -> usize {
 		let mut read_bytes = 0;
 

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -3,8 +3,8 @@ name = "polkadot-executor"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Polkadot node implementation in Rust."
+edition = "2018"
 
 [dependencies]
 substrate-executor = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-substrate-primitives = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
 polkadot-runtime = { path = "../runtime" }

--- a/executor/src/lib.rs
+++ b/executor/src/lib.rs
@@ -17,9 +17,7 @@
 //! A `CodeExecutor` specialisation which uses natively compiled runtime when the wasm to be
 //! executed is equivalent to the natively compiled code.
 
-extern crate polkadot_runtime;
-#[macro_use] extern crate substrate_executor;
-extern crate substrate_primitives as primitives;
+use substrate_executor::native_executor_instance;
 
 native_executor_instance!(
     pub Executor,

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -3,15 +3,15 @@ name = "polkadot-network"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Polkadot-specific networking protocol"
+edition = "2018"
 
 [dependencies]
 arrayvec = "0.4"
 parking_lot = "0.7.1"
-polkadot-availability-store = { path = "../availability-store" }
+av_store = { package = "polkadot-availability-store", path = "../availability-store" }
 polkadot-validation = { path = "../validation" }
 polkadot-primitives = { path = "../primitives" }
-parity-codec = "3.0"
-parity-codec-derive = "3.0"
+parity-codec = { version = "3.0", features = ["derive"] }
 substrate-network = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
 substrate-primitives = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
 sr-primitives = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }

--- a/network/src/collator_pool.rs
+++ b/network/src/collator_pool.rs
@@ -16,6 +16,7 @@
 
 //! Bridge between the network and consensus service for getting collations to it.
 
+use parity_codec::{Encode, Decode};
 use polkadot_primitives::Hash;
 use polkadot_primitives::parachain::{CollatorId, Id as ParaId, Collation};
 use futures::sync::oneshot;

--- a/network/src/gossip.rs
+++ b/network/src/gossip.rs
@@ -23,15 +23,16 @@ use substrate_network::consensus_gossip::{
 };
 use polkadot_validation::{GenericStatement, SignedStatement};
 use polkadot_primitives::{Block, Hash, SessionKey, parachain::ValidatorIndex};
-use codec::{Decode, Encode};
+use parity_codec::{Decode, Encode};
 
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use parking_lot::RwLock;
+use log::warn;
 
 use super::NetworkService;
-use router::attestation_topic;
+use crate::router::attestation_topic;
 
 /// The engine ID of the polkadot attestation system.
 pub const POLKADOT_ENGINE_ID: sr_primitives::ConsensusEngineId = [b'd', b'o', b't', b'1'];

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -19,39 +19,13 @@
 //! This manages routing for parachain statements, parachain block and extrinsic data fetching,
 //! communication between collators and validators, and more.
 
-extern crate parity_codec as codec;
-extern crate substrate_network;
-extern crate substrate_primitives;
-extern crate sr_primitives;
-
-extern crate polkadot_validation;
-extern crate polkadot_availability_store as av_store;
-extern crate polkadot_primitives;
-
-extern crate arrayvec;
-extern crate parking_lot;
-extern crate tokio;
-extern crate exit_future;
-
-extern crate futures;
-#[macro_use]
-extern crate log;
-#[macro_use]
-extern crate parity_codec_derive;
-
-#[cfg(test)]
-extern crate substrate_client;
-
-#[cfg(test)]
-extern crate substrate_keyring;
-
 mod collator_pool;
 mod local_collations;
 mod router;
 pub mod validation;
 pub mod gossip;
 
-use codec::{Decode, Encode};
+use parity_codec::{Decode, Encode};
 use futures::sync::oneshot;
 use polkadot_primitives::{Block, SessionKey, Hash, Header};
 use polkadot_primitives::parachain::{
@@ -65,6 +39,7 @@ use substrate_network::StatusMessage as GenericFullStatus;
 use self::validation::{LiveValidationSessions, RecentValidatorIds, InsertedRecentKey};
 use self::collator_pool::{CollatorPool, Role, Action};
 use self::local_collations::LocalCollations;
+use log::{trace, debug, warn};
 
 use std::collections::{HashMap, HashSet};
 

--- a/network/src/local_collations.rs
+++ b/network/src/local_collations.rs
@@ -21,7 +21,7 @@
 
 use polkadot_primitives::{Hash, SessionKey};
 
-use collator_pool::Role;
+use crate::collator_pool::Role;
 
 use std::collections::{HashMap, HashSet};
 use std::time::{Duration, Instant};

--- a/network/src/router.rs
+++ b/network/src/router.rs
@@ -31,17 +31,18 @@ use polkadot_primitives::{Block, Hash};
 use polkadot_primitives::parachain::{Extrinsic, CandidateReceipt, ParachainHost,
 	ValidatorIndex, Collation, PoVBlock,
 };
-use gossip::RegisteredMessageValidator;
+use crate::gossip::RegisteredMessageValidator;
 
-use codec::{Encode, Decode};
+use parity_codec::{Encode, Decode};
 use futures::prelude::*;
 use parking_lot::Mutex;
+use log::{debug, trace};
 
 use std::collections::{HashMap, HashSet};
 use std::io;
 use std::sync::Arc;
 
-use validation::{self, SessionDataFetcher, NetworkService, Executor};
+use crate::validation::{self, SessionDataFetcher, NetworkService, Executor};
 
 /// Compute the gossip topic for attestations on the given parent hash.
 pub(crate) fn attestation_topic(parent_hash: Hash) -> Hash {

--- a/network/src/tests/mod.rs
+++ b/network/src/tests/mod.rs
@@ -18,7 +18,7 @@
 
 use std::collections::HashMap;
 use super::{PolkadotProtocol, Status, Message, FullStatus};
-use validation::SessionParams;
+use crate::validation::SessionParams;
 
 use polkadot_validation::GenericStatement;
 use polkadot_primitives::{Block, Hash, SessionKey};
@@ -27,7 +27,7 @@ use polkadot_primitives::parachain::{
 	ConsolidatedIngressRoots,
 };
 use substrate_primitives::crypto::UncheckedInto;
-use codec::Encode;
+use parity_codec::Encode;
 use substrate_network::{
 	PeerId, Context, config::Roles,
 	message::generic::ConsensusMessage,

--- a/network/src/tests/validation.rs
+++ b/network/src/tests/validation.rs
@@ -18,12 +18,12 @@
 
 #![allow(unused)]
 
-use validation::{NetworkService, GossipService};
+use crate::validation::{NetworkService, GossipService};
 use substrate_network::Context as NetContext;
 use substrate_network::consensus_gossip::TopicNotification;
 use substrate_primitives::{NativeOrEncoded, ExecutionContext};
 use substrate_keyring::AuthorityKeyring;
-use {PolkadotProtocol};
+use crate::PolkadotProtocol;
 
 use polkadot_validation::{SharedTable, MessagesFrom, Network};
 use polkadot_primitives::{SessionKey, Block, Hash, Header, BlockId};
@@ -322,7 +322,7 @@ impl ParachainHost<Block> for RuntimeApi {
 	}
 }
 
-type TestValidationNetwork = ::validation::ValidationNetwork<
+type TestValidationNetwork = crate::validation::ValidationNetwork<
 	TestApi,
 	NeverExit,
 	TestNetwork,

--- a/network/src/validation.rs
+++ b/network/src/validation.rs
@@ -40,9 +40,10 @@ use std::sync::Arc;
 use arrayvec::ArrayVec;
 use tokio::runtime::TaskExecutor;
 use parking_lot::Mutex;
+use log::warn;
 
-use router::Router;
-use gossip::{POLKADOT_ENGINE_ID, RegisteredMessageValidator, MessageValidationData};
+use crate::router::Router;
+use crate::gossip::{POLKADOT_ENGINE_ID, RegisteredMessageValidator, MessageValidationData};
 
 use super::PolkadotProtocol;
 

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -2,17 +2,17 @@
 name = "polkadot-primitives"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2018"
 
 [dependencies]
-serde = { version = "1.0", optional = true }
-serde_derive = { version = "1.0", optional = true }
+serde = { version = "1.0", optional = true, features = ["derive"] }
 parity-codec = { version = "3.0", default-features = false }
 parity-codec-derive = { version = "3.0", default-features = false }
-substrate-primitives = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
+primitives = { package = "substrate-primitives", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
 substrate-client = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
 sr-version = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-sr-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-sr-primitives = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
+rstd = { package = "sr-std", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
+runtime_primitives = { package = "sr-primitives", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
 polkadot-parachain = { path = "../parachain", default-features = false }
 
 [dev-dependencies]
@@ -24,12 +24,11 @@ default = ["std"]
 std = [
 	"parity-codec/std",
 	"parity-codec-derive/std",
-	"substrate-primitives/std",
+	"primitives/std",
 	"substrate-client/std",
-	"sr-std/std",
+	"rstd/std",
 	"sr-version/std",
-	"sr-primitives/std",
-	"serde_derive",
+	"runtime_primitives/std",
 	"serde",
 	"polkadot-parachain/std",
 ]

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -20,38 +20,19 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-extern crate parity_codec as codec;
-extern crate substrate_primitives as primitives;
-extern crate sr_primitives as runtime_primitives;
-extern crate sr_std as rstd;
-extern crate sr_version;
-extern crate polkadot_parachain;
-
-#[cfg(test)]
-extern crate substrate_serializer;
-
-#[macro_use]
-extern crate parity_codec_derive;
-
 #[cfg(feature = "std")]
-#[macro_use]
-extern crate serde_derive;
-
-#[cfg(feature = "std")]
-extern crate serde;
-
-#[macro_use]
-extern crate substrate_client;
+use serde::{Serialize, Deserialize};
 
 use rstd::prelude::*;
 use runtime_primitives::{generic, traits::Extrinsic, AnySignature};
+use parity_codec::{Encode, Decode};
+use primitives::ed25519;
 
 pub use runtime_primitives::traits::{BlakeTwo256, Hash as HashT, Verify};
-use primitives::ed25519;
 
 pub mod parachain;
 
-pub use codec::Compact;
+pub use parity_codec::Compact;
 
 #[cfg(feature = "std")]
 use primitives::bytes;

--- a/primitives/src/parachain.rs
+++ b/primitives/src/parachain.rs
@@ -18,7 +18,11 @@
 
 use rstd::prelude::*;
 use rstd::cmp::Ordering;
+use parity_codec::{Encode, Decode};
 use super::Hash;
+
+#[cfg(feature = "std")]
+use serde::{Serialize, Deserialize};
 
 #[cfg(feature = "std")]
 use primitives::bytes;
@@ -297,7 +301,7 @@ impl AttestedCandidate {
 	}
 }
 
-decl_runtime_apis! {
+substrate_client::decl_runtime_apis! {
 	/// The API for querying the state of parachains on-chain.
 	pub trait ParachainHost {
 		/// Get the current validators.

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -2,6 +2,7 @@
 name = "polkadot-runtime"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2018"
 
 [dependencies]
 bitvec = { version = "0.8", default-features = false, features = ["alloc"] }
@@ -10,41 +11,40 @@ log = { version = "0.3", optional = true }
 serde = { version = "1.0", default-features = false }
 serde_derive = { version = "1.0", optional = true }
 safe-mix = { version = "1.0", default-features = false}
-polkadot-primitives = { path = "../primitives", default-features = false }
-parity-codec = { version = "3.0", default-features = false }
-parity-codec-derive = { version = "3.0", default-features = false }
+primitives = { package = "polkadot-primitives", path = "../primitives", default-features = false }
+parity-codec = { version = "3.0", default-features = false, features = ["derive"] }
 substrate-serializer = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-sr-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
+rstd = { package = "sr-std", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
 sr-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
 srml-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
 substrate-primitives = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-substrate-client = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-substrate-inherents = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-substrate-consensus-aura-primitives = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-substrate-offchain-primitives = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-srml-aura = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-srml-balances = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-srml-consensus = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-srml-council = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-srml-democracy = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-srml-executive = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-srml-grandpa = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-srml-indices = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
+client = { package = "substrate-client", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
+inherents = { package = "substrate-inherents", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
+consensus_aura = { package = "substrate-consensus-aura-primitives", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
+offchain_primitives = { package = "substrate-offchain-primitives", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
+aura = { package = "srml-aura", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
+balances = { package = "srml-balances", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
+consensus = { package = "srml-consensus", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
+council = { package = "srml-council", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
+democracy = { package = "srml-democracy", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
+executive = { package = "srml-executive", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
+grandpa = { package = "srml-grandpa", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
+indices = { package = "srml-indices", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
 sr-primitives = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-srml-session = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-srml-staking = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-srml-sudo = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-srml-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-srml-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-srml-treasury = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-sr-version = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-substrate-consensus-authorities = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
+session = { package = "srml-session", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
+staking = { package = "srml-staking", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
+sudo = { package = "srml-sudo", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
+system = { package = "srml-system", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
+timestamp = { package = "srml-timestamp", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
+treasury = { package = "srml-treasury", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
+version = { package = "sr-version", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
+consensus_authorities = { package = "substrate-consensus-authorities", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
 
 [dev-dependencies]
-hex-literal = "0.1.0"
+hex-literal = "0.2.0"
 libsecp256k1 = "0.2.1"
 tiny-keccak = "1.4.2"
-substrate-keyring = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+keyring = { package = "substrate-keyring", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
 substrate-trie = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
 trie-db = "0.12"
 
@@ -52,36 +52,34 @@ trie-db = "0.12"
 default = ["std"]
 std = [
 	"bitvec/std",
-	"polkadot-primitives/std",
+	"primitives/std",
 	"rustc-hex/std",
 	"parity-codec/std",
-	"parity-codec-derive/std",
-	"substrate-inherents/std",
+	"inherents/std",
 	"substrate-primitives/std",
-	"substrate-client/std",
-	"substrate-inherents/std",
-	"substrate-offchain-primitives/std",
-	"sr-std/std",
+	"client/std",
+	"offchain_primitives/std",
+	"rstd/std",
 	"sr-io/std",
 	"srml-support/std",
-	"srml-balances/std",
-	"srml-consensus/std",
-	"srml-council/std",
-	"srml-democracy/std",
-	"srml-executive/std",
-	"srml-grandpa/std",
-	"srml-indices/std",
+	"balances/std",
+	"consensus/std",
+	"council/std",
+	"democracy/std",
+	"executive/std",
+	"grandpa/std",
+	"indices/std",
 	"sr-primitives/std",
-	"srml-session/std",
-	"srml-staking/std",
-	"srml-sudo/std",
-	"srml-system/std",
-	"srml-timestamp/std",
-	"srml-treasury/std",
-	"sr-version/std",
+	"session/std",
+	"staking/std",
+	"sudo/std",
+	"system/std",
+	"timestamp/std",
+	"treasury/std",
+	"version/std",
 	"serde_derive",
 	"serde/std",
 	"log",
 	"safe-mix/std",
-	"substrate-consensus-authorities/std"
+	"consensus_authorities/std"
 ]

--- a/runtime/src/claims.rs
+++ b/runtime/src/claims.rs
@@ -18,10 +18,10 @@
 
 use rstd::prelude::*;
 use sr_io::{keccak_256, secp256k1_ecdsa_recover};
-use srml_support::{StorageValue, StorageMap};
+use srml_support::{StorageValue, StorageMap, decl_event, decl_storage, decl_module};
 use srml_support::traits::Currency;
 use system::ensure_none;
-use codec::Encode;
+use parity_codec::{Encode, Decode};
 #[cfg(feature = "std")]
 use sr_primitives::traits::Zero;
 use sr_primitives::traits::ValidateUnsigned;
@@ -183,17 +183,19 @@ impl<T: Trait> ValidateUnsigned for Module<T> {
 mod tests {
 	use secp256k1;
 	use tiny_keccak::keccak256;
+	use hex_literal::hex;
 	use super::*;
 
 	use sr_io::with_externalities;
 	use substrate_primitives::{H256, Blake2Hasher};
-	use codec::{Decode, Encode};
+	use parity_codec::{Decode, Encode};
 	// The testing primitives are very useful for avoiding having to work with signatures
 	// or public keys. `u64` is used as the `AccountId` and no `Signature`s are requried.
 	use sr_primitives::{
 		BuildStorage, traits::{BlakeTwo256, IdentityLookup}, testing::{Digest, DigestItem, Header}
 	};
 	use balances;
+	use srml_support::{impl_outer_origin, assert_ok, assert_err, assert_noop};
 
 	impl_outer_origin! {
 		pub enum Origin for Test {}

--- a/runtime/src/curated_grandpa.rs
+++ b/runtime/src/curated_grandpa.rs
@@ -17,9 +17,10 @@
 //! A module for manually curated GRANDPA set.
 
 use {grandpa, system};
-use codec::Decode;
+use parity_codec::Decode;
 use sr_primitives::traits::{Hash as HashT, BlakeTwo256, Zero};
 use rstd::prelude::*;
+use srml_support::{decl_storage, decl_module};
 
 pub trait Trait: grandpa::Trait {}
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -20,59 +20,6 @@
 // `construct_runtime!` does a lot of recursion and requires us to increase the limit to 256.
 #![recursion_limit="256"]
 
-#[cfg(test)]
-#[macro_use]
-extern crate hex_literal;
-#[cfg(test)]
-extern crate secp256k1;
-#[cfg(test)]
-extern crate tiny_keccak;
-
-#[macro_use]
-extern crate bitvec;
-
-extern crate parity_codec_derive;
-extern crate parity_codec as codec;
-
-extern crate substrate_consensus_aura_primitives as consensus_aura;
-extern crate substrate_primitives;
-extern crate substrate_inherents as inherents;
-extern crate substrate_offchain_primitives as offchain_primitives;
-#[macro_use]
-extern crate substrate_client as client;
-
-extern crate sr_std as rstd;
-extern crate sr_io;
-extern crate sr_version as version;
-#[macro_use]
-extern crate sr_primitives;
-
-#[macro_use]
-extern crate srml_support;
-extern crate srml_aura as aura;
-extern crate srml_balances as balances;
-extern crate srml_consensus as consensus;
-extern crate srml_council as council;
-extern crate srml_democracy as democracy;
-extern crate srml_executive as executive;
-extern crate srml_grandpa as grandpa;
-extern crate srml_indices as indices;
-extern crate srml_session as session;
-extern crate srml_staking as staking;
-extern crate srml_sudo as sudo;
-extern crate srml_system as system;
-extern crate srml_timestamp as timestamp;
-extern crate srml_treasury as treasury;
-extern crate substrate_consensus_authorities as consensus_authorities;
-
-extern crate polkadot_primitives as primitives;
-
-#[cfg(test)]
-extern crate substrate_keyring as keyring;
-
-#[cfg(test)]
-extern crate substrate_trie;
-
 mod curated_grandpa;
 mod parachains;
 mod claims;
@@ -87,10 +34,10 @@ use primitives::{
 };
 use client::{
 	block_builder::api::{self as block_builder_api, InherentData, CheckInherentsResult},
-	runtime_api as client_api,
+	runtime_api as client_api, impl_runtime_apis,
 };
 use sr_primitives::{
-	ApplyResult, generic, transaction_validity::TransactionValidity,
+	ApplyResult, generic, transaction_validity::TransactionValidity, create_runtime_str,
 	traits::{
 		BlakeTwo256, Block as BlockT, DigestFor, StaticLookup, Convert, AuthorityIdFor
 	}
@@ -103,6 +50,7 @@ use council::seats as council_seats;
 #[cfg(any(feature = "std", test))]
 use version::NativeVersion;
 use substrate_primitives::OpaqueMetadata;
+use srml_support::{parameter_types, construct_runtime};
 
 #[cfg(feature = "std")]
 pub use staking::StakerStatus;

--- a/runtime/src/slot_range.rs
+++ b/runtime/src/slot_range.rs
@@ -19,6 +19,7 @@
 
 use rstd::{result, ops::Add, convert::{TryFrom, TryInto}};
 use sr_primitives::traits::CheckedSub;
+use parity_codec::{Encode, Decode};
 
 /// Total number of possible sub ranges of slots.
 pub const SLOT_RANGE_COUNT: usize = 10;

--- a/runtime/src/slots.rs
+++ b/runtime/src/slots.rs
@@ -20,8 +20,8 @@
 
 use rstd::{prelude::*, mem::swap, convert::TryInto};
 use sr_primitives::traits::{CheckedSub, StaticLookup, Zero, One, CheckedConversion, Hash};
-use codec::Decode;
-use srml_support::{decl_module, decl_storage, decl_event, StorageValue, StorageMap,
+use parity_codec::{Encode, Decode};
+use srml_support::{decl_module, decl_storage, decl_event, StorageValue, StorageMap, ensure,
 	traits::{Currency, ReservableCurrency, WithdrawReason, ExistenceRequirement, Get}};
 use primitives::parachain::AccountIdConversion;
 use crate::parachains::ParachainRegistrar;
@@ -785,7 +785,7 @@ mod tests {
 		traits::{BlakeTwo256, Hash, IdentityLookup, OnInitialize, OnFinalize},
 		testing::{Digest, DigestItem, Header}
 	};
-	use srml_support::{impl_outer_origin, assert_ok};
+	use srml_support::{impl_outer_origin, parameter_types, assert_ok, assert_noop};
 	use balances;
 	use primitives::parachain::Id as ParaId;
 

--- a/runtime/wasm/Cargo.toml
+++ b/runtime/wasm/Cargo.toml
@@ -2,6 +2,7 @@
 name = "polkadot-runtime-wasm"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2018"
 
 [lib]
 name = "polkadot_runtime"

--- a/runtime/wasm/src/lib.rs
+++ b/runtime/wasm/src/lib.rs
@@ -18,5 +18,4 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-extern crate polkadot_runtime;
 pub use polkadot_runtime::*;

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -2,6 +2,7 @@
 name = "polkadot-service"
 version = "0.5.0"
 authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2018"
 
 [dependencies]
 parking_lot = "0.7.1"
@@ -10,22 +11,22 @@ lazy_static = "1.0"
 log = "0.4.6"
 slog = "^2"
 tokio = "0.1.7"
-hex-literal = "0.1"
-polkadot-availability-store = { path = "../availability-store" }
-polkadot-validation = { path = "../validation" }
+hex-literal = "0.2"
+av_store = { package = "polkadot-availability-store", path = "../availability-store" }
+consensus = { package = "polkadot-validation", path = "../validation" }
 polkadot-primitives = { path = "../primitives" }
 polkadot-runtime = { path = "../runtime" }
 polkadot-executor = { path = "../executor" }
 polkadot-network = { path = "../network"  }
 sr-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
 sr-primitives = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-substrate-primitives = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-substrate-client = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-substrate-consensus-aura = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-substrate-consensus-common = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-substrate-finality-grandpa = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-substrate-inherents = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-substrate-service = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-substrate-telemetry = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-substrate-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+primitives = { package = "substrate-primitives", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+client = { package = "substrate-client", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+aura = { package = "substrate-consensus-aura", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+consensus_common = { package = "substrate-consensus-common", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+grandpa = { package = "substrate-finality-grandpa", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+inherents = { package = "substrate-inherents", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+service = { package = "substrate-service", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+telemetry = { package = "substrate-telemetry", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+transaction_pool = { package = "substrate-transaction-pool", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
 substrate-keystore = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }

--- a/service/src/chain_spec.rs
+++ b/service/src/chain_spec.rs
@@ -25,6 +25,7 @@ use polkadot_runtime::{
 	CuratedGrandpaConfig, StakerStatus,
 };
 use telemetry::TelemetryEndpoints;
+use hex_literal::hex;
 
 const STAGING_TELEMETRY_URL: &str = "wss://telemetry.polkadot.io/submit/";
 const DEFAULT_PROTOCOL_ID: &str = "dot";

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -16,30 +16,6 @@
 
 //! Polkadot service. Specialized wrapper over substrate service.
 
-extern crate polkadot_availability_store as av_store;
-extern crate polkadot_validation as consensus;
-extern crate polkadot_primitives;
-extern crate polkadot_runtime;
-extern crate polkadot_executor;
-extern crate polkadot_network;
-extern crate sr_primitives;
-extern crate substrate_primitives as primitives;
-extern crate substrate_client as client;
-#[macro_use]
-extern crate substrate_service as service;
-extern crate substrate_consensus_aura as aura;
-extern crate substrate_consensus_common as consensus_common;
-extern crate substrate_finality_grandpa as grandpa;
-extern crate substrate_transaction_pool as transaction_pool;
-extern crate substrate_telemetry as telemetry;
-extern crate tokio;
-extern crate substrate_inherents as inherents;
-
-#[macro_use]
-extern crate log;
-#[macro_use]
-extern crate hex_literal;
-
 pub mod chain_spec;
 
 use client::LongestChain;
@@ -55,6 +31,7 @@ use service::{FactoryFullConfiguration, FullBackend, LightBackend, FullExecutor,
 use transaction_pool::txpool::{Pool as TransactionPool};
 use aura::{import_queue, start_aura, AuraImportQueue, SlotDuration, NothingExtra};
 use inherents::InherentDataProviders;
+use log::info;
 pub use service::{
 	Roles, PruningMode, TransactionPoolOptions, ComponentClient,
 	Error, ComponentBlock, LightComponents, FullComponents,
@@ -169,7 +146,7 @@ impl PolkadotService for Service<LightComponents<Factory>> {
 	}
 }
 
-construct_service_factory! {
+service::construct_service_factory! {
 	struct Factory {
 		Block = Block,
 		RuntimeApi = RuntimeApi,

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,10 +18,6 @@
 
 #![warn(missing_docs)]
 
-extern crate polkadot_cli as cli;
-extern crate ctrlc;
-extern crate futures;
-
 use cli::{PolkadotService, VersionInfo, TaskExecutor};
 use futures::sync::oneshot;
 use futures::{future, Future};

--- a/statement-table/Cargo.toml
+++ b/statement-table/Cargo.toml
@@ -2,9 +2,9 @@
 name = "polkadot-statement-table"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2018"
 
 [dependencies]
-parity-codec = "3.0"
-parity-codec-derive = "3.0"
+parity-codec = { version = "3.0", features = ["derive"] }
 substrate-primitives = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-polkadot-primitives = { path = "../primitives" }
+primitives = { package = "polkadot-primitives", path = "../primitives" }

--- a/statement-table/src/generic.rs
+++ b/statement-table/src/generic.rs
@@ -28,6 +28,8 @@ use std::collections::hash_map::{HashMap, Entry};
 use std::hash::Hash;
 use std::fmt::Debug;
 
+use parity_codec::{Encode, Decode};
+
 /// Context for the statement table.
 pub trait Context {
 	/// A authority ID

--- a/statement-table/src/lib.rs
+++ b/statement-table/src/lib.rs
@@ -14,13 +14,6 @@
 //! propose and attest to validity of candidates, and those who can only attest
 //! to availability.
 
-extern crate parity_codec as codec;
-extern crate substrate_primitives;
-extern crate polkadot_primitives as primitives;
-
-#[macro_use]
-extern crate parity_codec_derive;
-
 pub mod generic;
 
 pub use generic::Table;

--- a/test-parachains/adder/Cargo.toml
+++ b/test-parachains/adder/Cargo.toml
@@ -3,9 +3,9 @@ name = "adder"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Test parachain which adds to a number as its state transition"
+edition = "2018"
 
 [dependencies]
-polkadot-parachain = { path = "../../parachain/", default-features = false }
-parity-codec = { version = "3.5", default-features = false }
-parity-codec-derive = { version = "3.3", default-features = false }
+parachain = { package = "polkadot-parachain", path = "../../parachain/", default-features = false }
+parity-codec = { version = "3.5", default-features = false, features = ["derive"] }
 tiny-keccak = "1.4"

--- a/test-parachains/adder/collator/Cargo.toml
+++ b/test-parachains/adder/collator/Cargo.toml
@@ -2,12 +2,13 @@
 name = "adder-collator"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2018"
 
 [dependencies]
 adder = { path = ".." }
-polkadot-parachain = { path = "../../../parachain" }
-polkadot-collator = { path = "../../../collator" }
-polkadot-primitives = { path = "../../../primitives" }
+parachain = { package = "polkadot-parachain", path = "../../../parachain" }
+collator = { package = "polkadot-collator", path = "../../../collator" }
+primitives = { package = "polkadot-primitives", path = "../../../primitives" }
 substrate-primitives = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
 parking_lot = "0.7.1"
 ctrlc = { version = "3.0", features = ["termination"] }

--- a/test-parachains/adder/collator/src/main.rs
+++ b/test-parachains/adder/collator/src/main.rs
@@ -16,16 +16,6 @@
 
 //! Collator for polkadot
 
-extern crate adder;
-extern crate substrate_primitives;
-extern crate polkadot_parachain as parachain;
-extern crate polkadot_primitives as primitives;
-extern crate polkadot_collator as collator;
-extern crate parking_lot;
-extern crate ctrlc;
-extern crate futures;
-extern crate exit_future;
-
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/test-parachains/adder/src/lib.rs
+++ b/test-parachains/adder/src/lib.rs
@@ -18,12 +18,6 @@
 
 #![no_std]
 
-#[macro_use]
-extern crate parity_codec_derive;
-extern crate parity_codec;
-extern crate polkadot_parachain as parachain;
-extern crate tiny_keccak;
-
 use parity_codec::{Encode, Decode};
 
 /// Head data for this parachain.

--- a/test-parachains/adder/wasm/Cargo.toml
+++ b/test-parachains/adder/wasm/Cargo.toml
@@ -2,10 +2,11 @@
 name = "adder-wasm"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2018"
 
 [dependencies]
 adder = { path = ".." }
-polkadot-parachain = { path = "../../../parachain", default-features = false, features = ["wasm-api"] }
+parachain = { package = "polkadot-parachain", path = "../../../parachain", default-features = false, features = ["wasm-api"] }
 tiny-keccak = "1.4"
 dlmalloc = { version = "0.1.2", features = ["global"] }
 

--- a/test-parachains/adder/wasm/src/lib.rs
+++ b/test-parachains/adder/wasm/src/lib.rs
@@ -22,12 +22,6 @@
 	alloc, core_intrinsics, lang_items, core_panic_info, alloc_error_handler
 )]
 
-extern crate alloc;
-extern crate adder;
-extern crate polkadot_parachain as parachain;
-extern crate tiny_keccak;
-extern crate dlmalloc;
-
 #[global_allocator]
 static ALLOC: dlmalloc::GlobalDlmalloc = dlmalloc::GlobalDlmalloc;
 

--- a/validation/Cargo.toml
+++ b/validation/Cargo.toml
@@ -2,6 +2,7 @@
 name = "polkadot-validation"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2018"
 
 [dependencies]
 futures = "0.1.17"
@@ -11,23 +12,23 @@ error-chain = "0.12"
 log = "0.4.6"
 exit-future = "0.1"
 parity-codec = "3.1"
-polkadot-availability-store = { path = "../availability-store" }
-polkadot-parachain = { path = "../parachain" }
+extrinsic_store = { package = "polkadot-availability-store", path = "../availability-store" }
+parachain = { package = "polkadot-parachain", path = "../parachain" }
 polkadot-primitives = { path = "../primitives" }
 polkadot-runtime = { path = "../runtime" }
-polkadot-statement-table = { path = "../statement-table" }
-substrate-consensus-aura = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-substrate-consensus-aura-primitives = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-substrate-finality-grandpa = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-substrate-inherents = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-substrate-consensus-common = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-substrate-primitives = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-substrate-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-srml-aura = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-substrate-client = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-substrate-trie = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sr-primitives = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-substrate-consensus-authorities = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+table = { package = "polkadot-statement-table", path = "../statement-table" }
+aura = { package = "substrate-consensus-aura", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+aura_primitives = { package = "substrate-consensus-aura-primitives", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+grandpa = { package = "substrate-finality-grandpa", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+inherents = { package = "substrate-inherents", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+consensus = { package = "substrate-consensus-common", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+primitives = { package = "substrate-primitives", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+transaction_pool = { package = "substrate-transaction-pool", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+runtime_aura = { package = "srml-aura", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+client = { package = "substrate-client", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+trie = { package = "substrate-trie", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+runtime_primitives = { package = "sr-primitives", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+consensus_authorities = { package = "substrate-consensus-authorities", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
 
 [dev-dependencies]
 substrate-keyring = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }

--- a/validation/src/attestation_service.rs
+++ b/validation/src/attestation_service.rs
@@ -42,6 +42,7 @@ use runtime_primitives::traits::{ProvideRuntimeApi, Header as HeaderT};
 use tokio::runtime::TaskExecutor;
 use tokio::runtime::current_thread::Runtime as LocalRuntime;
 use tokio::timer::Interval;
+use log::{warn, debug};
 
 use super::{Network, Collators};
 
@@ -49,7 +50,7 @@ use super::{Network, Collators};
 pub(crate) fn fetch_candidates<P: BlockBody<Block>>(client: &P, block: &BlockId)
 	-> ClientResult<Option<impl Iterator<Item=CandidateReceipt>>>
 {
-	use codec::{Encode, Decode};
+	use parity_codec::{Encode, Decode};
 	use polkadot_runtime::{Call, ParachainsCall, UncheckedExtrinsic as RuntimeExtrinsic};
 
 	let extrinsics = client.block_body(block)?;
@@ -106,7 +107,7 @@ pub(crate) struct ServiceHandle {
 pub(crate) fn start<C, N, P, SC>(
 	client: Arc<P>,
 	select_chain: SC,
-	parachain_validation: Arc<::ParachainValidation<C, N, P>>,
+	parachain_validation: Arc<crate::ParachainValidation<C, N, P>>,
 	thread_pool: TaskExecutor,
 	key: Arc<ed25519::Pair>,
 	extrinsic_store: ExtrinsicStore,

--- a/validation/src/collation.rs
+++ b/validation/src/collation.rs
@@ -31,6 +31,8 @@ use parachain::{wasm_executor::{self, ExternalitiesError}, MessageRef};
 use error_chain::bail;
 
 use futures::prelude::*;
+use error_chain::*;
+use log::debug;
 
 /// Encapsulates connections to collators and allows collation on any parachain.
 ///
@@ -113,7 +115,7 @@ impl<C: Collators, P: ProvideRuntimeApi> Future for CollationFetch<C, P>
 					.get_or_insert_with(move || c.collate(parachain, r).into_future())
 					.poll();
 
-				try_ready!(poll)
+				futures::try_ready!(poll)
 			};
 
 			let res = validate_collation(&*self.client, &self.relay_parent, &collation, self.max_block_data_size);

--- a/validation/src/error.rs
+++ b/validation/src/error.rs
@@ -17,8 +17,8 @@
 //! Errors that can occur during the validation process.
 
 use runtime_primitives::RuntimeString;
-
 use primitives::ed25519::Public as AuthorityId;
+use error_chain::*;
 
 error_chain! {
 	foreign_links {

--- a/validation/src/evaluation.rs
+++ b/validation/src/evaluation.rs
@@ -18,9 +18,10 @@
 
 use super::MAX_TRANSACTIONS_SIZE;
 
-use codec::Encode;
+use parity_codec::Encode;
 use polkadot_primitives::{Block, Hash, BlockNumber};
 use polkadot_primitives::parachain::Id as ParaId;
+use error_chain::*;
 
 error_chain! {
 	foreign_links {


### PR DESCRIPTION
Additionally the `cli::informant::start` deprecation warning has been fixed.