### PR TITLE
Introduce a maximum code size and head data size

### DIFF
--- a/runtime/common/src/crowdfund.rs
+++ b/runtime/common/src/crowdfund.rs
@@ -659,6 +659,9 @@ mod tests {
 			RefCell<HashMap<u32, (Vec<u8>, Vec<u8>)>> = RefCell::new(HashMap::new());
 	}
 
+	const MAX_CODE_SIZE: u32 = 100;
+	const MAX_HEAD_DATA_SIZE: u32 = 10;
+
 	pub struct TestParachains;
 	impl Registrar<u64> for TestParachains {
 		fn new_id() -> ParaId {
@@ -666,6 +669,14 @@ mod tests {
 				*p.borrow_mut() += 1;
 				(*p.borrow() - 1).into()
 			})
+		}
+
+		fn head_data_size_allowed(head_data_size: u32) -> bool {
+			head_data_size <= MAX_HEAD_DATA_SIZE
+		}
+
+		fn code_size_allowed(code_size: u32) -> bool {
+			code_size <= MAX_CODE_SIZE
 		}
 
 		fn register_para(
@@ -884,13 +895,14 @@ mod tests {
 				Origin::signed(1),
 				0,
 				<Test as system::Trait>::Hash::default(),
+				0,
 				vec![0]
 			));
 
 			let fund = Crowdfund::funds(0).unwrap();
 
 			// Confirm deploy data is stored correctly
-			assert_eq!(fund.deploy_data, Some((<Test as system::Trait>::Hash::default(), vec![0])));
+			assert_eq!(fund.deploy_data, Some((<Test as system::Trait>::Hash::default(), 0, vec![0])));
 		});
 	}
 
@@ -906,6 +918,7 @@ mod tests {
 				Origin::signed(2),
 				0,
 				<Test as system::Trait>::Hash::default(),
+				0,
 				vec![0]),
 				Error::<Test>::InvalidOrigin
 			);
@@ -915,6 +928,7 @@ mod tests {
 				Origin::signed(1),
 				1,
 				<Test as system::Trait>::Hash::default(),
+				0,
 				vec![0]),
 				Error::<Test>::InvalidFundIndex
 			);
@@ -924,6 +938,7 @@ mod tests {
 				Origin::signed(1),
 				0,
 				<Test as system::Trait>::Hash::default(),
+				0,
 				vec![0]
 			));
 
@@ -931,6 +946,7 @@ mod tests {
 				Origin::signed(1),
 				0,
 				<Test as system::Trait>::Hash::default(),
+				0,
 				vec![1]),
 				Error::<Test>::ExistingDeployData
 			);
@@ -950,6 +966,7 @@ mod tests {
 				Origin::signed(1),
 				0,
 				<Test as system::Trait>::Hash::default(),
+				0,
 				vec![0]
 			));
 
@@ -995,6 +1012,7 @@ mod tests {
 				Origin::signed(1),
 				0,
 				<Test as system::Trait>::Hash::default(),
+				0,
 				vec![0]
 			));
 
@@ -1022,6 +1040,7 @@ mod tests {
 				Origin::signed(1),
 				0,
 				<Test as system::Trait>::Hash::default(),
+				0,
 				vec![0]
 			));
 
@@ -1064,6 +1083,7 @@ mod tests {
 				Origin::signed(1),
 				0,
 				<Test as system::Trait>::Hash::default(),
+				0,
 				vec![0]
 			));
 
@@ -1205,6 +1225,7 @@ mod tests {
 				Origin::signed(1),
 				0,
 				<Test as system::Trait>::Hash::default(),
+				0,
 				vec![0]
 			));
 			assert_ok!(Crowdfund::onboard(Origin::signed(1), 0, 0.into()));
@@ -1233,6 +1254,7 @@ mod tests {
 				Origin::signed(1),
 				0,
 				<Test as system::Trait>::Hash::default(),
+				0,
 				vec![0]
 			));
 			// Move to the end of auction...
@@ -1271,12 +1293,14 @@ mod tests {
 				Origin::signed(1),
 				0,
 				<Test as system::Trait>::Hash::default(),
+				0,
 				vec![0]
 			));
 			assert_ok!(Crowdfund::fix_deploy_data(
 				Origin::signed(2),
 				1,
 				<Test as system::Trait>::Hash::default(),
+				0,
 				vec![0]
 			));
 

--- a/runtime/common/src/crowdfund.rs
+++ b/runtime/common/src/crowdfund.rs
@@ -119,7 +119,6 @@ pub enum LastContribution<BlockNumber> {
 	Ending(BlockNumber),
 }
 
-/// An internal record. This is public only due to a bug in the `Encode` derivation.
 #[derive(Encode, Decode, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "std", derive(Debug))]
 struct DeployData<Hash> {

--- a/runtime/common/src/crowdfund.rs
+++ b/runtime/common/src/crowdfund.rs
@@ -119,6 +119,7 @@ pub enum LastContribution<BlockNumber> {
 	Ending(BlockNumber),
 }
 
+/// An internal record. This is public only due to a bug in the `Encode` derivation.
 #[derive(Encode, Decode, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "std", derive(Debug))]
 struct DeployData<Hash> {
@@ -129,6 +130,7 @@ struct DeployData<Hash> {
 
 #[derive(Encode, Decode, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "std", derive(Debug))]
+#[codec(dumb_trait_bound)]
 pub struct FundInfo<AccountId, Balance, Hash, BlockNumber> {
 	/// The parachain that this fund has funded, if there is one. As long as this is `Some`, then
 	/// the funds may not be withdrawn and the fund cannot be dissolved.

--- a/runtime/common/src/parachains.rs
+++ b/runtime/common/src/parachains.rs
@@ -243,8 +243,6 @@ decl_error! {
 		ParentMismatch,
 		/// Head data was too large.
 		HeadDataTooLarge,
-		/// Para validation code was too large.
-		CodeTooLarge,
 	}
 }
 

--- a/runtime/common/src/parachains.rs
+++ b/runtime/common/src/parachains.rs
@@ -129,6 +129,14 @@ pub trait Trait: attestations::Trait {
 
 	/// The way that we are able to register parachains.
 	type Registrar: Registrar<Self::AccountId>;
+
+	/// Maximum code size for parachains, in bytes. Note that this is not
+	/// the entire storage burden of the parachain, as old code is stored for
+	/// `SlashPeriod` blocks.
+	type MaxCodeSize: Get<u32>;
+
+	/// Max head data size.
+	type MaxHeadDataSize: Get<u32>;
 }
 
 /// Origin for the parachains module.
@@ -233,6 +241,10 @@ decl_error! {
 		UntaggedVotes,
 		/// Wrong parent head for parachain receipt.
 		ParentMismatch,
+		/// Head data was too large.
+		HeadDataTooLarge,
+		/// Para validation code was too large.
+		CodeTooLarge,
 	}
 }
 
@@ -778,6 +790,8 @@ impl<T: Trait> Module<T> {
 		let mut validator_groups = GroupedDutyIter::new(&sorted_validators[..]);
 
 		let mut para_block_hashes = Vec::new();
+
+		let max_head_data_size = T::MaxHeadDataSize::get();
 		for candidate in attested_candidates {
 			let para_id = candidate.parachain_index();
 			let validator_group = validator_groups.group_for(para_id)
@@ -799,6 +813,11 @@ impl<T: Trait> Module<T> {
 			ensure!(
 				candidate.validity_votes.len() <= authorities.len(),
 				Error::<T>::VotesExceedsAuthorities,
+			);
+
+			ensure!(
+				max_head_data_size >= candidate.candidate().head_data.0.len() as _,
+				Error::<T>::HeadDataTooLarge,
 			);
 
 			let fees = candidate.candidate().fees;
@@ -1152,6 +1171,11 @@ mod tests {
 		type MaxRetries = MaxRetries;
 	}
 
+	parameter_types! {
+		pub const MaxHeadDataSize: u32 = 100;
+		pub const MaxCodeSize: u32 = 100;
+	}
+
 	impl Trait for Test {
 		type Origin = Origin;
 		type Call = Call;
@@ -1159,6 +1183,8 @@ mod tests {
 		type Randomness = RandomnessCollectiveFlip;
 		type ActiveParachains = registrar::Module<Test>;
 		type Registrar = registrar::Module<Test>;
+		type MaxCodeSize = MaxCodeSize;
+		type MaxHeadDataSize = MaxHeadDataSize;
 	}
 
 	type Parachains = Module<Test>;

--- a/runtime/common/src/registrar.rs
+++ b/runtime/common/src/registrar.rs
@@ -973,7 +973,7 @@ mod tests {
 
 			run_to_block(10);
 			let h = BlakeTwo256::hash(&[2u8; 3]);
-			assert_ok!(Slots::fix_deploy_data(Origin::signed(1), 0, user_id(1), h, vec![2; 3]));
+			assert_ok!(Slots::fix_deploy_data(Origin::signed(1), 0, user_id(1), h, 3, vec![2; 3]));
 			assert_ok!(Slots::elaborate_deploy_data(Origin::signed(0), user_id(1), vec![2; 3]));
 			assert_ok!(Slots::set_offboarding(Origin::signed(user_id(1).into_account()), 1));
 

--- a/runtime/common/src/slots.rs
+++ b/runtime/common/src/slots.rs
@@ -1177,7 +1177,7 @@ mod tests {
 
 			run_to_block(9);
 			let h = BlakeTwo256::hash(&[42u8][..]);
-			assert_ok!(Slots::fix_deploy_data(Origin::signed(1), 0, 0.into(), h, vec![69]));
+			assert_ok!(Slots::fix_deploy_data(Origin::signed(1), 0, 0.into(), h, 1, vec![69]));
 			assert_ok!(Slots::elaborate_deploy_data(Origin::signed(0), 0.into(), vec![42]));
 
 			run_to_block(10);
@@ -1202,7 +1202,7 @@ mod tests {
 
 			run_to_block(11);
 			let h = BlakeTwo256::hash(&[42u8][..]);
-			assert_ok!(Slots::fix_deploy_data(Origin::signed(1), 0, 0.into(), h, vec![69]));
+			assert_ok!(Slots::fix_deploy_data(Origin::signed(1), 0, 0.into(), h, 1, vec![69]));
 			assert_ok!(Slots::elaborate_deploy_data(Origin::signed(0), 0.into(), vec![42]));
 			with_parachains(|p| {
 				assert_eq!(p.len(), 1);
@@ -1312,7 +1312,7 @@ mod tests {
 
 			for &(para, sub, acc) in &[(0, 0, 1), (1, 0, 2), (2, 0, 3), (3, 1, 4), (4, 1, 5)] {
 				let h = BlakeTwo256::hash(&[acc][..]);
-				assert_ok!(Slots::fix_deploy_data(Origin::signed(acc as _), sub, para.into(), h, vec![acc]));
+				assert_ok!(Slots::fix_deploy_data(Origin::signed(acc as _), sub, para.into(), h, 1, vec![acc]));
 				assert_ok!(Slots::elaborate_deploy_data(Origin::signed(0), para.into(), vec![acc]));
 			}
 
@@ -1359,7 +1359,7 @@ mod tests {
 
 			run_to_block(10);
 			let h = BlakeTwo256::hash(&[1u8][..]);
-			assert_ok!(Slots::fix_deploy_data(Origin::signed(1), 0, 0.into(), h, vec![1]));
+			assert_ok!(Slots::fix_deploy_data(Origin::signed(1), 0, 0.into(), h, 1, vec![1]));
 			assert_ok!(Slots::elaborate_deploy_data(Origin::signed(0), 0.into(), vec![1]));
 
 			assert_ok!(Slots::new_auction(Origin::ROOT, 5, 2));
@@ -1404,7 +1404,7 @@ mod tests {
 
 			run_to_block(10);
 			let h = BlakeTwo256::hash(&[1u8][..]);
-			assert_ok!(Slots::fix_deploy_data(Origin::signed(1), 0, 0.into(), h, vec![1]));
+			assert_ok!(Slots::fix_deploy_data(Origin::signed(1), 0, 0.into(), h, 1, vec![1]));
 			assert_ok!(Slots::elaborate_deploy_data(Origin::signed(0), 0.into(), vec![1]));
 
 			assert_ok!(Slots::new_auction(Origin::ROOT, 5, 2));

--- a/runtime/common/src/slots.rs
+++ b/runtime/common/src/slots.rs
@@ -1608,9 +1608,12 @@ mod tests {
 
 			let code = vec![0u8; (MAX_CODE_SIZE + 1) as _];
 			let h = BlakeTwo256::hash(&code[..]);
-			assert!(Slots::fix_deploy_data(
-				Origin::signed(1), 0, 0.into(), h, code.len() as _, vec![1],
-			).is_err());
+			assert_eq!(
+				Slots::fix_deploy_data(
+					Origin::signed(1), 0, 0.into(), h, code.len() as _, vec![1],
+				),
+				Err(Error::<Test>::CodeTooLarge.into()),
+			);
 		});
 	}
 
@@ -1650,9 +1653,12 @@ mod tests {
 			let code = vec![0u8; MAX_CODE_SIZE as _];
 			let head_data = vec![1u8; (MAX_HEAD_DATA_SIZE + 1) as _];
 			let h = BlakeTwo256::hash(&code[..]);
-			assert!(Slots::fix_deploy_data(
-				Origin::signed(1), 0, 0.into(), h, code.len() as _, head_data,
-			).is_err());
+			assert_eq!(
+				Slots::fix_deploy_data(
+					Origin::signed(1), 0, 0.into(), h, code.len() as _, head_data,
+				),
+				Err(Error::<Test>::HeadDataTooLarge.into()),
+			);
 		});
 	}
 

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -77,7 +77,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("kusama"),
 	impl_name: create_runtime_str!("parity-kusama"),
 	authoring_version: 2,
-	spec_version: 1047,
+	spec_version: 1048,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 };
@@ -461,6 +461,11 @@ impl attestations::Trait for Runtime {
 	type RewardAttestation = Staking;
 }
 
+parameter_types! {
+	pub const MaxCodeSize: u32 = 50 * 1024 * 1024; // 50 MB
+	pub const MaxHeadDataSize: u32 = 20 * 1024; // 20 KB
+}
+
 impl parachains::Trait for Runtime {
 	type Origin = Origin;
 	type Call = Call;
@@ -468,6 +473,8 @@ impl parachains::Trait for Runtime {
 	type Randomness = RandomnessCollectiveFlip;
 	type ActiveParachains = Registrar;
 	type Registrar = Registrar;
+	type MaxCodeSize = MaxCodeSize;
+	type MaxHeadDataSize = MaxHeadDataSize;
 }
 
 parameter_types! {

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -462,7 +462,7 @@ impl attestations::Trait for Runtime {
 }
 
 parameter_types! {
-	pub const MaxCodeSize: u32 = 50 * 1024 * 1024; // 50 MB
+	pub const MaxCodeSize: u32 = 10 * 1024 * 1024; // 10 MB
 	pub const MaxHeadDataSize: u32 = 20 * 1024; // 20 KB
 }
 

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -78,7 +78,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("polkadot"),
 	impl_name: create_runtime_str!("parity-polkadot"),
 	authoring_version: 2,
-	spec_version: 1002,
+	spec_version: 1003,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 };
@@ -465,6 +465,11 @@ impl attestations::Trait for Runtime {
 	type RewardAttestation = Staking;
 }
 
+parameter_types! {
+	pub const MaxCodeSize: u32 = 50 * 1024 * 1024; // 50 MB
+	pub const MaxHeadDataSize: u32 = 20 * 1024; // 20 KB
+}
+
 impl parachains::Trait for Runtime {
 	type Origin = Origin;
 	type Call = Call;
@@ -472,6 +477,8 @@ impl parachains::Trait for Runtime {
 	type Randomness = RandomnessCollectiveFlip;
 	type ActiveParachains = Registrar;
 	type Registrar = Registrar;
+	type MaxCodeSize = MaxCodeSize;
+	type MaxHeadDataSize = MaxHeadDataSize;
 }
 
 parameter_types! {

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -466,7 +466,7 @@ impl attestations::Trait for Runtime {
 }
 
 parameter_types! {
-	pub const MaxCodeSize: u32 = 50 * 1024 * 1024; // 50 MB
+	pub const MaxCodeSize: u32 = 10 * 1024 * 1024; // 10 MB
 	pub const MaxHeadDataSize: u32 = 20 * 1024; // 20 KB
 }
 


### PR DESCRIPTION
The maximum code size right now for Kusama is 50MB (edit: 10MB) and the maximum head data size is 20KB.

cc @bkchr is this reasonable compared to what Cumulus usually produces?