### PR TITLE
crowdfund/contribute()

### DIFF
--- a/runtime/src/crowdfund.rs
+++ b/runtime/src/crowdfund.rs
@@ -249,8 +249,8 @@ decl_module! {
 			let now = <system::Module<T>>::block_number();
 			ensure!(fund.end > now, "contribution period ended");
 
-			// Make sure the proposed contribution won't cause fund to exceed its cap (if accepted)
-			ensure!(fund.raised + value < fund.cap, "contributions exceed cap");
+			// Make sure the proposed contribution won't cause fund to exceed its cap
+			ensure!(fund.raised + value <= fund.cap, "contributions exceed cap");
 			T::Currency::transfer(&who, &Self::fund_account_id(index), value)?;
 			fund.raised += value;
 


### PR DESCRIPTION
Before the `fund.raised` increases by `&value`, we should check that the crowdfund hasn't ended. For example, if the crowdfund had ended, the previous order of operations would have increased `fund.raised` before the `ensure!(fund.end > now, "contribution period ended");` panicked.

I also changed the check from `fund.raised <= fund.cap` to `fund.raised + value <= fund.cap`. If I used the previous check after reordering operations, it would allow a contribution that results in `fund.raised` exceeding `fund.cap` after the contribution is added. This is not the intended hard cap because it only prevents contributions after `fund.raised` has already exceeded `fund.cap`, so I changed it.

I also think the `checked_add` is unnecessary because `cap` is a field of `FundInfo` and `cap` will be much smaller than when `Balance` would be expected to overflow.