### PR TITLE
ci: make sure master branch is available for check_runtime

### DIFF
--- a/scripts/gitlab/check_runtime.sh
+++ b/scripts/gitlab/check_runtime.sh
@@ -12,6 +12,9 @@ set -e # fail on any error
 # give some context
 git log --graph --oneline --decorate=short -n 10
 
+# make sure the master branch is available in shallow clones
+git fetch --depth=${GIT_DEPTH:-100} origin master
+
 
 github_label () {
 	echo


### PR DESCRIPTION
check_runtime patch for shallow clones got lost in #714 

redo of #708 