### PR TITLE
Add runtime benchmarking suite to all runtimes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -126,7 +126,7 @@ test-linux-stable:                 &test
     RUSTFLAGS: -Cdebug-assertions=y
     TARGET: native
   script:
-    - time cargo test --all --release --verbose --locked
+    - time cargo test --all --release --verbose --locked --features runtime-benchmarks
     - sccache -s
 
 
@@ -281,4 +281,3 @@ deploy-polkasync-kusama:
     POLKADOT_CI_COMMIT_REF:        "${CI_COMMIT_REF}"
   allow_failure:                   true
   trigger:                         "parity/infrastructure/parity-testnet"
-

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1227,7 +1227,7 @@ checksum = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 [[package]]
 name = "fork-tree"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -1235,7 +1235,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1252,7 +1252,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "frame-benchmarking",
  "parity-scale-codec",
@@ -1271,7 +1271,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1286,7 +1286,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata"
 version = "11.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -1297,7 +1297,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "bitmask",
  "frame-metadata",
@@ -1321,7 +1321,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "frame-support-procedural-tools",
  "proc-macro2 1.0.10",
@@ -1332,7 +1332,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -1344,7 +1344,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "proc-macro2 1.0.10",
  "quote 1.0.3",
@@ -1354,7 +1354,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -1370,7 +1370,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -2249,10 +2249,12 @@ dependencies = [
  "pallet-membership",
  "pallet-nicks",
  "pallet-offences",
+ "pallet-offences-benchmarking",
  "pallet-randomness-collective-flip",
  "pallet-recovery",
  "pallet-scheduler",
  "pallet-session",
+ "pallet-session-benchmarking",
  "pallet-society",
  "pallet-staking",
  "pallet-staking-reward-curve",
@@ -3258,7 +3260,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3276,7 +3278,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3293,7 +3295,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3314,7 +3316,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3329,7 +3331,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3345,7 +3347,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3360,7 +3362,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3374,7 +3376,7 @@ dependencies = [
 [[package]]
 name = "pallet-finality-tracker"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3390,7 +3392,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3408,7 +3410,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -3424,8 +3426,9 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
+ "frame-benchmarking",
  "frame-support",
  "frame-system",
  "pallet-authorship",
@@ -3443,7 +3446,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3459,7 +3462,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3473,7 +3476,7 @@ dependencies = [
 [[package]]
 name = "pallet-nicks"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3487,7 +3490,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3500,9 +3503,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-offences-benchmarking"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "pallet-im-online",
+ "pallet-offences",
+ "pallet-session",
+ "pallet-staking",
+ "parity-scale-codec",
+ "sp-io",
+ "sp-runtime",
+ "sp-staking",
+ "sp-std",
+]
+
+[[package]]
 name = "pallet-randomness-collective-flip"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3515,7 +3537,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "enumflags2",
  "frame-support",
@@ -3530,7 +3552,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3545,7 +3567,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3561,9 +3583,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-session-benchmarking"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "pallet-session",
+ "pallet-staking",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "pallet-society"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3578,13 +3614,15 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
+ "frame-benchmarking",
  "frame-support",
  "frame-system",
  "pallet-authorship",
  "pallet-session",
  "parity-scale-codec",
+ "rand_chacha 0.2.2",
  "serde",
  "sp-application-crypto",
  "sp-core",
@@ -3599,7 +3637,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.10",
@@ -3610,7 +3648,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3624,7 +3662,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3633,6 +3671,7 @@ dependencies = [
  "parity-scale-codec",
  "serde",
  "sp-inherents",
+ "sp-io",
  "sp-runtime",
  "sp-std",
  "sp-timestamp",
@@ -3641,7 +3680,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3654,7 +3693,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -3672,7 +3711,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -3685,8 +3724,9 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
+ "frame-benchmarking",
  "frame-support",
  "frame-system",
  "pallet-balances",
@@ -3699,8 +3739,9 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
+ "frame-benchmarking",
  "frame-support",
  "frame-system",
  "parity-scale-codec",
@@ -3714,9 +3755,10 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "enumflags2",
+ "frame-benchmarking",
  "frame-support",
  "frame-system",
  "parity-scale-codec",
@@ -4257,9 +4299,11 @@ dependencies = [
  "pallet-membership",
  "pallet-nicks",
  "pallet-offences",
+ "pallet-offences-benchmarking",
  "pallet-randomness-collective-flip",
  "pallet-scheduler",
  "pallet-session",
+ "pallet-session-benchmarking",
  "pallet-staking",
  "pallet-staking-reward-curve",
  "pallet-sudo",
@@ -5226,7 +5270,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "bytes 0.5.4",
  "derive_more 0.99.5",
@@ -5253,7 +5297,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -5269,7 +5313,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "impl-trait-for-tuples",
  "sc-chain-spec-derive",
@@ -5285,7 +5329,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.10",
@@ -5296,7 +5340,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "ansi_term 0.12.1",
  "app_dirs",
@@ -5338,7 +5382,7 @@ dependencies = [
 [[package]]
 name = "sc-client"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "derive_more 0.99.5",
  "fnv",
@@ -5375,7 +5419,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "derive_more 0.99.5",
  "fnv",
@@ -5410,7 +5454,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "blake2-rfc",
  "hash-db",
@@ -5440,7 +5484,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "derive_more 0.99.5",
  "fork-tree",
@@ -5482,7 +5526,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -5495,7 +5539,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "futures 0.3.4",
  "futures-timer 3.0.2",
@@ -5516,7 +5560,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-uncles"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "log 0.4.8",
  "sc-client-api",
@@ -5530,7 +5574,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "derive_more 0.99.5",
  "lazy_static",
@@ -5558,7 +5602,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "derive_more 0.99.5",
  "log 0.4.8",
@@ -5575,7 +5619,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "log 0.4.8",
  "parity-scale-codec",
@@ -5590,7 +5634,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "cranelift-codegen",
  "cranelift-wasm",
@@ -5611,7 +5655,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "assert_matches",
  "finality-grandpa",
@@ -5647,7 +5691,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "ansi_term 0.12.1",
  "futures 0.3.4",
@@ -5664,7 +5708,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "derive_more 0.99.5",
  "hex",
@@ -5679,7 +5723,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "bitflags",
  "bytes 0.5.4",
@@ -5732,7 +5776,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "futures 0.3.4",
  "futures-timer 3.0.2",
@@ -5748,7 +5792,7 @@ dependencies = [
 [[package]]
 name = "sc-network-test"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "env_logger 0.7.1",
  "futures 0.3.4",
@@ -5774,7 +5818,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "bytes 0.5.4",
  "fnv",
@@ -5801,7 +5845,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "futures 0.3.4",
  "libp2p",
@@ -5814,7 +5858,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "futures 0.3.4",
  "hash-db",
@@ -5847,7 +5891,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "derive_more 0.99.5",
  "futures 0.3.4",
@@ -5871,7 +5915,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-http-server",
@@ -5886,7 +5930,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "derive_more 0.99.5",
  "exit-future",
@@ -5937,7 +5981,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "log 0.4.8",
  "parity-scale-codec",
@@ -5951,7 +5995,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "bytes 0.5.4",
  "futures 0.3.4",
@@ -5973,7 +6017,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "erased-serde",
  "log 0.4.8",
@@ -5988,7 +6032,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-graph"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "derive_more 0.99.5",
  "futures 0.3.4",
@@ -6008,7 +6052,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "derive_more 0.99.5",
  "futures 0.3.4",
@@ -6393,7 +6437,7 @@ dependencies = [
 [[package]]
 name = "sp-allocator"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "derive_more 0.99.5",
  "log 0.4.8",
@@ -6405,7 +6449,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
@@ -6420,7 +6464,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate",
@@ -6432,7 +6476,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -6444,7 +6488,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "integer-sqrt",
  "num-traits 0.2.11",
@@ -6458,7 +6502,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6470,7 +6514,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -6481,7 +6525,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6493,7 +6537,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "derive_more 0.99.5",
  "log 0.4.8",
@@ -6509,7 +6553,7 @@ dependencies = [
 [[package]]
 name = "sp-chain-spec"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "serde",
  "serde_json",
@@ -6518,7 +6562,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "derive_more 0.99.5",
  "futures 0.3.4",
@@ -6541,7 +6585,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6555,7 +6599,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6571,7 +6615,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "parity-scale-codec",
  "schnorrkel",
@@ -6583,7 +6627,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "base58",
  "blake2-rfc",
@@ -6624,7 +6668,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "kvdb",
  "parking_lot 0.10.2",
@@ -6633,7 +6677,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "proc-macro2 1.0.10",
  "quote 1.0.3",
@@ -6643,7 +6687,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "environmental",
  "sp-std",
@@ -6653,7 +6697,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -6666,7 +6710,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-tracker"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -6676,7 +6720,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "derive_more 0.99.5",
  "parity-scale-codec",
@@ -6688,7 +6732,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "futures 0.3.4",
  "hash-db",
@@ -6708,7 +6752,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -6719,7 +6763,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -6729,7 +6773,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "backtrace",
  "log 0.4.8",
@@ -6738,7 +6782,7 @@ dependencies = [
 [[package]]
 name = "sp-phragmen"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -6750,7 +6794,7 @@ dependencies = [
 [[package]]
 name = "sp-phragmen-compact"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.10",
@@ -6761,7 +6805,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "serde",
  "sp-core",
@@ -6770,7 +6814,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "hash256-std-hasher",
  "impl-trait-for-tuples",
@@ -6791,7 +6835,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "parity-scale-codec",
  "primitive-types",
@@ -6806,7 +6850,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -6818,7 +6862,7 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "serde",
  "serde_json",
@@ -6827,7 +6871,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -6838,7 +6882,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -6848,7 +6892,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "hash-db",
  "log 0.4.8",
@@ -6867,12 +6911,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 
 [[package]]
 name = "sp-storage"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "impl-serde 0.2.3",
  "ref-cast",
@@ -6884,7 +6928,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -6898,7 +6942,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "tracing",
 ]
@@ -6906,7 +6950,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "derive_more 0.99.5",
  "futures 0.3.4",
@@ -6921,7 +6965,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -6935,7 +6979,7 @@ dependencies = [
 [[package]]
 name = "sp-utils"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "futures 0.3.4",
  "futures-core",
@@ -6946,7 +6990,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "impl-serde 0.2.3",
  "parity-scale-codec",
@@ -6958,7 +7002,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -7086,7 +7130,7 @@ dependencies = [
 [[package]]
 name = "substrate-browser-utils"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "chrono",
  "clear_on_drop",
@@ -7113,7 +7157,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "platforms",
 ]
@@ -7121,7 +7165,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.4",
@@ -7142,7 +7186,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "async-std",
  "derive_more 0.99.5",
@@ -7156,7 +7200,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "futures 0.3.4",
  "hash-db",
@@ -7176,7 +7220,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "cfg-if",
  "frame-executive",
@@ -7215,7 +7259,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime-client"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 dependencies = [
  "futures 0.3.4",
  "parity-scale-codec",
@@ -7233,7 +7277,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder-runner"
 version = "1.0.5"
-source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
+source = "git+https://github.com/paritytech/substrate#4b64b617112b0316d67b8f579c40504858f46232"
 
 [[package]]
 name = "substrate-wasm-builder-runner"
@@ -8375,10 +8419,12 @@ dependencies = [
  "pallet-membership",
  "pallet-nicks",
  "pallet-offences",
+ "pallet-offences-benchmarking",
  "pallet-randomness-collective-flip",
  "pallet-recovery",
  "pallet-scheduler",
  "pallet-session",
+ "pallet-session-benchmarking",
  "pallet-society",
  "pallet-staking",
  "pallet-staking-reward-curve",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1227,7 +1227,7 @@ checksum = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 [[package]]
 name = "fork-tree"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -1235,7 +1235,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1252,7 +1252,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "frame-benchmarking",
  "parity-scale-codec",
@@ -1271,7 +1271,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1286,7 +1286,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata"
 version = "11.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -1297,7 +1297,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "bitmask",
  "frame-metadata",
@@ -1321,7 +1321,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "frame-support-procedural-tools",
  "proc-macro2 1.0.10",
@@ -1332,7 +1332,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -1344,7 +1344,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "proc-macro2 1.0.10",
  "quote 1.0.3",
@@ -1354,7 +1354,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -1370,7 +1370,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -2249,10 +2249,12 @@ dependencies = [
  "pallet-membership",
  "pallet-nicks",
  "pallet-offences",
+ "pallet-offences-benchmarking",
  "pallet-randomness-collective-flip",
  "pallet-recovery",
  "pallet-scheduler",
  "pallet-session",
+ "pallet-session-benchmarking",
  "pallet-society",
  "pallet-staking",
  "pallet-staking-reward-curve",
@@ -3258,7 +3260,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3276,7 +3278,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3293,7 +3295,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3314,7 +3316,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3329,7 +3331,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3345,7 +3347,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3360,7 +3362,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3374,7 +3376,7 @@ dependencies = [
 [[package]]
 name = "pallet-finality-tracker"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3390,7 +3392,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3408,7 +3410,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -3424,8 +3426,9 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
+ "frame-benchmarking",
  "frame-support",
  "frame-system",
  "pallet-authorship",
@@ -3443,7 +3446,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3459,7 +3462,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3473,7 +3476,7 @@ dependencies = [
 [[package]]
 name = "pallet-nicks"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3487,7 +3490,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3500,9 +3503,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-offences-benchmarking"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "pallet-im-online",
+ "pallet-offences",
+ "pallet-session",
+ "pallet-staking",
+ "parity-scale-codec",
+ "sp-io",
+ "sp-runtime",
+ "sp-staking",
+ "sp-std",
+]
+
+[[package]]
 name = "pallet-randomness-collective-flip"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3515,7 +3537,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "enumflags2",
  "frame-support",
@@ -3530,7 +3552,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3545,7 +3567,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3561,9 +3583,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-session-benchmarking"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "pallet-session",
+ "pallet-staking",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "pallet-society"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3578,13 +3614,15 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
+ "frame-benchmarking",
  "frame-support",
  "frame-system",
  "pallet-authorship",
  "pallet-session",
  "parity-scale-codec",
+ "rand_chacha 0.2.2",
  "serde",
  "sp-application-crypto",
  "sp-core",
@@ -3599,7 +3637,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.10",
@@ -3610,7 +3648,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3624,7 +3662,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3633,6 +3671,7 @@ dependencies = [
  "parity-scale-codec",
  "serde",
  "sp-inherents",
+ "sp-io",
  "sp-runtime",
  "sp-std",
  "sp-timestamp",
@@ -3641,7 +3680,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3654,7 +3693,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -3672,7 +3711,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -3685,8 +3724,9 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
+ "frame-benchmarking",
  "frame-support",
  "frame-system",
  "pallet-balances",
@@ -3699,8 +3739,9 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
+ "frame-benchmarking",
  "frame-support",
  "frame-system",
  "parity-scale-codec",
@@ -3714,9 +3755,10 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "enumflags2",
+ "frame-benchmarking",
  "frame-support",
  "frame-system",
  "parity-scale-codec",
@@ -4256,9 +4298,11 @@ dependencies = [
  "pallet-membership",
  "pallet-nicks",
  "pallet-offences",
+ "pallet-offences-benchmarking",
  "pallet-randomness-collective-flip",
  "pallet-scheduler",
  "pallet-session",
+ "pallet-session-benchmarking",
  "pallet-staking",
  "pallet-staking-reward-curve",
  "pallet-sudo",
@@ -5225,7 +5269,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "bytes 0.5.4",
  "derive_more 0.99.5",
@@ -5252,7 +5296,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -5268,7 +5312,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "impl-trait-for-tuples",
  "sc-chain-spec-derive",
@@ -5284,7 +5328,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.10",
@@ -5295,7 +5339,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "ansi_term 0.12.1",
  "app_dirs",
@@ -5337,7 +5381,7 @@ dependencies = [
 [[package]]
 name = "sc-client"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "derive_more 0.99.5",
  "fnv",
@@ -5374,7 +5418,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "derive_more 0.99.5",
  "fnv",
@@ -5409,7 +5453,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "blake2-rfc",
  "hash-db",
@@ -5439,7 +5483,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "derive_more 0.99.5",
  "fork-tree",
@@ -5481,7 +5525,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -5494,7 +5538,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "futures 0.3.4",
  "futures-timer 3.0.2",
@@ -5515,7 +5559,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-uncles"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "log 0.4.8",
  "sc-client-api",
@@ -5529,7 +5573,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "derive_more 0.99.5",
  "lazy_static",
@@ -5557,7 +5601,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "derive_more 0.99.5",
  "log 0.4.8",
@@ -5574,7 +5618,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "log 0.4.8",
  "parity-scale-codec",
@@ -5589,7 +5633,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "cranelift-codegen",
  "cranelift-wasm",
@@ -5610,7 +5654,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "assert_matches",
  "finality-grandpa",
@@ -5646,7 +5690,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "ansi_term 0.12.1",
  "futures 0.3.4",
@@ -5663,7 +5707,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "derive_more 0.99.5",
  "hex",
@@ -5678,7 +5722,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "bitflags",
  "bytes 0.5.4",
@@ -5731,7 +5775,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "futures 0.3.4",
  "futures-timer 3.0.2",
@@ -5747,7 +5791,7 @@ dependencies = [
 [[package]]
 name = "sc-network-test"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "env_logger 0.7.1",
  "futures 0.3.4",
@@ -5773,7 +5817,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "bytes 0.5.4",
  "fnv",
@@ -5800,7 +5844,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "futures 0.3.4",
  "libp2p",
@@ -5813,7 +5857,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "futures 0.3.4",
  "hash-db",
@@ -5846,7 +5890,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "derive_more 0.99.5",
  "futures 0.3.4",
@@ -5870,7 +5914,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-http-server",
@@ -5885,7 +5929,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "derive_more 0.99.5",
  "exit-future",
@@ -5936,7 +5980,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "log 0.4.8",
  "parity-scale-codec",
@@ -5950,7 +5994,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "bytes 0.5.4",
  "futures 0.3.4",
@@ -5972,7 +6016,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "erased-serde",
  "log 0.4.8",
@@ -5987,7 +6031,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-graph"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "derive_more 0.99.5",
  "futures 0.3.4",
@@ -6007,7 +6051,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "derive_more 0.99.5",
  "futures 0.3.4",
@@ -6392,7 +6436,7 @@ dependencies = [
 [[package]]
 name = "sp-allocator"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "derive_more 0.99.5",
  "log 0.4.8",
@@ -6404,7 +6448,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
@@ -6419,7 +6463,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate",
@@ -6431,7 +6475,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -6443,7 +6487,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "integer-sqrt",
  "num-traits 0.2.11",
@@ -6457,7 +6501,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6469,7 +6513,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -6480,7 +6524,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6492,7 +6536,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "derive_more 0.99.5",
  "log 0.4.8",
@@ -6508,7 +6552,7 @@ dependencies = [
 [[package]]
 name = "sp-chain-spec"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "serde",
  "serde_json",
@@ -6517,7 +6561,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "derive_more 0.99.5",
  "futures 0.3.4",
@@ -6540,7 +6584,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6554,7 +6598,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6570,7 +6614,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "parity-scale-codec",
  "schnorrkel",
@@ -6582,7 +6626,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "base58",
  "blake2-rfc",
@@ -6623,7 +6667,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "kvdb",
  "parking_lot 0.10.2",
@@ -6632,7 +6676,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "proc-macro2 1.0.10",
  "quote 1.0.3",
@@ -6642,7 +6686,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "environmental",
  "sp-std",
@@ -6652,7 +6696,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -6665,7 +6709,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-tracker"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -6675,7 +6719,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "derive_more 0.99.5",
  "parity-scale-codec",
@@ -6687,7 +6731,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "futures 0.3.4",
  "hash-db",
@@ -6707,7 +6751,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -6718,7 +6762,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -6728,7 +6772,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "backtrace",
  "log 0.4.8",
@@ -6737,7 +6781,7 @@ dependencies = [
 [[package]]
 name = "sp-phragmen"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -6749,7 +6793,7 @@ dependencies = [
 [[package]]
 name = "sp-phragmen-compact"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.10",
@@ -6760,7 +6804,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "serde",
  "sp-core",
@@ -6769,7 +6813,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "hash256-std-hasher",
  "impl-trait-for-tuples",
@@ -6790,7 +6834,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "parity-scale-codec",
  "primitive-types",
@@ -6805,7 +6849,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -6817,7 +6861,7 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "serde",
  "serde_json",
@@ -6826,7 +6870,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -6837,7 +6881,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -6847,7 +6891,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "hash-db",
  "log 0.4.8",
@@ -6866,12 +6910,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 
 [[package]]
 name = "sp-storage"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "impl-serde 0.2.3",
  "ref-cast",
@@ -6883,7 +6927,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -6897,7 +6941,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "tracing",
 ]
@@ -6905,7 +6949,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "derive_more 0.99.5",
  "futures 0.3.4",
@@ -6920,7 +6964,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -6934,7 +6978,7 @@ dependencies = [
 [[package]]
 name = "sp-utils"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "futures 0.3.4",
  "futures-core",
@@ -6945,7 +6989,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "impl-serde 0.2.3",
  "parity-scale-codec",
@@ -6957,7 +7001,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -7085,7 +7129,7 @@ dependencies = [
 [[package]]
 name = "substrate-browser-utils"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "chrono",
  "clear_on_drop",
@@ -7112,7 +7156,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "platforms",
 ]
@@ -7120,7 +7164,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.4",
@@ -7141,7 +7185,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "async-std",
  "derive_more 0.99.5",
@@ -7155,7 +7199,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "futures 0.3.4",
  "hash-db",
@@ -7175,7 +7219,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "cfg-if",
  "frame-executive",
@@ -7214,7 +7258,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime-client"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 dependencies = [
  "futures 0.3.4",
  "parity-scale-codec",
@@ -7232,7 +7276,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder-runner"
 version = "1.0.5"
-source = "git+https://github.com/paritytech/substrate#cddb42c63faf5b27009e07051623079bcf4e6791"
+source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
 
 [[package]]
 name = "substrate-wasm-builder-runner"
@@ -8374,10 +8418,12 @@ dependencies = [
  "pallet-membership",
  "pallet-nicks",
  "pallet-offences",
+ "pallet-offences-benchmarking",
  "pallet-randomness-collective-flip",
  "pallet-recovery",
  "pallet-scheduler",
  "pallet-session",
+ "pallet-session-benchmarking",
  "pallet-society",
  "pallet-staking",
  "pallet-staking-reward-curve",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,7 +167,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d0864d84b8e07b145449be9a8537db86bf9de5ce03b913214694643b4743502"
 dependencies = [
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -503,9 +503,9 @@ checksum = "4964518bd3b4a8190e832886cdc0da9794f12e8e6c1613a9e90ff331c4c8724b"
 
 [[package]]
 name = "cc"
-version = "1.0.50"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95e28fa049fda1c330bcf9d723be7663a899c4679724b34c81e9f5a326aab8cd"
+checksum = "c3d87b23d6a92cd03af510a5ade527033f6aa6fa92161e2d5863a907d4c5e31d"
 dependencies = [
  "jobserver",
 ]
@@ -676,7 +676,7 @@ dependencies = [
  "gimli",
  "log 0.4.8",
  "serde",
- "smallvec 1.3.0",
+ "smallvec 1.4.0",
  "target-lexicon",
  "thiserror",
 ]
@@ -714,7 +714,7 @@ checksum = "518344698fa6c976d853319218415fdfb4f1bc6b42d0b2e2df652e55dff1f778"
 dependencies = [
  "cranelift-codegen",
  "log 0.4.8",
- "smallvec 1.3.0",
+ "smallvec 1.4.0",
  "target-lexicon",
 ]
 
@@ -898,7 +898,7 @@ checksum = "e2323f3f47db9a0e77ce7a300605d8d2098597fc451ed1a97bb1f6411bb550a7"
 dependencies = [
  "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -1018,7 +1018,7 @@ checksum = "946ee94e3dbf58fdd324f9ce245c7b238d46a66f00e86a020b71996349e46cce"
 dependencies = [
  "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -1138,7 +1138,7 @@ checksum = "030a733c8287d6213886dd487564ff5c8f6aae10278b3588ed177f9d18f8d231"
 dependencies = [
  "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
  "synstructure",
 ]
 
@@ -1227,7 +1227,7 @@ checksum = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 [[package]]
 name = "fork-tree"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -1235,7 +1235,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1252,7 +1252,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "frame-benchmarking",
  "parity-scale-codec",
@@ -1271,7 +1271,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1286,7 +1286,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata"
 version = "11.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -1297,7 +1297,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "bitmask",
  "frame-metadata",
@@ -1321,40 +1321,40 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "frame-support-procedural-tools",
  "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
  "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
 name = "frame-system"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -1370,7 +1370,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -1506,7 +1506,7 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -1628,7 +1628,7 @@ dependencies = [
  "byteorder",
  "fallible-iterator",
  "indexmap",
- "smallvec 1.3.0",
+ "smallvec 1.4.0",
  "stable_deref_trait",
 ]
 
@@ -1708,7 +1708,7 @@ dependencies = [
  "indexmap",
  "log 0.4.8",
  "slab",
- "tokio 0.2.18",
+ "tokio 0.2.19",
  "tokio-util",
 ]
 
@@ -1909,7 +1909,7 @@ dependencies = [
  "net2",
  "pin-project",
  "time",
- "tokio 0.2.18",
+ "tokio 0.2.19",
  "tower-service",
  "want 0.3.0",
 ]
@@ -1927,7 +1927,7 @@ dependencies = [
  "log 0.4.8",
  "rustls",
  "rustls-native-certs",
- "tokio 0.2.18",
+ "tokio 0.2.19",
  "tokio-rustls",
  "webpki",
 ]
@@ -1989,7 +1989,7 @@ checksum = "7ef5550a42e3740a0e71f909d4c861056a284060af885ae7aa6242820f920d9d"
 dependencies = [
  "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -2145,7 +2145,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -2249,12 +2249,10 @@ dependencies = [
  "pallet-membership",
  "pallet-nicks",
  "pallet-offences",
- "pallet-offences-benchmarking",
  "pallet-randomness-collective-flip",
  "pallet-recovery",
  "pallet-scheduler",
  "pallet-session",
- "pallet-session-benchmarking",
  "pallet-society",
  "pallet-staking",
  "pallet-staking-reward-curve",
@@ -2308,7 +2306,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cad096c6849b2ef027fabe35c4aed356d0e3d3f586d0a8361e5e17f1e50a7ce5"
 dependencies = [
  "parity-util-mem",
- "smallvec 1.3.0",
+ "smallvec 1.4.0",
 ]
 
 [[package]]
@@ -2338,7 +2336,7 @@ dependencies = [
  "parking_lot 0.10.2",
  "regex",
  "rocksdb",
- "smallvec 1.3.0",
+ "smallvec 1.4.0",
 ]
 
 [[package]]
@@ -2438,7 +2436,7 @@ dependencies = [
  "parity-multiaddr 0.8.0",
  "parking_lot 0.10.2",
  "pin-project",
- "smallvec 1.3.0",
+ "smallvec 1.4.0",
  "wasm-timer",
 ]
 
@@ -2469,7 +2467,7 @@ dependencies = [
  "ring",
  "rw-stream-sink",
  "sha2",
- "smallvec 1.3.0",
+ "smallvec 1.4.0",
  "thiserror",
  "unsigned-varint",
  "void",
@@ -2483,7 +2481,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "329127858e4728db5ab60c33d5ae352a999325fdf190ed022ec7d3a4685ae2e6"
 dependencies = [
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -2509,7 +2507,7 @@ dependencies = [
  "log 0.4.8",
  "prost",
  "prost-build",
- "smallvec 1.3.0",
+ "smallvec 1.4.0",
  "wasm-timer",
 ]
 
@@ -2533,7 +2531,7 @@ dependencies = [
  "prost-build",
  "rand 0.7.3",
  "sha2",
- "smallvec 1.3.0",
+ "smallvec 1.4.0",
  "uint",
  "unsigned-varint",
  "void",
@@ -2557,7 +2555,7 @@ dependencies = [
  "log 0.4.8",
  "net2",
  "rand 0.7.3",
- "smallvec 1.3.0",
+ "smallvec 1.4.0",
  "void",
  "wasm-timer",
 ]
@@ -2654,7 +2652,7 @@ dependencies = [
  "libp2p-core",
  "log 0.4.8",
  "rand 0.7.3",
- "smallvec 1.3.0",
+ "smallvec 1.4.0",
  "void",
  "wasm-timer",
 ]
@@ -2724,9 +2722,9 @@ dependencies = [
 
 [[package]]
 name = "librocksdb-sys"
-version = "6.6.4"
+version = "6.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3b727e2dd20ec2fb7ed93f23d9fd5328a0871185485ebdaff007b47d3e27e4"
+checksum = "883213ae3d09bfc3d104aefe94b25ebb183b6f4d3a515b23b14817e1f4854005"
 dependencies = [
  "bindgen",
  "cc",
@@ -3018,7 +3016,7 @@ dependencies = [
  "futures 0.3.4",
  "log 0.4.8",
  "pin-project",
- "smallvec 1.3.0",
+ "smallvec 1.4.0",
  "unsigned-varint",
 ]
 
@@ -3260,7 +3258,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3278,7 +3276,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3295,7 +3293,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3316,7 +3314,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3331,7 +3329,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3347,7 +3345,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3362,7 +3360,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3376,7 +3374,7 @@ dependencies = [
 [[package]]
 name = "pallet-finality-tracker"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3392,7 +3390,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3410,7 +3408,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -3426,9 +3424,8 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
- "frame-benchmarking",
  "frame-support",
  "frame-system",
  "pallet-authorship",
@@ -3446,7 +3443,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3462,7 +3459,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3476,7 +3473,7 @@ dependencies = [
 [[package]]
 name = "pallet-nicks"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3490,7 +3487,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3503,28 +3500,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "pallet-offences-benchmarking"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
-dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "pallet-im-online",
- "pallet-offences",
- "pallet-session",
- "pallet-staking",
- "parity-scale-codec",
- "sp-io",
- "sp-runtime",
- "sp-staking",
- "sp-std",
-]
-
-[[package]]
 name = "pallet-randomness-collective-flip"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3537,7 +3515,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "enumflags2",
  "frame-support",
@@ -3552,7 +3530,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3567,7 +3545,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3583,23 +3561,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "pallet-session-benchmarking"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
-dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "pallet-session",
- "pallet-staking",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
 name = "pallet-society"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3614,15 +3578,13 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
- "frame-benchmarking",
  "frame-support",
  "frame-system",
  "pallet-authorship",
  "pallet-session",
  "parity-scale-codec",
- "rand_chacha 0.2.2",
  "serde",
  "sp-application-crypto",
  "sp-core",
@@ -3637,18 +3599,18 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
 name = "pallet-sudo"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3662,7 +3624,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3671,7 +3633,6 @@ dependencies = [
  "parity-scale-codec",
  "serde",
  "sp-inherents",
- "sp-io",
  "sp-runtime",
  "sp-std",
  "sp-timestamp",
@@ -3680,7 +3641,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3693,7 +3654,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -3711,7 +3672,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -3724,9 +3685,8 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
- "frame-benchmarking",
  "frame-support",
  "frame-system",
  "pallet-balances",
@@ -3739,9 +3699,8 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
- "frame-benchmarking",
  "frame-support",
  "frame-system",
  "parity-scale-codec",
@@ -3755,10 +3714,9 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "enumflags2",
- "frame-benchmarking",
  "frame-support",
  "frame-system",
  "parity-scale-codec",
@@ -3770,11 +3728,12 @@ dependencies = [
 
 [[package]]
 name = "parity-db"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "288f7e4d049b6c9adeb8a69deaa9a4085ec601a1dbf36fe4fd1dd686f44b12cc"
+checksum = "00d595e372d119261593297debbe4193811a4dc811d2a1ccbb8caaa6666ad7ab"
 dependencies = [
  "blake2-rfc",
+ "crc32fast",
  "libc",
  "log 0.4.8",
  "memmap",
@@ -3854,7 +3813,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -3875,7 +3834,7 @@ dependencies = [
  "parity-util-mem-derive",
  "parking_lot 0.10.2",
  "primitive-types",
- "smallvec 1.3.0",
+ "smallvec 1.4.0",
  "winapi 0.3.8",
 ]
 
@@ -3886,7 +3845,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f557c32c6d268a07c921471619c0295f5efad3a0e76d4f97a05c091a51d110b2"
 dependencies = [
  "proc-macro2 1.0.10",
- "syn 1.0.17",
+ "syn 1.0.18",
  "synstructure",
 ]
 
@@ -3942,7 +3901,7 @@ dependencies = [
  "cloudabi",
  "libc",
  "redox_syscall",
- "smallvec 1.3.0",
+ "smallvec 1.4.0",
  "winapi 0.3.8",
 ]
 
@@ -3965,7 +3924,7 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -4029,7 +3988,7 @@ checksum = "8988430ce790d8682672117bc06dda364c0be32d3abd738234f19f3240bad99a"
 dependencies = [
  "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -4040,9 +3999,9 @@ checksum = "237844750cfbb86f67afe27eee600dfbbcb6188d734139b534cbfbf4f96792ae"
 
 [[package]]
 name = "pin-utils"
-version = "0.1.0-alpha.4"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5894c618ce612a3fa23881b152b608bafb8c56cfc22f434a3ba3120b40f7b587"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
@@ -4099,7 +4058,7 @@ dependencies = [
  "sp-consensus",
  "sp-core",
  "sp-runtime",
- "tokio 0.2.18",
+ "tokio 0.2.19",
 ]
 
 [[package]]
@@ -4122,7 +4081,7 @@ dependencies = [
  "structopt",
  "substrate-browser-utils",
  "substrate-build-script-utils",
- "tokio 0.2.18",
+ "tokio 0.2.19",
  "wasm-bindgen",
  "wasm-bindgen-futures",
 ]
@@ -4150,7 +4109,7 @@ dependencies = [
  "sp-core",
  "sp-keyring",
  "sp-runtime",
- "tokio 0.2.18",
+ "tokio 0.2.19",
 ]
 
 [[package]]
@@ -4298,11 +4257,9 @@ dependencies = [
  "pallet-membership",
  "pallet-nicks",
  "pallet-offences",
- "pallet-offences-benchmarking",
  "pallet-randomness-collective-flip",
  "pallet-scheduler",
  "pallet-session",
- "pallet-session-benchmarking",
  "pallet-staking",
  "pallet-staking-reward-curve",
  "pallet-sudo",
@@ -4555,7 +4512,7 @@ dependencies = [
  "sp-timestamp",
  "sp-transaction-pool",
  "sp-trie",
- "tokio 0.2.18",
+ "tokio 0.2.19",
 ]
 
 [[package]]
@@ -4630,7 +4587,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
  "version_check",
 ]
 
@@ -4642,7 +4599,7 @@ checksum = "4f5444ead4e9935abd7f27dc51f7e852a0569ac888096d5ec2499470794e2e53"
 dependencies = [
  "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
  "syn-mid",
  "version_check",
 ]
@@ -4744,7 +4701,7 @@ dependencies = [
  "itertools",
  "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -5067,7 +5024,7 @@ version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a415a013dd7c5d4221382329a5a3482566da675737494935cbbbcdec04662f9d"
 dependencies = [
- "smallvec 1.3.0",
+ "smallvec 1.4.0",
 ]
 
 [[package]]
@@ -5087,7 +5044,7 @@ checksum = "602eb59cda66fcb9aec25841fb76bc01d2b34282dcdd705028da297db6f3eec8"
 dependencies = [
  "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -5253,9 +5210,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "535622e6be132bccd223f4bb2b8ac8d53cda3c7a6394944d3b2b33fb974f9d76"
+checksum = "ed3d612bc64430efeb3f7ee6ef26d590dce0c43249217bddc62112540c7941e1"
 
 [[package]]
 name = "safe-mix"
@@ -5269,7 +5226,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "bytes 0.5.4",
  "derive_more 0.99.5",
@@ -5296,7 +5253,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -5312,7 +5269,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "impl-trait-for-tuples",
  "sc-chain-spec-derive",
@@ -5328,18 +5285,18 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
 name = "sc-cli"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "ansi_term 0.12.1",
  "app_dirs",
@@ -5375,13 +5332,13 @@ dependencies = [
  "structopt",
  "substrate-prometheus-endpoint",
  "time",
- "tokio 0.2.18",
+ "tokio 0.2.19",
 ]
 
 [[package]]
 name = "sc-client"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "derive_more 0.99.5",
  "fnv",
@@ -5418,7 +5375,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "derive_more 0.99.5",
  "fnv",
@@ -5453,7 +5410,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "blake2-rfc",
  "hash-db",
@@ -5483,7 +5440,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "derive_more 0.99.5",
  "fork-tree",
@@ -5525,7 +5482,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -5538,7 +5495,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "futures 0.3.4",
  "futures-timer 3.0.2",
@@ -5559,7 +5516,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-uncles"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "log 0.4.8",
  "sc-client-api",
@@ -5573,7 +5530,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "derive_more 0.99.5",
  "lazy_static",
@@ -5601,7 +5558,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "derive_more 0.99.5",
  "log 0.4.8",
@@ -5618,7 +5575,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "log 0.4.8",
  "parity-scale-codec",
@@ -5633,7 +5590,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "cranelift-codegen",
  "cranelift-wasm",
@@ -5654,7 +5611,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "assert_matches",
  "finality-grandpa",
@@ -5690,7 +5647,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "ansi_term 0.12.1",
  "futures 0.3.4",
@@ -5707,7 +5664,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "derive_more 0.99.5",
  "hex",
@@ -5722,7 +5679,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "bitflags",
  "bytes 0.5.4",
@@ -5775,7 +5732,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "futures 0.3.4",
  "futures-timer 3.0.2",
@@ -5791,7 +5748,7 @@ dependencies = [
 [[package]]
 name = "sc-network-test"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "env_logger 0.7.1",
  "futures 0.3.4",
@@ -5817,7 +5774,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "bytes 0.5.4",
  "fnv",
@@ -5844,7 +5801,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "futures 0.3.4",
  "libp2p",
@@ -5857,7 +5814,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "futures 0.3.4",
  "hash-db",
@@ -5890,7 +5847,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "derive_more 0.99.5",
  "futures 0.3.4",
@@ -5914,7 +5871,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-http-server",
@@ -5929,7 +5886,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "derive_more 0.99.5",
  "exit-future",
@@ -5980,7 +5937,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "log 0.4.8",
  "parity-scale-codec",
@@ -5994,7 +5951,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "bytes 0.5.4",
  "futures 0.3.4",
@@ -6016,7 +5973,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "erased-serde",
  "log 0.4.8",
@@ -6031,7 +5988,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-graph"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "derive_more 0.99.5",
  "futures 0.3.4",
@@ -6051,7 +6008,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "derive_more 0.99.5",
  "futures 0.3.4",
@@ -6131,7 +6088,7 @@ checksum = "f8584eea9b9ff42825b46faf46a8c24d2cff13ec152fa2a50df788b87c07ee28"
 dependencies = [
  "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -6146,9 +6103,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "572dfa3a0785509e7a44b5b4bebcf94d41ba34e9ed9eb9df722545c3b3c4144a"
+checksum = "3f331b9025654145cd425b9ded0caf8f5ae0df80d418b326e2dc1c3dc5eb0620"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -6159,9 +6116,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ddb15a5fec93b7021b8a9e96009c5d8d51c15673569f7c0f6b7204e5b7b404f"
+checksum = "17bf11d99252f512695eb468de5516e5cf75455521e69dfe343f3b74e4748405"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -6217,7 +6174,7 @@ checksum = "9e549e3abf4fb8621bd1609f11dfc9f5e50320802273b12f3811a67e6716ea6c"
 dependencies = [
  "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -6377,7 +6334,7 @@ checksum = "a945ec7f7ce853e89ffa36be1e27dce9a43e82ff9093bf3461c30d5da74ed11b"
 dependencies = [
  "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -6391,9 +6348,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05720e22615919e4734f6a99ceae50d00226c3c5aca406e102ebc33298214e0a"
+checksum = "c7cb5678e1615754284ec264d9bb5b4c27d2018577fd90ac0ceb578591ed5ee4"
 
 [[package]]
 name = "snow"
@@ -6428,7 +6385,7 @@ dependencies = [
  "log 0.4.8",
  "rand 0.7.3",
  "sha1",
- "smallvec 1.3.0",
+ "smallvec 1.4.0",
  "static_assertions",
  "thiserror",
 ]
@@ -6436,7 +6393,7 @@ dependencies = [
 [[package]]
 name = "sp-allocator"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "derive_more 0.99.5",
  "log 0.4.8",
@@ -6448,7 +6405,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
@@ -6463,19 +6420,19 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate",
  "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
 name = "sp-application-crypto"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -6487,7 +6444,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "integer-sqrt",
  "num-traits 0.2.11",
@@ -6501,7 +6458,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6513,7 +6470,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -6524,7 +6481,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6536,7 +6493,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "derive_more 0.99.5",
  "log 0.4.8",
@@ -6552,7 +6509,7 @@ dependencies = [
 [[package]]
 name = "sp-chain-spec"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "serde",
  "serde_json",
@@ -6561,7 +6518,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "derive_more 0.99.5",
  "futures 0.3.4",
@@ -6584,7 +6541,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6598,7 +6555,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6614,7 +6571,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "parity-scale-codec",
  "schnorrkel",
@@ -6626,7 +6583,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "base58",
  "blake2-rfc",
@@ -6667,7 +6624,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "kvdb",
  "parking_lot 0.10.2",
@@ -6676,17 +6633,17 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
 name = "sp-externalities"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "environmental",
  "sp-std",
@@ -6696,7 +6653,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -6709,7 +6666,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-tracker"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -6719,7 +6676,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "derive_more 0.99.5",
  "parity-scale-codec",
@@ -6731,7 +6688,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "futures 0.3.4",
  "hash-db",
@@ -6751,7 +6708,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -6762,7 +6719,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -6772,7 +6729,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "backtrace",
  "log 0.4.8",
@@ -6781,7 +6738,7 @@ dependencies = [
 [[package]]
 name = "sp-phragmen"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -6793,18 +6750,18 @@ dependencies = [
 [[package]]
 name = "sp-phragmen-compact"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
 name = "sp-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "serde",
  "sp-core",
@@ -6813,7 +6770,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "hash256-std-hasher",
  "impl-trait-for-tuples",
@@ -6834,7 +6791,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "parity-scale-codec",
  "primitive-types",
@@ -6849,19 +6806,19 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
  "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
 name = "sp-serializer"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "serde",
  "serde_json",
@@ -6870,7 +6827,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -6881,7 +6838,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -6891,7 +6848,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "hash-db",
  "log 0.4.8",
@@ -6910,12 +6867,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 
 [[package]]
 name = "sp-storage"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "impl-serde 0.2.3",
  "ref-cast",
@@ -6927,7 +6884,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -6941,7 +6898,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "tracing",
 ]
@@ -6949,7 +6906,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "derive_more 0.99.5",
  "futures 0.3.4",
@@ -6964,7 +6921,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -6978,7 +6935,7 @@ dependencies = [
 [[package]]
 name = "sp-utils"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "futures 0.3.4",
  "futures-core",
@@ -6989,7 +6946,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "impl-serde 0.2.3",
  "parity-scale-codec",
@@ -7001,7 +6958,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -7071,9 +7028,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "structopt"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff6da2e8d107dfd7b74df5ef4d205c6aebee0706c647f6bc6a2d5789905c00fb"
+checksum = "863246aaf5ddd0d6928dfeb1a9ca65f505599e4e1b399935ef7e75107516b4ef"
 dependencies = [
  "clap",
  "lazy_static",
@@ -7082,15 +7039,15 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a489c87c08fbaf12e386665109dd13470dcc9c4583ea3e10dd2b4523e5ebd9ac"
+checksum = "d239ca4b13aee7a2142e6795cbd69e457665ff8037aed33b3effdc430d2f927a"
 dependencies = [
  "heck",
  "proc-macro-error",
  "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -7111,7 +7068,7 @@ dependencies = [
  "heck",
  "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -7129,7 +7086,7 @@ dependencies = [
 [[package]]
 name = "substrate-browser-utils"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "chrono",
  "clear_on_drop",
@@ -7156,7 +7113,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "platforms",
 ]
@@ -7164,7 +7121,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.4",
@@ -7185,7 +7142,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "async-std",
  "derive_more 0.99.5",
@@ -7193,13 +7150,13 @@ dependencies = [
  "hyper 0.13.5",
  "log 0.4.8",
  "prometheus",
- "tokio 0.2.18",
+ "tokio 0.2.19",
 ]
 
 [[package]]
 name = "substrate-test-client"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "futures 0.3.4",
  "hash-db",
@@ -7219,7 +7176,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "cfg-if",
  "frame-executive",
@@ -7258,7 +7215,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime-client"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 dependencies = [
  "futures 0.3.4",
  "parity-scale-codec",
@@ -7276,7 +7233,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder-runner"
 version = "1.0.5"
-source = "git+https://github.com/paritytech/substrate#688f7021a242c22da375f170540ad8b2e96dbcc4"
+source = "git+https://github.com/paritytech/substrate#32ae0fd2221456d275471a2304fb30eba9736b14"
 
 [[package]]
 name = "substrate-wasm-builder-runner"
@@ -7389,9 +7346,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0df0eb663f387145cab623dea85b09c2c5b4b0aef44e945d928e682fce71bb03"
+checksum = "410a7488c0a728c7ceb4ad59b9567eb4053d02e8cc7f5c0e0eeeb39518369213"
 dependencies = [
  "proc-macro2 1.0.10",
  "quote 1.0.3",
@@ -7406,7 +7363,7 @@ checksum = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
 dependencies = [
  "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -7426,7 +7383,7 @@ checksum = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
 dependencies = [
  "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
  "unicode-xid 0.2.0",
 ]
 
@@ -7576,7 +7533,7 @@ checksum = "ca972988113b7715266f91250ddb98070d033c62a011fa0fcc57434a649310dd"
 dependencies = [
  "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -7590,9 +7547,9 @@ dependencies = [
 
 [[package]]
 name = "threadpool"
-version = "1.7.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2f0c90a5f3459330ac8bc0d2f879c693bb7a2f59689c1083fc4ef83834da865"
+checksum = "e8dae184447c15d5a6916d973c642aec485105a13cd238192a6927ae3e077d66"
 dependencies = [
  "num_cpus",
 ]
@@ -7667,9 +7624,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ef16d072d2b6dc8b4a56c70f5c5ced1a37752116f8e7c1e80c659aa7cb6713"
+checksum = "7d9c43f1bb96970e153bcbae39a65e249ccb942bd9d36dbdf086024920417c9c"
 dependencies = [
  "bytes 0.5.4",
  "fnv",
@@ -7778,7 +7735,7 @@ checksum = "4adb8b3e5f86b707f1b54e7c15b6de52617a823608ccda98a15d3a24222f265a"
 dependencies = [
  "futures-core",
  "rustls",
- "tokio 0.2.18",
+ "tokio 0.2.19",
  "webpki",
 ]
 
@@ -7879,7 +7836,7 @@ dependencies = [
  "futures-sink",
  "log 0.4.8",
  "pin-project-lite",
- "tokio 0.2.18",
+ "tokio 0.2.19",
 ]
 
 [[package]]
@@ -7915,7 +7872,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fbad39da2f9af1cae3016339ad7f2c7a9e870f12e8fd04c4fd7ef35b30c0d2b"
 dependencies = [
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -7943,7 +7900,7 @@ dependencies = [
  "hashbrown",
  "log 0.4.8",
  "rustc-hex",
- "smallvec 1.3.0",
+ "smallvec 1.4.0",
 ]
 
 [[package]]
@@ -8023,7 +7980,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5479532badd04e128284890390c1e876ef7a993d0570b3597ae43dfa1d59afa4"
 dependencies = [
- "smallvec 1.3.0",
+ "smallvec 1.4.0",
 ]
 
 [[package]]
@@ -8183,7 +8140,7 @@ dependencies = [
  "log 0.4.8",
  "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
  "wasm-bindgen-shared",
 ]
 
@@ -8217,7 +8174,7 @@ checksum = "d68a5b36eef1be7868f668632863292e37739656a80fc4b9acec7b0bd35a4931"
 dependencies = [
  "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -8418,12 +8375,10 @@ dependencies = [
  "pallet-membership",
  "pallet-nicks",
  "pallet-offences",
- "pallet-offences-benchmarking",
  "pallet-randomness-collective-flip",
  "pallet-recovery",
  "pallet-scheduler",
  "pallet-session",
- "pallet-session-benchmarking",
  "pallet-society",
  "pallet-staking",
  "pallet-staking-reward-curve",
@@ -8591,7 +8546,7 @@ checksum = "de251eec69fc7c1bc3923403d18ececb929380e016afe103da75f396704f8ca2"
 dependencies = [
  "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
  "synstructure",
 ]
 

--- a/runtime/common/src/claims.rs
+++ b/runtime/common/src/claims.rs
@@ -699,9 +699,9 @@ mod benchmarking {
 			let c in ...;
 			// Crate signature
 			let secret_key = secp256k1::SecretKey::parse(&keccak_256(&c.encode())).unwrap();
-			let caller: T::AccountId = account("user", c, SEED);
-			let signature = sig::<T>(&secret_key, &caller.encode());
-			let call = Call::<T>::claim(caller, signature);
+			let account: T::AccountId = account("user", c, SEED);
+			let signature = sig::<T>(&secret_key, &account.encode());
+			let call = Call::<T>::claim(account, signature);
 			let source = sp_runtime::transaction_validity::TransactionSource::External;
 		}: {
 			super::Module::<T>::validate_unsigned(source, &call)?

--- a/runtime/common/src/claims.rs
+++ b/runtime/common/src/claims.rs
@@ -674,7 +674,7 @@ mod benchmarking {
 			let u in 0 .. 1000;
 			let secret_key = secp256k1::SecretKey::parse(&keccak_256(&u.encode())).unwrap();
 			let eth_address = eth(&secret_key);
-			let account: T::AccountId = account("caller", u, SEED);
+			let account: T::AccountId = account("user", u, SEED);
 			let vesting = Some((100_000.into(), 1_000.into(), 100.into()));
 			let signature = sig::<T>(&secret_key, &account.encode());
 			super::Module::<T>::mint_claim(RawOrigin::Root.into(), eth_address, VALUE.into(), vesting)?;
@@ -699,7 +699,7 @@ mod benchmarking {
 			let c in ...;
 			// Crate signature
 			let secret_key = secp256k1::SecretKey::parse(&keccak_256(&c.encode())).unwrap();
-			let caller: T::AccountId = account("caller", c, SEED);
+			let caller: T::AccountId = account("user", c, SEED);
 			let signature = sig::<T>(&secret_key, &caller.encode());
 			let call = Call::<T>::claim(caller, signature);
 			let source = sp_runtime::transaction_validity::TransactionSource::External;
@@ -722,7 +722,7 @@ mod benchmarking {
 			let i in 0 .. 1_000;
 			// Crate signature
 			let secret_key = secp256k1::SecretKey::parse(&keccak_256(&i.encode())).unwrap();
-			let account: T::AccountId = account("caller", i, SEED);
+			let account: T::AccountId = account("user", i, SEED);
 			let signature = sig::<T>(&secret_key, &account.encode());
 			let data = account.using_encoded(to_ascii_hex);
 		}: {

--- a/runtime/kusama/Cargo.toml
+++ b/runtime/kusama/Cargo.toml
@@ -60,7 +60,10 @@ timestamp = { package = "pallet-timestamp", git = "https://github.com/paritytech
 treasury = { package = "pallet-treasury", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 utility = { package = "pallet-utility", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 vesting = { package = "pallet-vesting", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false, optional = true }
+pallet-offences-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false, optional = true }
+pallet-session-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false, optional = true }
 
 runtime-common = { package = "polkadot-runtime-common", path = "../common", default-features = false }
 primitives = { package = "polkadot-primitives", path = "../../primitives", default-features = false }
@@ -137,11 +140,23 @@ std = [
 	"runtime-common/std",
 ]
 runtime-benchmarks = [
-	"collective/runtime-benchmarks",
+	"runtime-common/runtime-benchmarks",
 	"frame-benchmarking",
 	"frame-support/runtime-benchmarks",
-	"runtime-common/runtime-benchmarks",
-	"elections-phragmen/runtime-benchmarks",
-	"society/runtime-benchmarks",
 	"system/runtime-benchmarks",
+	"sp-runtime/runtime-benchmarks",
+	"balances/runtime-benchmarks",
+	"collective/runtime-benchmarks",
+	"democracy/runtime-benchmarks",
+	"elections-phragmen/runtime-benchmarks",
+	"identity/runtime-benchmarks",
+	"im-online/runtime-benchmarks",
+	"society/runtime-benchmarks",
+	"staking/runtime-benchmarks",
+	"timestamp/runtime-benchmarks",
+	"treasury/runtime-benchmarks",
+	"utility/runtime-benchmarks",
+	"vesting/runtime-benchmarks",
+	"pallet-offences-benchmarking",
+	"pallet-session-benchmarking",
 ]

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -1002,10 +1002,33 @@ sp_api::impl_runtime_apis! {
 			repeat: u32,
 		) -> Result<Vec<frame_benchmarking::BenchmarkBatch>, RuntimeString> {
 			use frame_benchmarking::{Benchmarking, BenchmarkBatch, add_benchmark};
+			// Trying to add benchmarks directly to the Session Pallet caused cyclic dependency issues.
+			// To get around that, we separated the Session benchmarks into its own crate, which is why
+			// we need these two lines below.
+			use pallet_session_benchmarking::Module as SessionBench;
+			use pallet_offences_benchmarking::Module as OffencesBench;
+
+			impl pallet_session_benchmarking::Trait for Runtime {}
+			impl pallet_offences_benchmarking::Trait for Runtime {}
 
 			let mut batches = Vec::<BenchmarkBatch>::new();
 			let params = (&pallet, &benchmark, &lowest_range_values, &highest_range_values, &steps, repeat);
+			// Polkadot
 			add_benchmark!(params, batches, b"claims", Claims);
+			// Substrate
+			add_benchmark!(params, batches, b"balances", Balances);
+			add_benchmark!(params, batches, b"collective", Council);
+			add_benchmark!(params, batches, b"democracy", Democracy);
+			add_benchmark!(params, batches, b"identity", Identity);
+			add_benchmark!(params, batches, b"im-online", ImOnline);
+			add_benchmark!(params, batches, b"offences", OffencesBench::<Runtime>);
+			add_benchmark!(params, batches, b"session", SessionBench::<Runtime>);
+			add_benchmark!(params, batches, b"staking", Staking);
+			add_benchmark!(params, batches, b"timestamp", Timestamp);
+			add_benchmark!(params, batches, b"treasury", Treasury);
+			add_benchmark!(params, batches, b"utility", Utility);
+			add_benchmark!(params, batches, b"vesting", Vesting);
+
 			if batches.is_empty() { return Err("Benchmark not found for this pallet.".into()) }
 			Ok(batches)
 		}

--- a/runtime/polkadot/Cargo.toml
+++ b/runtime/polkadot/Cargo.toml
@@ -57,7 +57,10 @@ timestamp = { package = "pallet-timestamp", git = "https://github.com/paritytech
 treasury = { package = "pallet-treasury", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 sudo = { package = "pallet-sudo", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 vesting = { package = "pallet-vesting", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false, optional = true }
+pallet-offences-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false, optional = true }
+pallet-session-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false, optional = true }
 
 runtime-common = { package = "polkadot-runtime-common", path = "../common", default-features = false }
 primitives = { package = "polkadot-primitives", path = "../../primitives", default-features = false }
@@ -131,10 +134,20 @@ std = [
 	"vesting/std",
 ]
 runtime-benchmarks = [
-	"collective/runtime-benchmarks",
+	"runtime-common/runtime-benchmarks",
 	"frame-benchmarking",
 	"frame-support/runtime-benchmarks",
-	"runtime-common/runtime-benchmarks",
-	"elections-phragmen/runtime-benchmarks",
 	"system/runtime-benchmarks",
+	"sp-runtime/runtime-benchmarks",
+	"balances/runtime-benchmarks",
+	"collective/runtime-benchmarks",
+	"democracy/runtime-benchmarks",
+	"elections-phragmen/runtime-benchmarks",
+	"im-online/runtime-benchmarks",
+	"staking/runtime-benchmarks",
+	"timestamp/runtime-benchmarks",
+	"treasury/runtime-benchmarks",
+	"vesting/runtime-benchmarks",
+	"pallet-offences-benchmarking",
+	"pallet-session-benchmarking",
 ]

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -917,10 +917,31 @@ sp_api::impl_runtime_apis! {
 			repeat: u32,
 		) -> Result<Vec<frame_benchmarking::BenchmarkBatch>, RuntimeString> {
 			use frame_benchmarking::{Benchmarking, BenchmarkBatch, add_benchmark};
+			// Trying to add benchmarks directly to the Session Pallet caused cyclic dependency issues.
+			// To get around that, we separated the Session benchmarks into its own crate, which is why
+			// we need these two lines below.
+			use pallet_session_benchmarking::Module as SessionBench;
+			use pallet_offences_benchmarking::Module as OffencesBench;
+
+			impl pallet_session_benchmarking::Trait for Runtime {}
+			impl pallet_offences_benchmarking::Trait for Runtime {}
 
 			let mut batches = Vec::<BenchmarkBatch>::new();
 			let params = (&pallet, &benchmark, &lowest_range_values, &highest_range_values, &steps, repeat);
+			// Polkadot
 			add_benchmark!(params, batches, b"claims", Claims);
+			// Substrate
+			add_benchmark!(params, batches, b"balances", Balances);
+			add_benchmark!(params, batches, b"collective", Council);
+			add_benchmark!(params, batches, b"democracy", Democracy);
+			add_benchmark!(params, batches, b"im-online", ImOnline);
+			add_benchmark!(params, batches, b"offences", OffencesBench::<Runtime>);
+			add_benchmark!(params, batches, b"session", SessionBench::<Runtime>);
+			add_benchmark!(params, batches, b"staking", Staking);
+			add_benchmark!(params, batches, b"timestamp", Timestamp);
+			add_benchmark!(params, batches, b"treasury", Treasury);
+			add_benchmark!(params, batches, b"vesting", Vesting);
+
 			if batches.is_empty() { return Err("Benchmark not found for this pallet.".into()) }
 			Ok(batches)
 		}

--- a/runtime/westend/Cargo.toml
+++ b/runtime/westend/Cargo.toml
@@ -61,7 +61,10 @@ timestamp = { package = "pallet-timestamp", git = "https://github.com/paritytech
 treasury = { package = "pallet-treasury", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 utility = { package = "pallet-utility", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 vesting = { package = "pallet-vesting", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false, optional = true }
+pallet-offences-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false, optional = true }
+pallet-session-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false, optional = true }
 
 runtime-common = { package = "polkadot-runtime-common", path = "../common", default-features = false }
 primitives = { package = "polkadot-primitives", path = "../../primitives", default-features = false }
@@ -141,11 +144,23 @@ std = [
 	"runtime-common/std",
 ]
 runtime-benchmarks = [
-	"collective/runtime-benchmarks",
+	"runtime-common/runtime-benchmarks",
 	"frame-benchmarking",
 	"frame-support/runtime-benchmarks",
-	"runtime-common/runtime-benchmarks",
-	"elections-phragmen/runtime-benchmarks",
-	"society/runtime-benchmarks",
 	"system/runtime-benchmarks",
+	"sp-runtime/runtime-benchmarks",
+	"balances/runtime-benchmarks",
+	"collective/runtime-benchmarks",
+	"democracy/runtime-benchmarks",
+	"elections-phragmen/runtime-benchmarks",
+	"identity/runtime-benchmarks",
+	"im-online/runtime-benchmarks",
+	"society/runtime-benchmarks",
+	"staking/runtime-benchmarks",
+	"timestamp/runtime-benchmarks",
+	"treasury/runtime-benchmarks",
+	"utility/runtime-benchmarks",
+	"vesting/runtime-benchmarks",
+	"pallet-offences-benchmarking",
+	"pallet-session-benchmarking",
 ]

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -809,9 +809,28 @@ sp_api::impl_runtime_apis! {
 			repeat: u32,
 		) -> Result<Vec<frame_benchmarking::BenchmarkBatch>, RuntimeString> {
 			use frame_benchmarking::{Benchmarking, BenchmarkBatch, add_benchmark};
+			// Trying to add benchmarks directly to the Session Pallet caused cyclic dependency issues.
+			// To get around that, we separated the Session benchmarks into its own crate, which is why
+			// we need these two lines below.
+			use pallet_session_benchmarking::Module as SessionBench;
+			use pallet_offences_benchmarking::Module as OffencesBench;
+
+			impl pallet_session_benchmarking::Trait for Runtime {}
+			impl pallet_offences_benchmarking::Trait for Runtime {}
 
 			let mut batches = Vec::<BenchmarkBatch>::new();
 			let params = (&pallet, &benchmark, &lowest_range_values, &highest_range_values, &steps, repeat);
+
+			add_benchmark!(params, batches, b"balances", Balances);
+			add_benchmark!(params, batches, b"identity", Identity);
+			add_benchmark!(params, batches, b"im-online", ImOnline);
+			add_benchmark!(params, batches, b"offences", OffencesBench::<Runtime>);
+			add_benchmark!(params, batches, b"session", SessionBench::<Runtime>);
+			add_benchmark!(params, batches, b"staking", Staking);
+			add_benchmark!(params, batches, b"timestamp", Timestamp);
+			add_benchmark!(params, batches, b"utility", Utility);
+			add_benchmark!(params, batches, b"vesting", Vesting);
+
 			if batches.is_empty() { return Err("Benchmark not found for this pallet.".into()) }
 			Ok(batches)
 		}


### PR DESCRIPTION
This adds the full suite of benchmarks to the Kusama, Polkadot, and Westend runtimes.

It also adds verification functions and tests to the `claims` pallet.

Finally, it adds the `runtime-benchmarks` feature flag to the `test-linux-stable` CI pipeline to make sure benchmarks don't break with runtime upgrades.