### PR TITLE
Add networkId to Kusama chain spec

### DIFF
--- a/service/res/kusama.json
+++ b/service/res/kusama.json
@@ -13,6 +13,7 @@
   "protocolId": "dot",
   "consensusEngine": null,
   "properties": {
+		"networkId": 2,
 		"tokenDecimals": 15,
 		"tokenSymbol": "DOT"
   },

--- a/service/res/kusama.json
+++ b/service/res/kusama.json
@@ -13,7 +13,7 @@
   "protocolId": "dot",
   "consensusEngine": null,
   "properties": {
-		"networkId": 2,
+		"ss58Format": 2,
 		"tokenDecimals": 15,
 		"tokenSymbol": "DOT"
   },


### PR DESCRIPTION
This add the `networkId: 2` to the Kusama chain properties file. This is used by anything that connects to the network to determine the prefix to use as part of the ss-58 encoding. 

The spec no doubt needs a lot of updates as it stands, however making this PR so we have this on the horizon and it makes it into the final version. (We last used this property in BBQ)

Naming can really be anything that makes sense as to the context - `chainId`, `ss58Prefix`, ...