### PR TITLE
Fix `runtime-benchmarks` build

### DIFF
--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -75,4 +75,8 @@ std = [
 	"serde/std",
 	"log",
 ]
-runtime-benchmarks = ["frame-benchmarking", "libsecp256k1"]
+runtime-benchmarks = [
+	"libsecp256k1",
+	"frame-benchmarking",
+	"frame-support/runtime-benchmarks"
+]

--- a/runtime/common/src/claims.rs
+++ b/runtime/common/src/claims.rs
@@ -122,17 +122,17 @@ decl_storage! {
 	// This allows for type-safe usage of the Substrate storage database, so you can
 	// keep things around between blocks.
 	trait Store for Module<T: Trait> as Claims {
-		Claims get(claims) build(|config: &GenesisConfig<T>| {
+		Claims get(fn claims) build(|config: &GenesisConfig<T>| {
 			config.claims.iter().map(|(a, b)| (a.clone(), b.clone())).collect::<Vec<_>>()
 		}): map hasher(identity) EthereumAddress => Option<BalanceOf<T>>;
-		Total get(total) build(|config: &GenesisConfig<T>| {
+		Total get(fn total) build(|config: &GenesisConfig<T>| {
 			config.claims.iter().fold(Zero::zero(), |acc: BalanceOf<T>, &(_, n)| acc + n)
 		}): BalanceOf<T>;
 		/// Vesting schedule for a claim.
 		/// First balance is the total amount that should be held for vesting.
 		/// Second balance is how much should be unlocked per block.
 		/// The block number is when the vesting should start.
-		Vesting get(vesting) config():
+		Vesting get(fn vesting) config():
 			map hasher(identity) EthereumAddress
 			=> Option<(BalanceOf<T>, BalanceOf<T>, T::BlockNumber)>;
 	}
@@ -285,7 +285,6 @@ impl<T: Trait> Module<T> {
 	}
 }
 
-#[allow(deprecated)] // Allow `ValidateUnsigned`
 impl<T: Trait> sp_runtime::traits::ValidateUnsigned for Module<T> {
 	type Call = Call<T>;
 

--- a/runtime/common/src/crowdfund.rs
+++ b/runtime/common/src/crowdfund.rs
@@ -166,19 +166,19 @@ pub struct FundInfo<AccountId, Balance, Hash, BlockNumber> {
 decl_storage! {
 	trait Store for Module<T: Trait> as Crowdfund {
 		/// Info on all of the funds.
-		Funds get(funds):
+		Funds get(fn funds):
 			map hasher(twox_64_concat) FundIndex
 			=> Option<FundInfo<T::AccountId, BalanceOf<T>, T::Hash, T::BlockNumber>>;
 
 		/// The total number of funds that have so far been allocated.
-		FundCount get(fund_count): FundIndex;
+		FundCount get(fn fund_count): FundIndex;
 
 		/// The funds that have had additional contributions during the last block. This is used
 		/// in order to determine which funds should submit new or updated bids.
-		NewRaise get(new_raise): Vec<FundIndex>;
+		NewRaise get(fn new_raise): Vec<FundIndex>;
 
 		/// The number of auctions that have entered into their ending period so far.
-		EndingsCount get(endings_count): slots::AuctionIndex;
+		EndingsCount get(fn endings_count): slots::AuctionIndex;
 	}
 }
 
@@ -643,6 +643,8 @@ mod tests {
 	impl Contains<u64> for Nobody {
 		fn contains(_: &u64) -> bool { false }
 		fn sorted_members() -> Vec<u64> { vec![] }
+		#[cfg(feature = "runtime-benchmarks")]
+		fn add(_: &u64) { unimplemented!() }
 	}
 	impl treasury::Trait for Test {
 		type Currency = balances::Module<Test>;

--- a/runtime/common/src/parachains.rs
+++ b/runtime/common/src/parachains.rs
@@ -312,11 +312,11 @@ decl_storage! {
 	trait Store for Module<T: Trait> as Parachains
 	{
 		/// All authorities' keys at the moment.
-		pub Authorities get(authorities): Vec<ValidatorId>;
+		pub Authorities get(fn authorities): Vec<ValidatorId>;
 		/// The parachains registered at present.
-		pub Code get(parachain_code): map hasher(twox_64_concat) ParaId => Option<Vec<u8>>;
+		pub Code get(fn parachain_code): map hasher(twox_64_concat) ParaId => Option<Vec<u8>>;
 		/// The heads of the parachains registered at present.
-		pub Heads get(parachain_head): map hasher(twox_64_concat) ParaId => Option<Vec<u8>>;
+		pub Heads get(fn parachain_head): map hasher(twox_64_concat) ParaId => Option<Vec<u8>>;
 		/// Messages ready to be dispatched onto the relay chain. It is subject to
 		/// `MAX_MESSAGE_COUNT` and `WATERMARK_MESSAGE_SIZE`.
 		pub RelayDispatchQueue: map hasher(twox_64_concat) ParaId => Vec<UpwardMessage>;
@@ -336,14 +336,14 @@ decl_storage! {
 		/// The mapping from parent block hashes to session indexes.
 		///
 		/// Used for double vote report validation.
-		pub ParentToSessionIndex get(session_at_block):
+		pub ParentToSessionIndex get(fn session_at_block):
 			map hasher(twox_64_concat) T::Hash => SessionIndex;
 
 		/// The era that is active currently.
 		///
 		/// Changes with the `ActiveEra` from `staking`. Upon these changes `ParentToSessionIndex`
 		/// is pruned.
-		ActiveEra get(active_era): Option<staking::EraIndex>;
+		ActiveEra get(fn active_era): Option<staking::EraIndex>;
 	}
 	add_extra_genesis {
 		config(authorities): Vec<ValidatorId>;

--- a/runtime/common/src/registrar.rs
+++ b/runtime/common/src/registrar.rs
@@ -180,10 +180,10 @@ decl_storage! {
 		PendingSwap: map hasher(twox_64_concat) ParaId => Option<ParaId>;
 
 		/// Map of all registered parathreads/chains.
-		Paras get(paras): map hasher(twox_64_concat) ParaId => Option<ParaInfo>;
+		Paras get(fn paras): map hasher(twox_64_concat) ParaId => Option<ParaInfo>;
 
 		/// The current queue for parathreads that should be retried.
-		RetryQueue get(retry_queue): Vec<Vec<(ParaId, CollatorId)>>;
+		RetryQueue get(fn retry_queue): Vec<Vec<(ParaId, CollatorId)>>;
 
 		/// Users who have paid a parathread's deposit
 		Debtors: map hasher(twox_64_concat) ParaId => T::AccountId;

--- a/runtime/common/src/slots.rs
+++ b/runtime/common/src/slots.rs
@@ -131,11 +131,11 @@ type WinnersData<T> =
 decl_storage! {
 	trait Store for Module<T: Trait> as Slots {
 		/// The number of auctions that have been started so far.
-		pub AuctionCounter get(auction_counter): AuctionIndex;
+		pub AuctionCounter get(fn auction_counter): AuctionIndex;
 
 		/// Ordered list of all `ParaId` values that are managed by this module. This includes
 		/// chains that are not yet deployed (but have won an auction in the future).
-		pub ManagedIds get(managed_ids): Vec<ParaId>;
+		pub ManagedIds get(fn managed_ids): Vec<ParaId>;
 
 		/// Various amounts on deposit for each parachain. An entry in `ManagedIds` implies a non-
 		/// default entry here.
@@ -150,40 +150,40 @@ decl_storage! {
 		/// If a parachain doesn't exist *yet* but is scheduled to exist in the future, then it
 		/// will be left-padded with one or more zeroes to denote the fact that nothing is held on
 		/// deposit for the non-existent chain currently, but is held at some point in the future.
-		pub Deposits get(deposits): map hasher(twox_64_concat) ParaId => Vec<BalanceOf<T>>;
+		pub Deposits get(fn deposits): map hasher(twox_64_concat) ParaId => Vec<BalanceOf<T>>;
 
 		/// Information relating to the current auction, if there is one.
 		///
 		/// The first item in the tuple is the lease period index that the first of the four
 		/// contiguous lease periods on auction is for. The second is the block number when the
 		/// auction will "begin to end", i.e. the first block of the Ending Period of the auction.
-		pub AuctionInfo get(auction_info): Option<(LeasePeriodOf<T>, T::BlockNumber)>;
+		pub AuctionInfo get(fn auction_info): Option<(LeasePeriodOf<T>, T::BlockNumber)>;
 
 		/// The winning bids for each of the 10 ranges at each block in the final Ending Period of
 		/// the current auction. The map's key is the 0-based index into the Ending Period. The
 		/// first block of the ending period is 0; the last is `EndingPeriod - 1`.
-		pub Winning get(winning): map hasher(twox_64_concat) T::BlockNumber => Option<WinningData<T>>;
+		pub Winning get(fn winning): map hasher(twox_64_concat) T::BlockNumber => Option<WinningData<T>>;
 
 		/// Amounts currently reserved in the accounts of the bidders currently winning
 		/// (sub-)ranges.
-		pub ReservedAmounts get(reserved_amounts):
+		pub ReservedAmounts get(fn reserved_amounts):
 			map hasher(twox_64_concat) Bidder<T::AccountId> => Option<BalanceOf<T>>;
 
 		/// The set of Para IDs that have won and need to be on-boarded at an upcoming lease-period.
 		/// This is cleared out on the first block of the lease period.
-		pub OnboardQueue get(onboard_queue): map hasher(twox_64_concat) LeasePeriodOf<T> => Vec<ParaId>;
+		pub OnboardQueue get(fn onboard_queue): map hasher(twox_64_concat) LeasePeriodOf<T> => Vec<ParaId>;
 
 		/// The actual on-boarding information. Only exists when one of the following is true:
 		/// - It is before the lease period that the parachain should be on-boarded.
 		/// - The full on-boarding information has not yet been provided and the parachain is not
 		/// yet due to be off-boarded.
-		pub Onboarding get(onboarding):
+		pub Onboarding get(fn onboarding):
 			map hasher(twox_64_concat) ParaId =>
 			Option<(LeasePeriodOf<T>, IncomingParachain<T::AccountId, T::Hash>)>;
 
 		/// Off-boarding account; currency held on deposit for the parachain gets placed here if the
 		/// parachain gets off-boarded; i.e. its lease period is up and it isn't renewed.
-		pub Offboarding get(offboarding): map hasher(twox_64_concat) ParaId => T::AccountId;
+		pub Offboarding get(fn offboarding): map hasher(twox_64_concat) ParaId => T::AccountId;
 	}
 }
 


### PR DESCRIPTION
There was a new feature flag introduced downstream, and this adds it to polkadot too and fixes compilation with the `runtime-benchmarks` feature flag.

This also adds an insubstantial update to the syntax of declaring Runtime Storage `getter` functions.