### PR TITLE
Use tempdir for tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4037,6 +4037,7 @@ dependencies = [
  "parity-util-mem",
  "polkadot-cli",
  "polkadot-service",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ parity-util-mem = { version = "*", default-features = false, features = ["jemall
 [dev-dependencies]
 assert_cmd = "0.12"
 nix = "0.17"
+tempfile = "3.1.0"
 
 [workspace]
 members = [

--- a/tests/invalid_order_arguments.rs
+++ b/tests/invalid_order_arguments.rs
@@ -22,10 +22,11 @@ use tempfile::tempdir;
 #[cfg(unix)]
 fn invalid_order_arguments() {
 	let tmpdir = tempdir().expect("could not create temp dir");
-	let base_path = tmpdir.path().to_str().expect("path should consist of valid utf8 characters");
 
 	let status = Command::new(cargo_bin("polkadot"))
-		.args(&["--dev", "invalid_order_arguments", "-d", base_path, "-y"])
+		.args(&["--dev", "invalid_order_arguments", "-d"])
+		.args(tmpdir.path())
+		.args(&["-y"])
 		.status()
 		.unwrap();
 	assert!(!status.success());

--- a/tests/invalid_order_arguments.rs
+++ b/tests/invalid_order_arguments.rs
@@ -21,8 +21,8 @@ use tempfile::tempdir;
 #[test]
 #[cfg(unix)]
 fn invalid_order_arguments() {
-	let tmp = tempdir().expect("could not create temp dir");
-	let base_path = tmp.path().to_str().expect("path should consist of valid utf8 characters");
+	let tmpdir = tempdir().expect("could not create temp dir");
+	let base_path = tmpdir.path().to_str().expect("path should consist of valid utf8 characters");
 
 	let status = Command::new(cargo_bin("polkadot"))
 		.args(&["--dev", "invalid_order_arguments", "-d", base_path, "-y"])

--- a/tests/invalid_order_arguments.rs
+++ b/tests/invalid_order_arguments.rs
@@ -25,8 +25,8 @@ fn invalid_order_arguments() {
 
 	let status = Command::new(cargo_bin("polkadot"))
 		.args(&["--dev", "invalid_order_arguments", "-d"])
-		.args(tmpdir.path())
-		.args(&["-y"])
+		.arg(tmpdir.path())
+		.arg("-y")
 		.status()
 		.unwrap();
 	assert!(!status.success());

--- a/tests/invalid_order_arguments.rs
+++ b/tests/invalid_order_arguments.rs
@@ -16,11 +16,13 @@
 
 use assert_cmd::cargo::cargo_bin;
 use std::process::Command;
+use tempfile::tempdir;
 
 #[test]
 #[cfg(unix)]
 fn invalid_order_arguments() {
-	let base_path = "invalid_order_arguments";
+	let tmp = tempdir().expect("could not create temp dir");
+	let base_path = tmp.path().to_str().expect("path should consist of valid utf8 characters");
 
 	let status = Command::new(cargo_bin("polkadot"))
 		.args(&["--dev", "invalid_order_arguments", "-d", base_path, "-y"])

--- a/tests/purge_chain_works.rs
+++ b/tests/purge_chain_works.rs
@@ -15,7 +15,8 @@
 // along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
 use assert_cmd::cargo::cargo_bin;
-use std::{convert::TryInto, process::Command, thread, time::Duration, fs, path::PathBuf};
+use std::{convert::TryInto, process::Command, thread, time::Duration};
+use tempfile::tempdir;
 
 mod common;
 
@@ -25,9 +26,9 @@ fn purge_chain_works() {
 	use nix::sys::signal::{kill, Signal::SIGINT};
 	use nix::unistd::Pid;
 
-	let base_path = "purge_chain_test";
+	let tmpdir = tempdir().expect("could not create temp dir");
+	let base_path = tmpdir.path().to_str().expect("path should consist of valid utf8 characters");
 
-	let _ = fs::remove_dir_all(base_path);
 	let mut cmd = Command::new(cargo_bin("polkadot"))
 		.args(&["--dev", "-d", base_path])
 		.spawn()
@@ -49,6 +50,6 @@ fn purge_chain_works() {
 	assert!(status.success());
 
 	// Make sure that the `dev` chain folder exists, but the `db` is deleted.
-	assert!(PathBuf::from(base_path).join("chains/dev/").exists());
-	assert!(!PathBuf::from(base_path).join("chains/dev/db").exists());
+	assert!(tmpdir.path().join("chains/dev/").exists());
+	assert!(!tmpdir.path().join("chains/dev/db").exists());
 }

--- a/tests/purge_chain_works.rs
+++ b/tests/purge_chain_works.rs
@@ -46,7 +46,7 @@ fn purge_chain_works() {
 	let status = Command::new(cargo_bin("polkadot"))
 		.args(&["purge-chain", "--dev", "-d"])
 		.arg(tmpdir.path())
-		.arg( "-y")
+		.arg("-y")
 		.status()
 		.unwrap();
 	assert!(status.success());

--- a/tests/purge_chain_works.rs
+++ b/tests/purge_chain_works.rs
@@ -27,10 +27,10 @@ fn purge_chain_works() {
 	use nix::unistd::Pid;
 
 	let tmpdir = tempdir().expect("could not create temp dir");
-	let base_path = tmpdir.path().to_str().expect("path should consist of valid utf8 characters");
 
 	let mut cmd = Command::new(cargo_bin("polkadot"))
-		.args(&["--dev", "-d", base_path])
+		.args(&["--dev", "-d"])
+		.args(tmpdir.path())
 		.spawn()
 		.unwrap();
 
@@ -44,7 +44,9 @@ fn purge_chain_works() {
 
 	// Purge chain
 	let status = Command::new(cargo_bin("polkadot"))
-		.args(&["purge-chain", "--dev", "-d", base_path, "-y"])
+		.args(&["purge-chain", "--dev", "-d"])
+		.args(tmpdir.path())
+		.args( &["-y"])
 		.status()
 		.unwrap();
 	assert!(status.success());

--- a/tests/purge_chain_works.rs
+++ b/tests/purge_chain_works.rs
@@ -30,7 +30,7 @@ fn purge_chain_works() {
 
 	let mut cmd = Command::new(cargo_bin("polkadot"))
 		.args(&["--dev", "-d"])
-		.args(tmpdir.path())
+		.arg(tmpdir.path())
 		.spawn()
 		.unwrap();
 
@@ -45,8 +45,8 @@ fn purge_chain_works() {
 	// Purge chain
 	let status = Command::new(cargo_bin("polkadot"))
 		.args(&["purge-chain", "--dev", "-d"])
-		.args(tmpdir.path())
-		.args( &["-y"])
+		.arg(tmpdir.path())
+		.arg( "-y")
 		.status()
 		.unwrap();
 	assert!(status.success());

--- a/tests/running_the_node_and_interrupt.rs
+++ b/tests/running_the_node_and_interrupt.rs
@@ -31,7 +31,7 @@ fn running_the_node_works_and_can_be_interrupted() {
 
 		let mut cmd = Command::new(cargo_bin("polkadot"))
 			.args(&["--dev", "-d"])
-			.args(tmpdir.path())
+			.arg(tmpdir.path())
 			.spawn()
 			.unwrap();
 

--- a/tests/running_the_node_and_interrupt.rs
+++ b/tests/running_the_node_and_interrupt.rs
@@ -15,7 +15,8 @@
 // along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
 use assert_cmd::cargo::cargo_bin;
-use std::{convert::TryInto, process::Command, thread, time::Duration, fs};
+use std::{convert::TryInto, process::Command, thread, time::Duration};
+use tempfile::tempdir;
 
 mod common;
 
@@ -26,9 +27,11 @@ fn running_the_node_works_and_can_be_interrupted() {
 	use nix::unistd::Pid;
 
 	fn run_command_and_kill(signal: Signal) {
-		let _ = fs::remove_dir_all("interrupt_test");
+		let tmp = tempdir().expect("coult not create temp dir");
+		let base_path = tmp.path().to_str().expect("path should be valid utf8");
+
 		let mut cmd = Command::new(cargo_bin("polkadot"))
-			.args(&["--dev", "-d", "interrupt_test"])
+			.args(&["--dev", "-d", base_path])
 			.spawn()
 			.unwrap();
 

--- a/tests/running_the_node_and_interrupt.rs
+++ b/tests/running_the_node_and_interrupt.rs
@@ -28,10 +28,10 @@ fn running_the_node_works_and_can_be_interrupted() {
 
 	fn run_command_and_kill(signal: Signal) {
 		let tmpdir = tempdir().expect("coult not create temp dir");
-		let base_path = tmpdir.path().to_str().expect("path should consist of valid utf8 characters");
 
 		let mut cmd = Command::new(cargo_bin("polkadot"))
-			.args(&["--dev", "-d", base_path])
+			.args(&["--dev", "-d"])
+			.args(tmpdir.path())
 			.spawn()
 			.unwrap();
 

--- a/tests/running_the_node_and_interrupt.rs
+++ b/tests/running_the_node_and_interrupt.rs
@@ -28,7 +28,7 @@ fn running_the_node_works_and_can_be_interrupted() {
 
 	fn run_command_and_kill(signal: Signal) {
 		let tmpdir = tempdir().expect("coult not create temp dir");
-		let base_path = tmpdir.path().to_str().expect("path should be valid utf8");
+		let base_path = tmpdir.path().to_str().expect("path should consist of valid utf8 characters");
 
 		let mut cmd = Command::new(cargo_bin("polkadot"))
 			.args(&["--dev", "-d", base_path])

--- a/tests/running_the_node_and_interrupt.rs
+++ b/tests/running_the_node_and_interrupt.rs
@@ -27,8 +27,8 @@ fn running_the_node_works_and_can_be_interrupted() {
 	use nix::unistd::Pid;
 
 	fn run_command_and_kill(signal: Signal) {
-		let tmp = tempdir().expect("coult not create temp dir");
-		let base_path = tmp.path().to_str().expect("path should be valid utf8");
+		let tmpdir = tempdir().expect("coult not create temp dir");
+		let base_path = tmpdir.path().to_str().expect("path should be valid utf8");
 
 		let mut cmd = Command::new(cargo_bin("polkadot"))
 			.args(&["--dev", "-d", base_path])


### PR DESCRIPTION
This PR adds the [tempfile](https://docs.rs/tempfile/3.1.0/tempfile/index.html) crate as a dev-dependency and replaces the hardcoded test directories to temporary directories.

Running tests should no longer leak any unwanted files.

Closes #992 