### PR TITLE
ci: fix release tagging after tags are added on the master branch

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -176,15 +176,13 @@ build-linux-release:               &build
     - mkdir -p ./artifacts
     - mv ./target/release/polkadot ./artifacts/.
     - sha256sum ./artifacts/polkadot | tee ./artifacts/polkadot.sha256
-    - VERSION="$(./artifacts/polkadot --version |
-        sed -n -r 's/^polkadot ([0-9.]+.*-[0-9a-f]{7,13})-.*$/\1/p')";
-      VERSION="${VERSION}-$(cut -c 1-8 ./artifacts/polkadot.sha256)";
+    - VERSION="${CI_COMMIT_REF_NAME}" # will be tag or branch name
     - if [ "${CI_COMMIT_TAG}" ]; then
-        EXTRATAG="${CI_COMMIT_TAG}";
-      elif [ "${CI_COMMIT_REF_NAME}" != "master" ]; then
-        EXTRATAG="${CI_COMMIT_REF_NAME}";
-      else
         EXTRATAG="latest";
+      else
+        EXTRATAG="$(./artifacts/polkadot --version |
+          sed -n -r 's/^polkadot ([0-9.]+.*-[0-9a-f]{7,13})-.*$/\1/p')";
+        EXTRATAG="${CI_COMMIT_REF_NAME}-${EXTRATAG}-$(cut -c 1-8 ./artifacts/polkadot.sha256)";
       fi
     - echo "Polkadot version = ${VERSION} (EXTRATAG ${EXTRATAG})"
     - echo -n ${VERSION} > ./artifacts/VERSION

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -176,18 +176,15 @@ build-linux-release:               &build
     - mkdir -p ./artifacts
     - mv ./target/release/polkadot ./artifacts/.
     - sha256sum ./artifacts/polkadot | tee ./artifacts/polkadot.sha256
+    - VERSION="$(./artifacts/polkadot --version |
+        sed -n -r 's/^polkadot ([0-9.]+.*-[0-9a-f]{7,13})-.*$/\1/p')";
+      VERSION="${VERSION}-$(cut -c 1-8 ./artifacts/polkadot.sha256)";
     - if [ "${CI_COMMIT_TAG}" ]; then
-        VERSION="${CI_COMMIT_TAG}";
+        EXTRATAG="${CI_COMMIT_TAG}";
+      elif [ "${CI_COMMIT_REF_NAME}" != "master" ]; then
+        EXTRATAG="${CI_COMMIT_REF_NAME}";
       else
-        VERSION="$(./artifacts/polkadot --version |
-          sed -n -r 's/^polkadot ([0-9.]+.*-[0-9a-f]{7,13})-.*$/\1/p')";
-        VERSION="${VERSION}-$(cut -c 1-8 ./artifacts/polkadot.sha256)";
-      fi
-    - LATEST_BRANCH="$(ls -1 .git/refs/remotes/origin/ | sed -r -n 's:v([0-9]+)\.([0-9]+):v\1.\2:p' | sort -V | tail -n1)"
-    - if expr match x${CI_COMMIT_TAG} x${LATEST_BRANCH}; then
         EXTRATAG="latest";
-      else
-        EXTRATAG="latest-${CI_COMMIT_REF_NAME}";
       fi
     - echo "Polkadot version = ${VERSION} (EXTRATAG ${EXTRATAG})"
     - echo -n ${VERSION} > ./artifacts/VERSION


### PR DESCRIPTION
the release tagging for s3 and docker publishing is broken since switching release tagging to on the master branch. This will fix it. But not sure if the `latest` tag is added as intended.

This pr will:
- add a version tag to every release (polkadot binary version plus short of the binaries hash)
- add a second tag which is either the build tag (if it's a tag build, the ref name e.g. the branch if not the master branch or the `latest` tag.

I'm not sure here whether the latest tag should point to the latest tag release or the latest master build.

Update:
This pr will:
- add latest tag to tagged release builds (assuming that a tag build will always be the latest) or tag as branch name (VERSION)
- add release tag name to release tag if present otherwise construct tag from branch name, version and short binary build hash (EXTRATAG)