### PR TITLE
Add CI check for `runtime-benchmarks`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -162,6 +162,16 @@ check-web-wasm:                    &test
     - time cargo build --locked --target=wasm32-unknown-unknown --manifest-path cli/Cargo.toml --no-default-features --features browser
     - sccache -s
 
+check-runtime-benchmarks:          &test
+  stage:                           test
+  <<:                              *test-refs
+  <<:                              *docker-env
+  <<:                              *compiler_info
+  script:
+    # Check that the node will compile with `runtime-benchmarks` feature flag.
+    - time cargo check --features runtime-benchmarks
+    - sccache -s
+
 
 build-linux-release:               &build
   stage:                           build
@@ -266,7 +276,7 @@ publish-s3-release:
     - |
       cat <<-EOM
       |
-      |  polkadot binary paths: 
+      |  polkadot binary paths:
       |
       |  - https://${BUCKET}/${PREFIX}/${EXTRATAG}/polkadot
       |  - https://${BUCKET}/${PREFIX}/${VERSION}/polkadot
@@ -375,5 +385,3 @@ deploy-polkasync-kusama:
         -F "ref=master" \
         -F "variables[POLKADOT_BUILD_REF]=${CI_COMMIT_REF_NAME}" \
         ${GITLAB_API}/projects/${GITHUB_API_PROJECT}/trigger/pipeline | jq .
-
-

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -76,7 +76,7 @@ std = [
 	"log",
 ]
 runtime-benchmarks = [
-	"libsecp256k1",
+	"libsecp256k1/hmac",
 	"frame-benchmarking",
 	"frame-support/runtime-benchmarks"
 ]

--- a/runtime/kusama/Cargo.toml
+++ b/runtime/kusama/Cargo.toml
@@ -136,4 +136,9 @@ std = [
 	"randomness-collective-flip/std",
 	"runtime-common/std",
 ]
-runtime-benchmarks = ["frame-benchmarking", "runtime-common/runtime-benchmarks"]
+runtime-benchmarks = [
+	"frame-benchmarking",
+	"frame-support/runtime-benchmarks",
+	"runtime-common/runtime-benchmarks",
+	"elections-phragmen/runtime-benchmarks"
+]

--- a/runtime/polkadot/Cargo.toml
+++ b/runtime/polkadot/Cargo.toml
@@ -130,4 +130,9 @@ std = [
 	"sudo/std",
 	"vesting/std",
 ]
-runtime-benchmarks = ["frame-benchmarking", "runtime-common/runtime-benchmarks"]
+runtime-benchmarks = [
+	"frame-benchmarking",
+	"frame-support/runtime-benchmarks",
+	"runtime-common/runtime-benchmarks",
+	"elections-phragmen/runtime-benchmarks"
+]


### PR DESCRIPTION
We should verify that changes to the Polkadot/Kusama Runtime also do not break benchmarks.

This does some final maintenance on the cargo.toml files with the correct features, and adds a new CI pipeline.