### PR TITLE
Fix pending-release alert script

### DIFF
--- a/scripts/gitlab/alert_pending_release.sh
+++ b/scripts/gitlab/alert_pending_release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # structure_message $content $formatted_content (optional)
 structure_message() {


### PR DESCRIPTION
... parity/tools doesn't have /bin/bash