### PR TITLE
Change BlockHashCount Parameter

### DIFF
--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -51,7 +51,7 @@ pub use impls::{CurrencyToVoteHandler, TargetedFeeAdjustment, ToAuthor};
 pub type NegativeImbalance<T> = <balances::Module<T> as Currency<<T as system::Trait>::AccountId>>::NegativeImbalance;
 
 parameter_types! {
-	pub const BlockHashCount: BlockNumber = 250;
+	pub const BlockHashCount: BlockNumber = 2400;
 	pub const MaximumBlockWeight: Weight = 2 * WEIGHT_PER_SECOND;
 	pub const AvailableBlockRatio: Perbill = Perbill::from_percent(75);
 	pub const MaximumBlockLength: u32 = 5 * 1024 * 1024;


### PR DESCRIPTION
Parameter change of `BlockHashCount` from 250 to 2400. This is meant to ease integration and should have a minimal impact on the chain's performance.

### Reasons

Many custodians and validator operators have more involved signing processes and key access operations. For example, the person/team who signs payloads may not have access to the systems to generate signing payloads; if they did, then a single employee could access their clients' tokens. Therefore, there are often large gaps between construction, signing, and broadcast.

Immortals are a no-go because if an account were ever reaped and someone refunded it, a custody provider would not have full control over the address.

### Impact

Impact on performance should be minimal. 

- Additional 67.2 kB of state (`(2400 - 250 items) * 32 bytes/item / 1024`)
- 2150 additional keys under a prefix
  - Benchmarking was done with 200k keys (so this is about 1% of that)
  - Would add 1 hop in the trie to access keys under this prefix

#### Question

I know that transaction size is sensitive and by going over 255, I've crossed over 1 byte territory. `BlockHashCount` and `(Period, Phase)` are `u32` and `(u64, u64)`, respectively, so 2400 is well under those limits. I tested on a local dev chain with this setting and my transactions succeeded up to 2400 blocks and were stale after, as expected. They also decode in the same way that Kusama transactions decode. So, I _think_ that it's OK, but someone familiar with transaction mortality and encoding should review.