### PR TITLE
Re-do #810 but properly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,8 +165,8 @@ dependencies = [
 
 [[package]]
 name = "async-std"
-version = "1.4.0"
-source = "git+https://github.com/async-rs/async-std#1d875836a2302681a395ee44512a518f0222da4a"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "async-task 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "broadcaster 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1523,7 +1523,7 @@ name = "grafana-data-source"
 version = "0.8.0"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#e65957e5efceea82d88f8b4e1248171eb3c2167e"
 dependencies = [
- "async-std 1.4.0 (git+https://github.com/async-rs/async-std)",
+ "async-std 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-timer 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2355,7 +2355,7 @@ name = "libp2p-mdns"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "async-std 1.4.0 (git+https://github.com/async-rs/async-std)",
+ "async-std 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "data-encoding 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "dns-parser 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2483,7 +2483,7 @@ name = "libp2p-tcp"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "async-std 1.4.0 (git+https://github.com/async-rs/async-std)",
+ "async-std 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-timer 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "get_if_addrs 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2497,7 +2497,7 @@ name = "libp2p-uds"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "async-std 1.4.0 (git+https://github.com/async-rs/async-std)",
+ "async-std 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libp2p-core 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -7334,7 +7334,7 @@ dependencies = [
 "checksum arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
 "checksum asn1_der 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6fce6b6a0ffdafebd82c87e79e3f40e8d2c523e5fea5566ff6b90509bf98d638"
 "checksum asn1_der_derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0d0864d84b8e07b145449be9a8537db86bf9de5ce03b913214694643b4743502"
-"checksum async-std 1.4.0 (git+https://github.com/async-rs/async-std)" = "<none>"
+"checksum async-std 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "538ecb01eb64eecd772087e5b6f7540cbc917f047727339a472dafed2185b267"
 "checksum async-task 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f20c6fda19d0fc02406779587ca4f9a4171cd32e4a5bda0bd016f0a1334c8d4a"
 "checksum async-tls 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce6977f57fa68da77ffe5542950d47e9c23d65f5bc7cb0a9f8700996913eec7"
 "checksum atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,3 @@ maintenance = { status = "actively-developed" }
 [profile.release]
 # Polkadot runtime requires unwinding.
 panic = "unwind"
-
-[patch.crates-io]
-"async-std" = { git = "https://github.com/async-rs/async-std" }


### PR DESCRIPTION
`async-std` 1.5 has been published, so let's switch to it.
This PR doesn't improve anything, it's just a clean-up.
