### PR TITLE
Some Fixes to Parathread Compile

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -486,6 +486,8 @@ impl parachains::Trait for Runtime {
 
 parameter_types! {
 	pub const ParathreadDeposit: Balance = 500 * DOLLARS;
+	pub const QueueSize: usize = 2;
+	pub const MaxRetries: u32 = 3;
 }
 
 impl registrar::Trait for Runtime {
@@ -494,6 +496,8 @@ impl registrar::Trait for Runtime {
 	type Currency = Balances;
 	type ParathreadDeposit = ParathreadDeposit;
 	type SwapAux = Slots;
+	type QueueSize = QueueSize;
+	type MaxRetries = MaxRetries;
 }
 
 parameter_types!{

--- a/runtime/src/parachains.rs
+++ b/runtime/src/parachains.rs
@@ -1064,6 +1064,8 @@ mod tests {
 
 	parameter_types! {
 		pub const ParathreadDeposit: Balance = 10;
+		pub const QueueSize: usize = 2;
+		pub const MaxRetries: u32 = 3;
 	}
 
 	impl registrar::Trait for Test {
@@ -1072,6 +1074,8 @@ mod tests {
 		type Currency = balances::Module<Test>;
 		type ParathreadDeposit = ParathreadDeposit;
 		type SwapAux = slots::Module<Test>;
+		type QueueSize = QueueSize;
+		type MaxRetries = MaxRetries;
 	}
 
 	impl Trait for Test {
@@ -1575,7 +1579,7 @@ mod tests {
 			assert_eq!(Parachains::parachain_code(ParaId::from(5u32)), Some(vec![1,2,3]));
 			assert_eq!(Parachains::parachain_code(ParaId::from(100u32)), Some(vec![4,5,6]));
 
-			assert_ok!(Registrar::register_para(Origin::ROOT, 99u32.into(), vec![7,8,9], vec![1, 1, 1], ParaInfo{scheduling: Scheduling::Always}));
+			assert_ok!(Registrar::register_para(Origin::ROOT, 99u32.into(), ParaInfo{scheduling: Scheduling::Always}, vec![7,8,9], vec![1, 1, 1]));
 			assert_ok!(Parachains::set_heads(Origin::NONE, vec![]));
 
 			run_to_block(3);

--- a/runtime/src/registrar.rs
+++ b/runtime/src/registrar.rs
@@ -130,7 +130,7 @@ pub trait Trait: parachains::Trait {
 	type QueueSize: Get<usize>;
 
 	/// The number of rotations that you will have as grace if you miss a block.
-	const MAX_RETRIES: u32;
+	type MaxRetries: Get<u32>;
 }
 
 decl_storage! {
@@ -165,7 +165,7 @@ decl_storage! {
 		Paras get(paras): map ParaId => Option<ParaInfo>;
 
 		/// The current queue for parathreads that should be retried.
-		RetryQueue get(retry_queue): [Vec<(ParaId, CollatorId)>; T::MAX_RETRIES as usize];
+		RetryQueue get(retry_queue): [Vec<(ParaId, CollatorId)>; T::MaxRetries::get() as usize];
 
 		/// Users who have paid a parathread's deposit
 		Debtors: map ParaId => T::AccountId;
@@ -436,7 +436,7 @@ impl<T: Trait> Module<T> {
 	}
 
 	fn retry_later(sched: (ParaId, CollatorId), retries: u32) {
-		if retries < T::MAX_RETRIES {
+		if retries < T::MaxRetries::get() {
 			RetryQueue::mutate(|q| q[retries as usize].push(sched));
 		}
 	}
@@ -711,6 +711,7 @@ mod tests {
 	parameter_types! {
 		pub const ParathreadDeposit: Balance = 10;
 		pub const QueueSize: usize = 2;
+		pub const MaxRetries: u32 = 3;
 	}
 
 	impl Trait for Test {
@@ -720,7 +721,7 @@ mod tests {
 		type ParathreadDeposit = ParathreadDeposit;
 		type SwapAux = slots::Module<Test>;
 		type QueueSize = QueueSize;
-		const MAX_RETRIES: u32 = 3;
+		type MaxRetries = MaxRetries;
 	}
 
 	type Balances = balances::Module<Test>;
@@ -1344,7 +1345,7 @@ mod tests {
 			);
 
 			// Assuming Queue Size is 2
-			assert_eq!(Test::QueueSize::get(), 2);
+			assert_eq!(<Test as self::Trait>::QueueSize::get(), 2);
 
 			// 2 blocks later
 			run_to_block(5);


### PR DESCRIPTION
- [ ] Need to fix `queue_upward_messages` and how to update the `NeedsDispatch` storage item.

    Something like `Vec::insert(&mut ordered_needs_dispatch.to_vec(), i, id);` allows it to compile, but it does not actually update storage since `to_vec()` makes a copy of the slice, and we need to update the original slice.

- [ ] Need to fix `RetryQueue` storage declaration. Cannot seem to use `T::MaxRetries::get() as usize` since it does not find the trait... Hard-coding the value `3` allows it to compile.