### PR TITLE
Add 2 channels to release announcements github action

### DIFF
--- a/.github/workflows/release-bot.yml
+++ b/.github/workflows/release-bot.yml
@@ -1,4 +1,4 @@
-name: Pushes release updates to a pre-defined Matrix room
+name: Push release notes to internal release notes channel
 on:
   release:
     types:
@@ -8,10 +8,35 @@ jobs:
   ping_matrix:
     runs-on: ubuntu-latest
     steps:
-      - name: send message
+      - name: Internal Release Notes Channel
         uses: s3krit/matrix-message-action@v0.0.2
         with:
           room_id: ${{ secrets.MATRIX_ROOM_ID }}
           access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
           message: "**${{github.event.repository.full_name}}:** A release has been ${{github.event.action}}<br/>Release version [${{github.event.release.tag_name}}](${{github.event.release.html_url}})<br/><br/>***Description:***<br/>${{github.event.release.body}}<br/>"
+          server: "matrix.parity.io"
+---
+name: Push release notes to validator lounge and kusama announcements
+on:
+  release:
+    types:
+      - published
+jobs:
+  ping_matrix:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validator Lounge
+        uses: s3krit/matrix-message-action@v0.0.2
+        with:
+          room_id: ${{ secrets.VALIDATOR_LOUNGE_MATRIX_ROOM_ID }}
+          access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
+          message: "***Kusama ${{github.event.release.tag_name}} has been released!***<br/>Please update at your earliest convenience.<br/>${{github.event.release.html_url}}<br/><br/>${{github.event.release.body}}<br/>"
+          server: "matrix.parity.io"
+
+      - name: Kusama Announcements
+        uses: s3krit/matrix-message-action@v0.0.2
+        with:
+          room_id: ${{ secrets.KUSAMA_ANNOUNCEMENTS_MATRIX_ROOM_ID }}
+          access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
+          message: "***Kusama ${{github.event.release.tag_name}} has been released!***<br/>Please update at your earliest convenience.<br/>${{github.event.release.html_url}}<br/><br/>${{github.event.release.body}}<br/>"
           server: "matrix.parity.io"

--- a/.github/workflows/release-bot.yml
+++ b/.github/workflows/release-bot.yml
@@ -2,7 +2,6 @@ name: Push release notes to internal release notes channel
 on:
   release:
     types:
-      - prereleased
       - published
 jobs:
   ping_matrix:
@@ -15,16 +14,7 @@ jobs:
           access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
           message: "**${{github.event.repository.full_name}}:** A release has been ${{github.event.action}}<br/>Release version [${{github.event.release.tag_name}}](${{github.event.release.html_url}})<br/><br/>***Description:***<br/>${{github.event.release.body}}<br/>"
           server: "matrix.parity.io"
----
-name: Push release notes to validator lounge and kusama announcements
-on:
-  release:
-    types:
-      - published
-jobs:
-  ping_matrix:
-    runs-on: ubuntu-latest
-    steps:
+
       - name: Validator Lounge
         uses: s3krit/matrix-message-action@v0.0.2
         with:


### PR DESCRIPTION
* Adds Kusama Announcements channel to release announcement github action
* Adds Kusama Validator Lounge channel to release announcement github action

Necessary environment secrets have already been added