### PR TITLE
Fix the browser light client

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -40,6 +40,7 @@ rocksdb = [ "service/rocksdb" ]
 cli = [
 	"tokio",
 	"sc-cli",
+	"service/full-node",
 ]
 browser = [
 	"wasm-bindgen",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -5,6 +5,11 @@ authors = ["Parity Technologies <admin@parity.io>"]
 description = "Polkadot node implementation in Rust."
 edition = "2018"
 
+[package.metadata.wasm-pack.profile.release]
+# `wasm-opt` has some problems on linux, see
+# https://github.com/rustwasm/wasm-pack/issues/781 etc.
+wasm-opt = false
+
 [lib]
 crate-type = ["cdylib", "rlib"]
 

--- a/cli/src/browser.rs
+++ b/cli/src/browser.rs
@@ -57,7 +57,7 @@ async fn start_inner(chain_spec: String, wasm_ext: browser_utils::Transport) -> 
 	info!("Roles: {:?}", config.roles);
 
 	// Create the service. This is the most heavy initialization step.
-	let service = service::kusama_new_light(config, None).map_err(|e| format!("{:?}", e))?;
+	let service = service::kusama_new_light(config).map_err(|e| format!("{:?}", e))?;
 
 	Ok(browser_utils::start_client(service))
 }

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -12,12 +12,9 @@ log = "0.4.8"
 futures = "0.3.4"
 slog = "2.5.2"
 hex-literal = "0.2.1"
-av_store = { package = "polkadot-availability-store", path = "../availability-store" }
-consensus = { package = "polkadot-validation", path = "../validation" }
 polkadot-primitives = { path = "../primitives" }
 polkadot-runtime = { path = "../runtime/polkadot" }
 kusama-runtime = { path = "../runtime/kusama" }
-polkadot-network = { path = "../network"  }
 polkadot-rpc = { path = "../rpc" }
 sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
 sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
@@ -53,6 +50,11 @@ codec = { package = "parity-scale-codec", version = "1.1.0" }
 sp-session = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
 sp-offchain = { package = "sp-offchain", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
 prometheus-endpoint = { package = "substrate-prometheus-endpoint", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+
+[target.'cfg(not(target_os = "unknown"))'.dependencies]
+av_store = { package = "polkadot-availability-store", path = "../availability-store" }
+consensus = { package = "polkadot-validation", path = "../validation" }
+polkadot-network = { path = "../network"  }
 
 [features]
 default = ["rocksdb"]

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -12,9 +12,12 @@ log = "0.4.8"
 futures = "0.3.4"
 slog = "2.5.2"
 hex-literal = "0.2.1"
+av_store = { package = "polkadot-availability-store", path = "../availability-store", optional = true }
+consensus = { package = "polkadot-validation", path = "../validation", optional = true }
 polkadot-primitives = { path = "../primitives" }
 polkadot-runtime = { path = "../runtime/polkadot" }
 kusama-runtime = { path = "../runtime/kusama" }
+polkadot-network = { path = "../network", optional = true }
 polkadot-rpc = { path = "../rpc" }
 sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
 sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
@@ -51,11 +54,7 @@ sp-session = { git = "https://github.com/paritytech/substrate", branch = "polkad
 sp-offchain = { package = "sp-offchain", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
 prometheus-endpoint = { package = "substrate-prometheus-endpoint", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
 
-[target.'cfg(not(target_os = "unknown"))'.dependencies]
-av_store = { package = "polkadot-availability-store", path = "../availability-store" }
-consensus = { package = "polkadot-validation", path = "../validation" }
-polkadot-network = { path = "../network"  }
-
 [features]
-default = ["rocksdb"]
+default = ["rocksdb", "full-node"]
 rocksdb = ["service/rocksdb"]
+full-node = ["av_store", "consensus", "polkadot-network"]

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -22,8 +22,8 @@ use sc_client::LongestChain;
 use std::sync::Arc;
 use std::time::Duration;
 use polkadot_primitives::{parachain, Hash, BlockId, AccountId, Nonce, Balance};
-use polkadot_network::legacy::gossip::Known;
-use polkadot_network::protocol as network_protocol;
+#[cfg(not(target_os = "unknown"))]
+use polkadot_network::{legacy::gossip::Known, protocol as network_protocol};
 use service::{error::{Error as ServiceError}, ServiceBuilder};
 use grandpa::{self, FinalityProofProvider as GrandpaFinalityProofProvider};
 use inherents::InherentDataProviders;
@@ -206,6 +206,7 @@ where
 }
 
 /// Create a new Polkadot service for a full node.
+#[cfg(not(target_os = "unknown"))]
 pub fn polkadot_new_full(
 	config: Configuration,
 	collating_for: Option<(CollatorId, parachain::Id)>,
@@ -228,6 +229,7 @@ pub fn polkadot_new_full(
 }
 
 /// Create a new Kusama service for a full node.
+#[cfg(not(target_os = "unknown"))]
 pub fn kusama_new_full(
 	config: Configuration,
 	collating_for: Option<(CollatorId, parachain::Id)>,
@@ -251,12 +253,14 @@ pub fn kusama_new_full(
 
 /// Handles to other sub-services that full nodes instantiate, which consumers
 /// of the node may use.
+#[cfg(not(target_os = "unknown"))]
 pub struct FullNodeHandles {
 	/// A handle to the Polkadot networking protocol.
 	pub polkadot_network: Option<network_protocol::Service>,
 }
 
 /// Builds a new service for a full client.
+#[cfg(not(target_os = "unknown"))]
 pub fn new_full<Runtime, Dispatch, Extrinsic>(
 	mut config: Configuration,
 	collating_for: Option<(CollatorId, parachain::Id)>,

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -22,7 +22,7 @@ use sc_client::LongestChain;
 use std::sync::Arc;
 use std::time::Duration;
 use polkadot_primitives::{parachain, Hash, BlockId, AccountId, Nonce, Balance};
-#[cfg(not(target_os = "unknown"))]
+#[cfg(feature = "full-node")]
 use polkadot_network::{legacy::gossip::Known, protocol as network_protocol};
 use service::{error::{Error as ServiceError}, ServiceBuilder};
 use grandpa::{self, FinalityProofProvider as GrandpaFinalityProofProvider};
@@ -206,7 +206,7 @@ where
 }
 
 /// Create a new Polkadot service for a full node.
-#[cfg(not(target_os = "unknown"))]
+#[cfg(feature = "full-node")]
 pub fn polkadot_new_full(
 	config: Configuration,
 	collating_for: Option<(CollatorId, parachain::Id)>,
@@ -229,7 +229,7 @@ pub fn polkadot_new_full(
 }
 
 /// Create a new Kusama service for a full node.
-#[cfg(not(target_os = "unknown"))]
+#[cfg(feature = "full-node")]
 pub fn kusama_new_full(
 	config: Configuration,
 	collating_for: Option<(CollatorId, parachain::Id)>,
@@ -253,14 +253,14 @@ pub fn kusama_new_full(
 
 /// Handles to other sub-services that full nodes instantiate, which consumers
 /// of the node may use.
-#[cfg(not(target_os = "unknown"))]
+#[cfg(feature = "full-node")]
 pub struct FullNodeHandles {
 	/// A handle to the Polkadot networking protocol.
 	pub polkadot_network: Option<network_protocol::Service>,
 }
 
 /// Builds a new service for a full client.
-#[cfg(not(target_os = "unknown"))]
+#[cfg(feature = "full-node")]
 pub fn new_full<Runtime, Dispatch, Extrinsic>(
 	mut config: Configuration,
 	collating_for: Option<(CollatorId, parachain::Id)>,


### PR DESCRIPTION
A recent tokio update seems to not compile on `wasm32-unknown-unknown`. The easiest work around for this is to just not pull in things like `polkadot-validation` that we don't use in the light client anyway.