### PR TITLE
update local chain name in docker-compose and docu

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,13 +198,13 @@ RUST_LOG=debug RUST_BACKTRACE=1 cargo run —- --dev
 If you want to see the multi-node consensus algorithm in action locally, then you can create a local testnet. You'll need two terminals open. In one, run:
 
 ```bash
-polkadot --chain=local --validator --key Alice -d /tmp/alice
+polkadot --chain=polkadot-local --validator --name Alice -d /tmp/alice
 ```
 
 And in the other, run:
 
 ```bash
-polkadot --chain=local --validator --key Bob -d /tmp/bob --port 30334 --bootnodes '/ip4/127.0.0.1/tcp/30333/p2p/ALICE_BOOTNODE_ID_HERE'
+polkadot --chain=polkadot-local --validator --name Bob -d /tmp/bob --port 30334 --bootnodes '/ip4/127.0.0.1/tcp/30333/p2p/ALICE_BOOTNODE_ID_HERE'
 ```
 
 Ensure you replace `ALICE_BOOTNODE_ID_HERE` with the node ID from the output of the first terminal.

--- a/README.md
+++ b/README.md
@@ -198,13 +198,13 @@ RUST_LOG=debug RUST_BACKTRACE=1 cargo run —- --dev
 If you want to see the multi-node consensus algorithm in action locally, then you can create a local testnet. You'll need two terminals open. In one, run:
 
 ```bash
-polkadot --chain=polkadot-local --validator --name Alice -d /tmp/alice
+polkadot --chain=polkadot-local --alice -d /tmp/alice
 ```
 
 And in the other, run:
 
 ```bash
-polkadot --chain=polkadot-local --validator --name Bob -d /tmp/bob --port 30334 --bootnodes '/ip4/127.0.0.1/tcp/30333/p2p/ALICE_BOOTNODE_ID_HERE'
+polkadot --chain=polkadot-local --bob -d /tmp/bob --port 30334 --bootnodes '/ip4/127.0.0.1/tcp/30333/p2p/ALICE_BOOTNODE_ID_HERE'
 ```
 
 Ensure you replace `ALICE_BOOTNODE_ID_HERE` with the node ID from the output of the first terminal.

--- a/doc/networks/local.md
+++ b/doc/networks/local.md
@@ -5,13 +5,13 @@ If you want to see the multi-node consensus algorithm in action locally, then
 you can create a local testnet. You'll need two terminals open. In one, run:
 
 ```bash
-polkadot --chain=poladot-local --validator --name Alice -d /tmp/alice
+polkadot --chain=poladot-local --alice -d /tmp/alice
 ```
 
 and in the other, run:
 
 ```bash
-polkadot --chain=polkadot-local --validator --name Bob -d /tmp/bob --port 30334 --bootnodes '/ip4/127.0.0.1/tcp/30333/p2p/ALICE_BOOTNODE_ID_HERE'
+polkadot --chain=polkadot-local --bob -d /tmp/bob --port 30334 --bootnodes '/ip4/127.0.0.1/tcp/30333/p2p/ALICE_BOOTNODE_ID_HERE'
 ```
 
 Ensure you replace `ALICE_BOOTNODE_ID_HERE` with the node ID from the output of

--- a/doc/networks/local.md
+++ b/doc/networks/local.md
@@ -5,13 +5,13 @@ If you want to see the multi-node consensus algorithm in action locally, then
 you can create a local testnet. You'll need two terminals open. In one, run:
 
 ```bash
-polkadot --chain=local --validator --key Alice -d /tmp/alice
+polkadot --chain=poladot-local --validator --name Alice -d /tmp/alice
 ```
 
 and in the other, run:
 
 ```bash
-polkadot --chain=local --validator --key Bob -d /tmp/bob --port 30334 --bootnodes '/ip4/127.0.0.1/tcp/30333/p2p/ALICE_BOOTNODE_ID_HERE'
+polkadot --chain=polkadot-local --validator --name Bob -d /tmp/bob --port 30334 --bootnodes '/ip4/127.0.0.1/tcp/30333/p2p/ALICE_BOOTNODE_ID_HERE'
 ```
 
 Ensure you replace `ALICE_BOOTNODE_ID_HERE` with the node ID from the output of

--- a/docker/docker-compose-local.yml
+++ b/docker/docker-compose-local.yml
@@ -10,7 +10,7 @@ services:
     image: chevdor/polkadot:latest
     volumes:
       - "polkadot-data-alice:/data"
-    command: polkadot --chain=local --validator --key Alice -d /data --node-key 0000000000000000000000000000000000000000000000000000000000000001
+    command: polkadot --chain=polkadot-local --validator --name Alice -d /data --node-key 0000000000000000000000000000000000000000000000000000000000000001
     networks:
       testing_net:
         ipv4_address: 172.28.1.1
@@ -27,7 +27,7 @@ services:
       - "polkadot-data-bob:/data"
     links:
       - "node_alice:alice"
-    command: polkadot --chain=local --validator --key Bob -d /data --port 30344 --rpc-port 9935 --ws-port 9945 --bootnodes '/ip4/172.28.1.1/tcp/30333/p2p/QmQZ8TjTqeDj3ciwr93EJ95hxfDsb9pEYDizUAbWpigtQN'
+    command: polkadot --chain=polkadot-local --validator --name Bob -d /data --port 30344 --rpc-port 9935 --ws-port 9945 --bootnodes '/ip4/172.28.1.1/tcp/30333/p2p/QmRpheLN4JWdAnY7HGJfWFNbfkQCb6tFf4vvA6hgjMZKrR'
     networks:
       testing_net:
         ipv4_address: 172.28.1.2

--- a/docker/docker-compose-local.yml
+++ b/docker/docker-compose-local.yml
@@ -10,7 +10,7 @@ services:
     image: chevdor/polkadot:latest
     volumes:
       - "polkadot-data-alice:/data"
-    command: polkadot --chain=polkadot-local --validator --name Alice -d /data --node-key 0000000000000000000000000000000000000000000000000000000000000001
+    command: polkadot --chain=polkadot-local --alice -d /data --node-key 0000000000000000000000000000000000000000000000000000000000000001
     networks:
       testing_net:
         ipv4_address: 172.28.1.1
@@ -27,7 +27,7 @@ services:
       - "polkadot-data-bob:/data"
     links:
       - "node_alice:alice"
-    command: polkadot --chain=polkadot-local --validator --name Bob -d /data --port 30344 --rpc-port 9935 --ws-port 9945 --bootnodes '/ip4/172.28.1.1/tcp/30333/p2p/QmRpheLN4JWdAnY7HGJfWFNbfkQCb6tFf4vvA6hgjMZKrR'
+    command: polkadot --chain=polkadot-local --bob -d /data --port 30344 --rpc-port 9935 --ws-port 9945 --bootnodes '/ip4/172.28.1.1/tcp/30333/p2p/QmRpheLN4JWdAnY7HGJfWFNbfkQCb6tFf4vvA6hgjMZKrR'
     networks:
       testing_net:
         ipv4_address: 172.28.1.2


### PR DESCRIPTION
the name of a local network changed from `local` to `polkadot-local` so
some local test environments were broken and the ticket #965 was
created

This PR should fix the `docker-compose-local.yml` and the documentation.