### PR TITLE
CI: Don't announce releases on updated

### DIFF
--- a/.github/workflows/release-bot.yml
+++ b/.github/workflows/release-bot.yml
@@ -2,7 +2,6 @@ name: Pushes release updates to a pre-defined Matrix room
 on:
   release:
     types:
-      - edited
       - prereleased
       - published
 jobs:


### PR DESCRIPTION
We were getting double-posts for newly-published releases in the matrix Release Notes channel- we don't need to post to the channel when releases are updated.