### PR TITLE
Substrate breaking change: Update use of session API

### DIFF
--- a/runtime/common/src/parachains.rs
+++ b/runtime/common/src/parachains.rs
@@ -968,12 +968,11 @@ mod tests {
 	}
 
 	impl session::Trait for Test {
-		type OnSessionEnding = ();
+		type SessionManager = staking::Module<Self>;
 		type Keys = UintAuthorityId;
 		type ShouldEndSession = session::PeriodicSessions<Period, Offset>;
 		type SessionHandler = session::TestSessionHandler;
 		type Event = ();
-		type SelectInitialValidators = staking::Module<Self>;
 		type ValidatorId = u64;
 		type ValidatorIdOf = staking::StashOf<Self>;
 		type DisabledValidatorsThreshold = DisabledValidatorsThreshold;

--- a/runtime/common/src/registrar.rs
+++ b/runtime/common/src/registrar.rs
@@ -688,12 +688,11 @@ mod tests {
 	}
 
 	impl session::Trait for Test {
-		type OnSessionEnding = ();
+		type SessionManager = ();
 		type Keys = UintAuthorityId;
 		type ShouldEndSession = session::PeriodicSessions<Period, Offset>;
 		type SessionHandler = session::TestSessionHandler;
 		type Event = ();
-		type SelectInitialValidators = ();
 		type ValidatorId = u64;
 		type ValidatorIdOf = ();
 		type DisabledValidatorsThreshold = DisabledValidatorsThreshold;

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -241,14 +241,13 @@ parameter_types! {
 }
 
 impl session::Trait for Runtime {
-	type OnSessionEnding = Staking;
+	type SessionManager = Staking;
 	type SessionHandler = <SessionKeys as OpaqueKeys>::KeyTypeIdProviders;
 	type ShouldEndSession = Babe;
 	type Event = Event;
 	type Keys = SessionKeys;
 	type ValidatorId = AccountId;
 	type ValidatorIdOf = staking::StashOf<Self>;
-	type SelectInitialValidators = Staking;
 	type DisabledValidatorsThreshold = DisabledValidatorsThreshold;
 }
 

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -77,7 +77,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("kusama"),
 	impl_name: create_runtime_str!("parity-kusama"),
 	authoring_version: 2,
-	spec_version: 1042,
+	spec_version: 1043,
 	impl_version: 3,
 	apis: RUNTIME_API_VERSIONS,
 };

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -245,14 +245,13 @@ parameter_types! {
 }
 
 impl session::Trait for Runtime {
-	type OnSessionEnding = Staking;
+	type SessionManager = Staking;
 	type SessionHandler = <SessionKeys as OpaqueKeys>::KeyTypeIdProviders;
 	type ShouldEndSession = Babe;
 	type Event = Event;
 	type Keys = SessionKeys;
 	type ValidatorId = AccountId;
 	type ValidatorIdOf = staking::StashOf<Self>;
-	type SelectInitialValidators = Staking;
 	type DisabledValidatorsThreshold = DisabledValidatorsThreshold;
 }
 


### PR DESCRIPTION
companion PR from https://github.com/paritytech/substrate/pull/4609

the API of session has changed slightly.