### PR TITLE
ci: add runtime version check

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -80,6 +80,33 @@ variables:
 
 
 
+#### stage:                        test
+
+check-runtime:
+  stage:                           test
+  image:                           parity/tools:latest
+  <<:                              *kubernetes-env
+  only:
+    - /^[0-9]+$/
+  variables:
+    GITLAB_API:                    "https://gitlab.parity.io/api/v4"
+    GITHUB_API_PROJECT:            "parity%2Finfrastructure%2Fgithub-api"
+  script:
+    - ./scripts/gitlab/check_runtime.sh
+  allow_failure:                   true
+
+
+check-line-width:
+  stage:                           test
+  image:                           parity/tools:latest
+  <<:                              *kubernetes-env
+  only:
+    - /^[0-9]+$/
+  script:
+    - ./scripts/gitlab/check_line_width.sh
+  allow_failure:                   true
+
+
 
 
 test-linux-stable:                 &test
@@ -305,6 +332,7 @@ deploy-polkasync-kusama:
   variables:
     GITLAB_API:                    "https://gitlab.parity.io/api/v4"
     GITHUB_API_PROJECT:            "parity%2Finfrastructure%2Fparity-testnet"
+    GIT_STRATEGY:                  none
   allow_failure:                   true
   script:
     - |

--- a/scripts/gitlab/check_line_width.sh
+++ b/scripts/gitlab/check_line_width.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+#
+# check if line width of rust source files is not beyond x characters
+#
+
+
+BASE_BRANCH="origin/master"
+LINE_WIDTH="121"
+GOOD_LINE_WIDTH="101"
+
+
+git diff --name-only ${BASE_BRANCH}...${CI_COMMIT_SHA} \*.rs | ( while read file
+do
+  if [ ! -f ${file} ];
+  then
+	echo "Skipping removed file."
+  elif git diff ${BASE_BRANCH}...${CI_COMMIT_SHA} ${file} | grep -q "^+.\{${LINE_WIDTH}\}"
+  then
+    if [ -z "${FAIL}" ]
+    then
+      echo "| warning!"
+      echo "| Lines should not be longer than 120 characters."
+      echo "| "
+      echo "| see more https://wiki.parity.io/Substrate-Style-Guide"
+      echo "|"
+      FAIL="true"
+    fi
+    echo "| file: ${file}"
+    git diff ${BASE_BRANCH}...${CI_COMMIT_SHA} ${file} \
+      | grep -n "^+.\{${LINE_WIDTH}\}"
+    echo "|"
+  else
+    if git diff ${BASE_BRANCH}...${CI_COMMIT_SHA} ${file} | grep -q "^+.\{${GOOD_LINE_WIDTH}\}"
+    then
+      if [ -z "${FAIL}" ]
+      then
+        echo "| warning!"
+        echo "| Lines should be longer than 100 characters only in exceptional circumstances!"
+        echo "| "
+        echo "| see more https://wiki.parity.io/Substrate-Style-Guide"
+        echo "|"
+      fi
+      echo "| file: ${file}"
+      git diff ${BASE_BRANCH}...${CI_COMMIT_SHA} ${file} \
+        | grep -n "^+.\{${LINE_WIDTH}\}"
+      echo "|"
+    fi
+  fi
+done
+
+test -z "${FAIL}"
+)

--- a/scripts/gitlab/check_runtime.sh
+++ b/scripts/gitlab/check_runtime.sh
@@ -1,0 +1,117 @@
+#!/bin/sh
+#
+#
+# check for any changes in the node/src/runtime, srml/ and core/sr_* trees. if
+# there are any changes found, it should mark the PR breaksconsensus and
+# "auto-fail" the PR if there isn't a change in the runtime/src/lib.rs file 
+# that alters the version.
+
+set -e # fail on any error
+
+
+# give some context
+git log --graph --oneline --decorate=short -n 10
+
+
+VERSIONS_FILE="runtime/src/lib.rs"
+
+github_label () {
+	echo
+	echo "# run github-api job for labeling it ${1}"
+	curl -sS -X POST \
+		-F "token=${CI_JOB_TOKEN}" \
+		-F "ref=master" \
+		-F "variables[LABEL]=${1}" \
+		-F "variables[PRNO]=${CI_COMMIT_REF_NAME}" \
+		-F "variables[PROJECT]=paritytech/polkadot" \
+		${GITLAB_API}/projects/${GITHUB_API_PROJECT}/trigger/pipeline
+}
+
+
+
+
+# check if the wasm sources changed
+if ! git diff --name-only origin/master...${CI_COMMIT_SHA} \
+	| grep -q -e '^runtime/'
+then
+	cat <<-EOT
+	
+	no changes to the runtime source code detected
+
+	EOT
+
+	exit 0
+fi
+
+
+
+# check for spec_version updates: if the spec versions changed, then there is
+# consensus-critical logic that has changed. the runtime wasm blobs must be
+# rebuilt.
+
+add_spec_version="$(git diff origin/master...${CI_COMMIT_SHA} ${VERSIONS_FILE} \
+	| sed -n -r "s/^\+[[:space:]]+spec_version: +([0-9]+),$/\1/p")"
+sub_spec_version="$(git diff origin/master...${CI_COMMIT_SHA} ${VERSIONS_FILE} \
+	| sed -n -r "s/^\-[[:space:]]+spec_version: +([0-9]+),$/\1/p")"
+
+
+# see if the version and the binary blob changed
+if [ "${add_spec_version}" != "${sub_spec_version}" ]
+then
+
+	github_label "B2-breaksapi"
+
+	cat <<-EOT
+		
+		changes to the runtime sources and changes in the spec version.
+	
+		spec_version: ${sub_spec_version} -> ${add_spec_version}
+	
+	EOT
+	exit 0
+
+else
+	# check for impl_version updates: if only the impl versions changed, we assume
+	# there is no consensus-critical logic that has changed.
+
+	add_impl_version="$(git diff origin/master...${CI_COMMIT_SHA} ${VERSIONS_FILE} \
+		| sed -n -r 's/^\+[[:space:]]+impl_version: +([0-9]+),$/\1/p')"
+	sub_impl_version="$(git diff origin/master...${CI_COMMIT_SHA} ${VERSIONS_FILE} \
+		| sed -n -r 's/^\-[[:space:]]+impl_version: +([0-9]+),$/\1/p')"
+
+
+	# see if the impl version changed
+	if [ "${add_impl_version}" != "${sub_impl_version}" ]
+	then
+		cat <<-EOT
+		
+		changes to the runtime sources and changes in the impl version.
+
+		impl_version: ${sub_impl_version} -> ${add_impl_version}
+
+		EOT
+		exit 0
+	fi
+
+
+	cat <<-EOT
+
+	wasm source files changed but not the spec/impl version and the runtime
+	binary blob. If changes made do not alter logic, just bump 'impl_version'.
+	If they do change logic, bump 'spec_version' and rebuild wasm.
+
+	source file directories:
+	- runtime
+
+	versions file: ${VERSIONS_FILE}
+
+	EOT
+
+	# drop through into pushing `gotissues` and exit 1...
+fi
+
+# dropped through. there's something wrong;  exit 1.
+
+exit 1
+
+# vim: noexpandtab


### PR DESCRIPTION
This pull request adds 2 tests to the gitlab ci:
- check_runtime
- check_line_width

when files in the `runtime/` directory are changed the runtime version must also be changed e.g. bump the `spec_version` if it's a change in the logic and bump `impl_version` if it's only a cosmetic change.

This scripts are adapted from the ones in the substrate repository.