### PR TITLE
Don't depend directly on libp2p

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4237,7 +4237,6 @@ version = "0.8.0"
 dependencies = [
  "env_logger 0.7.1",
  "futures 0.3.4",
- "libp2p",
  "log 0.4.8",
  "parking_lot 0.10.0",
  "polkadot-test-runtime-client",

--- a/network/test/Cargo.toml
+++ b/network/test/Cargo.toml
@@ -10,7 +10,6 @@ log = "0.4.8"
 parking_lot = "0.10.0"
 futures = "0.3.1"
 rand = "0.7.2"
-libp2p = { version = "0.16.2", default-features = false, features = ["libp2p-websocket"] }
 sc-network = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sc-network-test = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sp-consensus = { git = "https://github.com/paritytech/substrate", branch = "master" }

--- a/network/test/src/lib.rs
+++ b/network/test/src/lib.rs
@@ -22,7 +22,7 @@ mod block_import;
 use std::{collections::HashMap, pin::Pin, sync::Arc, marker::PhantomData, task::{Poll, Context as FutureContext}};
 
 use log::trace;
-use sc_network::{config::build_multiaddr, FinalityProofProvider};
+use sc_network::config::{build_multiaddr, FinalityProofProvider};
 use sp_blockchain::{
 	Result as ClientResult, well_known_cache_keys::{self, Id as CacheKeyId}, Info as BlockchainInfo,
 };

--- a/network/test/src/lib.rs
+++ b/network/test/src/lib.rs
@@ -21,9 +21,8 @@ mod block_import;
 
 use std::{collections::HashMap, pin::Pin, sync::Arc, marker::PhantomData, task::{Poll, Context as FutureContext}};
 
-use libp2p::build_multiaddr;
 use log::trace;
-use sc_network::config::FinalityProofProvider;
+use sc_network::{config::build_multiaddr, FinalityProofProvider};
 use sp_blockchain::{
 	Result as ClientResult, well_known_cache_keys::{self, Id as CacheKeyId}, Info as BlockchainInfo,
 };
@@ -47,10 +46,9 @@ use sp_consensus::{BlockOrigin, BlockImportParams, BlockCheckParams, Justificati
 use futures::prelude::*;
 use sc_network::{NetworkWorker, NetworkStateInfo, NetworkService, ReportHandle, config::ProtocolId};
 use sc_network::config::{NetworkConfiguration, TransportConfig, BoxFinalityProofRequestBuilder};
-use libp2p::PeerId;
 use parking_lot::Mutex;
 use sp_core::H256;
-use sc_network::config::{ProtocolConfig, TransactionPool};
+use sc_network::{PeerId, config::{ProtocolConfig, TransactionPool}};
 use sp_runtime::generic::BlockId;
 use sp_runtime::traits::{Block as BlockT, Header as HeaderT, NumberFor};
 use sp_runtime::Justification;


### PR DESCRIPTION
Removed the direct dependency on libp2p.

The `sc_network` crate purposefully re-exports everything that's needed, and directly depending on `libp2p` serves nothing but creating potential compilation errors.
