### PR TITLE
ci: label substrate version changes breaksapi

### DIFF
--- a/scripts/gitlab/check_runtime.sh
+++ b/scripts/gitlab/check_runtime.sh
@@ -106,6 +106,7 @@ then
 	spec_version or or impl_version have changed in substrate after updating Cargo.lock
 	please make sure versions are bumped in polkadot accordingly
 	EOT
+	github_label "B2-breaksapi"
 fi
 
 


### PR DESCRIPTION
add breaksapi label if spec/impl version has changed of the referenced commits of the substrate repository.