### PR TITLE
service/src/lib.rs: Pass --sentry-nodes flag to authority discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ dependencies = [
  "dlmalloc 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-parachain 0.7.5",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "substrate-wasm-builder-runner 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -33,9 +33,9 @@ dependencies = [
  "polkadot-collator 0.7.5",
  "polkadot-parachain 0.7.5",
  "polkadot-primitives 0.7.5",
- "sc-client 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-client-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
@@ -1067,7 +1067,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "fork-tree"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1075,58 +1075,58 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "frame-system 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
 name = "frame-metadata"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
 name = "frame-support"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "bitmask 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "frame-metadata 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-support-procedural 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-metadata 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "frame-support-procedural 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "paste 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-arithmetic 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-state-machine 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-arithmetic 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-inherents 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-state-machine 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "tracing 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "frame-support-procedural"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
- "frame-support-procedural-tools 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support-procedural-tools 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1135,9 +1135,9 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
- "frame-support-procedural-tools-derive 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support-procedural-tools-derive 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1147,7 +1147,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1157,27 +1157,27 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-version 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
@@ -1464,7 +1464,7 @@ dependencies = [
 [[package]]
 name = "grafana-data-source"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "async-std 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2810,286 +2810,286 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "frame-system 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "pallet-session 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-application-crypto 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-authority-discovery 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-authorship"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "frame-system 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-authorship 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-authorship 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-inherents 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-babe"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "frame-system 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "hex-literal 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "pallet-session 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "pallet-timestamp 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-consensus-babe 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-consensus-babe 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-inherents 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-staking 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-timestamp 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-balances"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "frame-system 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-collective"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "frame-system 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-democracy"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "frame-system 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-elections-phragmen"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "frame-system 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-phragmen 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-phragmen 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-finality-tracker"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "frame-system 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-finality-tracker 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-inherents 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-grandpa"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "frame-system 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "pallet-finality-tracker 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "pallet-session 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-finality-granpda 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-finality-granpda 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-staking 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-im-online"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-authorship 0.1.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "frame-system 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "pallet-authorship 0.1.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "pallet-session 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-application-crypto 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-staking 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-indices"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "frame-system 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-keyring 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-membership"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "frame-system 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-nicks"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "frame-system 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-offences"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-balances 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "frame-system 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "pallet-balances 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-staking 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "frame-system 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-session"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "frame-system 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "pallet-timestamp 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-staking 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-trie 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-staking"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-authorship 0.1.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "frame-system 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "pallet-authorship 0.1.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "pallet-session 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-phragmen 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-keyring 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-phragmen 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-staking 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3100,74 +3100,74 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "frame-system 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-inherents 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-timestamp 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-transaction-payment"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-transaction-payment-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "frame-system 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "pallet-transaction-payment-rpc-runtime-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "jsonrpc-core 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core-client 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-derive 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-transaction-payment-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "pallet-transaction-payment-rpc-runtime-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-rpc 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-blockchain 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-rpc 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-treasury"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-balances 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "frame-system 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "pallet-balances 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
@@ -3481,15 +3481,15 @@ dependencies = [
  "polkadot-erasure-coding 0.7.5",
  "polkadot-primitives 0.7.5",
  "polkadot-runtime 0.7.5",
- "sc-client 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-network 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-client-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-keystore 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-network 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-blockchain 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-consensus 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3501,7 +3501,7 @@ dependencies = [
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-service 0.7.5",
- "sc-cli 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-cli 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "structopt 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3520,12 +3520,12 @@ dependencies = [
  "polkadot-runtime 0.7.5",
  "polkadot-service 0.7.5",
  "polkadot-validation 0.7.5",
- "sc-client 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-network 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-client-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-network 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-consensus 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-keyring 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3537,8 +3537,8 @@ dependencies = [
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-primitives 0.7.5",
  "reed-solomon-erasure 4.0.0 (git+https://github.com/paritytech/reed-solomon-erasure)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-trie 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
@@ -3546,7 +3546,7 @@ name = "polkadot-executor"
 version = "0.7.5"
 dependencies = [
  "polkadot-runtime 0.7.5",
- "sc-executor 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-executor 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
@@ -3564,13 +3564,13 @@ dependencies = [
  "polkadot-erasure-coding 0.7.5",
  "polkadot-primitives 0.7.5",
  "polkadot-validation 0.7.5",
- "sc-client 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-network 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-network 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-blockchain 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-keyring 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
@@ -3586,8 +3586,8 @@ dependencies = [
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "shared_memory 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmi 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3597,19 +3597,19 @@ name = "polkadot-primitives"
 version = "0.7.5"
 dependencies = [
  "bitvec 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-babe 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "pallet-babe 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-parachain 0.7.5",
  "pretty_assertions 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-application-crypto 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-serializer 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-serializer 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-trie 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-version 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
@@ -3617,14 +3617,14 @@ name = "polkadot-rpc"
 version = "0.7.5"
 dependencies = [
  "jsonrpc-core 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-transaction-payment-rpc 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "pallet-transaction-payment-rpc 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "polkadot-primitives 0.7.5",
  "polkadot-runtime 0.7.5",
- "sc-client 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-rpc 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-transaction-pool-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "substrate-frame-rpc-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-rpc 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-transaction-pool-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "substrate-frame-rpc-system 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
@@ -3632,35 +3632,35 @@ name = "polkadot-runtime"
 version = "0.7.5"
 dependencies = [
  "bitvec 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "frame-executive 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-executive 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "frame-system 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "frame-system-rpc-runtime-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "hex-literal 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsecp256k1 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-authority-discovery 0.1.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-authorship 0.1.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-babe 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-balances 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-collective 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-democracy 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-elections-phragmen 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-grandpa 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-im-online 0.1.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-indices 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-membership 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-nicks 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-offences 1.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-randomness-collective-flip 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-staking-reward-curve 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-transaction-payment 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-transaction-payment-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-treasury 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "pallet-authority-discovery 0.1.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "pallet-authorship 0.1.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "pallet-babe 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "pallet-balances 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "pallet-collective 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "pallet-democracy 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "pallet-elections-phragmen 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "pallet-finality-tracker 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "pallet-grandpa 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "pallet-im-online 0.1.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "pallet-indices 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "pallet-membership 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "pallet-nicks 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "pallet-offences 1.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "pallet-randomness-collective-flip 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "pallet-session 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "pallet-staking 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "pallet-staking-reward-curve 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "pallet-timestamp 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "pallet-transaction-payment 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "pallet-transaction-payment-rpc-runtime-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "pallet-treasury 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-parachain 0.7.5",
  "polkadot-primitives 0.7.5",
@@ -3669,23 +3669,23 @@ dependencies = [
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-block-builder 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus-babe 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-offchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-serializer 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-transaction-pool-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-authority-discovery 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-block-builder 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-consensus-babe 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-inherents 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-keyring 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-offchain 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-serializer 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-session 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-staking 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-transaction-pool-runtime-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-trie 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-version 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "substrate-wasm-builder-runner 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "trie-db 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3701,9 +3701,9 @@ dependencies = [
  "hex-literal 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-babe 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-im-online 0.1.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "pallet-babe 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "pallet-im-online 0.1.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "pallet-staking 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-availability-store 0.7.5",
  "polkadot-executor 0.7.5",
@@ -3712,29 +3712,29 @@ dependencies = [
  "polkadot-rpc 0.7.5",
  "polkadot-runtime 0.7.5",
  "polkadot-validation 0.7.5",
- "sc-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client-db 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-consensus-babe 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-executor 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-finality-grandpa 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-network 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-service 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-authority-discovery 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-client 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-client-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-client-db 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-consensus-babe 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-executor 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-finality-grandpa 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-keystore 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-network 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-service 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-telemetry 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-transaction-pool 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus-babe 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-finality-granpda 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-transaction-pool-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-authority-discovery 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-consensus 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-consensus-babe 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-finality-granpda 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-inherents 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-transaction-pool-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
@@ -3743,7 +3743,7 @@ version = "0.7.5"
 dependencies = [
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-primitives 0.7.5",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
@@ -3758,7 +3758,7 @@ dependencies = [
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-timer 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-babe 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "pallet-babe 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-availability-store 0.7.5",
@@ -3767,21 +3767,21 @@ dependencies = [
  "polkadot-primitives 0.7.5",
  "polkadot-runtime 0.7.5",
  "polkadot-statement-table 0.7.5",
- "sc-block-builder 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-finality-grandpa 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus-babe 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-transaction-pool-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-block-builder 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-client-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-finality-grandpa 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-keystore 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-blockchain 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-consensus 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-consensus-babe 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-inherents 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-keyring 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-timestamp 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-transaction-pool-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-trie 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.2.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -4290,19 +4290,19 @@ dependencies = [
 [[package]]
 name = "sc-application-crypto"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
 name = "sc-authority-discovery"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4313,49 +4313,49 @@ dependencies = [
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-build 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-network 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-keystore 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-network 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-authority-discovery 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-blockchain 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
 name = "sc-block-builder"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-block-builder 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-state-machine 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-block-builder 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-blockchain 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-state-machine 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
 name = "sc-chain-spec"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-chain-spec-derive 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-network 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-chain-spec-derive 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-network 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-telemetry 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
 name = "sc-chain-spec-derive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4366,7 +4366,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "ansi_term 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "app_dirs 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4382,18 +4382,18 @@ dependencies = [
  "names 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rpassword 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-network 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-service 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-tracing 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-network 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-service 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-telemetry 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-tracing 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-panic-handler 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-state-machine 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-blockchain 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-keyring 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-panic-handler 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-state-machine 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "structopt 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4402,7 +4402,7 @@ dependencies = [
 [[package]]
 name = "sc-client"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4413,29 +4413,29 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-block-builder 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-executor 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-externalities 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-state-machine 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-block-builder 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-client-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-executor 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-telemetry 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-blockchain 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-consensus 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-externalities 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-inherents 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-keyring 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-state-machine 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-trie 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-version 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "tracing 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sc-client-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4446,28 +4446,28 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-block-builder 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-executor 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-externalities 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-state-machine 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-transaction-pool-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-block-builder 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-executor 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-telemetry 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-blockchain 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-consensus 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-externalities 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-inherents 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-keyring 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-state-machine 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-transaction-pool-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-trie 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-version 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
 name = "sc-client-db"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "kvdb 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4477,25 +4477,25 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-executor 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-state-db 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-state-machine 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-client-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-executor 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-state-db 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-blockchain 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-consensus 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-state-machine 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-trie 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
 name = "sc-consensus-babe"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "fork-tree 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "fork-tree 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-timer 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4508,64 +4508,64 @@ dependencies = [
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pdqselect 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-consensus-slots 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-consensus-uncles 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-application-crypto 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-client 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-client-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-consensus-slots 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-consensus-uncles 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-keystore 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-telemetry 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "schnorrkel 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-block-builder 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus-babe 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-block-builder 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-blockchain 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-consensus 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-consensus-babe 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-inherents 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-timestamp 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-version 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
 name = "sc-consensus-slots"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-timer 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-telemetry 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-blockchain 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-consensus 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-inherents 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
 name = "sc-consensus-uncles"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-authorship 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-authorship 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-consensus 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-inherents 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
 name = "sc-executor"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "cranelift-codegen 0.50.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cranelift-entity 0.50.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4579,15 +4579,15 @@ dependencies = [
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-wasm 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-externalities 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-panic-handler 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-serializer 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-externalities 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-panic-handler 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-runtime-interface 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-serializer 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-trie 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-version 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-wasm-interface 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "wasmi 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmtime-environ 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmtime-jit 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4597,29 +4597,29 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "finality-grandpa 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fork-tree 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "fork-tree 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-network 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-client-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-keystore 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-network 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-telemetry 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-finality-granpda 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-blockchain 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-consensus 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-finality-granpda 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-finality-tracker 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-inherents 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -4627,22 +4627,22 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-application-crypto 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "subtle 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sc-network"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4650,7 +4650,7 @@ dependencies = [
  "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "erased-serde 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "fork-tree 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "fork-tree 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-timer 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4663,21 +4663,21 @@ dependencies = [
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-block-builder 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-peerset 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-block-builder 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-client 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-client-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-peerset 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog_derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-arithmetic 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus-babe 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-arithmetic 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-blockchain 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-consensus 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-consensus-babe 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "unsigned-varint 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4687,7 +4687,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4701,20 +4701,20 @@ dependencies = [
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-network 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-offchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-keystore 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-network 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-offchain 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sc-peerset"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libp2p 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4725,7 +4725,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4734,27 +4734,27 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-executor 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-rpc-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-client-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-executor 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-keystore 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-rpc-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-rpc 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-state-machine 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-transaction-pool-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-blockchain 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-rpc 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-session 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-state-machine 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-transaction-pool-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-version 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
 name = "sc-rpc-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4767,16 +4767,16 @@ dependencies = [
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-rpc 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-transaction-pool-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-rpc 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-transaction-pool-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-version 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
 name = "sc-rpc-server"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "jsonrpc-core 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-http-server 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4785,50 +4785,50 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
 name = "sc-service"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "exit-future 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "grafana-data-source 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "grafana-data-source 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-multiaddr 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-chain-spec 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client-db 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-executor 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-network 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-offchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-rpc 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-rpc-server 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-tracing 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-application-crypto 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-chain-spec 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-client 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-client-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-client-db 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-executor 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-keystore 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-network 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-offchain 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-rpc 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-rpc-server 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-telemetry 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-tracing 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-transaction-pool 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-transaction-pool-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-transaction-pool-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-blockchain 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-consensus 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-session 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-transaction-pool-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-transaction-pool-runtime-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "sysinfo 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "target_info 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4839,18 +4839,18 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
 name = "sc-telemetry"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4872,13 +4872,13 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "erased-serde 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "grafana-data-source 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "grafana-data-source 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-telemetry 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4888,36 +4888,36 @@ dependencies = [
 [[package]]
 name = "sc-transaction-graph"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-transaction-pool-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-transaction-pool-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
 name = "sc-transaction-pool"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-transaction-graph 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-transaction-pool-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-transaction-pool-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-transaction-graph 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-blockchain 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-transaction-pool-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-transaction-pool-runtime-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
@@ -5195,21 +5195,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "sp-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api-proc-macro 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-state-machine 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api-proc-macro 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-state-machine 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-version 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-api-proc-macro"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5221,70 +5221,70 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "integer-sqrt 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-debug-derive 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-debug-derive 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-authority-discovery"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-application-crypto 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-authorship"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-inherents 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-block-builder"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-inherents 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-blockchain"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-block-builder 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-state-machine 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-block-builder 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-consensus 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-state-machine 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-consensus"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5293,33 +5293,33 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-inherents 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-version 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-consensus-babe"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-consensus-slots 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-application-crypto 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sc-consensus-slots 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "schnorrkel 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-inherents 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-timestamp 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-core"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "base58 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5342,11 +5342,11 @@ dependencies = [
  "schnorrkel 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core-storage 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-debug-derive 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-externalities 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core-storage 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-debug-derive 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-externalities 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-runtime-interface 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "substrate-bip39 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-bip39 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5358,18 +5358,18 @@ dependencies = [
 [[package]]
 name = "sp-core-storage"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "impl-serde 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-debug-derive 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-debug-derive 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-debug-derive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5379,89 +5379,89 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "environmental 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core-storage 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core-storage 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-finality-granpda"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-application-crypto 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-finality-tracker"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-inherents 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-inherents"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-io"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsecp256k1 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-externalities 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-state-machine 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-externalities 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-runtime-interface 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-state-machine 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-trie 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-keyring"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "strum 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sp-offchain"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-panic-handler"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5470,60 +5470,60 @@ dependencies = [
 [[package]]
 name = "sp-phragmen"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-rpc"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-runtime"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "paste 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-application-crypto 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-arithmetic 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-arithmetic 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-inherents 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-runtime-interface"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "environmental 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "primitive-types 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-externalities 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime-interface-proc-macro 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-externalities 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-runtime-interface-proc-macro 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-wasm-interface 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "Inflector 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5535,7 +5535,7 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5544,27 +5544,27 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-staking"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-state-machine"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5572,10 +5572,10 @@ dependencies = [
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-externalities 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-panic-handler 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-externalities 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-panic-handler 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-trie 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "trie-db 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "trie-root 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -5583,55 +5583,55 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 
 [[package]]
 name = "sp-timestamp"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-inherents 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-transaction-pool-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-transaction-pool-runtime-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-trie"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "memory-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "trie-db 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "trie-root 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -5639,19 +5639,19 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "impl-serde 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-wasm-interface"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmi 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5755,21 +5755,21 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#042dc459f3875d65bec412068ba1939172c5e8c2"
+source = "git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master#e86381fcba0ffd62cecafd9d503fade386945883"
 dependencies = [
- "frame-system-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-system-rpc-runtime-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core-client 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-derive 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-transaction-pool-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-blockchain 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
+ "sp-transaction-pool-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)",
 ]
 
 [[package]]
@@ -6987,15 +6987,15 @@ dependencies = [
 "checksum fixedbitset 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "86d4de0081402f5e88cdac65c8dcdcc73118c1a7a465e2a05f0da05843a8ea33"
 "checksum flate2 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6bd6d6f4752952feb71363cffc9ebac9411b75b87c6ab6058c40c8900cf43c0f"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
-"checksum fork-tree 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum frame-executive 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum frame-metadata 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum frame-support-procedural 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum frame-support-procedural-tools 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum frame-support-procedural-tools-derive 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum frame-system-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
+"checksum fork-tree 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum frame-executive 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum frame-metadata 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum frame-support 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum frame-support-procedural 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum frame-support-procedural-tools 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum frame-support-procedural-tools-derive 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum frame-system 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum frame-system-rpc-runtime-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
 "checksum fs-swap 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "921d332c89b3b61a826de38c61ee5b6e02c56806cade1b0e5d81bd71f57a71bb"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
@@ -7029,7 +7029,7 @@ dependencies = [
 "checksum glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 "checksum globset 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "925aa2cac82d8834e2b2a4415b6f6879757fb5c0928fc445ae76461a12eed8f2"
 "checksum goblin 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5e6040506480da04a63de51a478e8021892d65d8411f29b2a422c2648bdd8bcb"
-"checksum grafana-data-source 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
+"checksum grafana-data-source 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
 "checksum h2 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "a5b34c246847f938a410a03c5458c7fee2274436675e76d8b903c08efc29c462"
 "checksum h2 0.2.0-alpha.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0f107db1419ef8271686187b1a5d47c6431af4a7f4d98b495e7b7fc249bb0a78"
 "checksum hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d23bd4e7b5eda0d0f3a307e8b381fdc8ba9000f26fbe912250c0a4cc3956364a"
@@ -7152,29 +7152,29 @@ dependencies = [
 "checksum once_cell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "891f486f630e5c5a4916c7e16c4b24a53e78c860b646e9f8e005e4f16847bfed"
 "checksum opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 "checksum owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
-"checksum pallet-authority-discovery 0.1.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-authorship 0.1.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-babe 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-balances 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-collective 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-democracy 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-elections-phragmen 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-grandpa 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-im-online 0.1.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-indices 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-membership 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-nicks 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-offences 1.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-randomness-collective-flip 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-staking-reward-curve 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-transaction-payment 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-transaction-payment-rpc 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-transaction-payment-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-treasury 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
+"checksum pallet-authority-discovery 0.1.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum pallet-authorship 0.1.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum pallet-babe 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum pallet-balances 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum pallet-collective 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum pallet-democracy 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum pallet-elections-phragmen 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum pallet-finality-tracker 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum pallet-grandpa 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum pallet-im-online 0.1.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum pallet-indices 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum pallet-membership 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum pallet-nicks 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum pallet-offences 1.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum pallet-randomness-collective-flip 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum pallet-session 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum pallet-staking 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum pallet-staking-reward-curve 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum pallet-timestamp 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum pallet-transaction-payment 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum pallet-transaction-payment-rpc 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum pallet-transaction-payment-rpc-runtime-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum pallet-treasury 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
 "checksum parity-bytes 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0c276d76c5333b8c2579e02d49a06733a55b8282d2d9b13e8d53b6406bd7e30a"
 "checksum parity-multiaddr 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "045b3c7af871285146300da35b1932bb6e4639b66c7c98e85d06a32cbc4e8fa7"
 "checksum parity-multiaddr 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "82afcb7461eae5d122543d8be1c57d306ed89af2d6ff7f8b0f5a3cc8f7e511bc"
@@ -7262,33 +7262,33 @@ dependencies = [
 "checksum rw-stream-sink 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9cbe61c20455d3015b2bb7be39e1872310283b8e5a52f5b242b0ac7581fe78"
 "checksum ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
 "checksum safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7f7bf422d23a88c16d5090d455f182bc99c60af4df6a345c63428acf5129e347"
-"checksum sc-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-block-builder 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-chain-spec 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-chain-spec-derive 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-cli 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-client 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-client-db 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-consensus-babe 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-consensus-slots 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-consensus-uncles 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-executor 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-finality-grandpa 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-network 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-offchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-peerset 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-rpc 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-rpc-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-rpc-server 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-service 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-state-db 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-tracing 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-transaction-graph 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
+"checksum sc-application-crypto 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum sc-authority-discovery 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum sc-block-builder 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum sc-chain-spec 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum sc-chain-spec-derive 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum sc-cli 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum sc-client 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum sc-client-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum sc-client-db 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum sc-consensus-babe 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum sc-consensus-slots 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum sc-consensus-uncles 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum sc-executor 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum sc-finality-grandpa 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum sc-keystore 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum sc-network 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum sc-offchain 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum sc-peerset 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum sc-rpc 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum sc-rpc-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum sc-rpc-server 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum sc-service 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum sc-state-db 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum sc-telemetry 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum sc-tracing 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum sc-transaction-graph 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum sc-transaction-pool 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
 "checksum schnorrkel 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)" = "eacd8381b3c37840c9c9f40472af529e49975bdcbc24f83c31059fd6539023d3"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
@@ -7319,42 +7319,42 @@ dependencies = [
 "checksum snow 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "91eecae35b461ed26bda7a76bea2cc5bda2bf4b8dd06761879f19e6fdd50c2dd"
 "checksum soketto 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bceb1a3a15232d013d9a3b7cac9e5ce8e2313f348f01d4bc1097e5e53aa07095"
 "checksum sourcefile 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf77cb82ba8453b42b6ae1d692e4cdc92f9a47beaf89a847c8be83f4e328ad3"
-"checksum sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-api-proc-macro 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-arithmetic 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-authorship 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-block-builder 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-consensus 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-consensus-babe 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-core-storage 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-debug-derive 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-externalities 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-finality-granpda 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-offchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-panic-handler 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-phragmen 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-rpc 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-runtime-interface-proc-macro 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-serializer 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-state-machine 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-transaction-pool-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-transaction-pool-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
+"checksum sp-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum sp-api-proc-macro 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum sp-arithmetic 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum sp-authority-discovery 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum sp-authorship 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum sp-block-builder 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum sp-blockchain 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum sp-consensus 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum sp-consensus-babe 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum sp-core-storage 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum sp-debug-derive 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum sp-externalities 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum sp-finality-granpda 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum sp-finality-tracker 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum sp-inherents 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum sp-io 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum sp-keyring 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum sp-offchain 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum sp-panic-handler 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum sp-phragmen 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum sp-rpc 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum sp-runtime-interface 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum sp-runtime-interface-proc-macro 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum sp-serializer 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum sp-session 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum sp-staking 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum sp-state-machine 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum sp-timestamp 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum sp-transaction-pool-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum sp-transaction-pool-runtime-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum sp-trie 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum sp-version 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
+"checksum sp-wasm-interface 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
 "checksum spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
@@ -7367,7 +7367,7 @@ dependencies = [
 "checksum strum 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6138f8f88a16d90134763314e3fc76fa3ed6a7db4725d6acf9a3ef95a3188d22"
 "checksum strum_macros 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0054a7df764039a6cd8592b9de84be4bec368ff081d203a7d5371cbfa8e65c81"
 "checksum substrate-bip39 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3be511be555a3633e71739a79e4ddff6a6aaa6579fa6114182a51d72c3eb93c5"
-"checksum substrate-frame-rpc-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
+"checksum substrate-frame-rpc-system 2.0.0 (git+https://github.com/mxinden/substrate?branch=sentry-nodes-flag-polkadot-master)" = "<none>"
 "checksum substrate-wasm-builder-runner 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bd48273fe9d7f92c1f7d6c1c537bb01c8068f925b47ad2cd8367e11dc32f8550"
 "checksum subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 "checksum subtle 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab3af2eb31c42e8f0ccf43548232556c42737e01a96db6e1777b0be108e79799"

--- a/availability-store/Cargo.toml
+++ b/availability-store/Cargo.toml
@@ -17,15 +17,15 @@ futures = { package = "futures", version = "0.3.1", features = ["compat"] }
 tokio = "0.1.7"
 exit-future = "0.1"
 codec = { package = "parity-scale-codec", version = "1.1.0", default-features = false, features = ["derive"] }
-sc-network = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-consensus_common = { package = "sp-consensus", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-client = { package = "sc-client-api", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sc-client = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-keystore = { package = "sc-keystore", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+sc-network = { git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
+consensus_common = { package = "sp-consensus", git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
+client = { package = "sc-client-api", git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
+sc-client = { git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
+sp-runtime = { git = "https://github.com/mxinden/substrate", default-features = false, branch = "sentry-nodes-flag-polkadot-master" }
+sp-blockchain = { git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
+sp-api = { git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
+keystore = { package = "sc-keystore", git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
+sp-core = { git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
 kvdb = "0.1.1"
 kvdb-memorydb = "0.1.2"
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -11,7 +11,7 @@ tokio = "0.1.22"
 futures = { version = "0.3.1", features = ["compat"] }
 futures01 = { package = "futures", version = "0.1.29" }
 structopt = "0.3.4"
-cli = { package = "sc-cli", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+cli = { package = "sc-cli", git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
 service = { package = "polkadot-service", path = "../service" }
 
 [features]

--- a/collator/Cargo.toml
+++ b/collator/Cargo.toml
@@ -8,11 +8,11 @@ edition = "2018"
 [dependencies]
 futures01 = { package = "futures", version = "0.1.17" }
 futures = { version = "0.3.1", features = ["compat"] }
-client = { package = "sc-client", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-client-api = { package = "sc-client-api", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-primitives = { package = "sp-core", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sc-network = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-consensus_common = { package = "sp-consensus", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+client = { package = "sc-client", git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
+client-api = { package = "sc-client-api", git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
+primitives = { package = "sp-core", git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
+sc-network = { git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
+consensus_common = { package = "sp-consensus", git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
 polkadot-runtime = { path = "../runtime" }
 polkadot-primitives = { path = "../primitives" }
 polkadot-cli = { path = "../cli" }
@@ -24,4 +24,4 @@ tokio = "0.1.22"
 futures-timer = "1.0"
 
 [dev-dependencies]
-keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+keyring = { package = "sp-keyring", git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }

--- a/erasure-coding/Cargo.toml
+++ b/erasure-coding/Cargo.toml
@@ -8,6 +8,6 @@ edition = "2018"
 primitives = { package = "polkadot-primitives", path = "../primitives" }
 reed_solomon = { package = "reed-solomon-erasure", git = "https://github.com/paritytech/reed-solomon-erasure" }
 codec = { package = "parity-scale-codec", version = "1.1.0", default-features = false, features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-trie = { package = "sp-trie", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+sp-core = { git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
+trie = { package = "sp-trie", git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
 derive_more = "0.15.0"

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -6,5 +6,5 @@ description = "Polkadot node implementation in Rust."
 edition = "2018"
 
 [dependencies]
-sc-executor = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+sc-executor = { git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
 polkadot-runtime = { path = "../runtime" }

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -13,16 +13,16 @@ polkadot-validation = { path = "../validation" }
 polkadot-primitives = { path = "../primitives" }
 polkadot-erasure-coding = { path = "../erasure-coding" }
 codec = { package = "parity-scale-codec", version = "1.1.0", default-features = false, features = ["derive"] }
-sc-network = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+sc-network = { git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
+sp-core = { git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
+sp-runtime = { git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
 futures = "0.1"
 futures03 = { package = "futures", version = "0.3.1", features = ["compat"] }
 log = "0.4.8"
 exit-future = "0.1.4"
-sc-client = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+sc-client = { git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
+sp-blockchain = { git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
 
 [dev-dependencies]
-sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+sp-keyring = { git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
+sp-api = { git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }

--- a/parachain/Cargo.toml
+++ b/parachain/Cargo.toml
@@ -10,8 +10,8 @@ codec = { package = "parity-scale-codec", version = "1.1.0", default-features = 
 wasmi = { version = "0.4.5", optional = true }
 derive_more = { version = "0.14.1", optional = true }
 serde = { version = "1.0.102", default-features = false, features = [ "derive" ] }
-rstd = { package = "sp-std", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
+rstd = { package = "sp-std", git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master", default-features = false }
+sp-core = { git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master", default-features = false }
 lazy_static = { version = "1.4.0", optional = true }
 parking_lot = { version = "0.7.1", optional = true }
 log = { version = "0.4.8", optional = true }

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -7,19 +7,19 @@ edition = "2018"
 [dependencies]
 serde = { version = "1.0.102", optional = true, features = ["derive"] }
 parity-scale-codec = { version = "1.1.0", default-features = false, features = ["bit-vec", "derive"] }
-primitives = { package = "sp-core", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-application-crypto = { package = "sc-application-crypto", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-rstd = { package = "sp-std", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-runtime_primitives = { package = "sp-runtime", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
+primitives = { package = "sp-core", git = "https://github.com/mxinden/substrate", default-features = false, branch = "sentry-nodes-flag-polkadot-master" }
+application-crypto = { package = "sc-application-crypto", git = "https://github.com/mxinden/substrate", default-features = false, branch = "sentry-nodes-flag-polkadot-master" }
+sp-api = { git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master", default-features = false }
+sp-version = { git = "https://github.com/mxinden/substrate", default-features = false, branch = "sentry-nodes-flag-polkadot-master" }
+rstd = { package = "sp-std", git = "https://github.com/mxinden/substrate", default-features = false, branch = "sentry-nodes-flag-polkadot-master" }
+runtime_primitives = { package = "sp-runtime", git = "https://github.com/mxinden/substrate", default-features = false, branch = "sentry-nodes-flag-polkadot-master" }
 polkadot-parachain = { path = "../parachain", default-features = false }
-trie = { package = "sp-trie", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
+trie = { package = "sp-trie", git = "https://github.com/mxinden/substrate", default-features = false, branch = "sentry-nodes-flag-polkadot-master" }
 bitvec = { version = "0.15.2", default-features = false, features = ["alloc"] }
-babe = { package = "pallet-babe", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
+babe = { package = "pallet-babe", git = "https://github.com/mxinden/substrate", default-features = false, branch = "sentry-nodes-flag-polkadot-master" }
 
 [dev-dependencies]
-sp-serializer = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+sp-serializer = { git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
 pretty_assertions = "0.5.1"
 
 [features]

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -5,13 +5,13 @@ authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 
 [dependencies]
-client = { package = "sc-client", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+client = { package = "sc-client", git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
 jsonrpc-core = "14.0.3"
 polkadot-primitives = { path = "../primitives" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master"  }
-sc-rpc = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-txpool-api = { package = "sp-transaction-pool-api", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-frame-rpc-system = { package = "substrate-frame-rpc-system", git = "https://github.com/paritytech/substrate", branch = "polkadot-master"  }
-pallet-transaction-payment-rpc = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+sp-runtime = { git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master"  }
+sc-rpc = { git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
+txpool-api = { package = "sp-transaction-pool-api", git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
+frame-rpc-system = { package = "substrate-frame-rpc-system", git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master"  }
+pallet-transaction-payment-rpc = { git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
 polkadot-runtime = { path = "../runtime" }
 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -14,48 +14,48 @@ safe-mix = { version = "1.0.0", default-features = false }
 serde = { version = "1.0.102", default-features = false }
 serde_derive = { version = "1.0.102", optional = true }
 
-authority-discovery-primitives = { package = "sp-authority-discovery", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-offchain-primitives = { package = "sp-offchain", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-rstd = { package = "sp-std", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-sp-staking = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-sp-serializer = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-sp-session = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-version = { package = "sp-version", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-tx-pool-api = { package = "sp-transaction-pool-runtime-api", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-block-builder-api = { package = "sp-block-builder", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
+authority-discovery-primitives = { package = "sp-authority-discovery", git = "https://github.com/mxinden/substrate", default-features = false, branch = "sentry-nodes-flag-polkadot-master" }
+babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/mxinden/substrate", default-features = false, branch = "sentry-nodes-flag-polkadot-master" }
+sp-api = { git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master", default-features = false }
+inherents = { package = "sp-inherents", git = "https://github.com/mxinden/substrate", default-features = false, branch = "sentry-nodes-flag-polkadot-master" }
+offchain-primitives = { package = "sp-offchain", git = "https://github.com/mxinden/substrate", default-features = false, branch = "sentry-nodes-flag-polkadot-master" }
+rstd = { package = "sp-std", git = "https://github.com/mxinden/substrate", default-features = false, branch = "sentry-nodes-flag-polkadot-master" }
+sp-io = { git = "https://github.com/mxinden/substrate", default-features = false, branch = "sentry-nodes-flag-polkadot-master" }
+sp-runtime = { git = "https://github.com/mxinden/substrate", default-features = false, branch = "sentry-nodes-flag-polkadot-master" }
+sp-staking = { git = "https://github.com/mxinden/substrate", default-features = false, branch = "sentry-nodes-flag-polkadot-master" }
+sp-core = { git = "https://github.com/mxinden/substrate", default-features = false, branch = "sentry-nodes-flag-polkadot-master" }
+sp-serializer = { git = "https://github.com/mxinden/substrate", default-features = false, branch = "sentry-nodes-flag-polkadot-master" }
+sp-session = { git = "https://github.com/mxinden/substrate", default-features = false, branch = "sentry-nodes-flag-polkadot-master" }
+version = { package = "sp-version", git = "https://github.com/mxinden/substrate", default-features = false, branch = "sentry-nodes-flag-polkadot-master" }
+tx-pool-api = { package = "sp-transaction-pool-runtime-api", git = "https://github.com/mxinden/substrate", default-features = false, branch = "sentry-nodes-flag-polkadot-master" }
+block-builder-api = { package = "sp-block-builder", git = "https://github.com/mxinden/substrate", default-features = false, branch = "sentry-nodes-flag-polkadot-master" }
 
-authority-discovery = { package = "pallet-authority-discovery", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-authorship = { package = "pallet-authorship", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-babe = { package = "pallet-babe", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-balances = { package = "pallet-balances", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-transaction-payment = { package = "pallet-transaction-payment", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-collective = { package = "pallet-collective", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-democracy = { package = "pallet-democracy", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-elections-phragmen = { package = "pallet-elections-phragmen", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-executive = { package = "frame-executive", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-finality-tracker = { package = "pallet-finality-tracker", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-grandpa = { package = "pallet-grandpa", git = "https://github.com/paritytech/substrate", default-features = false, features = ["migrate-authorities"], branch = "polkadot-master" }
-im-online = { package = "pallet-im-online", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-indices = { package = "pallet-indices", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-membership = { package = "pallet-membership", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-nicks = { package = "pallet-nicks", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-offences = { package = "pallet-offences", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-randomness-collective-flip = { package = "pallet-randomness-collective-flip", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-session = { package = "pallet-session", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-staking = { package = "pallet-staking", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-pallet-staking-reward-curve = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-system = { package = "frame-system", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-system_rpc_runtime_api = { package = "frame-system-rpc-runtime-api", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-timestamp = { package = "pallet-timestamp", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-treasury = { package = "pallet-treasury", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
+authority-discovery = { package = "pallet-authority-discovery", git = "https://github.com/mxinden/substrate", default-features = false, branch = "sentry-nodes-flag-polkadot-master" }
+authorship = { package = "pallet-authorship", git = "https://github.com/mxinden/substrate", default-features = false, branch = "sentry-nodes-flag-polkadot-master" }
+babe = { package = "pallet-babe", git = "https://github.com/mxinden/substrate", default-features = false, branch = "sentry-nodes-flag-polkadot-master" }
+balances = { package = "pallet-balances", git = "https://github.com/mxinden/substrate", default-features = false, branch = "sentry-nodes-flag-polkadot-master" }
+transaction-payment = { package = "pallet-transaction-payment", git = "https://github.com/mxinden/substrate", default-features = false, branch = "sentry-nodes-flag-polkadot-master" }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/mxinden/substrate", default-features = false, branch = "sentry-nodes-flag-polkadot-master" }
+collective = { package = "pallet-collective", git = "https://github.com/mxinden/substrate", default-features = false, branch = "sentry-nodes-flag-polkadot-master" }
+democracy = { package = "pallet-democracy", git = "https://github.com/mxinden/substrate", default-features = false, branch = "sentry-nodes-flag-polkadot-master" }
+elections-phragmen = { package = "pallet-elections-phragmen", git = "https://github.com/mxinden/substrate", default-features = false, branch = "sentry-nodes-flag-polkadot-master" }
+executive = { package = "frame-executive", git = "https://github.com/mxinden/substrate", default-features = false, branch = "sentry-nodes-flag-polkadot-master" }
+finality-tracker = { package = "pallet-finality-tracker", git = "https://github.com/mxinden/substrate", default-features = false, branch = "sentry-nodes-flag-polkadot-master" }
+grandpa = { package = "pallet-grandpa", git = "https://github.com/mxinden/substrate", default-features = false, features = ["migrate-authorities"], branch = "sentry-nodes-flag-polkadot-master" }
+im-online = { package = "pallet-im-online", git = "https://github.com/mxinden/substrate", default-features = false, branch = "sentry-nodes-flag-polkadot-master" }
+indices = { package = "pallet-indices", git = "https://github.com/mxinden/substrate", default-features = false, branch = "sentry-nodes-flag-polkadot-master" }
+membership = { package = "pallet-membership", git = "https://github.com/mxinden/substrate", default-features = false, branch = "sentry-nodes-flag-polkadot-master" }
+nicks = { package = "pallet-nicks", git = "https://github.com/mxinden/substrate", default-features = false, branch = "sentry-nodes-flag-polkadot-master" }
+offences = { package = "pallet-offences", git = "https://github.com/mxinden/substrate", default-features = false, branch = "sentry-nodes-flag-polkadot-master" }
+randomness-collective-flip = { package = "pallet-randomness-collective-flip", git = "https://github.com/mxinden/substrate", default-features = false, branch = "sentry-nodes-flag-polkadot-master" }
+session = { package = "pallet-session", git = "https://github.com/mxinden/substrate", default-features = false, branch = "sentry-nodes-flag-polkadot-master" }
+frame-support = { git = "https://github.com/mxinden/substrate", default-features = false, branch = "sentry-nodes-flag-polkadot-master" }
+staking = { package = "pallet-staking", git = "https://github.com/mxinden/substrate", default-features = false, branch = "sentry-nodes-flag-polkadot-master" }
+pallet-staking-reward-curve = { git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
+system = { package = "frame-system", git = "https://github.com/mxinden/substrate", default-features = false, branch = "sentry-nodes-flag-polkadot-master" }
+system_rpc_runtime_api = { package = "frame-system-rpc-runtime-api", git = "https://github.com/mxinden/substrate", default-features = false, branch = "sentry-nodes-flag-polkadot-master" }
+timestamp = { package = "pallet-timestamp", git = "https://github.com/mxinden/substrate", default-features = false, branch = "sentry-nodes-flag-polkadot-master" }
+treasury = { package = "pallet-treasury", git = "https://github.com/mxinden/substrate", default-features = false, branch = "sentry-nodes-flag-polkadot-master" }
 
 primitives = { package = "polkadot-primitives", path = "../primitives", default-features = false }
 polkadot-parachain = { path = "../parachain", default-features = false }
@@ -64,8 +64,8 @@ polkadot-parachain = { path = "../parachain", default-features = false }
 hex-literal = "0.2.1"
 libsecp256k1 = "0.3.2"
 tiny-keccak = "1.5.0"
-keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-trie = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+keyring = { package = "sp-keyring", git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
+sp-trie = { git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
 trie-db = "0.16.0"
 serde_json = "1.0.41"
 

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -20,28 +20,28 @@ polkadot-runtime = { path = "../runtime" }
 polkadot-executor = { path = "../executor" }
 polkadot-network = { path = "../network"  }
 polkadot-rpc = { path = "../rpc" }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-primitives = { package = "sp-core", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-client = { package = "sc-client", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-client-api = { package = "sc-client-api", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-client-db = { package = "sc-client-db", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sc-executor = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sc-network = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-consensus_common = { package = "sp-consensus", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-grandpa = { package = "sc-finality-grandpa", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-grandpa_primitives = { package = "sp-finality-granpda", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-service = { package = "sc-service", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-telemetry = { package = "sc-telemetry", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-txpool = { package = "sc-transaction-pool", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-txpool-api = { package = "sp-transaction-pool-api", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sc-keystore = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-pallet-babe = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-pallet-staking = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-im-online = { package = "pallet-im-online", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
-authority-discovery = { package = "sc-authority-discovery", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-authority-discovery-primitives = { package = "sp-authority-discovery", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-babe = { package = "sc-consensus-babe", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-master" }
+sp-io = { git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
+sp-api = { git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
+sp-runtime = { git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
+primitives = { package = "sp-core", git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
+client = { package = "sc-client", git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
+client-api = { package = "sc-client-api", git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
+client-db = { package = "sc-client-db", git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
+sc-executor = { git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
+sc-network = { git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
+consensus_common = { package = "sp-consensus", git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
+grandpa = { package = "sc-finality-grandpa", git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
+grandpa_primitives = { package = "sp-finality-granpda", git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
+inherents = { package = "sp-inherents", git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
+service = { package = "sc-service", git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
+telemetry = { package = "sc-telemetry", git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
+txpool = { package = "sc-transaction-pool", git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
+txpool-api = { package = "sp-transaction-pool-api", git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
+sc-keystore = { git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
+pallet-babe = { git = "https://github.com/mxinden/substrate", default-features = false, branch = "sentry-nodes-flag-polkadot-master" }
+pallet-staking = { git = "https://github.com/mxinden/substrate", default-features = false, branch = "sentry-nodes-flag-polkadot-master" }
+im-online = { package = "pallet-im-online", git = "https://github.com/mxinden/substrate", default-features = false, branch = "sentry-nodes-flag-polkadot-master" }
+authority-discovery = { package = "sc-authority-discovery", git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
+authority-discovery-primitives = { package = "sp-authority-discovery", git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
+babe = { package = "sc-consensus-babe", git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
+babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/mxinden/substrate", default-features = false, branch = "sentry-nodes-flag-polkadot-master" }

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -169,6 +169,7 @@ pub fn new_full(config: Configuration<CustomConfiguration, GenesisConfig>)
 	let disable_grandpa = config.disable_grandpa;
 	let name = config.name.clone();
 	let authority_discovery_enabled = config.custom.authority_discovery_enabled;
+	let sentry_nodes = config.network.sentry_nodes.clone();
 
 	// sentry nodes announce themselves as authorities to the network
 	// and should run the same protocols authorities do, but it should
@@ -313,6 +314,7 @@ pub fn new_full(config: Configuration<CustomConfiguration, GenesisConfig>)
 			let authority_discovery = authority_discovery::AuthorityDiscovery::new(
 				service.client(),
 				service.network(),
+				sentry_nodes,
 				service.keystore(),
 				future03_dht_event_rx,
 			);

--- a/statement-table/Cargo.toml
+++ b/statement-table/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2018"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.1.0", default-features = false, features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+sp-core = { git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
 primitives = { package = "polkadot-primitives", path = "../primitives" }

--- a/test-parachains/adder/Cargo.toml
+++ b/test-parachains/adder/Cargo.toml
@@ -13,7 +13,7 @@ tiny-keccak = "1.5.0"
 dlmalloc = { version = "0.1.3", features = [ "global" ] }
 
 # We need to make sure the global allocator is disabled until we have support of full substrate externalities
-runtime-io = { package = "sp-io", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false, features = [ "disable_allocator" ] }
+runtime-io = { package = "sp-io", git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master", default-features = false, features = [ "disable_allocator" ] }
 
 [build-dependencies]
 wasm-builder-runner = { package = "substrate-wasm-builder-runner", version = "1.0.4" }

--- a/test-parachains/adder/collator/Cargo.toml
+++ b/test-parachains/adder/collator/Cargo.toml
@@ -9,9 +9,9 @@ adder = { path = ".." }
 parachain = { package = "polkadot-parachain", path = "../../../parachain" }
 collator = { package = "polkadot-collator", path = "../../../collator" }
 primitives = { package = "polkadot-primitives", path = "../../../primitives" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-client = { package = "sc-client", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-client-api = { package = "sc-client-api", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+sp-core = { git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
+client = { package = "sc-client", git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
+client-api = { package = "sc-client-api", git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
 parking_lot = "0.9.0"
 ctrlc = { version = "3.1.3", features = ["termination"] }
 futures = "0.3.1"

--- a/validation/Cargo.toml
+++ b/validation/Cargo.toml
@@ -22,22 +22,22 @@ polkadot-primitives = { path = "../primitives" }
 polkadot-erasure-coding = { path = "../erasure-coding" }
 polkadot-runtime = { path = "../runtime" }
 table = { package = "polkadot-statement-table", path = "../statement-table" }
-grandpa = { package = "sc-finality-grandpa", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-consensus = { package = "sp-consensus", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-primitives = { package = "sp-core", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-txpool-api = { package = "sp-transaction-pool-api", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-client = { package = "sc-client-api", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-block-builder = { package = "sc-block-builder", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-trie = { package = "sp-trie", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-runtime_primitives = { package = "sp-runtime", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+grandpa = { package = "sc-finality-grandpa", git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
+inherents = { package = "sp-inherents", git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
+consensus = { package = "sp-consensus", git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
+primitives = { package = "sp-core", git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
+txpool-api = { package = "sp-transaction-pool-api", git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
+client = { package = "sc-client-api", git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
+sp-blockchain = { git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
+sp-api = { git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
+sp-timestamp = { git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
+block-builder = { package = "sc-block-builder", git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
+trie = { package = "sp-trie", git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
+runtime_primitives = { package = "sp-runtime", git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
 bitvec = { version = "0.15.2", default-features = false, features = ["alloc"] }
-runtime_babe = { package = "pallet-babe", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-keystore = { package = "sc-keystore", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+runtime_babe = { package = "pallet-babe", git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
+babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
+keystore = { package = "sc-keystore", git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }
 
 [dev-dependencies]
-sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+sp-keyring = { git = "https://github.com/mxinden/substrate", branch = "sentry-nodes-flag-polkadot-master" }


### PR DESCRIPTION
Follow up to and blocked on: https://github.com/paritytech/substrate/pull/4285.

First commit directs Polkadot to a fork of Substrate with the changes of https://github.com/paritytech/substrate/pull/4285 in order to compile. It can be **ignored** and **needs to be reverted before merging this pull request**.

Second commit (https://github.com/paritytech/polkadot/commit/08b457ba576f73cad15b9c86779839571ec389ee) is the actual two-liner of this pull request.