### PR TITLE
Enable `substrate-session` `std` feature and remove unused traits

### DIFF
--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -110,4 +110,5 @@ std = [
 	"safe-mix/std",
 	"babe/std",
 	"babe-primitives/std",
+	"substrate-session/std",
 ]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -67,7 +67,6 @@ pub use timestamp::Call as TimestampCall;
 pub use balances::Call as BalancesCall;
 pub use attestations::{Call as AttestationsCall, MORE_ATTESTATIONS_IDENTIFIER};
 pub use parachains::{Call as ParachainsCall, NEW_HEADS_IDENTIFIER};
-pub use srml_support::StorageValue;
 
 /// Implementations of some helper traits passed into runtime modules as associated types.
 pub mod impls;

--- a/runtime/src/slots.rs
+++ b/runtime/src/slots.rs
@@ -23,7 +23,7 @@ use sr_primitives::traits::{CheckedSub, StaticLookup, Zero, One, CheckedConversi
 use sr_primitives::weights::SimpleDispatchInfo;
 use codec::{Encode, Decode};
 use srml_support::{
-	decl_module, decl_storage, decl_event, StorageMap, ensure,
+	decl_module, decl_storage, decl_event, ensure,
 	traits::{Currency, ReservableCurrency, WithdrawReason, ExistenceRequirement, Get},
 };
 use primitives::parachain::AccountIdConversion;


### PR DESCRIPTION
Closes: https://github.com/paritytech/substrate/issues/3718