### PR TITLE
cli: fix node shutdown

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -158,5 +158,8 @@ fn run_until_exit<T, SC, B, CE, W>(
 	let _ = runtime.block_on(service.select(work));
 	exit_send.fire();
 
+	// TODO [andre]: timeout this future substrate/#1318
+	let _ = runtime.shutdown_on_idle().wait();
+
 	Ok(())
 }


### PR DESCRIPTION
This was removed in #321 but it is needed, otherwise futures still running in the pool won't be properly dropped and we get errors like:

```
2019-11-11 14:09:12 Imported #623740 (0xce9c…5d92)
^P^Cpthread lock: Invalid argument
^P[1]    824784 abort (core dumped)  ./target/release/polkadot
```
and
```
Thread 'tokio-runtime-worker-6' panicked at 'slog-scope: No logger set. Use `slog_scope::set_global_logger` or `slog_scope::scope`.', /home/andre/.cargo/registry/src/github.com-1ecc6299db9ec823/slog-scope-4.3.0/lib.rs:125
```