### PR TITLE
Companion PR to substrate Rename StorageMap::exists to ::contains_key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ dependencies = [
  "dlmalloc 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-parachain 0.7.20",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "substrate-wasm-builder-runner 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -32,9 +32,9 @@ dependencies = [
  "polkadot-collator 0.7.20",
  "polkadot-parachain 0.7.20",
  "polkadot-primitives 0.7.20",
- "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
@@ -400,7 +400,7 @@ dependencies = [
 [[package]]
 name = "browser-utils"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "console_error_panic_hook 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -408,17 +408,22 @@ dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "js-sys 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvdb-web 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kvdb-web 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libp2p 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-chain-spec 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-service 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-chain-spec 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-service 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "wasm-bindgen 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-futures 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "bs58"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bs58"
@@ -1125,7 +1130,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "fork-tree"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1133,58 +1138,58 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "frame-metadata"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "frame-support"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "bitmask 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "frame-metadata 11.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-support-procedural 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-metadata 11.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-support-procedural 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "paste 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-arithmetic 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-arithmetic 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "tracing 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "frame-support-procedural"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
- "frame-support-procedural-tools 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support-procedural-tools 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1193,9 +1198,9 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
- "frame-support-procedural-tools-derive 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support-procedural-tools-derive 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1205,7 +1210,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1215,26 +1220,26 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
@@ -1516,7 +1521,7 @@ dependencies = [
 [[package]]
 name = "grafana-data-source"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "async-std 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2019,40 +2024,40 @@ name = "kusama-runtime"
 version = "0.7.20"
 dependencies = [
  "bitvec 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "frame-executive 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-executive 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "hex-literal 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsecp256k1 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-authorship 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-babe 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-balances 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-collective 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-democracy 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-elections-phragmen 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-grandpa 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-identity 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-im-online 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-indices 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-membership 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-nicks 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-offences 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-randomness-collective-flip 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-recovery 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-society 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-staking-reward-curve 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-transaction-payment 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-transaction-payment-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-treasury 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-utility 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-vesting 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "pallet-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-authorship 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-babe 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-balances 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-collective 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-democracy 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-elections-phragmen 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-grandpa 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-identity 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-im-online 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-indices 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-membership 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-nicks 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-offences 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-randomness-collective-flip 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-recovery 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-society 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-staking-reward-curve 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-transaction-payment 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-transaction-payment-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-treasury 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-utility 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-vesting 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-parachain 0.7.20",
  "polkadot-primitives 0.7.20",
@@ -2061,22 +2066,22 @@ dependencies = [
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-block-builder 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-offchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-block-builder 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-offchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "substrate-wasm-builder-runner 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "trie-db 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2101,16 +2106,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kvdb"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "parity-bytes 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-util-mem 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "kvdb-memorydb"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2118,16 +2113,6 @@ dependencies = [
  "kvdb 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-util-mem 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "kvdb-memorydb"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "kvdb 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-util-mem 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2149,34 +2134,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "kvdb-rocksdb"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "fs-swap 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "interleaved-ordered 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvdb 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-util-mem 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocksdb 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "kvdb-web"
-version = "0.4.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "js-sys 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvdb 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvdb-memorydb 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kvdb 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kvdb-memorydb 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-util-mem 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-util-mem 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "send_wrapper 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "web-sys 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2693,6 +2660,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "malloc_size_of_derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synstructure 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2717,13 +2694,13 @@ dependencies = [
 
 [[package]]
 name = "memory-db"
-version = "0.19.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ahash 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashbrown 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-util-mem 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-util-mem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2991,326 +2968,326 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "pallet-authorship"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-authorship 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-authorship 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "pallet-babe"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "hex-literal 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "pallet-balances"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "pallet-collective"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "pallet-democracy"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "pallet-elections-phragmen"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-phragmen 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-phragmen 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "pallet-finality-tracker"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "pallet-grandpa"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-finality-grandpa 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-finality-grandpa 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "pallet-identity"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "enumflags2 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "pallet-im-online"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-authorship 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-authorship 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "pallet-indices"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "pallet-membership"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "pallet-nicks"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "pallet-offences"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-balances 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-balances 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "pallet-recovery"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "enumflags2 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "pallet-session"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "pallet-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "pallet-society"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "pallet-staking"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-authorship 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-authorship 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-phragmen 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-phragmen 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3321,125 +3298,142 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "pallet-timestamp"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "pallet-transaction-payment"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-transaction-payment-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-transaction-payment-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "jsonrpc-core 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core-client 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-derive 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-transaction-payment-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "pallet-transaction-payment-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-rpc 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-rpc 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "pallet-treasury"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-balances 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-balances 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "pallet-utility"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "pallet-vesting"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "enumflags2 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "parity-bytes"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "parity-multiaddr"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "arrayref 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bs58 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "data-encoding 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-multihash 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unsigned-varint 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "parity-multiaddr"
@@ -3456,6 +3450,20 @@ dependencies = [
  "static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unsigned-varint 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "parity-multihash"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "blake2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha-1 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha3 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unsigned-varint 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3502,6 +3510,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "parity-util-mem"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "malloc_size_of_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "parity-util-mem"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -3509,20 +3527,6 @@ dependencies = [
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-util-mem-derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "parity-util-mem"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-util-mem-derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "primitive-types 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3732,15 +3736,15 @@ dependencies = [
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-erasure-coding 0.7.20",
  "polkadot-primitives 0.7.20",
- "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3748,18 +3752,18 @@ dependencies = [
 name = "polkadot-cli"
 version = "0.7.20"
 dependencies = [
- "browser-utils 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "browser-utils 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-service 0.7.20",
- "sc-cli 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client-db 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-executor 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-cli 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-client-db 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-executor 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "structopt 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3779,16 +3783,16 @@ dependencies = [
  "polkadot-primitives 0.7.20",
  "polkadot-service 0.7.20",
  "polkadot-validation 0.7.20",
- "sc-cli 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-cli 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3800,8 +3804,8 @@ dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-primitives 0.7.20",
  "reed-solomon-erasure 4.0.0 (git+https://github.com/paritytech/reed-solomon-erasure)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
@@ -3818,15 +3822,15 @@ dependencies = [
  "polkadot-erasure-coding 0.7.20",
  "polkadot-primitives 0.7.20",
  "polkadot-validation 0.7.20",
- "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-network-gossip 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-network-gossip 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "wasm-timer 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3841,14 +3845,14 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-executor 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-executor 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "shared_memory 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-externalities 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-externalities 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3857,20 +3861,20 @@ name = "polkadot-primitives"
 version = "0.7.20"
 dependencies = [
  "bitvec 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-babe 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "pallet-babe 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-parachain 0.7.20",
  "pretty_assertions 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-serializer 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-serializer 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
@@ -3878,15 +3882,15 @@ name = "polkadot-rpc"
 version = "0.7.20"
 dependencies = [
  "jsonrpc-core 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-transaction-payment-rpc 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "pallet-transaction-payment-rpc 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-primitives 0.7.20",
- "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-rpc 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "substrate-frame-rpc-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-rpc 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "substrate-frame-rpc-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
@@ -3894,38 +3898,38 @@ name = "polkadot-runtime"
 version = "0.7.20"
 dependencies = [
  "bitvec 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "frame-executive 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-executive 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "hex-literal 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsecp256k1 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-authorship 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-babe 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-balances 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-collective 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-democracy 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-elections-phragmen 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-grandpa 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-identity 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-im-online 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-indices 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-membership 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-nicks 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-offences 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-randomness-collective-flip 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-staking-reward-curve 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-sudo 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-transaction-payment 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-transaction-payment-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-treasury 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-vesting 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "pallet-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-authorship 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-babe 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-balances 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-collective 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-democracy 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-elections-phragmen 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-grandpa 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-identity 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-im-online 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-indices 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-membership 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-nicks 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-offences 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-randomness-collective-flip 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-staking-reward-curve 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-sudo 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-transaction-payment 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-transaction-payment-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-treasury 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-vesting 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-parachain 0.7.20",
  "polkadot-primitives 0.7.20",
@@ -3934,21 +3938,21 @@ dependencies = [
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-block-builder 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-offchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-block-builder 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-offchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "substrate-wasm-builder-runner 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "trie-db 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3959,21 +3963,21 @@ name = "polkadot-runtime-common"
 version = "0.7.20"
 dependencies = [
  "bitvec 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "hex-literal 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsecp256k1 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-authorship 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-babe 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-balances 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-randomness-collective-flip 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-staking-reward-curve 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-treasury 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-vesting 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "pallet-authorship 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-babe 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-balances 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-randomness-collective-flip 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-staking-reward-curve 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-treasury 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-vesting 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-parachain 0.7.20",
  "polkadot-primitives 0.7.20",
@@ -3981,15 +3985,15 @@ dependencies = [
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "trie-db 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3998,16 +4002,16 @@ dependencies = [
 name = "polkadot-service"
 version = "0.7.20"
 dependencies = [
- "frame-system-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-system-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-literal 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "kusama-runtime 0.7.20",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-babe 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-im-online 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-transaction-payment-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "pallet-babe 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-im-online 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-transaction-payment-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-availability-store 0.7.20",
@@ -4016,35 +4020,35 @@ dependencies = [
  "polkadot-rpc 0.7.20",
  "polkadot-runtime 0.7.20",
  "polkadot-validation 0.7.20",
- "sc-authority-discovery 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-chain-spec 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client-db 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-executor 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-finality-grandpa 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-service 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-authority-discovery 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-chain-spec 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-client-db 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-executor 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-finality-grandpa 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-service 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-block-builder 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-finality-grandpa 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-offchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-block-builder 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-finality-grandpa 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-offchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
@@ -4053,7 +4057,7 @@ version = "0.7.20"
 dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-primitives 0.7.20",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
@@ -4066,7 +4070,7 @@ dependencies = [
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-timer 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-babe 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "pallet-babe 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-availability-store 0.7.20",
@@ -4074,21 +4078,21 @@ dependencies = [
  "polkadot-parachain 0.7.20",
  "polkadot-primitives 0.7.20",
  "polkadot-statement-table 0.7.20",
- "sc-block-builder 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-finality-grandpa 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-block-builder 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-finality-grandpa 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -4648,7 +4652,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4660,52 +4664,52 @@ dependencies = [
  "prost 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-build 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sc-block-builder"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-block-builder 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-block-builder 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sc-chain-spec"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-chain-spec-derive 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-chain-spec-derive 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sc-chain-spec-derive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4716,7 +4720,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "ansi_term 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "app_dirs 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4730,21 +4734,20 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "names 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-util-mem 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rpassword 4.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-service 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-tracing 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-service 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-tracing 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-panic-handler 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-panic-handler 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "structopt 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4753,100 +4756,100 @@ dependencies = [
 [[package]]
 name = "sc-client"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-literal 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvdb 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kvdb 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-block-builder 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-executor 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-externalities 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-block-builder 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-executor 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-externalities 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "tracing 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sc-client-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-literal 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvdb 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kvdb 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-executor 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-externalities 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-executor 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-externalities 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sc-client-db"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvdb 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvdb-memorydb 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvdb-rocksdb 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kvdb 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kvdb-memorydb 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kvdb-rocksdb 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-util-mem 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-util-mem 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-executor 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-state-db 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-executor 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-state-db 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sc-consensus-babe"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "fork-tree 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "fork-tree 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-timer 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4858,80 +4861,80 @@ dependencies = [
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pdqselect 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-consensus-epochs 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-consensus-slots 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-consensus-uncles 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-consensus-epochs 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-consensus-slots 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-consensus-uncles 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "schnorrkel 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-block-builder 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-block-builder 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
- "fork-tree 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "fork-tree 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sc-consensus-slots"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-timer 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sc-consensus-uncles"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-authorship 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-authorship 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sc-executor"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4940,57 +4943,57 @@ dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-wasm 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-executor-common 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-executor-wasmi 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-executor-wasmtime 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-externalities 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-panic-handler 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-serializer 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-executor-common 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-executor-wasmi 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-executor-wasmtime 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-externalities 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-panic-handler 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-serializer 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "wasmi 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sc-executor-common"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-allocator 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-serializer 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-allocator 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-serializer 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "wasmi 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-wasm 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-executor-common 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-allocator 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-executor-common 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-allocator 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "wasmi 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "cranelift-codegen 0.50.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cranelift-entity 0.50.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5000,11 +5003,11 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-wasm 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-executor-common 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-allocator 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-executor-common 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-allocator 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "wasmi 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmtime-environ 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmtime-jit 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5014,11 +5017,11 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "finality-grandpa 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fork-tree 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "fork-tree 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-timer 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5026,42 +5029,42 @@ dependencies = [
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-network-gossip 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-network-gossip 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-arithmetic 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-finality-grandpa 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-arithmetic 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-finality-grandpa 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sc-keystore"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "subtle 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sc-network"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5069,7 +5072,7 @@ dependencies = [
  "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "erased-serde 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "fork-tree 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "fork-tree 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-timer 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures_codec 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5082,21 +5085,21 @@ dependencies = [
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-block-builder 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-peerset 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-block-builder 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-peerset 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog_derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-arithmetic 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-arithmetic 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "unsigned-varint 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5105,7 +5108,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5114,14 +5117,14 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sc-offchain"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5135,20 +5138,20 @@ dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-offchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-offchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sc-peerset"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "libp2p 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5159,7 +5162,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5168,28 +5171,28 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-executor 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-rpc-api 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-executor 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-rpc-api 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-offchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-rpc 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-offchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-rpc 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sc-rpc-api"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5202,16 +5205,16 @@ dependencies = [
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-rpc 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-rpc 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sc-rpc-server"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "jsonrpc-core 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-http-server 14.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5220,13 +5223,13 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sc-service"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "exit-future 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5234,38 +5237,37 @@ dependencies = [
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-diagnose 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-timer 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "grafana-data-source 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "grafana-data-source 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-multiaddr 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-multiaddr 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-util-mem 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-chain-spec 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client-db 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-executor 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-offchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-rpc 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-rpc-server 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-tracing 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-chain-spec 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-client-db 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-executor 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-offchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-rpc 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-rpc-server 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-tracing 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "sysinfo 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "target_info 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5275,18 +5277,18 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sc-telemetry"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5307,13 +5309,13 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "erased-serde 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "grafana-data-source 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "grafana-data-source 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5323,38 +5325,36 @@ dependencies = [
 [[package]]
 name = "sc-transaction-graph"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-util-mem 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sc-transaction-pool"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-diagnose 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-util-mem 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-transaction-graph 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-transaction-graph 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
@@ -5648,34 +5648,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "sp-allocator"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sp-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api-proc-macro 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api-proc-macro 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sp-api-proc-macro"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5687,83 +5687,83 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sp-arithmetic"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "integer-sqrt 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-debug-derive 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-debug-derive 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sp-authority-discovery"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sp-authorship"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sp-block-builder"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sp-blockchain"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-block-builder 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-block-builder 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sp-consensus"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5774,34 +5774,34 @@ dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sp-consensus-babe"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "schnorrkel 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sp-core"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "base58 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5816,7 +5816,6 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-util-mem 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "primitive-types 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5825,11 +5824,11 @@ dependencies = [
  "schnorrkel 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-debug-derive 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-externalities 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-storage 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-debug-derive 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-externalities 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-storage 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "substrate-bip39 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-bip39 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5841,7 +5840,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5851,90 +5850,90 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "environmental 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-storage 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-storage 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sp-finality-grandpa"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sp-finality-tracker"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sp-inherents"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sp-io"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsecp256k1 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-externalities 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-externalities 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sp-keyring"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "strum 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sp-offchain"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sp-panic-handler"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "backtrace 0.3.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5943,60 +5942,59 @@ dependencies = [
 [[package]]
 name = "sp-phragmen"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sp-rpc"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sp-runtime"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-util-mem 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "paste 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-arithmetic 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-arithmetic 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sp-runtime-interface"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "primitive-types 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-externalities 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime-interface-proc-macro 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-externalities 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime-interface-proc-macro 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "Inflector 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6008,7 +6006,7 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6017,28 +6015,28 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sp-staking"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sp-state-machine"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6046,10 +6044,10 @@ dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-externalities 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-panic-handler 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-externalities 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-panic-handler 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "trie-db 0.19.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "trie-root 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -6057,80 +6055,80 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 
 [[package]]
 name = "sp-storage"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "impl-serde 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-debug-derive 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-debug-derive 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sp-timestamp"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sp-transaction-pool"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sp-trie"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "memory-db 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memory-db 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "trie-db 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "trie-root 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "trie-db 0.19.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "trie-root 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sp-version"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "impl-serde 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sp-wasm-interface"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "wasmi 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -6233,22 +6231,22 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
- "frame-system-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-system-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core-client 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-derive 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
@@ -6749,14 +6747,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "trie-root"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "try-lock"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6837,6 +6827,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "unicode-xid"
 version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unsigned-varint"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -7385,7 +7380,8 @@ dependencies = [
 "checksum block-cipher-trait 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1c924d49bd09e7c06003acda26cd9742e796e34282ec6c1189404dee0c1f4774"
 "checksum block-padding 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
 "checksum broadcaster 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9c972e21e0d055a36cf73e4daae870941fe7a8abcd5ac3396aab9e4c126bd87"
-"checksum browser-utils 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
+"checksum browser-utils 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum bs58 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "c95ee6bba9d950218b6cc910cf62bc9e0a171d0f4537e3627b0f54d08549b188"
 "checksum bs58 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b170cd256a3f9fa6b9edae3e44a7dfdfc77e8124dbc3e2612d75f9c3e2396dae"
 "checksum bstr 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "502ae1441a0a5adb8fbd38a5955a6416b9493e92b465de5e4a9bde6a539c2c48"
 "checksum bumpalo 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1f359dc14ff8911330a51ef78022d376f25ed00248912803b58f00cb1c27f742"
@@ -7467,15 +7463,15 @@ dependencies = [
 "checksum fixedbitset 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 "checksum flate2 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6bd6d6f4752952feb71363cffc9ebac9411b75b87c6ab6058c40c8900cf43c0f"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
-"checksum fork-tree 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum frame-executive 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum frame-metadata 11.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum frame-support-procedural 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum frame-support-procedural-tools 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum frame-support-procedural-tools-derive 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum frame-system-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
+"checksum fork-tree 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum frame-executive 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum frame-metadata 11.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum frame-support-procedural 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum frame-support-procedural-tools 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum frame-support-procedural-tools-derive 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum frame-system-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
 "checksum fs-swap 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "921d332c89b3b61a826de38c61ee5b6e02c56806cade1b0e5d81bd71f57a71bb"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
@@ -7507,7 +7503,7 @@ dependencies = [
 "checksum glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 "checksum globset 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "925aa2cac82d8834e2b2a4415b6f6879757fb5c0928fc445ae76461a12eed8f2"
 "checksum goblin 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3081214398d39e4bd7f2c1975f0488ed04614ffdd976c6fc7a0708278552c0da"
-"checksum grafana-data-source 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
+"checksum grafana-data-source 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
 "checksum h2 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "a5b34c246847f938a410a03c5458c7fee2274436675e76d8b903c08efc29c462"
 "checksum h2 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b9433d71e471c1736fd5a61b671fc0b148d7a2992f666c958d03cd8feb3b88d1"
 "checksum hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d23bd4e7b5eda0d0f3a307e8b381fdc8ba9000f26fbe912250c0a4cc3956364a"
@@ -7558,12 +7554,9 @@ dependencies = [
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum kv-log-macro 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c54d9f465d530a752e6ebdc217e081a7a614b48cb200f6f0aee21ba6bc9aabb"
 "checksum kvdb 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8396be0e5561ccd1bf7ff0b2007487cdd7a87a056873fe6ea906b35d4dbf7ed8"
-"checksum kvdb 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "03080afe6f42cd996da9f568d6add5d7fb5ee2ea7fb7802d2d2cbd836958fd87"
 "checksum kvdb-memorydb 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4d25ef14155e418515c4839e9144c839de3506e68946f255a32b7f166095493d"
-"checksum kvdb-memorydb 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b9355274e5a9e0a7e8ef43916950eae3949024de2a8dffe4d5a6c13974a37c8e"
 "checksum kvdb-rocksdb 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5a1053e90a54421a842b6bf5d0e4a5cb5364c0bf570f713c58e44a9906f501d9"
-"checksum kvdb-rocksdb 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "af36fd66ccd99f3f771ae39b75aaba28b952372b6debfb971134bf1f03466ab2"
-"checksum kvdb-web 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a985c47b4c46429e96033ebf6eaed784a81ceccb4e5df13d63f3b9078a4df81"
+"checksum kvdb-web 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "37a0e36637fb86454de401e7cb88f40eb0ad1b9bcee837d46785e7c451f1ebf4"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 "checksum libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)" = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
@@ -7601,11 +7594,12 @@ dependencies = [
 "checksum lru 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "5d8f669d42c72d18514dfca8115689c5f6370a17d980cb5bd777a67f404594c8"
 "checksum lru 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0609345ddee5badacf857d4f547e0e5a2e987db77085c24cd887f73573a04237"
 "checksum mach 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "86dd2487cdfea56def77b88438a2c915fb45113c5319bfe7e14306ca4cd0b0e1"
+"checksum malloc_size_of_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e37c5d4cd9473c5f4c9c111f033f15d4df9bd378fdf615944e360a4f55a05f0b"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 "checksum memchr 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3197e20c7edb283f87c071ddfc7a2cca8f8e0b888c242959846a6fce03c72223"
 "checksum memoffset 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "75189eb85871ea5c2e2c15abbdd541185f63b408415e5051f5cac122d8c774b9"
-"checksum memory-db 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)" = "198831fe8722331a395bc199a5d08efbc197497ef354cb4c77b969c02ffc0fc4"
+"checksum memory-db 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)" = "881736a0f68a6fae1b596bb066c5bd16d7b3ed645a4dd8ffaefd02f585abaf71"
 "checksum memory_units 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "71d96e3f3c0b6325d8ccd83c33b28acb183edcb6c67938ba104ec546854b0882"
 "checksum memrange 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cc29ba65898edc4fdc252cb31cd3925f37c1a8ba25bb46eec883569984976530"
 "checksum merlin 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2b0942b357c1b4d0dc43ba724674ec89c3218e6ca2b3e8269e7cb53bcecd2f6e"
@@ -7636,43 +7630,45 @@ dependencies = [
 "checksum once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b1c601810575c99596d4afc46f78a678c80105117c379eb3650cf99b8a21ce5b"
 "checksum opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 "checksum owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
-"checksum pallet-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-authorship 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-babe 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-balances 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-collective 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-democracy 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-elections-phragmen 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-grandpa 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-identity 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-im-online 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-indices 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-membership 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-nicks 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-offences 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-randomness-collective-flip 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-recovery 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-society 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-staking-reward-curve 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-sudo 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-transaction-payment 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-transaction-payment-rpc 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-transaction-payment-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-treasury 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-utility 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-vesting 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
+"checksum pallet-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum pallet-authorship 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum pallet-babe 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum pallet-balances 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum pallet-collective 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum pallet-democracy 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum pallet-elections-phragmen 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum pallet-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum pallet-grandpa 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum pallet-identity 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum pallet-im-online 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum pallet-indices 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum pallet-membership 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum pallet-nicks 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum pallet-offences 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum pallet-randomness-collective-flip 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum pallet-recovery 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum pallet-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum pallet-society 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum pallet-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum pallet-staking-reward-curve 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum pallet-sudo 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum pallet-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum pallet-transaction-payment 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum pallet-transaction-payment-rpc 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum pallet-transaction-payment-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum pallet-treasury 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum pallet-utility 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum pallet-vesting 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
 "checksum parity-bytes 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0c276d76c5333b8c2579e02d49a06733a55b8282d2d9b13e8d53b6406bd7e30a"
+"checksum parity-multiaddr 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "045b3c7af871285146300da35b1932bb6e4639b66c7c98e85d06a32cbc4e8fa7"
 "checksum parity-multiaddr 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "80878c27f90dd162d3143333d672e80b194d6b080f05c83440e3dfda42e409f2"
+"checksum parity-multihash 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "df3a17dc27848fd99e4f87eb0f8c9baba6ede0a6d555400c850ca45254ef4ce3"
 "checksum parity-multihash 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b11f42bbd3a021c5061b77154bd3334d5a57e1a03eb162de0b962681cc25800d"
 "checksum parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f747c06d9f3b2ad387ac881b9667298c81b1243aa9833f086e05996937c35507"
 "checksum parity-scale-codec-derive 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "34e513ff3e406f3ede6796dcdc83d0b32ffb86668cea1ccf7363118abeb00476"
 "checksum parity-send-wrapper 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aa9777aa91b8ad9dd5aaa04a9b6bcb02c7f1deb952fca5a66034d5e63afc5c6f"
+"checksum parity-util-mem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8174d85e62c4d615fddd1ef67966bdc5757528891d0742f15b131ad04667b3f9"
 "checksum parity-util-mem 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "01b04e4d2588668d5aa93144b3bd719be963542e60042d66c7586ca763838a5b"
-"checksum parity-util-mem 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ef1476e40bf8f5c6776e9600983435821ca86eb9819d74a6207cca69d091406a"
 "checksum parity-util-mem-derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f557c32c6d268a07c921471619c0295f5efad3a0e76d4f97a05c091a51d110b2"
 "checksum parity-wasm 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc878dac00da22f8f61e7af3157988424567ab01d9920b962ef7dcbd7cd865"
 "checksum parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "92e98c49ab0b7ce5b222f2cc9193fc4efe11c6d0bd4f648e374684a6857b1cfc"
@@ -7756,37 +7752,37 @@ dependencies = [
 "checksum rw-stream-sink 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4da5fcb054c46f5a5dff833b129285a93d3f0179531735e6c866e8cc307d2020"
 "checksum ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
 "checksum safe-mix 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6d3d055a2582e6b00ed7a31c1524040aa391092bf636328350813f3a0605215c"
-"checksum sc-authority-discovery 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-block-builder 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-chain-spec 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-chain-spec-derive 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-cli 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-client-db 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-consensus-epochs 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-consensus-slots 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-consensus-uncles 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-executor 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-executor-common 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-executor-wasmi 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-executor-wasmtime 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-finality-grandpa 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-network-gossip 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-offchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-peerset 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-rpc 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-rpc-api 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-rpc-server 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-service 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-state-db 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-tracing 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-transaction-graph 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
+"checksum sc-authority-discovery 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sc-block-builder 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sc-chain-spec 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sc-chain-spec-derive 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sc-cli 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sc-client-db 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sc-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sc-consensus-epochs 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sc-consensus-slots 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sc-consensus-uncles 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sc-executor 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sc-executor-common 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sc-executor-wasmi 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sc-executor-wasmtime 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sc-finality-grandpa 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sc-network-gossip 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sc-offchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sc-peerset 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sc-rpc 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sc-rpc-api 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sc-rpc-server 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sc-service 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sc-state-db 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sc-tracing 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sc-transaction-graph 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sc-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
 "checksum schnorrkel 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)" = "eacd8381b3c37840c9c9f40472af529e49975bdcbc24f83c31059fd6539023d3"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
@@ -7819,43 +7815,43 @@ dependencies = [
 "checksum snow 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "afb767eee7d257ba202f0b9b08673bc13b22281632ef45267b19f13100accd2f"
 "checksum soketto 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1c9dab3f95c9ebdf3a88268c19af668f637a3c5039c2c56ff2d40b1b2d64a25b"
 "checksum sourcefile 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf77cb82ba8453b42b6ae1d692e4cdc92f9a47beaf89a847c8be83f4e328ad3"
-"checksum sp-allocator 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-api-proc-macro 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-arithmetic 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-authorship 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-block-builder 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-debug-derive 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-externalities 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-finality-grandpa 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-offchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-panic-handler 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-phragmen 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-rpc 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-runtime-interface-proc-macro 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-serializer 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-storage 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
+"checksum sp-allocator 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-api-proc-macro 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-arithmetic 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-authorship 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-block-builder 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-debug-derive 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-externalities 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-finality-grandpa 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-offchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-panic-handler 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-phragmen 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-rpc 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-runtime-interface-proc-macro 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-serializer 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-storage 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
 "checksum spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
@@ -7868,7 +7864,7 @@ dependencies = [
 "checksum strum 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6138f8f88a16d90134763314e3fc76fa3ed6a7db4725d6acf9a3ef95a3188d22"
 "checksum strum_macros 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0054a7df764039a6cd8592b9de84be4bec368ff081d203a7d5371cbfa8e65c81"
 "checksum substrate-bip39 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3be511be555a3633e71739a79e4ddff6a6aaa6579fa6114182a51d72c3eb93c5"
-"checksum substrate-frame-rpc-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
+"checksum substrate-frame-rpc-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
 "checksum substrate-wasm-builder-runner 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e30c70de7e7d5fd404fe26db1e7a4d6b553e2760b1ac490f249c04a960c483b8"
 "checksum subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 "checksum subtle 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7c65d530b10ccaeac294f349038a597e435b18fb456aadd0840a623f83b9e941"
@@ -7918,7 +7914,6 @@ dependencies = [
 "checksum trie-db 0.19.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a0d747ae5b6f078df7e46477fcc7df66df9eb4f27a031cf4a7c890a8dd03d8e6"
 "checksum trie-db 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de9222c50cc325855621271157c973da27a0dcd26fa06f8edf81020bd2333df0"
 "checksum trie-root 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0b779f7c1c8fe9276365d9d5be5c4b5adeacf545117bb3f64c974305789c5c0b"
-"checksum trie-root 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "652931506d2c1244d7217a70b99f56718a7b4161b37f04e7cd868072a99f68cd"
 "checksum try-lock 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
 "checksum twofish 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712d261e83e727c8e2dbb75dacac67c36e35db36a958ee504f2164fc052434e1"
 "checksum twox-hash 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3bfd5b7557925ce778ff9b9ef90e3ade34c524b5ff10e239c69a42d546d2af56"
@@ -7931,6 +7926,7 @@ dependencies = [
 "checksum unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+"checksum unsigned-varint 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a7f0023a96687fe169081e8adce3f65e3874426b7886e9234d490af2dc077959"
 "checksum unsigned-varint 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c689459fbaeb50e56c6749275f084decfd02194ac5852e6617d95d0d3cf02eaf"
 "checksum untrusted 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60369ef7a31de49bcb3f6ca728d4ba7300d9a1658f94c727d4cab8c8d9f4aece"
 "checksum url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ dependencies = [
  "dlmalloc 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-parachain 0.7.20",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "substrate-wasm-builder-runner 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -32,9 +32,9 @@ dependencies = [
  "polkadot-collator 0.7.20",
  "polkadot-parachain 0.7.20",
  "polkadot-primitives 0.7.20",
- "sc-client 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
@@ -400,7 +400,7 @@ dependencies = [
 [[package]]
 name = "browser-utils"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "console_error_panic_hook 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -408,17 +408,22 @@ dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "js-sys 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvdb-web 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kvdb-web 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libp2p 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-chain-spec 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sc-network 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sc-service 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sc-chain-spec 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-service 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "wasm-bindgen 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-futures 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "bs58"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bs58"
@@ -1125,7 +1130,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "fork-tree"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1133,58 +1138,58 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "frame-metadata"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "frame-support"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "bitmask 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "frame-metadata 11.0.0 (git+https://github.com/paritytech/substrate)",
- "frame-support-procedural 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-metadata 11.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-support-procedural 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "paste 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-arithmetic 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-arithmetic 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "tracing 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "frame-support-procedural"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
- "frame-support-procedural-tools 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-support-procedural-tools 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1193,9 +1198,9 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
- "frame-support-procedural-tools-derive 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-support-procedural-tools-derive 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1205,7 +1210,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1215,26 +1220,26 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-version 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
@@ -1516,7 +1521,7 @@ dependencies = [
 [[package]]
 name = "grafana-data-source"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "async-std 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2019,40 +2024,40 @@ name = "kusama-runtime"
 version = "0.7.20"
 dependencies = [
  "bitvec 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "frame-executive 2.0.0 (git+https://github.com/paritytech/substrate)",
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate)",
- "frame-system-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-executive 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "hex-literal 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsecp256k1 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-authorship 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-babe 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-balances 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-collective 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-democracy 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-elections-phragmen 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-grandpa 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-identity 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-im-online 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-indices 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-membership 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-nicks 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-offences 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-randomness-collective-flip 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-recovery 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-society 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-staking 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-staking-reward-curve 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-timestamp 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-transaction-payment 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-transaction-payment-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-treasury 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-utility 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-vesting 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-authorship 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-babe 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-balances 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-collective 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-democracy 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-elections-phragmen 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-grandpa 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-identity 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-im-online 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-indices 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-membership 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-nicks 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-offences 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-randomness-collective-flip 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-recovery 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-society 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-staking-reward-curve 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-transaction-payment 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-transaction-payment-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-treasury 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-utility 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-vesting 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-parachain 0.7.20",
  "polkadot-primitives 0.7.20",
@@ -2061,22 +2066,22 @@ dependencies = [
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-block-builder 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-offchain 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-session 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-version 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-block-builder 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-offchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "substrate-wasm-builder-runner 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "trie-db 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2101,16 +2106,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kvdb"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "parity-bytes 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-util-mem 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "kvdb-memorydb"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2118,16 +2113,6 @@ dependencies = [
  "kvdb 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-util-mem 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "kvdb-memorydb"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "kvdb 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-util-mem 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2149,34 +2134,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "kvdb-rocksdb"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "fs-swap 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "interleaved-ordered 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvdb 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-util-mem 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocksdb 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "kvdb-web"
-version = "0.4.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "js-sys 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvdb 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvdb-memorydb 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kvdb 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kvdb-memorydb 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-util-mem 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-util-mem 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "send_wrapper 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "web-sys 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2693,6 +2660,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "malloc_size_of_derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synstructure 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2717,13 +2694,13 @@ dependencies = [
 
 [[package]]
 name = "memory-db"
-version = "0.19.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ahash 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashbrown 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-util-mem 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-util-mem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2991,326 +2968,326 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "pallet-authorship"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-authorship 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-authorship 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "pallet-babe"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "hex-literal 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-timestamp 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-timestamp 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "pallet-balances"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "pallet-collective"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "pallet-democracy"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "pallet-elections-phragmen"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-phragmen 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-phragmen 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "pallet-finality-tracker"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "pallet-grandpa"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-finality-grandpa 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-finality-grandpa 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "pallet-identity"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "enumflags2 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "pallet-im-online"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-authorship 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-authorship 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "pallet-indices"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "pallet-membership"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "pallet-nicks"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "pallet-offences"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-balances 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-balances 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "pallet-recovery"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "enumflags2 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "pallet-session"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-timestamp 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "pallet-society"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "pallet-staking"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-authorship 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-authorship 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-phragmen 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-phragmen 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3321,125 +3298,142 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "pallet-timestamp"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-timestamp 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "pallet-transaction-payment"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-transaction-payment-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-transaction-payment-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "jsonrpc-core 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core-client 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-derive 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-transaction-payment-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-transaction-payment-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-rpc 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-rpc 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "pallet-treasury"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-balances 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-balances 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "pallet-utility"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "pallet-vesting"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "enumflags2 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "parity-bytes"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "parity-multiaddr"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "arrayref 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bs58 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "data-encoding 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-multihash 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unsigned-varint 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "parity-multiaddr"
@@ -3456,6 +3450,20 @@ dependencies = [
  "static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unsigned-varint 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "parity-multihash"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "blake2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha-1 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha3 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unsigned-varint 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3502,6 +3510,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "parity-util-mem"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "malloc_size_of_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "parity-util-mem"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -3509,20 +3527,6 @@ dependencies = [
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-util-mem-derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "parity-util-mem"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-util-mem-derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "primitive-types 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3732,15 +3736,15 @@ dependencies = [
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-erasure-coding 0.7.20",
  "polkadot-primitives 0.7.20",
- "sc-client 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sc-network 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3748,18 +3752,18 @@ dependencies = [
 name = "polkadot-cli"
 version = "0.7.20"
 dependencies = [
- "browser-utils 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "browser-utils 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-service 0.7.20",
- "sc-cli 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sc-client 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sc-client-db 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sc-executor 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sc-cli 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-client-db 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-executor 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "structopt 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3779,16 +3783,16 @@ dependencies = [
  "polkadot-primitives 0.7.20",
  "polkadot-service 0.7.20",
  "polkadot-validation 0.7.20",
- "sc-cli 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sc-client 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sc-network 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sc-cli 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3800,8 +3804,8 @@ dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-primitives 0.7.20",
  "reed-solomon-erasure 4.0.0 (git+https://github.com/paritytech/reed-solomon-erasure)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
@@ -3818,15 +3822,15 @@ dependencies = [
  "polkadot-erasure-coding 0.7.20",
  "polkadot-primitives 0.7.20",
  "polkadot-validation 0.7.20",
- "sc-client 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sc-network 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sc-network-gossip 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-network-gossip 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "wasm-timer 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3841,14 +3845,14 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-executor 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sc-executor 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "shared_memory 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-externalities 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-externalities 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3857,20 +3861,20 @@ name = "polkadot-primitives"
 version = "0.7.20"
 dependencies = [
  "bitvec 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-babe 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-babe 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-parachain 0.7.20",
  "pretty_assertions 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-serializer 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-version 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-serializer 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
@@ -3878,15 +3882,15 @@ name = "polkadot-rpc"
 version = "0.7.20"
 dependencies = [
  "jsonrpc-core 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-transaction-payment-rpc 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-transaction-payment-rpc 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-primitives 0.7.20",
- "sc-client 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sc-rpc 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate)",
- "substrate-frame-rpc-system 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-rpc 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "substrate-frame-rpc-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
@@ -3894,38 +3898,38 @@ name = "polkadot-runtime"
 version = "0.7.20"
 dependencies = [
  "bitvec 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "frame-executive 2.0.0 (git+https://github.com/paritytech/substrate)",
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate)",
- "frame-system-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-executive 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "hex-literal 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsecp256k1 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-authorship 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-babe 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-balances 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-collective 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-democracy 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-elections-phragmen 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-grandpa 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-identity 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-im-online 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-indices 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-membership 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-nicks 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-offences 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-randomness-collective-flip 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-staking 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-staking-reward-curve 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-sudo 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-timestamp 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-transaction-payment 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-transaction-payment-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-treasury 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-vesting 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-authorship 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-babe 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-balances 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-collective 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-democracy 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-elections-phragmen 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-grandpa 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-identity 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-im-online 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-indices 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-membership 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-nicks 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-offences 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-randomness-collective-flip 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-staking-reward-curve 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-sudo 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-transaction-payment 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-transaction-payment-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-treasury 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-vesting 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-parachain 0.7.20",
  "polkadot-primitives 0.7.20",
@@ -3934,21 +3938,21 @@ dependencies = [
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-block-builder 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-offchain 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-session 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-version 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-block-builder 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-offchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "substrate-wasm-builder-runner 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "trie-db 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3959,21 +3963,21 @@ name = "polkadot-runtime-common"
 version = "0.7.20"
 dependencies = [
  "bitvec 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "hex-literal 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsecp256k1 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-authorship 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-babe 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-balances 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-randomness-collective-flip 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-staking 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-staking-reward-curve 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-timestamp 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-treasury 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-vesting 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-authorship 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-babe 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-balances 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-randomness-collective-flip 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-staking-reward-curve 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-treasury 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-vesting 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-parachain 0.7.20",
  "polkadot-primitives 0.7.20",
@@ -3981,15 +3985,15 @@ dependencies = [
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "trie-db 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3998,16 +4002,16 @@ dependencies = [
 name = "polkadot-service"
 version = "0.7.20"
 dependencies = [
- "frame-system-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-system-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-literal 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "kusama-runtime 0.7.20",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-babe 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-im-online 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-staking 2.0.0 (git+https://github.com/paritytech/substrate)",
- "pallet-transaction-payment-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-babe 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-im-online 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-transaction-payment-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-availability-store 0.7.20",
@@ -4016,35 +4020,35 @@ dependencies = [
  "polkadot-rpc 0.7.20",
  "polkadot-runtime 0.7.20",
  "polkadot-validation 0.7.20",
- "sc-authority-discovery 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sc-chain-spec 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sc-client 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sc-client-db 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sc-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sc-executor 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sc-finality-grandpa 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sc-network 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sc-service 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sc-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sc-authority-discovery 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-chain-spec 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-client-db 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-executor 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-finality-grandpa 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-service 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-block-builder 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sp-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-finality-grandpa 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-offchain 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-session 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-block-builder 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-finality-grandpa 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-offchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
@@ -4053,7 +4057,7 @@ version = "0.7.20"
 dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-primitives 0.7.20",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
@@ -4066,7 +4070,7 @@ dependencies = [
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-timer 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-babe 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-babe 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-availability-store 0.7.20",
@@ -4074,21 +4078,21 @@ dependencies = [
  "polkadot-parachain 0.7.20",
  "polkadot-primitives 0.7.20",
  "polkadot-statement-table 0.7.20",
- "sc-block-builder 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sc-finality-grandpa 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sp-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-timestamp 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sc-block-builder 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-finality-grandpa 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -4648,7 +4652,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4660,52 +4664,52 @@ dependencies = [
  "prost 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-build 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sc-network 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sc-block-builder"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-block-builder 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-block-builder 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sc-chain-spec"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-chain-spec-derive 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sc-network 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sc-chain-spec-derive 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sc-chain-spec-derive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4716,7 +4720,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "ansi_term 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "app_dirs 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4730,21 +4734,20 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "names 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-util-mem 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rpassword 4.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sc-network 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sc-service 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sc-tracing 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-service 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-tracing 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-panic-handler 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-panic-handler 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "structopt 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4753,101 +4756,100 @@ dependencies = [
 [[package]]
 name = "sc-client"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-literal 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvdb 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kvdb 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-block-builder 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sc-executor 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-externalities 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-version 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sc-block-builder 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-executor 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-externalities 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "tracing 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sc-client-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-literal 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvdb 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kvdb 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-executor 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-externalities 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-version 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sc-executor 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-externalities 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sc-client-db"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvdb 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvdb-memorydb 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvdb-rocksdb 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kvdb 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kvdb-memorydb 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kvdb-rocksdb 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-util-mem 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-util-mem 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sc-executor 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sc-state-db 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-executor 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-state-db 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sc-consensus-babe"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "fork-tree 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "fork-tree 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-timer 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4859,80 +4861,80 @@ dependencies = [
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pdqselect 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sc-consensus-epochs 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sc-consensus-slots 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sc-consensus-uncles 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-consensus-epochs 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-consensus-slots 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-consensus-uncles 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "schnorrkel 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-block-builder 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sp-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-timestamp 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-version 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-block-builder 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
- "fork-tree 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "fork-tree 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sc-consensus-slots"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-timer 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sc-consensus-uncles"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-authorship 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-authorship 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sc-executor"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4941,57 +4943,57 @@ dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-wasm 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-executor-common 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sc-executor-wasmi 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sc-executor-wasmtime 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-externalities 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-panic-handler 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-serializer 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-version 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sc-executor-common 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-executor-wasmi 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-executor-wasmtime 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-externalities 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-panic-handler 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-serializer 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "wasmi 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sc-executor-common"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-allocator 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-serializer 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-allocator 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-serializer 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "wasmi 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-wasm 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-executor-common 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sp-allocator 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sc-executor-common 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-allocator 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "wasmi 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "cranelift-codegen 0.50.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cranelift-entity 0.50.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5001,11 +5003,11 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-wasm 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-executor-common 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sp-allocator 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sc-executor-common 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-allocator 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "wasmi 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmtime-environ 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmtime-jit 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5015,11 +5017,11 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "finality-grandpa 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fork-tree 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "fork-tree 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-timer 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5027,42 +5029,42 @@ dependencies = [
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sc-network 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sc-network-gossip 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-network-gossip 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-arithmetic 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-finality-grandpa 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-arithmetic 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-finality-grandpa 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sc-keystore"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "subtle 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sc-network"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5070,7 +5072,7 @@ dependencies = [
  "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "erased-serde 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "fork-tree 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "fork-tree 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-timer 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures_codec 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5083,21 +5085,21 @@ dependencies = [
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-block-builder 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sc-client 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sc-peerset 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sc-block-builder 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-peerset 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog_derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-arithmetic 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sp-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-arithmetic 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "unsigned-varint 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5106,7 +5108,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5115,14 +5117,14 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-network 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sc-offchain"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5136,20 +5138,20 @@ dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sc-network 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-offchain 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-offchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sc-peerset"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "libp2p 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5160,7 +5162,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5169,28 +5171,28 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sc-executor 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sc-rpc-api 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-executor 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-rpc-api 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-offchain 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-rpc 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-session 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-version 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-offchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-rpc 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sc-rpc-api"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5203,16 +5205,16 @@ dependencies = [
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-rpc 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-version 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-rpc 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sc-rpc-server"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "jsonrpc-core 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-http-server 14.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5221,13 +5223,13 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sc-service"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "exit-future 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5235,38 +5237,37 @@ dependencies = [
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-diagnose 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-timer 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "grafana-data-source 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "grafana-data-source 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-multiaddr 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-multiaddr 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-util-mem 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-chain-spec 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sc-client 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sc-client-db 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sc-executor 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sc-network 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sc-offchain 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sc-rpc 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sc-rpc-server 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sc-tracing 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sc-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sc-chain-spec 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-client-db 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-executor 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-offchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-rpc 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-rpc-server 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-tracing 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-session 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "sysinfo 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "target_info 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5276,18 +5277,18 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sc-telemetry"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5308,13 +5309,13 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "erased-serde 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "grafana-data-source 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "grafana-data-source 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5324,38 +5325,36 @@ dependencies = [
 [[package]]
 name = "sc-transaction-graph"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-util-mem 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sc-transaction-pool"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-diagnose 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-util-mem 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sc-transaction-graph 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-transaction-graph 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
@@ -5649,34 +5648,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "sp-allocator"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sp-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api-proc-macro 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-version 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-api-proc-macro 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sp-api-proc-macro"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5688,83 +5687,83 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sp-arithmetic"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "integer-sqrt 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-debug-derive 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-debug-derive 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sp-authority-discovery"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sp-authorship"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sp-block-builder"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sp-blockchain"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-block-builder 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sp-block-builder 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sp-consensus"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5775,34 +5774,34 @@ dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-version 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sp-consensus-babe"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "schnorrkel 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-timestamp 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sp-core"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "base58 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5817,7 +5816,6 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-util-mem 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "primitive-types 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5826,11 +5824,11 @@ dependencies = [
  "schnorrkel 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-debug-derive 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-externalities 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-storage 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-debug-derive 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-externalities 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-storage 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "substrate-bip39 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-bip39 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5842,7 +5840,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5852,90 +5850,90 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "environmental 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-storage 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-storage 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sp-finality-grandpa"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sp-finality-tracker"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sp-inherents"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sp-io"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsecp256k1 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-externalities 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-externalities 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sp-keyring"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "strum 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sp-offchain"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sp-panic-handler"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "backtrace 0.3.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5944,60 +5942,59 @@ dependencies = [
 [[package]]
 name = "sp-phragmen"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sp-rpc"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sp-runtime"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-util-mem 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "paste 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-arithmetic 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-arithmetic 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sp-runtime-interface"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "primitive-types 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-externalities 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime-interface-proc-macro 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-externalities 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime-interface-proc-macro 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "Inflector 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6009,7 +6006,7 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6018,28 +6015,28 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sp-staking"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sp-state-machine"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6047,10 +6044,10 @@ dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-externalities 0.8.0 (git+https://github.com/paritytech/substrate)",
- "sp-panic-handler 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-externalities 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-panic-handler 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "trie-db 0.19.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "trie-root 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -6058,80 +6055,80 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 
 [[package]]
 name = "sp-storage"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "impl-serde 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-debug-derive 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-debug-derive 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sp-timestamp"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sp-transaction-pool"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sp-trie"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "memory-db 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memory-db 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
- "trie-db 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "trie-root 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "trie-db 0.19.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "trie-root 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sp-version"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "impl-serde 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
 name = "sp-wasm-interface"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "wasmi 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -6234,22 +6231,22 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
+source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
 dependencies = [
- "frame-system-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-system-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core-client 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-derive 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
- "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
 ]
 
 [[package]]
@@ -6750,14 +6747,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "trie-root"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "try-lock"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6838,6 +6827,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "unicode-xid"
 version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unsigned-varint"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -7386,7 +7380,8 @@ dependencies = [
 "checksum block-cipher-trait 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1c924d49bd09e7c06003acda26cd9742e796e34282ec6c1189404dee0c1f4774"
 "checksum block-padding 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
 "checksum broadcaster 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9c972e21e0d055a36cf73e4daae870941fe7a8abcd5ac3396aab9e4c126bd87"
-"checksum browser-utils 0.8.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum browser-utils 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum bs58 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "c95ee6bba9d950218b6cc910cf62bc9e0a171d0f4537e3627b0f54d08549b188"
 "checksum bs58 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b170cd256a3f9fa6b9edae3e44a7dfdfc77e8124dbc3e2612d75f9c3e2396dae"
 "checksum bstr 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "502ae1441a0a5adb8fbd38a5955a6416b9493e92b465de5e4a9bde6a539c2c48"
 "checksum bumpalo 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1f359dc14ff8911330a51ef78022d376f25ed00248912803b58f00cb1c27f742"
@@ -7468,15 +7463,15 @@ dependencies = [
 "checksum fixedbitset 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 "checksum flate2 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6bd6d6f4752952feb71363cffc9ebac9411b75b87c6ab6058c40c8900cf43c0f"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
-"checksum fork-tree 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum frame-executive 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum frame-metadata 11.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum frame-support 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum frame-support-procedural 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum frame-support-procedural-tools 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum frame-support-procedural-tools-derive 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum frame-system 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum frame-system-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum fork-tree 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum frame-executive 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum frame-metadata 11.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum frame-support-procedural 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum frame-support-procedural-tools 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum frame-support-procedural-tools-derive 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum frame-system-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
 "checksum fs-swap 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "921d332c89b3b61a826de38c61ee5b6e02c56806cade1b0e5d81bd71f57a71bb"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
@@ -7508,7 +7503,7 @@ dependencies = [
 "checksum glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 "checksum globset 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "925aa2cac82d8834e2b2a4415b6f6879757fb5c0928fc445ae76461a12eed8f2"
 "checksum goblin 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3081214398d39e4bd7f2c1975f0488ed04614ffdd976c6fc7a0708278552c0da"
-"checksum grafana-data-source 0.8.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum grafana-data-source 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
 "checksum h2 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "a5b34c246847f938a410a03c5458c7fee2274436675e76d8b903c08efc29c462"
 "checksum h2 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b9433d71e471c1736fd5a61b671fc0b148d7a2992f666c958d03cd8feb3b88d1"
 "checksum hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d23bd4e7b5eda0d0f3a307e8b381fdc8ba9000f26fbe912250c0a4cc3956364a"
@@ -7559,12 +7554,9 @@ dependencies = [
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum kv-log-macro 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c54d9f465d530a752e6ebdc217e081a7a614b48cb200f6f0aee21ba6bc9aabb"
 "checksum kvdb 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8396be0e5561ccd1bf7ff0b2007487cdd7a87a056873fe6ea906b35d4dbf7ed8"
-"checksum kvdb 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "03080afe6f42cd996da9f568d6add5d7fb5ee2ea7fb7802d2d2cbd836958fd87"
 "checksum kvdb-memorydb 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4d25ef14155e418515c4839e9144c839de3506e68946f255a32b7f166095493d"
-"checksum kvdb-memorydb 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b9355274e5a9e0a7e8ef43916950eae3949024de2a8dffe4d5a6c13974a37c8e"
 "checksum kvdb-rocksdb 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5a1053e90a54421a842b6bf5d0e4a5cb5364c0bf570f713c58e44a9906f501d9"
-"checksum kvdb-rocksdb 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "af36fd66ccd99f3f771ae39b75aaba28b952372b6debfb971134bf1f03466ab2"
-"checksum kvdb-web 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a985c47b4c46429e96033ebf6eaed784a81ceccb4e5df13d63f3b9078a4df81"
+"checksum kvdb-web 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "37a0e36637fb86454de401e7cb88f40eb0ad1b9bcee837d46785e7c451f1ebf4"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 "checksum libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)" = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
@@ -7602,11 +7594,12 @@ dependencies = [
 "checksum lru 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "5d8f669d42c72d18514dfca8115689c5f6370a17d980cb5bd777a67f404594c8"
 "checksum lru 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0609345ddee5badacf857d4f547e0e5a2e987db77085c24cd887f73573a04237"
 "checksum mach 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "86dd2487cdfea56def77b88438a2c915fb45113c5319bfe7e14306ca4cd0b0e1"
+"checksum malloc_size_of_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e37c5d4cd9473c5f4c9c111f033f15d4df9bd378fdf615944e360a4f55a05f0b"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 "checksum memchr 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3197e20c7edb283f87c071ddfc7a2cca8f8e0b888c242959846a6fce03c72223"
 "checksum memoffset 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "75189eb85871ea5c2e2c15abbdd541185f63b408415e5051f5cac122d8c774b9"
-"checksum memory-db 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)" = "198831fe8722331a395bc199a5d08efbc197497ef354cb4c77b969c02ffc0fc4"
+"checksum memory-db 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)" = "881736a0f68a6fae1b596bb066c5bd16d7b3ed645a4dd8ffaefd02f585abaf71"
 "checksum memory_units 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "71d96e3f3c0b6325d8ccd83c33b28acb183edcb6c67938ba104ec546854b0882"
 "checksum memrange 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cc29ba65898edc4fdc252cb31cd3925f37c1a8ba25bb46eec883569984976530"
 "checksum merlin 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2b0942b357c1b4d0dc43ba724674ec89c3218e6ca2b3e8269e7cb53bcecd2f6e"
@@ -7637,43 +7630,45 @@ dependencies = [
 "checksum once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b1c601810575c99596d4afc46f78a678c80105117c379eb3650cf99b8a21ce5b"
 "checksum opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 "checksum owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
-"checksum pallet-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum pallet-authorship 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum pallet-babe 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum pallet-balances 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum pallet-collective 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum pallet-democracy 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum pallet-elections-phragmen 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum pallet-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum pallet-grandpa 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum pallet-identity 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum pallet-im-online 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum pallet-indices 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum pallet-membership 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum pallet-nicks 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum pallet-offences 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum pallet-randomness-collective-flip 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum pallet-recovery 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum pallet-session 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum pallet-society 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum pallet-staking 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum pallet-staking-reward-curve 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum pallet-sudo 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum pallet-timestamp 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum pallet-transaction-payment 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum pallet-transaction-payment-rpc 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum pallet-transaction-payment-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum pallet-treasury 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum pallet-utility 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum pallet-vesting 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum pallet-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum pallet-authorship 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum pallet-babe 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum pallet-balances 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum pallet-collective 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum pallet-democracy 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum pallet-elections-phragmen 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum pallet-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum pallet-grandpa 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum pallet-identity 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum pallet-im-online 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum pallet-indices 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum pallet-membership 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum pallet-nicks 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum pallet-offences 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum pallet-randomness-collective-flip 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum pallet-recovery 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum pallet-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum pallet-society 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum pallet-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum pallet-staking-reward-curve 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum pallet-sudo 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum pallet-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum pallet-transaction-payment 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum pallet-transaction-payment-rpc 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum pallet-transaction-payment-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum pallet-treasury 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum pallet-utility 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum pallet-vesting 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
 "checksum parity-bytes 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0c276d76c5333b8c2579e02d49a06733a55b8282d2d9b13e8d53b6406bd7e30a"
+"checksum parity-multiaddr 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "045b3c7af871285146300da35b1932bb6e4639b66c7c98e85d06a32cbc4e8fa7"
 "checksum parity-multiaddr 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "80878c27f90dd162d3143333d672e80b194d6b080f05c83440e3dfda42e409f2"
+"checksum parity-multihash 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "df3a17dc27848fd99e4f87eb0f8c9baba6ede0a6d555400c850ca45254ef4ce3"
 "checksum parity-multihash 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b11f42bbd3a021c5061b77154bd3334d5a57e1a03eb162de0b962681cc25800d"
 "checksum parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f747c06d9f3b2ad387ac881b9667298c81b1243aa9833f086e05996937c35507"
 "checksum parity-scale-codec-derive 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "34e513ff3e406f3ede6796dcdc83d0b32ffb86668cea1ccf7363118abeb00476"
 "checksum parity-send-wrapper 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aa9777aa91b8ad9dd5aaa04a9b6bcb02c7f1deb952fca5a66034d5e63afc5c6f"
+"checksum parity-util-mem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8174d85e62c4d615fddd1ef67966bdc5757528891d0742f15b131ad04667b3f9"
 "checksum parity-util-mem 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "01b04e4d2588668d5aa93144b3bd719be963542e60042d66c7586ca763838a5b"
-"checksum parity-util-mem 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ef1476e40bf8f5c6776e9600983435821ca86eb9819d74a6207cca69d091406a"
 "checksum parity-util-mem-derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f557c32c6d268a07c921471619c0295f5efad3a0e76d4f97a05c091a51d110b2"
 "checksum parity-wasm 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc878dac00da22f8f61e7af3157988424567ab01d9920b962ef7dcbd7cd865"
 "checksum parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "92e98c49ab0b7ce5b222f2cc9193fc4efe11c6d0bd4f648e374684a6857b1cfc"
@@ -7757,37 +7752,37 @@ dependencies = [
 "checksum rw-stream-sink 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4da5fcb054c46f5a5dff833b129285a93d3f0179531735e6c866e8cc307d2020"
 "checksum ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
 "checksum safe-mix 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6d3d055a2582e6b00ed7a31c1524040aa391092bf636328350813f3a0605215c"
-"checksum sc-authority-discovery 0.8.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sc-block-builder 0.8.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sc-chain-spec 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sc-chain-spec-derive 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sc-cli 0.8.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sc-client 0.8.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sc-client-db 0.8.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sc-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sc-consensus-epochs 0.8.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sc-consensus-slots 0.8.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sc-consensus-uncles 0.8.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sc-executor 0.8.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sc-executor-common 0.8.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sc-executor-wasmi 0.8.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sc-executor-wasmtime 0.8.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sc-finality-grandpa 0.8.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sc-network 0.8.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sc-network-gossip 0.8.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sc-offchain 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sc-peerset 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sc-rpc 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sc-rpc-api 0.8.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sc-rpc-server 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sc-service 0.8.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sc-state-db 0.8.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sc-tracing 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sc-transaction-graph 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sc-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sc-authority-discovery 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sc-block-builder 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sc-chain-spec 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sc-chain-spec-derive 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sc-cli 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sc-client-db 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sc-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sc-consensus-epochs 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sc-consensus-slots 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sc-consensus-uncles 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sc-executor 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sc-executor-common 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sc-executor-wasmi 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sc-executor-wasmtime 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sc-finality-grandpa 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sc-network-gossip 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sc-offchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sc-peerset 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sc-rpc 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sc-rpc-api 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sc-rpc-server 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sc-service 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sc-state-db 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sc-tracing 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sc-transaction-graph 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sc-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
 "checksum schnorrkel 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)" = "eacd8381b3c37840c9c9f40472af529e49975bdcbc24f83c31059fd6539023d3"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
@@ -7820,43 +7815,43 @@ dependencies = [
 "checksum snow 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "afb767eee7d257ba202f0b9b08673bc13b22281632ef45267b19f13100accd2f"
 "checksum soketto 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1c9dab3f95c9ebdf3a88268c19af668f637a3c5039c2c56ff2d40b1b2d64a25b"
 "checksum sourcefile 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf77cb82ba8453b42b6ae1d692e4cdc92f9a47beaf89a847c8be83f4e328ad3"
-"checksum sp-allocator 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sp-api 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sp-api-proc-macro 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sp-arithmetic 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sp-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sp-authorship 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sp-block-builder 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sp-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sp-core 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sp-debug-derive 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sp-externalities 0.8.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sp-finality-grandpa 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sp-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sp-io 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sp-offchain 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sp-panic-handler 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sp-phragmen 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sp-rpc 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sp-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sp-runtime-interface-proc-macro 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sp-serializer 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sp-session 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sp-staking 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sp-std 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sp-storage 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sp-timestamp 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sp-trie 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sp-version 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
-"checksum sp-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sp-allocator 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-api-proc-macro 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-arithmetic 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-authorship 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-block-builder 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-debug-derive 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-externalities 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-finality-grandpa 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-offchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-panic-handler 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-phragmen 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-rpc 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-runtime-interface-proc-macro 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-serializer 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-storage 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
 "checksum spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
@@ -7869,7 +7864,7 @@ dependencies = [
 "checksum strum 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6138f8f88a16d90134763314e3fc76fa3ed6a7db4725d6acf9a3ef95a3188d22"
 "checksum strum_macros 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0054a7df764039a6cd8592b9de84be4bec368ff081d203a7d5371cbfa8e65c81"
 "checksum substrate-bip39 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3be511be555a3633e71739a79e4ddff6a6aaa6579fa6114182a51d72c3eb93c5"
-"checksum substrate-frame-rpc-system 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum substrate-frame-rpc-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
 "checksum substrate-wasm-builder-runner 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e30c70de7e7d5fd404fe26db1e7a4d6b553e2760b1ac490f249c04a960c483b8"
 "checksum subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 "checksum subtle 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7c65d530b10ccaeac294f349038a597e435b18fb456aadd0840a623f83b9e941"
@@ -7919,7 +7914,6 @@ dependencies = [
 "checksum trie-db 0.19.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a0d747ae5b6f078df7e46477fcc7df66df9eb4f27a031cf4a7c890a8dd03d8e6"
 "checksum trie-db 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de9222c50cc325855621271157c973da27a0dcd26fa06f8edf81020bd2333df0"
 "checksum trie-root 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0b779f7c1c8fe9276365d9d5be5c4b5adeacf545117bb3f64c974305789c5c0b"
-"checksum trie-root 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "652931506d2c1244d7217a70b99f56718a7b4161b37f04e7cd868072a99f68cd"
 "checksum try-lock 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
 "checksum twofish 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712d261e83e727c8e2dbb75dacac67c36e35db36a958ee504f2164fc052434e1"
 "checksum twox-hash 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3bfd5b7557925ce778ff9b9ef90e3ade34c524b5ff10e239c69a42d546d2af56"
@@ -7932,6 +7926,7 @@ dependencies = [
 "checksum unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+"checksum unsigned-varint 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a7f0023a96687fe169081e8adce3f65e3874426b7886e9234d490af2dc077959"
 "checksum unsigned-varint 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c689459fbaeb50e56c6749275f084decfd02194ac5852e6617d95d0d3cf02eaf"
 "checksum untrusted 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60369ef7a31de49bcb3f6ca728d4ba7300d9a1658f94c727d4cab8c8d9f4aece"
 "checksum url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ dependencies = [
  "dlmalloc 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-parachain 0.7.20",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate)",
  "substrate-wasm-builder-runner 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -32,9 +32,9 @@ dependencies = [
  "polkadot-collator 0.7.20",
  "polkadot-parachain 0.7.20",
  "polkadot-primitives 0.7.20",
- "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-client 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
@@ -400,7 +400,7 @@ dependencies = [
 [[package]]
 name = "browser-utils"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "console_error_panic_hook 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -408,22 +408,17 @@ dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "js-sys 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvdb-web 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kvdb-web 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libp2p 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-chain-spec 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-service 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-chain-spec 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sc-network 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sc-service 0.8.0 (git+https://github.com/paritytech/substrate)",
  "wasm-bindgen 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-futures 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "bs58"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bs58"
@@ -1130,7 +1125,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "fork-tree"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1138,58 +1133,58 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "frame-metadata"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "frame-support"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "bitmask 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "frame-metadata 11.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "frame-support-procedural 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-metadata 11.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-support-procedural 2.0.0 (git+https://github.com/paritytech/substrate)",
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "paste 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-arithmetic 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-arithmetic 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
  "tracing 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "frame-support-procedural"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
- "frame-support-procedural-tools 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-support-procedural-tools 2.0.0 (git+https://github.com/paritytech/substrate)",
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1198,9 +1193,9 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
- "frame-support-procedural-tools-derive 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-support-procedural-tools-derive 2.0.0 (git+https://github.com/paritytech/substrate)",
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1210,7 +1205,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1220,26 +1215,26 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate)",
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-version 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
@@ -1521,7 +1516,7 @@ dependencies = [
 [[package]]
 name = "grafana-data-source"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "async-std 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2024,40 +2019,40 @@ name = "kusama-runtime"
 version = "0.7.20"
 dependencies = [
  "bitvec 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "frame-executive 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "frame-system-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-executive 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-system-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate)",
  "hex-literal 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsecp256k1 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-authorship 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-babe 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-balances 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-collective 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-democracy 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-elections-phragmen 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-grandpa 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-identity 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-im-online 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-indices 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-membership 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-nicks 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-offences 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-randomness-collective-flip 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-recovery 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-society 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-staking-reward-curve 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-transaction-payment 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-transaction-payment-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-treasury 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-utility 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-vesting 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-authorship 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-babe 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-balances 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-collective 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-democracy 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-elections-phragmen 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-grandpa 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-identity 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-im-online 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-indices 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-membership 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-nicks 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-offences 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-randomness-collective-flip 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-recovery 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-society 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-staking 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-staking-reward-curve 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-timestamp 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-transaction-payment 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-transaction-payment-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-treasury 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-utility 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-vesting 2.0.0 (git+https://github.com/paritytech/substrate)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-parachain 0.7.20",
  "polkadot-primitives 0.7.20",
@@ -2066,22 +2061,22 @@ dependencies = [
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-block-builder 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-offchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-block-builder 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-offchain 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-session 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-version 2.0.0 (git+https://github.com/paritytech/substrate)",
  "substrate-wasm-builder-runner 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "trie-db 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2106,6 +2101,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "kvdb"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "parity-bytes 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-util-mem 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "kvdb-memorydb"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2113,6 +2118,16 @@ dependencies = [
  "kvdb 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-util-mem 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "kvdb-memorydb"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kvdb 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-util-mem 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2134,16 +2149,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "kvdb-rocksdb"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fs-swap 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "interleaved-ordered 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kvdb 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-util-mem 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rocksdb 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "kvdb-web"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "js-sys 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvdb 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvdb-memorydb 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kvdb 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kvdb-memorydb 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-util-mem 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-util-mem 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "send_wrapper 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "web-sys 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2660,16 +2693,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "malloc_size_of_derive"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "synstructure 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "matches"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2694,13 +2717,13 @@ dependencies = [
 
 [[package]]
 name = "memory-db"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ahash 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashbrown 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-util-mem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-util-mem 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2968,326 +2991,326 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "pallet-authorship"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate)",
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-authorship 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-authorship 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "pallet-babe"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate)",
  "hex-literal 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-timestamp 2.0.0 (git+https://github.com/paritytech/substrate)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-timestamp 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "pallet-balances"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "pallet-collective"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "pallet-democracy"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "pallet-elections-phragmen"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-phragmen 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-phragmen 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "pallet-finality-tracker"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate)",
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "pallet-grandpa"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-finality-grandpa 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-finality-grandpa 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "pallet-identity"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "enumflags2 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "pallet-im-online"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-authorship 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-authorship 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "pallet-indices"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "pallet-membership"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "pallet-nicks"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "pallet-offences"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-balances 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-balances 2.0.0 (git+https://github.com/paritytech/substrate)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "pallet-recovery"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "enumflags2 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "pallet-session"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate)",
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-timestamp 2.0.0 (git+https://github.com/paritytech/substrate)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "pallet-society"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "pallet-staking"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-authorship 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-authorship 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-phragmen 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-phragmen 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3298,142 +3321,125 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "pallet-timestamp"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate)",
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-timestamp 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "pallet-transaction-payment"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-transaction-payment-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-transaction-payment-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "jsonrpc-core 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core-client 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-derive 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-transaction-payment-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-transaction-payment-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-rpc 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-rpc 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "pallet-treasury"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-balances 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-balances 2.0.0 (git+https://github.com/paritytech/substrate)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "pallet-utility"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "pallet-vesting"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "enumflags2 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "parity-bytes"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "parity-multiaddr"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "arrayref 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "bs58 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "data-encoding 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-multihash 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "unsigned-varint 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "parity-multiaddr"
@@ -3450,20 +3456,6 @@ dependencies = [
  "static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unsigned-varint 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "parity-multihash"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "blake2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha-1 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha3 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "unsigned-varint 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3510,16 +3502,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "parity-util-mem"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "malloc_size_of_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "parity-util-mem"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -3527,6 +3509,20 @@ dependencies = [
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-util-mem-derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "parity-util-mem"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-util-mem-derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "primitive-types 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3736,15 +3732,15 @@ dependencies = [
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-erasure-coding 0.7.20",
  "polkadot-primitives 0.7.20",
- "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-client 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sc-network 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
  "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3752,18 +3748,18 @@ dependencies = [
 name = "polkadot-cli"
 version = "0.7.20"
 dependencies = [
- "browser-utils 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "browser-utils 0.8.0 (git+https://github.com/paritytech/substrate)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-service 0.7.20",
- "sc-cli 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-client-db 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-executor 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-cli 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sc-client 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sc-client-db 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sc-executor 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
  "structopt 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3783,16 +3779,16 @@ dependencies = [
  "polkadot-primitives 0.7.20",
  "polkadot-service 0.7.20",
  "polkadot-validation 0.7.20",
- "sc-cli 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-cli 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sc-client 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sc-network 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
  "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3804,8 +3800,8 @@ dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-primitives 0.7.20",
  "reed-solomon-erasure 4.0.0 (git+https://github.com/paritytech/reed-solomon-erasure)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
@@ -3822,15 +3818,15 @@ dependencies = [
  "polkadot-erasure-coding 0.7.20",
  "polkadot-primitives 0.7.20",
  "polkadot-validation 0.7.20",
- "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-network-gossip 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-client 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sc-network 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sc-network-gossip 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate)",
  "wasm-timer 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3845,14 +3841,14 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-executor 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-executor 0.8.0 (git+https://github.com/paritytech/substrate)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "shared_memory 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-externalities 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-externalities 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
  "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3861,20 +3857,20 @@ name = "polkadot-primitives"
 version = "0.7.20"
 dependencies = [
  "bitvec 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-babe 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-babe 2.0.0 (git+https://github.com/paritytech/substrate)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-parachain 0.7.20",
  "pretty_assertions 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-serializer 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-serializer 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-version 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
@@ -3882,15 +3878,15 @@ name = "polkadot-rpc"
 version = "0.7.20"
 dependencies = [
  "jsonrpc-core 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-transaction-payment-rpc 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-transaction-payment-rpc 2.0.0 (git+https://github.com/paritytech/substrate)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-primitives 0.7.20",
- "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-rpc 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "substrate-frame-rpc-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-client 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sc-rpc 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "substrate-frame-rpc-system 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
@@ -3898,38 +3894,38 @@ name = "polkadot-runtime"
 version = "0.7.20"
 dependencies = [
  "bitvec 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "frame-executive 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "frame-system-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-executive 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-system-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate)",
  "hex-literal 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsecp256k1 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-authorship 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-babe 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-balances 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-collective 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-democracy 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-elections-phragmen 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-grandpa 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-identity 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-im-online 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-indices 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-membership 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-nicks 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-offences 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-randomness-collective-flip 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-staking-reward-curve 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-sudo 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-transaction-payment 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-transaction-payment-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-treasury 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-vesting 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-authorship 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-babe 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-balances 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-collective 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-democracy 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-elections-phragmen 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-grandpa 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-identity 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-im-online 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-indices 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-membership 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-nicks 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-offences 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-randomness-collective-flip 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-staking 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-staking-reward-curve 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-sudo 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-timestamp 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-transaction-payment 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-transaction-payment-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-treasury 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-vesting 2.0.0 (git+https://github.com/paritytech/substrate)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-parachain 0.7.20",
  "polkadot-primitives 0.7.20",
@@ -3938,21 +3934,21 @@ dependencies = [
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-block-builder 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-offchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-block-builder 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-offchain 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-session 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-version 2.0.0 (git+https://github.com/paritytech/substrate)",
  "substrate-wasm-builder-runner 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "trie-db 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3963,21 +3959,21 @@ name = "polkadot-runtime-common"
 version = "0.7.20"
 dependencies = [
  "bitvec 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate)",
  "hex-literal 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsecp256k1 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-authorship 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-babe 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-balances 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-randomness-collective-flip 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-staking-reward-curve 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-treasury 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-vesting 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-authorship 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-babe 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-balances 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-randomness-collective-flip 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-staking 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-staking-reward-curve 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-timestamp 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-treasury 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-vesting 2.0.0 (git+https://github.com/paritytech/substrate)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-parachain 0.7.20",
  "polkadot-primitives 0.7.20",
@@ -3985,15 +3981,15 @@ dependencies = [
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate)",
  "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "trie-db 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -4002,16 +3998,16 @@ dependencies = [
 name = "polkadot-service"
 version = "0.7.20"
 dependencies = [
- "frame-system-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-literal 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "kusama-runtime 0.7.20",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-babe 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-im-online 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "pallet-transaction-payment-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-babe 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-im-online 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-staking 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "pallet-transaction-payment-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-availability-store 0.7.20",
@@ -4020,35 +4016,35 @@ dependencies = [
  "polkadot-rpc 0.7.20",
  "polkadot-runtime 0.7.20",
  "polkadot-validation 0.7.20",
- "sc-authority-discovery 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-chain-spec 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-client-db 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-executor 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-finality-grandpa 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-service 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-authority-discovery 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sc-chain-spec 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sc-client 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sc-client-db 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sc-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sc-executor 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sc-finality-grandpa 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sc-network 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sc-service 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sc-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-block-builder 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-finality-grandpa 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-offchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-block-builder 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sp-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-finality-grandpa 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-offchain 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-session 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
@@ -4057,7 +4053,7 @@ version = "0.7.20"
 dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-primitives 0.7.20",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
@@ -4070,7 +4066,7 @@ dependencies = [
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-timer 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-babe 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "pallet-babe 2.0.0 (git+https://github.com/paritytech/substrate)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-availability-store 0.7.20",
@@ -4078,21 +4074,21 @@ dependencies = [
  "polkadot-parachain 0.7.20",
  "polkadot-primitives 0.7.20",
  "polkadot-statement-table 0.7.20",
- "sc-block-builder 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-finality-grandpa 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-block-builder 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sc-finality-grandpa 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sp-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-timestamp 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate)",
  "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -4652,7 +4648,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4664,52 +4660,52 @@ dependencies = [
  "prost 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-build 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sc-network 0.8.0 (git+https://github.com/paritytech/substrate)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "sc-block-builder"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-block-builder 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-block-builder 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "sc-chain-spec"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-chain-spec-derive 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-chain-spec-derive 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sc-network 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "sc-chain-spec-derive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4720,7 +4716,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "ansi_term 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "app_dirs 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4734,20 +4730,21 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "names 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-util-mem 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rpassword 4.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-service 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-tracing 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sc-network 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sc-service 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sc-tracing 2.0.0 (git+https://github.com/paritytech/substrate)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-panic-handler 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-panic-handler 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate)",
  "structopt 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4756,100 +4753,101 @@ dependencies = [
 [[package]]
 name = "sc-client"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-literal 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvdb 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kvdb 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-block-builder 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-executor 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-externalities 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-block-builder 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sc-executor 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-externalities 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-version 2.0.0 (git+https://github.com/paritytech/substrate)",
  "tracing 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sc-client-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-literal 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvdb 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kvdb 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-executor 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-externalities 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-executor 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-externalities 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-version 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "sc-client-db"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvdb 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvdb-memorydb 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvdb-rocksdb 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kvdb 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kvdb-memorydb 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kvdb-rocksdb 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-util-mem 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-util-mem 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-executor 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-state-db 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sc-client 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sc-executor 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sc-state-db 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "sc-consensus-babe"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "fork-tree 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "fork-tree 2.0.0 (git+https://github.com/paritytech/substrate)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-timer 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4861,80 +4859,80 @@ dependencies = [
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pdqselect 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-consensus-epochs 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-consensus-slots 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-consensus-uncles 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-client 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sc-consensus-epochs 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sc-consensus-slots 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sc-consensus-uncles 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate)",
  "schnorrkel 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-block-builder 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-block-builder 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sp-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-timestamp 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-version 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
- "fork-tree 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "fork-tree 2.0.0 (git+https://github.com/paritytech/substrate)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "sc-consensus-slots"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-timer 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "sc-consensus-uncles"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-authorship 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-authorship 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "sc-executor"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4943,57 +4941,57 @@ dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-wasm 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-executor-common 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-executor-wasmi 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-executor-wasmtime 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-externalities 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-panic-handler 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-serializer 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-executor-common 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sc-executor-wasmi 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sc-executor-wasmtime 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-externalities 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-panic-handler 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-serializer 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-version 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate)",
  "wasmi 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sc-executor-common"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-allocator 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-serializer 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-allocator 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-serializer 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate)",
  "wasmi 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-wasm 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-executor-common 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-allocator 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-executor-common 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sp-allocator 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate)",
  "wasmi 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "cranelift-codegen 0.50.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cranelift-entity 0.50.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5003,11 +5001,11 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-wasm 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-executor-common 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-allocator 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-executor-common 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sp-allocator 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate)",
  "wasmi 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmtime-environ 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmtime-jit 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5017,11 +5015,11 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "finality-grandpa 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fork-tree 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "fork-tree 2.0.0 (git+https://github.com/paritytech/substrate)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-timer 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5029,42 +5027,42 @@ dependencies = [
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-network-gossip 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-client 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sc-network 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sc-network-gossip 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-arithmetic 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-finality-grandpa 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-arithmetic 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-finality-grandpa 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "sc-keystore"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
  "subtle 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sc-network"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5072,7 +5070,7 @@ dependencies = [
  "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "erased-serde 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "fork-tree 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "fork-tree 2.0.0 (git+https://github.com/paritytech/substrate)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-timer 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures_codec 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5085,21 +5083,21 @@ dependencies = [
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-block-builder 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-peerset 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-block-builder 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sc-client 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sc-peerset 2.0.0 (git+https://github.com/paritytech/substrate)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog_derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-arithmetic 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-arithmetic 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sp-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
  "unsigned-varint 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5108,7 +5106,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5117,14 +5115,14 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-network 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "sc-offchain"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5138,20 +5136,20 @@ dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-offchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sc-network 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-offchain 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
  "threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sc-peerset"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "libp2p 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5162,7 +5160,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5171,28 +5169,28 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-executor 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-rpc-api 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-client 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sc-executor 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sc-rpc-api 0.8.0 (git+https://github.com/paritytech/substrate)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-offchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-rpc 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-offchain 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-rpc 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-session 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-version 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "sc-rpc-api"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5205,16 +5203,16 @@ dependencies = [
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-rpc 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-rpc 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-version 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "sc-rpc-server"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "jsonrpc-core 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-http-server 14.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5223,13 +5221,13 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "sc-service"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "exit-future 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5237,37 +5235,38 @@ dependencies = [
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-diagnose 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-timer 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "grafana-data-source 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "grafana-data-source 0.8.0 (git+https://github.com/paritytech/substrate)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-multiaddr 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-multiaddr 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-util-mem 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-chain-spec 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-client-db 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-executor 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-offchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-rpc 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-rpc-server 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-tracing 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-chain-spec 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sc-client 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sc-client-db 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sc-executor 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sc-network 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sc-offchain 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sc-rpc 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sc-rpc-server 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sc-tracing 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sc-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-session 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate)",
  "sysinfo 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "target_info 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5277,18 +5276,18 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "sc-telemetry"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5309,13 +5308,13 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "erased-serde 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "grafana-data-source 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "grafana-data-source 0.8.0 (git+https://github.com/paritytech/substrate)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5325,36 +5324,38 @@ dependencies = [
 [[package]]
 name = "sc-transaction-graph"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-util-mem 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "sc-transaction-pool"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-diagnose 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-util-mem 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sc-transaction-graph 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sc-transaction-graph 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
@@ -5648,34 +5649,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "sp-allocator"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "sp-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api-proc-macro 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-api-proc-macro 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-version 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "sp-api-proc-macro"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5687,83 +5688,83 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "sp-arithmetic"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "integer-sqrt 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-debug-derive 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-debug-derive 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "sp-authority-discovery"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "sp-authorship"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "sp-block-builder"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "sp-blockchain"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-block-builder 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-block-builder 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "sp-consensus"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5774,34 +5775,34 @@ dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-version 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "sp-consensus-babe"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "schnorrkel 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-timestamp 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "sp-core"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "base58 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5816,6 +5817,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-util-mem 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "primitive-types 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5824,11 +5826,11 @@ dependencies = [
  "schnorrkel 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-debug-derive 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-externalities 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-storage 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-debug-derive 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-externalities 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-storage 2.0.0 (git+https://github.com/paritytech/substrate)",
  "substrate-bip39 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-bip39 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5840,7 +5842,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5850,90 +5852,90 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "environmental 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-storage 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-storage 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "sp-finality-grandpa"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "sp-finality-tracker"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "sp-inherents"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "sp-io"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsecp256k1 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-externalities 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-externalities 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "sp-keyring"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
  "strum 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sp-offchain"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "sp-panic-handler"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "backtrace 0.3.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5942,59 +5944,60 @@ dependencies = [
 [[package]]
 name = "sp-phragmen"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "sp-rpc"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "sp-runtime"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-util-mem 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "paste 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-arithmetic 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-arithmetic 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-io 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "sp-runtime-interface"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "primitive-types 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-externalities 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime-interface-proc-macro 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-externalities 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime-interface-proc-macro 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate)",
  "static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "Inflector 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6006,7 +6009,7 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6015,28 +6018,28 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "sp-staking"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "sp-state-machine"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6044,10 +6047,10 @@ dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-externalities 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-panic-handler 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-externalities 0.8.0 (git+https://github.com/paritytech/substrate)",
+ "sp-panic-handler 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate)",
  "trie-db 0.19.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "trie-root 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -6055,80 +6058,80 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 
 [[package]]
 name = "sp-storage"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "impl-serde 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-debug-derive 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-debug-derive 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "sp-timestamp"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "sp-transaction-pool"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "sp-trie"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "memory-db 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memory-db 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "trie-db 0.19.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "trie-root 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "trie-db 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "trie-root 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sp-version"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "impl-serde 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
 name = "sp-wasm-interface"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate)",
  "wasmi 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -6231,22 +6234,22 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key#daac70a02dce49c38213d9bf3dae0ecdb539eb41"
+source = "git+https://github.com/paritytech/substrate#f735d3e2491d347825ec9560e8916decd72a4f11"
 dependencies = [
- "frame-system-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "frame-system-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core-client 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-derive 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sc-client 0.8.0 (git+https://github.com/paritytech/substrate)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
- "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)",
+ "sp-api 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-core 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate)",
 ]
 
 [[package]]
@@ -6747,6 +6750,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "trie-root"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6827,11 +6838,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "unicode-xid"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "unsigned-varint"
-version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -7380,8 +7386,7 @@ dependencies = [
 "checksum block-cipher-trait 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1c924d49bd09e7c06003acda26cd9742e796e34282ec6c1189404dee0c1f4774"
 "checksum block-padding 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
 "checksum broadcaster 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9c972e21e0d055a36cf73e4daae870941fe7a8abcd5ac3396aab9e4c126bd87"
-"checksum browser-utils 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum bs58 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "c95ee6bba9d950218b6cc910cf62bc9e0a171d0f4537e3627b0f54d08549b188"
+"checksum browser-utils 0.8.0 (git+https://github.com/paritytech/substrate)" = "<none>"
 "checksum bs58 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b170cd256a3f9fa6b9edae3e44a7dfdfc77e8124dbc3e2612d75f9c3e2396dae"
 "checksum bstr 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "502ae1441a0a5adb8fbd38a5955a6416b9493e92b465de5e4a9bde6a539c2c48"
 "checksum bumpalo 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1f359dc14ff8911330a51ef78022d376f25ed00248912803b58f00cb1c27f742"
@@ -7463,15 +7468,15 @@ dependencies = [
 "checksum fixedbitset 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 "checksum flate2 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6bd6d6f4752952feb71363cffc9ebac9411b75b87c6ab6058c40c8900cf43c0f"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
-"checksum fork-tree 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum frame-executive 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum frame-metadata 11.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum frame-support-procedural 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum frame-support-procedural-tools 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum frame-support-procedural-tools-derive 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum frame-system-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum fork-tree 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum frame-executive 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum frame-metadata 11.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum frame-support 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum frame-support-procedural 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum frame-support-procedural-tools 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum frame-support-procedural-tools-derive 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum frame-system 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum frame-system-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
 "checksum fs-swap 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "921d332c89b3b61a826de38c61ee5b6e02c56806cade1b0e5d81bd71f57a71bb"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
@@ -7503,7 +7508,7 @@ dependencies = [
 "checksum glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 "checksum globset 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "925aa2cac82d8834e2b2a4415b6f6879757fb5c0928fc445ae76461a12eed8f2"
 "checksum goblin 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3081214398d39e4bd7f2c1975f0488ed04614ffdd976c6fc7a0708278552c0da"
-"checksum grafana-data-source 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum grafana-data-source 0.8.0 (git+https://github.com/paritytech/substrate)" = "<none>"
 "checksum h2 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "a5b34c246847f938a410a03c5458c7fee2274436675e76d8b903c08efc29c462"
 "checksum h2 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b9433d71e471c1736fd5a61b671fc0b148d7a2992f666c958d03cd8feb3b88d1"
 "checksum hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d23bd4e7b5eda0d0f3a307e8b381fdc8ba9000f26fbe912250c0a4cc3956364a"
@@ -7554,9 +7559,12 @@ dependencies = [
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum kv-log-macro 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c54d9f465d530a752e6ebdc217e081a7a614b48cb200f6f0aee21ba6bc9aabb"
 "checksum kvdb 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8396be0e5561ccd1bf7ff0b2007487cdd7a87a056873fe6ea906b35d4dbf7ed8"
+"checksum kvdb 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "03080afe6f42cd996da9f568d6add5d7fb5ee2ea7fb7802d2d2cbd836958fd87"
 "checksum kvdb-memorydb 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4d25ef14155e418515c4839e9144c839de3506e68946f255a32b7f166095493d"
+"checksum kvdb-memorydb 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b9355274e5a9e0a7e8ef43916950eae3949024de2a8dffe4d5a6c13974a37c8e"
 "checksum kvdb-rocksdb 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5a1053e90a54421a842b6bf5d0e4a5cb5364c0bf570f713c58e44a9906f501d9"
-"checksum kvdb-web 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "37a0e36637fb86454de401e7cb88f40eb0ad1b9bcee837d46785e7c451f1ebf4"
+"checksum kvdb-rocksdb 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "af36fd66ccd99f3f771ae39b75aaba28b952372b6debfb971134bf1f03466ab2"
+"checksum kvdb-web 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a985c47b4c46429e96033ebf6eaed784a81ceccb4e5df13d63f3b9078a4df81"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 "checksum libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)" = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
@@ -7594,12 +7602,11 @@ dependencies = [
 "checksum lru 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "5d8f669d42c72d18514dfca8115689c5f6370a17d980cb5bd777a67f404594c8"
 "checksum lru 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0609345ddee5badacf857d4f547e0e5a2e987db77085c24cd887f73573a04237"
 "checksum mach 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "86dd2487cdfea56def77b88438a2c915fb45113c5319bfe7e14306ca4cd0b0e1"
-"checksum malloc_size_of_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e37c5d4cd9473c5f4c9c111f033f15d4df9bd378fdf615944e360a4f55a05f0b"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 "checksum memchr 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3197e20c7edb283f87c071ddfc7a2cca8f8e0b888c242959846a6fce03c72223"
 "checksum memoffset 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "75189eb85871ea5c2e2c15abbdd541185f63b408415e5051f5cac122d8c774b9"
-"checksum memory-db 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)" = "881736a0f68a6fae1b596bb066c5bd16d7b3ed645a4dd8ffaefd02f585abaf71"
+"checksum memory-db 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)" = "198831fe8722331a395bc199a5d08efbc197497ef354cb4c77b969c02ffc0fc4"
 "checksum memory_units 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "71d96e3f3c0b6325d8ccd83c33b28acb183edcb6c67938ba104ec546854b0882"
 "checksum memrange 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cc29ba65898edc4fdc252cb31cd3925f37c1a8ba25bb46eec883569984976530"
 "checksum merlin 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2b0942b357c1b4d0dc43ba724674ec89c3218e6ca2b3e8269e7cb53bcecd2f6e"
@@ -7630,45 +7637,43 @@ dependencies = [
 "checksum once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b1c601810575c99596d4afc46f78a678c80105117c379eb3650cf99b8a21ce5b"
 "checksum opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 "checksum owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
-"checksum pallet-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum pallet-authorship 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum pallet-babe 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum pallet-balances 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum pallet-collective 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum pallet-democracy 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum pallet-elections-phragmen 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum pallet-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum pallet-grandpa 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum pallet-identity 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum pallet-im-online 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum pallet-indices 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum pallet-membership 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum pallet-nicks 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum pallet-offences 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum pallet-randomness-collective-flip 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum pallet-recovery 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum pallet-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum pallet-society 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum pallet-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum pallet-staking-reward-curve 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum pallet-sudo 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum pallet-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum pallet-transaction-payment 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum pallet-transaction-payment-rpc 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum pallet-transaction-payment-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum pallet-treasury 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum pallet-utility 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum pallet-vesting 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum pallet-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum pallet-authorship 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum pallet-babe 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum pallet-balances 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum pallet-collective 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum pallet-democracy 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum pallet-elections-phragmen 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum pallet-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum pallet-grandpa 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum pallet-identity 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum pallet-im-online 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum pallet-indices 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum pallet-membership 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum pallet-nicks 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum pallet-offences 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum pallet-randomness-collective-flip 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum pallet-recovery 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum pallet-session 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum pallet-society 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum pallet-staking 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum pallet-staking-reward-curve 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum pallet-sudo 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum pallet-timestamp 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum pallet-transaction-payment 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum pallet-transaction-payment-rpc 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum pallet-transaction-payment-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum pallet-treasury 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum pallet-utility 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum pallet-vesting 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
 "checksum parity-bytes 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0c276d76c5333b8c2579e02d49a06733a55b8282d2d9b13e8d53b6406bd7e30a"
-"checksum parity-multiaddr 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "045b3c7af871285146300da35b1932bb6e4639b66c7c98e85d06a32cbc4e8fa7"
 "checksum parity-multiaddr 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "80878c27f90dd162d3143333d672e80b194d6b080f05c83440e3dfda42e409f2"
-"checksum parity-multihash 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "df3a17dc27848fd99e4f87eb0f8c9baba6ede0a6d555400c850ca45254ef4ce3"
 "checksum parity-multihash 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b11f42bbd3a021c5061b77154bd3334d5a57e1a03eb162de0b962681cc25800d"
 "checksum parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f747c06d9f3b2ad387ac881b9667298c81b1243aa9833f086e05996937c35507"
 "checksum parity-scale-codec-derive 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "34e513ff3e406f3ede6796dcdc83d0b32ffb86668cea1ccf7363118abeb00476"
 "checksum parity-send-wrapper 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aa9777aa91b8ad9dd5aaa04a9b6bcb02c7f1deb952fca5a66034d5e63afc5c6f"
-"checksum parity-util-mem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8174d85e62c4d615fddd1ef67966bdc5757528891d0742f15b131ad04667b3f9"
 "checksum parity-util-mem 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "01b04e4d2588668d5aa93144b3bd719be963542e60042d66c7586ca763838a5b"
+"checksum parity-util-mem 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ef1476e40bf8f5c6776e9600983435821ca86eb9819d74a6207cca69d091406a"
 "checksum parity-util-mem-derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f557c32c6d268a07c921471619c0295f5efad3a0e76d4f97a05c091a51d110b2"
 "checksum parity-wasm 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc878dac00da22f8f61e7af3157988424567ab01d9920b962ef7dcbd7cd865"
 "checksum parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "92e98c49ab0b7ce5b222f2cc9193fc4efe11c6d0bd4f648e374684a6857b1cfc"
@@ -7752,37 +7757,37 @@ dependencies = [
 "checksum rw-stream-sink 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4da5fcb054c46f5a5dff833b129285a93d3f0179531735e6c866e8cc307d2020"
 "checksum ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
 "checksum safe-mix 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6d3d055a2582e6b00ed7a31c1524040aa391092bf636328350813f3a0605215c"
-"checksum sc-authority-discovery 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sc-block-builder 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sc-chain-spec 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sc-chain-spec-derive 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sc-cli 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sc-client-db 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sc-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sc-consensus-epochs 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sc-consensus-slots 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sc-consensus-uncles 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sc-executor 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sc-executor-common 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sc-executor-wasmi 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sc-executor-wasmtime 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sc-finality-grandpa 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sc-network-gossip 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sc-offchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sc-peerset 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sc-rpc 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sc-rpc-api 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sc-rpc-server 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sc-service 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sc-state-db 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sc-tracing 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sc-transaction-graph 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sc-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sc-authority-discovery 0.8.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sc-block-builder 0.8.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sc-chain-spec 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sc-chain-spec-derive 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sc-cli 0.8.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sc-client 0.8.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sc-client-db 0.8.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sc-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sc-consensus-epochs 0.8.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sc-consensus-slots 0.8.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sc-consensus-uncles 0.8.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sc-executor 0.8.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sc-executor-common 0.8.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sc-executor-wasmi 0.8.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sc-executor-wasmtime 0.8.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sc-finality-grandpa 0.8.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sc-network 0.8.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sc-network-gossip 0.8.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sc-offchain 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sc-peerset 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sc-rpc 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sc-rpc-api 0.8.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sc-rpc-server 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sc-service 0.8.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sc-state-db 0.8.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sc-tracing 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sc-transaction-graph 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sc-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
 "checksum schnorrkel 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)" = "eacd8381b3c37840c9c9f40472af529e49975bdcbc24f83c31059fd6539023d3"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
@@ -7815,43 +7820,43 @@ dependencies = [
 "checksum snow 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "afb767eee7d257ba202f0b9b08673bc13b22281632ef45267b19f13100accd2f"
 "checksum soketto 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1c9dab3f95c9ebdf3a88268c19af668f637a3c5039c2c56ff2d40b1b2d64a25b"
 "checksum sourcefile 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf77cb82ba8453b42b6ae1d692e4cdc92f9a47beaf89a847c8be83f4e328ad3"
-"checksum sp-allocator 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sp-api-proc-macro 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sp-arithmetic 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sp-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sp-authorship 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sp-block-builder 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sp-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sp-debug-derive 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sp-externalities 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sp-finality-grandpa 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sp-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sp-offchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sp-panic-handler 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sp-phragmen 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sp-rpc 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sp-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sp-runtime-interface-proc-macro 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sp-serializer 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sp-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sp-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sp-storage 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sp-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
-"checksum sp-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum sp-allocator 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sp-api 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sp-api-proc-macro 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sp-arithmetic 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sp-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sp-authorship 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sp-block-builder 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sp-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sp-core 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sp-debug-derive 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sp-externalities 0.8.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sp-finality-grandpa 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sp-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sp-io 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sp-offchain 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sp-panic-handler 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sp-phragmen 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sp-rpc 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sp-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sp-runtime-interface-proc-macro 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sp-serializer 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sp-session 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sp-staking 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sp-std 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sp-storage 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sp-timestamp 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sp-trie 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sp-version 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
+"checksum sp-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
 "checksum spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
@@ -7864,7 +7869,7 @@ dependencies = [
 "checksum strum 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6138f8f88a16d90134763314e3fc76fa3ed6a7db4725d6acf9a3ef95a3188d22"
 "checksum strum_macros 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0054a7df764039a6cd8592b9de84be4bec368ff081d203a7d5371cbfa8e65c81"
 "checksum substrate-bip39 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3be511be555a3633e71739a79e4ddff6a6aaa6579fa6114182a51d72c3eb93c5"
-"checksum substrate-frame-rpc-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=apopiak-rename-exists-to-contains-key)" = "<none>"
+"checksum substrate-frame-rpc-system 2.0.0 (git+https://github.com/paritytech/substrate)" = "<none>"
 "checksum substrate-wasm-builder-runner 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e30c70de7e7d5fd404fe26db1e7a4d6b553e2760b1ac490f249c04a960c483b8"
 "checksum subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 "checksum subtle 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7c65d530b10ccaeac294f349038a597e435b18fb456aadd0840a623f83b9e941"
@@ -7914,6 +7919,7 @@ dependencies = [
 "checksum trie-db 0.19.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a0d747ae5b6f078df7e46477fcc7df66df9eb4f27a031cf4a7c890a8dd03d8e6"
 "checksum trie-db 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de9222c50cc325855621271157c973da27a0dcd26fa06f8edf81020bd2333df0"
 "checksum trie-root 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0b779f7c1c8fe9276365d9d5be5c4b5adeacf545117bb3f64c974305789c5c0b"
+"checksum trie-root 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "652931506d2c1244d7217a70b99f56718a7b4161b37f04e7cd868072a99f68cd"
 "checksum try-lock 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
 "checksum twofish 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712d261e83e727c8e2dbb75dacac67c36e35db36a958ee504f2164fc052434e1"
 "checksum twox-hash 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3bfd5b7557925ce778ff9b9ef90e3ade34c524b5ff10e239c69a42d546d2af56"
@@ -7926,7 +7932,6 @@ dependencies = [
 "checksum unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
-"checksum unsigned-varint 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a7f0023a96687fe169081e8adce3f65e3874426b7886e9234d490af2dc077959"
 "checksum unsigned-varint 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c689459fbaeb50e56c6749275f084decfd02194ac5852e6617d95d0d3cf02eaf"
 "checksum untrusted 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60369ef7a31de49bcb3f6ca728d4ba7300d9a1658f94c727d4cab8c8d9f4aece"
 "checksum url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"

--- a/availability-store/Cargo.toml
+++ b/availability-store/Cargo.toml
@@ -15,15 +15,15 @@ futures = "0.3.4"
 tokio = { version = "0.2.10", features = ["rt-core"] }
 exit-future = "0.2.0"
 codec = { package = "parity-scale-codec", version = "1.1.0", features = ["derive"] }
-sc-network = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-consensus_common = { package = "sp-consensus", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-client = { package = "sc-client-api", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-sc-client = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-keystore = { package = "sc-keystore", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sc-network = { git = "https://github.com/paritytech/substrate", branch = "master" }
+consensus_common = { package = "sp-consensus", git = "https://github.com/paritytech/substrate", branch = "master" }
+client = { package = "sc-client-api", git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-client = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "master" }
+keystore = { package = "sc-keystore", git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
 kvdb = "0.3.1"
 kvdb-memorydb = "0.3.1"
 

--- a/availability-store/Cargo.toml
+++ b/availability-store/Cargo.toml
@@ -15,15 +15,15 @@ futures = "0.3.4"
 tokio = { version = "0.2.10", features = ["rt-core"] }
 exit-future = "0.2.0"
 codec = { package = "parity-scale-codec", version = "1.1.0", features = ["derive"] }
-sc-network = { git = "https://github.com/paritytech/substrate", branch = "master" }
-consensus_common = { package = "sp-consensus", git = "https://github.com/paritytech/substrate", branch = "master" }
-client = { package = "sc-client-api", git = "https://github.com/paritytech/substrate", branch = "master" }
-sc-client = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "master" }
-keystore = { package = "sc-keystore", git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-network = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+consensus_common = { package = "sp-consensus", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+client = { package = "sc-client-api", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sc-client = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+keystore = { package = "sc-keystore", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
 kvdb = "0.3.1"
 kvdb-memorydb = "0.3.1"
 

--- a/availability-store/Cargo.toml
+++ b/availability-store/Cargo.toml
@@ -15,15 +15,15 @@ futures = "0.3.4"
 tokio = { version = "0.2.10", features = ["rt-core"] }
 exit-future = "0.2.0"
 codec = { package = "parity-scale-codec", version = "1.1.0", features = ["derive"] }
-sc-network = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-consensus_common = { package = "sp-consensus", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-client = { package = "sc-client-api", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sc-client = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-keystore = { package = "sc-keystore", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+sc-network = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+consensus_common = { package = "sp-consensus", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+client = { package = "sc-client-api", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sc-client = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+keystore = { package = "sc-keystore", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
 kvdb = "0.3.1"
 kvdb-memorydb = "0.3.1"
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -12,21 +12,21 @@ crate-type = ["cdylib", "rlib"]
 log = "0.4.8"
 futures = { version = "0.3.4", features = ["compat"] }
 structopt = "0.3.8"
-sc-cli = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", optional = true }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-sc-client = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-sc-client-db = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-sc-executor = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sc-cli = { git = "https://github.com/paritytech/substrate", branch = "master", optional = true }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-client = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-client-db = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-executor = { git = "https://github.com/paritytech/substrate", branch = "master" }
 service = { package = "polkadot-service", path = "../service", default-features = false }
 
 tokio = { version = "0.2.10", features = ["rt-threaded"], optional = true }
 
 wasm-bindgen = { version = "0.2.57", optional = true }
 wasm-bindgen-futures = { version = "0.4.7", optional = true }
-browser-utils = { package = "browser-utils", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", optional = true }
+browser-utils = { package = "browser-utils", git = "https://github.com/paritytech/substrate", branch = "master", optional = true }
 
 [features]
 default = [ "wasmtime", "rocksdb", "cli" ]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -12,21 +12,21 @@ crate-type = ["cdylib", "rlib"]
 log = "0.4.8"
 futures = { version = "0.3.4", features = ["compat"] }
 structopt = "0.3.8"
-sc-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", optional = true }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sc-client = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sc-client-db = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sc-executor = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+sc-cli = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", optional = true }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sc-client = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sc-client-db = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sc-executor = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
 service = { package = "polkadot-service", path = "../service", default-features = false }
 
 tokio = { version = "0.2.10", features = ["rt-threaded"], optional = true }
 
 wasm-bindgen = { version = "0.2.57", optional = true }
 wasm-bindgen-futures = { version = "0.4.7", optional = true }
-browser-utils = { package = "browser-utils", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", optional = true }
+browser-utils = { package = "browser-utils", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", optional = true }
 
 [features]
 default = [ "wasmtime", "rocksdb", "cli" ]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -12,21 +12,21 @@ crate-type = ["cdylib", "rlib"]
 log = "0.4.8"
 futures = { version = "0.3.4", features = ["compat"] }
 structopt = "0.3.8"
-sc-cli = { git = "https://github.com/paritytech/substrate", branch = "master", optional = true }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sc-client = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sc-client-db = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sc-executor = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-cli = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", optional = true }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sc-client = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sc-client-db = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sc-executor = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
 service = { package = "polkadot-service", path = "../service", default-features = false }
 
 tokio = { version = "0.2.10", features = ["rt-threaded"], optional = true }
 
 wasm-bindgen = { version = "0.2.57", optional = true }
 wasm-bindgen-futures = { version = "0.4.7", optional = true }
-browser-utils = { package = "browser-utils", git = "https://github.com/paritytech/substrate", branch = "master", optional = true }
+browser-utils = { package = "browser-utils", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", optional = true }
 
 [features]
 default = [ "wasmtime", "rocksdb", "cli" ]

--- a/collator/Cargo.toml
+++ b/collator/Cargo.toml
@@ -7,15 +7,15 @@ edition = "2018"
 
 [dependencies]
 futures = "0.3.4"
-sc-client = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-sc-cli = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-sc-network = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-consensus_common = { package = "sp-consensus", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sc-client = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-cli = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-network = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master" }
+consensus_common = { package = "sp-consensus", git = "https://github.com/paritytech/substrate", branch = "master" }
 polkadot-primitives = { path = "../primitives" }
 polkadot-cli = { path = "../cli" }
 polkadot-network = { path = "../network" }
@@ -27,4 +27,4 @@ futures-timer = "2.0"
 codec = { package = "parity-scale-codec", version = "1.1.0" }
 
 [dev-dependencies]
-keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate", branch = "master" }

--- a/collator/Cargo.toml
+++ b/collator/Cargo.toml
@@ -7,15 +7,15 @@ edition = "2018"
 
 [dependencies]
 futures = "0.3.4"
-sc-client = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sc-cli = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sc-network = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master" }
-consensus_common = { package = "sp-consensus", git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-client = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sc-cli = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sc-network = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+consensus_common = { package = "sp-consensus", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
 polkadot-primitives = { path = "../primitives" }
 polkadot-cli = { path = "../cli" }
 polkadot-network = { path = "../network" }
@@ -27,4 +27,4 @@ futures-timer = "2.0"
 codec = { package = "parity-scale-codec", version = "1.1.0" }
 
 [dev-dependencies]
-keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate", branch = "master" }
+keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }

--- a/collator/Cargo.toml
+++ b/collator/Cargo.toml
@@ -7,15 +7,15 @@ edition = "2018"
 
 [dependencies]
 futures = "0.3.4"
-sc-client = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sc-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sc-network = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-consensus_common = { package = "sp-consensus", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+sc-client = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sc-cli = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sc-network = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+consensus_common = { package = "sp-consensus", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
 polkadot-primitives = { path = "../primitives" }
 polkadot-cli = { path = "../cli" }
 polkadot-network = { path = "../network" }
@@ -27,4 +27,4 @@ futures-timer = "2.0"
 codec = { package = "parity-scale-codec", version = "1.1.0" }
 
 [dev-dependencies]
-keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }

--- a/erasure-coding/Cargo.toml
+++ b/erasure-coding/Cargo.toml
@@ -8,6 +8,6 @@ edition = "2018"
 primitives = { package = "polkadot-primitives", path = "../primitives" }
 reed_solomon = { package = "reed-solomon-erasure", git = "https://github.com/paritytech/reed-solomon-erasure" }
 codec = { package = "parity-scale-codec", version = "1.1.0", default-features = false, features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-trie = { package = "sp-trie", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+trie = { package = "sp-trie", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
 derive_more = "0.15.0"

--- a/erasure-coding/Cargo.toml
+++ b/erasure-coding/Cargo.toml
@@ -8,6 +8,6 @@ edition = "2018"
 primitives = { package = "polkadot-primitives", path = "../primitives" }
 reed_solomon = { package = "reed-solomon-erasure", git = "https://github.com/paritytech/reed-solomon-erasure" }
 codec = { package = "parity-scale-codec", version = "1.1.0", default-features = false, features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-trie = { package = "sp-trie", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
+trie = { package = "sp-trie", git = "https://github.com/paritytech/substrate", branch = "master" }
 derive_more = "0.15.0"

--- a/erasure-coding/Cargo.toml
+++ b/erasure-coding/Cargo.toml
@@ -8,6 +8,6 @@ edition = "2018"
 primitives = { package = "polkadot-primitives", path = "../primitives" }
 reed_solomon = { package = "reed-solomon-erasure", git = "https://github.com/paritytech/reed-solomon-erasure" }
 codec = { package = "parity-scale-codec", version = "1.1.0", default-features = false, features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
-trie = { package = "sp-trie", git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+trie = { package = "sp-trie", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
 derive_more = "0.15.0"

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -13,18 +13,18 @@ polkadot-validation = { path = "../validation" }
 polkadot-primitives = { path = "../primitives" }
 polkadot-erasure-coding = { path = "../erasure-coding" }
 codec = { package = "parity-scale-codec", version = "1.1.0", default-features = false, features = ["derive"] }
-sc-network = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sc-network-gossip = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-network = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sc-network-gossip = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
 futures = "0.3.4"
 log = "0.4.8"
 exit-future = "0.2.0"
-sc-client = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-client = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
 wasm-timer = "0.2.4"
 
 [dev-dependencies]
-sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-state-machine = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-state-machine = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -13,18 +13,18 @@ polkadot-validation = { path = "../validation" }
 polkadot-primitives = { path = "../primitives" }
 polkadot-erasure-coding = { path = "../erasure-coding" }
 codec = { package = "parity-scale-codec", version = "1.1.0", default-features = false, features = ["derive"] }
-sc-network = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sc-network-gossip = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+sc-network = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sc-network-gossip = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
 futures = "0.3.4"
 log = "0.4.8"
 exit-future = "0.2.0"
-sc-client = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+sc-client = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
 wasm-timer = "0.2.4"
 
 [dev-dependencies]
-sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-state-machine = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-state-machine = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -13,18 +13,18 @@ polkadot-validation = { path = "../validation" }
 polkadot-primitives = { path = "../primitives" }
 polkadot-erasure-coding = { path = "../erasure-coding" }
 codec = { package = "parity-scale-codec", version = "1.1.0", default-features = false, features = ["derive"] }
-sc-network = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-sc-network-gossip = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sc-network = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-network-gossip = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master" }
 futures = "0.3.4"
 log = "0.4.8"
 exit-future = "0.2.0"
-sc-client = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sc-client = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "master" }
 wasm-timer = "0.2.4"
 
 [dev-dependencies]
-sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-sp-state-machine = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-state-machine = { git = "https://github.com/paritytech/substrate", branch = "master" }

--- a/parachain/Cargo.toml
+++ b/parachain/Cargo.toml
@@ -9,12 +9,12 @@ edition = "2018"
 codec = { package = "parity-scale-codec", version = "1.1.0", default-features = false, features = [ "derive" ] }
 derive_more = { version = "0.99.2", optional = true }
 serde = { version = "1.0.102", default-features = false, features = [ "derive" ], optional = true }
-rstd = { package = "sp-std", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sp-runtime-interface = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sp-externalities = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", optional = true }
-sc-executor = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", optional = true }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", optional = true }
+rstd = { package = "sp-std", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+sp-runtime-interface = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+sp-externalities = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", optional = true }
+sc-executor = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", optional = true }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", optional = true }
 lazy_static = { version = "1.4.0", optional = true }
 parking_lot = { version = "0.10.0", optional = true }
 log = { version = "0.4.8", optional = true }

--- a/parachain/Cargo.toml
+++ b/parachain/Cargo.toml
@@ -9,12 +9,12 @@ edition = "2018"
 codec = { package = "parity-scale-codec", version = "1.1.0", default-features = false, features = [ "derive" ] }
 derive_more = { version = "0.99.2", optional = true }
 serde = { version = "1.0.102", default-features = false, features = [ "derive" ], optional = true }
-rstd = { package = "sp-std", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-sp-runtime-interface = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-sp-externalities = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", optional = true }
-sc-executor = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", optional = true }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", optional = true }
+rstd = { package = "sp-std", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+sp-runtime-interface = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+sp-externalities = { git = "https://github.com/paritytech/substrate", branch = "master", optional = true }
+sc-executor = { git = "https://github.com/paritytech/substrate", branch = "master", optional = true }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "master", optional = true }
 lazy_static = { version = "1.4.0", optional = true }
 parking_lot = { version = "0.10.0", optional = true }
 log = { version = "0.4.8", optional = true }

--- a/parachain/Cargo.toml
+++ b/parachain/Cargo.toml
@@ -9,12 +9,12 @@ edition = "2018"
 codec = { package = "parity-scale-codec", version = "1.1.0", default-features = false, features = [ "derive" ] }
 derive_more = { version = "0.99.2", optional = true }
 serde = { version = "1.0.102", default-features = false, features = [ "derive" ], optional = true }
-rstd = { package = "sp-std", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-runtime-interface = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-externalities = { git = "https://github.com/paritytech/substrate", branch = "master", optional = true }
-sc-executor = { git = "https://github.com/paritytech/substrate", branch = "master", optional = true }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "master", optional = true }
+rstd = { package = "sp-std", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+sp-runtime-interface = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+sp-externalities = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", optional = true }
+sc-executor = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", optional = true }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", optional = true }
 lazy_static = { version = "1.4.0", optional = true }
 parking_lot = { version = "0.10.0", optional = true }
 log = { version = "0.4.8", optional = true }

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -7,20 +7,20 @@ edition = "2018"
 [dependencies]
 serde = { version = "1.0.102", optional = true, features = ["derive"] }
 parity-scale-codec = { version = "1.1.0", default-features = false, features = ["bit-vec", "derive"] }
-primitives = { package = "sp-core", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-application-crypto = { package = "sp-application-crypto", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sp-version = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-rstd = { package = "sp-std", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-runtime_primitives = { package = "sp-runtime", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
+primitives = { package = "sp-core", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+application-crypto = { package = "sp-application-crypto", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+sp-version = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+rstd = { package = "sp-std", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+runtime_primitives = { package = "sp-runtime", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
 polkadot-parachain = { path = "../parachain", default-features = false }
-trie = { package = "sp-trie", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
+trie = { package = "sp-trie", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
 bitvec = { version = "0.15.2", default-features = false, features = ["alloc"] }
-babe = { package = "pallet-babe", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
+babe = { package = "pallet-babe", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
 
 [dev-dependencies]
-sp-serializer = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+sp-serializer = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
 pretty_assertions = "0.5.1"
 
 [features]

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -7,20 +7,20 @@ edition = "2018"
 [dependencies]
 serde = { version = "1.0.102", optional = true, features = ["derive"] }
 parity-scale-codec = { version = "1.1.0", default-features = false, features = ["bit-vec", "derive"] }
-primitives = { package = "sp-core", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-application-crypto = { package = "sp-application-crypto", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-version = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-rstd = { package = "sp-std", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-runtime_primitives = { package = "sp-runtime", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+primitives = { package = "sp-core", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+application-crypto = { package = "sp-application-crypto", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+sp-version = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+rstd = { package = "sp-std", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+runtime_primitives = { package = "sp-runtime", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
 polkadot-parachain = { path = "../parachain", default-features = false }
-trie = { package = "sp-trie", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+trie = { package = "sp-trie", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
 bitvec = { version = "0.15.2", default-features = false, features = ["alloc"] }
-babe = { package = "pallet-babe", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+babe = { package = "pallet-babe", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
 
 [dev-dependencies]
-sp-serializer = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-serializer = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
 pretty_assertions = "0.5.1"
 
 [features]

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -7,20 +7,20 @@ edition = "2018"
 [dependencies]
 serde = { version = "1.0.102", optional = true, features = ["derive"] }
 parity-scale-codec = { version = "1.1.0", default-features = false, features = ["bit-vec", "derive"] }
-primitives = { package = "sp-core", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-application-crypto = { package = "sp-application-crypto", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-sp-version = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-rstd = { package = "sp-std", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-runtime_primitives = { package = "sp-runtime", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+primitives = { package = "sp-core", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+application-crypto = { package = "sp-application-crypto", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+sp-version = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+rstd = { package = "sp-std", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+runtime_primitives = { package = "sp-runtime", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 polkadot-parachain = { path = "../parachain", default-features = false }
-trie = { package = "sp-trie", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+trie = { package = "sp-trie", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 bitvec = { version = "0.15.2", default-features = false, features = ["alloc"] }
-babe = { package = "pallet-babe", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+babe = { package = "pallet-babe", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 
 [dev-dependencies]
-sp-serializer = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-serializer = { git = "https://github.com/paritytech/substrate", branch = "master" }
 pretty_assertions = "0.5.1"
 
 [features]

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -5,13 +5,13 @@ authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 
 [dependencies]
-client = { package = "sc-client", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+client = { package = "sc-client", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
 jsonrpc-core = "14.0.3"
 polkadot-primitives = { path = "../primitives" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master"  }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master"  }
-sc-rpc = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-txpool-api = { package = "sp-transaction-pool", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-frame-rpc-system = { package = "substrate-frame-rpc-system", git = "https://github.com/paritytech/substrate", branch = "polkadot-master"  }
-pallet-transaction-payment-rpc = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key"  }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key"  }
+sc-rpc = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+txpool-api = { package = "sp-transaction-pool", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+frame-rpc-system = { package = "substrate-frame-rpc-system", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key"  }
+pallet-transaction-payment-rpc = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
 codec = { package = "parity-scale-codec", version = "1.1.0", default-features = false }

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -5,13 +5,13 @@ authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 
 [dependencies]
-client = { package = "sc-client", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+client = { package = "sc-client", git = "https://github.com/paritytech/substrate", branch = "master" }
 jsonrpc-core = "14.0.3"
 polkadot-primitives = { path = "../primitives" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key"  }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key"  }
-sc-rpc = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-txpool-api = { package = "sp-transaction-pool", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-frame-rpc-system = { package = "substrate-frame-rpc-system", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key"  }
-pallet-transaction-payment-rpc = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master"  }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "master"  }
+sc-rpc = { git = "https://github.com/paritytech/substrate", branch = "master" }
+txpool-api = { package = "sp-transaction-pool", git = "https://github.com/paritytech/substrate", branch = "master" }
+frame-rpc-system = { package = "substrate-frame-rpc-system", git = "https://github.com/paritytech/substrate", branch = "master"  }
+pallet-transaction-payment-rpc = { git = "https://github.com/paritytech/substrate", branch = "master" }
 codec = { package = "parity-scale-codec", version = "1.1.0", default-features = false }

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -5,13 +5,13 @@ authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 
 [dependencies]
-client = { package = "sc-client", git = "https://github.com/paritytech/substrate", branch = "master" }
+client = { package = "sc-client", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
 jsonrpc-core = "14.0.3"
 polkadot-primitives = { path = "../primitives" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master"  }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "master"  }
-sc-rpc = { git = "https://github.com/paritytech/substrate", branch = "master" }
-txpool-api = { package = "sp-transaction-pool", git = "https://github.com/paritytech/substrate", branch = "master" }
-frame-rpc-system = { package = "substrate-frame-rpc-system", git = "https://github.com/paritytech/substrate", branch = "master"  }
-pallet-transaction-payment-rpc = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key"  }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key"  }
+sc-rpc = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+txpool-api = { package = "sp-transaction-pool", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+frame-rpc-system = { package = "substrate-frame-rpc-system", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key"  }
+pallet-transaction-payment-rpc = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
 codec = { package = "parity-scale-codec", version = "1.1.0", default-features = false }

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -12,22 +12,22 @@ rustc-hex = { version = "2.0.1", default-features = false }
 serde = { version = "1.0.102", default-features = false }
 serde_derive = { version = "1.0.102", optional = true }
 
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-rstd = { package = "sp-std", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-sp-staking = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+rstd = { package = "sp-std", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+sp-staking = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 
-authorship = { package = "pallet-authorship", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-balances = { package = "pallet-balances", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-session = { package = "pallet-session", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-staking = { package = "pallet-staking", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-system = { package = "frame-system", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-timestamp = { package = "pallet-timestamp", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-vesting = { package = "pallet-vesting", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+authorship = { package = "pallet-authorship", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+balances = { package = "pallet-balances", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+session = { package = "pallet-session", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+staking = { package = "pallet-staking", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+system = { package = "frame-system", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+timestamp = { package = "pallet-timestamp", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+vesting = { package = "pallet-vesting", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 
 primitives = { package = "polkadot-primitives", path = "../../primitives", default-features = false }
 polkadot-parachain = { path = "../../parachain", default-features = false }
@@ -36,12 +36,12 @@ polkadot-parachain = { path = "../../parachain", default-features = false }
 hex-literal = "0.2.1"
 libsecp256k1 = "0.3.2"
 tiny-keccak = "1.5.0"
-keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-sp-trie = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-babe = { package = "pallet-babe", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-randomness-collective-flip = { package = "pallet-randomness-collective-flip", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-pallet-staking-reward-curve = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-treasury = { package = "pallet-treasury", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-trie = { git = "https://github.com/paritytech/substrate", branch = "master" }
+babe = { package = "pallet-babe", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+randomness-collective-flip = { package = "pallet-randomness-collective-flip", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+pallet-staking-reward-curve = { git = "https://github.com/paritytech/substrate", branch = "master" }
+treasury = { package = "pallet-treasury", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 trie-db = "0.20.0"
 serde_json = "1.0.41"
 

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -12,22 +12,22 @@ rustc-hex = { version = "2.0.1", default-features = false }
 serde = { version = "1.0.102", default-features = false }
 serde_derive = { version = "1.0.102", optional = true }
 
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-rstd = { package = "sp-std", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sp-staking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+rstd = { package = "sp-std", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+sp-staking = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
 
-authorship = { package = "pallet-authorship", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-balances = { package = "pallet-balances", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-session = { package = "pallet-session", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-staking = { package = "pallet-staking", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-system = { package = "frame-system", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-timestamp = { package = "pallet-timestamp", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-vesting = { package = "pallet-vesting", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
+authorship = { package = "pallet-authorship", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+balances = { package = "pallet-balances", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+session = { package = "pallet-session", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+staking = { package = "pallet-staking", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+system = { package = "frame-system", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+timestamp = { package = "pallet-timestamp", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+vesting = { package = "pallet-vesting", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
 
 primitives = { package = "polkadot-primitives", path = "../../primitives", default-features = false }
 polkadot-parachain = { path = "../../parachain", default-features = false }
@@ -36,12 +36,12 @@ polkadot-parachain = { path = "../../parachain", default-features = false }
 hex-literal = "0.2.1"
 libsecp256k1 = "0.3.2"
 tiny-keccak = "1.5.0"
-keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-trie = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-babe = { package = "pallet-babe", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-randomness-collective-flip = { package = "pallet-randomness-collective-flip", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-pallet-staking-reward-curve = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-treasury = { package = "pallet-treasury", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
+keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-trie = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+babe = { package = "pallet-babe", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+randomness-collective-flip = { package = "pallet-randomness-collective-flip", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+pallet-staking-reward-curve = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+treasury = { package = "pallet-treasury", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
 trie-db = "0.20.0"
 serde_json = "1.0.41"
 

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -12,22 +12,22 @@ rustc-hex = { version = "2.0.1", default-features = false }
 serde = { version = "1.0.102", default-features = false }
 serde_derive = { version = "1.0.102", optional = true }
 
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-rstd = { package = "sp-std", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-staking = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+rstd = { package = "sp-std", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+sp-staking = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
 
-authorship = { package = "pallet-authorship", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-balances = { package = "pallet-balances", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-session = { package = "pallet-session", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-staking = { package = "pallet-staking", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-system = { package = "frame-system", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-timestamp = { package = "pallet-timestamp", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-vesting = { package = "pallet-vesting", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+authorship = { package = "pallet-authorship", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+balances = { package = "pallet-balances", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+session = { package = "pallet-session", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+staking = { package = "pallet-staking", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+system = { package = "frame-system", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+timestamp = { package = "pallet-timestamp", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+vesting = { package = "pallet-vesting", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
 
 primitives = { package = "polkadot-primitives", path = "../../primitives", default-features = false }
 polkadot-parachain = { path = "../../parachain", default-features = false }
@@ -36,12 +36,12 @@ polkadot-parachain = { path = "../../parachain", default-features = false }
 hex-literal = "0.2.1"
 libsecp256k1 = "0.3.2"
 tiny-keccak = "1.5.0"
-keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-trie = { git = "https://github.com/paritytech/substrate", branch = "master" }
-babe = { package = "pallet-babe", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-randomness-collective-flip = { package = "pallet-randomness-collective-flip", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-staking-reward-curve = { git = "https://github.com/paritytech/substrate", branch = "master" }
-treasury = { package = "pallet-treasury", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-trie = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+babe = { package = "pallet-babe", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+randomness-collective-flip = { package = "pallet-randomness-collective-flip", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+pallet-staking-reward-curve = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+treasury = { package = "pallet-treasury", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
 trie-db = "0.20.0"
 serde_json = "1.0.41"
 

--- a/runtime/common/src/claims.rs
+++ b/runtime/common/src/claims.rs
@@ -268,7 +268,7 @@ impl<T: Trait> sp_runtime::traits::ValidateUnsigned for Module<T> {
 					).into();
 				};
 
-				if !<Claims<T>>::exists(&signer) {
+				if !<Claims<T>>::contains_key(&signer) {
 					return Err(InvalidTransaction::Custom(
 						ValidityError::SignerHasNoClaim.into(),
 					).into());

--- a/runtime/common/src/registrar.rs
+++ b/runtime/common/src/registrar.rs
@@ -70,7 +70,7 @@ impl<T: Trait> Registrar<T::AccountId> for Module<T> {
 		code: Vec<u8>,
 		initial_head_data: Vec<u8>,
 	) -> DispatchResult {
-		ensure!(!Paras::exists(id), Error::<T>::ParaAlreadyExists);
+		ensure!(!Paras::contains_key(id), Error::<T>::ParaAlreadyExists);
 		if let Scheduling::Always = info.scheduling {
 			Parachains::mutate(|parachains|
 				match parachains.binary_search(&id) {

--- a/runtime/common/src/slots.rs
+++ b/runtime/common/src/slots.rs
@@ -185,7 +185,7 @@ decl_storage! {
 
 impl<T: Trait> SwapAux for Module<T> {
 	fn ensure_can_swap(one: ParaId, other: ParaId) -> Result<(), &'static str> {
-		if <Onboarding<T>>::exists(one) || <Onboarding<T>>::exists(other) {
+		if <Onboarding<T>>::contains_key(one) || <Onboarding<T>>::contains_key(other) {
 			Err("can't swap an undeployed parachain")?
 		}
 		Ok(())
@@ -284,7 +284,7 @@ decl_module! {
 			// winner information is duplicated from the previous block in case no bids happened
 			// in this block.
 			if let Some(offset) = Self::is_ending(now) {
-				if !<Winning<T>>::exists(&offset) {
+				if !<Winning<T>>::contains_key(&offset) {
 					<Winning<T>>::insert(offset,
 						offset.checked_sub(&One::one())
 							.and_then(<Winning<T>>::get)

--- a/runtime/kusama/Cargo.toml
+++ b/runtime/kusama/Cargo.toml
@@ -13,52 +13,52 @@ rustc-hex = { version = "2.0.1", default-features = false }
 serde = { version = "1.0.102", default-features = false }
 serde_derive = { version = "1.0.102", optional = true }
 
-authority-discovery-primitives = { package = "sp-authority-discovery", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-offchain-primitives = { package = "sp-offchain", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-rstd = { package = "sp-std", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-staking = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-session = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-version = { package = "sp-version", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-tx-pool-api = { package = "sp-transaction-pool", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-block-builder-api = { package = "sp-block-builder", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+authority-discovery-primitives = { package = "sp-authority-discovery", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+offchain-primitives = { package = "sp-offchain", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+rstd = { package = "sp-std", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+sp-staking = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+sp-session = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+version = { package = "sp-version", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+tx-pool-api = { package = "sp-transaction-pool", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+block-builder-api = { package = "sp-block-builder", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
 
-authority-discovery = { package = "pallet-authority-discovery", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-authorship = { package = "pallet-authorship", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-babe = { package = "pallet-babe", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-balances = { package = "pallet-balances", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-transaction-payment = { package = "pallet-transaction-payment", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-collective = { package = "pallet-collective", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-democracy = { package = "pallet-democracy", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-elections-phragmen = { package = "pallet-elections-phragmen", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-executive = { package = "frame-executive", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-finality-tracker = { package = "pallet-finality-tracker", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-grandpa = { package = "pallet-grandpa", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false, features = ["migrate-authorities"] }
-identity = { package = "pallet-identity", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-im-online = { package = "pallet-im-online", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-indices = { package = "pallet-indices", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-membership = { package = "pallet-membership", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-nicks = { package = "pallet-nicks", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-offences = { package = "pallet-offences", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-randomness-collective-flip = { package = "pallet-randomness-collective-flip", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-recovery = { package = "pallet-recovery", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-session = { package = "pallet-session", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-society = { package = "pallet-society", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-staking = { package = "pallet-staking", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-staking-reward-curve = { git = "https://github.com/paritytech/substrate", branch = "master" }
-system = { package = "frame-system", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-system_rpc_runtime_api = { package = "frame-system-rpc-runtime-api", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-timestamp = { package = "pallet-timestamp", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-treasury = { package = "pallet-treasury", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-utility = { package = "pallet-utility", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-vesting = { package = "pallet-vesting", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+authority-discovery = { package = "pallet-authority-discovery", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+authorship = { package = "pallet-authorship", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+babe = { package = "pallet-babe", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+balances = { package = "pallet-balances", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+transaction-payment = { package = "pallet-transaction-payment", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+collective = { package = "pallet-collective", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+democracy = { package = "pallet-democracy", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+elections-phragmen = { package = "pallet-elections-phragmen", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+executive = { package = "frame-executive", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+finality-tracker = { package = "pallet-finality-tracker", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+grandpa = { package = "pallet-grandpa", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false, features = ["migrate-authorities"] }
+identity = { package = "pallet-identity", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+im-online = { package = "pallet-im-online", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+indices = { package = "pallet-indices", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+membership = { package = "pallet-membership", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+nicks = { package = "pallet-nicks", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+offences = { package = "pallet-offences", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+randomness-collective-flip = { package = "pallet-randomness-collective-flip", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+recovery = { package = "pallet-recovery", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+session = { package = "pallet-session", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+society = { package = "pallet-society", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+staking = { package = "pallet-staking", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+pallet-staking-reward-curve = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+system = { package = "frame-system", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+system_rpc_runtime_api = { package = "frame-system-rpc-runtime-api", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+timestamp = { package = "pallet-timestamp", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+treasury = { package = "pallet-treasury", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+utility = { package = "pallet-utility", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+vesting = { package = "pallet-vesting", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
 
 runtime-common = { package = "polkadot-runtime-common", path = "../common", default-features = false }
 primitives = { package = "polkadot-primitives", path = "../../primitives", default-features = false }
@@ -68,8 +68,8 @@ polkadot-parachain = { path = "../../parachain", default-features = false }
 hex-literal = "0.2.1"
 libsecp256k1 = "0.3.2"
 tiny-keccak = "1.5.0"
-keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-trie = { git = "https://github.com/paritytech/substrate", branch = "master" }
+keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-trie = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
 trie-db = "0.20.0"
 serde_json = "1.0.41"
 

--- a/runtime/kusama/Cargo.toml
+++ b/runtime/kusama/Cargo.toml
@@ -13,52 +13,52 @@ rustc-hex = { version = "2.0.1", default-features = false }
 serde = { version = "1.0.102", default-features = false }
 serde_derive = { version = "1.0.102", optional = true }
 
-authority-discovery-primitives = { package = "sp-authority-discovery", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-offchain-primitives = { package = "sp-offchain", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-rstd = { package = "sp-std", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sp-staking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sp-session = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-version = { package = "sp-version", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-tx-pool-api = { package = "sp-transaction-pool", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-block-builder-api = { package = "sp-block-builder", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
+authority-discovery-primitives = { package = "sp-authority-discovery", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+offchain-primitives = { package = "sp-offchain", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+rstd = { package = "sp-std", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+sp-staking = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+sp-session = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+version = { package = "sp-version", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+tx-pool-api = { package = "sp-transaction-pool", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+block-builder-api = { package = "sp-block-builder", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
 
-authority-discovery = { package = "pallet-authority-discovery", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-authorship = { package = "pallet-authorship", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-babe = { package = "pallet-babe", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-balances = { package = "pallet-balances", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-transaction-payment = { package = "pallet-transaction-payment", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-collective = { package = "pallet-collective", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-democracy = { package = "pallet-democracy", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-elections-phragmen = { package = "pallet-elections-phragmen", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-executive = { package = "frame-executive", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-finality-tracker = { package = "pallet-finality-tracker", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-grandpa = { package = "pallet-grandpa", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false, features = ["migrate-authorities"] }
-identity = { package = "pallet-identity", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-im-online = { package = "pallet-im-online", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-indices = { package = "pallet-indices", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-membership = { package = "pallet-membership", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-nicks = { package = "pallet-nicks", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-offences = { package = "pallet-offences", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-randomness-collective-flip = { package = "pallet-randomness-collective-flip", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-recovery = { package = "pallet-recovery", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-session = { package = "pallet-session", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-society = { package = "pallet-society", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-staking = { package = "pallet-staking", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false, features = ["migrate"] }
-pallet-staking-reward-curve = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-system = { package = "frame-system", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-system_rpc_runtime_api = { package = "frame-system-rpc-runtime-api", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-timestamp = { package = "pallet-timestamp", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-treasury = { package = "pallet-treasury", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-utility = { package = "pallet-utility", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-vesting = { package = "pallet-vesting", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
+authority-discovery = { package = "pallet-authority-discovery", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+authorship = { package = "pallet-authorship", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+babe = { package = "pallet-babe", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+balances = { package = "pallet-balances", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+transaction-payment = { package = "pallet-transaction-payment", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+collective = { package = "pallet-collective", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+democracy = { package = "pallet-democracy", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+elections-phragmen = { package = "pallet-elections-phragmen", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+executive = { package = "frame-executive", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+finality-tracker = { package = "pallet-finality-tracker", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+grandpa = { package = "pallet-grandpa", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false, features = ["migrate-authorities"] }
+identity = { package = "pallet-identity", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+im-online = { package = "pallet-im-online", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+indices = { package = "pallet-indices", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+membership = { package = "pallet-membership", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+nicks = { package = "pallet-nicks", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+offences = { package = "pallet-offences", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+randomness-collective-flip = { package = "pallet-randomness-collective-flip", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+recovery = { package = "pallet-recovery", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+session = { package = "pallet-session", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+society = { package = "pallet-society", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+staking = { package = "pallet-staking", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+pallet-staking-reward-curve = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+system = { package = "frame-system", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+system_rpc_runtime_api = { package = "frame-system-rpc-runtime-api", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+timestamp = { package = "pallet-timestamp", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+treasury = { package = "pallet-treasury", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+utility = { package = "pallet-utility", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+vesting = { package = "pallet-vesting", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
 
 runtime-common = { package = "polkadot-runtime-common", path = "../common", default-features = false }
 primitives = { package = "polkadot-primitives", path = "../../primitives", default-features = false }
@@ -68,8 +68,8 @@ polkadot-parachain = { path = "../../parachain", default-features = false }
 hex-literal = "0.2.1"
 libsecp256k1 = "0.3.2"
 tiny-keccak = "1.5.0"
-keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-trie = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-trie = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
 trie-db = "0.20.0"
 serde_json = "1.0.41"
 

--- a/runtime/kusama/Cargo.toml
+++ b/runtime/kusama/Cargo.toml
@@ -13,52 +13,52 @@ rustc-hex = { version = "2.0.1", default-features = false }
 serde = { version = "1.0.102", default-features = false }
 serde_derive = { version = "1.0.102", optional = true }
 
-authority-discovery-primitives = { package = "sp-authority-discovery", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-offchain-primitives = { package = "sp-offchain", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-rstd = { package = "sp-std", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-sp-staking = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-sp-session = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-version = { package = "sp-version", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-tx-pool-api = { package = "sp-transaction-pool", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-block-builder-api = { package = "sp-block-builder", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+authority-discovery-primitives = { package = "sp-authority-discovery", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+offchain-primitives = { package = "sp-offchain", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+rstd = { package = "sp-std", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+sp-staking = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+sp-session = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+version = { package = "sp-version", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+tx-pool-api = { package = "sp-transaction-pool", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+block-builder-api = { package = "sp-block-builder", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 
-authority-discovery = { package = "pallet-authority-discovery", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-authorship = { package = "pallet-authorship", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-babe = { package = "pallet-babe", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-balances = { package = "pallet-balances", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-transaction-payment = { package = "pallet-transaction-payment", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-collective = { package = "pallet-collective", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-democracy = { package = "pallet-democracy", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-elections-phragmen = { package = "pallet-elections-phragmen", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-executive = { package = "frame-executive", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-finality-tracker = { package = "pallet-finality-tracker", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-grandpa = { package = "pallet-grandpa", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false, features = ["migrate-authorities"] }
-identity = { package = "pallet-identity", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-im-online = { package = "pallet-im-online", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-indices = { package = "pallet-indices", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-membership = { package = "pallet-membership", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-nicks = { package = "pallet-nicks", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-offences = { package = "pallet-offences", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-randomness-collective-flip = { package = "pallet-randomness-collective-flip", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-recovery = { package = "pallet-recovery", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-session = { package = "pallet-session", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-society = { package = "pallet-society", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-staking = { package = "pallet-staking", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-pallet-staking-reward-curve = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-system = { package = "frame-system", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-system_rpc_runtime_api = { package = "frame-system-rpc-runtime-api", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-timestamp = { package = "pallet-timestamp", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-treasury = { package = "pallet-treasury", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-utility = { package = "pallet-utility", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-vesting = { package = "pallet-vesting", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+authority-discovery = { package = "pallet-authority-discovery", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+authorship = { package = "pallet-authorship", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+babe = { package = "pallet-babe", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+balances = { package = "pallet-balances", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+transaction-payment = { package = "pallet-transaction-payment", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+collective = { package = "pallet-collective", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+democracy = { package = "pallet-democracy", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+elections-phragmen = { package = "pallet-elections-phragmen", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+executive = { package = "frame-executive", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+finality-tracker = { package = "pallet-finality-tracker", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+grandpa = { package = "pallet-grandpa", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false, features = ["migrate-authorities"] }
+identity = { package = "pallet-identity", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+im-online = { package = "pallet-im-online", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+indices = { package = "pallet-indices", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+membership = { package = "pallet-membership", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+nicks = { package = "pallet-nicks", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+offences = { package = "pallet-offences", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+randomness-collective-flip = { package = "pallet-randomness-collective-flip", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+recovery = { package = "pallet-recovery", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+session = { package = "pallet-session", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+society = { package = "pallet-society", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+staking = { package = "pallet-staking", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+pallet-staking-reward-curve = { git = "https://github.com/paritytech/substrate", branch = "master" }
+system = { package = "frame-system", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+system_rpc_runtime_api = { package = "frame-system-rpc-runtime-api", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+timestamp = { package = "pallet-timestamp", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+treasury = { package = "pallet-treasury", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+utility = { package = "pallet-utility", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+vesting = { package = "pallet-vesting", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 
 runtime-common = { package = "polkadot-runtime-common", path = "../common", default-features = false }
 primitives = { package = "polkadot-primitives", path = "../../primitives", default-features = false }
@@ -68,8 +68,8 @@ polkadot-parachain = { path = "../../parachain", default-features = false }
 hex-literal = "0.2.1"
 libsecp256k1 = "0.3.2"
 tiny-keccak = "1.5.0"
-keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-sp-trie = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-trie = { git = "https://github.com/paritytech/substrate", branch = "master" }
 trie-db = "0.20.0"
 serde_json = "1.0.41"
 

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -78,7 +78,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	impl_name: create_runtime_str!("parity-kusama"),
 	authoring_version: 2,
 	spec_version: 1047,
-	impl_version: 0,
+	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 };
 

--- a/runtime/polkadot/Cargo.toml
+++ b/runtime/polkadot/Cargo.toml
@@ -13,49 +13,49 @@ rustc-hex = { version = "2.0.1", default-features = false }
 serde = { version = "1.0.102", default-features = false }
 serde_derive = { version = "1.0.102", optional = true }
 
-authority-discovery-primitives = { package = "sp-authority-discovery", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-offchain-primitives = { package = "sp-offchain", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-rstd = { package = "sp-std", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-staking = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-session = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-version = { package = "sp-version", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-tx-pool-api = { package = "sp-transaction-pool", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-block-builder-api = { package = "sp-block-builder", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+authority-discovery-primitives = { package = "sp-authority-discovery", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+offchain-primitives = { package = "sp-offchain", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+rstd = { package = "sp-std", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+sp-staking = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+sp-session = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+version = { package = "sp-version", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+tx-pool-api = { package = "sp-transaction-pool", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+block-builder-api = { package = "sp-block-builder", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
 
-authority-discovery = { package = "pallet-authority-discovery", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-authorship = { package = "pallet-authorship", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-babe = { package = "pallet-babe", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-balances = { package = "pallet-balances", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-transaction-payment = { package = "pallet-transaction-payment", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-collective = { package = "pallet-collective", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-democracy = { package = "pallet-democracy", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-elections-phragmen = { package = "pallet-elections-phragmen", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-executive = { package = "frame-executive", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-finality-tracker = { package = "pallet-finality-tracker", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-grandpa = { package = "pallet-grandpa", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false, features = ["migrate-authorities"] }
-identity = { package = "pallet-identity", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-im-online = { package = "pallet-im-online", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-indices = { package = "pallet-indices", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-membership = { package = "pallet-membership", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-nicks = { package = "pallet-nicks", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-offences = { package = "pallet-offences", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-randomness-collective-flip = { package = "pallet-randomness-collective-flip", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-session = { package = "pallet-session", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-staking = { package = "pallet-staking", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-staking-reward-curve = { git = "https://github.com/paritytech/substrate", branch = "master" }
-system = { package = "frame-system", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-system_rpc_runtime_api = { package = "frame-system-rpc-runtime-api", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-timestamp = { package = "pallet-timestamp", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-treasury = { package = "pallet-treasury", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sudo = { package = "pallet-sudo", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-vesting = { package = "pallet-vesting", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+authority-discovery = { package = "pallet-authority-discovery", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+authorship = { package = "pallet-authorship", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+babe = { package = "pallet-babe", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+balances = { package = "pallet-balances", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+transaction-payment = { package = "pallet-transaction-payment", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+collective = { package = "pallet-collective", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+democracy = { package = "pallet-democracy", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+elections-phragmen = { package = "pallet-elections-phragmen", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+executive = { package = "frame-executive", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+finality-tracker = { package = "pallet-finality-tracker", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+grandpa = { package = "pallet-grandpa", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false, features = ["migrate-authorities"] }
+identity = { package = "pallet-identity", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+im-online = { package = "pallet-im-online", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+indices = { package = "pallet-indices", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+membership = { package = "pallet-membership", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+nicks = { package = "pallet-nicks", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+offences = { package = "pallet-offences", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+randomness-collective-flip = { package = "pallet-randomness-collective-flip", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+session = { package = "pallet-session", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+staking = { package = "pallet-staking", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+pallet-staking-reward-curve = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+system = { package = "frame-system", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+system_rpc_runtime_api = { package = "frame-system-rpc-runtime-api", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+timestamp = { package = "pallet-timestamp", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+treasury = { package = "pallet-treasury", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+sudo = { package = "pallet-sudo", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+vesting = { package = "pallet-vesting", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
 
 runtime-common = { package = "polkadot-runtime-common", path = "../common", default-features = false }
 primitives = { package = "polkadot-primitives", path = "../../primitives", default-features = false }
@@ -65,8 +65,8 @@ polkadot-parachain = { path = "../../parachain", default-features = false }
 hex-literal = "0.2.1"
 libsecp256k1 = "0.3.2"
 tiny-keccak = "1.5.0"
-keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-trie = { git = "https://github.com/paritytech/substrate", branch = "master" }
+keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-trie = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
 trie-db = "0.20.0"
 serde_json = "1.0.41"
 

--- a/runtime/polkadot/Cargo.toml
+++ b/runtime/polkadot/Cargo.toml
@@ -13,49 +13,49 @@ rustc-hex = { version = "2.0.1", default-features = false }
 serde = { version = "1.0.102", default-features = false }
 serde_derive = { version = "1.0.102", optional = true }
 
-authority-discovery-primitives = { package = "sp-authority-discovery", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-offchain-primitives = { package = "sp-offchain", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-rstd = { package = "sp-std", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-sp-staking = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-sp-session = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-version = { package = "sp-version", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-tx-pool-api = { package = "sp-transaction-pool", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-block-builder-api = { package = "sp-block-builder", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+authority-discovery-primitives = { package = "sp-authority-discovery", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+offchain-primitives = { package = "sp-offchain", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+rstd = { package = "sp-std", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+sp-staking = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+sp-session = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+version = { package = "sp-version", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+tx-pool-api = { package = "sp-transaction-pool", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+block-builder-api = { package = "sp-block-builder", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 
-authority-discovery = { package = "pallet-authority-discovery", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-authorship = { package = "pallet-authorship", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-babe = { package = "pallet-babe", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-balances = { package = "pallet-balances", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-transaction-payment = { package = "pallet-transaction-payment", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-collective = { package = "pallet-collective", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-democracy = { package = "pallet-democracy", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-elections-phragmen = { package = "pallet-elections-phragmen", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-executive = { package = "frame-executive", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-finality-tracker = { package = "pallet-finality-tracker", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-grandpa = { package = "pallet-grandpa", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false, features = ["migrate-authorities"] }
-identity = { package = "pallet-identity", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-im-online = { package = "pallet-im-online", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-indices = { package = "pallet-indices", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-membership = { package = "pallet-membership", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-nicks = { package = "pallet-nicks", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-offences = { package = "pallet-offences", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-randomness-collective-flip = { package = "pallet-randomness-collective-flip", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-session = { package = "pallet-session", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-staking = { package = "pallet-staking", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-pallet-staking-reward-curve = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-system = { package = "frame-system", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-system_rpc_runtime_api = { package = "frame-system-rpc-runtime-api", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-timestamp = { package = "pallet-timestamp", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-treasury = { package = "pallet-treasury", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-sudo = { package = "pallet-sudo", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-vesting = { package = "pallet-vesting", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+authority-discovery = { package = "pallet-authority-discovery", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+authorship = { package = "pallet-authorship", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+babe = { package = "pallet-babe", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+balances = { package = "pallet-balances", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+transaction-payment = { package = "pallet-transaction-payment", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+collective = { package = "pallet-collective", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+democracy = { package = "pallet-democracy", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+elections-phragmen = { package = "pallet-elections-phragmen", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+executive = { package = "frame-executive", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+finality-tracker = { package = "pallet-finality-tracker", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+grandpa = { package = "pallet-grandpa", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false, features = ["migrate-authorities"] }
+identity = { package = "pallet-identity", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+im-online = { package = "pallet-im-online", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+indices = { package = "pallet-indices", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+membership = { package = "pallet-membership", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+nicks = { package = "pallet-nicks", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+offences = { package = "pallet-offences", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+randomness-collective-flip = { package = "pallet-randomness-collective-flip", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+session = { package = "pallet-session", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+staking = { package = "pallet-staking", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+pallet-staking-reward-curve = { git = "https://github.com/paritytech/substrate", branch = "master" }
+system = { package = "frame-system", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+system_rpc_runtime_api = { package = "frame-system-rpc-runtime-api", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+timestamp = { package = "pallet-timestamp", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+treasury = { package = "pallet-treasury", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+sudo = { package = "pallet-sudo", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+vesting = { package = "pallet-vesting", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 
 runtime-common = { package = "polkadot-runtime-common", path = "../common", default-features = false }
 primitives = { package = "polkadot-primitives", path = "../../primitives", default-features = false }
@@ -65,8 +65,8 @@ polkadot-parachain = { path = "../../parachain", default-features = false }
 hex-literal = "0.2.1"
 libsecp256k1 = "0.3.2"
 tiny-keccak = "1.5.0"
-keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-sp-trie = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-trie = { git = "https://github.com/paritytech/substrate", branch = "master" }
 trie-db = "0.20.0"
 serde_json = "1.0.41"
 

--- a/runtime/polkadot/Cargo.toml
+++ b/runtime/polkadot/Cargo.toml
@@ -13,49 +13,49 @@ rustc-hex = { version = "2.0.1", default-features = false }
 serde = { version = "1.0.102", default-features = false }
 serde_derive = { version = "1.0.102", optional = true }
 
-authority-discovery-primitives = { package = "sp-authority-discovery", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-offchain-primitives = { package = "sp-offchain", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-rstd = { package = "sp-std", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sp-staking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sp-session = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-version = { package = "sp-version", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-tx-pool-api = { package = "sp-transaction-pool", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-block-builder-api = { package = "sp-block-builder", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
+authority-discovery-primitives = { package = "sp-authority-discovery", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+offchain-primitives = { package = "sp-offchain", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+rstd = { package = "sp-std", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+sp-staking = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+sp-session = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+version = { package = "sp-version", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+tx-pool-api = { package = "sp-transaction-pool", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+block-builder-api = { package = "sp-block-builder", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
 
-authority-discovery = { package = "pallet-authority-discovery", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-authorship = { package = "pallet-authorship", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-babe = { package = "pallet-babe", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-balances = { package = "pallet-balances", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-transaction-payment = { package = "pallet-transaction-payment", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-collective = { package = "pallet-collective", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-democracy = { package = "pallet-democracy", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-elections-phragmen = { package = "pallet-elections-phragmen", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-executive = { package = "frame-executive", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-finality-tracker = { package = "pallet-finality-tracker", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-grandpa = { package = "pallet-grandpa", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false, features = ["migrate-authorities"] }
-identity = { package = "pallet-identity", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-im-online = { package = "pallet-im-online", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-indices = { package = "pallet-indices", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-membership = { package = "pallet-membership", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-nicks = { package = "pallet-nicks", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-offences = { package = "pallet-offences", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-randomness-collective-flip = { package = "pallet-randomness-collective-flip", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-session = { package = "pallet-session", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-staking = { package = "pallet-staking", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false, features = ["migrate"] }
-pallet-staking-reward-curve = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-system = { package = "frame-system", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-system_rpc_runtime_api = { package = "frame-system-rpc-runtime-api", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-timestamp = { package = "pallet-timestamp", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-treasury = { package = "pallet-treasury", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sudo = { package = "pallet-sudo", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-vesting = { package = "pallet-vesting", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
+authority-discovery = { package = "pallet-authority-discovery", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+authorship = { package = "pallet-authorship", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+babe = { package = "pallet-babe", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+balances = { package = "pallet-balances", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+transaction-payment = { package = "pallet-transaction-payment", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+collective = { package = "pallet-collective", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+democracy = { package = "pallet-democracy", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+elections-phragmen = { package = "pallet-elections-phragmen", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+executive = { package = "frame-executive", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+finality-tracker = { package = "pallet-finality-tracker", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+grandpa = { package = "pallet-grandpa", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false, features = ["migrate-authorities"] }
+identity = { package = "pallet-identity", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+im-online = { package = "pallet-im-online", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+indices = { package = "pallet-indices", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+membership = { package = "pallet-membership", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+nicks = { package = "pallet-nicks", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+offences = { package = "pallet-offences", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+randomness-collective-flip = { package = "pallet-randomness-collective-flip", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+session = { package = "pallet-session", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+staking = { package = "pallet-staking", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+pallet-staking-reward-curve = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+system = { package = "frame-system", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+system_rpc_runtime_api = { package = "frame-system-rpc-runtime-api", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+timestamp = { package = "pallet-timestamp", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+treasury = { package = "pallet-treasury", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+sudo = { package = "pallet-sudo", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+vesting = { package = "pallet-vesting", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
 
 runtime-common = { package = "polkadot-runtime-common", path = "../common", default-features = false }
 primitives = { package = "polkadot-primitives", path = "../../primitives", default-features = false }
@@ -65,8 +65,8 @@ polkadot-parachain = { path = "../../parachain", default-features = false }
 hex-literal = "0.2.1"
 libsecp256k1 = "0.3.2"
 tiny-keccak = "1.5.0"
-keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-trie = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-trie = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
 trie-db = "0.20.0"
 serde_json = "1.0.41"
 

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -79,7 +79,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	impl_name: create_runtime_str!("parity-polkadot"),
 	authoring_version: 2,
 	spec_version: 1002,
-	impl_version: 0,
+	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 };
 

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -19,39 +19,39 @@ polkadot-runtime = { path = "../runtime/polkadot" }
 kusama-runtime = { path = "../runtime/kusama" }
 polkadot-network = { path = "../network"  }
 polkadot-rpc = { path = "../rpc" }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sc-client = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sc-client-db = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sc-chain-spec = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sc-executor = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sc-network = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-consensus_common = { package = "sp-consensus", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-grandpa = { package = "sc-finality-grandpa", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-grandpa_primitives = { package = "sp-finality-grandpa", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-service = { package = "sc-service", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-telemetry = { package = "sc-telemetry", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sc-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sc-keystore = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-pallet-babe = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-pallet-staking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-im-online = { package = "pallet-im-online", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-authority-discovery = { package = "sc-authority-discovery", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-authority-discovery-primitives = { package = "sp-authority-discovery", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-babe = { package = "sc-consensus-babe", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-block-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-system_rpc_runtime_api = { package = "frame-system-rpc-runtime-api", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sc-client = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sc-client-db = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sc-chain-spec = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sc-executor = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sc-network = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+consensus_common = { package = "sp-consensus", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+grandpa = { package = "sc-finality-grandpa", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+grandpa_primitives = { package = "sp-finality-grandpa", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+service = { package = "sc-service", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+telemetry = { package = "sc-telemetry", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sc-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sc-keystore = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+pallet-babe = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+pallet-staking = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+im-online = { package = "pallet-im-online", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+authority-discovery = { package = "sc-authority-discovery", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+authority-discovery-primitives = { package = "sp-authority-discovery", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+babe = { package = "sc-consensus-babe", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-block-builder = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+system_rpc_runtime_api = { package = "frame-system-rpc-runtime-api", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
 codec = { package = "parity-scale-codec", version = "1.1.0" }
-sp-session = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-offchain = { package = "sp-offchain", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+sp-session = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-offchain = { package = "sp-offchain", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
 
 [features]
 default = ["rocksdb"]

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -19,39 +19,39 @@ polkadot-runtime = { path = "../runtime/polkadot" }
 kusama-runtime = { path = "../runtime/kusama" }
 polkadot-network = { path = "../network"  }
 polkadot-rpc = { path = "../rpc" }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-sc-client = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-sc-client-db = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-sc-chain-spec = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-sc-executor = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-sc-network = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-consensus_common = { package = "sp-consensus", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-grandpa = { package = "sc-finality-grandpa", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-grandpa_primitives = { package = "sp-finality-grandpa", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-service = { package = "sc-service", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
-telemetry = { package = "sc-telemetry", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-sc-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-sp-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-sc-keystore = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-pallet-babe = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-pallet-staking = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-im-online = { package = "pallet-im-online", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-authority-discovery = { package = "sc-authority-discovery", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-authority-discovery-primitives = { package = "sp-authority-discovery", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-babe = { package = "sc-consensus-babe", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-sp-block-builder = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-system_rpc_runtime_api = { package = "frame-system-rpc-runtime-api", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-client = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-client-db = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-chain-spec = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-executor = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-network = { git = "https://github.com/paritytech/substrate", branch = "master" }
+consensus_common = { package = "sp-consensus", git = "https://github.com/paritytech/substrate", branch = "master" }
+grandpa = { package = "sc-finality-grandpa", git = "https://github.com/paritytech/substrate", branch = "master" }
+grandpa_primitives = { package = "sp-finality-grandpa", git = "https://github.com/paritytech/substrate", branch = "master" }
+inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "master" }
+service = { package = "sc-service", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+telemetry = { package = "sc-telemetry", git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-keystore = { git = "https://github.com/paritytech/substrate", branch = "master" }
+pallet-babe = { git = "https://github.com/paritytech/substrate", branch = "master" }
+pallet-staking = { git = "https://github.com/paritytech/substrate", branch = "master" }
+im-online = { package = "pallet-im-online", git = "https://github.com/paritytech/substrate", branch = "master" }
+authority-discovery = { package = "sc-authority-discovery", git = "https://github.com/paritytech/substrate", branch = "master" }
+authority-discovery-primitives = { package = "sp-authority-discovery", git = "https://github.com/paritytech/substrate", branch = "master" }
+babe = { package = "sc-consensus-babe", git = "https://github.com/paritytech/substrate", branch = "master" }
+babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-block-builder = { git = "https://github.com/paritytech/substrate", branch = "master" }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "master" }
+system_rpc_runtime_api = { package = "frame-system-rpc-runtime-api", git = "https://github.com/paritytech/substrate", branch = "master" }
 codec = { package = "parity-scale-codec", version = "1.1.0" }
-sp-session = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-sp-offchain = { package = "sp-offchain", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-session = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-offchain = { package = "sp-offchain", git = "https://github.com/paritytech/substrate", branch = "master" }
 
 [features]
 default = ["rocksdb"]

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -19,39 +19,39 @@ polkadot-runtime = { path = "../runtime/polkadot" }
 kusama-runtime = { path = "../runtime/kusama" }
 polkadot-network = { path = "../network"  }
 polkadot-rpc = { path = "../rpc" }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sc-client = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sc-client-db = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sc-chain-spec = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sc-executor = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sc-network = { git = "https://github.com/paritytech/substrate", branch = "master" }
-consensus_common = { package = "sp-consensus", git = "https://github.com/paritytech/substrate", branch = "master" }
-grandpa = { package = "sc-finality-grandpa", git = "https://github.com/paritytech/substrate", branch = "master" }
-grandpa_primitives = { package = "sp-finality-grandpa", git = "https://github.com/paritytech/substrate", branch = "master" }
-inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "master" }
-service = { package = "sc-service", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-telemetry = { package = "sc-telemetry", git = "https://github.com/paritytech/substrate", branch = "master" }
-sc-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sc-keystore = { git = "https://github.com/paritytech/substrate", branch = "master" }
-pallet-babe = { git = "https://github.com/paritytech/substrate", branch = "master" }
-pallet-staking = { git = "https://github.com/paritytech/substrate", branch = "master" }
-im-online = { package = "pallet-im-online", git = "https://github.com/paritytech/substrate", branch = "master" }
-authority-discovery = { package = "sc-authority-discovery", git = "https://github.com/paritytech/substrate", branch = "master" }
-authority-discovery-primitives = { package = "sp-authority-discovery", git = "https://github.com/paritytech/substrate", branch = "master" }
-babe = { package = "sc-consensus-babe", git = "https://github.com/paritytech/substrate", branch = "master" }
-babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-block-builder = { git = "https://github.com/paritytech/substrate", branch = "master" }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "master" }
-system_rpc_runtime_api = { package = "frame-system-rpc-runtime-api", git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sc-client = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sc-client-db = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sc-chain-spec = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sc-executor = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sc-network = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+consensus_common = { package = "sp-consensus", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+grandpa = { package = "sc-finality-grandpa", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+grandpa_primitives = { package = "sp-finality-grandpa", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+service = { package = "sc-service", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false }
+telemetry = { package = "sc-telemetry", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sc-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sc-keystore = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+pallet-babe = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+pallet-staking = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+im-online = { package = "pallet-im-online", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+authority-discovery = { package = "sc-authority-discovery", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+authority-discovery-primitives = { package = "sp-authority-discovery", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+babe = { package = "sc-consensus-babe", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-block-builder = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+system_rpc_runtime_api = { package = "frame-system-rpc-runtime-api", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
 codec = { package = "parity-scale-codec", version = "1.1.0" }
-sp-session = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-offchain = { package = "sp-offchain", git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-session = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-offchain = { package = "sp-offchain", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
 
 [features]
 default = ["rocksdb"]

--- a/statement-table/Cargo.toml
+++ b/statement-table/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2018"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.1.0", default-features = false, features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
 primitives = { package = "polkadot-primitives", path = "../primitives" }

--- a/statement-table/Cargo.toml
+++ b/statement-table/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2018"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.1.0", default-features = false, features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
 primitives = { package = "polkadot-primitives", path = "../primitives" }

--- a/statement-table/Cargo.toml
+++ b/statement-table/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2018"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.1.0", default-features = false, features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
 primitives = { package = "polkadot-primitives", path = "../primitives" }

--- a/test-parachains/adder/Cargo.toml
+++ b/test-parachains/adder/Cargo.toml
@@ -13,7 +13,7 @@ tiny-keccak = "1.5.0"
 dlmalloc = { version = "0.1.3", features = [ "global" ] }
 
 # We need to make sure the global allocator is disabled until we have support of full substrate externalities
-runtime-io = { package = "sp-io", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false, features = [ "disable_allocator" ] }
+runtime-io = { package = "sp-io", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false, features = [ "disable_allocator" ] }
 
 [build-dependencies]
 wasm-builder-runner = { package = "substrate-wasm-builder-runner", version = "1.0.5" }

--- a/test-parachains/adder/Cargo.toml
+++ b/test-parachains/adder/Cargo.toml
@@ -13,7 +13,7 @@ tiny-keccak = "1.5.0"
 dlmalloc = { version = "0.1.3", features = [ "global" ] }
 
 # We need to make sure the global allocator is disabled until we have support of full substrate externalities
-runtime-io = { package = "sp-io", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false, features = [ "disable_allocator" ] }
+runtime-io = { package = "sp-io", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false, features = [ "disable_allocator" ] }
 
 [build-dependencies]
 wasm-builder-runner = { package = "substrate-wasm-builder-runner", version = "1.0.5" }

--- a/test-parachains/adder/Cargo.toml
+++ b/test-parachains/adder/Cargo.toml
@@ -13,7 +13,7 @@ tiny-keccak = "1.5.0"
 dlmalloc = { version = "0.1.3", features = [ "global" ] }
 
 # We need to make sure the global allocator is disabled until we have support of full substrate externalities
-runtime-io = { package = "sp-io", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key", default-features = false, features = [ "disable_allocator" ] }
+runtime-io = { package = "sp-io", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false, features = [ "disable_allocator" ] }
 
 [build-dependencies]
 wasm-builder-runner = { package = "substrate-wasm-builder-runner", version = "1.0.5" }

--- a/test-parachains/adder/collator/Cargo.toml
+++ b/test-parachains/adder/collator/Cargo.toml
@@ -9,9 +9,9 @@ adder = { path = ".." }
 parachain = { package = "polkadot-parachain", path = "../../../parachain" }
 collator = { package = "polkadot-collator", path = "../../../collator" }
 primitives = { package = "polkadot-primitives", path = "../../../primitives" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-client = { package = "sc-client", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-client-api = { package = "sc-client-api", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+client = { package = "sc-client", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+client-api = { package = "sc-client-api", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
 parking_lot = "0.10.0"
 codec = { package = "parity-scale-codec", version = "1.1.0" }
 futures = "0.3.4"

--- a/test-parachains/adder/collator/Cargo.toml
+++ b/test-parachains/adder/collator/Cargo.toml
@@ -9,9 +9,9 @@ adder = { path = ".." }
 parachain = { package = "polkadot-parachain", path = "../../../parachain" }
 collator = { package = "polkadot-collator", path = "../../../collator" }
 primitives = { package = "polkadot-primitives", path = "../../../primitives" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
-client = { package = "sc-client", git = "https://github.com/paritytech/substrate", branch = "master" }
-client-api = { package = "sc-client-api", git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+client = { package = "sc-client", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+client-api = { package = "sc-client-api", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
 parking_lot = "0.10.0"
 codec = { package = "parity-scale-codec", version = "1.1.0" }
 futures = "0.3.4"

--- a/test-parachains/adder/collator/Cargo.toml
+++ b/test-parachains/adder/collator/Cargo.toml
@@ -9,9 +9,9 @@ adder = { path = ".." }
 parachain = { package = "polkadot-parachain", path = "../../../parachain" }
 collator = { package = "polkadot-collator", path = "../../../collator" }
 primitives = { package = "polkadot-primitives", path = "../../../primitives" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-client = { package = "sc-client", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-client-api = { package = "sc-client-api", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
+client = { package = "sc-client", git = "https://github.com/paritytech/substrate", branch = "master" }
+client-api = { package = "sc-client-api", git = "https://github.com/paritytech/substrate", branch = "master" }
 parking_lot = "0.10.0"
 codec = { package = "parity-scale-codec", version = "1.1.0" }
 futures = "0.3.4"

--- a/validation/Cargo.toml
+++ b/validation/Cargo.toml
@@ -18,22 +18,22 @@ parachain = { package = "polkadot-parachain", path = "../parachain" }
 polkadot-primitives = { path = "../primitives" }
 polkadot-erasure-coding = { path = "../erasure-coding" }
 table = { package = "polkadot-statement-table", path = "../statement-table" }
-grandpa = { package = "sc-finality-grandpa", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-consensus = { package = "sp-consensus", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-primitives = { package = "sp-core", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-txpool-api = { package = "sp-transaction-pool", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-block-builder = { package = "sc-block-builder", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-trie = { package = "sp-trie", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-runtime_primitives = { package = "sp-runtime", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+grandpa = { package = "sc-finality-grandpa", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+consensus = { package = "sp-consensus", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+primitives = { package = "sp-core", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+txpool-api = { package = "sp-transaction-pool", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-timestamp = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+block-builder = { package = "sc-block-builder", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+trie = { package = "sp-trie", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+runtime_primitives = { package = "sp-runtime", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
 bitvec = { version = "0.15.2", default-features = false, features = ["alloc"] }
-runtime_babe = { package = "pallet-babe", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-keystore = { package = "sc-keystore", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+runtime_babe = { package = "pallet-babe", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+keystore = { package = "sc-keystore", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
 
 [dev-dependencies]
-sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }

--- a/validation/Cargo.toml
+++ b/validation/Cargo.toml
@@ -18,22 +18,22 @@ parachain = { package = "polkadot-parachain", path = "../parachain" }
 polkadot-primitives = { path = "../primitives" }
 polkadot-erasure-coding = { path = "../erasure-coding" }
 table = { package = "polkadot-statement-table", path = "../statement-table" }
-grandpa = { package = "sc-finality-grandpa", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-consensus = { package = "sp-consensus", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-primitives = { package = "sp-core", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-txpool-api = { package = "sp-transaction-pool", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-sp-timestamp = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-block-builder = { package = "sc-block-builder", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-trie = { package = "sp-trie", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-runtime_primitives = { package = "sp-runtime", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+grandpa = { package = "sc-finality-grandpa", git = "https://github.com/paritytech/substrate", branch = "master" }
+inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "master" }
+consensus = { package = "sp-consensus", git = "https://github.com/paritytech/substrate", branch = "master" }
+primitives = { package = "sp-core", git = "https://github.com/paritytech/substrate", branch = "master" }
+txpool-api = { package = "sp-transaction-pool", git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-timestamp = { git = "https://github.com/paritytech/substrate", branch = "master" }
+block-builder = { package = "sc-block-builder", git = "https://github.com/paritytech/substrate", branch = "master" }
+trie = { package = "sp-trie", git = "https://github.com/paritytech/substrate", branch = "master" }
+runtime_primitives = { package = "sp-runtime", git = "https://github.com/paritytech/substrate", branch = "master" }
 bitvec = { version = "0.15.2", default-features = false, features = ["alloc"] }
-runtime_babe = { package = "pallet-babe", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
-keystore = { package = "sc-keystore", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+runtime_babe = { package = "pallet-babe", git = "https://github.com/paritytech/substrate", branch = "master" }
+babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/paritytech/substrate", branch = "master" }
+keystore = { package = "sc-keystore", git = "https://github.com/paritytech/substrate", branch = "master" }
 
 [dev-dependencies]
-sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "master" }

--- a/validation/Cargo.toml
+++ b/validation/Cargo.toml
@@ -18,22 +18,22 @@ parachain = { package = "polkadot-parachain", path = "../parachain" }
 polkadot-primitives = { path = "../primitives" }
 polkadot-erasure-coding = { path = "../erasure-coding" }
 table = { package = "polkadot-statement-table", path = "../statement-table" }
-grandpa = { package = "sc-finality-grandpa", git = "https://github.com/paritytech/substrate", branch = "master" }
-inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "master" }
-consensus = { package = "sp-consensus", git = "https://github.com/paritytech/substrate", branch = "master" }
-primitives = { package = "sp-core", git = "https://github.com/paritytech/substrate", branch = "master" }
-txpool-api = { package = "sp-transaction-pool", git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-timestamp = { git = "https://github.com/paritytech/substrate", branch = "master" }
-block-builder = { package = "sc-block-builder", git = "https://github.com/paritytech/substrate", branch = "master" }
-trie = { package = "sp-trie", git = "https://github.com/paritytech/substrate", branch = "master" }
-runtime_primitives = { package = "sp-runtime", git = "https://github.com/paritytech/substrate", branch = "master" }
+grandpa = { package = "sc-finality-grandpa", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+consensus = { package = "sp-consensus", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+primitives = { package = "sp-core", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+txpool-api = { package = "sp-transaction-pool", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+sp-timestamp = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+block-builder = { package = "sc-block-builder", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+trie = { package = "sp-trie", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+runtime_primitives = { package = "sp-runtime", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
 bitvec = { version = "0.15.2", default-features = false, features = ["alloc"] }
-runtime_babe = { package = "pallet-babe", git = "https://github.com/paritytech/substrate", branch = "master" }
-babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/paritytech/substrate", branch = "master" }
-keystore = { package = "sc-keystore", git = "https://github.com/paritytech/substrate", branch = "master" }
+runtime_babe = { package = "pallet-babe", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
+keystore = { package = "sc-keystore", git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }
 
 [dev-dependencies]
-sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "apopiak-rename-exists-to-contains-key" }


### PR DESCRIPTION
fixes usages of `StorageMap::exists(key)` by using the new `StorageMap::contains_key(key)` introduced in paritytech/substrate#4847 instead.
See Issue paritytech/substrate#4839 for the motivation.