### PR TITLE
add comments for WonRenewal event

### DIFF
--- a/runtime/src/slots.rs
+++ b/runtime/src/slots.rs
@@ -212,7 +212,7 @@ decl_event!(
 		/// Someone won the right to deploy a parachain. Balance amount is deducted for deposit.
 		WonDeploy(NewBidder<AccountId>, SlotRange, ParaId, Balance),
 		/// An existing parachain won the right to continue.
-		/// First balance is the total amount reseved. Second is the extra amount reserved.
+		/// First balance is the extra amount reseved. Second is the total amount reserved.
 		WonRenewal(ParaId, SlotRange, Balance, Balance),
 		/// Funds were reserved for a winning bid. First balance is the extra amount reserved.
 		/// Second is the total.
@@ -553,7 +553,7 @@ impl<T: Trait> Module<T> {
 					} else {
 						Default::default()
 					};
-					Self::deposit_event(RawEvent::WonRenewal(para_id, range, amount, extra));
+					Self::deposit_event(RawEvent::WonRenewal(para_id, range, extra, amount));
 				}
 			}
 

--- a/runtime/src/slots.rs
+++ b/runtime/src/slots.rs
@@ -212,6 +212,7 @@ decl_event!(
 		/// Someone won the right to deploy a parachain. Balance amount is deducted for deposit.
 		WonDeploy(NewBidder<AccountId>, SlotRange, ParaId, Balance),
 		/// An existing parachain won the right to continue.
+		/// First balance is the total amount reseved. Second is the extra amount reserved.
 		WonRenewal(ParaId, SlotRange, Balance, Balance),
 		/// Funds were reserved for a winning bid. First balance is the extra amount reserved.
 		/// Second is the total.


### PR DESCRIPTION
I don't think this is intended but for `WonRenewal` the first balance is total, second is extra and for `Reserved` the first is extra and second is `total`. This is confusing.