### PR TITLE
ci: fix check_runtime on busybox

### DIFF
--- a/scripts/gitlab/check_runtime.sh
+++ b/scripts/gitlab/check_runtime.sh
@@ -89,7 +89,7 @@ then
 	EOT
 
 	# okay so now need to fetch the substrate repository and check whether spec_version or impl_version has changed there
-	SUBSTRATE_CLONE_DIR="$(mktemp -t -d substrate-XXX)"
+	SUBSTRATE_CLONE_DIR="$(mktemp -t -d substrate-XXXXXX)"
 	trap "rm -rf ${SUBSTRATE_CLONE_DIR}" INT QUIT TERM ABRT EXIT
 
 


### PR DESCRIPTION
dash, bash and posix-like shells accept 3 template characters `XXX` for `mktemp`. on busybox based containers it's default shell requires six e.g. `XXXXXXX`.

https://git.busybox.net/busybox/tree/debianutils/mktemp.c?id=0a8971d1121c7312d51febe7075e9b8115cc1c66#n38
