### PR TITLE
refactor out validation hosts to pool struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4260,7 +4260,6 @@ dependencies = [
  "adder",
  "derive_more 0.99.3",
  "halt",
- "lazy_static",
  "log 0.4.8",
  "parity-scale-codec",
  "parking_lot 0.10.0",

--- a/network/src/protocol/tests.rs
+++ b/network/src/protocol/tests.rs
@@ -299,6 +299,7 @@ fn consensus_instances_cleaned_up() {
 		signing_context,
 		AvailabilityStore::new_in_memory(service.clone()),
 		None,
+		None,
 	));
 
 	pool.spawner().spawn_local(worker_task).unwrap();
@@ -328,6 +329,7 @@ fn collation_is_received_with_dropped_router() {
 		Some(Arc::new(Sr25519Keyring::Alice.pair().into())),
 		signing_context,
 		AvailabilityStore::new_in_memory(service.clone()),
+		None,
 		None,
 	));
 
@@ -549,6 +551,7 @@ fn fetches_pov_block_from_gossip() {
 		None,
 		signing_context,
 		AvailabilityStore::new_in_memory(service.clone()),
+		None,
 		None,
 	));
 

--- a/parachain/Cargo.toml
+++ b/parachain/Cargo.toml
@@ -16,7 +16,6 @@ sp-wasm-interface = { git = "https://github.com/paritytech/substrate", branch = 
 sp-externalities = { git = "https://github.com/paritytech/substrate", branch = "master", optional = true }
 sc-executor = { git = "https://github.com/paritytech/substrate", branch = "master", optional = true }
 sp-io = { git = "https://github.com/paritytech/substrate", branch = "master", optional = true }
-lazy_static = { version = "1.4.0", optional = true }
 parking_lot = { version = "0.10.0", optional = true }
 log = { version = "0.4.8", optional = true }
 
@@ -38,7 +37,6 @@ std = [
 	"sp-std/std",
 	"shared_memory",
 	"sp-core/std",
-	"lazy_static",
 	"parking_lot",
 	"log",
 	"sp-runtime-interface/std",

--- a/parachain/src/wasm_executor/mod.rs
+++ b/parachain/src/wasm_executor/mod.rs
@@ -29,6 +29,7 @@ use sp_wasm_interface::HostFunctions as _;
 
 #[cfg(not(target_os = "unknown"))]
 pub use validation_host::{run_worker, EXECUTION_TIMEOUT_SEC};
+pub use validation_host::ValidationPool;
 
 mod validation_host;
 
@@ -51,13 +52,13 @@ impl ParachainExt {
 /// WASM code execution mode.
 ///
 /// > Note: When compiling for WASM, the `Remote` variants are not available.
-pub enum ExecutionMode {
+pub enum ExecutionMode<'a> {
 	/// Execute in-process. The execution can not be interrupted or aborted.
 	Local,
 	/// Remote execution in a spawned process.
-	Remote,
+	Remote(&'a ValidationPool),
 	/// Remote execution in a spawned test runner.
-	RemoteTest,
+	RemoteTest(&'a ValidationPool),
 }
 
 /// Error type for the wasm executor
@@ -115,27 +116,27 @@ pub fn validate_candidate<E: Externalities + 'static>(
 	validation_code: &[u8],
 	params: ValidationParams,
 	ext: E,
-	options: ExecutionMode,
+	options: ExecutionMode<'_>,
 ) -> Result<ValidationResult, Error> {
 	match options {
 		ExecutionMode::Local => {
 			validate_candidate_internal(validation_code, &params.encode(), ext)
 		},
 		#[cfg(not(target_os = "unknown"))]
-		ExecutionMode::Remote => {
-			validation_host::validate_candidate(validation_code, params, ext, false)
+		ExecutionMode::Remote(pool) => {
+			pool.validate_candidate(validation_code, params, ext, false)
 		},
 		#[cfg(not(target_os = "unknown"))]
-		ExecutionMode::RemoteTest => {
-			validation_host::validate_candidate(validation_code, params, ext, true)
+		ExecutionMode::RemoteTest(pool) => {
+			pool.validate_candidate(validation_code, params, ext, true)
 		},
 		#[cfg(target_os = "unknown")]
-		ExecutionMode::Remote =>
+		ExecutionMode::Remote(pool) =>
 			Err(Error::System(Box::<dyn std::error::Error + Send + Sync>::from(
 				"Remote validator not available".to_string()
 			) as Box<_>)),
 		#[cfg(target_os = "unknown")]
-		ExecutionMode::RemoteTest =>
+		ExecutionMode::RemoteTest(pool) =>
 			Err(Error::System(Box::<dyn std::error::Error + Send + Sync>::from(
 				"Remote validator not available".to_string()
 			) as Box<_>)),

--- a/parachain/src/wasm_executor/mod.rs
+++ b/parachain/src/wasm_executor/mod.rs
@@ -51,7 +51,7 @@ impl ParachainExt {
 /// A stub validation-pool defined when compiling for WASM.
 #[cfg(target_os = "unknown")]
 #[derive(Clone)]
-pub struct ValidatonPool {
+pub struct ValidationPool {
 	_inner: (), // private field means not publicly-instantiable
 }
 

--- a/parachain/src/wasm_executor/mod.rs
+++ b/parachain/src/wasm_executor/mod.rs
@@ -28,8 +28,7 @@ use sp_core::traits::CallInWasm;
 use sp_wasm_interface::HostFunctions as _;
 
 #[cfg(not(target_os = "unknown"))]
-pub use validation_host::{run_worker, EXECUTION_TIMEOUT_SEC};
-pub use validation_host::ValidationPool;
+pub use validation_host::{run_worker, ValidationPool, EXECUTION_TIMEOUT_SEC};
 
 mod validation_host;
 
@@ -46,6 +45,21 @@ sp_externalities::decl_extension! {
 impl ParachainExt {
 	pub fn new<T: Externalities + 'static>(ext: T) -> Self {
 		Self(Box::new(ext))
+	}
+}
+
+/// A stub validation-pool defined when compiling for WASM.
+#[cfg(target_os = "unknown")]
+#[derive(Clone)]
+pub struct ValidatonPool {
+	_inner: (), // private field means not publicly-instantiable
+}
+
+#[cfg(target_os = "unknown")]
+impl ValidationPool {
+	/// Create a new `ValidationPool`.
+	pub fn new() -> Self {
+		ValidationPool { _inner: () }
 	}
 }
 

--- a/parachain/src/wasm_executor/validation_host.rs
+++ b/parachain/src/wasm_executor/validation_host.rs
@@ -33,8 +33,6 @@ const WORKER_ARGS_TEST: &[&'static str] = &["--nocapture", "validation_worker"];
 const WORKER_ARG: &'static str = "validation-worker";
 const WORKER_ARGS: &[&'static str] = &[WORKER_ARG];
 
-const NUM_HOSTS: usize = 8;
-
 /// Execution timeout in seconds;
 #[cfg(debug_assertions)]
 pub const EXECUTION_TIMEOUT_SEC: u64 =  30;
@@ -70,7 +68,45 @@ enum Event {
 }
 
 lazy_static::lazy_static! {
-	static ref HOSTS: [Mutex<ValidationHost>; NUM_HOSTS] = Default::default();
+	static ref HOSTS: [Mutex<ValidationHost>; DEFAULT_NUM_HOSTS] = Default::default();
+}
+
+/// A pool of hosts.
+#[derive(Clone)]
+pub struct ValidationPool {
+	hosts: Arc<Vec<Mutex<ValidationHost>>>,
+}
+
+const DEFAULT_NUM_HOSTS: usize = 8;
+
+impl ValidationPool {
+	/// Creates a validation pool with the default configuration.
+	pub fn new() -> ValidationPool {
+		ValidationPool {
+			hosts: Arc::new((0..DEFAULT_NUM_HOSTS).map(|_| Default::default()).collect()),
+		}
+	}
+
+	/// Validate a candidate under the given validation code using the next
+	/// free validation host.
+	///
+	/// This will fail if the validation code is not a proper parachain validation module.
+	pub fn validate_candidate<E: Externalities>(
+		&self,
+		validation_code: &[u8],
+		params: ValidationParams,
+		externalities: E,
+		test_mode: bool,
+	) -> Result<ValidationResult, Error> {
+		for host in self.hosts.iter() {
+			if let Some(mut host) = host.try_lock() {
+				return host.validate_candidate(validation_code, params, externalities, test_mode);
+			}
+		}
+
+		// all workers are busy, just wait for the first one
+		self.hosts[0].lock().validate_candidate(validation_code, params, externalities, test_mode)
+	}
 }
 
 /// Validation worker process entry point. Runs a loop waiting for candidates to validate
@@ -182,25 +218,6 @@ struct ValidationHost {
 	worker: Option<process::Child>,
 	memory: Option<SharedMem>,
 	id: u32,
-}
-
-/// Validate a candidate under the given validation code.
-///
-/// This will fail if the validation code is not a proper parachain validation module.
-pub fn validate_candidate<E: Externalities>(
-	validation_code: &[u8],
-	params: ValidationParams,
-	externalities: E,
-	test_mode: bool,
-) -> Result<ValidationResult, Error> {
-	for host in HOSTS.iter() {
-		if let Some(mut host) = host.try_lock() {
-			return host.validate_candidate(validation_code, params, externalities, test_mode);
-		}
-	}
-
-	// all workers are busy, just wait for the first one
-	HOSTS[0].lock().validate_candidate(validation_code, params, externalities, test_mode)
 }
 
 impl Drop for ValidationHost {

--- a/parachain/src/wasm_executor/validation_host.rs
+++ b/parachain/src/wasm_executor/validation_host.rs
@@ -67,10 +67,6 @@ enum Event {
 	WorkerReady = 2,
 }
 
-lazy_static::lazy_static! {
-	static ref HOSTS: [Mutex<ValidationHost>; DEFAULT_NUM_HOSTS] = Default::default();
-}
-
 /// A pool of hosts.
 #[derive(Clone)]
 pub struct ValidationPool {

--- a/parachain/tests/adder/mod.rs
+++ b/parachain/tests/adder/mod.rs
@@ -70,6 +70,8 @@ pub fn execute_good_on_parent() {
 		add: 512,
 	};
 
+	let pool = parachain::wasm_executor::ValidationPool::new();
+
 	let ret = parachain::wasm_executor::validate_candidate(
 		TEST_CODE,
 		ValidationParams {
@@ -77,7 +79,7 @@ pub fn execute_good_on_parent() {
 			block_data: block_data.encode(),
 		},
 		DummyExt,
-		parachain::wasm_executor::ExecutionMode::RemoteTest,
+		parachain::wasm_executor::ExecutionMode::RemoteTest(&pool),
 	).unwrap();
 
 	let new_head = HeadData::decode(&mut &ret.head_data[..]).unwrap();
@@ -92,6 +94,7 @@ fn execute_good_chain_on_parent() {
 	let mut number = 0;
 	let mut parent_hash = [0; 32];
 	let mut last_state = 0;
+	let pool = parachain::wasm_executor::ValidationPool::new();
 
 	for add in 0..10 {
 		let parent_head = HeadData {
@@ -112,7 +115,7 @@ fn execute_good_chain_on_parent() {
 				block_data: block_data.encode(),
 			},
 			DummyExt,
-			parachain::wasm_executor::ExecutionMode::RemoteTest,
+			parachain::wasm_executor::ExecutionMode::RemoteTest(&pool),
 		).unwrap();
 
 		let new_head = HeadData::decode(&mut &ret.head_data[..]).unwrap();
@@ -129,6 +132,8 @@ fn execute_good_chain_on_parent() {
 
 #[test]
 fn execute_bad_on_parent() {
+	let pool = parachain::wasm_executor::ValidationPool::new();
+
 	let parent_head = HeadData {
 		number: 0,
 		parent_hash: [0; 32],
@@ -147,6 +152,6 @@ fn execute_bad_on_parent() {
 			block_data: block_data.encode(),
 		},
 		DummyExt,
-		parachain::wasm_executor::ExecutionMode::RemoteTest,
+		parachain::wasm_executor::ExecutionMode::RemoteTest(&pool),
 	).unwrap_err();
 }

--- a/validation/src/collation.rs
+++ b/validation/src/collation.rs
@@ -59,6 +59,7 @@ pub trait Collators: Clone {
 
 /// A future which resolves when a collation is available.
 pub async fn collation_fetch<C: Collators, P>(
+	validation_pool: Option<crate::pipeline::ValidationPool>,
 	parachain: ParaId,
 	relay_parent: Hash,
 	collators: C,
@@ -76,6 +77,7 @@ pub async fn collation_fetch<C: Collators, P>(
 		let collation = collators.collate(parachain, relay_parent).await?;
 		let Collation { info, pov } = collation;
 		let res = crate::pipeline::full_output_validation_with_api(
+			validation_pool.as_ref(),
 			&*client,
 			&info,
 			&pov,


### PR DESCRIPTION
Previously, this was a `lazy_static!` global. This extracts out the logic to a `ValidationPool` struct, which is instantiated for each remote-validation test individually, and only once in `polkadot-validation`.

This should solve the issue in #918 where adding more tests lead to other tests failing. Here's @arkpar's description of the problem:
> So the root problem is there's a static pool of 8 validation hosts that's shared between all tests. That particual test verifies that two hosts can work in parallel. But it may randomly happen that all hosts are occupied by other tests waiting for timeouts or execution, so validation requests are serialized

