### PR TITLE
Blocktime and epoch length tweaks.

### DIFF
--- a/runtime/src/constants.rs
+++ b/runtime/src/constants.rs
@@ -28,9 +28,7 @@ pub mod currency {
 pub mod time {
 	use primitives::{Moment, BlockNumber};
 	pub const MILLISECS_PER_BLOCK: Moment = 6000;
-
-	pub const SLOT_DURATION: Moment = 6000;
-
+	pub const SLOT_DURATION: Moment = MILLISECS_PER_BLOCK;
 	pub const EPOCH_DURATION_IN_BLOCKS: BlockNumber = 4 * HOURS;
 
 	// These time units are defined in number of blocks.

--- a/runtime/src/constants.rs
+++ b/runtime/src/constants.rs
@@ -24,8 +24,7 @@ pub mod currency {
 	pub const MILLICENTS: Balance = CENTS / 1_000;
 }
 
-
-/// Time.
+/// Time and blocks.
 pub mod time {
 	use primitives::{Moment, BlockNumber};
 	pub const MILLISECS_PER_BLOCK: Moment = 6000;
@@ -38,6 +37,9 @@ pub mod time {
 	pub const MINUTES: BlockNumber = 60_000 / (MILLISECS_PER_BLOCK as BlockNumber);
 	pub const HOURS: BlockNumber = MINUTES * 60;
 	pub const DAYS: BlockNumber = HOURS * 24;
+
+	// 1 in 4 blocks (on average, not counting collisions) will be primary babe blocks.
+	pub const PRIMARY_PROBABILITY: (u64, u64) = (1, 4);
 }
 
 /// Fee-related.

--- a/runtime/src/constants.rs
+++ b/runtime/src/constants.rs
@@ -30,14 +30,9 @@ pub mod time {
 	use primitives::{Moment, BlockNumber};
 	pub const MILLISECS_PER_BLOCK: Moment = 6000;
 
-	pub const SLOT_DURATION: Moment = 1650;
+	pub const SLOT_DURATION: Moment = 6000;
 
-	pub const EPOCH_DURATION_IN_BLOCKS: BlockNumber = 10 * MINUTES;
-	pub const EPOCH_DURATION_IN_SLOTS: u64 = {
-		const SLOT_FILL_RATE: f64 = MILLISECS_PER_BLOCK as f64 / SLOT_DURATION as f64;
-
-		(EPOCH_DURATION_IN_BLOCKS as f64 * SLOT_FILL_RATE) as u64
-	};
+	pub const EPOCH_DURATION_IN_BLOCKS: BlockNumber = 4 * HOURS;
 
 	// These time units are defined in number of blocks.
 	pub const MINUTES: BlockNumber = 60_000 / (MILLISECS_PER_BLOCK as BlockNumber);

--- a/runtime/src/constants.rs
+++ b/runtime/src/constants.rs
@@ -27,9 +27,15 @@ pub mod currency {
 /// Time and blocks.
 pub mod time {
 	use primitives::{Moment, BlockNumber};
-	pub const MILLISECS_PER_BLOCK: Moment = 6000;
+	// Kusama & mainnet
+//	pub const MILLISECS_PER_BLOCK: Moment = 6000;
+	// Testnet
+	pub const MILLISECS_PER_BLOCK: Moment = 1000;
 	pub const SLOT_DURATION: Moment = MILLISECS_PER_BLOCK;
-	pub const EPOCH_DURATION_IN_BLOCKS: BlockNumber = 4 * HOURS;
+	// Kusama & mainnet
+//	pub const EPOCH_DURATION_IN_BLOCKS: BlockNumber = 4 * HOURS;
+	// Testnet
+	pub const EPOCH_DURATION_IN_BLOCKS: BlockNumber = 10 * MINUTES;
 
 	// These time units are defined in number of blocks.
 	pub const MINUTES: BlockNumber = 60_000 / (MILLISECS_PER_BLOCK as BlockNumber);

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -647,7 +647,7 @@ impl_runtime_apis! {
 			babe_primitives::BabeConfiguration {
 				median_required_blocks: 1000,
 				slot_duration: Babe::slot_duration(),
-				c: (278, 1000),
+				c: PRIMARY_PROBABILITY,
 			}
 		}
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -162,7 +162,7 @@ impl system::Trait for Runtime {
 }
 
 parameter_types! {
-	pub const EpochDuration: u64 = EPOCH_DURATION_IN_SLOTS;
+	pub const EpochDuration: u64 = EPOCH_DURATION_IN_BLOCKS as u64;
 	pub const ExpectedBlockTime: Moment = MILLISECS_PER_BLOCK;
 }
 

--- a/runtime/src/parachains.rs
+++ b/runtime/src/parachains.rs
@@ -969,7 +969,7 @@ mod tests {
 	}
 
 	parameter_types! {
-		pub const EpochDuration: u64 = EPOCH_DURATION_IN_SLOTS;
+		pub const EpochDuration: u64 = EPOCH_DURATION_IN_BLOCKS as u64;
 		pub const ExpectedBlockTime: u64 = MILLISECS_PER_BLOCK;
 	}
 


### PR DESCRIPTION
- P(primary blocks) = 0.25
- Kusama: 6 second block time, 4 hour epoch (session), 24 hour era.
- Testnet: 1 second block time, 10 minute epoch (session), 1 hour era.