### PR TITLE
ci: fetch master branch for runtime diff

### DIFF
--- a/scripts/gitlab/check_runtime.sh
+++ b/scripts/gitlab/check_runtime.sh
@@ -29,6 +29,9 @@ github_label () {
 
 
 
+# make sure the master branch is available in shallow clones
+git fetch --depth=${GIT_DEPTH:-100} origin master
+
 
 # check if the wasm sources changed
 if ! git diff --name-only origin/master...${CI_COMMIT_SHA} \


### PR DESCRIPTION
follow-up change from the corresponding substrate patch https://github.com/paritytech/substrate/pull/4481

The check after fetching is not needed anymore, since the fetch will already fail the check when the branch cannot be made available.


(extends https://github.com/paritytech/polkadot/pull/707)