### PR TITLE
Make Existential Deposit in Runtime Tests Non-Zero

### DIFF
--- a/runtime/common/src/claims.rs
+++ b/runtime/common/src/claims.rs
@@ -338,8 +338,7 @@ mod tests {
 	}
 
 	parameter_types! {
-		pub const ExistentialDeposit: u64 = 0;
-		pub const TransferFee: u64 = 0;
+		pub const ExistentialDeposit: u64 = 1;
 		pub const CreationFee: u64 = 0;
 	}
 

--- a/runtime/common/src/crowdfund.rs
+++ b/runtime/common/src/crowdfund.rs
@@ -616,7 +616,7 @@ mod tests {
 		type ModuleToIndex = ();
 	}
 	parameter_types! {
-		pub const ExistentialDeposit: u64 = 0;
+		pub const ExistentialDeposit: u64 = 1;
 		pub const CreationFee: u64 = 0;
 	}
 	impl balances::Trait for Test {

--- a/runtime/common/src/parachains.rs
+++ b/runtime/common/src/parachains.rs
@@ -1083,7 +1083,7 @@ mod tests {
 	}
 
 	parameter_types! {
-		pub const ExistentialDeposit: Balance = 0;
+		pub const ExistentialDeposit: Balance = 1;
 		pub const CreationFee: Balance = 0;
 	}
 

--- a/runtime/common/src/registrar.rs
+++ b/runtime/common/src/registrar.rs
@@ -709,7 +709,7 @@ mod tests {
 	}
 
 	parameter_types! {
-		pub const ExistentialDeposit: Balance = 0;
+		pub const ExistentialDeposit: Balance = 1;
 		pub const CreationFee: Balance = 0;
 	}
 

--- a/runtime/common/src/slots.rs
+++ b/runtime/common/src/slots.rs
@@ -918,7 +918,7 @@ mod tests {
 	}
 
 	parameter_types! {
-		pub const ExistentialDeposit: u64 = 0;
+		pub const ExistentialDeposit: u64 = 1;
 		pub const CreationFee: u64 = 0;
 	}
 


### PR DESCRIPTION
This is a companion PR for https://github.com/paritytech/substrate/pull/4894, but can be merged in whenever.

It updates all the runtime tests to use a non-zero existential deposit.

Fortunately, no logic or tests needed to change to make this work.