### PR TITLE
Some fixes to compile for Android

### DIFF
--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -164,8 +164,14 @@ pub fn run() -> Result<()> {
 		},
 		Some(Subcommand::ValidationWorker(cmd)) => {
 			sc_cli::init_logger("");
-			service::run_validation_worker(&cmd.mem_id)?;
-			Ok(())
+
+			if cfg!(feature = "browser") {
+				Err(sc_cli::Error::Input("Cannot run validation worker in browser".into()))
+			} else {
+				#[cfg(not(feature = "browser"))]
+				service::run_validation_worker(&cmd.mem_id)?;
+				Ok(())
+			}
 		},
 		Some(Subcommand::Benchmark(cmd)) => {
 			let runtime = cli.create_runner(cmd)?;

--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -164,14 +164,8 @@ pub fn run() -> Result<()> {
 		},
 		Some(Subcommand::ValidationWorker(cmd)) => {
 			sc_cli::init_logger("");
-
-			if cfg!(feature = "browser") {
-				Err(sc_cli::Error::Input("Cannot run validation worker in browser".into()))
-			} else {
-				#[cfg(not(feature = "browser"))]
-				service::run_validation_worker(&cmd.mem_id)?;
-				Ok(())
-			}
+			service::run_validation_worker(&cmd.mem_id)?;
+			Ok(())
 		},
 		Some(Subcommand::Benchmark(cmd)) => {
 			let runtime = cli.create_runner(cmd)?;

--- a/parachain/Cargo.toml
+++ b/parachain/Cargo.toml
@@ -24,7 +24,7 @@ sp-io = { git = "https://github.com/paritytech/substrate", branch = "master", op
 parking_lot = { version = "0.10.0", optional = true }
 log = { version = "0.4.8", optional = true }
 
-[target.'cfg(not(target_os = "unknown"))'.dependencies]
+[target.'cfg(not(any(target_os = "android", target_os = "unknown")))'.dependencies]
 shared_memory = { version = "0.10.0", optional = true }
 
 [features]

--- a/parachain/src/wasm_executor/mod.rs
+++ b/parachain/src/wasm_executor/mod.rs
@@ -28,7 +28,7 @@ use sp_core::traits::CallInWasm;
 use sp_wasm_interface::HostFunctions as _;
 use sp_externalities::Extensions;
 
-#[cfg(not(target_os = "unknown"))]
+#[cfg(not(any(target_os = "android", target_os = "unknown")))]
 pub use validation_host::{run_worker, ValidationPool, EXECUTION_TIMEOUT_SEC};
 
 mod validation_host;
@@ -49,19 +49,25 @@ impl ParachainExt {
 	}
 }
 
-/// A stub validation-pool defined when compiling for WASM.
-#[cfg(target_os = "unknown")]
+/// A stub validation-pool defined when compiling for Android or WASM.
+#[cfg(any(target_os = "android", target_os = "unknown"))]
 #[derive(Clone)]
 pub struct ValidationPool {
 	_inner: (), // private field means not publicly-instantiable
 }
 
-#[cfg(target_os = "unknown")]
+#[cfg(any(target_os = "android", target_os = "unknown"))]
 impl ValidationPool {
 	/// Create a new `ValidationPool`.
 	pub fn new() -> Self {
 		ValidationPool { _inner: () }
 	}
+}
+
+/// A stub function defined when compiling for Android or WASM.
+#[cfg(any(target_os = "android", target_os = "unknown"))]
+pub fn run_worker(_: &str) -> Result<(), String> {
+	Err("Cannot run validation worker on this platform".to_string())
 }
 
 /// WASM code execution mode.
@@ -101,7 +107,7 @@ pub enum Error {
 	#[display(fmt = "WASM worker error: {}", _0)]
 	External(String),
 	#[display(fmt = "Shared memory error: {}", _0)]
-	#[cfg(not(target_os = "unknown"))]
+	#[cfg(not(any(target_os = "android", target_os = "unknown")))]
 	SharedMem(shared_memory::SharedMemError),
 }
 
@@ -111,7 +117,7 @@ impl std::error::Error for Error {
 			Error::WasmExecutor(ref err) => Some(err),
 			Error::Io(ref err) => Some(err),
 			Error::System(ref err) => Some(&**err),
-			#[cfg(not(target_os = "unknown"))]
+			#[cfg(not(any(target_os = "android", target_os = "unknown")))]
 			Error::SharedMem(ref err) => Some(err),
 			_ => None,
 		}
@@ -137,20 +143,20 @@ pub fn validate_candidate<E: Externalities + 'static>(
 		ExecutionMode::Local => {
 			validate_candidate_internal(validation_code, &params.encode(), ext)
 		},
-		#[cfg(not(target_os = "unknown"))]
+		#[cfg(not(any(target_os = "android", target_os = "unknown")))]
 		ExecutionMode::Remote(pool) => {
 			pool.validate_candidate(validation_code, params, ext, false)
 		},
-		#[cfg(not(target_os = "unknown"))]
+		#[cfg(not(any(target_os = "android", target_os = "unknown")))]
 		ExecutionMode::RemoteTest(pool) => {
 			pool.validate_candidate(validation_code, params, ext, true)
 		},
-		#[cfg(target_os = "unknown")]
+		#[cfg(any(target_os = "android", target_os = "unknown"))]
 		ExecutionMode::Remote(pool) =>
 			Err(Error::System(Box::<dyn std::error::Error + Send + Sync>::from(
 				"Remote validator not available".to_string()
 			) as Box<_>)),
-		#[cfg(target_os = "unknown")]
+		#[cfg(any(target_os = "android", target_os = "unknown"))]
 		ExecutionMode::RemoteTest(pool) =>
 			Err(Error::System(Box::<dyn std::error::Error + Send + Sync>::from(
 				"Remote validator not available".to_string()

--- a/parachain/src/wasm_executor/validation_host.rs
+++ b/parachain/src/wasm_executor/validation_host.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
-#![cfg(not(target_os = "unknown"))]
+#![cfg(not(any(target_os = "android", target_os = "unknown")))]
 
 use std::{process, env, sync::Arc, sync::atomic, mem};
 use codec::{Decode, Encode, EncodeAppend};

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -45,6 +45,7 @@ pub use polkadot_primitives::parachain::{CollatorId, ParachainHost};
 pub use polkadot_primitives::Block;
 pub use sp_runtime::traits::{Block as BlockT, self as runtime_traits, BlakeTwo256};
 pub use chain_spec::{PolkadotChainSpec, KusamaChainSpec, WestendChainSpec};
+#[cfg(feature = "full-node")]
 pub use consensus::run_validation_worker;
 pub use codec::Codec;
 pub use polkadot_runtime;

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -45,7 +45,6 @@ pub use polkadot_primitives::parachain::{CollatorId, ParachainHost};
 pub use polkadot_primitives::Block;
 pub use sp_runtime::traits::{Block as BlockT, self as runtime_traits, BlakeTwo256};
 pub use chain_spec::{PolkadotChainSpec, KusamaChainSpec, WestendChainSpec};
-#[cfg(not(target_os = "unknown"))]
 pub use consensus::run_validation_worker;
 pub use codec::Codec;
 pub use polkadot_runtime;

--- a/validation/src/lib.rs
+++ b/validation/src/lib.rs
@@ -53,7 +53,6 @@ pub use self::shared_table::{
 };
 pub use self::validation_service::{ServiceHandle, ServiceBuilder};
 
-#[cfg(not(target_os = "unknown"))]
 pub use parachain::wasm_executor::run_worker as run_validation_worker;
 
 mod dynamic_inclusion;


### PR DESCRIPTION
Some work to make Polkadot compile for Android.
Fix #1027

What I did is:

- Disable the validation worker code for Android just like it's already disabled for Wasm.

- Remove the cfg(wasm) guards around `run_worker`, and instead provide a dummy implementation of this function that returns an error on Android and Wasm.

The second point is to avoid having to propagate error-prone cfg guards everywhere.
Keep in mind that `run_worker` can theoretically fail on regular (Linux) platforms, so any code that uses it must account for failures. It therefore makes sense to me that on Android and Wasm we simply treat the impossibility to have a worker as a regular failure rather than a special platform-specific thing.
