### PR TITLE
Add versioning to `ParachainHost` runtime API

### DIFF
--- a/availability-store/src/worker.rs
+++ b/availability-store/src/worker.rs
@@ -220,7 +220,7 @@ where
 			if api.has_api_with::<dyn ParachainHost<Block, Error = ApiErrorFor<P, Block>>, _>(
 				parent,
 				|version| version >= 2,
-			)? {
+			).map_err(|_| ConsensusError::ChainLookup("outdated runtime API".into()))? {
 				api.get_heads(&parent, extrinsics)
 					.map_err(|_| ConsensusError::ChainLookup("".into()))?
 					.map(|v| v.into_iter())

--- a/availability-store/src/worker.rs
+++ b/availability-store/src/worker.rs
@@ -22,7 +22,7 @@ use std::thread;
 use log::{error, info, trace, warn};
 use sp_blockchain::{Result as ClientResult};
 use sp_runtime::traits::{Header as HeaderT, ProvideRuntimeApi};
-use sp_api::ApiExt;
+use sp_api::{ApiExt, ApiErrorFor};
 use client::{
 	BlockchainEvents, BlockBody,
 	blockchain::ProvideCache,
@@ -214,9 +214,20 @@ where
 {
 	let extrinsics = client.block_body(block)?;
 	Ok(match extrinsics {
-		Some(extrinsics) => client.runtime_api()
-			.get_heads(&parent, extrinsics).map_err(|_| ConsensusError::ChainLookup("".into()))?
-			.and_then(|v| Some(v.into_iter())),
+		Some(extrinsics) => {
+			let api = client.runtime_api();
+
+			if api.has_api_with::<dyn ParachainHost<Block, Error = ApiErrorFor<P, Block>>, _>(
+				parent,
+				|version| version >= 2,
+			)? {
+				api.get_heads(&parent, extrinsics)
+					.map_err(|_| ConsensusError::ChainLookup("".into()))?
+					.map(|v| v.into_iter())
+			} else {
+				None
+			}
+	}
 		None => None,
 	})
 }

--- a/primitives/src/parachain.rs
+++ b/primitives/src/parachain.rs
@@ -591,6 +591,7 @@ use runtime_primitives::traits::{Block as BlockT};
 
 sp_api::decl_runtime_apis! {
 	/// The API for querying the state of parachains on-chain.
+	#[api_version(2)]
 	pub trait ParachainHost {
 		/// Get the current validators.
 		fn validators() -> Vec<ValidatorId>;


### PR DESCRIPTION
This attempts to work around an authoring issue and backwards incompatibility introduced by #475 by correctly versioning the `ParachainHost` API.