### PR TITLE
Update to upstream reed-solomon-erasure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5139,10 +5139,11 @@ dependencies = [
 
 [[package]]
 name = "reed-solomon-erasure"
-version = "4.0.0"
-source = "git+https://github.com/paritytech/reed-solomon-erasure#63c609beaef0f8174a9a21f058d7d3e46c3a762c"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a415a013dd7c5d4221382329a5a3482566da675737494935cbbbcdec04662f9d"
 dependencies = [
- "smallvec 0.6.13",
+ "smallvec 1.2.0",
 ]
 
 [[package]]

--- a/erasure-coding/Cargo.toml
+++ b/erasure-coding/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 primitives = { package = "polkadot-primitives", path = "../primitives" }
-reed_solomon = { package = "reed-solomon-erasure", git = "https://github.com/paritytech/reed-solomon-erasure" }
+reed_solomon = { package = "reed-solomon-erasure", version = "4.0.2"}
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
 trie = { package = "sp-trie", git = "https://github.com/paritytech/substrate", branch = "master" }


### PR DESCRIPTION
In an attempt to investigate whether we are effected by the [memory leak known in reed-solomon-erasure](https://github.com/darrenldl/reed-solomon-erasure/issues/74), this updates the dependency – switching from our fork to the upstream version, which is just ahead of ours (includes all our PR).

Unfortunately I do not know enough about this particular part of the code base to understand whether this might have unintended side-effects. Please think about that hard when reviewing.