### PR TITLE
Add the /ws bootnode to the chain specs

### DIFF
--- a/service/res/kusama.json
+++ b/service/res/kusama.json
@@ -9,6 +9,7 @@
     "/dns4/p2p.cc3-4.kusama.network/tcp/30100/p2p/QmP3zYRhAxxw4fDf6Vq5agM8AZt1m2nKpPAEDmyEHPK5go",
     "/dns4/p2p.cc3-5.kusama.network/tcp/30100/p2p/QmdePe9MiAJT4yHT2tEwmazCsckAZb19uaoSUgRDffPq3G",
     "/dns4/kusama-bootnode-0.paritytech.net/tcp/30333/p2p/QmaEYixpsZy126nijCeP1LFhUipvGs23RU15jJJyAePxWn",
+    "/dns4/kusama-bootnode-0.paritytech.net/tcp/30334/ws/p2p/QmaEYixpsZy126nijCeP1LFhUipvGs23RU15jJJyAePxWn",
     "/dns4/kusama-bootnode-1.paritytech.net/tcp/30333/p2p/QmV32G18YzenpNFmhqg2n7TtdjYRK7oU6FhLbDL4oRgsbe"
   ],
   "telemetryEndpoints": [


### PR DESCRIPTION
The in-browser node can only connect through the WebSockets protocol. We now have a bootnode that has a WebSocket listening port.
cc @expenses 