### PR TITLE
grandpa: set justification period to 512 blocks

### DIFF
--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -283,7 +283,7 @@ pub fn new_full(config: Configuration<CustomConfiguration, GenesisConfig>)
 	let config = grandpa::Config {
 		// FIXME substrate#1578 make this available through chainspec
 		gossip_duration: Duration::from_millis(333),
-		justification_period: 4096,
+		justification_period: 512,
 		name: Some(name),
 		keystore: Some(service.keystore()),
 	};


### PR DESCRIPTION
Was previously added in v0.5.2 (https://github.com/paritytech/polkadot/pull/439) as well. To avoid long stretches of unfinalized blocks when syncing, particularly when there aren't many (or no) authority changes.