### PR TITLE
Enable Babe RPC for getting epoch authorship

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4267,11 +4267,17 @@ dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
  "sc-client-api",
+ "sc-consensus-babe",
+ "sc-consensus-babe-rpc",
+ "sc-consensus-epochs",
  "sc-finality-grandpa",
  "sc-finality-grandpa-rpc",
+ "sc-keystore",
  "sc-rpc",
  "sp-api",
  "sp-blockchain",
+ "sp-consensus",
+ "sp-consensus-babe",
  "sp-runtime",
  "sp-transaction-pool",
  "substrate-frame-rpc-system",
@@ -5522,6 +5528,28 @@ dependencies = [
  "sp-runtime",
  "sp-timestamp",
  "sp-version",
+]
+
+[[package]]
+name = "sc-consensus-babe-rpc"
+version = "0.8.0-dev"
+source = "git+https://github.com/paritytech/substrate#c0ccc24d02080ab4fbb2c65440327fc72acb6c42"
+dependencies = [
+ "derive_more 0.99.5",
+ "futures 0.3.4",
+ "jsonrpc-core",
+ "jsonrpc-core-client",
+ "jsonrpc-derive",
+ "sc-consensus-babe",
+ "sc-consensus-epochs",
+ "sc-keystore",
+ "serde",
+ "sp-api",
+ "sp-blockchain",
+ "sp-consensus",
+ "sp-consensus-babe",
+ "sp-core",
+ "sp-runtime",
 ]
 
 [[package]]

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -11,9 +11,15 @@ sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "mas
 sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "master"  }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master"  }
 sp-api = { git = "https://github.com/paritytech/substrate", branch = "master"  }
+sp-consensus = { git = "https://github.com/paritytech/substrate", branch = "master"  }
+sp-consensus-babe = { git = "https://github.com/paritytech/substrate", branch = "master"  }
 sc-rpc = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-consensus-babe = { git = "https://github.com/paritytech/substrate", branch = "master"}
+sc-consensus-babe-rpc = { git = "https://github.com/paritytech/substrate", branch = "master"}
+sc-consensus-epochs = { git = "https://github.com/paritytech/substrate", branch = "master"}
 sc-finality-grandpa = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sc-finality-grandpa-rpc = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-keystore = { git = "https://github.com/paritytech/substrate", branch = "master"}
 txpool-api = { package = "sp-transaction-pool", git = "https://github.com/paritytech/substrate", branch = "master" }
 frame-rpc-system = { package = "substrate-frame-rpc-system", git = "https://github.com/paritytech/substrate", branch = "master"  }
 pallet-transaction-payment-rpc = { git = "https://github.com/paritytech/substrate", branch = "master" }

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -204,16 +204,29 @@ macro_rules! new_full_start {
 				Ok(import_queue)
 			})?
 			.with_rpc_extensions(|builder| -> Result<polkadot_rpc::RpcExtension, _> {
+				let babe_link = import_setup.as_ref().map(|s| &s.2)
+					.expect("BabeLink is present for full services or set up faile; qed.");
 				let grandpa_link = import_setup.as_ref().map(|s| &s.1)
 					.expect("GRANDPA LinkHalf is present for full services or set up failed; qed.");
 				let shared_authority_set = grandpa_link.shared_authority_set();
 				let shared_voter_state = SharedVoterState::empty();
-				let grandpa_deps = polkadot_rpc::GrandpaDeps {
-					shared_voter_state: shared_voter_state.clone(),
-					shared_authority_set: shared_authority_set.clone(),
+				let deps = polkadot_rpc::FullDeps {
+					client: builder.client().clone(),
+					pool: builder.pool(),
+					select_chain: builder.select_chain().cloned()
+						.expect("SelectChain is present for full services or set up failed; qed."),
+					babe: polkadot_rpc::BabeDeps {
+						keystore: builder.keystore(),
+						babe_config: babe::BabeLink::config(babe_link).clone(),
+						shared_epoch_changes: babe::BabeLink::epoch_changes(babe_link).clone(),
+					},
+					grandpa: polkadot_rpc::GrandpaDeps {
+						shared_voter_state: shared_voter_state.clone(),
+						shared_authority_set: shared_authority_set.clone(),
+					},
 				};
 				rpc_setup = Some((shared_voter_state));
-				Ok(polkadot_rpc::create_full(builder.client().clone(), builder.pool(), grandpa_deps))
+				Ok(polkadot_rpc::create_full(deps))
 			})?;
 
 		(builder, import_setup, inherent_data_providers, rpc_setup)
@@ -566,7 +579,13 @@ macro_rules! new_light {
 				let remote_blockchain = builder.remote_backend()
 					.ok_or_else(|| "Trying to start node RPC without active remote blockchain")?;
 
-				Ok(polkadot_rpc::create_light(builder.client().clone(), remote_blockchain, fetcher, builder.pool()))
+				let light_deps = polkadot_rpc::LightDeps {
+					remote_blockchain,
+					fetcher,
+					client: builder.client().clone(),
+					pool: builder.pool(),
+				};
+				Ok(polkadot_rpc::create_light(light_deps))
 			})?
 			.build()
 	}}


### PR DESCRIPTION
Enable `babe_epochAuthorship` that was added in https://github.com/paritytech/substrate/pull/4729, which returns all the slots that can be claimed in the current epoch.