### PR TITLE
Allow providing a custom block announce validator

### DIFF
--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -193,6 +193,7 @@ where
 			authority_discovery_enabled,
 			6000,
 			grandpa_pause,
+			None,
 		).map(|(s, _)| s),
 		D::native_version().runtime_version,
 	)

--- a/parachain/test-parachains/adder/collator/src/main.rs
+++ b/parachain/test-parachains/adder/collator/src/main.rs
@@ -136,11 +136,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 	let cli = Cli::from_iter(&["-dev"]);
 	let runner = cli.create_runner(&cli.run.base)?;
 	runner.async_run(|config| {
-		collator::start_collator(
+		collator::start_collator_polkadot(
 			context,
 			id,
 			key,
 			config,
+			None,
 		).map_err(|e| e.into())
 	})?;
 

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -41,7 +41,7 @@ pub use sc_client::{ExecutionStrategy, CallExecutor, Client};
 pub use sc_client_api::backend::Backend;
 pub use sp_api::{Core as CoreApi, ConstructRuntimeApi, ProvideRuntimeApi, StateBackend};
 pub use sp_runtime::traits::{HashFor, NumberFor};
-pub use consensus_common::SelectChain;
+pub use consensus_common::{block_validation::BlockAnnounceValidator, SelectChain};
 pub use polkadot_primitives::parachain::{CollatorId, ParachainHost};
 pub use polkadot_primitives::Block;
 pub use sp_runtime::traits::{Block as BlockT, self as runtime_traits, BlakeTwo256};
@@ -233,6 +233,9 @@ pub fn polkadot_new_full(
 	authority_discovery_enabled: bool,
 	slot_duration: u64,
 	grandpa_pause: Option<(u32, u32)>,
+	block_announce_validator_builder:
+		Option<Box<dyn FnOnce(Arc<service::TFullClient<Block, polkadot_runtime::RuntimeApi,
+			PolkadotExecutor>>) -> Box<dyn BlockAnnounceValidator<Block> + Send> + Send + 'static>>,
 )
 	-> Result<(
 		impl AbstractService<
@@ -252,6 +255,7 @@ pub fn polkadot_new_full(
 		authority_discovery_enabled,
 		slot_duration,
 		grandpa_pause,
+		block_announce_validator_builder,
 	)
 }
 
@@ -264,6 +268,9 @@ pub fn kusama_new_full(
 	authority_discovery_enabled: bool,
 	slot_duration: u64,
 	grandpa_pause: Option<(u32, u32)>,
+	block_announce_validator_builder:
+		Option<Box<dyn FnOnce(Arc<service::TFullClient<Block, kusama_runtime::RuntimeApi,
+			KusamaExecutor>>) -> Box<dyn BlockAnnounceValidator<Block> + Send> + Send + 'static>>,
 )
 	-> Result<(
 		impl AbstractService<
@@ -283,6 +290,7 @@ pub fn kusama_new_full(
 		authority_discovery_enabled,
 		slot_duration,
 		grandpa_pause,
+		block_announce_validator_builder,
 	)
 }
 
@@ -295,6 +303,9 @@ pub fn westend_new_full(
 	authority_discovery_enabled: bool,
 	slot_duration: u64,
 	grandpa_pause: Option<(u32, u32)>,
+	block_announce_validator_builder:
+		Option<Box<dyn FnOnce(Arc<service::TFullClient<Block, westend_runtime::RuntimeApi,
+			KusamaExecutor>>) -> Box<dyn BlockAnnounceValidator<Block> + Send> + Send + 'static>>,
 )
 	-> Result<(
 		impl AbstractService<
@@ -314,6 +325,7 @@ pub fn westend_new_full(
 		authority_discovery_enabled,
 		slot_duration,
 		grandpa_pause,
+		block_announce_validator_builder,
 	)
 }
 
@@ -337,6 +349,8 @@ pub fn new_full<Runtime, Dispatch, Extrinsic>(
 	authority_discovery_enabled: bool,
 	slot_duration: u64,
 	grandpa_pause: Option<(u32, u32)>,
+	block_announce_validator_builder: Option<Box<dyn FnOnce(Arc<service::TFullClient<Block, Runtime,
+		Dispatch>>) -> Box<dyn BlockAnnounceValidator<Block> + Send> + Send + 'static>>,
 )
 	-> Result<(
 		impl AbstractService<
@@ -375,9 +389,13 @@ pub fn new_full<Runtime, Dispatch, Extrinsic>(
 	let authority_discovery_enabled = authority_discovery_enabled;
 	let slot_duration = slot_duration;
 
-	let (builder, mut import_setup, inherent_data_providers) = new_full_start!(config, Runtime, Dispatch);
+	let (mut builder, mut import_setup, inherent_data_providers) = new_full_start!(config, Runtime, Dispatch);
 
 	let backend = builder.backend().clone();
+
+	if let Some(f) = block_announce_validator_builder {
+		builder = builder.with_block_announce_validator(f)?;
+	}
 
 	let service = builder
 		.with_finality_proof_provider(|client, backend| {


### PR DESCRIPTION
This feature is relevant for https://github.com/paritytech/cumulus/issues/7

It allows providing a builder for the block announce validator in the ServiceBuilder introduced in https://github.com/paritytech/substrate/pull/5797

Unfortunately I had to split `start_collator` for polkadot, kusama and westend because the signature of the builder depends on the client.