### PR TITLE
Add matrix release alert script and gitlab job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -116,7 +116,7 @@ alert-pending-release:
   image:                           parity/tools:latest
   only:
     - tags
-    - /^v[0-9]+\.[0-9]+\.[0-9].*$/        # i.e. v1.0.1, v2.1.0rc1
+    - /^v[0-9]+\.[0-9]+\.[0-9]+.*$/        # i.e. v1.0.1, v2.1.0rc1
   script:
     - ./scripts/gitlab/alert_pending_release.sh
 
@@ -369,6 +369,5 @@ deploy-polkasync-kusama:
         -F "ref=master" \
         -F "variables[POLKADOT_BUILD_REF]=${CI_COMMIT_REF_NAME}" \
         ${GITLAB_API}/projects/${GITHUB_API_PROJECT}/trigger/pipeline | jq .
-
 
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -111,8 +111,14 @@ check-line-width:
   interruptible:                   true
   allow_failure:                   true
 
-
-
+alert-pending-release:
+  stage:                           test
+  image:                           parity/tools:latest
+  only:
+    - tags
+    - /^v[0-9]+\.[0-9]+\.[0-9].*$/        # i.e. v1.0.1, v2.1.0rc1
+  script:
+    - ./scripts/gitlab/alert_pending_release.sh
 
 test-linux-stable:                 &test
   stage:                           test

--- a/scripts/gitlab/alert_pending_release.sh
+++ b/scripts/gitlab/alert_pending_release.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# structure_message $content $formatted_content (optional)
+structure_message() {
+  if [ -z "$2" ]; then
+    body=$(jq -Rs --arg body "$1" '{"msgtype": "m.text", $body}' < /dev/null)
+  else
+    body=$(jq -Rs --arg body "$1" --arg formatted_body "$2" '{"msgtype": "m.text", $body, "format": "org.matrix.custom.html", $formatted_body}' < /dev/null)
+  fi
+  echo $body
+}
+
+# send_message $body (json formatted) $room_id $access_token
+send_message() {
+curl -XPOST -d "$1" "https://matrix.parity.io/_matrix/client/r0/rooms/$2/send/m.room.message?access_token=$3"
+}
+
+# Receive keys
+trusted_keys=(
+27E36F4D3DB8D09946B14802EC077FBE1556877C # gavin@parity.io
+)
+
+for key in ${trusted_keys[@]}; do
+  gpg --keyserver hkps://keys.openpgp.org --recv-keys $key
+done
+
+# If the tag's not signed by any of the above keys, exit failing
+if ! git tag -v $CI_COMMIT_TAG; then
+  echo "[!] FATAL: TAG NOT VERIFIED WITH A GPG SIGNATURE, QUITTING"
+  exit 1
+fi
+
+echo "[+] Tag present and verified. Alerting #polkadot and release-manager"
+
+# Format and send message to #polkadot channel
+msg_body=$(cat <<EOF
+**New version of polkadot tagged:** $CI_COMMIT_TAG.
+Build pipeline: $CI_PIPELINE_URL
+A release will be created on completion of this pipeline.
+EOF
+)
+
+# Created formatted body for clients that support it (???)
+formatted_msg_body=$(cat <<EOF
+<strong>New version of polkadot tagged:</strong> $CI_COMMIT_TAG.<br />
+Build pipeline: $CI_PIPELINE_URL<br />
+A release will be pending upon completion of this pipeline.
+EOF
+)
+
+echo "[+] Sending message to Polkadot room"
+send_message "$(structure_message "$msg_body" "$formatted_msg_body")" $MATRIX_ROOM_ID $MATRIX_ACCESS_TOKEN
+
+# Format and send message to release manager
+msg_body=$(cat <<EOF
+**New version of polkadot tagged:** $CI_COMMIT_TAG.
+Build pipeline: $CI_PIPELINE_URL
+When the build finishes, it is safe to perform a release.
+EOF
+)
+
+echo "[+] Sending message to release manager"
+send_message "$(structure_message "$msg_body")" $REL_MAN_ROOM_ID $MATRIX_ACCESS_TOKEN


### PR DESCRIPTION
This script should run whenever a tag formatted like 'v1.2.3' is detected, and will send an alert to Matrix that there is a pending release - provided the tag is signed by an approved GPG signing key.