### PR TITLE
Change crowdfund module for child trie unique id

### DIFF
--- a/runtime/src/crowdfund.rs
+++ b/runtime/src/crowdfund.rs
@@ -464,24 +464,34 @@ impl<T: Trait> Module<T> {
 			.collect()
 	}
 
+	/// Child trie unique id for a crowdfund is built from the hash part of the fund id.
+	pub fn trie_unique_id(fund_id: &[u8]) -> child::ChildInfo {
+		let start = CHILD_STORAGE_KEY_PREFIX.len() + b"default:".len();
+		child::ChildInfo::new_default(&fund_id[start..])
+	}
+
 	pub fn contribution_put(index: FundIndex, who: &T::AccountId, balance: &BalanceOf<T>) {
 		let id = Self::id_from_index(index);
-		who.using_encoded(|b| child::put(id.as_ref(), b, balance));
+		who.using_encoded(|b| child::put(id.as_ref(), Self::trie_unique_id(id.as_ref()), b, balance));
 	}
 
 	pub fn contribution_get(index: FundIndex, who: &T::AccountId) -> BalanceOf<T> {
 		let id = Self::id_from_index(index);
-		who.using_encoded(|b| child::get_or_default::<BalanceOf<T>>(id.as_ref(), b))
+		who.using_encoded(|b| child::get_or_default::<BalanceOf<T>>(
+			id.as_ref(),
+			Self::trie_unique_id(id.as_ref()),
+			b,
+		))
 	}
 
 	pub fn contribution_kill(index: FundIndex, who: &T::AccountId) {
 		let id = Self::id_from_index(index);
-		who.using_encoded(|b| child::kill(id.as_ref(), b));
+		who.using_encoded(|b| child::kill(id.as_ref(), Self::trie_unique_id(id.as_ref()), b));
 	}
 
 	pub fn crowdfund_kill(index: FundIndex) {
 		let id = Self::id_from_index(index);
-		child::kill_storage(id.as_ref());
+		child::kill_storage(id.as_ref(), Self::trie_unique_id(id.as_ref()));
 	}
 }
 


### PR DESCRIPTION
This PR change crowdfund to use the hash part of the id as a unique id for the child trie use.
This PR is here for the time when substrate branch `polkadot-master` will include https://github.com/paritytech/substrate/pull/4162