### PR TITLE
cli: fix version info in config

### DIFF
--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -27,7 +27,7 @@ use sc_cli::{VersionInfo, display_role, error};
 pub fn run(version: VersionInfo) -> error::Result<()> {
 	let opt = sc_cli::from_args::<Cli>(&version);
 
-	let mut config = service::Configuration::default();
+	let mut config = service::Configuration::new(&version);
 	config.impl_name = "parity-polkadot";
 
 	match opt.subcommand {


### PR DESCRIPTION
Config was being constructed with default `VersionInfo` resulting in:

```
2020-02-19 17:42:59 Parity Polkadot
2020-02-19 17:42:59   version 0.0.0-x86_64-linux-gnu
2020-02-19 17:42:59   by Parity Team <admin@parity.io>, 2017-2020
```