### PR TITLE
add space to bottom of file to trigger license detection

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -672,3 +672,4 @@ may consider it more useful to permit linking proprietary applications with
 the library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.  But first, please read
 <http://www.gnu.org/philosophy/why-not-lgpl.html>.
+


### PR DESCRIPTION
## what does this do?
This PR simply adds a space to the bottom of the `LICENSE` file in order to trigger GitHub license detection. It seems that simply renaming `license_header.txt` in #1032 was not enough to trigger a recheck.

## why is this important?
The new CLA license bot will rely heavily on the GitHub API and correct license detection will be important for the proper functioning of the CLA bot.