### PR TITLE
Propagate substrate#3225

### DIFF
--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -382,7 +382,12 @@ service::construct_service_factory! {
 		LightService = LightComponents<Self>
 			{ |config| <LightComponents<Factory>>::new(config) },
 		FullImportQueue = BabeImportQueue<Self::Block>
-			{ |config: &mut FactoryFullConfiguration<Self>, client: Arc<FullClient<Self>>, select_chain: Self::SelectChain| {
+			{ |
+				config: &mut FactoryFullConfiguration<Self>,
+				client: Arc<FullClient<Self>>,
+				select_chain: Self::SelectChain,
+				transaction_pool: Option<Arc<TransactionPool<Self::FullTransactionPoolApi>>>
+			| {
 				let (block_import, link_half) =
 					grandpa::block_import::<_, _, _, RuntimeApi, FullClient<Self>, _>(
 						client.clone(), client.clone(), select_chain
@@ -397,6 +402,7 @@ service::construct_service_factory! {
 					client.clone(),
 					client,
 					config.custom.inherent_data_providers.clone(),
+					transaction_pool,
 				)?;
 
 				config.custom.import_setup = Some((babe_block_import.clone(), link_half, babe_link));
@@ -419,7 +425,7 @@ service::construct_service_factory! {
 				let finality_proof_request_builder = finality_proof_import.create_finality_proof_request_builder();
 
 				// FIXME: pruning task isn't started since light client doesn't do `AuthoritySetup`.
-				let (import_queue, ..) = import_queue(
+				let (import_queue, ..) = import_queue::<_, _, _, _, _, _, TransactionPool<Self::FullTransactionPoolApi>>(
 					Config::get_or_compute(&*client)?,
 					block_import,
 					None,
@@ -427,6 +433,7 @@ service::construct_service_factory! {
 					client.clone(),
 					client,
 					config.custom.inherent_data_providers.clone(),
+					None,
 				)?;
 
 				Ok((import_queue, finality_proof_request_builder))


### PR DESCRIPTION
Propagates breaking change https://github.com/paritytech/substrate/pull/3225 to Polkadot.
I tested that blindly, as we don't have any branch that works on top of Substrate master.

cc @gavofyork 

This PR is more to show the diff to apply rather than to be merged.
Feel free to do `git cherry-pick 0db4d60d1dc679ff8fd643207d0a01e83779625a` and close this PR.