### PR TITLE
grandpa: increase gossip duration to 1s

### DIFF
--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -481,7 +481,7 @@ pub fn new_full<Runtime, Dispatch, Extrinsic>(config: Configuration)
 
 	let config = grandpa::Config {
 		// FIXME substrate#1578 make this available through chainspec
-		gossip_duration: Duration::from_millis(333),
+		gossip_duration: Duration::from_millis(1000),
 		justification_period: 512,
 		name: Some(name),
 		observer_enabled: false,


### PR DESCRIPTION
On Kusama block times are 6 seconds, additionally we cap GRANDPA votes to `best - 2`, having a gossip duration of 333 ms just means that we'll go through several rounds finalizing the same block, introducing churn on the network and additional processing overhead on the nodes. IMO at this point it makes more sense to be conservative about this, we can keep this lower on other testnets as a way to battle test our gossip and networking infrastructure.