### PR TITLE
*: Ensure GossipEngine is being polled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ dependencies = [
  "dlmalloc 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-parachain 0.7.20",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "substrate-wasm-builder-runner 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -32,9 +32,9 @@ dependencies = [
  "polkadot-collator 0.7.20",
  "polkadot-parachain 0.7.20",
  "polkadot-primitives 0.7.20",
- "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-client-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
@@ -400,7 +400,7 @@ dependencies = [
 [[package]]
 name = "browser-utils"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "console_error_panic_hook 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -413,9 +413,9 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-chain-spec 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-service 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-chain-spec 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-network 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-service 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "wasm-bindgen 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-futures 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1125,7 +1125,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "fork-tree"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1133,58 +1133,58 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "frame-system 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "frame-metadata"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "frame-support"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "bitmask 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "frame-metadata 11.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-support-procedural 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-metadata 11.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "frame-support-procedural 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "paste 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-arithmetic 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-arithmetic 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-inherents 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-state-machine 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "tracing 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "frame-support-procedural"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
- "frame-support-procedural-tools 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support-procedural-tools 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1193,9 +1193,9 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
- "frame-support-procedural-tools-derive 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support-procedural-tools-derive 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1205,7 +1205,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1215,26 +1215,26 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-version 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
@@ -1516,7 +1516,7 @@ dependencies = [
 [[package]]
 name = "grafana-data-source"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "async-std 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2019,40 +2019,40 @@ name = "kusama-runtime"
 version = "0.7.20"
 dependencies = [
  "bitvec 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "frame-executive 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-executive 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "frame-system 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "frame-system-rpc-runtime-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "hex-literal 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsecp256k1 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-authorship 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-babe 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-balances 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-collective 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-democracy 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-elections-phragmen 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-grandpa 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-identity 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-im-online 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-indices 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-membership 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-nicks 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-offences 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-randomness-collective-flip 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-recovery 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-society 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-staking-reward-curve 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-transaction-payment 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-transaction-payment-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-treasury 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-utility 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-vesting 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "pallet-authority-discovery 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-authorship 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-babe 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-balances 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-collective 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-democracy 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-elections-phragmen 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-finality-tracker 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-grandpa 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-identity 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-im-online 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-indices 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-membership 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-nicks 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-offences 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-randomness-collective-flip 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-recovery 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-session 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-society 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-staking 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-staking-reward-curve 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-timestamp 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-transaction-payment 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-transaction-payment-rpc-runtime-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-treasury 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-utility 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-vesting 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-parachain 0.7.20",
  "polkadot-primitives 0.7.20",
@@ -2061,22 +2061,22 @@ dependencies = [
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-block-builder 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-offchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-authority-discovery 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-block-builder 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-consensus-babe 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-inherents 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-keyring 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-offchain 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-session 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-staking 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-trie 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-version 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "substrate-wasm-builder-runner 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "trie-db 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2991,326 +2991,326 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "frame-system 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-session 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-application-crypto 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-authority-discovery 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-authorship"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "frame-system 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-authorship 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-authorship 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-inherents 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-babe"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "frame-system 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "hex-literal 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "pallet-session 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-timestamp 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-consensus-babe 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-inherents 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-staking 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-timestamp 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-balances"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "frame-system 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-collective"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "frame-system 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-democracy"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "frame-system 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-elections-phragmen"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "frame-system 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-phragmen 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-phragmen 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-finality-tracker"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "frame-system 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-finality-tracker 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-inherents 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-grandpa"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "frame-system 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-finality-tracker 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-session 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-finality-grandpa 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-finality-grandpa 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-staking 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-identity"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "enumflags2 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "frame-system 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-im-online"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-authorship 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "frame-system 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-authorship 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-session 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-application-crypto 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-staking 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-indices"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "frame-system 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-keyring 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-membership"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "frame-system 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-nicks"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "frame-system 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-offences"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-balances 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "frame-system 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-balances 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-staking 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "frame-system 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-recovery"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "enumflags2 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "frame-system 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-session"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "frame-system 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "pallet-timestamp 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-staking 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-trie 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-society"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "frame-system 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-staking"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-authorship 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "frame-system 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-authorship 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-session 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-phragmen 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-keyring 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-phragmen 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-staking 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3321,119 +3321,119 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "frame-system 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-timestamp"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "frame-system 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-inherents 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-timestamp 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-transaction-payment"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-transaction-payment-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "frame-system 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-transaction-payment-rpc-runtime-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "jsonrpc-core 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core-client 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-derive 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-transaction-payment-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "pallet-transaction-payment-rpc-runtime-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-rpc 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-blockchain 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-rpc 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-treasury"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-balances 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "frame-system 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-balances 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-utility"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "frame-system 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-vesting"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "enumflags2 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "frame-system 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
@@ -3732,15 +3732,15 @@ dependencies = [
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-erasure-coding 0.7.20",
  "polkadot-primitives 0.7.20",
- "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-client-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-keystore 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-network 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-blockchain 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-consensus 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3748,18 +3748,18 @@ dependencies = [
 name = "polkadot-cli"
 version = "0.7.20"
 dependencies = [
- "browser-utils 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "browser-utils 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-service 0.7.20",
- "sc-cli 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client-db 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-executor 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-cli 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-client 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-client-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-client-db 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-executor 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "structopt 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3779,16 +3779,16 @@ dependencies = [
  "polkadot-primitives 0.7.20",
  "polkadot-service 0.7.20",
  "polkadot-validation 0.7.20",
- "sc-cli 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-cli 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-client 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-client-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-network 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-blockchain 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-consensus 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-keyring 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3800,8 +3800,8 @@ dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-primitives 0.7.20",
  "reed-solomon-erasure 4.0.0 (git+https://github.com/paritytech/reed-solomon-erasure)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-trie 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
@@ -3821,15 +3821,15 @@ dependencies = [
  "polkadot-erasure-coding 0.7.20",
  "polkadot-primitives 0.7.20",
  "polkadot-validation 0.7.20",
- "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-network-gossip 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-network 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-network-gossip 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-blockchain 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-keyring 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-state-machine 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "wasm-timer 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3844,14 +3844,14 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-executor 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-executor 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "shared_memory 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-externalities 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-externalities 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime-interface 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3860,20 +3860,20 @@ name = "polkadot-primitives"
 version = "0.7.20"
 dependencies = [
  "bitvec 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-babe 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "pallet-babe 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-parachain 0.7.20",
  "pretty_assertions 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-serializer 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-application-crypto 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-inherents 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-serializer 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-trie 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-version 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
@@ -3881,15 +3881,15 @@ name = "polkadot-rpc"
 version = "0.7.20"
 dependencies = [
  "jsonrpc-core 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-transaction-payment-rpc 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "pallet-transaction-payment-rpc 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-primitives 0.7.20",
- "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-rpc 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "substrate-frame-rpc-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-rpc 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "substrate-frame-rpc-system 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
@@ -3897,38 +3897,38 @@ name = "polkadot-runtime"
 version = "0.7.20"
 dependencies = [
  "bitvec 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "frame-executive 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-executive 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "frame-system 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "frame-system-rpc-runtime-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "hex-literal 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsecp256k1 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-authorship 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-babe 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-balances 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-collective 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-democracy 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-elections-phragmen 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-grandpa 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-identity 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-im-online 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-indices 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-membership 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-nicks 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-offences 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-randomness-collective-flip 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-staking-reward-curve 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-sudo 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-transaction-payment 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-transaction-payment-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-treasury 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-vesting 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "pallet-authority-discovery 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-authorship 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-babe 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-balances 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-collective 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-democracy 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-elections-phragmen 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-finality-tracker 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-grandpa 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-identity 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-im-online 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-indices 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-membership 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-nicks 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-offences 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-randomness-collective-flip 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-session 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-staking 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-staking-reward-curve 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-sudo 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-timestamp 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-transaction-payment 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-transaction-payment-rpc-runtime-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-treasury 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-vesting 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-parachain 0.7.20",
  "polkadot-primitives 0.7.20",
@@ -3937,21 +3937,21 @@ dependencies = [
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-block-builder 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-offchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-authority-discovery 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-block-builder 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-consensus-babe 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-inherents 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-keyring 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-offchain 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-session 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-staking 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-trie 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-version 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "substrate-wasm-builder-runner 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "trie-db 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3962,21 +3962,21 @@ name = "polkadot-runtime-common"
 version = "0.7.20"
 dependencies = [
  "bitvec 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "frame-system 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "hex-literal 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsecp256k1 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-authorship 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-babe 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-balances 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-randomness-collective-flip 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-staking-reward-curve 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-treasury 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-vesting 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "pallet-authorship 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-babe 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-balances 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-randomness-collective-flip 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-session 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-staking 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-staking-reward-curve 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-timestamp 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-treasury 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-vesting 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-parachain 0.7.20",
  "polkadot-primitives 0.7.20",
@@ -3984,15 +3984,15 @@ dependencies = [
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-inherents 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-keyring 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-staking 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-trie 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "trie-db 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -4001,16 +4001,16 @@ dependencies = [
 name = "polkadot-service"
 version = "0.7.20"
 dependencies = [
- "frame-system-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-system-rpc-runtime-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-literal 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "kusama-runtime 0.7.20",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-babe 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-im-online 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-transaction-payment-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "pallet-babe 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-im-online 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-staking 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "pallet-transaction-payment-rpc-runtime-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-availability-store 0.7.20",
@@ -4019,35 +4019,35 @@ dependencies = [
  "polkadot-rpc 0.7.20",
  "polkadot-runtime 0.7.20",
  "polkadot-validation 0.7.20",
- "sc-authority-discovery 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-chain-spec 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client-db 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-executor 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-finality-grandpa 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-service 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-authority-discovery 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-chain-spec 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-client 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-client-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-client-db 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-consensus-babe 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-executor 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-finality-grandpa 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-keystore 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-network 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-service 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-telemetry 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-transaction-pool 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-block-builder 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-finality-grandpa 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-offchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-authority-discovery 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-block-builder 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-blockchain 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-consensus 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-consensus-babe 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-finality-grandpa 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-inherents 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-offchain 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-session 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
@@ -4056,7 +4056,7 @@ version = "0.7.20"
 dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-primitives 0.7.20",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
@@ -4069,7 +4069,7 @@ dependencies = [
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-timer 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-babe 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "pallet-babe 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-availability-store 0.7.20",
@@ -4077,21 +4077,21 @@ dependencies = [
  "polkadot-parachain 0.7.20",
  "polkadot-primitives 0.7.20",
  "polkadot-statement-table 0.7.20",
- "sc-block-builder 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-finality-grandpa 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-block-builder 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-client-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-finality-grandpa 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-keystore 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-blockchain 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-consensus 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-consensus-babe 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-inherents 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-keyring 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-timestamp 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-trie 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -4651,7 +4651,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4663,52 +4663,52 @@ dependencies = [
  "prost 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-build 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-keystore 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-network 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-authority-discovery 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-blockchain 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "sc-block-builder"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-block-builder 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-block-builder 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-blockchain 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-consensus 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-state-machine 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "sc-chain-spec"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-chain-spec-derive 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-chain-spec-derive 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-network 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-telemetry 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "sc-chain-spec-derive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4719,7 +4719,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "ansi_term 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "app_dirs 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4736,18 +4736,18 @@ dependencies = [
  "parity-util-mem 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rpassword 4.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-service 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-tracing 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-network 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-service 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-telemetry 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-tracing 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-panic-handler 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-blockchain 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-keyring 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-panic-handler 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-state-machine 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "structopt 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4756,7 +4756,7 @@ dependencies = [
 [[package]]
 name = "sc-client"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4767,29 +4767,29 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-block-builder 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-executor 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-externalities 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-block-builder 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-client-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-executor 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-telemetry 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-blockchain 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-consensus 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-externalities 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-inherents 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-keyring 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-state-machine 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-trie 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-version 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "tracing 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sc-client-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4800,27 +4800,27 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-executor 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-externalities 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-executor 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-telemetry 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-blockchain 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-consensus 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-externalities 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-inherents 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-keyring 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-state-machine 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-trie 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-version 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "sc-client-db"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "kvdb 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4831,25 +4831,25 @@ dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-util-mem 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-executor 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-state-db 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-client-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-executor 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-state-db 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-blockchain 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-consensus 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-state-machine 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-trie 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "sc-consensus-babe"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "fork-tree 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "fork-tree 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-timer 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4861,80 +4861,80 @@ dependencies = [
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pdqselect 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-consensus-epochs 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-consensus-slots 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-consensus-uncles 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-client-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-consensus-epochs 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-consensus-slots 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-consensus-uncles 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-keystore 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-telemetry 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "schnorrkel 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-block-builder 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-application-crypto 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-block-builder 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-blockchain 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-consensus 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-consensus-babe 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-inherents 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-timestamp 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-version 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
- "fork-tree 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "fork-tree 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-blockchain 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "sc-consensus-slots"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-timer 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-telemetry 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-blockchain 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-consensus 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-inherents 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-state-machine 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "sc-consensus-uncles"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-authorship 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-authorship 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-consensus 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-inherents 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "sc-executor"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4943,57 +4943,57 @@ dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-wasm 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-executor-common 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-executor-wasmi 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-executor-wasmtime 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-externalities 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-panic-handler 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-serializer 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-executor-common 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-executor-wasmi 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-executor-wasmtime 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-externalities 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-panic-handler 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime-interface 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-serializer 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-trie 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-version 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-wasm-interface 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "wasmi 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sc-executor-common"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-allocator 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-serializer 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-allocator 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime-interface 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-serializer 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-wasm-interface 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "wasmi 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-wasm 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-executor-common 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-allocator 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-executor-common 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-allocator 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime-interface 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-wasm-interface 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "wasmi 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "cranelift-codegen 0.50.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cranelift-entity 0.50.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5003,11 +5003,11 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-wasm 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-executor-common 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-allocator 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-executor-common 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-allocator 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime-interface 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-wasm-interface 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "wasmi 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmtime-environ 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmtime-jit 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5017,11 +5017,11 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "finality-grandpa 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fork-tree 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "fork-tree 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-timer 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5029,42 +5029,42 @@ dependencies = [
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-network-gossip 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-client-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-keystore 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-network 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-network-gossip 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-telemetry 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-arithmetic 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-finality-grandpa 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-arithmetic 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-blockchain 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-consensus 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-finality-grandpa 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-finality-tracker 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-inherents 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "sc-keystore"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-application-crypto 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "subtle 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sc-network"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5072,7 +5072,7 @@ dependencies = [
  "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "erased-serde 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "fork-tree 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "fork-tree 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-timer 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures_codec 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5085,21 +5085,21 @@ dependencies = [
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-block-builder 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-peerset 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-block-builder 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-client 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-client-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-peerset 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog_derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-arithmetic 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-arithmetic 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-blockchain 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-consensus 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-consensus-babe 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "unsigned-varint 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5108,7 +5108,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5117,14 +5117,14 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-network 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "sc-offchain"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5138,20 +5138,20 @@ dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-offchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-keystore 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-network 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-offchain 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sc-peerset"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "libp2p 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5162,7 +5162,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5171,28 +5171,28 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-executor 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-rpc-api 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-client-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-executor 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-keystore 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-rpc-api 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-offchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-rpc 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-blockchain 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-offchain 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-rpc 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-session 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-state-machine 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-version 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "sc-rpc-api"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5205,16 +5205,16 @@ dependencies = [
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-rpc 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-rpc 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-version 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "sc-rpc-server"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "jsonrpc-core 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-http-server 14.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5223,13 +5223,13 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "sc-service"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "exit-future 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5237,38 +5237,38 @@ dependencies = [
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-diagnose 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-timer 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "grafana-data-source 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "grafana-data-source 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-multiaddr 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-util-mem 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-chain-spec 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client-db 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-executor 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-offchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-rpc 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-rpc-server 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-tracing 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-chain-spec 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-client 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-client-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-client-db 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-executor 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-keystore 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-network 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-offchain 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-rpc 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-rpc-server 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-telemetry 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-tracing 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-transaction-pool 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-application-crypto 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-blockchain 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-consensus 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-session 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "sysinfo 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "target_info 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5278,18 +5278,18 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "sc-telemetry"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5310,13 +5310,13 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "erased-serde 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "grafana-data-source 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "grafana-data-source 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-telemetry 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5326,7 +5326,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-graph"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5334,15 +5334,15 @@ dependencies = [
  "parity-util-mem 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "sc-transaction-pool"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5351,13 +5351,13 @@ dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-util-mem 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-transaction-graph 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sc-transaction-graph 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-blockchain 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
@@ -5651,34 +5651,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "sp-allocator"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-wasm-interface 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api-proc-macro 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api-proc-macro 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-state-machine 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-version 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-api-proc-macro"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5690,83 +5690,83 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-arithmetic"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "integer-sqrt 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-debug-derive 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-debug-derive 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-authority-discovery"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-application-crypto 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-authorship"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-inherents 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-block-builder"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-inherents 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-blockchain"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-block-builder 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-block-builder 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-consensus 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-state-machine 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-consensus"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5777,34 +5777,34 @@ dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-inherents 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-state-machine 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-version 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-consensus-babe"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "schnorrkel 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-application-crypto 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-consensus 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-inherents 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-timestamp 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-core"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "base58 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5828,11 +5828,11 @@ dependencies = [
  "schnorrkel 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-debug-derive 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-externalities 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-storage 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-debug-derive 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-externalities 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime-interface 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-storage 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "substrate-bip39 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-bip39 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5844,7 +5844,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5854,90 +5854,90 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "environmental 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-storage 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-storage 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-finality-grandpa"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-application-crypto 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-finality-tracker"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-inherents 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-inherents"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-io"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsecp256k1 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-externalities 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-externalities 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime-interface 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-state-machine 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-trie 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-wasm-interface 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-keyring"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "strum 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sp-offchain"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-panic-handler"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "backtrace 0.3.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5946,26 +5946,26 @@ dependencies = [
 [[package]]
 name = "sp-phragmen"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-rpc"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-runtime"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5974,32 +5974,32 @@ dependencies = [
  "paste 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-arithmetic 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-application-crypto 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-arithmetic 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-inherents 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-io 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-runtime-interface"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "primitive-types 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-externalities 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime-interface-proc-macro 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-externalities 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime-interface-proc-macro 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-wasm-interface 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "Inflector 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6011,7 +6011,7 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6020,28 +6020,28 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-staking"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-state-machine"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6049,10 +6049,10 @@ dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-externalities 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-panic-handler 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-externalities 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-panic-handler 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-trie 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "trie-db 0.19.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "trie-root 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -6060,56 +6060,56 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 
 [[package]]
 name = "sp-storage"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "impl-serde 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-debug-derive 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-debug-derive 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-timestamp"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-inherents 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-transaction-pool"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-trie"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "memory-db 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "trie-db 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "trie-root 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -6117,23 +6117,23 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "impl-serde 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-wasm-interface"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "wasmi 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -6236,22 +6236,22 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#aa15e17a71e28eea1291f2e5d169574d4894bc38"
+source = "git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master#07416927627902c2ef17ee64d9ee11e5efecb45b"
 dependencies = [
- "frame-system-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-system-rpc-runtime-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core-client 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-derive 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-blockchain 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)",
 ]
 
 [[package]]
@@ -7388,7 +7388,7 @@ dependencies = [
 "checksum block-cipher-trait 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1c924d49bd09e7c06003acda26cd9742e796e34282ec6c1189404dee0c1f4774"
 "checksum block-padding 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
 "checksum broadcaster 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9c972e21e0d055a36cf73e4daae870941fe7a8abcd5ac3396aab9e4c126bd87"
-"checksum browser-utils 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
+"checksum browser-utils 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
 "checksum bs58 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b170cd256a3f9fa6b9edae3e44a7dfdfc77e8124dbc3e2612d75f9c3e2396dae"
 "checksum bstr 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "502ae1441a0a5adb8fbd38a5955a6416b9493e92b465de5e4a9bde6a539c2c48"
 "checksum bumpalo 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1f359dc14ff8911330a51ef78022d376f25ed00248912803b58f00cb1c27f742"
@@ -7470,15 +7470,15 @@ dependencies = [
 "checksum fixedbitset 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 "checksum flate2 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6bd6d6f4752952feb71363cffc9ebac9411b75b87c6ab6058c40c8900cf43c0f"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
-"checksum fork-tree 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum frame-executive 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum frame-metadata 11.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum frame-support 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum frame-support-procedural 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum frame-support-procedural-tools 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum frame-support-procedural-tools-derive 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum frame-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum frame-system-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
+"checksum fork-tree 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum frame-executive 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum frame-metadata 11.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum frame-support 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum frame-support-procedural 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum frame-support-procedural-tools 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum frame-support-procedural-tools-derive 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum frame-system 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum frame-system-rpc-runtime-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
 "checksum fs-swap 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "921d332c89b3b61a826de38c61ee5b6e02c56806cade1b0e5d81bd71f57a71bb"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
@@ -7510,7 +7510,7 @@ dependencies = [
 "checksum glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 "checksum globset 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "925aa2cac82d8834e2b2a4415b6f6879757fb5c0928fc445ae76461a12eed8f2"
 "checksum goblin 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3081214398d39e4bd7f2c1975f0488ed04614ffdd976c6fc7a0708278552c0da"
-"checksum grafana-data-source 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
+"checksum grafana-data-source 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
 "checksum h2 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "a5b34c246847f938a410a03c5458c7fee2274436675e76d8b903c08efc29c462"
 "checksum h2 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b9433d71e471c1736fd5a61b671fc0b148d7a2992f666c958d03cd8feb3b88d1"
 "checksum hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d23bd4e7b5eda0d0f3a307e8b381fdc8ba9000f26fbe912250c0a4cc3956364a"
@@ -7639,35 +7639,35 @@ dependencies = [
 "checksum once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b1c601810575c99596d4afc46f78a678c80105117c379eb3650cf99b8a21ce5b"
 "checksum opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 "checksum owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
-"checksum pallet-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-authorship 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-babe 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-balances 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-collective 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-democracy 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-elections-phragmen 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-grandpa 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-identity 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-im-online 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-indices 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-membership 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-nicks 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-offences 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-randomness-collective-flip 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-recovery 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-society 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-staking-reward-curve 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-sudo 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-transaction-payment 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-transaction-payment-rpc 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-transaction-payment-rpc-runtime-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-treasury 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-utility 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-vesting 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
+"checksum pallet-authority-discovery 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum pallet-authorship 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum pallet-babe 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum pallet-balances 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum pallet-collective 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum pallet-democracy 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum pallet-elections-phragmen 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum pallet-finality-tracker 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum pallet-grandpa 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum pallet-identity 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum pallet-im-online 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum pallet-indices 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum pallet-membership 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum pallet-nicks 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum pallet-offences 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum pallet-randomness-collective-flip 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum pallet-recovery 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum pallet-session 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum pallet-society 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum pallet-staking 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum pallet-staking-reward-curve 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum pallet-sudo 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum pallet-timestamp 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum pallet-transaction-payment 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum pallet-transaction-payment-rpc 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum pallet-transaction-payment-rpc-runtime-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum pallet-treasury 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum pallet-utility 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum pallet-vesting 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
 "checksum parity-bytes 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0c276d76c5333b8c2579e02d49a06733a55b8282d2d9b13e8d53b6406bd7e30a"
 "checksum parity-multiaddr 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "80878c27f90dd162d3143333d672e80b194d6b080f05c83440e3dfda42e409f2"
 "checksum parity-multihash 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b11f42bbd3a021c5061b77154bd3334d5a57e1a03eb162de0b962681cc25800d"
@@ -7759,37 +7759,37 @@ dependencies = [
 "checksum rw-stream-sink 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4da5fcb054c46f5a5dff833b129285a93d3f0179531735e6c866e8cc307d2020"
 "checksum ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
 "checksum safe-mix 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6d3d055a2582e6b00ed7a31c1524040aa391092bf636328350813f3a0605215c"
-"checksum sc-authority-discovery 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-block-builder 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-chain-spec 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-chain-spec-derive 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-cli 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-client 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-client-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-client-db 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-consensus-epochs 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-consensus-slots 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-consensus-uncles 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-executor 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-executor-common 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-executor-wasmi 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-executor-wasmtime 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-finality-grandpa 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-keystore 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-network 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-network-gossip 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-offchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-peerset 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-rpc 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-rpc-api 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-rpc-server 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-service 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-state-db 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-tracing 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-transaction-graph 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
+"checksum sc-authority-discovery 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sc-block-builder 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sc-chain-spec 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sc-chain-spec-derive 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sc-cli 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sc-client 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sc-client-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sc-client-db 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sc-consensus-babe 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sc-consensus-epochs 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sc-consensus-slots 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sc-consensus-uncles 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sc-executor 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sc-executor-common 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sc-executor-wasmi 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sc-executor-wasmtime 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sc-finality-grandpa 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sc-keystore 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sc-network 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sc-network-gossip 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sc-offchain 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sc-peerset 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sc-rpc 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sc-rpc-api 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sc-rpc-server 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sc-service 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sc-state-db 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sc-telemetry 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sc-tracing 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sc-transaction-graph 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sc-transaction-pool 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
 "checksum schnorrkel 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)" = "eacd8381b3c37840c9c9f40472af529e49975bdcbc24f83c31059fd6539023d3"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
@@ -7822,43 +7822,43 @@ dependencies = [
 "checksum snow 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "afb767eee7d257ba202f0b9b08673bc13b22281632ef45267b19f13100accd2f"
 "checksum soketto 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1c9dab3f95c9ebdf3a88268c19af668f637a3c5039c2c56ff2d40b1b2d64a25b"
 "checksum sourcefile 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf77cb82ba8453b42b6ae1d692e4cdc92f9a47beaf89a847c8be83f4e328ad3"
-"checksum sp-allocator 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-api 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-api-proc-macro 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-arithmetic 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-authorship 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-block-builder 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-blockchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-consensus 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-consensus-babe 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-core 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-debug-derive 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-externalities 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-finality-grandpa 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-io 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-keyring 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-offchain 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-panic-handler 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-phragmen 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-rpc 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-runtime-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-runtime-interface-proc-macro 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-serializer 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-session 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-staking 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-state-machine 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-std 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-storage 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-trie 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-version 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
+"checksum sp-allocator 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sp-api 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sp-api-proc-macro 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sp-application-crypto 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sp-arithmetic 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sp-authority-discovery 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sp-authorship 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sp-block-builder 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sp-blockchain 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sp-consensus 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sp-consensus-babe 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sp-core 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sp-debug-derive 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sp-externalities 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sp-finality-grandpa 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sp-finality-tracker 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sp-inherents 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sp-io 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sp-keyring 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sp-offchain 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sp-panic-handler 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sp-phragmen 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sp-rpc 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sp-runtime 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sp-runtime-interface 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sp-runtime-interface-proc-macro 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sp-serializer 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sp-session 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sp-staking 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sp-state-machine 0.8.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sp-std 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sp-storage 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sp-timestamp 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sp-transaction-pool 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sp-trie 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sp-version 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
+"checksum sp-wasm-interface 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
 "checksum spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
@@ -7871,7 +7871,7 @@ dependencies = [
 "checksum strum 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6138f8f88a16d90134763314e3fc76fa3ed6a7db4725d6acf9a3ef95a3188d22"
 "checksum strum_macros 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0054a7df764039a6cd8592b9de84be4bec368ff081d203a7d5371cbfa8e65c81"
 "checksum substrate-bip39 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3be511be555a3633e71739a79e4ddff6a6aaa6579fa6114182a51d72c3eb93c5"
-"checksum substrate-frame-rpc-system 2.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
+"checksum substrate-frame-rpc-system 2.0.0 (git+https://github.com/mxinden/substrate?branch=restructure-gossip-engine-polkadot-master)" = "<none>"
 "checksum substrate-wasm-builder-runner 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e30c70de7e7d5fd404fe26db1e7a4d6b553e2760b1ac490f249c04a960c483b8"
 "checksum subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 "checksum subtle 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7c65d530b10ccaeac294f349038a597e435b18fb456aadd0840a623f83b9e941"

--- a/availability-store/Cargo.toml
+++ b/availability-store/Cargo.toml
@@ -15,15 +15,15 @@ futures = "0.3.4"
 tokio = { version = "0.2.10", features = ["rt-core"] }
 exit-future = "0.2.0"
 codec = { package = "parity-scale-codec", version = "1.1.0", features = ["derive"] }
-sc-network = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-consensus_common = { package = "sp-consensus", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-client = { package = "sc-client-api", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sc-client = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-keystore = { package = "sc-keystore", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+sc-network = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+consensus_common = { package = "sp-consensus", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+client = { package = "sc-client-api", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+sc-client = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+sp-runtime = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+sp-blockchain = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+sp-api = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+keystore = { package = "sc-keystore", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+sp-core = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
 kvdb = "0.3.1"
 kvdb-memorydb = "0.3.1"
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -12,21 +12,21 @@ crate-type = ["cdylib", "rlib"]
 log = "0.4.8"
 futures = { version = "0.3.4", features = ["compat"] }
 structopt = "0.3.8"
-sc-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", optional = true }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sc-client = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sc-client-db = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sc-executor = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+sc-cli = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", optional = true }
+sp-api = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+sp-core = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+sp-runtime = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+sc-client = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+sc-client-api = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+sc-client-db = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+sc-executor = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
 service = { package = "polkadot-service", path = "../service", default-features = false }
 
 tokio = { version = "0.2.10", features = ["rt-threaded"], optional = true }
 
 wasm-bindgen = { version = "0.2.57", optional = true }
 wasm-bindgen-futures = { version = "0.4.7", optional = true }
-browser-utils = { package = "browser-utils", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", optional = true }
+browser-utils = { package = "browser-utils", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", optional = true }
 
 [features]
 default = [ "wasmtime", "rocksdb", "cli" ]

--- a/collator/Cargo.toml
+++ b/collator/Cargo.toml
@@ -7,15 +7,15 @@ edition = "2018"
 
 [dependencies]
 futures = "0.3.4"
-sc-client = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sc-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sc-network = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-consensus_common = { package = "sp-consensus", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+sc-client = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+sc-cli = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+sc-client-api = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+sc-network = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+sp-blockchain = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+sp-api = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+sp-core = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+sp-runtime = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+consensus_common = { package = "sp-consensus", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
 polkadot-primitives = { path = "../primitives" }
 polkadot-cli = { path = "../cli" }
 polkadot-network = { path = "../network" }
@@ -27,4 +27,4 @@ futures-timer = "2.0"
 codec = { package = "parity-scale-codec", version = "1.1.0" }
 
 [dev-dependencies]
-keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+keyring = { package = "sp-keyring", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }

--- a/erasure-coding/Cargo.toml
+++ b/erasure-coding/Cargo.toml
@@ -8,6 +8,6 @@ edition = "2018"
 primitives = { package = "polkadot-primitives", path = "../primitives" }
 reed_solomon = { package = "reed-solomon-erasure", git = "https://github.com/paritytech/reed-solomon-erasure" }
 codec = { package = "parity-scale-codec", version = "1.1.0", default-features = false, features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-trie = { package = "sp-trie", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+sp-core = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+trie = { package = "sp-trie", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
 derive_more = "0.15.0"

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -15,19 +15,19 @@ polkadot-validation = { path = "../validation" }
 polkadot-primitives = { path = "../primitives" }
 polkadot-erasure-coding = { path = "../erasure-coding" }
 codec = { package = "parity-scale-codec", version = "1.1.0", default-features = false, features = ["derive"] }
-sc-network = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sc-network-gossip = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+sc-network = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+sc-network-gossip = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+sp-core = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+sp-runtime = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
 futures = "0.3.4"
 log = "0.4.8"
 exit-future = "0.2.0"
 futures-timer = "2.0"
-sc-client = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+sc-client = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+sp-blockchain = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+sp-api = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
 wasm-timer = "0.2.4"
 
 [dev-dependencies]
-sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-state-machine = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+sp-keyring = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+sp-state-machine = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }

--- a/network/src/legacy/gossip/mod.rs
+++ b/network/src/legacy/gossip/mod.rs
@@ -334,10 +334,18 @@ pub fn register_validator<C: ChainContext + 'static, S: NetworkSpecialization<Bl
 	let gossip_side = validator.clone();
 	let gossip_engine = sc_network_gossip::GossipEngine::new(
 		service.clone(),
-		executor,
 		POLKADOT_ENGINE_ID,
 		gossip_side,
 	);
+
+	// Ideally this would not be spawned as an orphaned task, but polled by
+	// `RegisteredMessageValidator` which in turn would be polled by a `ValidationNetwork`.
+	let spawn_res = executor.spawn_obj(futures::task::FutureObj::from(Box::new(gossip_engine.clone())));
+
+	// Note: we consider the chances of an error to spawn a background task almost null.
+	if spawn_res.is_err() {
+		log::error!(target: "polkadot-gossip", "Failed to spawn background task");
+	}
 
 	RegisteredMessageValidator {
 		inner: validator as _,

--- a/parachain/Cargo.toml
+++ b/parachain/Cargo.toml
@@ -9,12 +9,12 @@ edition = "2018"
 codec = { package = "parity-scale-codec", version = "1.1.0", default-features = false, features = [ "derive" ] }
 derive_more = { version = "0.99.2", optional = true }
 serde = { version = "1.0.102", default-features = false, features = [ "derive" ], optional = true }
-rstd = { package = "sp-std", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sp-runtime-interface = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sp-externalities = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", optional = true }
-sc-executor = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", optional = true }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", optional = true }
+rstd = { package = "sp-std", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+sp-core = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+sp-runtime-interface = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+sp-externalities = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", optional = true }
+sc-executor = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", optional = true }
+sp-io = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", optional = true }
 lazy_static = { version = "1.4.0", optional = true }
 parking_lot = { version = "0.10.0", optional = true }
 log = { version = "0.4.8", optional = true }

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -7,20 +7,20 @@ edition = "2018"
 [dependencies]
 serde = { version = "1.0.102", optional = true, features = ["derive"] }
 parity-scale-codec = { version = "1.1.0", default-features = false, features = ["bit-vec", "derive"] }
-primitives = { package = "sp-core", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-application-crypto = { package = "sp-application-crypto", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sp-version = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-rstd = { package = "sp-std", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-runtime_primitives = { package = "sp-runtime", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
+primitives = { package = "sp-core", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+inherents = { package = "sp-inherents", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+application-crypto = { package = "sp-application-crypto", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+sp-api = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+sp-version = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+rstd = { package = "sp-std", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+runtime_primitives = { package = "sp-runtime", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
 polkadot-parachain = { path = "../parachain", default-features = false }
-trie = { package = "sp-trie", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
+trie = { package = "sp-trie", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
 bitvec = { version = "0.15.2", default-features = false, features = ["alloc"] }
-babe = { package = "pallet-babe", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
+babe = { package = "pallet-babe", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
 
 [dev-dependencies]
-sp-serializer = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+sp-serializer = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
 pretty_assertions = "0.5.1"
 
 [features]

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -5,13 +5,13 @@ authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 
 [dependencies]
-client = { package = "sc-client", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+client = { package = "sc-client", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
 jsonrpc-core = "14.0.3"
 polkadot-primitives = { path = "../primitives" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master"  }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master"  }
-sc-rpc = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-txpool-api = { package = "sp-transaction-pool", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-frame-rpc-system = { package = "substrate-frame-rpc-system", git = "https://github.com/paritytech/substrate", branch = "polkadot-master"  }
-pallet-transaction-payment-rpc = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+sp-runtime = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master"  }
+sp-api = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master"  }
+sc-rpc = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+txpool-api = { package = "sp-transaction-pool", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+frame-rpc-system = { package = "substrate-frame-rpc-system", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master"  }
+pallet-transaction-payment-rpc = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
 codec = { package = "parity-scale-codec", version = "1.1.0", default-features = false }

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -12,22 +12,22 @@ rustc-hex = { version = "2.0.1", default-features = false }
 serde = { version = "1.0.102", default-features = false }
 serde_derive = { version = "1.0.102", optional = true }
 
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-rstd = { package = "sp-std", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sp-staking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
+sp-api = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+inherents = { package = "sp-inherents", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+rstd = { package = "sp-std", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+sp-io = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+sp-runtime = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+sp-staking = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+sp-core = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
 
-authorship = { package = "pallet-authorship", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-balances = { package = "pallet-balances", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-session = { package = "pallet-session", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-staking = { package = "pallet-staking", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-system = { package = "frame-system", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-timestamp = { package = "pallet-timestamp", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-vesting = { package = "pallet-vesting", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
+authorship = { package = "pallet-authorship", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+balances = { package = "pallet-balances", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+session = { package = "pallet-session", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+frame-support = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+staking = { package = "pallet-staking", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+system = { package = "frame-system", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+timestamp = { package = "pallet-timestamp", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+vesting = { package = "pallet-vesting", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
 
 primitives = { package = "polkadot-primitives", path = "../../primitives", default-features = false }
 polkadot-parachain = { path = "../../parachain", default-features = false }
@@ -36,12 +36,12 @@ polkadot-parachain = { path = "../../parachain", default-features = false }
 hex-literal = "0.2.1"
 libsecp256k1 = "0.3.2"
 tiny-keccak = "1.5.0"
-keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-trie = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-babe = { package = "pallet-babe", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-randomness-collective-flip = { package = "pallet-randomness-collective-flip", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-pallet-staking-reward-curve = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-treasury = { package = "pallet-treasury", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
+keyring = { package = "sp-keyring", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+sp-trie = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+babe = { package = "pallet-babe", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+randomness-collective-flip = { package = "pallet-randomness-collective-flip", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+pallet-staking-reward-curve = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+treasury = { package = "pallet-treasury", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
 trie-db = "0.20.0"
 serde_json = "1.0.41"
 

--- a/runtime/kusama/Cargo.toml
+++ b/runtime/kusama/Cargo.toml
@@ -13,52 +13,52 @@ rustc-hex = { version = "2.0.1", default-features = false }
 serde = { version = "1.0.102", default-features = false }
 serde_derive = { version = "1.0.102", optional = true }
 
-authority-discovery-primitives = { package = "sp-authority-discovery", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-offchain-primitives = { package = "sp-offchain", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-rstd = { package = "sp-std", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sp-staking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sp-session = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-version = { package = "sp-version", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-tx-pool-api = { package = "sp-transaction-pool", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-block-builder-api = { package = "sp-block-builder", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
+authority-discovery-primitives = { package = "sp-authority-discovery", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+sp-api = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+inherents = { package = "sp-inherents", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+offchain-primitives = { package = "sp-offchain", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+rstd = { package = "sp-std", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+sp-io = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+sp-runtime = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+sp-staking = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+sp-core = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+sp-session = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+version = { package = "sp-version", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+tx-pool-api = { package = "sp-transaction-pool", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+block-builder-api = { package = "sp-block-builder", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
 
-authority-discovery = { package = "pallet-authority-discovery", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-authorship = { package = "pallet-authorship", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-babe = { package = "pallet-babe", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-balances = { package = "pallet-balances", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-transaction-payment = { package = "pallet-transaction-payment", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-collective = { package = "pallet-collective", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-democracy = { package = "pallet-democracy", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-elections-phragmen = { package = "pallet-elections-phragmen", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-executive = { package = "frame-executive", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-finality-tracker = { package = "pallet-finality-tracker", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-grandpa = { package = "pallet-grandpa", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false, features = ["migrate-authorities"] }
-identity = { package = "pallet-identity", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-im-online = { package = "pallet-im-online", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-indices = { package = "pallet-indices", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-membership = { package = "pallet-membership", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-nicks = { package = "pallet-nicks", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-offences = { package = "pallet-offences", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-randomness-collective-flip = { package = "pallet-randomness-collective-flip", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-recovery = { package = "pallet-recovery", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-session = { package = "pallet-session", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-society = { package = "pallet-society", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-staking = { package = "pallet-staking", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false, features = ["migrate"] }
-pallet-staking-reward-curve = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-system = { package = "frame-system", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-system_rpc_runtime_api = { package = "frame-system-rpc-runtime-api", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-timestamp = { package = "pallet-timestamp", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-treasury = { package = "pallet-treasury", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-utility = { package = "pallet-utility", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-vesting = { package = "pallet-vesting", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
+authority-discovery = { package = "pallet-authority-discovery", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+authorship = { package = "pallet-authorship", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+babe = { package = "pallet-babe", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+balances = { package = "pallet-balances", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+transaction-payment = { package = "pallet-transaction-payment", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+collective = { package = "pallet-collective", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+democracy = { package = "pallet-democracy", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+elections-phragmen = { package = "pallet-elections-phragmen", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+executive = { package = "frame-executive", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+finality-tracker = { package = "pallet-finality-tracker", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+grandpa = { package = "pallet-grandpa", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false, features = ["migrate-authorities"] }
+identity = { package = "pallet-identity", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+im-online = { package = "pallet-im-online", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+indices = { package = "pallet-indices", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+membership = { package = "pallet-membership", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+nicks = { package = "pallet-nicks", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+offences = { package = "pallet-offences", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+randomness-collective-flip = { package = "pallet-randomness-collective-flip", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+recovery = { package = "pallet-recovery", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+session = { package = "pallet-session", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+society = { package = "pallet-society", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+frame-support = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+staking = { package = "pallet-staking", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false, features = ["migrate"] }
+pallet-staking-reward-curve = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+system = { package = "frame-system", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+system_rpc_runtime_api = { package = "frame-system-rpc-runtime-api", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+timestamp = { package = "pallet-timestamp", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+treasury = { package = "pallet-treasury", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+utility = { package = "pallet-utility", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+vesting = { package = "pallet-vesting", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
 
 runtime-common = { package = "polkadot-runtime-common", path = "../common", default-features = false }
 primitives = { package = "polkadot-primitives", path = "../../primitives", default-features = false }
@@ -68,8 +68,8 @@ polkadot-parachain = { path = "../../parachain", default-features = false }
 hex-literal = "0.2.1"
 libsecp256k1 = "0.3.2"
 tiny-keccak = "1.5.0"
-keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-trie = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+keyring = { package = "sp-keyring", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+sp-trie = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
 trie-db = "0.20.0"
 serde_json = "1.0.41"
 

--- a/runtime/polkadot/Cargo.toml
+++ b/runtime/polkadot/Cargo.toml
@@ -13,49 +13,49 @@ rustc-hex = { version = "2.0.1", default-features = false }
 serde = { version = "1.0.102", default-features = false }
 serde_derive = { version = "1.0.102", optional = true }
 
-authority-discovery-primitives = { package = "sp-authority-discovery", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-offchain-primitives = { package = "sp-offchain", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-rstd = { package = "sp-std", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sp-staking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sp-session = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-version = { package = "sp-version", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-tx-pool-api = { package = "sp-transaction-pool", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-block-builder-api = { package = "sp-block-builder", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
+authority-discovery-primitives = { package = "sp-authority-discovery", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+sp-api = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+inherents = { package = "sp-inherents", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+offchain-primitives = { package = "sp-offchain", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+rstd = { package = "sp-std", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+sp-runtime = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+sp-staking = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+sp-core = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+sp-session = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+version = { package = "sp-version", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+tx-pool-api = { package = "sp-transaction-pool", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+block-builder-api = { package = "sp-block-builder", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
 
-authority-discovery = { package = "pallet-authority-discovery", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-authorship = { package = "pallet-authorship", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-babe = { package = "pallet-babe", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-balances = { package = "pallet-balances", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-transaction-payment = { package = "pallet-transaction-payment", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-collective = { package = "pallet-collective", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-democracy = { package = "pallet-democracy", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-elections-phragmen = { package = "pallet-elections-phragmen", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-executive = { package = "frame-executive", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-finality-tracker = { package = "pallet-finality-tracker", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-grandpa = { package = "pallet-grandpa", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false, features = ["migrate-authorities"] }
-identity = { package = "pallet-identity", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-im-online = { package = "pallet-im-online", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-indices = { package = "pallet-indices", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-membership = { package = "pallet-membership", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-nicks = { package = "pallet-nicks", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-offences = { package = "pallet-offences", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-randomness-collective-flip = { package = "pallet-randomness-collective-flip", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-session = { package = "pallet-session", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-staking = { package = "pallet-staking", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false, features = ["migrate"] }
-pallet-staking-reward-curve = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-system = { package = "frame-system", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-system_rpc_runtime_api = { package = "frame-system-rpc-runtime-api", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-timestamp = { package = "pallet-timestamp", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-treasury = { package = "pallet-treasury", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sudo = { package = "pallet-sudo", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-vesting = { package = "pallet-vesting", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
+authority-discovery = { package = "pallet-authority-discovery", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+authorship = { package = "pallet-authorship", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+babe = { package = "pallet-babe", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+balances = { package = "pallet-balances", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+transaction-payment = { package = "pallet-transaction-payment", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+collective = { package = "pallet-collective", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+democracy = { package = "pallet-democracy", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+elections-phragmen = { package = "pallet-elections-phragmen", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+executive = { package = "frame-executive", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+finality-tracker = { package = "pallet-finality-tracker", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+grandpa = { package = "pallet-grandpa", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false, features = ["migrate-authorities"] }
+identity = { package = "pallet-identity", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+im-online = { package = "pallet-im-online", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+indices = { package = "pallet-indices", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+membership = { package = "pallet-membership", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+nicks = { package = "pallet-nicks", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+offences = { package = "pallet-offences", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+randomness-collective-flip = { package = "pallet-randomness-collective-flip", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+session = { package = "pallet-session", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+frame-support = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+staking = { package = "pallet-staking", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false, features = ["migrate"] }
+pallet-staking-reward-curve = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+system = { package = "frame-system", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+system_rpc_runtime_api = { package = "frame-system-rpc-runtime-api", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+timestamp = { package = "pallet-timestamp", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+treasury = { package = "pallet-treasury", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+sudo = { package = "pallet-sudo", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+vesting = { package = "pallet-vesting", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
 
 runtime-common = { package = "polkadot-runtime-common", path = "../common", default-features = false }
 primitives = { package = "polkadot-primitives", path = "../../primitives", default-features = false }
@@ -65,8 +65,8 @@ polkadot-parachain = { path = "../../parachain", default-features = false }
 hex-literal = "0.2.1"
 libsecp256k1 = "0.3.2"
 tiny-keccak = "1.5.0"
-keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-trie = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+keyring = { package = "sp-keyring", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+sp-trie = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
 trie-db = "0.20.0"
 serde_json = "1.0.41"
 

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -19,39 +19,39 @@ polkadot-runtime = { path = "../runtime/polkadot" }
 kusama-runtime = { path = "../runtime/kusama" }
 polkadot-network = { path = "../network"  }
 polkadot-rpc = { path = "../rpc" }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sc-client = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sc-client-db = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sc-chain-spec = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sc-executor = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sc-network = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-consensus_common = { package = "sp-consensus", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-grandpa = { package = "sc-finality-grandpa", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-grandpa_primitives = { package = "sp-finality-grandpa", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-service = { package = "sc-service", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-telemetry = { package = "sc-telemetry", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sc-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sc-keystore = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-pallet-babe = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-pallet-staking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-im-online = { package = "pallet-im-online", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-authority-discovery = { package = "sc-authority-discovery", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-authority-discovery-primitives = { package = "sp-authority-discovery", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-babe = { package = "sc-consensus-babe", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-block-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-system_rpc_runtime_api = { package = "frame-system-rpc-runtime-api", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+sp-io = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+sp-api = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+sp-runtime = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+sp-blockchain = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+sp-core = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+sc-client = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+sc-client-api = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+sc-client-db = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+sc-chain-spec = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+sc-executor = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+sc-network = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+consensus_common = { package = "sp-consensus", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+grandpa = { package = "sc-finality-grandpa", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+grandpa_primitives = { package = "sp-finality-grandpa", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+inherents = { package = "sp-inherents", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+service = { package = "sc-service", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false }
+telemetry = { package = "sc-telemetry", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+sc-transaction-pool = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+sp-transaction-pool = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+sc-keystore = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+pallet-babe = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+pallet-staking = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+im-online = { package = "pallet-im-online", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+authority-discovery = { package = "sc-authority-discovery", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+authority-discovery-primitives = { package = "sp-authority-discovery", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+babe = { package = "sc-consensus-babe", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+sp-block-builder = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+system_rpc_runtime_api = { package = "frame-system-rpc-runtime-api", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
 codec = { package = "parity-scale-codec", version = "1.1.0" }
-sp-session = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-offchain = { package = "sp-offchain", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+sp-session = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+sp-offchain = { package = "sp-offchain", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
 
 [features]
 default = ["rocksdb"]

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -479,7 +479,6 @@ pub fn new_full<Runtime, Dispatch, Extrinsic>(
 			on_exit: service.on_exit(),
 			telemetry_on_connect: Some(service.telemetry_on_connect_stream()),
 			voting_rule: grandpa::VotingRulesBuilder::default().build(),
-			executor: service.spawn_task_handle(),
 		};
 
 		service.spawn_essential_task(

--- a/statement-table/Cargo.toml
+++ b/statement-table/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2018"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.1.0", default-features = false, features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+sp-core = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
 primitives = { package = "polkadot-primitives", path = "../primitives" }

--- a/test-parachains/adder/Cargo.toml
+++ b/test-parachains/adder/Cargo.toml
@@ -13,7 +13,7 @@ tiny-keccak = "1.5.0"
 dlmalloc = { version = "0.1.3", features = [ "global" ] }
 
 # We need to make sure the global allocator is disabled until we have support of full substrate externalities
-runtime-io = { package = "sp-io", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false, features = [ "disable_allocator" ] }
+runtime-io = { package = "sp-io", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master", default-features = false, features = [ "disable_allocator" ] }
 
 [build-dependencies]
 wasm-builder-runner = { package = "substrate-wasm-builder-runner", version = "1.0.5" }

--- a/test-parachains/adder/collator/Cargo.toml
+++ b/test-parachains/adder/collator/Cargo.toml
@@ -9,9 +9,9 @@ adder = { path = ".." }
 parachain = { package = "polkadot-parachain", path = "../../../parachain" }
 collator = { package = "polkadot-collator", path = "../../../collator" }
 primitives = { package = "polkadot-primitives", path = "../../../primitives" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-client = { package = "sc-client", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-client-api = { package = "sc-client-api", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+sp-core = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+client = { package = "sc-client", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+client-api = { package = "sc-client-api", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
 parking_lot = "0.10.0"
 codec = { package = "parity-scale-codec", version = "1.1.0" }
 futures = "0.3.4"

--- a/validation/Cargo.toml
+++ b/validation/Cargo.toml
@@ -18,22 +18,22 @@ parachain = { package = "polkadot-parachain", path = "../parachain" }
 polkadot-primitives = { path = "../primitives" }
 polkadot-erasure-coding = { path = "../erasure-coding" }
 table = { package = "polkadot-statement-table", path = "../statement-table" }
-grandpa = { package = "sc-finality-grandpa", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-consensus = { package = "sp-consensus", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-primitives = { package = "sp-core", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-txpool-api = { package = "sp-transaction-pool", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-block-builder = { package = "sc-block-builder", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-trie = { package = "sp-trie", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-runtime_primitives = { package = "sp-runtime", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+grandpa = { package = "sc-finality-grandpa", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+inherents = { package = "sp-inherents", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+consensus = { package = "sp-consensus", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+primitives = { package = "sp-core", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+txpool-api = { package = "sp-transaction-pool", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+sp-blockchain = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+sp-api = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+sc-client-api = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+sp-timestamp = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+block-builder = { package = "sc-block-builder", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+trie = { package = "sp-trie", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+runtime_primitives = { package = "sp-runtime", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
 bitvec = { version = "0.15.2", default-features = false, features = ["alloc"] }
-runtime_babe = { package = "pallet-babe", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-keystore = { package = "sc-keystore", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+runtime_babe = { package = "pallet-babe", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
+keystore = { package = "sc-keystore", git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }
 
 [dev-dependencies]
-sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+sp-keyring = { git = "https://github.com/mxinden/substrate", branch = "restructure-gossip-engine-polkadot-master" }


### PR DESCRIPTION
With https://github.com/paritytech/substrate/pull/4767 a `GossipEngine`
does not spawn its own tasks, but relies on its owner to poll it. This
patch removes the unneeded executor argument and spawns the gossip
engine as an orphaned task onto the executor instead.

ba3b548   is the core of the pull request and should be reviewed.

c1fb81b is **temporary** and makes Polkadot use a patched version of Substrate's *polkadot-master* which includes https://github.com/paritytech/substrate/pull/4767.

:stop_sign: Please don't merge yet, given that c1fb81b is not yet removed.