### PR TITLE
PR for substrate breaking change:  Modify doublemap syntax #4576 

### DIFF
--- a/runtime/common/src/attestations.rs
+++ b/runtime/common/src/attestations.rs
@@ -99,7 +99,7 @@ decl_storage! {
 		pub RecentParaBlocks: map T::BlockNumber => Option<IncludedBlocks<T>>;
 
 		/// Attestations on a recent parachain block.
-		pub ParaBlockAttestations: double_map T::BlockNumber, blake2_128(Hash) => Option<BlockAttestations<T>>;
+		pub ParaBlockAttestations: double_map T::BlockNumber, hasher(blake2_128) Hash => Option<BlockAttestations<T>>;
 
 		// Did we already have more attestations included in this block?
 		DidUpdate: bool;


### PR DESCRIPTION
This PR solve the breaking change of https://github.com/paritytech/substrate/pull/4576

It update double_map syntax, changes are ready.