### PR TITLE
Fix invalid argument order

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -40,6 +40,11 @@ pub struct ValidationWorkerCommand {
 
 #[allow(missing_docs)]
 #[derive(Debug, StructOpt, Clone)]
+#[structopt(settings = &[
+	structopt::clap::AppSettings::GlobalVersion,
+	structopt::clap::AppSettings::ArgsNegateSubcommands,
+	structopt::clap::AppSettings::SubcommandsNegateReqs,
+])]
 pub struct Cli {
 	#[allow(missing_docs)]
 	#[structopt(subcommand)]

--- a/tests/invalid_order_arguments.rs
+++ b/tests/invalid_order_arguments.rs
@@ -1,0 +1,30 @@
+// Copyright 2020 Parity Technologies (UK) Ltd.
+// This file is part of Substrate.
+
+// Substrate is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Substrate is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
+
+use assert_cmd::cargo::cargo_bin;
+use std::process::Command;
+
+#[test]
+#[cfg(unix)]
+fn invalid_order_arguments() {
+	let base_path = "invalid_order_arguments";
+
+	let status = Command::new(cargo_bin("polkadot"))
+		.args(&["--dev", "invalid_order_arguments", "-d", base_path, "-y"])
+		.status()
+		.unwrap();
+	assert!(!status.success());
+}

--- a/tests/purge_chain_works.rs
+++ b/tests/purge_chain_works.rs
@@ -41,13 +41,6 @@ fn purge_chain_works() {
 	kill(Pid::from_raw(cmd.id().try_into().unwrap()), SIGINT).unwrap();
 	assert!(common::wait_for(&mut cmd, 30).map(|x| x.success()).unwrap_or_default());
 
-	// Does not accept invalid argument order
-	let status = Command::new(cargo_bin("polkadot"))
-		.args(&["--dev", "purge-chain", "-d", base_path, "-y"])
-		.status()
-		.unwrap();
-	assert!(!status.success());
-
 	// Purge chain
 	let status = Command::new(cargo_bin("polkadot"))
 		.args(&["purge-chain", "--dev", "-d", base_path, "-y"])

--- a/tests/purge_chain_works.rs
+++ b/tests/purge_chain_works.rs
@@ -41,6 +41,14 @@ fn purge_chain_works() {
 	kill(Pid::from_raw(cmd.id().try_into().unwrap()), SIGINT).unwrap();
 	assert!(common::wait_for(&mut cmd, 30).map(|x| x.success()).unwrap_or_default());
 
+	// Does not accept invalid argument order
+	let status = Command::new(cargo_bin("polkadot"))
+		.args(&["--dev", "purge-chain", "-d", base_path, "-y"])
+		.status()
+		.unwrap();
+	assert!(!status.success());
+
+	// Purge chain
 	let status = Command::new(cargo_bin("polkadot"))
 		.args(&["purge-chain", "--dev", "-d", base_path, "-y"])
 		.status()


### PR DESCRIPTION
@bkchr this PR enforces this behavior:

```
[0] [11:24:02] ~/r/polkadot master > ./target/debug/polkadot purge-chain --dev -y
"/home/cecile/.local/share/polkadot/chains/dev/db" did not exist.
[0] [11:25:36] ~/r/polkadot cecton-fix-invalid-argument-order > ./target/debug/polkadot --dev purge-chain -y
error: Found argument 'purge-chain' which wasn't expected, or isn't valid in this context

USAGE:
    polkadot --dev

For more information try --help
```