### PR TITLE
Be specific about the `BitVec` generic arguments

### DIFF
--- a/primitives/src/parachain.rs
+++ b/primitives/src/parachain.rs
@@ -514,7 +514,7 @@ pub struct AttestedCandidate {
 	/// Validity attestations.
 	pub validity_votes: Vec<ValidityAttestation>,
 	/// Indices of the corresponding validity votes.
-	pub validator_indices: BitVec,
+	pub validator_indices: BitVec<bitvec::cursor::LittleEndian, u8>,
 }
 
 impl AttestedCandidate {

--- a/runtime/common/src/registrar.rs
+++ b/runtime/common/src/registrar.rs
@@ -865,7 +865,7 @@ mod tests {
 				.collect(),
 			validator_indices: roster.iter()
 				.map(|i| i == &Chain::Parachain(id))
-				.collect::<BitVec>(),
+				.collect::<BitVec::<_, _>>(),
 		}
 	}
 

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -77,7 +77,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("kusama"),
 	impl_name: create_runtime_str!("parity-kusama"),
 	authoring_version: 2,
-	spec_version: 1046,
+	spec_version: 1047,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 };

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -78,7 +78,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("polkadot"),
 	impl_name: create_runtime_str!("parity-polkadot"),
 	authoring_version: 2,
-	spec_version: 1001,
+	spec_version: 1002,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 };

--- a/validation/src/shared_table/mod.rs
+++ b/validation/src/shared_table/mod.rs
@@ -519,7 +519,11 @@ impl SharedTable {
 				}).collect();
 				validity_votes.sort_by(|(id1, _), (id2, _)| id1.cmp(id2));
 
-				let mut validator_indices = bitvec![0; validity_votes.last().map(|(i, _)| i + 1).unwrap_or_default()];
+				let mut validator_indices = bitvec![
+					bitvec::cursor::LittleEndian, u8;
+					0;
+					validity_votes.last().map(|(i, _)| i + 1).unwrap_or_default()
+				];
 				for (id, _) in &validity_votes {
 					validator_indices.set(*id, true);
 				}


### PR DESCRIPTION
Currently we use the default generic arguments for `BitVec`. This means
we use `BigEndian` and `u8`. These default values are not stable, with
`0.17` of the `BitVec` crate this changes. To make sure we don't break
anything in the future, make sure we explictly set the generics.