### PR TITLE
Add method network_service to get a copy of the NetworkService from Network

### DIFF
--- a/collator/src/lib.rs
+++ b/collator/src/lib.rs
@@ -84,11 +84,18 @@ pub trait Network: Send + Sync {
 	/// dropped when it is not required anymore. Otherwise, it will stick around in memory
 	/// infinitely.
 	fn checked_statements(&self, relay_parent: Hash) -> Pin<Box<dyn Stream<Item=SignedStatement> + Send>>;
+
+	/// Returns the `NetworkService`
+	fn network_service(&self) -> Arc<polkadot_network::PolkadotNetworkService>;
 }
 
 impl Network for polkadot_network::protocol::Service {
 	fn checked_statements(&self, relay_parent: Hash) -> Pin<Box<dyn Stream<Item=SignedStatement> + Send>> {
 		polkadot_network::protocol::Service::checked_statements(self, relay_parent).boxed()
+	}
+
+	fn network_service(&self) -> Arc<polkadot_network::PolkadotNetworkService> {
+		polkadot_network::protocol::Service::network_service(self)
 	}
 }
 

--- a/network/src/protocol/mod.rs
+++ b/network/src/protocol/mod.rs
@@ -207,6 +207,12 @@ impl<N> Clone for Service<N> {
 	}
 }
 
+impl<N> Service<N> {
+	pub fn network_service(&self) -> Arc<N> {
+		self.network_service.clone()
+	}
+}
+
 /// Registers the protocol.
 ///
 /// You are very strongly encouraged to call this method very early on. Any connection open

--- a/network/src/protocol/mod.rs
+++ b/network/src/protocol/mod.rs
@@ -208,6 +208,7 @@ impl<N> Clone for Service<N> {
 }
 
 impl<N> Service<N> {
+	/// Returns the `NetworkService`
 	pub fn network_service(&self) -> Arc<N> {
 		self.network_service.clone()
 	}


### PR DESCRIPTION
This is needed for cumulus to allow cumulus to call `announce_block`.

Related to https://github.com/paritytech/cumulus/issues/7