### PR TITLE
Companion PR for substrate 4818 and 5038

### DIFF
--- a/parachain/src/wasm_executor/mod.rs
+++ b/parachain/src/wasm_executor/mod.rs
@@ -251,6 +251,14 @@ impl sp_externalities::Externalities for ValidationExternalities {
 	fn next_storage_key(&self, _: &[u8]) -> Option<Vec<u8>> {
 		panic!("next_storage_key: unsupported feature for parachain validation")
 	}
+
+	fn wipe(&mut self) {
+		panic!("wipe: unsupported feature for parachain validation")
+	}
+
+	fn commit(&mut self) {
+		panic!("commit: unsupported feature for parachain validation")
+	}
 }
 
 impl sp_externalities::ExtensionStore for ValidationExternalities {

--- a/parachain/src/wasm_executor/mod.rs
+++ b/parachain/src/wasm_executor/mod.rs
@@ -143,7 +143,6 @@ pub fn validate_candidate<E: Externalities + 'static>(
 /// The host functions provided by the wasm executor to the parachain wasm blob.
 type HostFunctions = (
 	sp_io::SubstrateHostFunctions,
-	sc_executor::deprecated_host_interface::SubstrateExternals,
 	crate::wasm_api::parachain::HostFunctions,
 );
 


### PR DESCRIPTION
https://github.com/paritytech/substrate/pull/4818 introduces `commit` and `wipe` externalities for the DB.

This resolves an error which complains these functions are not implemented in Polkadot.

https://github.com/paritytech/substrate/pull/5038/ removes `deprecated_host_interface`, and this does the same.