### PR TITLE
service: don't use the grandpa observer

### DIFF
--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -258,7 +258,6 @@ pub fn new_full(config: Configuration<CustomConfiguration, GenesisConfig>)
 		};
 
 		let babe = babe::start_babe(babe_config)?;
-		let babe = babe.select(service.on_exit()).then(|_| Ok(()));
 		service.spawn_essential_task(babe);
 	}
 

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -259,8 +259,8 @@ pub fn new_full(config: Configuration<CustomConfiguration, GenesisConfig>)
 		};
 
 		let babe = start_babe(babe_config)?;
-		let select = babe.select(service.on_exit()).then(|_| Ok(()));
-		service.spawn_essential_task(Box::new(select));
+		let babe = babe.select(service.on_exit()).then(|_| Ok(()));
+		service.spawn_essential_task(babe);
 	}
 
 	let keystore = if is_authority {
@@ -293,7 +293,7 @@ pub fn new_full(config: Configuration<CustomConfiguration, GenesisConfig>)
 			telemetry_on_connect: Some(service.telemetry_on_connect_stream()),
 			voting_rule: grandpa::VotingRulesBuilder::default().build(),
 		};
-		service.spawn_essential_task(Box::new(grandpa::run_grandpa_voter(grandpa_config)?));
+		service.spawn_essential_task(grandpa::run_grandpa_voter(grandpa_config)?);
 	} else {
 		grandpa::setup_disabled_grandpa(
 			service.client(),

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -275,7 +275,8 @@ pub fn new_full(config: Configuration<CustomConfiguration, GenesisConfig>)
 		keystore,
 	};
 
-	if !disable_grandpa {
+	let enable_grandpa = !disable_grandpa;
+	if enable_grandpa {
 		// start the full GRANDPA voter
 		// NOTE: unlike in polkadot/master we are currently running the full
 		// GRANDPA voter protocol for all full nodes (regardless of whether


### PR DESCRIPTION
Only setting this to v0.6 to play it safe on Kusama. We can re-enable the observer code later on after addressing all potential vote/block data availability concerns.