### PR TITLE
Require --locked on CI for WASM runtime locks

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -84,7 +84,7 @@ test-linux-stable:                 &test
     variables:
       - $DEPLOY_TAG
   script:
-    - ./scripts/build.sh
+    - ./scripts/build.sh --locked
     - time cargo test --all --release --verbose --locked
     - sccache -s
 
@@ -107,7 +107,7 @@ build-linux-release:               &build
   tags:
     - linux-docker
   script:
-    - ./scripts/build.sh
+    - ./scripts/build.sh --locked
     - time cargo build --release --verbose
     - mkdir -p ./artifacts
     - mv ./target/release/polkadot ./artifacts/.

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -23,6 +23,6 @@ case $TARGET in
 	"wasm")
 		# Install prerequisites and build all wasm projects
 		./scripts/init.sh
-		./scripts/build.sh
+		./scripts/build.sh --locked
 		;;
 esac

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -17,12 +17,12 @@ case $TARGET in
 		sudo apt-get -y update
 		sudo apt-get install -y cmake pkg-config libssl-dev
 
-		cargo test --all --locked
+		cargo test --all --locked "$@"
 		;;
 
 	"wasm")
 		# Install prerequisites and build all wasm projects
 		./scripts/init.sh
-		./scripts/build.sh --locked
+		./scripts/build.sh --locked "$@"
 		;;
 esac

--- a/runtime/wasm/Cargo.lock
+++ b/runtime/wasm/Cargo.lock
@@ -2425,6 +2425,7 @@ version = "2.0.0"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#54d028551b11f40266628ceeb35bec0595d360c3"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
  "sr-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
  "srml-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",

--- a/runtime/wasm/build.sh
+++ b/runtime/wasm/build.sh
@@ -6,7 +6,7 @@ if cargo --version | grep -q "nightly"; then
 else
 	CARGO_CMD="cargo +nightly"
 fi
-RUSTFLAGS="-C link-arg=--export-table" $CARGO_CMD build --target=wasm32-unknown-unknown --release
+RUSTFLAGS="-C link-arg=--export-table" $CARGO_CMD build --target=wasm32-unknown-unknown --release $@
 for i in polkadot_runtime
 do
 	wasm-gc target/wasm32-unknown-unknown/release/$i.wasm target/wasm32-unknown-unknown/release/$i.compact.wasm

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -19,7 +19,7 @@ do
   echo "*** Building wasm binaries in $SRC"
   cd "$PROJECT_ROOT/$SRC"
 
-  ./build.sh
+  ./build.sh $@
 
   cd - >> /dev/null
 done

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -19,7 +19,7 @@ do
   echo "*** Building wasm binaries in $SRC"
   cd "$PROJECT_ROOT/$SRC"
 
-  ./build.sh $@
+  ./build.sh "$@"
 
   cd - >> /dev/null
 done

--- a/test-parachains/build.sh
+++ b/test-parachains/build.sh
@@ -7,7 +7,7 @@ export RUSTFLAGS="-C link-arg=--import-memory -C link-arg=--export-table -C pani
 for i in adder
 do
 	cd $i/wasm
-	cargo +nightly build --target=wasm32-unknown-unknown --release --no-default-features --target-dir target
+	cargo +nightly build --target=wasm32-unknown-unknown --release --no-default-features --target-dir target $@
 	wasm-gc target/wasm32-unknown-unknown/release/$i'_'wasm.wasm target/wasm32-unknown-unknown/release/$i.wasm
 	cp target/wasm32-unknown-unknown/release/$i.wasm ../../../parachain/tests/res/
 	rm -rf target

--- a/test-parachains/build.sh
+++ b/test-parachains/build.sh
@@ -7,7 +7,7 @@ export RUSTFLAGS="-C link-arg=--import-memory -C link-arg=--export-table -C pani
 for i in adder
 do
 	cd $i/wasm
-	cargo +nightly build --target=wasm32-unknown-unknown --release --no-default-features --target-dir target $@
+	cargo +nightly build --target=wasm32-unknown-unknown --release --no-default-features --target-dir target "$@"
 	wasm-gc target/wasm32-unknown-unknown/release/$i'_'wasm.wasm target/wasm32-unknown-unknown/release/$i.wasm
 	cp target/wasm32-unknown-unknown/release/$i.wasm ../../../parachain/tests/res/
 	rm -rf target


### PR DESCRIPTION
Same change as https://github.com/paritytech/substrate/pull/2813

There seems to be a `ci/script.sh` script which I update as well but that seems unused.