### PR TITLE
Port dev account balance changes from Substrate PR 2883 to Polkadot

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -83,15 +83,14 @@ pub fn native_version() -> NativeVersion {
 	}
 }
 
-const DOTS: Balance = 1_000_000_000_000;
-const BUCKS: Balance = DOTS / 100;
-const CENTS: Balance = BUCKS / 100;
-const MILLICENTS: Balance = CENTS / 1_000;
+pub const MILLICENTS: Balance = 1_000_000_000;
+pub const CENTS: Balance = 1_000 * MILLICENTS;    // assume this is worth about a cent.
+pub const DOLLARS: Balance = 100 * CENTS;
 
-const SECS_PER_BLOCK: BlockNumber = 6;
-const MINUTES: BlockNumber = 60 / SECS_PER_BLOCK;
-const HOURS: BlockNumber = MINUTES * 60;
-const DAYS: BlockNumber = HOURS * 24;
+pub const SECS_PER_BLOCK: BlockNumber = 6;
+pub const MINUTES: BlockNumber = 60 / SECS_PER_BLOCK;
+pub const HOURS: BlockNumber = MINUTES * 60;
+pub const DAYS: BlockNumber = HOURS * 24;
 
 parameter_types! {
 	pub const BlockHashCount: u64 = 250;
@@ -123,7 +122,7 @@ impl indices::Trait for Runtime {
 }
 
 parameter_types! {
-	pub const ExistentialDeposit: Balance = 1 * BUCKS;
+	pub const ExistentialDeposit: Balance = 1 * DOLLARS;
 	pub const TransferFee: Balance = 1 * CENTS;
 	pub const CreationFee: Balance = 1 * CENTS;
 	pub const TransactionBaseFee: Balance = 1 * CENTS;
@@ -257,7 +256,7 @@ parameter_types! {
 	pub const LaunchPeriod: BlockNumber = 28 * 24 * 60 * MINUTES;
 	pub const VotingPeriod: BlockNumber = 28 * 24 * 60 * MINUTES;
 	pub const EmergencyVotingPeriod: BlockNumber = 3 * 24 * 60 * MINUTES;
-	pub const MinimumDeposit: Balance = 100 * BUCKS;
+	pub const MinimumDeposit: Balance = 100 * DOLLARS;
 	pub const EnactmentPeriod: BlockNumber = 30 * 24 * 60 * MINUTES;
 	pub const CooloffPeriod: BlockNumber = 30 * 24 * 60 * MINUTES;
 }
@@ -288,9 +287,9 @@ impl collective::Trait<CouncilInstance> for Runtime {
 }
 
 parameter_types! {
-	pub const CandidacyBond: Balance = 10 * BUCKS;
-	pub const VotingBond: Balance = 1 * BUCKS;
-	pub const VotingFee: Balance = 2 * BUCKS;
+	pub const CandidacyBond: Balance = 10 * DOLLARS;
+	pub const VotingBond: Balance = 1 * DOLLARS;
+	pub const VotingFee: Balance = 2 * DOLLARS;
 	pub const PresentSlashPerVoter: Balance = 1 * CENTS;
 	pub const CarryCount: u32 = 6;
 	// one additional vote should go by before an inactive voter can be reaped.
@@ -326,7 +325,7 @@ impl collective::Trait<TechnicalInstance> for Runtime {
 
 parameter_types! {
 	pub const ProposalBond: Permill = Permill::from_percent(5);
-	pub const ProposalBondMinimum: Balance = 1 * BUCKS;
+	pub const ProposalBondMinimum: Balance = 1 * DOLLARS;
 	pub const SpendPeriod: BlockNumber = 1 * DAYS;
 	pub const Burn: Permill = Permill::from_percent(50);
 }

--- a/service/src/chain_spec.rs
+++ b/service/src/chain_spec.rs
@@ -21,7 +21,7 @@ use polkadot_primitives::{AccountId, SessionKey};
 use polkadot_runtime::{
 	GenesisConfig, CouncilConfig, ElectionsConfig, DemocracyConfig, SystemConfig, AuraConfig,
 	SessionConfig, StakingConfig, BalancesConfig, Perbill, SessionKeys, TechnicalCommitteeConfig,
-	GrandpaConfig, SudoConfig, IndicesConfig, CuratedGrandpaConfig, StakerStatus, WASM_BINARY,
+	GrandpaConfig, SudoConfig, IndicesConfig, CuratedGrandpaConfig, StakerStatus, WASM_BINARY, DAYS, DOLLARS,
 };
 use telemetry::TelemetryEndpoints;
 use hex_literal::hex;
@@ -61,15 +61,6 @@ fn staging_testnet_config_genesis() -> GenesisConfig {
 		hex!["123b9048ba61265547ad3f336dfa48c16851ba1a96691e5d1ab3be1725db0614"].unchecked_into(), // 5CUcQvAgMzXMpQSz8mgzeiswDFHED88NiEK4byfS5TLaTJow
 		hex!["8abecfa66704176be23df099bf441ea65444992d63b3ced3e76a17a4d38b0b0e"].unchecked_into(), // 5FCd9Y7RLNyxz5wnCAErfsLbXGG34L2BaZRHzhiJcMUMd5zd
 	)];
-
-	const MILLICENTS: u128 = 1_000_000_000;
-	const CENTS: u128 = 1_000 * MILLICENTS;    // assume this is worth about a cent.
-	const DOLLARS: u128 = 100 * CENTS;
-
-	const SECS_PER_BLOCK: u64 = 6;
-	const MINUTES: u64 = 60 / SECS_PER_BLOCK;
-	const HOURS: u64 = MINUTES * 60;
-	const DAYS: u64 = HOURS * 24;
 
 	const ENDOWMENT: u128 = 10_000_000 * DOLLARS;
 	const STASH: u128 = 100 * DOLLARS;
@@ -200,8 +191,9 @@ pub fn testnet_genesis(
 		]
 	});
 
-	const STASH: u128 = 1 << 20;
-	const ENDOWMENT: u128 = 1 << 20;
+	const ENDOWMENT: u128 = 10_000_000 * DOLLARS;
+	const STASH: u128 = 100 * DOLLARS;
+
 	let desired_seats = (endowed_accounts.len() / 2 - initial_authorities.len()) as u32;
 
 	GenesisConfig {


### PR DESCRIPTION
At the moment, the account balances of the dev accounts are less than the existential deposit in Polkadot Master / Kusama because some changes in the chain_spec from the following PR haven't been ported over.
https://github.com/paritytech/substrate/pull/2883/files#diff-5e5e1c3aec9ddfde0a9054d062ab3db9

That makes it impossible to run any extrinsics e2e tests against Kusama/ Master with the default chain_spec.
This PR is just a quick-fix to make testing on the JS API side possible again by bumping up the balances of the dev accounts.

The ExistentialDeposit is already (almost) up to date with Substrate Master (bumped up from `500`)
https://github.com/paritytech/polkadot/blob/87ab9f9bff2b89fd871f332df29834a3dca3fec0/runtime/src/lib.rs#L126

The part that is missing is this change:
```
- const STASH: u128 = 1 << 20;
- const ENDOWMENT: u128 = 1 << 20;
+ const ENDOWMENT: u128 = 10_000_000 * DOLLARS;
+ const STASH: u128 = 100 * DOLLARS;
```
