### PR TITLE
Better .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,2 @@
 doc
-target
+**/target


### PR DESCRIPTION
The previous pattern was not excluding all target folders.
This changes brings the amount passed to the first image from ~759MB down to ~113MB.

⇨ Better ⇨ Faster ⇨ Stronger  😋