### PR TITLE
Make sure collators join the validation network

### DIFF
--- a/network/src/protocol/mod.rs
+++ b/network/src/protocol/mod.rs
@@ -1375,7 +1375,7 @@ impl<N: NetworkServiceOps> Service<N> {
 	/// Take care to drop the stream, as the sending side will not be cleaned
 	/// up until it is.
 	pub fn checked_statements(&self, relay_parent: Hash)
-		-> Pin<Box<dyn Stream<Item = SignedStatement>>> {
+		-> impl Stream<Item = SignedStatement> + Send {
 		let (tx, rx) = oneshot::channel();
 		let mut sender = self.sender.clone();
 
@@ -1400,7 +1400,6 @@ impl<N: NetworkServiceOps> Service<N> {
 				}
 			})
 			.flatten_stream()
-			.boxed()
 	}
 }
 


### PR DESCRIPTION
Collators need to join the validation network to tell its connected
relay chain peers the leaf they listen on. This is required to make the
Parachain validator send the signed statement to the collators as well.