### PR TITLE
allow release alerts to fail

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -119,6 +119,8 @@ alert-pending-release:
     - /^v[0-9]+\.[0-9]+\.[0-9]+.*$/        # i.e. v1.0.1, v2.1.0rc1
   script:
     - ./scripts/gitlab/alert_pending_release.sh
+  interruptible:                   true
+  allow_failure:                   true
 
 test-linux-stable:                 &test
   stage:                           test


### PR DESCRIPTION
Release alerting is currently broken. Making it allowed to fail until the issue is resolved.