### PR TITLE
Enable nicknaming for accounts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -849,7 +849,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "fork-tree"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1361,13 +1361,13 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-client-transports"
-version = "14.0.3"
+version = "13.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-core 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-pubsub 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-core 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-pubsub 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1387,44 +1387,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonrpc-core"
-version = "14.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "jsonrpc-core-client"
-version = "14.0.3"
+version = "13.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "jsonrpc-client-transports 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-client-transports 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "jsonrpc-derive"
-version = "14.0.3"
+version = "13.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "jsonrpc-http-server"
-version = "14.0.3"
+version = "13.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "hyper 0.12.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-core 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-server-utils 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-core 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-server-utils 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1433,10 +1421,10 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-pubsub"
-version = "14.0.3"
+version = "13.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "jsonrpc-core 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-core 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1444,14 +1432,15 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-server-utils"
-version = "14.0.3"
+version = "13.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "globset 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-core 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-core 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 2.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1459,11 +1448,11 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-ws-server"
-version = "14.0.3"
+version = "13.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "jsonrpc-core 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-server-utils 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-core 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-server-utils 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3716,7 +3705,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "sr-api-macros"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3728,7 +3717,7 @@ dependencies = [
 [[package]]
 name = "sr-arithmetic"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "integer-sqrt 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3741,7 +3730,7 @@ dependencies = [
 [[package]]
 name = "sr-io"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsecp256k1 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3759,7 +3748,7 @@ dependencies = [
 [[package]]
 name = "sr-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "impl-trait-for-tuples 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3777,7 +3766,7 @@ dependencies = [
 [[package]]
 name = "sr-staking-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
@@ -3787,7 +3776,7 @@ dependencies = [
 [[package]]
 name = "sr-std"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3795,7 +3784,7 @@ dependencies = [
 [[package]]
 name = "sr-version"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "impl-serde 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3807,7 +3796,7 @@ dependencies = [
 [[package]]
 name = "srml-authority-discovery"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3824,7 +3813,7 @@ dependencies = [
 [[package]]
 name = "srml-authorship"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "impl-trait-for-tuples 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3840,7 +3829,7 @@ dependencies = [
 [[package]]
 name = "srml-babe"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "hex-literal 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3860,7 +3849,7 @@ dependencies = [
 [[package]]
 name = "srml-balances"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3875,7 +3864,7 @@ dependencies = [
 [[package]]
 name = "srml-collective"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3891,7 +3880,7 @@ dependencies = [
 [[package]]
 name = "srml-democracy"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3906,7 +3895,7 @@ dependencies = [
 [[package]]
 name = "srml-elections-phragmen"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3922,7 +3911,7 @@ dependencies = [
 [[package]]
 name = "srml-executive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3936,7 +3925,7 @@ dependencies = [
 [[package]]
 name = "srml-finality-tracker"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "impl-trait-for-tuples 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3951,7 +3940,7 @@ dependencies = [
 [[package]]
 name = "srml-grandpa"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3969,7 +3958,7 @@ dependencies = [
 [[package]]
 name = "srml-im-online"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3987,7 +3976,7 @@ dependencies = [
 [[package]]
 name = "srml-indices"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4004,7 +3993,7 @@ dependencies = [
 [[package]]
 name = "srml-membership"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4018,7 +4007,7 @@ dependencies = [
 [[package]]
 name = "srml-metadata"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4029,7 +4018,7 @@ dependencies = [
 [[package]]
 name = "srml-nicks"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4043,7 +4032,7 @@ dependencies = [
 [[package]]
 name = "srml-offences"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4058,7 +4047,7 @@ dependencies = [
 [[package]]
 name = "srml-randomness-collective-flip"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4071,7 +4060,7 @@ dependencies = [
 [[package]]
 name = "srml-session"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "impl-trait-for-tuples 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4090,7 +4079,7 @@ dependencies = [
 [[package]]
 name = "srml-staking"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4110,7 +4099,7 @@ dependencies = [
 [[package]]
 name = "srml-staking-reward-curve"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4121,7 +4110,7 @@ dependencies = [
 [[package]]
 name = "srml-sudo"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4135,7 +4124,7 @@ dependencies = [
 [[package]]
 name = "srml-support"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "bitmask 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "impl-trait-for-tuples 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4156,7 +4145,7 @@ dependencies = [
 [[package]]
 name = "srml-support-procedural"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4168,7 +4157,7 @@ dependencies = [
 [[package]]
 name = "srml-support-procedural-tools"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4180,7 +4169,7 @@ dependencies = [
 [[package]]
 name = "srml-support-procedural-tools-derive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4190,7 +4179,7 @@ dependencies = [
 [[package]]
 name = "srml-system"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "impl-trait-for-tuples 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4207,11 +4196,11 @@ dependencies = [
 [[package]]
 name = "srml-system-rpc"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
- "jsonrpc-core 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-core-client 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-derive 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-core 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-core-client 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-derive 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4225,7 +4214,7 @@ dependencies = [
 [[package]]
 name = "srml-system-rpc-runtime-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "substrate-client 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
@@ -4234,7 +4223,7 @@ dependencies = [
 [[package]]
 name = "srml-timestamp"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "impl-trait-for-tuples 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4249,7 +4238,7 @@ dependencies = [
 [[package]]
 name = "srml-transaction-payment"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
@@ -4261,7 +4250,7 @@ dependencies = [
 [[package]]
 name = "srml-treasury"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4348,7 +4337,7 @@ dependencies = [
 [[package]]
 name = "substrate-application-crypto"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4360,7 +4349,7 @@ dependencies = [
 [[package]]
 name = "substrate-authority-discovery"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4382,7 +4371,7 @@ dependencies = [
 [[package]]
 name = "substrate-authority-discovery-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
@@ -4404,7 +4393,7 @@ dependencies = [
 [[package]]
 name = "substrate-chain-spec"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "impl-trait-for-tuples 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4419,7 +4408,7 @@ dependencies = [
 [[package]]
 name = "substrate-chain-spec-derive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4430,7 +4419,7 @@ dependencies = [
 [[package]]
 name = "substrate-cli"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "ansi_term 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "app_dirs 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4466,7 +4455,7 @@ dependencies = [
 [[package]]
 name = "substrate-client"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4496,7 +4485,7 @@ dependencies = [
 [[package]]
 name = "substrate-client-db"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "kvdb 0.1.0 (git+https://github.com/paritytech/parity-common?rev=b0317f649ab2c665b7987b8475878fc4d2e1f81d)",
@@ -4520,7 +4509,7 @@ dependencies = [
 [[package]]
 name = "substrate-consensus-babe"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fork-tree 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
@@ -4558,7 +4547,7 @@ dependencies = [
 [[package]]
 name = "substrate-consensus-babe-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "schnorrkel 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4572,7 +4561,7 @@ dependencies = [
 [[package]]
 name = "substrate-consensus-common"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4591,7 +4580,7 @@ dependencies = [
 [[package]]
 name = "substrate-consensus-slots"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-timer 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4609,7 +4598,7 @@ dependencies = [
 [[package]]
 name = "substrate-consensus-uncles"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
@@ -4623,7 +4612,7 @@ dependencies = [
 [[package]]
 name = "substrate-debug-derive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4633,7 +4622,7 @@ dependencies = [
 [[package]]
 name = "substrate-executor"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4657,7 +4646,7 @@ dependencies = [
 [[package]]
 name = "substrate-externalities"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "environmental 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "primitive-types 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4668,7 +4657,7 @@ dependencies = [
 [[package]]
 name = "substrate-finality-grandpa"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "finality-grandpa 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fork-tree 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
@@ -4697,7 +4686,7 @@ dependencies = [
 [[package]]
 name = "substrate-finality-grandpa-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4710,7 +4699,7 @@ dependencies = [
 [[package]]
 name = "substrate-header-metadata"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4720,7 +4709,7 @@ dependencies = [
 [[package]]
 name = "substrate-inherents"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4731,7 +4720,7 @@ dependencies = [
 [[package]]
 name = "substrate-keyring"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
@@ -4743,7 +4732,7 @@ dependencies = [
 [[package]]
 name = "substrate-keystore"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4758,7 +4747,7 @@ dependencies = [
 [[package]]
 name = "substrate-network"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4800,7 +4789,7 @@ dependencies = [
 [[package]]
 name = "substrate-offchain"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4827,7 +4816,7 @@ dependencies = [
 [[package]]
 name = "substrate-offchain-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
  "substrate-client 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
@@ -4836,7 +4825,7 @@ dependencies = [
 [[package]]
 name = "substrate-panic-handler"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4845,7 +4834,7 @@ dependencies = [
 [[package]]
 name = "substrate-peerset"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "libp2p 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4858,7 +4847,7 @@ dependencies = [
 [[package]]
 name = "substrate-phragmen"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
  "sr-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
@@ -4867,7 +4856,7 @@ dependencies = [
 [[package]]
 name = "substrate-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "base58 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4905,7 +4894,7 @@ dependencies = [
 [[package]]
 name = "substrate-primitives-storage"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "impl-serde 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4916,12 +4905,12 @@ dependencies = [
 [[package]]
 name = "substrate-rpc"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-core 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-pubsub 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-core 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-pubsub 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4942,14 +4931,14 @@ dependencies = [
 [[package]]
 name = "substrate-rpc-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-core 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-core-client 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-derive 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-pubsub 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-core 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-core-client 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-derive 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-pubsub 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4964,7 +4953,7 @@ dependencies = [
 [[package]]
 name = "substrate-rpc-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
@@ -4973,12 +4962,12 @@ dependencies = [
 [[package]]
 name = "substrate-rpc-servers"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
- "jsonrpc-core 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-http-server 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-pubsub 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-ws-server 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-core 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-http-server 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-pubsub 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-ws-server 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4988,7 +4977,7 @@ dependencies = [
 [[package]]
 name = "substrate-serializer"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4997,7 +4986,7 @@ dependencies = [
 [[package]]
 name = "substrate-service"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "exit-future 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5039,7 +5028,7 @@ dependencies = [
 [[package]]
 name = "substrate-session"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
  "sr-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
@@ -5050,7 +5039,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-db"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5061,7 +5050,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-machine"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5080,7 +5069,7 @@ dependencies = [
 [[package]]
 name = "substrate-telemetry"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5102,7 +5091,7 @@ dependencies = [
 [[package]]
 name = "substrate-transaction-graph"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5116,7 +5105,7 @@ dependencies = [
 [[package]]
 name = "substrate-transaction-pool"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5132,7 +5121,7 @@ dependencies = [
 [[package]]
 name = "substrate-trie"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "memory-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5151,7 +5140,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "substrate-wasm-interface"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
 dependencies = [
  "wasmi 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -6168,15 +6157,14 @@ dependencies = [
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum jobserver 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "f2b1d42ef453b30b7387e113da1c83ab1605d90c5b4e0eb8e96d016ed3b8c160"
 "checksum js-sys 0.3.28 (registry+https://github.com/rust-lang/crates.io-index)" = "2cc9a97d7cec30128fd8b28a7c1f9df1c001ceb9b441e2b755e24130a6b43c79"
-"checksum jsonrpc-client-transports 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d389a085cb2184604dff060390cadb8cba1f063c7fd0ad710272c163c88b9f20"
+"checksum jsonrpc-client-transports 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dbf2466adbf6d5b4e618857f22be40b1e1cc6ed79d72751324358f6b539b06d"
 "checksum jsonrpc-core 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "91d767c183a7e58618a609499d359ce3820700b3ebb4823a18c343b4a2a41a0d"
-"checksum jsonrpc-core 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "34651edf3417637cc45e70ed0182ecfa9ced0b7e8131805fccf7400d989845ca"
-"checksum jsonrpc-core-client 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9dbaec1d57271ff952f24ca79d37d716cfd749c855b058d9aa5f053a6b8ae4ef"
-"checksum jsonrpc-derive 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d5d5c31575cc70a8b21542599028472c80a9248394aeea4d8918a045a0ab08a3"
-"checksum jsonrpc-http-server 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "aa54c4c2d88cb5e04b251a5031ba0f2ee8c6ef30970e31228955b89a80c3b611"
-"checksum jsonrpc-pubsub 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3ee1b8da0b9219a231c4b7cbc7110bfdb457cbcd8d90a6224d0b3cab8aae8443"
-"checksum jsonrpc-server-utils 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "87bc3c0a9a282211b2ec14abb3e977de33016bbec495332e9f7be858de7c5117"
-"checksum jsonrpc-ws-server 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "af36a129cef77a9db8028ac7552d927e1bb7b6928cd96b23dd25cc38bff974ab"
+"checksum jsonrpc-core-client 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "161dc223549fa6fe4a4eda675de2d1d3cff5a7164e5c031cdf1e22c734700f8b"
+"checksum jsonrpc-derive 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4a76285ebba4515680fbfe4b62498ccb2a932384c8732eed68351b02fb7ae475"
+"checksum jsonrpc-http-server 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "601fcc7bec888c7cbc7fd124d3d6744d72c0ebb540eca6fe2261b71f9cff6320"
+"checksum jsonrpc-pubsub 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "64e0fb0664d8ce287e826940dafbb45379443c595bdd71d93655f3c8f25fd992"
+"checksum jsonrpc-server-utils 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4d415f51d016a4682878e19dd03e8c0b61cd4394912d7cd3dc48d4f19f061a4e"
+"checksum jsonrpc-ws-server 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4699433c1ac006d7df178b4c29c191e5bb6d81e2dca18c5c804a094592900101"
 "checksum keccak 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum kvdb 0.1.0 (git+https://github.com/paritytech/parity-common?rev=616b40150ded71f57f650067fcbc5c99d7c343e6)" = "<none>"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -849,7 +849,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "fork-tree"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1361,13 +1361,13 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-client-transports"
-version = "13.2.0"
+version = "14.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-core 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-pubsub 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-core 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-pubsub 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1387,32 +1387,44 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonrpc-core-client"
-version = "13.2.0"
+name = "jsonrpc-core"
+version = "14.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "jsonrpc-client-transports 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "jsonrpc-core-client"
+version = "14.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "jsonrpc-client-transports 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "jsonrpc-derive"
-version = "13.2.0"
+version = "14.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "jsonrpc-http-server"
-version = "13.2.0"
+version = "14.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "hyper 0.12.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-core 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-server-utils 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-core 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-server-utils 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1421,10 +1433,10 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-pubsub"
-version = "13.2.0"
+version = "14.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "jsonrpc-core 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-core 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1432,15 +1444,14 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-server-utils"
-version = "13.2.0"
+version = "14.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "globset 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-core 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-core 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 2.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1448,11 +1459,11 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-ws-server"
-version = "13.2.0"
+version = "14.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "jsonrpc-core 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-server-utils 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-core 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-server-utils 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2825,6 +2836,7 @@ dependencies = [
  "srml-im-online 0.1.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
  "srml-indices 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
  "srml-membership 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "srml-nicks 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
  "srml-offences 1.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
  "srml-randomness-collective-flip 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
  "srml-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
@@ -3704,7 +3716,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "sr-api-macros"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3716,7 +3728,7 @@ dependencies = [
 [[package]]
 name = "sr-arithmetic"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "integer-sqrt 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3729,7 +3741,7 @@ dependencies = [
 [[package]]
 name = "sr-io"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsecp256k1 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3747,7 +3759,7 @@ dependencies = [
 [[package]]
 name = "sr-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "impl-trait-for-tuples 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3765,7 +3777,7 @@ dependencies = [
 [[package]]
 name = "sr-staking-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
@@ -3775,7 +3787,7 @@ dependencies = [
 [[package]]
 name = "sr-std"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3783,7 +3795,7 @@ dependencies = [
 [[package]]
 name = "sr-version"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "impl-serde 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3795,7 +3807,7 @@ dependencies = [
 [[package]]
 name = "srml-authority-discovery"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3812,7 +3824,7 @@ dependencies = [
 [[package]]
 name = "srml-authorship"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "impl-trait-for-tuples 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3828,7 +3840,7 @@ dependencies = [
 [[package]]
 name = "srml-babe"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "hex-literal 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3848,7 +3860,7 @@ dependencies = [
 [[package]]
 name = "srml-balances"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3863,7 +3875,7 @@ dependencies = [
 [[package]]
 name = "srml-collective"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3879,7 +3891,7 @@ dependencies = [
 [[package]]
 name = "srml-democracy"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3894,7 +3906,7 @@ dependencies = [
 [[package]]
 name = "srml-elections-phragmen"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3910,7 +3922,7 @@ dependencies = [
 [[package]]
 name = "srml-executive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3924,7 +3936,7 @@ dependencies = [
 [[package]]
 name = "srml-finality-tracker"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "impl-trait-for-tuples 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3939,7 +3951,7 @@ dependencies = [
 [[package]]
 name = "srml-grandpa"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3957,7 +3969,7 @@ dependencies = [
 [[package]]
 name = "srml-im-online"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3975,7 +3987,7 @@ dependencies = [
 [[package]]
 name = "srml-indices"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3992,7 +4004,7 @@ dependencies = [
 [[package]]
 name = "srml-membership"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4006,7 +4018,7 @@ dependencies = [
 [[package]]
 name = "srml-metadata"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4015,9 +4027,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "srml-nicks"
+version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
+dependencies = [
+ "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sr-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "srml-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "srml-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+]
+
+[[package]]
 name = "srml-offences"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4032,7 +4058,7 @@ dependencies = [
 [[package]]
 name = "srml-randomness-collective-flip"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4045,7 +4071,7 @@ dependencies = [
 [[package]]
 name = "srml-session"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "impl-trait-for-tuples 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4064,7 +4090,7 @@ dependencies = [
 [[package]]
 name = "srml-staking"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4084,7 +4110,7 @@ dependencies = [
 [[package]]
 name = "srml-staking-reward-curve"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4095,7 +4121,7 @@ dependencies = [
 [[package]]
 name = "srml-sudo"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4109,7 +4135,7 @@ dependencies = [
 [[package]]
 name = "srml-support"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "bitmask 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "impl-trait-for-tuples 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4130,7 +4156,7 @@ dependencies = [
 [[package]]
 name = "srml-support-procedural"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4142,7 +4168,7 @@ dependencies = [
 [[package]]
 name = "srml-support-procedural-tools"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4154,7 +4180,7 @@ dependencies = [
 [[package]]
 name = "srml-support-procedural-tools-derive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4164,7 +4190,7 @@ dependencies = [
 [[package]]
 name = "srml-system"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "impl-trait-for-tuples 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4181,11 +4207,11 @@ dependencies = [
 [[package]]
 name = "srml-system-rpc"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
- "jsonrpc-core 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-core-client 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-derive 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-core 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-core-client 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-derive 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4199,7 +4225,7 @@ dependencies = [
 [[package]]
 name = "srml-system-rpc-runtime-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "substrate-client 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
@@ -4208,7 +4234,7 @@ dependencies = [
 [[package]]
 name = "srml-timestamp"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "impl-trait-for-tuples 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4223,7 +4249,7 @@ dependencies = [
 [[package]]
 name = "srml-transaction-payment"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
@@ -4235,7 +4261,7 @@ dependencies = [
 [[package]]
 name = "srml-treasury"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4322,7 +4348,7 @@ dependencies = [
 [[package]]
 name = "substrate-application-crypto"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4334,7 +4360,7 @@ dependencies = [
 [[package]]
 name = "substrate-authority-discovery"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4356,7 +4382,7 @@ dependencies = [
 [[package]]
 name = "substrate-authority-discovery-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
@@ -4378,7 +4404,7 @@ dependencies = [
 [[package]]
 name = "substrate-chain-spec"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "impl-trait-for-tuples 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4393,7 +4419,7 @@ dependencies = [
 [[package]]
 name = "substrate-chain-spec-derive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4404,7 +4430,7 @@ dependencies = [
 [[package]]
 name = "substrate-cli"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "ansi_term 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "app_dirs 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4440,7 +4466,7 @@ dependencies = [
 [[package]]
 name = "substrate-client"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4470,7 +4496,7 @@ dependencies = [
 [[package]]
 name = "substrate-client-db"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "kvdb 0.1.0 (git+https://github.com/paritytech/parity-common?rev=b0317f649ab2c665b7987b8475878fc4d2e1f81d)",
@@ -4494,7 +4520,7 @@ dependencies = [
 [[package]]
 name = "substrate-consensus-babe"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fork-tree 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
@@ -4532,7 +4558,7 @@ dependencies = [
 [[package]]
 name = "substrate-consensus-babe-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "schnorrkel 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4546,7 +4572,7 @@ dependencies = [
 [[package]]
 name = "substrate-consensus-common"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4565,7 +4591,7 @@ dependencies = [
 [[package]]
 name = "substrate-consensus-slots"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-timer 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4583,7 +4609,7 @@ dependencies = [
 [[package]]
 name = "substrate-consensus-uncles"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
@@ -4597,7 +4623,7 @@ dependencies = [
 [[package]]
 name = "substrate-debug-derive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4607,7 +4633,7 @@ dependencies = [
 [[package]]
 name = "substrate-executor"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4631,7 +4657,7 @@ dependencies = [
 [[package]]
 name = "substrate-externalities"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "environmental 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "primitive-types 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4642,7 +4668,7 @@ dependencies = [
 [[package]]
 name = "substrate-finality-grandpa"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "finality-grandpa 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fork-tree 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
@@ -4671,7 +4697,7 @@ dependencies = [
 [[package]]
 name = "substrate-finality-grandpa-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4684,7 +4710,7 @@ dependencies = [
 [[package]]
 name = "substrate-header-metadata"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4694,7 +4720,7 @@ dependencies = [
 [[package]]
 name = "substrate-inherents"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4705,7 +4731,7 @@ dependencies = [
 [[package]]
 name = "substrate-keyring"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
@@ -4717,7 +4743,7 @@ dependencies = [
 [[package]]
 name = "substrate-keystore"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4732,7 +4758,7 @@ dependencies = [
 [[package]]
 name = "substrate-network"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4774,7 +4800,7 @@ dependencies = [
 [[package]]
 name = "substrate-offchain"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4801,7 +4827,7 @@ dependencies = [
 [[package]]
 name = "substrate-offchain-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
  "substrate-client 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
@@ -4810,7 +4836,7 @@ dependencies = [
 [[package]]
 name = "substrate-panic-handler"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4819,7 +4845,7 @@ dependencies = [
 [[package]]
 name = "substrate-peerset"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "libp2p 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4832,7 +4858,7 @@ dependencies = [
 [[package]]
 name = "substrate-phragmen"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
  "sr-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
@@ -4841,7 +4867,7 @@ dependencies = [
 [[package]]
 name = "substrate-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "base58 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4879,7 +4905,7 @@ dependencies = [
 [[package]]
 name = "substrate-primitives-storage"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "impl-serde 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4890,12 +4916,12 @@ dependencies = [
 [[package]]
 name = "substrate-rpc"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-core 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-pubsub 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-core 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-pubsub 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4916,14 +4942,14 @@ dependencies = [
 [[package]]
 name = "substrate-rpc-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-core 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-core-client 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-derive 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-pubsub 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-core 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-core-client 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-derive 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-pubsub 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4938,7 +4964,7 @@ dependencies = [
 [[package]]
 name = "substrate-rpc-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
@@ -4947,12 +4973,12 @@ dependencies = [
 [[package]]
 name = "substrate-rpc-servers"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
- "jsonrpc-core 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-http-server 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-pubsub 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-ws-server 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-core 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-http-server 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-pubsub 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-ws-server 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4962,7 +4988,7 @@ dependencies = [
 [[package]]
 name = "substrate-serializer"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4971,7 +4997,7 @@ dependencies = [
 [[package]]
 name = "substrate-service"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "exit-future 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5013,7 +5039,7 @@ dependencies = [
 [[package]]
 name = "substrate-session"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
  "sr-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
@@ -5024,7 +5050,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-db"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5035,7 +5061,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-machine"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5054,7 +5080,7 @@ dependencies = [
 [[package]]
 name = "substrate-telemetry"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5076,7 +5102,7 @@ dependencies = [
 [[package]]
 name = "substrate-transaction-graph"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5090,7 +5116,7 @@ dependencies = [
 [[package]]
 name = "substrate-transaction-pool"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5106,7 +5132,7 @@ dependencies = [
 [[package]]
 name = "substrate-trie"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "memory-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5125,7 +5151,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "substrate-wasm-interface"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#4a13f614cf66bf12d7f02f0d338e6f4e27389c48"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a57c72bedf0767a50333e1c58e5445150df0d917"
 dependencies = [
  "wasmi 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -6142,14 +6168,15 @@ dependencies = [
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum jobserver 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "f2b1d42ef453b30b7387e113da1c83ab1605d90c5b4e0eb8e96d016ed3b8c160"
 "checksum js-sys 0.3.28 (registry+https://github.com/rust-lang/crates.io-index)" = "2cc9a97d7cec30128fd8b28a7c1f9df1c001ceb9b441e2b755e24130a6b43c79"
-"checksum jsonrpc-client-transports 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dbf2466adbf6d5b4e618857f22be40b1e1cc6ed79d72751324358f6b539b06d"
+"checksum jsonrpc-client-transports 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d389a085cb2184604dff060390cadb8cba1f063c7fd0ad710272c163c88b9f20"
 "checksum jsonrpc-core 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "91d767c183a7e58618a609499d359ce3820700b3ebb4823a18c343b4a2a41a0d"
-"checksum jsonrpc-core-client 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "161dc223549fa6fe4a4eda675de2d1d3cff5a7164e5c031cdf1e22c734700f8b"
-"checksum jsonrpc-derive 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4a76285ebba4515680fbfe4b62498ccb2a932384c8732eed68351b02fb7ae475"
-"checksum jsonrpc-http-server 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "601fcc7bec888c7cbc7fd124d3d6744d72c0ebb540eca6fe2261b71f9cff6320"
-"checksum jsonrpc-pubsub 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "64e0fb0664d8ce287e826940dafbb45379443c595bdd71d93655f3c8f25fd992"
-"checksum jsonrpc-server-utils 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4d415f51d016a4682878e19dd03e8c0b61cd4394912d7cd3dc48d4f19f061a4e"
-"checksum jsonrpc-ws-server 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4699433c1ac006d7df178b4c29c191e5bb6d81e2dca18c5c804a094592900101"
+"checksum jsonrpc-core 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "34651edf3417637cc45e70ed0182ecfa9ced0b7e8131805fccf7400d989845ca"
+"checksum jsonrpc-core-client 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9dbaec1d57271ff952f24ca79d37d716cfd749c855b058d9aa5f053a6b8ae4ef"
+"checksum jsonrpc-derive 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d5d5c31575cc70a8b21542599028472c80a9248394aeea4d8918a045a0ab08a3"
+"checksum jsonrpc-http-server 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "aa54c4c2d88cb5e04b251a5031ba0f2ee8c6ef30970e31228955b89a80c3b611"
+"checksum jsonrpc-pubsub 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3ee1b8da0b9219a231c4b7cbc7110bfdb457cbcd8d90a6224d0b3cab8aae8443"
+"checksum jsonrpc-server-utils 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "87bc3c0a9a282211b2ec14abb3e977de33016bbec495332e9f7be858de7c5117"
+"checksum jsonrpc-ws-server 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "af36a129cef77a9db8028ac7552d927e1bb7b6928cd96b23dd25cc38bff974ab"
 "checksum keccak 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum kvdb 0.1.0 (git+https://github.com/paritytech/parity-common?rev=616b40150ded71f57f650067fcbc5c99d7c343e6)" = "<none>"
@@ -6365,6 +6392,7 @@ dependencies = [
 "checksum srml-indices 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
 "checksum srml-membership 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
 "checksum srml-metadata 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
+"checksum srml-nicks 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
 "checksum srml-offences 1.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
 "checksum srml-randomness-collective-flip 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
 "checksum srml-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -849,7 +849,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "fork-tree"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3705,7 +3705,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "sr-api-macros"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3717,7 +3717,7 @@ dependencies = [
 [[package]]
 name = "sr-arithmetic"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "integer-sqrt 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3730,7 +3730,7 @@ dependencies = [
 [[package]]
 name = "sr-io"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsecp256k1 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3748,7 +3748,7 @@ dependencies = [
 [[package]]
 name = "sr-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "impl-trait-for-tuples 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3766,7 +3766,7 @@ dependencies = [
 [[package]]
 name = "sr-staking-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
@@ -3776,7 +3776,7 @@ dependencies = [
 [[package]]
 name = "sr-std"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3784,7 +3784,7 @@ dependencies = [
 [[package]]
 name = "sr-version"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "impl-serde 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3796,7 +3796,7 @@ dependencies = [
 [[package]]
 name = "srml-authority-discovery"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3813,7 +3813,7 @@ dependencies = [
 [[package]]
 name = "srml-authorship"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "impl-trait-for-tuples 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3829,7 +3829,7 @@ dependencies = [
 [[package]]
 name = "srml-babe"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "hex-literal 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3849,7 +3849,7 @@ dependencies = [
 [[package]]
 name = "srml-balances"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3864,7 +3864,7 @@ dependencies = [
 [[package]]
 name = "srml-collective"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3880,7 +3880,7 @@ dependencies = [
 [[package]]
 name = "srml-democracy"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3895,7 +3895,7 @@ dependencies = [
 [[package]]
 name = "srml-elections-phragmen"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3911,7 +3911,7 @@ dependencies = [
 [[package]]
 name = "srml-executive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3925,7 +3925,7 @@ dependencies = [
 [[package]]
 name = "srml-finality-tracker"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "impl-trait-for-tuples 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3940,7 +3940,7 @@ dependencies = [
 [[package]]
 name = "srml-grandpa"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3958,7 +3958,7 @@ dependencies = [
 [[package]]
 name = "srml-im-online"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3976,7 +3976,7 @@ dependencies = [
 [[package]]
 name = "srml-indices"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3993,7 +3993,7 @@ dependencies = [
 [[package]]
 name = "srml-membership"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4007,7 +4007,7 @@ dependencies = [
 [[package]]
 name = "srml-metadata"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4018,7 +4018,7 @@ dependencies = [
 [[package]]
 name = "srml-nicks"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4032,7 +4032,7 @@ dependencies = [
 [[package]]
 name = "srml-offences"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4047,7 +4047,7 @@ dependencies = [
 [[package]]
 name = "srml-randomness-collective-flip"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4060,7 +4060,7 @@ dependencies = [
 [[package]]
 name = "srml-session"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "impl-trait-for-tuples 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4079,7 +4079,7 @@ dependencies = [
 [[package]]
 name = "srml-staking"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4099,7 +4099,7 @@ dependencies = [
 [[package]]
 name = "srml-staking-reward-curve"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4110,7 +4110,7 @@ dependencies = [
 [[package]]
 name = "srml-sudo"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4124,7 +4124,7 @@ dependencies = [
 [[package]]
 name = "srml-support"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "bitmask 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "impl-trait-for-tuples 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4145,7 +4145,7 @@ dependencies = [
 [[package]]
 name = "srml-support-procedural"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4157,7 +4157,7 @@ dependencies = [
 [[package]]
 name = "srml-support-procedural-tools"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4169,7 +4169,7 @@ dependencies = [
 [[package]]
 name = "srml-support-procedural-tools-derive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4179,7 +4179,7 @@ dependencies = [
 [[package]]
 name = "srml-system"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "impl-trait-for-tuples 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4196,7 +4196,7 @@ dependencies = [
 [[package]]
 name = "srml-system-rpc"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "jsonrpc-core 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core-client 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4214,7 +4214,7 @@ dependencies = [
 [[package]]
 name = "srml-system-rpc-runtime-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "substrate-client 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
@@ -4223,7 +4223,7 @@ dependencies = [
 [[package]]
 name = "srml-timestamp"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "impl-trait-for-tuples 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4238,7 +4238,7 @@ dependencies = [
 [[package]]
 name = "srml-transaction-payment"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
@@ -4250,7 +4250,7 @@ dependencies = [
 [[package]]
 name = "srml-treasury"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4337,7 +4337,7 @@ dependencies = [
 [[package]]
 name = "substrate-application-crypto"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4349,7 +4349,7 @@ dependencies = [
 [[package]]
 name = "substrate-authority-discovery"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4371,7 +4371,7 @@ dependencies = [
 [[package]]
 name = "substrate-authority-discovery-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
@@ -4393,7 +4393,7 @@ dependencies = [
 [[package]]
 name = "substrate-chain-spec"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "impl-trait-for-tuples 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4408,7 +4408,7 @@ dependencies = [
 [[package]]
 name = "substrate-chain-spec-derive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4419,7 +4419,7 @@ dependencies = [
 [[package]]
 name = "substrate-cli"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "ansi_term 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "app_dirs 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4455,7 +4455,7 @@ dependencies = [
 [[package]]
 name = "substrate-client"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4485,7 +4485,7 @@ dependencies = [
 [[package]]
 name = "substrate-client-db"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "kvdb 0.1.0 (git+https://github.com/paritytech/parity-common?rev=b0317f649ab2c665b7987b8475878fc4d2e1f81d)",
@@ -4509,7 +4509,7 @@ dependencies = [
 [[package]]
 name = "substrate-consensus-babe"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fork-tree 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
@@ -4547,7 +4547,7 @@ dependencies = [
 [[package]]
 name = "substrate-consensus-babe-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "schnorrkel 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4561,7 +4561,7 @@ dependencies = [
 [[package]]
 name = "substrate-consensus-common"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4580,7 +4580,7 @@ dependencies = [
 [[package]]
 name = "substrate-consensus-slots"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-timer 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4598,7 +4598,7 @@ dependencies = [
 [[package]]
 name = "substrate-consensus-uncles"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
@@ -4612,7 +4612,7 @@ dependencies = [
 [[package]]
 name = "substrate-debug-derive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4622,7 +4622,7 @@ dependencies = [
 [[package]]
 name = "substrate-executor"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4646,7 +4646,7 @@ dependencies = [
 [[package]]
 name = "substrate-externalities"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "environmental 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "primitive-types 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4657,7 +4657,7 @@ dependencies = [
 [[package]]
 name = "substrate-finality-grandpa"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "finality-grandpa 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fork-tree 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
@@ -4686,7 +4686,7 @@ dependencies = [
 [[package]]
 name = "substrate-finality-grandpa-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4699,7 +4699,7 @@ dependencies = [
 [[package]]
 name = "substrate-header-metadata"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4709,7 +4709,7 @@ dependencies = [
 [[package]]
 name = "substrate-inherents"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4720,7 +4720,7 @@ dependencies = [
 [[package]]
 name = "substrate-keyring"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
@@ -4732,7 +4732,7 @@ dependencies = [
 [[package]]
 name = "substrate-keystore"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4747,7 +4747,7 @@ dependencies = [
 [[package]]
 name = "substrate-network"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4789,7 +4789,7 @@ dependencies = [
 [[package]]
 name = "substrate-offchain"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4816,7 +4816,7 @@ dependencies = [
 [[package]]
 name = "substrate-offchain-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
  "substrate-client 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
@@ -4825,7 +4825,7 @@ dependencies = [
 [[package]]
 name = "substrate-panic-handler"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4834,7 +4834,7 @@ dependencies = [
 [[package]]
 name = "substrate-peerset"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "libp2p 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4847,7 +4847,7 @@ dependencies = [
 [[package]]
 name = "substrate-phragmen"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
  "sr-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
@@ -4856,7 +4856,7 @@ dependencies = [
 [[package]]
 name = "substrate-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "base58 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4894,7 +4894,7 @@ dependencies = [
 [[package]]
 name = "substrate-primitives-storage"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "impl-serde 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4905,7 +4905,7 @@ dependencies = [
 [[package]]
 name = "substrate-rpc"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4931,7 +4931,7 @@ dependencies = [
 [[package]]
 name = "substrate-rpc-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4953,7 +4953,7 @@ dependencies = [
 [[package]]
 name = "substrate-rpc-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
@@ -4962,7 +4962,7 @@ dependencies = [
 [[package]]
 name = "substrate-rpc-servers"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "jsonrpc-core 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-http-server 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4977,7 +4977,7 @@ dependencies = [
 [[package]]
 name = "substrate-serializer"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4986,7 +4986,7 @@ dependencies = [
 [[package]]
 name = "substrate-service"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "exit-future 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5028,7 +5028,7 @@ dependencies = [
 [[package]]
 name = "substrate-session"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
  "sr-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
@@ -5039,7 +5039,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-db"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5050,7 +5050,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-machine"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5069,7 +5069,7 @@ dependencies = [
 [[package]]
 name = "substrate-telemetry"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5091,7 +5091,7 @@ dependencies = [
 [[package]]
 name = "substrate-transaction-graph"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5105,7 +5105,7 @@ dependencies = [
 [[package]]
 name = "substrate-transaction-pool"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5121,7 +5121,7 @@ dependencies = [
 [[package]]
 name = "substrate-trie"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "memory-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5140,7 +5140,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "substrate-wasm-interface"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#37189e0e9b5ef2a02fac17892ac21279f1ed74a7"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#76a138f88cad878478f1c5ab565ec277b870362e"
 dependencies = [
  "wasmi 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -42,6 +42,7 @@ grandpa = { package = "srml-grandpa", git = "https://github.com/paritytech/subst
 im-online = { package = "srml-im-online", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
 indices = { package = "srml-indices", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
 membership = { package = "srml-membership", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
+nicks = { package = "srml-nicks", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
 offences = { package = "srml-offences", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
 randomness-collective-flip = { package = "srml-randomness-collective-flip", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
 session = { package = "srml-session", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
@@ -100,6 +101,7 @@ std = [
 	"im-online/std",
 	"indices/std",
 	"membership/std",
+	"nicks/std",
 	"offences/std",
 	"sr-primitives/std",
 	"sr-staking-primitives/std",

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -529,6 +529,22 @@ impl sudo::Trait for Runtime {
 	type Proposal = Call;
 }
 
+parameter_types! {
+	pub const ReservationFee: Balance = 1 * DOLLARS;
+	pub const MinLength: usize = 3;
+	pub const MaxLength: usize = 16;
+}
+
+impl nicks::Trait for Runtime {
+	type Event = Event;
+	type Currency = Balances;
+	type ReservationFee = ReservationFee;
+	type Slashed = Treasury;
+	type KillOrigin = collective::EnsureMember<AccountId, CouncilCollective>;
+	type MinLength = MinLength;
+	type MaxLength = MaxLength;
+}
+
 construct_runtime!(
 	pub enum Runtime where
 		Block = Block,
@@ -577,6 +593,9 @@ construct_runtime!(
 		// Sudo. Usable initially.
 		// RELEASE: remove this for release build.
 		Sudo: sudo,
+
+		// Simple nicknames module.
+		Nicks: nicks::{Module, Call, Storage, Event<T>},
 	}
 );
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -131,7 +131,7 @@ impl SignedExtension for OnlyStakingAndClaims {
 		match call {
 			Call::Staking(_) | Call::Claims(_) | Call::Sudo(_) | Call::Session(_)
 				| Call::ElectionsPhragmen(_) | Call::TechnicalMembership(_)
-				| Call::TechnicalCommittee(_)
+				| Call::TechnicalCommittee(_) | Call::Nicks(_)
 			=>
 				Ok(Default::default()),
 			_ => Err(InvalidTransaction::Custom(ValidityError::NoPermission.into()).into()),

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -99,7 +99,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("kusama"),
 	impl_name: create_runtime_str!("parity-kusama"),
 	authoring_version: 1,
-	spec_version: 1005,
+	spec_version: 1006,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 };


### PR DESCRIPTION
Just pulls in the latest Substrate and enables the nicknames module.

Copy'n'paste from already reviewed code in Substrate.