### PR TITLE
fix dockerfile build - upgrade image base from ubuntu 16 to 18

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/baseimage:0.10.2 as builder
+FROM phusion/baseimage:0.11 as builder
 LABEL maintainer "chevdor@gmail.com"
 LABEL description="This is the build stage for Polkadot. Here we create the binary."
 
@@ -17,7 +17,7 @@ RUN curl https://sh.rustup.rs -sSf | sh -s -- -y && \
 
 # ===== SECOND STAGE ======
 
-FROM phusion/baseimage:0.10.2
+FROM phusion/baseimage:0.11
 LABEL maintainer "chevdor@gmail.com"
 LABEL description="This is the 2nd stage: a very small image where we copy the Polkadot binary."
 ARG PROFILE=release


### PR DESCRIPTION
Current dockerfile build failed at `apt-get` commands with the following error : 
```
Configuration file '/etc/cron.weekly/fstrim'
 ==> Deleted (by you or by a script) since installation.
 ==> Package distributor has shipped an updated version.
   What would you like to do about it ?  Your options are:
    Y or I  : install the package maintainer's version
    N or O  : keep your currently-installed version
      D     : show the differences between the versions
      Z     : start a shell to examine the situation
 The default action is to keep your current version.
*** fstrim (Y/I/N/O/D/Z) [default=N] ? dpkg: error processing package util-linux (--configure):
 end of file on stdin at conffile prompt
Errors were encountered while processing:
 util-linux
E: Sub-process /usr/bin/dpkg returned an error code (1)
```

Upgrade image base from phusion/baseimage:0.10.2 to phusion/baseimage:0.11 solves it.

Note that this new image base switch from ubuntu 16 to ubuntu 18.
