### PR TITLE
ci: increase git cloning depth to 100

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,7 +16,7 @@ image:                             parity/rust-builder:latest
 
 variables:
   GIT_STRATEGY:                    fetch
-  GIT_DEPTH:                       3
+  GIT_DEPTH:                       100
   CARGO_HOME:                      "/ci-cache/${CI_PROJECT_NAME}/cargo/${CI_JOB_NAME}"
   SCCACHE_DIR:                     "/ci-cache/${CI_PROJECT_NAME}/sccache"
   CI_SERVER_NAME:                  "GitLab CI"


### PR DESCRIPTION
follow-up pr from substrate https://github.com/paritytech/substrate/pull/4481

CI checks can fail if there are more than 3 commits on a pull request.