### PR TITLE
Update Runtime Weights and Fee Calculation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,7 +166,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d0864d84b8e07b145449be9a8537db86bf9de5ce03b913214694643b4743502"
 dependencies = [
- "quote 1.0.3",
+ "quote 1.0.4",
  "syn 1.0.18",
 ]
 
@@ -275,9 +275,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace-sys"
-version = "0.1.36"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78848718ee1255a2485d1309ad9cdecfc2e7d0362dd11c6829364c6b35ae1bc7"
+checksum = "18fbebbe1c9d1f383a9cc7e8ccdb471b91c8d024ee9c2ca5b5346121fe8b4399"
 dependencies = [
  "cc",
  "libc",
@@ -294,6 +294,12 @@ name = "base64"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
+
+[[package]]
+name = "base64"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5ca2cd0adc3f48f9e9ea5a6bbdf9ccc0bfade884847e484d452414c7ccffb3"
 
 [[package]]
 name = "bincode"
@@ -321,8 +327,8 @@ dependencies = [
  "lazycell",
  "log 0.4.8",
  "peeking_take_while",
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "regex",
  "rustc-hash",
  "shlex",
@@ -655,18 +661,18 @@ checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.59.0"
+version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a9c21f8042b9857bda93f6c1910b9f9f24100187a3d3d52f214a34e3dc5818"
+checksum = "d4425bb6c3f3d2f581c650f1a1fdd3196a975490149cf59bea9d34c3bea79eda"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.59.0"
+version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7853f77a6e4a33c67a69c40f5e1bb982bd2dc5c4a22e17e67b65bbccf9b33b2e"
+checksum = "d166b289fd30062ee6de86284750fc3fe5d037c6b864b3326ce153239b0626e1"
 dependencies = [
  "byteorder",
  "cranelift-bforest",
@@ -675,6 +681,7 @@ dependencies = [
  "cranelift-entity",
  "gimli",
  "log 0.4.8",
+ "regalloc",
  "serde",
  "smallvec 1.4.0",
  "target-lexicon",
@@ -683,9 +690,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.59.0"
+version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "084cd6d5fb0d1da28acd72c199471bfb09acc703ec8f3bf07b1699584272a3b9"
+checksum = "02c9fb2306a36d41c5facd4bf3400bc6c157185c43a96eaaa503471c34c5144b"
 dependencies = [
  "cranelift-codegen-shared",
  "cranelift-entity",
@@ -693,24 +700,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.59.0"
+version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "701b599783305a58c25027a4d73f2d6b599b2d8ef3f26677275f480b4d51e05d"
+checksum = "44e0cfe9b1f97d9f836bca551618106c7d53b93b579029ecd38e73daa7eb689e"
 
 [[package]]
 name = "cranelift-entity"
-version = "0.59.0"
+version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b88e792b28e1ebbc0187b72ba5ba880dad083abe9231a99d19604d10c9e73f38"
+checksum = "926a73c432e5ba9c891171ff50b75e7d992cd76cd271f0a0a0ba199138077472"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.59.0"
+version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "518344698fa6c976d853319218415fdfb4f1bc6b42d0b2e2df652e55dff1f778"
+checksum = "e45f82e3446dd1ebb8c2c2f6a6b0e6cd6cd52965c7e5f7b1b35e9a9ace31ccde"
 dependencies = [
  "cranelift-codegen",
  "log 0.4.8",
@@ -720,9 +727,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.59.0"
+version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32daf082da21c0c05d93394ff4842c2ab7c4991b1f3186a1d952f8ac660edd0b"
+checksum = "488b5d481bb0996a143e55a9d1739ef425efa20d4a5e5e98c859a8573c9ead9a"
 dependencies = [
  "cranelift-codegen",
  "raw-cpuid",
@@ -731,9 +738,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.59.0"
+version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2aa816f554a3ef739a5d17ca3081a1f8983f04c944ea8ff60fb8d9dd8cd2d7b"
+checksum = "00aa8dde71fd9fdb1958e7b0ef8f524c1560e2c6165e4ea54bc302b40551c161"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -896,8 +903,8 @@ version = "0.99.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2323f3f47db9a0e77ce7a300605d8d2098597fc451ed1a97bb1f6411bb550a7"
 dependencies = [
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
 ]
 
@@ -1016,8 +1023,8 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "946ee94e3dbf58fdd324f9ce245c7b238d46a66f00e86a020b71996349e46cce"
 dependencies = [
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
 ]
 
@@ -1106,11 +1113,10 @@ dependencies = [
 
 [[package]]
 name = "faerie"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74b9ed6159e4a6212c61d9c6a86bee01876b192a64accecf58d5b5ae3b667b52"
+checksum = "dfef65b0e94693295c5d2fe2506f0ee6f43465342d4b5331659936aee8b16084"
 dependencies = [
- "anyhow",
  "goblin",
  "indexmap",
  "log 0.4.8",
@@ -1122,9 +1128,9 @@ dependencies = [
 
 [[package]]
 name = "failure"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8529c2421efa3066a5cbd8063d2244603824daccb6936b079010bb2aa89464b"
+checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
 dependencies = [
  "backtrace",
  "failure_derive",
@@ -1132,12 +1138,12 @@ dependencies = [
 
 [[package]]
 name = "failure_derive"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "030a733c8287d6213886dd487564ff5c8f6aae10278b3588ed177f9d18f8d231"
+checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
  "synstructure",
 ]
@@ -1175,10 +1181,11 @@ dependencies = [
 
 [[package]]
 name = "finality-grandpa"
-version = "0.11.2"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "024517816630be5204eba201e8d1d405042b1255a5e0e3f298b054fc24d59e1d"
+checksum = "5ab32971efbe776e46bfbc34d5b662d8e1de51fd14e26a2eba522c0f3470fc0f"
 dependencies = [
+ "either",
  "futures 0.3.4",
  "futures-timer 2.0.2",
  "log 0.4.8",
@@ -1189,9 +1196,9 @@ dependencies = [
 
 [[package]]
 name = "fixed-hash"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32529fc42e86ec06e5047092082aab9ad459b070c5d2a76b14f4f5ce70bf2e84"
+checksum = "11498d382790b7a8f2fd211780bec78619bba81cdad3a283997c0c41f836759c"
 dependencies = [
  "byteorder",
  "rand 0.7.3",
@@ -1227,7 +1234,7 @@ checksum = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 [[package]]
 name = "fork-tree"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -1235,7 +1242,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1252,7 +1259,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-benchmarking",
  "parity-scale-codec",
@@ -1270,7 +1277,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1285,7 +1292,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata"
 version = "11.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -1296,7 +1303,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "bitmask",
  "frame-metadata",
@@ -1320,40 +1327,40 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-support-procedural-tools",
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
 ]
 
 [[package]]
 name = "frame-system"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -1369,7 +1376,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -1503,8 +1510,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a5081aa3de1f7542a794a397cde100ed903b0630152d0973479018fd85423a7"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
 ]
 
@@ -1707,7 +1714,7 @@ dependencies = [
  "indexmap",
  "log 0.4.8",
  "slab",
- "tokio 0.2.19",
+ "tokio 0.2.20",
  "tokio-util",
 ]
 
@@ -1747,9 +1754,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d737e0f947a1864e93d33fdef4af8445a00d1ed8dc0c8ddb73139ea6abf15"
+checksum = "61565ff7aaace3525556587bd2dc31d4a07071957be715e63ce7b1eccf51a8f4"
 dependencies = [
  "libc",
 ]
@@ -1908,7 +1915,7 @@ dependencies = [
  "net2",
  "pin-project",
  "time",
- "tokio 0.2.19",
+ "tokio 0.2.20",
  "tower-service",
  "want 0.3.0",
 ]
@@ -1926,7 +1933,7 @@ dependencies = [
  "log 0.4.8",
  "rustls",
  "rustls-native-certs",
- "tokio 0.2.19",
+ "tokio 0.2.20",
  "tokio-rustls",
  "webpki",
 ]
@@ -1986,8 +1993,8 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef5550a42e3740a0e71f909d4c861056a284060af885ae7aa6242820f920d9d"
 dependencies = [
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
 ]
 
@@ -2090,9 +2097,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.37"
+version = "0.3.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a27d435371a2fa5b6d2b028a74bbdb1234f308da363226a2854ca3ff8ba7055"
+checksum = "fa5a448de267e7358beaf4a5d849518fe9a0c13fce7afd44b06e68550e5562a7"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2142,8 +2149,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8609af8f63b626e8e211f52441fcdb6ec54f1a446606b10d5c89ae9bf8a20058"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
 ]
 
@@ -2481,7 +2488,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "329127858e4728db5ab60c33d5ae352a999325fdf190ed022ec7d3a4685ae2e6"
 dependencies = [
- "quote 1.0.3",
+ "quote 1.0.4",
  "syn 1.0.18",
 ]
 
@@ -2928,9 +2935,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.6.21"
+version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "302dec22bcf6bae6dfb69c647187f4b4d0fb6f535521f7bc022430ce8e12008f"
+checksum = "fce347092656428bc8eaf6201042cb551b8d67855af7374542a92a0fbfcac430"
 dependencies = [
  "cfg-if",
  "fuchsia-zircon",
@@ -2959,9 +2966,9 @@ dependencies = [
 
 [[package]]
 name = "mio-uds"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "966257a94e196b11bb43aca423754d87429960a768de9414f3691d6957abf125"
+checksum = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
 dependencies = [
  "iovec",
  "libc",
@@ -3049,9 +3056,9 @@ dependencies = [
 
 [[package]]
 name = "net2"
-version = "0.2.33"
+version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
+checksum = "2ba7c918ac76704fb42afcbbb43891e72731f3dcca3bef2a19786297baf14af7"
 dependencies = [
  "cfg-if",
  "libc",
@@ -3204,16 +3211,13 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea44a4fd660ab0f38434934ca0212e90fbeaaee54126ef20a3451c30c95bafae"
+checksum = "e5666bbb90bc4d1e5bdcb26c0afda1822d25928341e9384ab187a9b37ab69e36"
 dependencies = [
  "flate2",
- "goblin",
- "parity-wasm",
- "scroll",
  "target-lexicon",
- "uuid",
+ "wasmparser",
 ]
 
 [[package]]
@@ -3259,7 +3263,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3277,7 +3281,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3294,7 +3298,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3302,6 +3306,7 @@ dependencies = [
  "pallet-timestamp",
  "parity-scale-codec",
  "serde",
+ "sp-application-crypto",
  "sp-consensus-babe",
  "sp-consensus-vrf",
  "sp-inherents",
@@ -3315,7 +3320,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3330,7 +3335,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3346,7 +3351,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3361,7 +3366,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3375,7 +3380,7 @@ dependencies = [
 [[package]]
 name = "pallet-finality-tracker"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3391,7 +3396,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3409,7 +3414,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -3425,7 +3430,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3445,7 +3450,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3461,7 +3466,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3475,7 +3480,7 @@ dependencies = [
 [[package]]
 name = "pallet-nicks"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3489,7 +3494,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3504,7 +3509,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3523,7 +3528,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3536,7 +3541,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "enumflags2",
  "frame-support",
@@ -3551,7 +3556,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3566,7 +3571,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3584,7 +3589,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3598,7 +3603,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3613,7 +3618,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3636,18 +3641,18 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
 ]
 
 [[package]]
 name = "pallet-sudo"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3661,7 +3666,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3679,7 +3684,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3692,7 +3697,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -3710,7 +3715,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -3723,7 +3728,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3738,7 +3743,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3754,7 +3759,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -3852,8 +3857,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a0ec292e92e8ec7c58e576adacc1e3f399c597c8f263c42f18420abe58e7245"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
 ]
 
@@ -3885,7 +3890,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f557c32c6d268a07c921471619c0295f5efad3a0e76d4f97a05c091a51d110b2"
 dependencies = [
- "proc-macro2 1.0.10",
+ "proc-macro2 1.0.12",
  "syn 1.0.18",
  "synstructure",
 ]
@@ -3948,9 +3953,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "0.1.10"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab4fb1930692d1b6a9cfabdde3d06ea0a7d186518e2f4d67660d8970e2fa647a"
+checksum = "0a229b1c58c692edcaa5b9b0948084f130f55d2dcc15b02fcc5340b2b4521476"
 dependencies = [
  "paste-impl",
  "proc-macro-hack",
@@ -3958,13 +3963,13 @@ dependencies = [
 
 [[package]]
 name = "paste-impl"
-version = "0.1.10"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62486e111e571b1e93b710b61e8f493c0013be39629b714cb166bdb06aa5a8a"
+checksum = "2e0bf239e447e67ff6d16a8bb5e4d4bd2343acf5066061c0e8e06ac5ba8ca68c"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
 ]
 
@@ -4014,21 +4019,21 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f6a7f5eee6292c559c793430c55c00aea9d3b3d1905e855806ca4d7253426a2"
+checksum = "36e3dcd42688c05a66f841d22c5d8390d9a5d4c9aaf57b9285eae4900a080063"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8988430ce790d8682672117bc06dda364c0be32d3abd738234f19f3240bad99a"
+checksum = "f4d7346ac577ff1296e06a418e7618e22655bae834d4970cb6e39d6da8119969"
 dependencies = [
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
 ]
 
@@ -4098,7 +4103,7 @@ dependencies = [
  "sp-consensus",
  "sp-core",
  "sp-runtime",
- "tokio 0.2.19",
+ "tokio 0.2.20",
 ]
 
 [[package]]
@@ -4120,7 +4125,7 @@ dependencies = [
  "structopt",
  "substrate-browser-utils",
  "substrate-build-script-utils",
- "tokio 0.2.19",
+ "tokio 0.2.20",
  "wasm-bindgen",
  "wasm-bindgen-futures",
 ]
@@ -4149,7 +4154,7 @@ dependencies = [
  "sp-core",
  "sp-keyring",
  "sp-runtime",
- "tokio 0.2.19",
+ "tokio 0.2.20",
 ]
 
 [[package]]
@@ -4556,7 +4561,7 @@ dependencies = [
  "sp-timestamp",
  "sp-transaction-pool",
  "sp-trie",
- "tokio 0.2.19",
+ "tokio 0.2.20",
 ]
 
 [[package]]
@@ -4603,9 +4608,9 @@ dependencies = [
 
 [[package]]
 name = "primitive-types"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5e4b9943a2da369aec5e96f7c10ebc74fcf434d39590d974b0a3460e6f67fbb"
+checksum = "d3dedac218327b6b55fff5ef05f63ce5127024e1a36342836da7e92cbfac4531"
 dependencies = [
  "fixed-hash",
  "impl-codec",
@@ -4629,8 +4634,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98e9e4b82e0ef281812565ea4751049f1bdcdfccda7d3f459f2e138a40c08678"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
  "version_check",
 ]
@@ -4641,8 +4646,8 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f5444ead4e9935abd7f27dc51f7e852a0569ac888096d5ec2499470794e2e53"
 dependencies = [
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
  "syn-mid",
  "version_check",
@@ -4671,9 +4676,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.10"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df246d292ff63439fea9bc8c0a270bed0e390d5ebd4db4ba15aba81111b5abe3"
+checksum = "8872cf6f48eee44265156c111456a700ab3483686b3f96df4cf5481c89157319"
 dependencies = [
  "unicode-xid 0.2.0",
 ]
@@ -4743,8 +4748,8 @@ checksum = "537aa19b95acde10a12fec4301466386f757403de4cd4e5b4fa78fb5ecb18f72"
 dependencies = [
  "anyhow",
  "itertools",
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
 ]
 
@@ -4798,11 +4803,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
+checksum = "4c1f4b0efa5fc5e8ceb705136bfee52cfdb6a4e3509f770b478cd6ed434232a7"
 dependencies = [
- "proc-macro2 1.0.10",
+ "proc-macro2 1.0.12",
 ]
 
 [[package]]
@@ -5096,9 +5101,20 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "602eb59cda66fcb9aec25841fb76bc01d2b34282dcdd705028da297db6f3eec8"
 dependencies = [
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
+]
+
+[[package]]
+name = "regalloc"
+version = "0.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b27b256b41986ac5141b37b8bbba85d314fbf546c182eb255af6720e07e4f804"
+dependencies = [
+ "log 0.4.8",
+ "rustc-hash",
+ "smallvec 1.4.0",
 ]
 
 [[package]]
@@ -5142,13 +5158,13 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.12"
+version = "0.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ba5a8ec64ee89a76c98c549af81ff14813df09c3e6dc4766c3856da48597a0c"
+checksum = "703516ae74571f24b465b4a1431e81e2ad51336cb0ded733a55a1aa3eccac196"
 dependencies = [
  "cc",
- "lazy_static",
  "libc",
+ "once_cell",
  "spin",
  "untrusted",
  "web-sys",
@@ -5187,7 +5203,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bc8af4bda8e1ff4932523b94d3dd20ee30a87232323eda55903ffd71d2fb017"
 dependencies = [
- "base64",
+ "base64 0.11.0",
  "blake2b_simd",
  "constant_time_eq",
  "crossbeam-utils",
@@ -5232,7 +5248,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0d4a31f5d68413404705d6982529b0e11a9aacd4839d1d6222ee3b8cb4015e1"
 dependencies = [
- "base64",
+ "base64 0.11.0",
  "log 0.4.8",
  "ring",
  "sct",
@@ -5280,7 +5296,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "bytes 0.5.4",
  "derive_more 0.99.5",
@@ -5307,7 +5323,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -5323,7 +5339,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "impl-trait-for-tuples",
  "sc-chain-spec-derive",
@@ -5339,18 +5355,18 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
 ]
 
 [[package]]
 name = "sc-cli"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "ansi_term 0.12.1",
  "app_dirs",
@@ -5386,13 +5402,13 @@ dependencies = [
  "structopt",
  "substrate-prometheus-endpoint",
  "time",
- "tokio 0.2.19",
+ "tokio 0.2.20",
 ]
 
 [[package]]
 name = "sc-client-api"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "derive_more 0.99.5",
  "fnv",
@@ -5428,7 +5444,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "blake2-rfc",
  "hash-db",
@@ -5457,7 +5473,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "sc-client-api",
  "sp-blockchain",
@@ -5468,7 +5484,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "derive_more 0.99.5",
  "fork-tree",
@@ -5509,7 +5525,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -5522,7 +5538,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "futures 0.3.4",
  "futures-timer 3.0.2",
@@ -5543,7 +5559,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-uncles"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "log 0.4.8",
  "sc-client-api",
@@ -5557,7 +5573,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "derive_more 0.99.5",
  "lazy_static",
@@ -5585,7 +5601,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "derive_more 0.99.5",
  "log 0.4.8",
@@ -5602,7 +5618,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "log 0.4.8",
  "parity-scale-codec",
@@ -5617,7 +5633,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "cranelift-codegen",
  "cranelift-wasm",
@@ -5638,9 +5654,10 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "assert_matches",
+ "derive_more 0.99.5",
  "finality-grandpa",
  "fork-tree",
  "futures 0.3.4",
@@ -5674,7 +5691,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "ansi_term 0.12.1",
  "futures 0.3.4",
@@ -5691,7 +5708,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "derive_more 0.99.5",
  "hex",
@@ -5706,7 +5723,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "bitflags",
  "bytes 0.5.4",
@@ -5758,7 +5775,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "futures 0.3.4",
  "futures-timer 3.0.2",
@@ -5774,7 +5791,7 @@ dependencies = [
 [[package]]
 name = "sc-network-test"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "env_logger 0.7.1",
  "futures 0.3.4",
@@ -5801,7 +5818,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "bytes 0.5.4",
  "fnv",
@@ -5828,7 +5845,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "futures 0.3.4",
  "libp2p",
@@ -5841,7 +5858,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "futures 0.3.4",
  "hash-db",
@@ -5873,7 +5890,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "derive_more 0.99.5",
  "futures 0.3.4",
@@ -5897,7 +5914,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-http-server",
@@ -5912,7 +5929,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "derive_more 0.99.5",
  "exit-future",
@@ -5970,7 +5987,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "log 0.4.8",
  "parity-scale-codec",
@@ -5984,7 +6001,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "bytes 0.5.4",
  "futures 0.3.4",
@@ -6006,7 +6023,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "erased-serde",
  "log 0.4.8",
@@ -6021,7 +6038,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-graph"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "derive_more 0.99.5",
  "futures 0.3.4",
@@ -6041,7 +6058,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "derive_more 0.99.5",
  "futures 0.3.4",
@@ -6119,8 +6136,8 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8584eea9b9ff42825b46faf46a8c24d2cff13ec152fa2a50df788b87c07ee28"
 dependencies = [
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
 ]
 
@@ -6205,16 +6222,16 @@ version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e549e3abf4fb8621bd1609f11dfc9f5e50320802273b12f3811a67e6716ea6c"
 dependencies = [
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.51"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da07b57ee2623368351e9a0488bb0b261322a15a6e0ae53e243cbdc0f4208da9"
+checksum = "a7894c8ed05b7a3a279aeb79025fdec1d3158080b75b98a08faf2806bb799edd"
 dependencies = [
  "itoa",
  "ryu",
@@ -6365,8 +6382,8 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a945ec7f7ce853e89ffa36be1e27dce9a43e82ff9093bf3461c30d5da74ed11b"
 dependencies = [
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
 ]
 
@@ -6409,7 +6426,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c9dab3f95c9ebdf3a88268c19af668f637a3c5039c2c56ff2d40b1b2d64a25b"
 dependencies = [
- "base64",
+ "base64 0.11.0",
  "bytes 0.5.4",
  "flate2",
  "futures 0.3.4",
@@ -6426,7 +6443,7 @@ dependencies = [
 [[package]]
 name = "sp-allocator"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "derive_more 0.99.5",
  "log 0.4.8",
@@ -6438,7 +6455,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
@@ -6453,19 +6470,19 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate",
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
 ]
 
 [[package]]
 name = "sp-application-crypto"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -6477,7 +6494,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "integer-sqrt",
  "num-traits 0.2.11",
@@ -6491,7 +6508,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6503,7 +6520,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -6514,7 +6531,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6526,7 +6543,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "derive_more 0.99.5",
  "log 0.4.8",
@@ -6542,7 +6559,7 @@ dependencies = [
 [[package]]
 name = "sp-chain-spec"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "serde",
  "serde_json",
@@ -6551,7 +6568,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "derive_more 0.99.5",
  "futures 0.3.4",
@@ -6573,7 +6590,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6587,8 +6604,9 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
+ "merlin",
  "parity-scale-codec",
  "sp-api",
  "sp-application-crypto",
@@ -6603,7 +6621,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "parity-scale-codec",
  "schnorrkel",
@@ -6615,7 +6633,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "base58",
  "blake2-rfc",
@@ -6656,7 +6674,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "kvdb",
  "parking_lot 0.10.2",
@@ -6665,17 +6683,17 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
 ]
 
 [[package]]
 name = "sp-externalities"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -6686,7 +6704,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -6699,7 +6717,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-tracker"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -6709,7 +6727,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "derive_more 0.99.5",
  "parity-scale-codec",
@@ -6721,7 +6739,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "futures 0.3.4",
  "hash-db",
@@ -6741,7 +6759,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -6752,7 +6770,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -6762,7 +6780,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "backtrace",
  "log 0.4.8",
@@ -6771,7 +6789,7 @@ dependencies = [
 [[package]]
 name = "sp-phragmen"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -6783,18 +6801,18 @@ dependencies = [
 [[package]]
 name = "sp-phragmen-compact"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
 ]
 
 [[package]]
 name = "sp-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "serde",
  "sp-core",
@@ -6803,7 +6821,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "hash256-std-hasher",
  "impl-trait-for-tuples",
@@ -6824,7 +6842,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "parity-scale-codec",
  "primitive-types",
@@ -6839,19 +6857,19 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
 ]
 
 [[package]]
 name = "sp-serializer"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "serde",
  "serde_json",
@@ -6860,7 +6878,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -6871,7 +6889,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -6881,7 +6899,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "hash-db",
  "log 0.4.8",
@@ -6900,12 +6918,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 
 [[package]]
 name = "sp-storage"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "impl-serde 0.2.3",
  "ref-cast",
@@ -6917,7 +6935,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -6931,7 +6949,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "tracing",
 ]
@@ -6939,7 +6957,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "derive_more 0.99.5",
  "futures 0.3.4",
@@ -6954,7 +6972,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -6968,7 +6986,7 @@ dependencies = [
 [[package]]
 name = "sp-utils"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "futures 0.3.4",
  "futures-core",
@@ -6979,7 +6997,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "impl-serde 0.2.3",
  "parity-scale-codec",
@@ -6991,7 +7009,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -7078,8 +7096,8 @@ checksum = "d239ca4b13aee7a2142e6795cbd69e457665ff8037aed33b3effdc430d2f927a"
 dependencies = [
  "heck",
  "proc-macro-error",
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
 ]
 
@@ -7099,8 +7117,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0054a7df764039a6cd8592b9de84be4bec368ff081d203a7d5371cbfa8e65c81"
 dependencies = [
  "heck",
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
 ]
 
@@ -7119,7 +7137,7 @@ dependencies = [
 [[package]]
 name = "substrate-browser-utils"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "chrono",
  "clear_on_drop",
@@ -7146,7 +7164,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "platforms",
 ]
@@ -7154,7 +7172,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.4",
@@ -7175,7 +7193,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "async-std",
  "derive_more 0.99.5",
@@ -7183,13 +7201,13 @@ dependencies = [
  "hyper 0.13.5",
  "log 0.4.8",
  "prometheus",
- "tokio 0.2.19",
+ "tokio 0.2.20",
 ]
 
 [[package]]
 name = "substrate-test-client"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "futures 0.3.4",
  "hash-db",
@@ -7210,7 +7228,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "cfg-if",
  "frame-executive",
@@ -7249,7 +7267,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime-client"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "futures 0.3.4",
  "parity-scale-codec",
@@ -7269,7 +7287,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder-runner"
 version = "1.0.5"
-source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 
 [[package]]
 name = "substrate-wasm-builder-runner"
@@ -7279,9 +7297,9 @@ checksum = "e30c70de7e7d5fd404fe26db1e7a4d6b553e2760b1ac490f249c04a960c483b8"
 
 [[package]]
 name = "substrate-wasmtime"
-version = "0.13.0-threadsafe.1"
+version = "0.16.0-threadsafe.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e512629525ecfe43bffe1f3d9e6bb0f08bf01155288ef27fcaae4ea086e4a9d"
+checksum = "3b8f9558e3fe7018b9aeac2aba318664dd7b15e307de11b09f58240695688a96"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -7291,20 +7309,20 @@ dependencies = [
  "region",
  "rustc-demangle",
  "substrate-wasmtime-jit",
+ "substrate-wasmtime-profiling",
  "substrate-wasmtime-runtime",
  "target-lexicon",
  "wasmparser",
  "wasmtime-environ",
- "wasmtime-profiling",
  "wat",
  "winapi 0.3.8",
 ]
 
 [[package]]
 name = "substrate-wasmtime-jit"
-version = "0.13.0-threadsafe.1"
+version = "0.16.0-threadsafe.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a20de5564886d2bcffdd351c9cd114ceb50758aa58eac3cedb14faabf7f93b91"
+checksum = "f6b681b90a8d48b9535e4287c02e5aef6c72228ff45cbb60b4d195a762cc0770"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -7313,23 +7331,44 @@ dependencies = [
  "cranelift-frontend",
  "cranelift-native",
  "cranelift-wasm",
+ "gimli",
+ "log 0.4.8",
  "more-asserts",
  "region",
+ "substrate-wasmtime-profiling",
  "substrate-wasmtime-runtime",
  "target-lexicon",
  "thiserror",
  "wasmparser",
  "wasmtime-debug",
  "wasmtime-environ",
- "wasmtime-profiling",
  "winapi 0.3.8",
 ]
 
 [[package]]
-name = "substrate-wasmtime-runtime"
-version = "0.13.0-threadsafe.1"
+name = "substrate-wasmtime-profiling"
+version = "0.16.0-threadsafe.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d08846f04293a7fc27eeb30f06262ca2e1b4ee20f5192cec1f3ce201e08ceb8"
+checksum = "b7cb99b24e771de6c20b380fdf2d26ffc2c20701892c540830beb83af98bb3b7"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "gimli",
+ "lazy_static",
+ "libc",
+ "object",
+ "scroll",
+ "serde",
+ "substrate-wasmtime-runtime",
+ "target-lexicon",
+ "wasmtime-environ",
+]
+
+[[package]]
+name = "substrate-wasmtime-runtime"
+version = "0.16.0-threadsafe.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaccd27cc466bd2904aa14f984f642083037bf5b47e251ccaf1009aed0a2a185"
 dependencies = [
  "backtrace",
  "cc",
@@ -7342,7 +7381,6 @@ dependencies = [
  "region",
  "thiserror",
  "wasmtime-environ",
- "wasmtime-profiling",
  "winapi 0.3.8",
 ]
 
@@ -7386,8 +7424,8 @@ version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "410a7488c0a728c7ceb4ad59b9567eb4053d02e8cc7f5c0e0eeeb39518369213"
 dependencies = [
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "unicode-xid 0.2.0",
 ]
 
@@ -7397,8 +7435,8 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
 dependencies = [
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
 ]
 
@@ -7417,8 +7455,8 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
 dependencies = [
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
  "unicode-xid 0.2.0",
 ]
@@ -7553,21 +7591,21 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b3d3d2ff68104100ab257bb6bb0cb26c901abe4bd4ba15961f3bf867924012"
+checksum = "d12a1dae4add0f0d568eebc7bf142f145ba1aa2544cafb195c76f0f409091b60"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca972988113b7715266f91250ddb98070d033c62a011fa0fcc57434a649310dd"
+checksum = "3f34e0c1caaa462fd840ec6b768946ea1e7842620d94fe29d5b847138f521269"
 dependencies = [
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
 ]
 
@@ -7659,9 +7697,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "0.2.19"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d9c43f1bb96970e153bcbae39a65e249ccb942bd9d36dbdf086024920417c9c"
+checksum = "05c1d570eb1a36f0345a5ce9c6c6e665b70b73d11236912c0b477616aeec47b1"
 dependencies = [
  "bytes 0.5.4",
  "fnv",
@@ -7770,7 +7808,7 @@ checksum = "4adb8b3e5f86b707f1b54e7c15b6de52617a823608ccda98a15d3a24222f265a"
 dependencies = [
  "futures-core",
  "rustls",
- "tokio 0.2.19",
+ "tokio 0.2.20",
  "webpki",
 ]
 
@@ -7871,7 +7909,7 @@ dependencies = [
  "futures-sink",
  "log 0.4.8",
  "pin-project-lite",
- "tokio 0.2.19",
+ "tokio 0.2.20",
 ]
 
 [[package]]
@@ -7906,7 +7944,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fbad39da2f9af1cae3016339ad7f2c7a9e870f12e8fd04c4fd7ef35b30c0d2b"
 dependencies = [
- "quote 1.0.3",
+ "quote 1.0.4",
  "syn 1.0.18",
 ]
 
@@ -7981,9 +8019,9 @@ checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
 
 [[package]]
 name = "uint"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e75a4cdd7b87b28840dba13c483b9a88ee6bbf16ba5c951ee1ecfcf723078e0d"
+checksum = "173cd16430c206dc1a430af8a89a0e9c076cf15cb42b4aedb10e8cc8fee73681"
 dependencies = [
  "byteorder",
  "crunchy",
@@ -8062,9 +8100,9 @@ dependencies = [
 
 [[package]]
 name = "untrusted"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60369ef7a31de49bcb3f6ca728d4ba7300d9a1658f94c727d4cab8c8d9f4aece"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
@@ -8087,12 +8125,6 @@ dependencies = [
  "matches",
  "percent-encoding 2.1.0",
 ]
-
-[[package]]
-name = "uuid"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
 
 [[package]]
 name = "vcpkg"
@@ -8156,9 +8188,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.60"
+version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc57ce05287f8376e998cbddfb4c8cb43b84a7ec55cf4551d7c00eef317a47f"
+checksum = "e3c7d40d09cdbf0f4895ae58cf57d92e1e57a9dd8ed2e8390514b54a47cc5551"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -8166,24 +8198,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.60"
+version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d967d37bf6c16cca2973ca3af071d0a2523392e4a594548155d89a678f4237cd"
+checksum = "c3972e137ebf830900db522d6c8fd74d1900dcfc733462e9a12e942b00b4ac94"
 dependencies = [
  "bumpalo",
  "lazy_static",
  "log 0.4.8",
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.10"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7add542ea1ac7fdaa9dc25e031a6af33b7d63376292bd24140c637d00d1c312a"
+checksum = "8a369c5e1dfb7569e14d62af4da642a3cbc2f9a3652fe586e26ac22222aa4b04"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -8193,22 +8225,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.60"
+version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bd151b63e1ea881bb742cd20e1d6127cef28399558f3b5d415289bc41eee3a4"
+checksum = "2cd85aa2c579e8892442954685f0d801f9129de24fa2136b2c6a539c76b65776"
 dependencies = [
- "quote 1.0.3",
+ "quote 1.0.4",
  "wasm-bindgen-macro-support",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.60"
+version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d68a5b36eef1be7868f668632863292e37739656a80fc4b9acec7b0bd35a4931"
+checksum = "8eb197bd3a47553334907ffd2f16507b4f4f01bbec3ac921a7719e0decdfe72a"
 dependencies = [
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
@@ -8216,9 +8248,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.60"
+version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf76fe7d25ac79748a37538b7daeed1c7a6867c92d3245c12c6222e4a20d639"
+checksum = "a91c2916119c17a8e316507afaaa2dd94b47646048014bbdf6bef098c1bb58ad"
 
 [[package]]
 name = "wasm-timer"
@@ -8267,9 +8299,9 @@ checksum = "aeb1956b19469d1c5e63e459d29e7b5aa0f558d9f16fcef09736f8a265e6c10a"
 
 [[package]]
 name = "wasmtime-debug"
-version = "0.12.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d3d007436043bf55ec252d2f4dc1d35834157b5e2f148da839ca502e611cfe1"
+checksum = "d39ba645aee700b29ff0093028b4123556dd142a74973f04ed6225eedb40e77d"
 dependencies = [
  "anyhow",
  "faerie",
@@ -8283,12 +8315,12 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "0.12.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80f3dea0e60c076dd0da27fa10c821323903c9554c617ed32eaab8e7a7e36c89"
+checksum = "ed54fd9d64dfeeee7c285fd126174a6b5e6d4efc7e5a1566fdb635e60ff6a74e"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.12.0",
  "bincode",
  "cranelift-codegen",
  "cranelift-entity",
@@ -8311,22 +8343,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmtime-profiling"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "984d29c8add3381e60d649f4e3e2a501da900fc2d2586e139502eec32fe0ebc8"
-dependencies = [
- "gimli",
- "goblin",
- "lazy_static",
- "libc",
- "object",
- "scroll",
- "serde",
- "target-lexicon",
-]
-
-[[package]]
 name = "wast"
 version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8346,9 +8362,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.37"
+version = "0.3.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6f51648d8c56c366144378a33290049eafdd784071077f6fe37dae64c1c4cb"
+checksum = "8bc359e5dd3b46cb9687a051d50a2fdd228e4ba7cf6fcf861a5365c3d671a642"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8581,8 +8597,8 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de251eec69fc7c1bc3923403d18ececb929380e016afe103da75f396704f8ca2"
 dependencies = [
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
  "synstructure",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,7 +166,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d0864d84b8e07b145449be9a8537db86bf9de5ce03b913214694643b4743502"
 dependencies = [
- "quote 1.0.4",
+ "quote 1.0.3",
  "syn 1.0.18",
 ]
 
@@ -275,9 +275,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace-sys"
-version = "0.1.37"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fbebbe1c9d1f383a9cc7e8ccdb471b91c8d024ee9c2ca5b5346121fe8b4399"
+checksum = "78848718ee1255a2485d1309ad9cdecfc2e7d0362dd11c6829364c6b35ae1bc7"
 dependencies = [
  "cc",
  "libc",
@@ -294,12 +294,6 @@ name = "base64"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
-
-[[package]]
-name = "base64"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d5ca2cd0adc3f48f9e9ea5a6bbdf9ccc0bfade884847e484d452414c7ccffb3"
 
 [[package]]
 name = "bincode"
@@ -327,8 +321,8 @@ dependencies = [
  "lazycell",
  "log 0.4.8",
  "peeking_take_while",
- "proc-macro2 1.0.12",
- "quote 1.0.4",
+ "proc-macro2 1.0.10",
+ "quote 1.0.3",
  "regex",
  "rustc-hash",
  "shlex",
@@ -661,18 +655,18 @@ checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.63.0"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4425bb6c3f3d2f581c650f1a1fdd3196a975490149cf59bea9d34c3bea79eda"
+checksum = "45a9c21f8042b9857bda93f6c1910b9f9f24100187a3d3d52f214a34e3dc5818"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.63.0"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d166b289fd30062ee6de86284750fc3fe5d037c6b864b3326ce153239b0626e1"
+checksum = "7853f77a6e4a33c67a69c40f5e1bb982bd2dc5c4a22e17e67b65bbccf9b33b2e"
 dependencies = [
  "byteorder",
  "cranelift-bforest",
@@ -681,7 +675,6 @@ dependencies = [
  "cranelift-entity",
  "gimli",
  "log 0.4.8",
- "regalloc",
  "serde",
  "smallvec 1.4.0",
  "target-lexicon",
@@ -690,9 +683,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.63.0"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02c9fb2306a36d41c5facd4bf3400bc6c157185c43a96eaaa503471c34c5144b"
+checksum = "084cd6d5fb0d1da28acd72c199471bfb09acc703ec8f3bf07b1699584272a3b9"
 dependencies = [
  "cranelift-codegen-shared",
  "cranelift-entity",
@@ -700,24 +693,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.63.0"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44e0cfe9b1f97d9f836bca551618106c7d53b93b579029ecd38e73daa7eb689e"
+checksum = "701b599783305a58c25027a4d73f2d6b599b2d8ef3f26677275f480b4d51e05d"
 
 [[package]]
 name = "cranelift-entity"
-version = "0.63.0"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "926a73c432e5ba9c891171ff50b75e7d992cd76cd271f0a0a0ba199138077472"
+checksum = "b88e792b28e1ebbc0187b72ba5ba880dad083abe9231a99d19604d10c9e73f38"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.63.0"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e45f82e3446dd1ebb8c2c2f6a6b0e6cd6cd52965c7e5f7b1b35e9a9ace31ccde"
+checksum = "518344698fa6c976d853319218415fdfb4f1bc6b42d0b2e2df652e55dff1f778"
 dependencies = [
  "cranelift-codegen",
  "log 0.4.8",
@@ -727,9 +720,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.63.0"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488b5d481bb0996a143e55a9d1739ef425efa20d4a5e5e98c859a8573c9ead9a"
+checksum = "32daf082da21c0c05d93394ff4842c2ab7c4991b1f3186a1d952f8ac660edd0b"
 dependencies = [
  "cranelift-codegen",
  "raw-cpuid",
@@ -738,9 +731,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.63.0"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00aa8dde71fd9fdb1958e7b0ef8f524c1560e2c6165e4ea54bc302b40551c161"
+checksum = "e2aa816f554a3ef739a5d17ca3081a1f8983f04c944ea8ff60fb8d9dd8cd2d7b"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -903,8 +896,8 @@ version = "0.99.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2323f3f47db9a0e77ce7a300605d8d2098597fc451ed1a97bb1f6411bb550a7"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.4",
+ "proc-macro2 1.0.10",
+ "quote 1.0.3",
  "syn 1.0.18",
 ]
 
@@ -1023,8 +1016,8 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "946ee94e3dbf58fdd324f9ce245c7b238d46a66f00e86a020b71996349e46cce"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.4",
+ "proc-macro2 1.0.10",
+ "quote 1.0.3",
  "syn 1.0.18",
 ]
 
@@ -1113,10 +1106,11 @@ dependencies = [
 
 [[package]]
 name = "faerie"
-version = "0.15.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfef65b0e94693295c5d2fe2506f0ee6f43465342d4b5331659936aee8b16084"
+checksum = "74b9ed6159e4a6212c61d9c6a86bee01876b192a64accecf58d5b5ae3b667b52"
 dependencies = [
+ "anyhow",
  "goblin",
  "indexmap",
  "log 0.4.8",
@@ -1128,9 +1122,9 @@ dependencies = [
 
 [[package]]
 name = "failure"
-version = "0.1.8"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
+checksum = "b8529c2421efa3066a5cbd8063d2244603824daccb6936b079010bb2aa89464b"
 dependencies = [
  "backtrace",
  "failure_derive",
@@ -1138,12 +1132,12 @@ dependencies = [
 
 [[package]]
 name = "failure_derive"
-version = "0.1.8"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
+checksum = "030a733c8287d6213886dd487564ff5c8f6aae10278b3588ed177f9d18f8d231"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.4",
+ "proc-macro2 1.0.10",
+ "quote 1.0.3",
  "syn 1.0.18",
  "synstructure",
 ]
@@ -1181,11 +1175,10 @@ dependencies = [
 
 [[package]]
 name = "finality-grandpa"
-version = "0.12.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ab32971efbe776e46bfbc34d5b662d8e1de51fd14e26a2eba522c0f3470fc0f"
+checksum = "024517816630be5204eba201e8d1d405042b1255a5e0e3f298b054fc24d59e1d"
 dependencies = [
- "either",
  "futures 0.3.4",
  "futures-timer 2.0.2",
  "log 0.4.8",
@@ -1196,9 +1189,9 @@ dependencies = [
 
 [[package]]
 name = "fixed-hash"
-version = "0.6.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11498d382790b7a8f2fd211780bec78619bba81cdad3a283997c0c41f836759c"
+checksum = "32529fc42e86ec06e5047092082aab9ad459b070c5d2a76b14f4f5ce70bf2e84"
 dependencies = [
  "byteorder",
  "rand 0.7.3",
@@ -1234,7 +1227,7 @@ checksum = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 [[package]]
 name = "fork-tree"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -1242,7 +1235,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1259,7 +1252,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "frame-benchmarking",
  "parity-scale-codec",
@@ -1277,7 +1270,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1292,7 +1285,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata"
 version = "11.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -1303,7 +1296,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "bitmask",
  "frame-metadata",
@@ -1327,40 +1320,40 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "frame-support-procedural-tools",
- "proc-macro2 1.0.12",
- "quote 1.0.4",
+ "proc-macro2 1.0.10",
+ "quote 1.0.3",
  "syn 1.0.18",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
- "proc-macro2 1.0.12",
- "quote 1.0.4",
+ "proc-macro2 1.0.10",
+ "quote 1.0.3",
  "syn 1.0.18",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.4",
+ "proc-macro2 1.0.10",
+ "quote 1.0.3",
  "syn 1.0.18",
 ]
 
 [[package]]
 name = "frame-system"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -1376,7 +1369,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -1510,8 +1503,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a5081aa3de1f7542a794a397cde100ed903b0630152d0973479018fd85423a7"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.12",
- "quote 1.0.4",
+ "proc-macro2 1.0.10",
+ "quote 1.0.3",
  "syn 1.0.18",
 ]
 
@@ -1714,7 +1707,7 @@ dependencies = [
  "indexmap",
  "log 0.4.8",
  "slab",
- "tokio 0.2.20",
+ "tokio 0.2.19",
  "tokio-util",
 ]
 
@@ -1754,9 +1747,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.12"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61565ff7aaace3525556587bd2dc31d4a07071957be715e63ce7b1eccf51a8f4"
+checksum = "8a0d737e0f947a1864e93d33fdef4af8445a00d1ed8dc0c8ddb73139ea6abf15"
 dependencies = [
  "libc",
 ]
@@ -1915,7 +1908,7 @@ dependencies = [
  "net2",
  "pin-project",
  "time",
- "tokio 0.2.20",
+ "tokio 0.2.19",
  "tower-service",
  "want 0.3.0",
 ]
@@ -1933,7 +1926,7 @@ dependencies = [
  "log 0.4.8",
  "rustls",
  "rustls-native-certs",
- "tokio 0.2.20",
+ "tokio 0.2.19",
  "tokio-rustls",
  "webpki",
 ]
@@ -1993,8 +1986,8 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef5550a42e3740a0e71f909d4c861056a284060af885ae7aa6242820f920d9d"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.4",
+ "proc-macro2 1.0.10",
+ "quote 1.0.3",
  "syn 1.0.18",
 ]
 
@@ -2097,9 +2090,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.39"
+version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa5a448de267e7358beaf4a5d849518fe9a0c13fce7afd44b06e68550e5562a7"
+checksum = "6a27d435371a2fa5b6d2b028a74bbdb1234f308da363226a2854ca3ff8ba7055"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2149,8 +2142,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8609af8f63b626e8e211f52441fcdb6ec54f1a446606b10d5c89ae9bf8a20058"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.12",
- "quote 1.0.4",
+ "proc-macro2 1.0.10",
+ "quote 1.0.3",
  "syn 1.0.18",
 ]
 
@@ -2488,7 +2481,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "329127858e4728db5ab60c33d5ae352a999325fdf190ed022ec7d3a4685ae2e6"
 dependencies = [
- "quote 1.0.4",
+ "quote 1.0.3",
  "syn 1.0.18",
 ]
 
@@ -2935,9 +2928,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.6.22"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fce347092656428bc8eaf6201042cb551b8d67855af7374542a92a0fbfcac430"
+checksum = "302dec22bcf6bae6dfb69c647187f4b4d0fb6f535521f7bc022430ce8e12008f"
 dependencies = [
  "cfg-if",
  "fuchsia-zircon",
@@ -2966,9 +2959,9 @@ dependencies = [
 
 [[package]]
 name = "mio-uds"
-version = "0.6.8"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
+checksum = "966257a94e196b11bb43aca423754d87429960a768de9414f3691d6957abf125"
 dependencies = [
  "iovec",
  "libc",
@@ -3056,9 +3049,9 @@ dependencies = [
 
 [[package]]
 name = "net2"
-version = "0.2.34"
+version = "0.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ba7c918ac76704fb42afcbbb43891e72731f3dcca3bef2a19786297baf14af7"
+checksum = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
 dependencies = [
  "cfg-if",
  "libc",
@@ -3211,13 +3204,16 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.18.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5666bbb90bc4d1e5bdcb26c0afda1822d25928341e9384ab187a9b37ab69e36"
+checksum = "ea44a4fd660ab0f38434934ca0212e90fbeaaee54126ef20a3451c30c95bafae"
 dependencies = [
  "flate2",
+ "goblin",
+ "parity-wasm",
+ "scroll",
  "target-lexicon",
- "wasmparser",
+ "uuid",
 ]
 
 [[package]]
@@ -3263,7 +3259,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3281,7 +3277,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3298,7 +3294,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3306,7 +3302,6 @@ dependencies = [
  "pallet-timestamp",
  "parity-scale-codec",
  "serde",
- "sp-application-crypto",
  "sp-consensus-babe",
  "sp-consensus-vrf",
  "sp-inherents",
@@ -3320,7 +3315,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3335,7 +3330,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3351,7 +3346,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3366,7 +3361,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3380,7 +3375,7 @@ dependencies = [
 [[package]]
 name = "pallet-finality-tracker"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3396,7 +3391,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3414,7 +3409,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -3430,7 +3425,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3450,7 +3445,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3466,7 +3461,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3480,7 +3475,7 @@ dependencies = [
 [[package]]
 name = "pallet-nicks"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3494,7 +3489,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3509,7 +3504,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3528,7 +3523,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3541,7 +3536,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "enumflags2",
  "frame-support",
@@ -3556,7 +3551,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3571,7 +3566,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3589,7 +3584,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3603,7 +3598,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3618,7 +3613,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3641,18 +3636,18 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.12",
- "quote 1.0.4",
+ "proc-macro2 1.0.10",
+ "quote 1.0.3",
  "syn 1.0.18",
 ]
 
 [[package]]
 name = "pallet-sudo"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3666,7 +3661,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3684,7 +3679,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3697,7 +3692,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -3715,7 +3710,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -3728,7 +3723,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3743,7 +3738,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3759,7 +3754,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -3857,8 +3852,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a0ec292e92e8ec7c58e576adacc1e3f399c597c8f263c42f18420abe58e7245"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.12",
- "quote 1.0.4",
+ "proc-macro2 1.0.10",
+ "quote 1.0.3",
  "syn 1.0.18",
 ]
 
@@ -3890,7 +3885,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f557c32c6d268a07c921471619c0295f5efad3a0e76d4f97a05c091a51d110b2"
 dependencies = [
- "proc-macro2 1.0.12",
+ "proc-macro2 1.0.10",
  "syn 1.0.18",
  "synstructure",
 ]
@@ -3953,9 +3948,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "0.1.12"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a229b1c58c692edcaa5b9b0948084f130f55d2dcc15b02fcc5340b2b4521476"
+checksum = "ab4fb1930692d1b6a9cfabdde3d06ea0a7d186518e2f4d67660d8970e2fa647a"
 dependencies = [
  "paste-impl",
  "proc-macro-hack",
@@ -3963,13 +3958,13 @@ dependencies = [
 
 [[package]]
 name = "paste-impl"
-version = "0.1.12"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e0bf239e447e67ff6d16a8bb5e4d4bd2343acf5066061c0e8e06ac5ba8ca68c"
+checksum = "a62486e111e571b1e93b710b61e8f493c0013be39629b714cb166bdb06aa5a8a"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.12",
- "quote 1.0.4",
+ "proc-macro2 1.0.10",
+ "quote 1.0.3",
  "syn 1.0.18",
 ]
 
@@ -4019,21 +4014,21 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.10"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36e3dcd42688c05a66f841d22c5d8390d9a5d4c9aaf57b9285eae4900a080063"
+checksum = "6f6a7f5eee6292c559c793430c55c00aea9d3b3d1905e855806ca4d7253426a2"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.10"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4d7346ac577ff1296e06a418e7618e22655bae834d4970cb6e39d6da8119969"
+checksum = "8988430ce790d8682672117bc06dda364c0be32d3abd738234f19f3240bad99a"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.4",
+ "proc-macro2 1.0.10",
+ "quote 1.0.3",
  "syn 1.0.18",
 ]
 
@@ -4103,7 +4098,7 @@ dependencies = [
  "sp-consensus",
  "sp-core",
  "sp-runtime",
- "tokio 0.2.20",
+ "tokio 0.2.19",
 ]
 
 [[package]]
@@ -4125,7 +4120,7 @@ dependencies = [
  "structopt",
  "substrate-browser-utils",
  "substrate-build-script-utils",
- "tokio 0.2.20",
+ "tokio 0.2.19",
  "wasm-bindgen",
  "wasm-bindgen-futures",
 ]
@@ -4154,7 +4149,7 @@ dependencies = [
  "sp-core",
  "sp-keyring",
  "sp-runtime",
- "tokio 0.2.20",
+ "tokio 0.2.19",
 ]
 
 [[package]]
@@ -4561,7 +4556,7 @@ dependencies = [
  "sp-timestamp",
  "sp-transaction-pool",
  "sp-trie",
- "tokio 0.2.20",
+ "tokio 0.2.19",
 ]
 
 [[package]]
@@ -4608,9 +4603,9 @@ dependencies = [
 
 [[package]]
 name = "primitive-types"
-version = "0.7.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dedac218327b6b55fff5ef05f63ce5127024e1a36342836da7e92cbfac4531"
+checksum = "e5e4b9943a2da369aec5e96f7c10ebc74fcf434d39590d974b0a3460e6f67fbb"
 dependencies = [
  "fixed-hash",
  "impl-codec",
@@ -4634,8 +4629,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98e9e4b82e0ef281812565ea4751049f1bdcdfccda7d3f459f2e138a40c08678"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.12",
- "quote 1.0.4",
+ "proc-macro2 1.0.10",
+ "quote 1.0.3",
  "syn 1.0.18",
  "version_check",
 ]
@@ -4646,8 +4641,8 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f5444ead4e9935abd7f27dc51f7e852a0569ac888096d5ec2499470794e2e53"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.4",
+ "proc-macro2 1.0.10",
+ "quote 1.0.3",
  "syn 1.0.18",
  "syn-mid",
  "version_check",
@@ -4676,9 +4671,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.12"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8872cf6f48eee44265156c111456a700ab3483686b3f96df4cf5481c89157319"
+checksum = "df246d292ff63439fea9bc8c0a270bed0e390d5ebd4db4ba15aba81111b5abe3"
 dependencies = [
  "unicode-xid 0.2.0",
 ]
@@ -4748,8 +4743,8 @@ checksum = "537aa19b95acde10a12fec4301466386f757403de4cd4e5b4fa78fb5ecb18f72"
 dependencies = [
  "anyhow",
  "itertools",
- "proc-macro2 1.0.12",
- "quote 1.0.4",
+ "proc-macro2 1.0.10",
+ "quote 1.0.3",
  "syn 1.0.18",
 ]
 
@@ -4803,11 +4798,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.4"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c1f4b0efa5fc5e8ceb705136bfee52cfdb6a4e3509f770b478cd6ed434232a7"
+checksum = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
 dependencies = [
- "proc-macro2 1.0.12",
+ "proc-macro2 1.0.10",
 ]
 
 [[package]]
@@ -5101,20 +5096,9 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "602eb59cda66fcb9aec25841fb76bc01d2b34282dcdd705028da297db6f3eec8"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.4",
+ "proc-macro2 1.0.10",
+ "quote 1.0.3",
  "syn 1.0.18",
-]
-
-[[package]]
-name = "regalloc"
-version = "0.0.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b27b256b41986ac5141b37b8bbba85d314fbf546c182eb255af6720e07e4f804"
-dependencies = [
- "log 0.4.8",
- "rustc-hash",
- "smallvec 1.4.0",
 ]
 
 [[package]]
@@ -5158,13 +5142,13 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.13"
+version = "0.16.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703516ae74571f24b465b4a1431e81e2ad51336cb0ded733a55a1aa3eccac196"
+checksum = "1ba5a8ec64ee89a76c98c549af81ff14813df09c3e6dc4766c3856da48597a0c"
 dependencies = [
  "cc",
+ "lazy_static",
  "libc",
- "once_cell",
  "spin",
  "untrusted",
  "web-sys",
@@ -5203,7 +5187,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bc8af4bda8e1ff4932523b94d3dd20ee30a87232323eda55903ffd71d2fb017"
 dependencies = [
- "base64 0.11.0",
+ "base64",
  "blake2b_simd",
  "constant_time_eq",
  "crossbeam-utils",
@@ -5248,7 +5232,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0d4a31f5d68413404705d6982529b0e11a9aacd4839d1d6222ee3b8cb4015e1"
 dependencies = [
- "base64 0.11.0",
+ "base64",
  "log 0.4.8",
  "ring",
  "sct",
@@ -5296,7 +5280,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "bytes 0.5.4",
  "derive_more 0.99.5",
@@ -5323,7 +5307,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -5339,7 +5323,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "impl-trait-for-tuples",
  "sc-chain-spec-derive",
@@ -5355,18 +5339,18 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.12",
- "quote 1.0.4",
+ "proc-macro2 1.0.10",
+ "quote 1.0.3",
  "syn 1.0.18",
 ]
 
 [[package]]
 name = "sc-cli"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "ansi_term 0.12.1",
  "app_dirs",
@@ -5402,13 +5386,13 @@ dependencies = [
  "structopt",
  "substrate-prometheus-endpoint",
  "time",
- "tokio 0.2.20",
+ "tokio 0.2.19",
 ]
 
 [[package]]
 name = "sc-client-api"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "derive_more 0.99.5",
  "fnv",
@@ -5444,7 +5428,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "blake2-rfc",
  "hash-db",
@@ -5473,7 +5457,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "sc-client-api",
  "sp-blockchain",
@@ -5484,7 +5468,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "derive_more 0.99.5",
  "fork-tree",
@@ -5525,7 +5509,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -5538,7 +5522,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "futures 0.3.4",
  "futures-timer 3.0.2",
@@ -5559,7 +5543,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-uncles"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "log 0.4.8",
  "sc-client-api",
@@ -5573,7 +5557,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "derive_more 0.99.5",
  "lazy_static",
@@ -5601,7 +5585,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "derive_more 0.99.5",
  "log 0.4.8",
@@ -5618,7 +5602,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "log 0.4.8",
  "parity-scale-codec",
@@ -5633,7 +5617,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "cranelift-codegen",
  "cranelift-wasm",
@@ -5654,10 +5638,9 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "assert_matches",
- "derive_more 0.99.5",
  "finality-grandpa",
  "fork-tree",
  "futures 0.3.4",
@@ -5691,7 +5674,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "ansi_term 0.12.1",
  "futures 0.3.4",
@@ -5708,7 +5691,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "derive_more 0.99.5",
  "hex",
@@ -5723,7 +5706,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "bitflags",
  "bytes 0.5.4",
@@ -5775,7 +5758,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "futures 0.3.4",
  "futures-timer 3.0.2",
@@ -5791,7 +5774,7 @@ dependencies = [
 [[package]]
 name = "sc-network-test"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "env_logger 0.7.1",
  "futures 0.3.4",
@@ -5818,7 +5801,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "bytes 0.5.4",
  "fnv",
@@ -5845,7 +5828,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "futures 0.3.4",
  "libp2p",
@@ -5858,7 +5841,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "futures 0.3.4",
  "hash-db",
@@ -5890,7 +5873,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "derive_more 0.99.5",
  "futures 0.3.4",
@@ -5914,7 +5897,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-http-server",
@@ -5929,7 +5912,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "derive_more 0.99.5",
  "exit-future",
@@ -5987,7 +5970,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "log 0.4.8",
  "parity-scale-codec",
@@ -6001,7 +5984,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "bytes 0.5.4",
  "futures 0.3.4",
@@ -6023,7 +6006,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "erased-serde",
  "log 0.4.8",
@@ -6038,7 +6021,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-graph"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "derive_more 0.99.5",
  "futures 0.3.4",
@@ -6058,7 +6041,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "derive_more 0.99.5",
  "futures 0.3.4",
@@ -6136,8 +6119,8 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8584eea9b9ff42825b46faf46a8c24d2cff13ec152fa2a50df788b87c07ee28"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.4",
+ "proc-macro2 1.0.10",
+ "quote 1.0.3",
  "syn 1.0.18",
 ]
 
@@ -6222,16 +6205,16 @@ version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e549e3abf4fb8621bd1609f11dfc9f5e50320802273b12f3811a67e6716ea6c"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.4",
+ "proc-macro2 1.0.10",
+ "quote 1.0.3",
  "syn 1.0.18",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.52"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7894c8ed05b7a3a279aeb79025fdec1d3158080b75b98a08faf2806bb799edd"
+checksum = "da07b57ee2623368351e9a0488bb0b261322a15a6e0ae53e243cbdc0f4208da9"
 dependencies = [
  "itoa",
  "ryu",
@@ -6382,8 +6365,8 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a945ec7f7ce853e89ffa36be1e27dce9a43e82ff9093bf3461c30d5da74ed11b"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.4",
+ "proc-macro2 1.0.10",
+ "quote 1.0.3",
  "syn 1.0.18",
 ]
 
@@ -6426,7 +6409,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c9dab3f95c9ebdf3a88268c19af668f637a3c5039c2c56ff2d40b1b2d64a25b"
 dependencies = [
- "base64 0.11.0",
+ "base64",
  "bytes 0.5.4",
  "flate2",
  "futures 0.3.4",
@@ -6443,7 +6426,7 @@ dependencies = [
 [[package]]
 name = "sp-allocator"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "derive_more 0.99.5",
  "log 0.4.8",
@@ -6455,7 +6438,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
@@ -6470,19 +6453,19 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate",
- "proc-macro2 1.0.12",
- "quote 1.0.4",
+ "proc-macro2 1.0.10",
+ "quote 1.0.3",
  "syn 1.0.18",
 ]
 
 [[package]]
 name = "sp-application-crypto"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -6494,7 +6477,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "integer-sqrt",
  "num-traits 0.2.11",
@@ -6508,7 +6491,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6520,7 +6503,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -6531,7 +6514,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6543,7 +6526,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "derive_more 0.99.5",
  "log 0.4.8",
@@ -6559,7 +6542,7 @@ dependencies = [
 [[package]]
 name = "sp-chain-spec"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "serde",
  "serde_json",
@@ -6568,7 +6551,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "derive_more 0.99.5",
  "futures 0.3.4",
@@ -6590,7 +6573,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6604,9 +6587,8 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
- "merlin",
  "parity-scale-codec",
  "sp-api",
  "sp-application-crypto",
@@ -6621,7 +6603,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "parity-scale-codec",
  "schnorrkel",
@@ -6633,7 +6615,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "base58",
  "blake2-rfc",
@@ -6674,7 +6656,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "kvdb",
  "parking_lot 0.10.2",
@@ -6683,17 +6665,17 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.4",
+ "proc-macro2 1.0.10",
+ "quote 1.0.3",
  "syn 1.0.18",
 ]
 
 [[package]]
 name = "sp-externalities"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -6704,7 +6686,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -6717,7 +6699,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-tracker"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -6727,7 +6709,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "derive_more 0.99.5",
  "parity-scale-codec",
@@ -6739,7 +6721,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "futures 0.3.4",
  "hash-db",
@@ -6759,7 +6741,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -6770,7 +6752,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -6780,7 +6762,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "backtrace",
  "log 0.4.8",
@@ -6789,7 +6771,7 @@ dependencies = [
 [[package]]
 name = "sp-phragmen"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -6801,18 +6783,18 @@ dependencies = [
 [[package]]
 name = "sp-phragmen-compact"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.12",
- "quote 1.0.4",
+ "proc-macro2 1.0.10",
+ "quote 1.0.3",
  "syn 1.0.18",
 ]
 
 [[package]]
 name = "sp-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "serde",
  "sp-core",
@@ -6821,7 +6803,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "hash256-std-hasher",
  "impl-trait-for-tuples",
@@ -6842,7 +6824,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "parity-scale-codec",
  "primitive-types",
@@ -6857,19 +6839,19 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
- "proc-macro2 1.0.12",
- "quote 1.0.4",
+ "proc-macro2 1.0.10",
+ "quote 1.0.3",
  "syn 1.0.18",
 ]
 
 [[package]]
 name = "sp-serializer"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "serde",
  "serde_json",
@@ -6878,7 +6860,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -6889,7 +6871,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -6899,7 +6881,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "hash-db",
  "log 0.4.8",
@@ -6918,12 +6900,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 
 [[package]]
 name = "sp-storage"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "impl-serde 0.2.3",
  "ref-cast",
@@ -6935,7 +6917,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -6949,7 +6931,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "tracing",
 ]
@@ -6957,7 +6939,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "derive_more 0.99.5",
  "futures 0.3.4",
@@ -6972,7 +6954,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -6986,7 +6968,7 @@ dependencies = [
 [[package]]
 name = "sp-utils"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "futures 0.3.4",
  "futures-core",
@@ -6997,7 +6979,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "impl-serde 0.2.3",
  "parity-scale-codec",
@@ -7009,7 +6991,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -7096,8 +7078,8 @@ checksum = "d239ca4b13aee7a2142e6795cbd69e457665ff8037aed33b3effdc430d2f927a"
 dependencies = [
  "heck",
  "proc-macro-error",
- "proc-macro2 1.0.12",
- "quote 1.0.4",
+ "proc-macro2 1.0.10",
+ "quote 1.0.3",
  "syn 1.0.18",
 ]
 
@@ -7117,8 +7099,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0054a7df764039a6cd8592b9de84be4bec368ff081d203a7d5371cbfa8e65c81"
 dependencies = [
  "heck",
- "proc-macro2 1.0.12",
- "quote 1.0.4",
+ "proc-macro2 1.0.10",
+ "quote 1.0.3",
  "syn 1.0.18",
 ]
 
@@ -7137,7 +7119,7 @@ dependencies = [
 [[package]]
 name = "substrate-browser-utils"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "chrono",
  "clear_on_drop",
@@ -7164,7 +7146,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "platforms",
 ]
@@ -7172,7 +7154,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.4",
@@ -7193,7 +7175,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "async-std",
  "derive_more 0.99.5",
@@ -7201,13 +7183,13 @@ dependencies = [
  "hyper 0.13.5",
  "log 0.4.8",
  "prometheus",
- "tokio 0.2.20",
+ "tokio 0.2.19",
 ]
 
 [[package]]
 name = "substrate-test-client"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "futures 0.3.4",
  "hash-db",
@@ -7228,7 +7210,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "cfg-if",
  "frame-executive",
@@ -7267,7 +7249,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime-client"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 dependencies = [
  "futures 0.3.4",
  "parity-scale-codec",
@@ -7287,7 +7269,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder-runner"
 version = "1.0.5"
-source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
+source = "git+https://github.com/paritytech/substrate#58e3b3717de726714c948bef36e1aea1bd0751db"
 
 [[package]]
 name = "substrate-wasm-builder-runner"
@@ -7297,9 +7279,9 @@ checksum = "e30c70de7e7d5fd404fe26db1e7a4d6b553e2760b1ac490f249c04a960c483b8"
 
 [[package]]
 name = "substrate-wasmtime"
-version = "0.16.0-threadsafe.1"
+version = "0.13.0-threadsafe.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b8f9558e3fe7018b9aeac2aba318664dd7b15e307de11b09f58240695688a96"
+checksum = "9e512629525ecfe43bffe1f3d9e6bb0f08bf01155288ef27fcaae4ea086e4a9d"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -7309,20 +7291,20 @@ dependencies = [
  "region",
  "rustc-demangle",
  "substrate-wasmtime-jit",
- "substrate-wasmtime-profiling",
  "substrate-wasmtime-runtime",
  "target-lexicon",
  "wasmparser",
  "wasmtime-environ",
+ "wasmtime-profiling",
  "wat",
  "winapi 0.3.8",
 ]
 
 [[package]]
 name = "substrate-wasmtime-jit"
-version = "0.16.0-threadsafe.1"
+version = "0.13.0-threadsafe.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6b681b90a8d48b9535e4287c02e5aef6c72228ff45cbb60b4d195a762cc0770"
+checksum = "a20de5564886d2bcffdd351c9cd114ceb50758aa58eac3cedb14faabf7f93b91"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -7331,44 +7313,23 @@ dependencies = [
  "cranelift-frontend",
  "cranelift-native",
  "cranelift-wasm",
- "gimli",
- "log 0.4.8",
  "more-asserts",
  "region",
- "substrate-wasmtime-profiling",
  "substrate-wasmtime-runtime",
  "target-lexicon",
  "thiserror",
  "wasmparser",
  "wasmtime-debug",
  "wasmtime-environ",
+ "wasmtime-profiling",
  "winapi 0.3.8",
 ]
 
 [[package]]
-name = "substrate-wasmtime-profiling"
-version = "0.16.0-threadsafe.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7cb99b24e771de6c20b380fdf2d26ffc2c20701892c540830beb83af98bb3b7"
-dependencies = [
- "anyhow",
- "cfg-if",
- "gimli",
- "lazy_static",
- "libc",
- "object",
- "scroll",
- "serde",
- "substrate-wasmtime-runtime",
- "target-lexicon",
- "wasmtime-environ",
-]
-
-[[package]]
 name = "substrate-wasmtime-runtime"
-version = "0.16.0-threadsafe.1"
+version = "0.13.0-threadsafe.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaccd27cc466bd2904aa14f984f642083037bf5b47e251ccaf1009aed0a2a185"
+checksum = "6d08846f04293a7fc27eeb30f06262ca2e1b4ee20f5192cec1f3ce201e08ceb8"
 dependencies = [
  "backtrace",
  "cc",
@@ -7381,6 +7342,7 @@ dependencies = [
  "region",
  "thiserror",
  "wasmtime-environ",
+ "wasmtime-profiling",
  "winapi 0.3.8",
 ]
 
@@ -7424,8 +7386,8 @@ version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "410a7488c0a728c7ceb4ad59b9567eb4053d02e8cc7f5c0e0eeeb39518369213"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.4",
+ "proc-macro2 1.0.10",
+ "quote 1.0.3",
  "unicode-xid 0.2.0",
 ]
 
@@ -7435,8 +7397,8 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.4",
+ "proc-macro2 1.0.10",
+ "quote 1.0.3",
  "syn 1.0.18",
 ]
 
@@ -7455,8 +7417,8 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.4",
+ "proc-macro2 1.0.10",
+ "quote 1.0.3",
  "syn 1.0.18",
  "unicode-xid 0.2.0",
 ]
@@ -7591,21 +7553,21 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.16"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d12a1dae4add0f0d568eebc7bf142f145ba1aa2544cafb195c76f0f409091b60"
+checksum = "54b3d3d2ff68104100ab257bb6bb0cb26c901abe4bd4ba15961f3bf867924012"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.16"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f34e0c1caaa462fd840ec6b768946ea1e7842620d94fe29d5b847138f521269"
+checksum = "ca972988113b7715266f91250ddb98070d033c62a011fa0fcc57434a649310dd"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.4",
+ "proc-macro2 1.0.10",
+ "quote 1.0.3",
  "syn 1.0.18",
 ]
 
@@ -7697,9 +7659,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "0.2.20"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05c1d570eb1a36f0345a5ce9c6c6e665b70b73d11236912c0b477616aeec47b1"
+checksum = "7d9c43f1bb96970e153bcbae39a65e249ccb942bd9d36dbdf086024920417c9c"
 dependencies = [
  "bytes 0.5.4",
  "fnv",
@@ -7808,7 +7770,7 @@ checksum = "4adb8b3e5f86b707f1b54e7c15b6de52617a823608ccda98a15d3a24222f265a"
 dependencies = [
  "futures-core",
  "rustls",
- "tokio 0.2.20",
+ "tokio 0.2.19",
  "webpki",
 ]
 
@@ -7909,7 +7871,7 @@ dependencies = [
  "futures-sink",
  "log 0.4.8",
  "pin-project-lite",
- "tokio 0.2.20",
+ "tokio 0.2.19",
 ]
 
 [[package]]
@@ -7944,7 +7906,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fbad39da2f9af1cae3016339ad7f2c7a9e870f12e8fd04c4fd7ef35b30c0d2b"
 dependencies = [
- "quote 1.0.4",
+ "quote 1.0.3",
  "syn 1.0.18",
 ]
 
@@ -8019,9 +7981,9 @@ checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
 
 [[package]]
 name = "uint"
-version = "0.8.3"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "173cd16430c206dc1a430af8a89a0e9c076cf15cb42b4aedb10e8cc8fee73681"
+checksum = "e75a4cdd7b87b28840dba13c483b9a88ee6bbf16ba5c951ee1ecfcf723078e0d"
 dependencies = [
  "byteorder",
  "crunchy",
@@ -8100,9 +8062,9 @@ dependencies = [
 
 [[package]]
 name = "untrusted"
-version = "0.7.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+checksum = "60369ef7a31de49bcb3f6ca728d4ba7300d9a1658f94c727d4cab8c8d9f4aece"
 
 [[package]]
 name = "url"
@@ -8125,6 +8087,12 @@ dependencies = [
  "matches",
  "percent-encoding 2.1.0",
 ]
+
+[[package]]
+name = "uuid"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
 
 [[package]]
 name = "vcpkg"
@@ -8188,9 +8156,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.62"
+version = "0.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c7d40d09cdbf0f4895ae58cf57d92e1e57a9dd8ed2e8390514b54a47cc5551"
+checksum = "2cc57ce05287f8376e998cbddfb4c8cb43b84a7ec55cf4551d7c00eef317a47f"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -8198,24 +8166,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.62"
+version = "0.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3972e137ebf830900db522d6c8fd74d1900dcfc733462e9a12e942b00b4ac94"
+checksum = "d967d37bf6c16cca2973ca3af071d0a2523392e4a594548155d89a678f4237cd"
 dependencies = [
  "bumpalo",
  "lazy_static",
  "log 0.4.8",
- "proc-macro2 1.0.12",
- "quote 1.0.4",
+ "proc-macro2 1.0.10",
+ "quote 1.0.3",
  "syn 1.0.18",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.12"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a369c5e1dfb7569e14d62af4da642a3cbc2f9a3652fe586e26ac22222aa4b04"
+checksum = "7add542ea1ac7fdaa9dc25e031a6af33b7d63376292bd24140c637d00d1c312a"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -8225,22 +8193,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.62"
+version = "0.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd85aa2c579e8892442954685f0d801f9129de24fa2136b2c6a539c76b65776"
+checksum = "8bd151b63e1ea881bb742cd20e1d6127cef28399558f3b5d415289bc41eee3a4"
 dependencies = [
- "quote 1.0.4",
+ "quote 1.0.3",
  "wasm-bindgen-macro-support",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.62"
+version = "0.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eb197bd3a47553334907ffd2f16507b4f4f01bbec3ac921a7719e0decdfe72a"
+checksum = "d68a5b36eef1be7868f668632863292e37739656a80fc4b9acec7b0bd35a4931"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.4",
+ "proc-macro2 1.0.10",
+ "quote 1.0.3",
  "syn 1.0.18",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
@@ -8248,9 +8216,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.62"
+version = "0.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a91c2916119c17a8e316507afaaa2dd94b47646048014bbdf6bef098c1bb58ad"
+checksum = "daf76fe7d25ac79748a37538b7daeed1c7a6867c92d3245c12c6222e4a20d639"
 
 [[package]]
 name = "wasm-timer"
@@ -8299,9 +8267,9 @@ checksum = "aeb1956b19469d1c5e63e459d29e7b5aa0f558d9f16fcef09736f8a265e6c10a"
 
 [[package]]
 name = "wasmtime-debug"
-version = "0.16.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d39ba645aee700b29ff0093028b4123556dd142a74973f04ed6225eedb40e77d"
+checksum = "9d3d007436043bf55ec252d2f4dc1d35834157b5e2f148da839ca502e611cfe1"
 dependencies = [
  "anyhow",
  "faerie",
@@ -8315,12 +8283,12 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "0.16.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed54fd9d64dfeeee7c285fd126174a6b5e6d4efc7e5a1566fdb635e60ff6a74e"
+checksum = "80f3dea0e60c076dd0da27fa10c821323903c9554c617ed32eaab8e7a7e36c89"
 dependencies = [
  "anyhow",
- "base64 0.12.0",
+ "base64",
  "bincode",
  "cranelift-codegen",
  "cranelift-entity",
@@ -8343,6 +8311,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmtime-profiling"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "984d29c8add3381e60d649f4e3e2a501da900fc2d2586e139502eec32fe0ebc8"
+dependencies = [
+ "gimli",
+ "goblin",
+ "lazy_static",
+ "libc",
+ "object",
+ "scroll",
+ "serde",
+ "target-lexicon",
+]
+
+[[package]]
 name = "wast"
 version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8362,9 +8346,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.39"
+version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bc359e5dd3b46cb9687a051d50a2fdd228e4ba7cf6fcf861a5365c3d671a642"
+checksum = "2d6f51648d8c56c366144378a33290049eafdd784071077f6fe37dae64c1c4cb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8597,8 +8581,8 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de251eec69fc7c1bc3923403d18ececb929380e016afe103da75f396704f8ca2"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.4",
+ "proc-macro2 1.0.10",
+ "quote 1.0.3",
  "syn 1.0.18",
  "synstructure",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,7 +166,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d0864d84b8e07b145449be9a8537db86bf9de5ce03b913214694643b4743502"
 dependencies = [
- "quote 1.0.3",
+ "quote 1.0.4",
  "syn 1.0.18",
 ]
 
@@ -275,9 +275,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace-sys"
-version = "0.1.36"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78848718ee1255a2485d1309ad9cdecfc2e7d0362dd11c6829364c6b35ae1bc7"
+checksum = "18fbebbe1c9d1f383a9cc7e8ccdb471b91c8d024ee9c2ca5b5346121fe8b4399"
 dependencies = [
  "cc",
  "libc",
@@ -327,8 +327,8 @@ dependencies = [
  "lazycell",
  "log 0.4.8",
  "peeking_take_while",
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "regex",
  "rustc-hash",
  "shlex",
@@ -903,8 +903,8 @@ version = "0.99.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2323f3f47db9a0e77ce7a300605d8d2098597fc451ed1a97bb1f6411bb550a7"
 dependencies = [
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
 ]
 
@@ -1023,8 +1023,8 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "946ee94e3dbf58fdd324f9ce245c7b238d46a66f00e86a020b71996349e46cce"
 dependencies = [
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
 ]
 
@@ -1128,9 +1128,9 @@ dependencies = [
 
 [[package]]
 name = "failure"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8529c2421efa3066a5cbd8063d2244603824daccb6936b079010bb2aa89464b"
+checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
 dependencies = [
  "backtrace",
  "failure_derive",
@@ -1138,12 +1138,12 @@ dependencies = [
 
 [[package]]
 name = "failure_derive"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "030a733c8287d6213886dd487564ff5c8f6aae10278b3588ed177f9d18f8d231"
+checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
  "synstructure",
 ]
@@ -1196,9 +1196,9 @@ dependencies = [
 
 [[package]]
 name = "fixed-hash"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32529fc42e86ec06e5047092082aab9ad459b070c5d2a76b14f4f5ce70bf2e84"
+checksum = "11498d382790b7a8f2fd211780bec78619bba81cdad3a283997c0c41f836759c"
 dependencies = [
  "byteorder",
  "rand 0.7.3",
@@ -1234,7 +1234,7 @@ checksum = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 [[package]]
 name = "fork-tree"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -1242,7 +1242,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1259,7 +1259,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-benchmarking",
  "parity-scale-codec",
@@ -1277,7 +1277,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1292,7 +1292,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata"
 version = "11.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -1303,7 +1303,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "bitmask",
  "frame-metadata",
@@ -1327,40 +1327,40 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-support-procedural-tools",
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
 ]
 
 [[package]]
 name = "frame-system"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -1376,7 +1376,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -1510,8 +1510,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a5081aa3de1f7542a794a397cde100ed903b0630152d0973479018fd85423a7"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
 ]
 
@@ -1714,7 +1714,7 @@ dependencies = [
  "indexmap",
  "log 0.4.8",
  "slab",
- "tokio 0.2.19",
+ "tokio 0.2.20",
  "tokio-util",
 ]
 
@@ -1754,9 +1754,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d737e0f947a1864e93d33fdef4af8445a00d1ed8dc0c8ddb73139ea6abf15"
+checksum = "61565ff7aaace3525556587bd2dc31d4a07071957be715e63ce7b1eccf51a8f4"
 dependencies = [
  "libc",
 ]
@@ -1915,7 +1915,7 @@ dependencies = [
  "net2",
  "pin-project",
  "time",
- "tokio 0.2.19",
+ "tokio 0.2.20",
  "tower-service",
  "want 0.3.0",
 ]
@@ -1933,7 +1933,7 @@ dependencies = [
  "log 0.4.8",
  "rustls",
  "rustls-native-certs",
- "tokio 0.2.19",
+ "tokio 0.2.20",
  "tokio-rustls",
  "webpki",
 ]
@@ -1993,8 +1993,8 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef5550a42e3740a0e71f909d4c861056a284060af885ae7aa6242820f920d9d"
 dependencies = [
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
 ]
 
@@ -2097,9 +2097,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.37"
+version = "0.3.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a27d435371a2fa5b6d2b028a74bbdb1234f308da363226a2854ca3ff8ba7055"
+checksum = "fa5a448de267e7358beaf4a5d849518fe9a0c13fce7afd44b06e68550e5562a7"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2149,8 +2149,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8609af8f63b626e8e211f52441fcdb6ec54f1a446606b10d5c89ae9bf8a20058"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
 ]
 
@@ -2488,7 +2488,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "329127858e4728db5ab60c33d5ae352a999325fdf190ed022ec7d3a4685ae2e6"
 dependencies = [
- "quote 1.0.3",
+ "quote 1.0.4",
  "syn 1.0.18",
 ]
 
@@ -2935,9 +2935,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.6.21"
+version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "302dec22bcf6bae6dfb69c647187f4b4d0fb6f535521f7bc022430ce8e12008f"
+checksum = "fce347092656428bc8eaf6201042cb551b8d67855af7374542a92a0fbfcac430"
 dependencies = [
  "cfg-if",
  "fuchsia-zircon",
@@ -2966,9 +2966,9 @@ dependencies = [
 
 [[package]]
 name = "mio-uds"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "966257a94e196b11bb43aca423754d87429960a768de9414f3691d6957abf125"
+checksum = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
 dependencies = [
  "iovec",
  "libc",
@@ -3056,9 +3056,9 @@ dependencies = [
 
 [[package]]
 name = "net2"
-version = "0.2.33"
+version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
+checksum = "2ba7c918ac76704fb42afcbbb43891e72731f3dcca3bef2a19786297baf14af7"
 dependencies = [
  "cfg-if",
  "libc",
@@ -3263,7 +3263,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3281,7 +3281,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3298,7 +3298,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3306,6 +3306,7 @@ dependencies = [
  "pallet-timestamp",
  "parity-scale-codec",
  "serde",
+ "sp-application-crypto",
  "sp-consensus-babe",
  "sp-consensus-vrf",
  "sp-inherents",
@@ -3319,7 +3320,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3334,7 +3335,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3350,7 +3351,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3365,7 +3366,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3379,7 +3380,7 @@ dependencies = [
 [[package]]
 name = "pallet-finality-tracker"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3395,7 +3396,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3413,7 +3414,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -3429,7 +3430,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3449,7 +3450,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3465,7 +3466,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3479,7 +3480,7 @@ dependencies = [
 [[package]]
 name = "pallet-nicks"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3493,7 +3494,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3508,7 +3509,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3527,7 +3528,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3540,7 +3541,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "enumflags2",
  "frame-support",
@@ -3555,7 +3556,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3570,7 +3571,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3588,7 +3589,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3602,7 +3603,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3617,7 +3618,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3640,18 +3641,18 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
 ]
 
 [[package]]
 name = "pallet-sudo"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3665,7 +3666,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3683,7 +3684,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3696,7 +3697,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -3714,7 +3715,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -3727,7 +3728,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3742,7 +3743,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3758,7 +3759,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -3856,8 +3857,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a0ec292e92e8ec7c58e576adacc1e3f399c597c8f263c42f18420abe58e7245"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
 ]
 
@@ -3889,7 +3890,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f557c32c6d268a07c921471619c0295f5efad3a0e76d4f97a05c091a51d110b2"
 dependencies = [
- "proc-macro2 1.0.10",
+ "proc-macro2 1.0.12",
  "syn 1.0.18",
  "synstructure",
 ]
@@ -3952,9 +3953,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "0.1.10"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab4fb1930692d1b6a9cfabdde3d06ea0a7d186518e2f4d67660d8970e2fa647a"
+checksum = "0a229b1c58c692edcaa5b9b0948084f130f55d2dcc15b02fcc5340b2b4521476"
 dependencies = [
  "paste-impl",
  "proc-macro-hack",
@@ -3962,13 +3963,13 @@ dependencies = [
 
 [[package]]
 name = "paste-impl"
-version = "0.1.10"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62486e111e571b1e93b710b61e8f493c0013be39629b714cb166bdb06aa5a8a"
+checksum = "2e0bf239e447e67ff6d16a8bb5e4d4bd2343acf5066061c0e8e06ac5ba8ca68c"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
 ]
 
@@ -4018,21 +4019,21 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f6a7f5eee6292c559c793430c55c00aea9d3b3d1905e855806ca4d7253426a2"
+checksum = "36e3dcd42688c05a66f841d22c5d8390d9a5d4c9aaf57b9285eae4900a080063"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8988430ce790d8682672117bc06dda364c0be32d3abd738234f19f3240bad99a"
+checksum = "f4d7346ac577ff1296e06a418e7618e22655bae834d4970cb6e39d6da8119969"
 dependencies = [
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
 ]
 
@@ -4102,7 +4103,7 @@ dependencies = [
  "sp-consensus",
  "sp-core",
  "sp-runtime",
- "tokio 0.2.19",
+ "tokio 0.2.20",
 ]
 
 [[package]]
@@ -4124,7 +4125,7 @@ dependencies = [
  "structopt",
  "substrate-browser-utils",
  "substrate-build-script-utils",
- "tokio 0.2.19",
+ "tokio 0.2.20",
  "wasm-bindgen",
  "wasm-bindgen-futures",
 ]
@@ -4153,7 +4154,7 @@ dependencies = [
  "sp-core",
  "sp-keyring",
  "sp-runtime",
- "tokio 0.2.19",
+ "tokio 0.2.20",
 ]
 
 [[package]]
@@ -4560,7 +4561,7 @@ dependencies = [
  "sp-timestamp",
  "sp-transaction-pool",
  "sp-trie",
- "tokio 0.2.19",
+ "tokio 0.2.20",
 ]
 
 [[package]]
@@ -4607,9 +4608,9 @@ dependencies = [
 
 [[package]]
 name = "primitive-types"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5e4b9943a2da369aec5e96f7c10ebc74fcf434d39590d974b0a3460e6f67fbb"
+checksum = "d3dedac218327b6b55fff5ef05f63ce5127024e1a36342836da7e92cbfac4531"
 dependencies = [
  "fixed-hash",
  "impl-codec",
@@ -4633,8 +4634,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98e9e4b82e0ef281812565ea4751049f1bdcdfccda7d3f459f2e138a40c08678"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
  "version_check",
 ]
@@ -4645,8 +4646,8 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f5444ead4e9935abd7f27dc51f7e852a0569ac888096d5ec2499470794e2e53"
 dependencies = [
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
  "syn-mid",
  "version_check",
@@ -4675,9 +4676,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.10"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df246d292ff63439fea9bc8c0a270bed0e390d5ebd4db4ba15aba81111b5abe3"
+checksum = "8872cf6f48eee44265156c111456a700ab3483686b3f96df4cf5481c89157319"
 dependencies = [
  "unicode-xid 0.2.0",
 ]
@@ -4747,8 +4748,8 @@ checksum = "537aa19b95acde10a12fec4301466386f757403de4cd4e5b4fa78fb5ecb18f72"
 dependencies = [
  "anyhow",
  "itertools",
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
 ]
 
@@ -4802,11 +4803,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
+checksum = "4c1f4b0efa5fc5e8ceb705136bfee52cfdb6a4e3509f770b478cd6ed434232a7"
 dependencies = [
- "proc-macro2 1.0.10",
+ "proc-macro2 1.0.12",
 ]
 
 [[package]]
@@ -5100,8 +5101,8 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "602eb59cda66fcb9aec25841fb76bc01d2b34282dcdd705028da297db6f3eec8"
 dependencies = [
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
 ]
 
@@ -5157,13 +5158,13 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.12"
+version = "0.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ba5a8ec64ee89a76c98c549af81ff14813df09c3e6dc4766c3856da48597a0c"
+checksum = "703516ae74571f24b465b4a1431e81e2ad51336cb0ded733a55a1aa3eccac196"
 dependencies = [
  "cc",
- "lazy_static",
  "libc",
+ "once_cell",
  "spin",
  "untrusted",
  "web-sys",
@@ -5295,7 +5296,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "bytes 0.5.4",
  "derive_more 0.99.5",
@@ -5322,7 +5323,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -5338,7 +5339,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "impl-trait-for-tuples",
  "sc-chain-spec-derive",
@@ -5354,18 +5355,18 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
 ]
 
 [[package]]
 name = "sc-cli"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "ansi_term 0.12.1",
  "app_dirs",
@@ -5401,13 +5402,13 @@ dependencies = [
  "structopt",
  "substrate-prometheus-endpoint",
  "time",
- "tokio 0.2.19",
+ "tokio 0.2.20",
 ]
 
 [[package]]
 name = "sc-client-api"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "derive_more 0.99.5",
  "fnv",
@@ -5443,7 +5444,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "blake2-rfc",
  "hash-db",
@@ -5472,7 +5473,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "sc-client-api",
  "sp-blockchain",
@@ -5483,7 +5484,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "derive_more 0.99.5",
  "fork-tree",
@@ -5524,7 +5525,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -5537,7 +5538,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "futures 0.3.4",
  "futures-timer 3.0.2",
@@ -5558,7 +5559,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-uncles"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "log 0.4.8",
  "sc-client-api",
@@ -5572,7 +5573,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "derive_more 0.99.5",
  "lazy_static",
@@ -5600,7 +5601,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "derive_more 0.99.5",
  "log 0.4.8",
@@ -5617,7 +5618,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "log 0.4.8",
  "parity-scale-codec",
@@ -5632,7 +5633,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "cranelift-codegen",
  "cranelift-wasm",
@@ -5653,7 +5654,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "assert_matches",
  "derive_more 0.99.5",
@@ -5690,7 +5691,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "ansi_term 0.12.1",
  "futures 0.3.4",
@@ -5707,7 +5708,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "derive_more 0.99.5",
  "hex",
@@ -5722,7 +5723,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "bitflags",
  "bytes 0.5.4",
@@ -5774,7 +5775,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "futures 0.3.4",
  "futures-timer 3.0.2",
@@ -5790,7 +5791,7 @@ dependencies = [
 [[package]]
 name = "sc-network-test"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "env_logger 0.7.1",
  "futures 0.3.4",
@@ -5817,7 +5818,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "bytes 0.5.4",
  "fnv",
@@ -5844,7 +5845,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "futures 0.3.4",
  "libp2p",
@@ -5857,7 +5858,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "futures 0.3.4",
  "hash-db",
@@ -5889,7 +5890,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "derive_more 0.99.5",
  "futures 0.3.4",
@@ -5913,7 +5914,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-http-server",
@@ -5928,7 +5929,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "derive_more 0.99.5",
  "exit-future",
@@ -5986,7 +5987,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "log 0.4.8",
  "parity-scale-codec",
@@ -6000,7 +6001,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "bytes 0.5.4",
  "futures 0.3.4",
@@ -6022,7 +6023,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "erased-serde",
  "log 0.4.8",
@@ -6037,7 +6038,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-graph"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "derive_more 0.99.5",
  "futures 0.3.4",
@@ -6057,7 +6058,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "derive_more 0.99.5",
  "futures 0.3.4",
@@ -6135,8 +6136,8 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8584eea9b9ff42825b46faf46a8c24d2cff13ec152fa2a50df788b87c07ee28"
 dependencies = [
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
 ]
 
@@ -6221,16 +6222,16 @@ version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e549e3abf4fb8621bd1609f11dfc9f5e50320802273b12f3811a67e6716ea6c"
 dependencies = [
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.51"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da07b57ee2623368351e9a0488bb0b261322a15a6e0ae53e243cbdc0f4208da9"
+checksum = "a7894c8ed05b7a3a279aeb79025fdec1d3158080b75b98a08faf2806bb799edd"
 dependencies = [
  "itoa",
  "ryu",
@@ -6381,8 +6382,8 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a945ec7f7ce853e89ffa36be1e27dce9a43e82ff9093bf3461c30d5da74ed11b"
 dependencies = [
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
 ]
 
@@ -6442,7 +6443,7 @@ dependencies = [
 [[package]]
 name = "sp-allocator"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "derive_more 0.99.5",
  "log 0.4.8",
@@ -6454,7 +6455,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
@@ -6469,19 +6470,19 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate",
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
 ]
 
 [[package]]
 name = "sp-application-crypto"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -6493,7 +6494,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "integer-sqrt",
  "num-traits 0.2.11",
@@ -6507,7 +6508,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6519,7 +6520,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -6530,7 +6531,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6542,7 +6543,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "derive_more 0.99.5",
  "log 0.4.8",
@@ -6558,7 +6559,7 @@ dependencies = [
 [[package]]
 name = "sp-chain-spec"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "serde",
  "serde_json",
@@ -6567,7 +6568,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "derive_more 0.99.5",
  "futures 0.3.4",
@@ -6589,7 +6590,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6603,8 +6604,9 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
+ "merlin",
  "parity-scale-codec",
  "sp-api",
  "sp-application-crypto",
@@ -6619,7 +6621,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "parity-scale-codec",
  "schnorrkel",
@@ -6631,7 +6633,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "base58",
  "blake2-rfc",
@@ -6672,7 +6674,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "kvdb",
  "parking_lot 0.10.2",
@@ -6681,17 +6683,17 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
 ]
 
 [[package]]
 name = "sp-externalities"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -6702,7 +6704,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -6715,7 +6717,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-tracker"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -6725,7 +6727,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "derive_more 0.99.5",
  "parity-scale-codec",
@@ -6737,7 +6739,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "futures 0.3.4",
  "hash-db",
@@ -6757,7 +6759,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -6768,7 +6770,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -6778,7 +6780,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "backtrace",
  "log 0.4.8",
@@ -6787,7 +6789,7 @@ dependencies = [
 [[package]]
 name = "sp-phragmen"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -6799,18 +6801,18 @@ dependencies = [
 [[package]]
 name = "sp-phragmen-compact"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
 ]
 
 [[package]]
 name = "sp-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "serde",
  "sp-core",
@@ -6819,7 +6821,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "hash256-std-hasher",
  "impl-trait-for-tuples",
@@ -6840,7 +6842,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "parity-scale-codec",
  "primitive-types",
@@ -6855,19 +6857,19 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
 ]
 
 [[package]]
 name = "sp-serializer"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "serde",
  "serde_json",
@@ -6876,7 +6878,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -6887,7 +6889,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -6897,7 +6899,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "hash-db",
  "log 0.4.8",
@@ -6916,12 +6918,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 
 [[package]]
 name = "sp-storage"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "impl-serde 0.2.3",
  "ref-cast",
@@ -6933,7 +6935,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -6947,7 +6949,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "tracing",
 ]
@@ -6955,7 +6957,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "derive_more 0.99.5",
  "futures 0.3.4",
@@ -6970,7 +6972,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -6984,7 +6986,7 @@ dependencies = [
 [[package]]
 name = "sp-utils"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "futures 0.3.4",
  "futures-core",
@@ -6995,7 +6997,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "impl-serde 0.2.3",
  "parity-scale-codec",
@@ -7007,7 +7009,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -7094,8 +7096,8 @@ checksum = "d239ca4b13aee7a2142e6795cbd69e457665ff8037aed33b3effdc430d2f927a"
 dependencies = [
  "heck",
  "proc-macro-error",
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
 ]
 
@@ -7115,8 +7117,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0054a7df764039a6cd8592b9de84be4bec368ff081d203a7d5371cbfa8e65c81"
 dependencies = [
  "heck",
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
 ]
 
@@ -7135,7 +7137,7 @@ dependencies = [
 [[package]]
 name = "substrate-browser-utils"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "chrono",
  "clear_on_drop",
@@ -7162,7 +7164,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "platforms",
 ]
@@ -7170,7 +7172,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.4",
@@ -7191,7 +7193,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "async-std",
  "derive_more 0.99.5",
@@ -7199,13 +7201,13 @@ dependencies = [
  "hyper 0.13.5",
  "log 0.4.8",
  "prometheus",
- "tokio 0.2.19",
+ "tokio 0.2.20",
 ]
 
 [[package]]
 name = "substrate-test-client"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "futures 0.3.4",
  "hash-db",
@@ -7226,7 +7228,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "cfg-if",
  "frame-executive",
@@ -7265,7 +7267,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime-client"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 dependencies = [
  "futures 0.3.4",
  "parity-scale-codec",
@@ -7285,7 +7287,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder-runner"
 version = "1.0.5"
-source = "git+https://github.com/paritytech/substrate#303941324a74645a3c1fab859d9a7e1bda95bedd"
+source = "git+https://github.com/paritytech/substrate#af70e66930e8094164579d016961d7092874e55d"
 
 [[package]]
 name = "substrate-wasm-builder-runner"
@@ -7422,8 +7424,8 @@ version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "410a7488c0a728c7ceb4ad59b9567eb4053d02e8cc7f5c0e0eeeb39518369213"
 dependencies = [
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "unicode-xid 0.2.0",
 ]
 
@@ -7433,8 +7435,8 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
 dependencies = [
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
 ]
 
@@ -7453,8 +7455,8 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
 dependencies = [
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
  "unicode-xid 0.2.0",
 ]
@@ -7589,21 +7591,21 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b3d3d2ff68104100ab257bb6bb0cb26c901abe4bd4ba15961f3bf867924012"
+checksum = "d12a1dae4add0f0d568eebc7bf142f145ba1aa2544cafb195c76f0f409091b60"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca972988113b7715266f91250ddb98070d033c62a011fa0fcc57434a649310dd"
+checksum = "3f34e0c1caaa462fd840ec6b768946ea1e7842620d94fe29d5b847138f521269"
 dependencies = [
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
 ]
 
@@ -7695,9 +7697,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "0.2.19"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d9c43f1bb96970e153bcbae39a65e249ccb942bd9d36dbdf086024920417c9c"
+checksum = "05c1d570eb1a36f0345a5ce9c6c6e665b70b73d11236912c0b477616aeec47b1"
 dependencies = [
  "bytes 0.5.4",
  "fnv",
@@ -7806,7 +7808,7 @@ checksum = "4adb8b3e5f86b707f1b54e7c15b6de52617a823608ccda98a15d3a24222f265a"
 dependencies = [
  "futures-core",
  "rustls",
- "tokio 0.2.19",
+ "tokio 0.2.20",
  "webpki",
 ]
 
@@ -7907,7 +7909,7 @@ dependencies = [
  "futures-sink",
  "log 0.4.8",
  "pin-project-lite",
- "tokio 0.2.19",
+ "tokio 0.2.20",
 ]
 
 [[package]]
@@ -7942,7 +7944,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fbad39da2f9af1cae3016339ad7f2c7a9e870f12e8fd04c4fd7ef35b30c0d2b"
 dependencies = [
- "quote 1.0.3",
+ "quote 1.0.4",
  "syn 1.0.18",
 ]
 
@@ -8017,9 +8019,9 @@ checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
 
 [[package]]
 name = "uint"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e75a4cdd7b87b28840dba13c483b9a88ee6bbf16ba5c951ee1ecfcf723078e0d"
+checksum = "173cd16430c206dc1a430af8a89a0e9c076cf15cb42b4aedb10e8cc8fee73681"
 dependencies = [
  "byteorder",
  "crunchy",
@@ -8098,9 +8100,9 @@ dependencies = [
 
 [[package]]
 name = "untrusted"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60369ef7a31de49bcb3f6ca728d4ba7300d9a1658f94c727d4cab8c8d9f4aece"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
@@ -8186,9 +8188,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.60"
+version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc57ce05287f8376e998cbddfb4c8cb43b84a7ec55cf4551d7c00eef317a47f"
+checksum = "e3c7d40d09cdbf0f4895ae58cf57d92e1e57a9dd8ed2e8390514b54a47cc5551"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -8196,24 +8198,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.60"
+version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d967d37bf6c16cca2973ca3af071d0a2523392e4a594548155d89a678f4237cd"
+checksum = "c3972e137ebf830900db522d6c8fd74d1900dcfc733462e9a12e942b00b4ac94"
 dependencies = [
  "bumpalo",
  "lazy_static",
  "log 0.4.8",
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.10"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7add542ea1ac7fdaa9dc25e031a6af33b7d63376292bd24140c637d00d1c312a"
+checksum = "8a369c5e1dfb7569e14d62af4da642a3cbc2f9a3652fe586e26ac22222aa4b04"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -8223,22 +8225,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.60"
+version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bd151b63e1ea881bb742cd20e1d6127cef28399558f3b5d415289bc41eee3a4"
+checksum = "2cd85aa2c579e8892442954685f0d801f9129de24fa2136b2c6a539c76b65776"
 dependencies = [
- "quote 1.0.3",
+ "quote 1.0.4",
  "wasm-bindgen-macro-support",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.60"
+version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d68a5b36eef1be7868f668632863292e37739656a80fc4b9acec7b0bd35a4931"
+checksum = "8eb197bd3a47553334907ffd2f16507b4f4f01bbec3ac921a7719e0decdfe72a"
 dependencies = [
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
@@ -8246,9 +8248,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.60"
+version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf76fe7d25ac79748a37538b7daeed1c7a6867c92d3245c12c6222e4a20d639"
+checksum = "a91c2916119c17a8e316507afaaa2dd94b47646048014bbdf6bef098c1bb58ad"
 
 [[package]]
 name = "wasm-timer"
@@ -8360,9 +8362,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.37"
+version = "0.3.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6f51648d8c56c366144378a33290049eafdd784071077f6fe37dae64c1c4cb"
+checksum = "8bc359e5dd3b46cb9687a051d50a2fdd228e4ba7cf6fcf861a5365c3d671a642"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8595,8 +8597,8 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de251eec69fc7c1bc3923403d18ececb929380e016afe103da75f396704f8ca2"
 dependencies = [
- "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "syn 1.0.18",
  "synstructure",
 ]

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -31,8 +31,10 @@ use primitives::BlockNumber;
 use sp_runtime::Perbill;
 use frame_support::{
 	parameter_types, traits::Currency,
-	weights::{Weight, RuntimeDbWeight},
+	weights::{Weight, constants::WEIGHT_PER_SECOND},
 };
+
+pub use frame_support::weights::constants::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight};
 
 #[cfg(feature = "std")]
 pub use staking::StakerStatus;
@@ -50,15 +52,7 @@ pub type NegativeImbalance<T> = <balances::Module<T> as Currency<<T as system::T
 
 parameter_types! {
 	pub const BlockHashCount: BlockNumber = 250;
-	pub const MaximumBlockWeight: Weight = 2_000_000_000_000;
+	pub const MaximumBlockWeight: Weight = 2 * WEIGHT_PER_SECOND;
 	pub const AvailableBlockRatio: Perbill = Perbill::from_percent(75);
 	pub const MaximumBlockLength: u32 = 5 * 1024 * 1024;
-	/// Executing 10,000 System remarks (no-op) txs takes ~1.26 seconds -> ~125 µs per tx
-	pub const ExtrinsicBaseWeight: Weight = 125_000_000;
-	/// Importing a block with 0 txs takes ~5 ms
-	pub const BlockExecutionWeight: Weight = 5_000_000_000;
-	pub const DbWeight: RuntimeDbWeight = RuntimeDbWeight {
-		read: 25_000_000, // ~25 µs @ 200,000 items
-		write: 100_000_000, // ~100 µs @ 200,000 items
-	};
 }

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -31,7 +31,7 @@ use primitives::BlockNumber;
 use sp_runtime::Perbill;
 use frame_support::{
 	parameter_types, traits::Currency,
-	weights::Weight,
+	weights::{Weight, RuntimeDbWeight},
 };
 
 #[cfg(feature = "std")]
@@ -53,6 +53,12 @@ parameter_types! {
 	pub const MaximumBlockWeight: Weight = 2_000_000_000_000;
 	pub const AvailableBlockRatio: Perbill = Perbill::from_percent(75);
 	pub const MaximumBlockLength: u32 = 5 * 1024 * 1024;
-	pub const ExtrinsicBaseWeight: Weight = 100_000_000; // TODO: Confirm/Update
-	pub const BlockExecutionWeight: Weight = 1_000_000_000; // TODO: Confirm/Update
+	/// Executing 10,000 System remarks (no-op) txs takes ~1.26 seconds -> ~125 µs per tx
+	pub const ExtrinsicBaseWeight: Weight = 125_000_000;
+	/// Importing a block with 0 txs takes ~5 ms
+	pub const BlockExecutionWeight: Weight = 5_000_000_000;
+	pub const DbWeight: RuntimeDbWeight = RuntimeDbWeight {
+		read: 25_000_000, // ~25 µs @ 200,000 items
+		write: 100_000_000, // ~100 µs @ 200,000 items
+	};
 }

--- a/runtime/kusama/src/constants.rs
+++ b/runtime/kusama/src/constants.rs
@@ -73,7 +73,7 @@ pub mod fee {
 	impl Convert<Weight, Balance> for WeightToFee {
 		fn convert(x: Weight) -> Balance {
 			// in Kusama, extrinsic base weight (smallest non-zero weight) is mapped to 1/10 CENT:
-			Balance::from(x).saturating_mul(super::currency::CENTS / (10 * ExtrinsicBaseWeight::get() as u128))
+			Balance::from(x).saturating_mul(super::currency::CENTS / 10) / Balance::from(ExtrinsicBaseWeight::get())
 		}
 	}
 }

--- a/runtime/kusama/src/constants.rs
+++ b/runtime/kusama/src/constants.rs
@@ -54,6 +54,7 @@ pub mod fee {
 	use primitives::Balance;
 	use frame_support::weights::Weight;
 	use sp_runtime::traits::Convert;
+	use runtime_common::ExtrinsicBaseWeight;
 
 	/// The block saturation level. Fees will be updates based on this value.
 	pub const TARGET_BLOCK_FULLNESS: Perbill = Perbill::from_percent(25);
@@ -71,8 +72,30 @@ pub mod fee {
 	pub struct WeightToFee;
 	impl Convert<Weight, Balance> for WeightToFee {
 		fn convert(x: Weight) -> Balance {
-			// in Kusama a weight of 10_000_000 (smallest non-zero weight) is mapped to 1/10 CENT:
-			Balance::from(x).saturating_mul(super::currency::CENTS / (10 * 10_000_000))
+			// in Kusama, extrinsic base weight (smallest non-zero weight) is mapped to 1/10 CENT:
+			Balance::from(x).saturating_mul(super::currency::CENTS / (10 * ExtrinsicBaseWeight::get() as u128))
 		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use sp_runtime::traits::Convert;
+	use runtime_common::{MaximumBlockWeight, ExtrinsicBaseWeight};
+	use super::fee::WeightToFee;
+	use super::currency::{CENTS, DOLLARS};
+
+	#[test]
+	// This function tests that the fee for `MaximumBlockWeight` of weight is correct
+	fn full_block_fee_is_correct() {
+		// A full block should cost 16 DOLLARS
+		assert_eq!(WeightToFee::convert(MaximumBlockWeight::get()), 16 * DOLLARS)
+	}
+
+	#[test]
+	// This function tests that the fee for `ExtrinsicBaseWeight` of weight is correct
+	fn extrinsic_base_fee_is_correct() {
+		// `ExtrinsicBaseWeight` should cost 1/10 of a CENT
+		assert_eq!(WeightToFee::convert(ExtrinsicBaseWeight::get()), CENTS / 10)
 	}
 }

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -30,7 +30,7 @@ use primitives::{
 use runtime_common::{attestations, claims, parachains, registrar, slots,
 	impls::{CurrencyToVoteHandler, TargetedFeeAdjustment, ToAuthor},
 	NegativeImbalance, BlockHashCount, MaximumBlockWeight, AvailableBlockRatio,
-	MaximumBlockLength, BlockExecutionWeight, ExtrinsicBaseWeight,
+	MaximumBlockLength, BlockExecutionWeight, ExtrinsicBaseWeight, DbWeight,
 };
 use sp_runtime::{
 	create_runtime_str, generic, impl_opaque_keys, ModuleId,
@@ -55,7 +55,6 @@ use sp_staking::SessionIndex;
 use frame_support::{
 	parameter_types, construct_runtime, debug,
 	traits::{KeyOwnerProofSystem, SplitTwoWays, Randomness, LockIdentifier},
-  weights::RuntimeDbWeight,
 };
 use im_online::sr25519::AuthorityId as ImOnlineId;
 use authority_discovery_primitives::AuthorityId as AuthorityDiscoveryId;
@@ -130,13 +129,6 @@ impl SignedExtension for RestrictFunctionality {
 
 parameter_types! {
 	pub const Version: RuntimeVersion = VERSION;
-}
-
-parameter_types! {
-	pub const DbWeight: RuntimeDbWeight = RuntimeDbWeight {
-		read: 60_000_000,
-		write: 200_000_000,
-	};
 }
 
 impl system::Trait for Runtime {

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -30,7 +30,7 @@ use primitives::{
 use runtime_common::{attestations, claims, parachains, registrar, slots,
 	impls::{CurrencyToVoteHandler, TargetedFeeAdjustment, ToAuthor},
 	NegativeImbalance, BlockHashCount, MaximumBlockWeight, AvailableBlockRatio,
-	MaximumBlockLength, BlockExecutionWeight, ExtrinsicBaseWeight, DbWeight,
+	MaximumBlockLength, BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight,
 };
 use sp_runtime::{
 	create_runtime_str, generic, impl_opaque_keys, ModuleId,
@@ -144,7 +144,7 @@ impl system::Trait for Runtime {
 	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type MaximumBlockWeight = MaximumBlockWeight;
-	type DbWeight = DbWeight;
+	type DbWeight = RocksDbWeight;
 	type BlockExecutionWeight = BlockExecutionWeight;
 	type ExtrinsicBaseWeight = ExtrinsicBaseWeight;
 	type MaximumBlockLength = MaximumBlockLength;

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -83,7 +83,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("kusama"),
 	impl_name: create_runtime_str!("parity-kusama"),
 	authoring_version: 2,
-	spec_version: 1061,
+	spec_version: 1062,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/runtime/polkadot/src/constants.rs
+++ b/runtime/polkadot/src/constants.rs
@@ -46,6 +46,7 @@ pub mod fee {
 	use primitives::Balance;
 	use frame_support::weights::Weight;
 	use sp_runtime::traits::Convert;
+	use runtime_common::ExtrinsicBaseWeight;
 
 	/// The block saturation level. Fees will be updates based on this value.
 	pub const TARGET_BLOCK_FULLNESS: Perbill = Perbill::from_percent(25);
@@ -63,8 +64,31 @@ pub mod fee {
 	pub struct WeightToFee;
 	impl Convert<Weight, Balance> for WeightToFee {
 		fn convert(x: Weight) -> Balance {
-			// in Polkadot a weight of 10_000_000 (smallest non-zero weight) is mapped to 1/10 CENT:
-			Balance::from(x).saturating_mul(super::currency::CENTS / (10 * 10_000_000))
+			// in Polkadot, extrinsic base weight (smallest non-zero weight) is mapped to 1/10 CENT:
+			Balance::from(x).saturating_mul(super::currency::CENTS / (10 * ExtrinsicBaseWeight::get() as u128))
 		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use sp_runtime::traits::Convert;
+	use runtime_common::{MaximumBlockWeight, ExtrinsicBaseWeight};
+	use super::fee::WeightToFee;
+	use super::currency::{CENTS, DOLLARS};
+
+	#[test]
+	// This function tests that the fee for `MaximumBlockWeight` of weight is correct
+	fn full_block_fee_is_correct() {
+		println!("{:?}", MaximumBlockWeight::get());
+		// A full block should cost 16 DOLLARS
+		assert_eq!(WeightToFee::convert(MaximumBlockWeight::get()), 16 * DOLLARS)
+	}
+
+	#[test]
+	// This function tests that the fee for `ExtrinsicBaseWeight` of weight is correct
+	fn extrinsic_base_fee_is_correct() {
+		// `ExtrinsicBaseWeight` should cost 1/10 of a CENT
+		assert_eq!(WeightToFee::convert(ExtrinsicBaseWeight::get()), CENTS / 10)
 	}
 }

--- a/runtime/polkadot/src/constants.rs
+++ b/runtime/polkadot/src/constants.rs
@@ -65,7 +65,7 @@ pub mod fee {
 	impl Convert<Weight, Balance> for WeightToFee {
 		fn convert(x: Weight) -> Balance {
 			// in Polkadot, extrinsic base weight (smallest non-zero weight) is mapped to 1/10 CENT:
-			Balance::from(x).saturating_mul(super::currency::CENTS / (10 * ExtrinsicBaseWeight::get() as u128))
+			Balance::from(x).saturating_mul(super::currency::CENTS / 10) / Balance::from(ExtrinsicBaseWeight::get())
 		}
 	}
 }

--- a/runtime/polkadot/src/constants.rs
+++ b/runtime/polkadot/src/constants.rs
@@ -80,7 +80,6 @@ mod tests {
 	#[test]
 	// This function tests that the fee for `MaximumBlockWeight` of weight is correct
 	fn full_block_fee_is_correct() {
-		println!("{:?}", MaximumBlockWeight::get());
 		// A full block should cost 16 DOLLARS
 		assert_eq!(WeightToFee::convert(MaximumBlockWeight::get()), 16 * DOLLARS)
 	}

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -23,7 +23,7 @@
 use runtime_common::{attestations, claims, parachains, registrar, slots,
 	impls::{CurrencyToVoteHandler, TargetedFeeAdjustment, ToAuthor},
 	NegativeImbalance, BlockHashCount, MaximumBlockWeight, AvailableBlockRatio,
-	MaximumBlockLength, BlockExecutionWeight, ExtrinsicBaseWeight, DbWeight,
+	MaximumBlockLength, BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight,
 };
 
 use sp_std::prelude::*;
@@ -150,7 +150,7 @@ impl system::Trait for Runtime {
 	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type MaximumBlockWeight = MaximumBlockWeight;
-	type DbWeight = DbWeight;
+	type DbWeight = RocksDbWeight;
 	type BlockExecutionWeight = BlockExecutionWeight;
 	type ExtrinsicBaseWeight = ExtrinsicBaseWeight;
 	type MaximumBlockLength = MaximumBlockLength;

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -86,7 +86,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("polkadot"),
 	impl_name: create_runtime_str!("parity-polkadot"),
 	authoring_version: 2,
-	spec_version: 1008,
+	spec_version: 1009,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -23,7 +23,7 @@
 use runtime_common::{attestations, claims, parachains, registrar, slots,
 	impls::{CurrencyToVoteHandler, TargetedFeeAdjustment, ToAuthor},
 	NegativeImbalance, BlockHashCount, MaximumBlockWeight, AvailableBlockRatio,
-	MaximumBlockLength, BlockExecutionWeight, ExtrinsicBaseWeight,
+	MaximumBlockLength, BlockExecutionWeight, ExtrinsicBaseWeight, DbWeight,
 };
 
 use sp_std::prelude::*;
@@ -57,7 +57,6 @@ use sp_staking::SessionIndex;
 use frame_support::{
 	parameter_types, construct_runtime, debug,
 	traits::{KeyOwnerProofSystem, SplitTwoWays, Randomness, LockIdentifier},
-  weights::RuntimeDbWeight,
 };
 use im_online::sr25519::AuthorityId as ImOnlineId;
 use authority_discovery_primitives::AuthorityId as AuthorityDiscoveryId;
@@ -136,13 +135,6 @@ impl SignedExtension for OnlyStakingAndClaims {
 
 parameter_types! {
 	pub const Version: RuntimeVersion = VERSION;
-}
-
-parameter_types! {
-	pub const DbWeight: RuntimeDbWeight = RuntimeDbWeight {
-		read: 60_000_000,
-		write: 200_000_000,
-	};
 }
 
 impl system::Trait for Runtime {

--- a/runtime/test-runtime/src/lib.rs
+++ b/runtime/test-runtime/src/lib.rs
@@ -81,7 +81,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("polkadot-test-runtime"),
 	impl_name: create_runtime_str!("parity-polkadot-test-runtime"),
 	authoring_version: 2,
-	spec_version: 1051,
+	spec_version: 1052,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/runtime/westend/src/constants.rs
+++ b/runtime/westend/src/constants.rs
@@ -46,6 +46,7 @@ pub mod fee {
 	use primitives::Balance;
 	use frame_support::weights::Weight;
 	use sp_runtime::traits::Convert;
+	use runtime_common::ExtrinsicBaseWeight;
 
 	/// The block saturation level. Fees will be updates based on this value.
 	pub const TARGET_BLOCK_FULLNESS: Perbill = Perbill::from_percent(25);
@@ -63,8 +64,30 @@ pub mod fee {
 	pub struct WeightToFee;
 	impl Convert<Weight, Balance> for WeightToFee {
 		fn convert(x: Weight) -> Balance {
-			// in Kusama a weight of 10_000 (smallest non-zero weight) is mapped to 1/10 CENT:
-			Balance::from(x).saturating_mul(super::currency::CENTS / (10 * 10_000))
+			// in Westend, extrinsic base weight (smallest non-zero weight) is mapped to 1/10 CENT:
+			Balance::from(x).saturating_mul(super::currency::CENTS / (10 * ExtrinsicBaseWeight::get() as u128))
 		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use sp_runtime::traits::Convert;
+	use runtime_common::{MaximumBlockWeight, ExtrinsicBaseWeight};
+	use super::fee::WeightToFee;
+	use super::currency::{CENTS, DOLLARS};
+
+	#[test]
+	// This function tests that the fee for `MaximumBlockWeight` of weight is correct
+	fn full_block_fee_is_correct() {
+		// A full block should cost 16 DOLLARS
+		assert_eq!(WeightToFee::convert(MaximumBlockWeight::get()), 16 * DOLLARS)
+	}
+
+	#[test]
+	// This function tests that the fee for `ExtrinsicBaseWeight` of weight is correct
+	fn extrinsic_base_fee_is_correct() {
+		// `ExtrinsicBaseWeight` should cost 1/10 of a CENT
+		assert_eq!(WeightToFee::convert(ExtrinsicBaseWeight::get()), CENTS / 10)
 	}
 }

--- a/runtime/westend/src/constants.rs
+++ b/runtime/westend/src/constants.rs
@@ -65,7 +65,7 @@ pub mod fee {
 	impl Convert<Weight, Balance> for WeightToFee {
 		fn convert(x: Weight) -> Balance {
 			// in Westend, extrinsic base weight (smallest non-zero weight) is mapped to 1/10 CENT:
-			Balance::from(x).saturating_mul(super::currency::CENTS / (10 * ExtrinsicBaseWeight::get() as u128))
+			Balance::from(x).saturating_mul(super::currency::CENTS / 10) / Balance::from(ExtrinsicBaseWeight::get())
 		}
 	}
 }

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -29,7 +29,7 @@ use primitives::{
 use runtime_common::{attestations, parachains, registrar,
 	impls::{CurrencyToVoteHandler, TargetedFeeAdjustment, ToAuthor},
 	BlockHashCount, MaximumBlockWeight, AvailableBlockRatio, MaximumBlockLength,
-	BlockExecutionWeight, ExtrinsicBaseWeight, DbWeight,
+	BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight,
 };
 use sp_runtime::{
 	create_runtime_str, generic, impl_opaque_keys,
@@ -144,7 +144,7 @@ impl system::Trait for Runtime {
 	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type MaximumBlockWeight = MaximumBlockWeight;
-	type DbWeight = DbWeight;
+	type DbWeight = RocksDbWeight;
 	type BlockExecutionWeight = BlockExecutionWeight;
 	type ExtrinsicBaseWeight = ExtrinsicBaseWeight;
 	type MaximumBlockLength = MaximumBlockLength;

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -29,7 +29,7 @@ use primitives::{
 use runtime_common::{attestations, parachains, registrar,
 	impls::{CurrencyToVoteHandler, TargetedFeeAdjustment, ToAuthor},
 	BlockHashCount, MaximumBlockWeight, AvailableBlockRatio, MaximumBlockLength,
-	BlockExecutionWeight, ExtrinsicBaseWeight
+	BlockExecutionWeight, ExtrinsicBaseWeight, DbWeight,
 };
 use sp_runtime::{
 	create_runtime_str, generic, impl_opaque_keys,
@@ -55,7 +55,6 @@ use sp_staking::SessionIndex;
 use frame_support::{
 	parameter_types, construct_runtime, debug,
 	traits::{KeyOwnerProofSystem, Randomness},
-	weights::RuntimeDbWeight,
 };
 use im_online::sr25519::AuthorityId as ImOnlineId;
 use authority_discovery_primitives::AuthorityId as AuthorityDiscoveryId;
@@ -132,13 +131,6 @@ parameter_types! {
 	pub const Version: RuntimeVersion = VERSION;
 }
 
-parameter_types! {
-	pub const DbWeight: RuntimeDbWeight = RuntimeDbWeight {
-		read: 60_000_000,
-		write: 200_000_000,
-	};
-}
-
 impl system::Trait for Runtime {
 	type Origin = Origin;
 	type Call = Call;
@@ -153,7 +145,7 @@ impl system::Trait for Runtime {
 	type BlockHashCount = BlockHashCount;
 	type MaximumBlockWeight = MaximumBlockWeight;
 	type DbWeight = DbWeight;
-  type BlockExecutionWeight = BlockExecutionWeight;
+	type BlockExecutionWeight = BlockExecutionWeight;
 	type ExtrinsicBaseWeight = ExtrinsicBaseWeight;
 	type MaximumBlockLength = MaximumBlockLength;
 	type AvailableBlockRatio = AvailableBlockRatio;

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -83,7 +83,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("westend"),
 	impl_name: create_runtime_str!("parity-westend"),
 	authoring_version: 2,
-	spec_version: 6,
+	spec_version: 7,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
This PR updates Runtime Weight constants to the latest in Substrate and our benchmark results, and also updates our fee calculation logic to take into account a `no-op` extrinsic costs .01 CENTS.

Specifically:

```
/// Executing 10,000 System remarks (no-op) txs takes ~1.26 seconds -> ~125 µs per tx
pub const ExtrinsicBaseWeight: Weight = 125_000_000;
/// Importing a block with 0 txs takes ~5 ms
pub const BlockExecutionWeight: Weight = 5_000_000_000;
pub const DbWeight: RuntimeDbWeight = RuntimeDbWeight {
	read: 25_000_000, // ~25 µs @ 200,000 items
	write: 100_000_000, // ~100 µs @ 200,000 items
};
```

And Weight to Fee of `ExtrinsicBaseWeight` -> 1/10 CENTS

Additionally, this transitions to use weight constants as defined here: https://github.com/paritytech/substrate/pull/5884