### PR TITLE
service/src/lib.rs: Pass Prometheus registry to authority discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ dependencies = [
  "dlmalloc 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-parachain 0.7.22",
- "sp-io 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-io 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "substrate-wasm-builder-runner 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -32,9 +32,9 @@ dependencies = [
  "polkadot-collator 0.7.22",
  "polkadot-parachain 0.7.22",
  "polkadot-primitives 0.7.22",
- "sc-client 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-client-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-core 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
@@ -1156,7 +1156,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "fork-tree"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1164,73 +1164,73 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
- "frame-support 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "frame-system 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime-interface 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-io 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime-interface 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "frame-executive"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
- "frame-support 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "frame-system 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-io 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "frame-metadata"
 version = "11.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "frame-support"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "bitmask 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "frame-metadata 11.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-support-procedural 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-metadata 11.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "frame-support-procedural 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "paste 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-arithmetic 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-state-machine 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-arithmetic 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-core 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-inherents 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-io 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-state-machine 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "tracing 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "frame-support-procedural"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
- "frame-support-procedural-tools 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support-procedural-tools 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1239,9 +1239,9 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
- "frame-support-procedural-tools-derive 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support-procedural-tools-derive 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1251,7 +1251,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1261,26 +1261,26 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
- "frame-support 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-version 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-io 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-version 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
@@ -2062,40 +2062,40 @@ name = "kusama-runtime"
 version = "0.7.22"
 dependencies = [
  "bitvec 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "frame-executive 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-support 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system-rpc-runtime-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-executive 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "frame-support 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "frame-system 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "frame-system-rpc-runtime-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "hex-literal 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsecp256k1 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-authority-discovery 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-authorship 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-babe 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-balances 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-collective 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-democracy 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-elections-phragmen 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-finality-tracker 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-grandpa 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-identity 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-im-online 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-indices 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-membership 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-nicks 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-offences 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-randomness-collective-flip 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-recovery 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-session 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-society 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-staking 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-staking-reward-curve 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-timestamp 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-transaction-payment 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-transaction-payment-rpc-runtime-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-treasury 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-utility 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-vesting 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "pallet-authority-discovery 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-authorship 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-babe 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-balances 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-collective 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-democracy 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-elections-phragmen 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-finality-tracker 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-grandpa 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-identity 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-im-online 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-indices 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-membership 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-nicks 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-offences 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-randomness-collective-flip 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-recovery 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-session 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-society 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-staking 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-staking-reward-curve 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-timestamp 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-transaction-payment 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-transaction-payment-rpc-runtime-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-treasury 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-utility 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-vesting 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-parachain 0.7.22",
  "polkadot-primitives 0.7.22",
@@ -2104,22 +2104,22 @@ dependencies = [
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-authority-discovery 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-block-builder 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus-babe 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-keyring 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-offchain 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-session 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-staking 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-transaction-pool 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-trie 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-version 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-authority-discovery 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-block-builder 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-consensus-babe 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-core 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-inherents 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-io 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-keyring 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-offchain 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-session 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-staking 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-transaction-pool 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-trie 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-version 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "substrate-wasm-builder-runner 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "trie-db 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3004,328 +3004,328 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
- "frame-support 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-session 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "frame-system 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-session 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-application-crypto 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-authority-discovery 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-application-crypto 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-authority-discovery 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-core 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-io 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-authorship"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
- "frame-support 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "frame-system 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-authorship 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-authorship 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-core 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-inherents 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-io 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-babe"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
- "frame-support 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "frame-system 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "hex-literal 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-session 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-timestamp 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "pallet-session 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-timestamp 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-consensus-babe 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-staking 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-timestamp 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-consensus-babe 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-inherents 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-io 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-staking 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-timestamp 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-balances"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
- "frame-benchmarking 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-support 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-benchmarking 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "frame-support 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "frame-system 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-io 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-collective"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
- "frame-support 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "frame-system 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-io 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-democracy"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
- "frame-support 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "frame-system 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-io 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-elections-phragmen"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
- "frame-support 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "frame-system 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-phragmen 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-phragmen 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-finality-tracker"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
- "frame-support 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "frame-system 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-finality-tracker 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-finality-tracker 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-inherents 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-grandpa"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
- "frame-support 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-finality-tracker 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-session 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "frame-system 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-finality-tracker 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-session 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-finality-grandpa 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-staking 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-finality-grandpa 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-staking 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-identity"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "enumflags2 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "frame-benchmarking 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-support 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-benchmarking 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "frame-support 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "frame-system 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-io 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-im-online"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
- "frame-support 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-authorship 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-session 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "frame-system 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-authorship 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-session 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-application-crypto 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-staking 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-application-crypto 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-core 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-io 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-staking 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-indices"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
- "frame-support 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "frame-system 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-keyring 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-io 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-keyring 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-membership"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
- "frame-support 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "frame-system 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-io 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-nicks"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
- "frame-support 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "frame-system 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-io 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-offences"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
- "frame-support 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-balances 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "frame-system 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-balances 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-staking 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-staking 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
- "frame-support 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "frame-system 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-recovery"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "enumflags2 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "frame-support 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "frame-system 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-io 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-session"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
- "frame-support 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "frame-system 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-timestamp 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "pallet-timestamp 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-staking 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-trie 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-io 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-staking 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-trie 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-society"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
- "frame-support 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "frame-system 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-io 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-staking"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
- "frame-support 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-authorship 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-session 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "frame-system 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-authorship 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-session 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-keyring 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-phragmen 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-staking 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-io 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-keyring 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-phragmen 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-staking 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3336,120 +3336,120 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
- "frame-support 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "frame-system 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-io 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-timestamp"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
- "frame-benchmarking 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-support 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-benchmarking 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "frame-support 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "frame-system 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-inherents 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-timestamp 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-inherents 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-timestamp 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-transaction-payment"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
- "frame-support 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-transaction-payment-rpc-runtime-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "frame-system 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-transaction-payment-rpc-runtime-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "jsonrpc-core 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core-client 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-derive 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-transaction-payment-rpc-runtime-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "pallet-transaction-payment-rpc-runtime-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-rpc 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-blockchain 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-core 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-rpc 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
- "frame-support 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-treasury"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
- "frame-support 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-balances 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "frame-system 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-balances 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-utility"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
- "frame-support 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "frame-system 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-io 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "pallet-vesting"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "enumflags2 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "frame-support 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "frame-system 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-io 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
@@ -3750,15 +3750,15 @@ dependencies = [
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-erasure-coding 0.7.22",
  "polkadot-primitives 0.7.22",
- "sc-client 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-keystore 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-network 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-client-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-keystore 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-network 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-blockchain 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-consensus 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-core 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3769,16 +3769,16 @@ dependencies = [
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-service 0.7.22",
- "sc-cli 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client-db 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-executor 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-cli 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-client 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-client-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-client-db 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-executor 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-core 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "structopt 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "substrate-browser-utils 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "substrate-browser-utils 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-futures 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3797,16 +3797,16 @@ dependencies = [
  "polkadot-primitives 0.7.22",
  "polkadot-service 0.7.22",
  "polkadot-validation 0.7.22",
- "sc-cli 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-network 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-keyring 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-cli 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-client 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-client-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-network 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-blockchain 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-consensus 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-core 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-keyring 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3818,8 +3818,8 @@ dependencies = [
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-primitives 0.7.22",
  "reed-solomon-erasure 4.0.0 (git+https://github.com/paritytech/reed-solomon-erasure)",
- "sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-trie 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-trie 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
@@ -3839,15 +3839,15 @@ dependencies = [
  "polkadot-erasure-coding 0.7.22",
  "polkadot-primitives 0.7.22",
  "polkadot-validation 0.7.22",
- "sc-client 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-network 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-network-gossip 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-keyring 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-state-machine 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-network 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-network-gossip 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-blockchain 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-core 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-keyring 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-state-machine 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "wasm-timer 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3862,15 +3862,15 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-executor 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-executor 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "shared_memory 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-externalities 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime-interface 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-wasm-interface 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-externalities 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-io 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime-interface 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-wasm-interface 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3879,20 +3879,20 @@ name = "polkadot-primitives"
 version = "0.7.22"
 dependencies = [
  "bitvec 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-babe 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "pallet-babe 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-parachain 0.7.22",
  "pretty_assertions 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-application-crypto 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-serializer 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-trie 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-version 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-application-crypto 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-core 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-inherents 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-serializer 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-trie 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-version 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
@@ -3900,15 +3900,15 @@ name = "polkadot-rpc"
 version = "0.7.22"
 dependencies = [
  "jsonrpc-core 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-transaction-payment-rpc 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "pallet-transaction-payment-rpc 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-primitives 0.7.22",
- "sc-client 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-rpc 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-transaction-pool 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "substrate-frame-rpc-system 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-rpc 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-transaction-pool 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "substrate-frame-rpc-system 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
@@ -3916,38 +3916,38 @@ name = "polkadot-runtime"
 version = "0.7.22"
 dependencies = [
  "bitvec 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "frame-executive 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-support 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system-rpc-runtime-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-executive 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "frame-support 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "frame-system 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "frame-system-rpc-runtime-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "hex-literal 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsecp256k1 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-authority-discovery 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-authorship 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-babe 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-balances 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-collective 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-democracy 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-elections-phragmen 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-finality-tracker 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-grandpa 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-identity 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-im-online 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-indices 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-membership 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-nicks 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-offences 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-randomness-collective-flip 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-session 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-staking 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-staking-reward-curve 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-sudo 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-timestamp 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-transaction-payment 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-transaction-payment-rpc-runtime-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-treasury 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-vesting 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "pallet-authority-discovery 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-authorship 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-babe 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-balances 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-collective 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-democracy 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-elections-phragmen 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-finality-tracker 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-grandpa 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-identity 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-im-online 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-indices 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-membership 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-nicks 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-offences 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-randomness-collective-flip 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-session 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-staking 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-staking-reward-curve 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-sudo 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-timestamp 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-transaction-payment 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-transaction-payment-rpc-runtime-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-treasury 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-vesting 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-parachain 0.7.22",
  "polkadot-primitives 0.7.22",
@@ -3956,21 +3956,21 @@ dependencies = [
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-authority-discovery 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-block-builder 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus-babe 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-keyring 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-offchain 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-session 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-staking 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-transaction-pool 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-trie 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-version 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-authority-discovery 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-block-builder 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-consensus-babe 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-core 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-inherents 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-keyring 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-offchain 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-session 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-staking 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-transaction-pool 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-trie 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-version 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "substrate-wasm-builder-runner 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "trie-db 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3981,21 +3981,21 @@ name = "polkadot-runtime-common"
 version = "0.7.22"
 dependencies = [
  "bitvec 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "frame-support 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "frame-system 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-support 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "frame-system 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "hex-literal 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsecp256k1 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-authorship 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-babe 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-balances 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-randomness-collective-flip 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-session 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-staking 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-staking-reward-curve 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-timestamp 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-treasury 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-vesting 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "pallet-authorship 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-babe 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-balances 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-randomness-collective-flip 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-session 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-staking 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-staking-reward-curve 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-timestamp 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-treasury 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-vesting 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-parachain 0.7.22",
  "polkadot-primitives 0.7.22",
@@ -4003,15 +4003,15 @@ dependencies = [
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-keyring 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-staking 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-trie 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-core 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-inherents 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-io 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-keyring 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-staking 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-trie 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "trie-db 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -4020,16 +4020,16 @@ dependencies = [
 name = "polkadot-service"
 version = "0.7.22"
 dependencies = [
- "frame-system-rpc-runtime-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-system-rpc-runtime-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-literal 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "kusama-runtime 0.7.22",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-babe 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-im-online 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-staking 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "pallet-transaction-payment-rpc-runtime-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "pallet-babe 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-im-online 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-staking 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "pallet-transaction-payment-rpc-runtime-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-availability-store 0.7.22",
@@ -4038,36 +4038,36 @@ dependencies = [
  "polkadot-rpc 0.7.22",
  "polkadot-runtime 0.7.22",
  "polkadot-validation 0.7.22",
- "sc-authority-discovery 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-chain-spec 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client-db 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-consensus-babe 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-executor 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-finality-grandpa 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-keystore 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-network 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-service 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-telemetry 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-transaction-pool 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-authority-discovery 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-chain-spec 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-client 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-client-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-client-db 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-consensus-babe 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-executor 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-finality-grandpa 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-keystore 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-network 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-service 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-telemetry 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-transaction-pool 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-authority-discovery 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-block-builder 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus-babe 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-finality-grandpa 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-offchain 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-session 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-transaction-pool 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "substrate-prometheus-endpoint 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-authority-discovery 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-block-builder 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-blockchain 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-consensus 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-consensus-babe 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-core 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-finality-grandpa 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-inherents 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-io 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-offchain 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-session 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-transaction-pool 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "substrate-prometheus-endpoint 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
@@ -4076,7 +4076,7 @@ version = "0.7.22"
 dependencies = [
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-primitives 0.7.22",
- "sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
@@ -4089,7 +4089,7 @@ dependencies = [
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-timer 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-babe 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "pallet-babe 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "polkadot-availability-store 0.7.22",
@@ -4097,21 +4097,21 @@ dependencies = [
  "polkadot-parachain 0.7.22",
  "polkadot-primitives 0.7.22",
  "polkadot-statement-table 0.7.22",
- "sc-block-builder 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-finality-grandpa 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-keystore 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus-babe 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-keyring 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-timestamp 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-transaction-pool 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-trie 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-block-builder 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-client-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-finality-grandpa 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-keystore 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-blockchain 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-consensus 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-consensus-babe 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-core 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-inherents 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-keyring 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-timestamp 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-transaction-pool 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-trie 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -4732,7 +4732,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.8.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4744,52 +4744,53 @@ dependencies = [
  "prost 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-build 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-keystore 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-network 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-keystore 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-network 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-authority-discovery 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-authority-discovery 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-blockchain 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-core 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "substrate-prometheus-endpoint 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "sc-block-builder"
 version = "0.8.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-block-builder 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-state-machine 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-block-builder 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-blockchain 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-consensus 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-core 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-state-machine 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "sc-chain-spec"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-chain-spec-derive 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-network 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-telemetry 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-chain-spec-derive 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-network 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-telemetry 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "sc-chain-spec-derive"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4800,7 +4801,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.8.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "ansi_term 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "app_dirs 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4817,21 +4818,21 @@ dependencies = [
  "parity-util-mem 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rpassword 4.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-informant 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-network 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-service 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-telemetry 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-tracing 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-informant 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-network 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-service 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-telemetry 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-tracing 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-blockchain 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-keyring 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-panic-handler 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-state-machine 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-blockchain 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-core 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-keyring 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-panic-handler 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-state-machine 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "structopt 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "substrate-prometheus-endpoint 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "substrate-prometheus-endpoint 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -4839,7 +4840,7 @@ dependencies = [
 [[package]]
 name = "sc-client"
 version = "0.8.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4850,30 +4851,30 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-block-builder 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-executor 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-telemetry 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-externalities 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-keyring 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-state-machine 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-trie 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-version 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "substrate-prometheus-endpoint 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-block-builder 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-client-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-executor 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-telemetry 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-blockchain 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-consensus 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-core 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-externalities 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-inherents 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-keyring 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-state-machine 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-trie 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-version 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "substrate-prometheus-endpoint 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "tracing 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sc-client-api"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4884,28 +4885,28 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-executor 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-telemetry 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-externalities 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-keyring 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-state-machine 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-storage 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-transaction-pool 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-trie 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-version 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-executor 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-telemetry 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-blockchain 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-consensus 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-core 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-externalities 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-inherents 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-keyring 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-state-machine 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-storage 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-transaction-pool 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-trie 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-version 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "sc-client-db"
 version = "0.8.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "kvdb 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4917,26 +4918,26 @@ dependencies = [
  "parity-util-mem 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-executor 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-state-db 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-state-machine 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-trie 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "substrate-prometheus-endpoint 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-client-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-executor 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-state-db 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-blockchain 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-consensus 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-core 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-state-machine 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-trie 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "substrate-prometheus-endpoint 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "sc-consensus-babe"
 version = "0.8.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "fork-tree 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "fork-tree 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-timer 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4948,81 +4949,81 @@ dependencies = [
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pdqselect 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-consensus-epochs 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-consensus-slots 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-consensus-uncles 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-keystore 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-telemetry 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-client-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-consensus-epochs 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-consensus-slots 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-consensus-uncles 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-keystore 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-telemetry 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "schnorrkel 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-application-crypto 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-block-builder 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus-babe 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-timestamp 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-version 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-application-crypto 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-block-builder 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-blockchain 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-consensus 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-consensus-babe 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-core 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-inherents 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-io 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-timestamp 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-version 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.8.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
- "fork-tree 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "fork-tree 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-blockchain 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "sc-consensus-slots"
 version = "0.8.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-timer 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-telemetry 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-state-machine 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-telemetry 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-blockchain 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-consensus 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-core 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-inherents 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-state-machine 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "sc-consensus-uncles"
 version = "0.8.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-authorship 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-authorship 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-consensus 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-core 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-inherents 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "sc-executor"
 version = "0.8.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5031,78 +5032,78 @@ dependencies = [
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-wasm 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-executor-common 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-executor-wasmi 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-executor-wasmtime 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-externalities 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-panic-handler 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime-interface 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-serializer 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-trie 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-version 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-wasm-interface 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-executor-common 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-executor-wasmi 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-executor-wasmtime 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-core 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-externalities 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-io 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-panic-handler 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime-interface 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-serializer 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-trie 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-version 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-wasm-interface 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "wasmi 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sc-executor-common"
 version = "0.8.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-allocator 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime-interface 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-serializer 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-wasm-interface 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-allocator 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-core 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime-interface 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-serializer 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-wasm-interface 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "wasmi 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.8.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-wasm 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-executor-common 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-allocator 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime-interface 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-wasm-interface 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-executor-common 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-allocator 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-core 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime-interface 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-wasm-interface 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "wasmi 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.8.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-wasm 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-executor-common 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-executor-common 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "scoped-tls 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-allocator 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime-interface 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-wasm-interface 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-allocator 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-core 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime-interface 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-wasm-interface 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "wasmtime 0.12.0 (git+https://github.com/paritytech/wasmtime?branch=a-thread-safe-api)",
 ]
 
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.8.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "finality-grandpa 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fork-tree 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "fork-tree 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-timer 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5110,62 +5111,62 @@ dependencies = [
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-block-builder 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-keystore 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-network 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-network-gossip 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-telemetry 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-block-builder 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-client 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-client-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-keystore 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-network 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-network-gossip 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-telemetry 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-arithmetic 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-finality-grandpa 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-finality-tracker 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "substrate-prometheus-endpoint 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-arithmetic 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-blockchain 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-consensus 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-core 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-finality-grandpa 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-finality-tracker 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-inherents 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "substrate-prometheus-endpoint 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "sc-informant"
 version = "0.8.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "ansi_term 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-util-mem 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-network 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-service 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-network 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-service 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-blockchain 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "wasm-timer 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sc-keystore"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-application-crypto 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-application-crypto 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-core 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "subtle 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sc-network"
 version = "0.8.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5173,7 +5174,7 @@ dependencies = [
  "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "erased-serde 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "fork-tree 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "fork-tree 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-timer 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures_codec 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5190,22 +5191,22 @@ dependencies = [
  "prost-build 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-block-builder 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-peerset 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-block-builder 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-client 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-client-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-peerset 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog_derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-arithmetic 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus-babe 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "substrate-prometheus-endpoint 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-arithmetic 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-blockchain 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-consensus 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-consensus-babe 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-core 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "substrate-prometheus-endpoint 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "thiserror 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "unsigned-varint 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5216,7 +5217,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.8.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-timer 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5224,15 +5225,15 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-network 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-network 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "wasm-timer 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sc-offchain"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5245,20 +5246,20 @@ dependencies = [
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-keystore 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-network 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-offchain 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-keystore 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-network 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-core 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-offchain 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sc-peerset"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "libp2p 0.16.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5270,7 +5271,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5279,28 +5280,28 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-executor 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-keystore 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-rpc-api 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-client-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-executor 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-keystore 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-rpc-api 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-offchain 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-rpc 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-session 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-state-machine 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-transaction-pool 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-version 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-blockchain 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-core 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-offchain 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-rpc 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-session 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-state-machine 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-transaction-pool 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-version 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "sc-rpc-api"
 version = "0.8.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5313,17 +5314,17 @@ dependencies = [
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-rpc 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-transaction-pool 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-version 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-rpc 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-transaction-pool 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-version 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "sc-rpc-server"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "jsonrpc-core 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-http-server 14.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5332,13 +5333,13 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "sc-service"
 version = "0.8.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "exit-future 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5352,32 +5353,32 @@ dependencies = [
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-util-mem 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-chain-spec 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-client-db 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-executor 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-keystore 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-network 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-offchain 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-rpc 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-rpc-server 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-telemetry 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-tracing 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-transaction-pool 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-chain-spec 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-client 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-client-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-client-db 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-executor 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-keystore 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-network 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-offchain 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-rpc 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-rpc-server 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-telemetry 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-tracing 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-transaction-pool 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-application-crypto 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-session 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-transaction-pool 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "substrate-prometheus-endpoint 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-application-crypto 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-blockchain 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-consensus 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-core 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-io 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-session 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-transaction-pool 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "substrate-prometheus-endpoint 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "sysinfo 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "target_info 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5387,21 +5388,21 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.8.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-util-mem 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-util-mem-derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-core 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "sc-telemetry"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5423,12 +5424,12 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "erased-serde 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-telemetry 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-telemetry 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5438,7 +5439,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-graph"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5447,17 +5448,17 @@ dependencies = [
  "parity-util-mem 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-blockchain 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-transaction-pool 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-blockchain 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-core 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-transaction-pool 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "wasm-timer 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sc-transaction-pool"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5467,13 +5468,13 @@ dependencies = [
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-util-mem 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-transaction-graph 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-transaction-pool 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-transaction-graph 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-blockchain 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-core 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-transaction-pool 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "wasm-timer 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -5806,34 +5807,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "sp-allocator"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-wasm-interface 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-wasm-interface 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-api"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api-proc-macro 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-state-machine 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-version 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api-proc-macro 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-core 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-state-machine 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-version 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-api-proc-macro"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5845,83 +5846,83 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-io 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-arithmetic"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "integer-sqrt 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-debug-derive 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-debug-derive 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-authority-discovery"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-application-crypto 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-application-crypto 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-authorship"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-inherents 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-inherents 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-block-builder"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-inherents 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-blockchain"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-block-builder 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-state-machine 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-block-builder 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-consensus 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-state-machine 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-consensus"
 version = "0.8.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5932,34 +5933,34 @@ dependencies = [
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-state-machine 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-version 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-inherents 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-state-machine 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-version 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-consensus-babe"
 version = "0.8.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "schnorrkel 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-application-crypto 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-consensus 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-timestamp 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-application-crypto 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-consensus 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-inherents 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-timestamp 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-core"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "base58 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5983,11 +5984,11 @@ dependencies = [
  "schnorrkel 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-debug-derive 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-externalities 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime-interface 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-storage 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-debug-derive 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-externalities 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime-interface 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-storage 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "substrate-bip39 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-bip39 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5999,7 +6000,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6009,90 +6010,90 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.8.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "environmental 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-storage 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-storage 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-finality-grandpa"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-application-crypto 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-application-crypto 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-finality-tracker"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-inherents 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-inherents 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-inherents"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-io"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsecp256k1 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-externalities 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime-interface 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-state-machine 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-trie 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-wasm-interface 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-externalities 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime-interface 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-state-machine 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-trie 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-wasm-interface 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-keyring"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "strum 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sp-offchain"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
- "sp-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-panic-handler"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "backtrace 0.3.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6101,26 +6102,26 @@ dependencies = [
 [[package]]
 name = "sp-phragmen"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-rpc"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-runtime"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "hash256-std-hasher 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6130,32 +6131,32 @@ dependencies = [
  "paste 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-application-crypto 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-arithmetic 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-io 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-application-crypto 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-arithmetic 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-core 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-inherents 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-io 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-runtime-interface"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "primitive-types 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-externalities 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime-interface-proc-macro 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-wasm-interface 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-externalities 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime-interface-proc-macro 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-wasm-interface 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "Inflector 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6167,7 +6168,7 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6176,28 +6177,28 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
- "sp-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-core 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-staking"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-state-machine"
 version = "0.8.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6205,10 +6206,10 @@ dependencies = [
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-externalities 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-panic-handler 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-trie 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-externalities 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-panic-handler 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-trie 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "trie-db 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "trie-root 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -6216,57 +6217,57 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 
 [[package]]
 name = "sp-storage"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "impl-serde 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-debug-derive 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-debug-derive 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-timestamp"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-inherents 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-inherents 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "wasm-timer 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sp-transaction-pool"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-trie"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "memory-db 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-core 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "trie-db 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "trie-root 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -6274,23 +6275,23 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "impl-serde 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "sp-wasm-interface"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "wasmi 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -6393,7 +6394,7 @@ dependencies = [
 [[package]]
 name = "substrate-browser-utils"
 version = "0.8.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6408,10 +6409,10 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-chain-spec 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-informant 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-network 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sc-service 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-chain-spec 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-informant 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-network 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sc-service 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "wasm-bindgen 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-futures 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -6419,28 +6420,28 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "2.0.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
- "frame-system-rpc-runtime-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "frame-system-rpc-runtime-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core-client 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-derive 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sc-client 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sc-client 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-blockchain 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
- "sp-transaction-pool 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)",
+ "sp-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-blockchain 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-core 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
+ "sp-transaction-pool 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)",
 ]
 
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.8.0-alpha.3"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-master#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
+source = "git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master#eeaccbff52c429ca0000a356b9b69238668a1da1"
 dependencies = [
  "async-std 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -7713,16 +7714,16 @@ dependencies = [
 "checksum fixedbitset 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 "checksum flate2 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6bd6d6f4752952feb71363cffc9ebac9411b75b87c6ab6058c40c8900cf43c0f"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
-"checksum fork-tree 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum frame-benchmarking 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum frame-executive 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum frame-metadata 11.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum frame-support 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum frame-support-procedural 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum frame-support-procedural-tools 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum frame-support-procedural-tools-derive 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum frame-system 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum frame-system-rpc-runtime-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
+"checksum fork-tree 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum frame-benchmarking 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum frame-executive 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum frame-metadata 11.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum frame-support 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum frame-support-procedural 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum frame-support-procedural-tools 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum frame-support-procedural-tools-derive 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum frame-system 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum frame-system-rpc-runtime-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
 "checksum fs-swap 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "921d332c89b3b61a826de38c61ee5b6e02c56806cade1b0e5d81bd71f57a71bb"
 "checksum fs_extra 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5f2a4a2034423744d2cc7ca2068453168dcdb82c438419e639a26bd87839c674"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
@@ -7880,35 +7881,35 @@ dependencies = [
 "checksum opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 "checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 "checksum owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
-"checksum pallet-authority-discovery 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-authorship 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-babe 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-balances 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-collective 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-democracy 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-elections-phragmen 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-finality-tracker 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-grandpa 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-identity 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-im-online 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-indices 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-membership 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-nicks 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-offences 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-randomness-collective-flip 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-recovery 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-session 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-society 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-staking 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-staking-reward-curve 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-sudo 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-timestamp 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-transaction-payment 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-transaction-payment-rpc 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-transaction-payment-rpc-runtime-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-treasury 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-utility 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum pallet-vesting 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
+"checksum pallet-authority-discovery 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum pallet-authorship 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum pallet-babe 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum pallet-balances 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum pallet-collective 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum pallet-democracy 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum pallet-elections-phragmen 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum pallet-finality-tracker 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum pallet-grandpa 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum pallet-identity 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum pallet-im-online 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum pallet-indices 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum pallet-membership 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum pallet-nicks 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum pallet-offences 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum pallet-randomness-collective-flip 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum pallet-recovery 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum pallet-session 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum pallet-society 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum pallet-staking 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum pallet-staking-reward-curve 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum pallet-sudo 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum pallet-timestamp 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum pallet-transaction-payment 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum pallet-transaction-payment-rpc 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum pallet-transaction-payment-rpc-runtime-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum pallet-treasury 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum pallet-utility 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum pallet-vesting 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
 "checksum parity-bytes 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0c276d76c5333b8c2579e02d49a06733a55b8282d2d9b13e8d53b6406bd7e30a"
 "checksum parity-multiaddr 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "045b3c7af871285146300da35b1932bb6e4639b66c7c98e85d06a32cbc4e8fa7"
 "checksum parity-multiaddr 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f77055f9e81921a8cc7bebeb6cded3d128931d51f1e3dd6251f0770a6d431477"
@@ -8006,38 +8007,38 @@ dependencies = [
 "checksum safe-mix 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6d3d055a2582e6b00ed7a31c1524040aa391092bf636328350813f3a0605215c"
 "checksum salsa20 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2324b0e8c3bb9a586a571fdb3136f70e7e2c748de00a78043f86e0cff91f91fe"
 "checksum salsa20-core 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2fe6cc1b9f5a5867853ade63099de70f042f7679e408d1ffe52821c9248e6e69"
-"checksum sc-authority-discovery 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-block-builder 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-chain-spec 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-chain-spec-derive 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-cli 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-client 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-client-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-client-db 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-consensus-babe 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-consensus-epochs 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-consensus-slots 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-consensus-uncles 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-executor 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-executor-common 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-executor-wasmi 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-executor-wasmtime 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-finality-grandpa 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-informant 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-keystore 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-network 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-network-gossip 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-offchain 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-peerset 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-rpc 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-rpc-api 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-rpc-server 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-service 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-state-db 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-telemetry 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-tracing 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-transaction-graph 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sc-transaction-pool 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
+"checksum sc-authority-discovery 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sc-block-builder 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sc-chain-spec 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sc-chain-spec-derive 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sc-cli 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sc-client 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sc-client-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sc-client-db 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sc-consensus-babe 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sc-consensus-epochs 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sc-consensus-slots 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sc-consensus-uncles 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sc-executor 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sc-executor-common 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sc-executor-wasmi 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sc-executor-wasmtime 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sc-finality-grandpa 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sc-informant 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sc-keystore 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sc-network 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sc-network-gossip 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sc-offchain 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sc-peerset 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sc-rpc 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sc-rpc-api 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sc-rpc-server 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sc-service 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sc-state-db 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sc-telemetry 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sc-tracing 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sc-transaction-graph 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sc-transaction-pool 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
 "checksum schannel 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "507a9e6e8ffe0a4e0ebb9a10293e62fdf7657c06f1b8bb07a8fcf697d2abf295"
 "checksum schnorrkel 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)" = "eacd8381b3c37840c9c9f40472af529e49975bdcbc24f83c31059fd6539023d3"
 "checksum scoped-tls 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
@@ -8074,43 +8075,43 @@ dependencies = [
 "checksum snow 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "afb767eee7d257ba202f0b9b08673bc13b22281632ef45267b19f13100accd2f"
 "checksum soketto 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1c9dab3f95c9ebdf3a88268c19af668f637a3c5039c2c56ff2d40b1b2d64a25b"
 "checksum sourcefile 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf77cb82ba8453b42b6ae1d692e4cdc92f9a47beaf89a847c8be83f4e328ad3"
-"checksum sp-allocator 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-api 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-api-proc-macro 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-application-crypto 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-arithmetic 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-authority-discovery 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-authorship 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-block-builder 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-blockchain 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-consensus 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-consensus-babe 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-core 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-debug-derive 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-externalities 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-finality-grandpa 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-finality-tracker 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-inherents 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-io 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-keyring 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-offchain 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-panic-handler 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-phragmen 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-rpc 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-runtime-interface 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-runtime-interface-proc-macro 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-serializer 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-session 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-staking 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-state-machine 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-std 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-storage 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-timestamp 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-transaction-pool 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-trie 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-version 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum sp-wasm-interface 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
+"checksum sp-allocator 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sp-api 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sp-api-proc-macro 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sp-application-crypto 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sp-arithmetic 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sp-authority-discovery 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sp-authorship 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sp-block-builder 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sp-blockchain 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sp-consensus 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sp-consensus-babe 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sp-core 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sp-debug-derive 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sp-externalities 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sp-finality-grandpa 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sp-finality-tracker 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sp-inherents 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sp-io 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sp-keyring 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sp-offchain 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sp-panic-handler 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sp-phragmen 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sp-rpc 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sp-runtime 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sp-runtime-interface 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sp-runtime-interface-proc-macro 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sp-serializer 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sp-session 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sp-staking 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sp-state-machine 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sp-std 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sp-storage 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sp-timestamp 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sp-transaction-pool 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sp-trie 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sp-version 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum sp-wasm-interface 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
 "checksum spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
@@ -8123,9 +8124,9 @@ dependencies = [
 "checksum strum 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6138f8f88a16d90134763314e3fc76fa3ed6a7db4725d6acf9a3ef95a3188d22"
 "checksum strum_macros 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0054a7df764039a6cd8592b9de84be4bec368ff081d203a7d5371cbfa8e65c81"
 "checksum substrate-bip39 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3be511be555a3633e71739a79e4ddff6a6aaa6579fa6114182a51d72c3eb93c5"
-"checksum substrate-browser-utils 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum substrate-frame-rpc-system 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
-"checksum substrate-prometheus-endpoint 0.8.0-alpha.3 (git+https://github.com/paritytech/substrate?branch=polkadot-master)" = "<none>"
+"checksum substrate-browser-utils 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum substrate-frame-rpc-system 2.0.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
+"checksum substrate-prometheus-endpoint 0.8.0-alpha.3 (git+https://github.com/mxinden/substrate?branch=authority-discovery-prometheus-polkadot-master)" = "<none>"
 "checksum substrate-wasm-builder-runner 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e30c70de7e7d5fd404fe26db1e7a4d6b553e2760b1ac490f249c04a960c483b8"
 "checksum subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 "checksum subtle 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7c65d530b10ccaeac294f349038a597e435b18fb456aadd0840a623f83b9e941"

--- a/availability-store/Cargo.toml
+++ b/availability-store/Cargo.toml
@@ -15,15 +15,15 @@ futures = "0.3.4"
 tokio = { version = "0.2.10", features = ["rt-core"] }
 exit-future = "0.2.0"
 codec = { package = "parity-scale-codec", version = "1.1.0", features = ["derive"] }
-sc-network = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-consensus_common = { package = "sp-consensus", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-client = { package = "sc-client-api", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sc-client = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-keystore = { package = "sc-keystore", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+sc-network = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+consensus_common = { package = "sp-consensus", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+client = { package = "sc-client-api", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+sc-client = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+sp-runtime = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+sp-blockchain = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+sp-api = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+keystore = { package = "sc-keystore", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+sp-core = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
 kvdb = "0.4.0"
 kvdb-memorydb = "0.4.0"
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -12,21 +12,21 @@ crate-type = ["cdylib", "rlib"]
 log = "0.4.8"
 futures = { version = "0.3.4", features = ["compat"] }
 structopt = "0.3.8"
-sc-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", optional = true }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sc-client = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sc-client-db = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sc-executor = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+sc-cli = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", optional = true }
+sp-api = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+sp-core = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+sp-runtime = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+sc-client = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+sc-client-api = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+sc-client-db = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+sc-executor = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
 service = { package = "polkadot-service", path = "../service", default-features = false }
 
 tokio = { version = "0.2.10", features = ["rt-threaded"], optional = true }
 
 wasm-bindgen = { version = "0.2.57", optional = true }
 wasm-bindgen-futures = { version = "0.4.7", optional = true }
-browser-utils = { package = "substrate-browser-utils", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", optional = true }
+browser-utils = { package = "substrate-browser-utils", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", optional = true }
 
 [features]
 default = [ "wasmtime", "rocksdb", "cli" ]

--- a/collator/Cargo.toml
+++ b/collator/Cargo.toml
@@ -7,15 +7,15 @@ edition = "2018"
 
 [dependencies]
 futures = "0.3.4"
-sc-client = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sc-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sc-network = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-consensus_common = { package = "sp-consensus", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+sc-client = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+sc-cli = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+sc-client-api = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+sc-network = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+sp-blockchain = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+sp-api = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+sp-core = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+sp-runtime = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+consensus_common = { package = "sp-consensus", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
 polkadot-primitives = { path = "../primitives" }
 polkadot-cli = { path = "../cli" }
 polkadot-network = { path = "../network" }
@@ -27,4 +27,4 @@ futures-timer = "2.0"
 codec = { package = "parity-scale-codec", version = "1.1.0" }
 
 [dev-dependencies]
-keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+keyring = { package = "sp-keyring", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }

--- a/erasure-coding/Cargo.toml
+++ b/erasure-coding/Cargo.toml
@@ -8,6 +8,6 @@ edition = "2018"
 primitives = { package = "polkadot-primitives", path = "../primitives" }
 reed_solomon = { package = "reed-solomon-erasure", git = "https://github.com/paritytech/reed-solomon-erasure" }
 codec = { package = "parity-scale-codec", version = "1.1.0", default-features = false, features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-trie = { package = "sp-trie", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+sp-core = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+trie = { package = "sp-trie", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
 derive_more = "0.15.0"

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -15,19 +15,19 @@ polkadot-validation = { path = "../validation" }
 polkadot-primitives = { path = "../primitives" }
 polkadot-erasure-coding = { path = "../erasure-coding" }
 codec = { package = "parity-scale-codec", version = "1.1.0", default-features = false, features = ["derive"] }
-sc-network = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sc-network-gossip = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+sc-network = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+sc-network-gossip = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+sp-core = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+sp-runtime = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
 futures = "0.3.4"
 log = "0.4.8"
 exit-future = "0.2.0"
 futures-timer = "2.0"
-sc-client = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+sc-client = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+sp-blockchain = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+sp-api = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
 wasm-timer = "0.2.4"
 
 [dev-dependencies]
-sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-state-machine = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+sp-keyring = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+sp-state-machine = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }

--- a/parachain/Cargo.toml
+++ b/parachain/Cargo.toml
@@ -9,13 +9,13 @@ edition = "2018"
 codec = { package = "parity-scale-codec", version = "1.1.0", default-features = false, features = [ "derive" ] }
 derive_more = { version = "0.99.2", optional = true }
 serde = { version = "1.0.102", default-features = false, features = [ "derive" ], optional = true }
-rstd = { package = "sp-std", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sp-runtime-interface = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sp-wasm-interface = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sp-externalities = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", optional = true }
-sc-executor = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", optional = true }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", optional = true }
+rstd = { package = "sp-std", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+sp-core = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+sp-runtime-interface = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+sp-wasm-interface = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+sp-externalities = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", optional = true }
+sc-executor = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", optional = true }
+sp-io = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", optional = true }
 lazy_static = { version = "1.4.0", optional = true }
 parking_lot = { version = "0.10.0", optional = true }
 log = { version = "0.4.8", optional = true }

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -7,20 +7,20 @@ edition = "2018"
 [dependencies]
 serde = { version = "1.0.102", optional = true, features = ["derive"] }
 parity-scale-codec = { version = "1.1.0", default-features = false, features = ["bit-vec", "derive"] }
-primitives = { package = "sp-core", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-application-crypto = { package = "sp-application-crypto", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sp-version = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-rstd = { package = "sp-std", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-runtime_primitives = { package = "sp-runtime", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
+primitives = { package = "sp-core", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+inherents = { package = "sp-inherents", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+application-crypto = { package = "sp-application-crypto", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+sp-api = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+sp-version = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+rstd = { package = "sp-std", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+runtime_primitives = { package = "sp-runtime", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
 polkadot-parachain = { path = "../parachain", default-features = false }
-trie = { package = "sp-trie", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
+trie = { package = "sp-trie", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
 bitvec = { version = "0.15.2", default-features = false, features = ["alloc"] }
-babe = { package = "pallet-babe", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
+babe = { package = "pallet-babe", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
 
 [dev-dependencies]
-sp-serializer = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+sp-serializer = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
 pretty_assertions = "0.5.1"
 
 [features]

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -5,13 +5,13 @@ authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 
 [dependencies]
-client = { package = "sc-client", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+client = { package = "sc-client", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
 jsonrpc-core = "14.0.3"
 polkadot-primitives = { path = "../primitives" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master"  }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master"  }
-sc-rpc = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-txpool-api = { package = "sp-transaction-pool", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-frame-rpc-system = { package = "substrate-frame-rpc-system", git = "https://github.com/paritytech/substrate", branch = "polkadot-master"  }
-pallet-transaction-payment-rpc = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+sp-runtime = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master"  }
+sp-api = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master"  }
+sc-rpc = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+txpool-api = { package = "sp-transaction-pool", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+frame-rpc-system = { package = "substrate-frame-rpc-system", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master"  }
+pallet-transaction-payment-rpc = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
 codec = { package = "parity-scale-codec", version = "1.1.0", default-features = false }

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -12,22 +12,22 @@ rustc-hex = { version = "2.0.1", default-features = false }
 serde = { version = "1.0.102", default-features = false }
 serde_derive = { version = "1.0.102", optional = true }
 
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-rstd = { package = "sp-std", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sp-staking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
+sp-api = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+inherents = { package = "sp-inherents", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+rstd = { package = "sp-std", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+sp-io = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+sp-runtime = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+sp-staking = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+sp-core = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
 
-authorship = { package = "pallet-authorship", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-balances = { package = "pallet-balances", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-session = { package = "pallet-session", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-staking = { package = "pallet-staking", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-system = { package = "frame-system", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-timestamp = { package = "pallet-timestamp", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-vesting = { package = "pallet-vesting", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
+authorship = { package = "pallet-authorship", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+balances = { package = "pallet-balances", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+session = { package = "pallet-session", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+frame-support = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+staking = { package = "pallet-staking", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+system = { package = "frame-system", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+timestamp = { package = "pallet-timestamp", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+vesting = { package = "pallet-vesting", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
 
 primitives = { package = "polkadot-primitives", path = "../../primitives", default-features = false }
 polkadot-parachain = { path = "../../parachain", default-features = false }
@@ -36,12 +36,12 @@ polkadot-parachain = { path = "../../parachain", default-features = false }
 hex-literal = "0.2.1"
 libsecp256k1 = "0.3.2"
 tiny-keccak = "1.5.0"
-keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-trie = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-babe = { package = "pallet-babe", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-randomness-collective-flip = { package = "pallet-randomness-collective-flip", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-pallet-staking-reward-curve = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-treasury = { package = "pallet-treasury", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
+keyring = { package = "sp-keyring", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+sp-trie = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+babe = { package = "pallet-babe", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+randomness-collective-flip = { package = "pallet-randomness-collective-flip", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+pallet-staking-reward-curve = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+treasury = { package = "pallet-treasury", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
 trie-db = "0.20.0"
 serde_json = "1.0.41"
 

--- a/runtime/kusama/Cargo.toml
+++ b/runtime/kusama/Cargo.toml
@@ -13,52 +13,52 @@ rustc-hex = { version = "2.0.1", default-features = false }
 serde = { version = "1.0.102", default-features = false }
 serde_derive = { version = "1.0.102", optional = true }
 
-authority-discovery-primitives = { package = "sp-authority-discovery", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-offchain-primitives = { package = "sp-offchain", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-rstd = { package = "sp-std", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sp-staking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sp-session = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-version = { package = "sp-version", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-tx-pool-api = { package = "sp-transaction-pool", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-block-builder-api = { package = "sp-block-builder", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
+authority-discovery-primitives = { package = "sp-authority-discovery", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+sp-api = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+inherents = { package = "sp-inherents", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+offchain-primitives = { package = "sp-offchain", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+rstd = { package = "sp-std", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+sp-io = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+sp-runtime = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+sp-staking = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+sp-core = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+sp-session = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+version = { package = "sp-version", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+tx-pool-api = { package = "sp-transaction-pool", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+block-builder-api = { package = "sp-block-builder", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
 
-authority-discovery = { package = "pallet-authority-discovery", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-authorship = { package = "pallet-authorship", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-babe = { package = "pallet-babe", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-balances = { package = "pallet-balances", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-transaction-payment = { package = "pallet-transaction-payment", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-collective = { package = "pallet-collective", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-democracy = { package = "pallet-democracy", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-elections-phragmen = { package = "pallet-elections-phragmen", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-executive = { package = "frame-executive", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-finality-tracker = { package = "pallet-finality-tracker", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-grandpa = { package = "pallet-grandpa", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false, features = ["migrate-authorities"] }
-identity = { package = "pallet-identity", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-im-online = { package = "pallet-im-online", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-indices = { package = "pallet-indices", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-membership = { package = "pallet-membership", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-nicks = { package = "pallet-nicks", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-offences = { package = "pallet-offences", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-randomness-collective-flip = { package = "pallet-randomness-collective-flip", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-recovery = { package = "pallet-recovery", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-session = { package = "pallet-session", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-society = { package = "pallet-society", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-staking = { package = "pallet-staking", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-pallet-staking-reward-curve = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-system = { package = "frame-system", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-system_rpc_runtime_api = { package = "frame-system-rpc-runtime-api", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-timestamp = { package = "pallet-timestamp", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-treasury = { package = "pallet-treasury", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-utility = { package = "pallet-utility", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-vesting = { package = "pallet-vesting", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
+authority-discovery = { package = "pallet-authority-discovery", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+authorship = { package = "pallet-authorship", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+babe = { package = "pallet-babe", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+balances = { package = "pallet-balances", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+transaction-payment = { package = "pallet-transaction-payment", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+collective = { package = "pallet-collective", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+democracy = { package = "pallet-democracy", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+elections-phragmen = { package = "pallet-elections-phragmen", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+executive = { package = "frame-executive", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+finality-tracker = { package = "pallet-finality-tracker", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+grandpa = { package = "pallet-grandpa", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false, features = ["migrate-authorities"] }
+identity = { package = "pallet-identity", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+im-online = { package = "pallet-im-online", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+indices = { package = "pallet-indices", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+membership = { package = "pallet-membership", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+nicks = { package = "pallet-nicks", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+offences = { package = "pallet-offences", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+randomness-collective-flip = { package = "pallet-randomness-collective-flip", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+recovery = { package = "pallet-recovery", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+session = { package = "pallet-session", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+society = { package = "pallet-society", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+frame-support = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+staking = { package = "pallet-staking", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+pallet-staking-reward-curve = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+system = { package = "frame-system", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+system_rpc_runtime_api = { package = "frame-system-rpc-runtime-api", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+timestamp = { package = "pallet-timestamp", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+treasury = { package = "pallet-treasury", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+utility = { package = "pallet-utility", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+vesting = { package = "pallet-vesting", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
 
 runtime-common = { package = "polkadot-runtime-common", path = "../common", default-features = false }
 primitives = { package = "polkadot-primitives", path = "../../primitives", default-features = false }
@@ -68,8 +68,8 @@ polkadot-parachain = { path = "../../parachain", default-features = false }
 hex-literal = "0.2.1"
 libsecp256k1 = "0.3.2"
 tiny-keccak = "1.5.0"
-keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-trie = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+keyring = { package = "sp-keyring", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+sp-trie = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
 trie-db = "0.20.0"
 serde_json = "1.0.41"
 

--- a/runtime/polkadot/Cargo.toml
+++ b/runtime/polkadot/Cargo.toml
@@ -13,49 +13,49 @@ rustc-hex = { version = "2.0.1", default-features = false }
 serde = { version = "1.0.102", default-features = false }
 serde_derive = { version = "1.0.102", optional = true }
 
-authority-discovery-primitives = { package = "sp-authority-discovery", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-offchain-primitives = { package = "sp-offchain", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-rstd = { package = "sp-std", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sp-staking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sp-session = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-version = { package = "sp-version", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-tx-pool-api = { package = "sp-transaction-pool", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-block-builder-api = { package = "sp-block-builder", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
+authority-discovery-primitives = { package = "sp-authority-discovery", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+sp-api = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+inherents = { package = "sp-inherents", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+offchain-primitives = { package = "sp-offchain", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+rstd = { package = "sp-std", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+sp-runtime = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+sp-staking = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+sp-core = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+sp-session = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+version = { package = "sp-version", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+tx-pool-api = { package = "sp-transaction-pool", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+block-builder-api = { package = "sp-block-builder", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
 
-authority-discovery = { package = "pallet-authority-discovery", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-authorship = { package = "pallet-authorship", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-babe = { package = "pallet-babe", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-balances = { package = "pallet-balances", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-transaction-payment = { package = "pallet-transaction-payment", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-collective = { package = "pallet-collective", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-democracy = { package = "pallet-democracy", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-elections-phragmen = { package = "pallet-elections-phragmen", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-executive = { package = "frame-executive", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-finality-tracker = { package = "pallet-finality-tracker", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-grandpa = { package = "pallet-grandpa", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false, features = ["migrate-authorities"] }
-identity = { package = "pallet-identity", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-im-online = { package = "pallet-im-online", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-indices = { package = "pallet-indices", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-membership = { package = "pallet-membership", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-nicks = { package = "pallet-nicks", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-offences = { package = "pallet-offences", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-randomness-collective-flip = { package = "pallet-randomness-collective-flip", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-session = { package = "pallet-session", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-staking = { package = "pallet-staking", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-pallet-staking-reward-curve = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-system = { package = "frame-system", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-system_rpc_runtime_api = { package = "frame-system-rpc-runtime-api", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-timestamp = { package = "pallet-timestamp", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-treasury = { package = "pallet-treasury", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-sudo = { package = "pallet-sudo", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-vesting = { package = "pallet-vesting", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
+authority-discovery = { package = "pallet-authority-discovery", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+authorship = { package = "pallet-authorship", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+babe = { package = "pallet-babe", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+balances = { package = "pallet-balances", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+transaction-payment = { package = "pallet-transaction-payment", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+collective = { package = "pallet-collective", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+democracy = { package = "pallet-democracy", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+elections-phragmen = { package = "pallet-elections-phragmen", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+executive = { package = "frame-executive", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+finality-tracker = { package = "pallet-finality-tracker", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+grandpa = { package = "pallet-grandpa", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false, features = ["migrate-authorities"] }
+identity = { package = "pallet-identity", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+im-online = { package = "pallet-im-online", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+indices = { package = "pallet-indices", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+membership = { package = "pallet-membership", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+nicks = { package = "pallet-nicks", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+offences = { package = "pallet-offences", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+randomness-collective-flip = { package = "pallet-randomness-collective-flip", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+session = { package = "pallet-session", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+frame-support = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+staking = { package = "pallet-staking", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+pallet-staking-reward-curve = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+system = { package = "frame-system", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+system_rpc_runtime_api = { package = "frame-system-rpc-runtime-api", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+timestamp = { package = "pallet-timestamp", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+treasury = { package = "pallet-treasury", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+sudo = { package = "pallet-sudo", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+vesting = { package = "pallet-vesting", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
 
 runtime-common = { package = "polkadot-runtime-common", path = "../common", default-features = false }
 primitives = { package = "polkadot-primitives", path = "../../primitives", default-features = false }
@@ -65,8 +65,8 @@ polkadot-parachain = { path = "../../parachain", default-features = false }
 hex-literal = "0.2.1"
 libsecp256k1 = "0.3.2"
 tiny-keccak = "1.5.0"
-keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-trie = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+keyring = { package = "sp-keyring", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+sp-trie = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
 trie-db = "0.20.0"
 serde_json = "1.0.41"
 

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -19,40 +19,40 @@ polkadot-runtime = { path = "../runtime/polkadot" }
 kusama-runtime = { path = "../runtime/kusama" }
 polkadot-network = { path = "../network"  }
 polkadot-rpc = { path = "../rpc" }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sc-client = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sc-client-db = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sc-chain-spec = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sc-executor = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sc-network = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-consensus_common = { package = "sp-consensus", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-grandpa = { package = "sc-finality-grandpa", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-grandpa_primitives = { package = "sp-finality-grandpa", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-service = { package = "sc-service", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false }
-telemetry = { package = "sc-telemetry", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sc-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sc-keystore = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-pallet-babe = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-pallet-staking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-im-online = { package = "pallet-im-online", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-authority-discovery = { package = "sc-authority-discovery", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-authority-discovery-primitives = { package = "sp-authority-discovery", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-babe = { package = "sc-consensus-babe", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-block-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-system_rpc_runtime_api = { package = "frame-system-rpc-runtime-api", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+sp-io = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+sp-api = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+sp-runtime = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+sp-blockchain = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+sp-core = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+sc-client = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+sc-client-api = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+sc-client-db = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+sc-chain-spec = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+sc-executor = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+sc-network = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+consensus_common = { package = "sp-consensus", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+grandpa = { package = "sc-finality-grandpa", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+grandpa_primitives = { package = "sp-finality-grandpa", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+inherents = { package = "sp-inherents", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+service = { package = "sc-service", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false }
+telemetry = { package = "sc-telemetry", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+sc-transaction-pool = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+sp-transaction-pool = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+sc-keystore = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+pallet-babe = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+pallet-staking = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+im-online = { package = "pallet-im-online", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+authority-discovery = { package = "sc-authority-discovery", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+authority-discovery-primitives = { package = "sp-authority-discovery", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+babe = { package = "sc-consensus-babe", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+sp-block-builder = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+system_rpc_runtime_api = { package = "frame-system-rpc-runtime-api", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
 codec = { package = "parity-scale-codec", version = "1.1.0" }
-sp-session = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-offchain = { package = "sp-offchain", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-prometheus-endpoint = { package = "substrate-prometheus-endpoint", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+sp-session = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+sp-offchain = { package = "sp-offchain", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+prometheus-endpoint = { package = "substrate-prometheus-endpoint", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
 
 [features]
 default = ["rocksdb"]

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -447,6 +447,7 @@ pub fn new_full<Runtime, Dispatch, Extrinsic>(
 				sentry_nodes,
 				service.keystore(),
 				dht_event_stream,
+				service.prometheus_registry(),
 			);
 			service.spawn_task("authority-discovery", authority_discovery);
 		}

--- a/statement-table/Cargo.toml
+++ b/statement-table/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2018"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.1.0", default-features = false, features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+sp-core = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
 primitives = { package = "polkadot-primitives", path = "../primitives" }

--- a/test-parachains/adder/Cargo.toml
+++ b/test-parachains/adder/Cargo.toml
@@ -13,7 +13,7 @@ tiny-keccak = "1.5.0"
 dlmalloc = { version = "0.1.3", features = [ "global" ] }
 
 # We need to make sure the global allocator is disabled until we have support of full substrate externalities
-runtime-io = { package = "sp-io", git = "https://github.com/paritytech/substrate", branch = "polkadot-master", default-features = false, features = [ "disable_allocator" ] }
+runtime-io = { package = "sp-io", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master", default-features = false, features = [ "disable_allocator" ] }
 
 [build-dependencies]
 wasm-builder-runner = { package = "substrate-wasm-builder-runner", version = "1.0.5" }

--- a/test-parachains/adder/collator/Cargo.toml
+++ b/test-parachains/adder/collator/Cargo.toml
@@ -9,9 +9,9 @@ adder = { path = ".." }
 parachain = { package = "polkadot-parachain", path = "../../../parachain" }
 collator = { package = "polkadot-collator", path = "../../../collator" }
 primitives = { package = "polkadot-primitives", path = "../../../primitives" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-client = { package = "sc-client", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-client-api = { package = "sc-client-api", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+sp-core = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+client = { package = "sc-client", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+client-api = { package = "sc-client-api", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
 parking_lot = "0.10.0"
 codec = { package = "parity-scale-codec", version = "1.2.0" }
 futures = "0.3.4"

--- a/validation/Cargo.toml
+++ b/validation/Cargo.toml
@@ -18,22 +18,22 @@ parachain = { package = "polkadot-parachain", path = "../parachain" }
 polkadot-primitives = { path = "../primitives" }
 polkadot-erasure-coding = { path = "../erasure-coding" }
 table = { package = "polkadot-statement-table", path = "../statement-table" }
-grandpa = { package = "sc-finality-grandpa", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-consensus = { package = "sp-consensus", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-primitives = { package = "sp-core", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-txpool-api = { package = "sp-transaction-pool", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-sp-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-block-builder = { package = "sc-block-builder", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-trie = { package = "sp-trie", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-runtime_primitives = { package = "sp-runtime", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+grandpa = { package = "sc-finality-grandpa", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+inherents = { package = "sp-inherents", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+consensus = { package = "sp-consensus", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+primitives = { package = "sp-core", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+txpool-api = { package = "sp-transaction-pool", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+sp-blockchain = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+sp-api = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+sc-client-api = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+sp-timestamp = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+block-builder = { package = "sc-block-builder", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+trie = { package = "sp-trie", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+runtime_primitives = { package = "sp-runtime", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
 bitvec = { version = "0.15.2", default-features = false, features = ["alloc"] }
-runtime_babe = { package = "pallet-babe", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
-keystore = { package = "sc-keystore", git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+runtime_babe = { package = "pallet-babe", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
+keystore = { package = "sc-keystore", git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }
 
 [dev-dependencies]
-sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "polkadot-master" }
+sp-keyring = { git = "https://github.com/mxinden/substrate", branch = "authority-discovery-prometheus-polkadot-master" }


### PR DESCRIPTION
Pass the Prometheus registry from the service to the authority discovery module as is required with https://github.com/paritytech/substrate/pull/5195.

As usual first commit contains the actual change, second commit points to a patched version of Substrate's `polkadot-master` branch.