### PR TITLE
[Future substrate update for substrate #4364]

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -220,7 +220,8 @@ parameter_types! {
 
 impl transaction_payment::Trait for Runtime {
 	type Currency = Balances;
-	type OnTransactionPayment = DealWithFees;
+	type OnTransactionFeePayment = DealWithFees;
+	type OnTransactionTipPayment = Author;
 	type TransactionBaseFee = TransactionBaseFee;
 	type TransactionByteFee = TransactionByteFee;
 	type WeightToFee = WeightToFee;


### PR DESCRIPTION
Needed for next substrate update if https://github.com/paritytech/substrate/pull/4364 gets included.

Also fix tip division as web3 spec https://github.com/paritytech/substrate/issues/4363 : 

>> The transaction fee is considered a base price. There will be a different field in the transaction called tip, and a user is free to put any amount of tokens in it or leave it at zero. Block producers receive 100% of the tip on top of the standard 20% of the fee, so they have an incentive to include transactions with large tips.