### PR TITLE
Forward ported version bump

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -98,7 +98,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("kusama"),
 	impl_name: create_runtime_str!("parity-kusama"),
 	authoring_version: 1,
-	spec_version: 1001,
+	spec_version: 1002,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 };

--- a/runtime/src/parachains.rs
+++ b/runtime/src/parachains.rs
@@ -38,9 +38,6 @@ use srml_support::{
 use inherents::{ProvideInherent, InherentData, RuntimeString, MakeFatalError, InherentIdentifier};
 
 #[cfg(any(feature = "std", test))]
-use sr_primitives::{StorageOverlay, ChildrenStorageOverlay};
-
-#[cfg(any(feature = "std", test))]
 use rstd::marker::PhantomData;
 
 use system::{ensure_none, ensure_root};


### PR DESCRIPTION
as we saw in https://github.com/paritytech/polkadot/pull/415 the substrate update missed the version bump. This just fix it.