### PR TITLE
Add tests for Polkadot runtime weights and fees

### DIFF
--- a/runtime/polkadot/src/constants.rs
+++ b/runtime/polkadot/src/constants.rs
@@ -19,9 +19,9 @@ pub mod currency {
 	use primitives::Balance;
 
 	pub const DOTS: Balance = 1_000_000_000_000;
-	pub const DOLLARS: Balance = DOTS / 100;
-	pub const CENTS: Balance = DOLLARS / 100;
-	pub const MILLICENTS: Balance = CENTS / 1_000;
+	pub const DOLLARS: Balance = DOTS / 100;       // 10_000_000_000
+	pub const CENTS: Balance = DOLLARS / 100;      // 100_000_000
+	pub const MILLICENTS: Balance = CENTS / 1_000; // 100_000
 }
 
 /// Time and blocks.

--- a/runtime/polkadot/tests/weights.rs
+++ b/runtime/polkadot/tests/weights.rs
@@ -1,4 +1,4 @@
-// Copyright 2017-2020 Parity Technologies (UK) Ltd.
+// Copyright 2020 Parity Technologies (UK) Ltd.
 // This file is part of Polkadot.
 
 // Polkadot is free software: you can redistribute it and/or modify

--- a/runtime/polkadot/tests/weights.rs
+++ b/runtime/polkadot/tests/weights.rs
@@ -76,8 +76,8 @@ fn weight_of_balances_transfer_keep_alive_is_correct() {
 
 #[test]
 fn weight_of_timestamp_set_is_correct() {
-	// #[weight = T::DbWeight::get().reads_writes(2, 1) + 9_000_000]
-	let expected_weight = (2 * DbWeight::get().read) + DbWeight::get().write + 9_000_000;
+	// #[weight = T::DbWeight::get().reads_writes(2, 1) + 8_000_000]
+	let expected_weight = (2 * DbWeight::get().read) + DbWeight::get().write + 8_000_000;
 	let weight = polkadot_runtime::TimestampCall::set::<Runtime>(Default::default()).get_dispatch_info().weight;
 
 	assert_eq!(weight, expected_weight);

--- a/runtime/polkadot/tests/weights.rs
+++ b/runtime/polkadot/tests/weights.rs
@@ -17,6 +17,11 @@
 //! Tests to make sure that Polkadot's weights and fees match what we
 //! expect from Substrate.
 //!
+//! These test are not meant to be exhaustive, as it is inevitable that
+//! weights in Substrate will change. Instead they are supposed to provide
+//! some sort of indicator that calls we consider important (e.g Balances::transfer)
+//! have not suddenly changed from under us.
+//!
 //! NOTE: All the tests assume RocksDB as the RuntimeDbWeight type
 //! which gives us the following weights:
 //!  - Read: 25 * WEIGHT_PER_MICROS = 25 * 100_000_000,

--- a/runtime/polkadot/tests/weights.rs
+++ b/runtime/polkadot/tests/weights.rs
@@ -42,31 +42,13 @@ use system::Call as SystemCall;
 use treasury::Call as TreasuryCall;
 
 #[test]
-fn sanity_check_weight_per_second_is_as_expected() {
-	// This value comes from Substrate, we want to make sure that if it
+fn sanity_check_weight_per_time_constants_are_as_expected() {
+	// These values comes from Substrate, we want to make sure that if it
 	// ever changes we don't accidently break Polkadot
-	assert_eq!(WEIGHT_PER_SECOND, 1_000_000_000_000)
-}
-
-#[test]
-fn sanity_check_weight_per_milli_is_as_expected() {
-	// This value comes from Substrate, we want to make sure that if it
-	// ever changes we don't accidently break Polkadot
-	assert_eq!(WEIGHT_PER_MILLIS, 1_000_000_000)
-}
-
-#[test]
-fn sanity_check_weight_per_micros_is_as_expected() {
-	// This value comes from Substrate, we want to make sure that if it
-	// ever changes we don't accidently break Polkadot
-	assert_eq!(WEIGHT_PER_MICROS, 1_000_000)
-}
-
-#[test]
-fn sanity_check_weight_per_nanos_is_as_expected() {
-	// This value comes from Substrate, we want to make sure that if it
-	// ever changes we don't accidently break Polkadot
-	assert_eq!(WEIGHT_PER_NANOS, 1_000)
+	assert_eq!(WEIGHT_PER_SECOND, 1_000_000_000_000);
+	assert_eq!(WEIGHT_PER_MILLIS, WEIGHT_PER_SECOND / 1000);
+	assert_eq!(WEIGHT_PER_MICROS, WEIGHT_PER_MILLIS / 1000);
+	assert_eq!(WEIGHT_PER_NANOS, WEIGHT_PER_MICROS / 1000);
 }
 
 #[test]

--- a/runtime/polkadot/tests/weights.rs
+++ b/runtime/polkadot/tests/weights.rs
@@ -184,8 +184,8 @@ fn weight_of_session_purge_keys_is_correct() {
 
 #[test]
 fn weight_of_democracy_propose_is_correct() {
-	// #[weight = 5_000_000_000]
-	let expected_weight = 5_000_000_000;
+	// #[weight = 50_000_000 + T::DbWeight::get().reads_writes(2, 3)]
+	let expected_weight = 50_000_000 + (DbWeight::get().read * 2) + (DbWeight::get().write * 3);
 	let weight = DemocracyCall::propose::<Runtime>(Default::default(), Default::default()).get_dispatch_info().weight;
 
 	assert_eq!(weight, expected_weight);
@@ -196,8 +196,11 @@ fn weight_of_democracy_vote_is_correct() {
 	use democracy::AccountVote;
 	let vote = AccountVote::Standard { vote: Default::default(), balance: Default::default() };
 
-	// #[weight = 200_000_000]
-	let expected_weight = 200_000_000;
+	// #[weight = 50_000_000 + 350_000 * Weight::from(T::MaxVotes::get()) + T::DbWeight::get().reads_writes(3, 3)]
+	let expected_weight = 50_000_000
+		+ 350_000 * (Weight::from(polkadot_runtime::MaxVotes::get()))
+		+ (DbWeight::get().read * 3)
+		+ (DbWeight::get().write * 3);
 	let weight = DemocracyCall::vote::<Runtime>(Default::default(), vote).get_dispatch_info().weight;
 
 	assert_eq!(weight, expected_weight);

--- a/runtime/polkadot/tests/weights.rs
+++ b/runtime/polkadot/tests/weights.rs
@@ -63,38 +63,6 @@ fn weight_of_balances_transfer_is_correct() {
 }
 
 #[test]
-fn weight_of_balances_set_balance_is_correct() {
-	// #[weight = T::DbWeight::get().reads_writes(1, 1) + 35_000_000]
-	let expected_weight = DbWeight::get().read + DbWeight::get().write + 35_000_000;
-
-	let weight = polkadot_runtime::BalancesCall::set_balance::<Runtime>(
-		Default::default(),
-		Default::default(),
-		Default::default(),
-	)
-	.get_dispatch_info()
-	.weight;
-
-	assert_eq!(weight, expected_weight);
-}
-
-#[test]
-fn weight_of_balances_force_transfer_is_correct() {
-	// #[weight = T::DbWeight::get().reads_writes(2, 2) + 70_000_000]
-	let expected_weight = (2 * DbWeight::get().read) + (2 * DbWeight::get().write) + 70_000_000;
-
-	let weight = polkadot_runtime::BalancesCall::force_transfer::<Runtime>(
-		Default::default(),
-		Default::default(),
-		Default::default(),
-	)
-	.get_dispatch_info()
-	.weight;
-
-	assert_eq!(weight, expected_weight);
-}
-
-#[test]
 fn weight_of_balances_transfer_keep_alive_is_correct() {
 	// #[weight = T::DbWeight::get().reads_writes(1, 1) + 50_000_000]
 	let expected_weight = DbWeight::get().read + DbWeight::get().write + 50_000_000;
@@ -127,33 +95,6 @@ fn weight_of_staking_bond_is_correct() {
 }
 
 #[test]
-fn weight_of_staking_bond_extra_is_correct() {
-	// #[weight = 500_000_000]
-	let expected_weight = 500_000_000;
-	let weight = StakingCall::bond_extra::<Runtime>(1 * DOLLARS).get_dispatch_info().weight;
-
-	assert_eq!(weight, expected_weight);
-}
-
-#[test]
-fn weight_of_staking_unbond_is_correct() {
-	// #[weight = 400_000_000]
-	let expected_weight = 400_000_000;
-	let weight = StakingCall::unbond::<Runtime>(Default::default()).get_dispatch_info().weight;
-
-	assert_eq!(weight, expected_weight);
-}
-
-#[test]
-fn weight_of_staking_widthdraw_unbonded_is_correct() {
-	// #[weight = 400_000_000]
-	let expected_weight = 400_000_000;
-	let weight = StakingCall::withdraw_unbonded::<Runtime>().get_dispatch_info().weight;
-
-	assert_eq!(weight, expected_weight);
-}
-
-#[test]
 fn weight_of_staking_validate_is_correct() {
 	// #[weight = 750_000_000]
 	let expected_weight = 750_000_000;
@@ -176,15 +117,6 @@ fn weight_of_system_set_code_is_correct() {
 	// #[weight = (T::MaximumBlockWeight::get(), DispatchClass::Operational)]
 	let expected_weight = MaximumBlockWeight::get();
 	let weight = SystemCall::set_code::<Runtime>(vec![]).get_dispatch_info().weight;
-
-	assert_eq!(weight, expected_weight);
-}
-
-#[test]
-fn weight_of_system_set_code_without_checks_is_correct() {
-	// #[weight = (T::MaximumBlockWeight::get(), DispatchClass::Operational)]
-	let expected_weight = MaximumBlockWeight::get();
-	let weight = SystemCall::set_code_without_checks::<Runtime>(vec![]).get_dispatch_info().weight;
 
 	assert_eq!(weight, expected_weight);
 }
@@ -274,7 +206,7 @@ fn weight_of_democracy_enact_proposal_is_correct() {
 }
 
 #[test]
-fn weight_of_phragment_vote_is_correct() {
+fn weight_of_phragmen_vote_is_correct() {
 	// #[weight = 100_000_000]
 	let expected_weight = 100_000_000;
 	let weight = PhragmenCall::vote::<Runtime>(Default::default(), Default::default()).get_dispatch_info().weight;
@@ -283,7 +215,7 @@ fn weight_of_phragment_vote_is_correct() {
 }
 
 #[test]
-fn weight_of_phragment_submit_candidacy_is_correct() {
+fn weight_of_phragmen_submit_candidacy_is_correct() {
 	// #[weight = 500_000_000]
 	let expected_weight = 500_000_000;
 	let weight = PhragmenCall::submit_candidacy::<Runtime>().get_dispatch_info().weight;
@@ -292,7 +224,7 @@ fn weight_of_phragment_submit_candidacy_is_correct() {
 }
 
 #[test]
-fn weight_of_phragment_renounce_candidacy_is_correct() {
+fn weight_of_phragmen_renounce_candidacy_is_correct() {
 	// #[weight = (2_000_000_000, DispatchClass::Operational)]
 	let expected_weight = 2_000_000_000;
 	let weight = PhragmenCall::renounce_candidacy::<Runtime>().get_dispatch_info().weight;

--- a/runtime/polkadot/tests/weights_and_fees.rs
+++ b/runtime/polkadot/tests/weights_and_fees.rs
@@ -30,6 +30,7 @@ use polkadot_runtime::constants::{currency::*, fee::*};
 use runtime_common::{MaximumBlockWeight, ExtrinsicBaseWeight};
 
 use democracy::Call as DemocracyCall;
+use elections_phragmen::Call as PhragmenCall;
 use session::Call as SessionCall;
 use staking::Call as StakingCall;
 use system::Call as SystemCall;
@@ -296,6 +297,33 @@ fn weight_of_democracy_enact_proposal_is_correct() {
 	// #[weight = T::MaximumBlockWeight::get()]
 	let expected_weight = MaximumBlockWeight::get();
 	let weight = DemocracyCall::enact_proposal::<Runtime>(Default::default(), Default::default()).get_dispatch_info().weight;
+
+	assert_eq!(weight, expected_weight);
+}
+
+#[test]
+fn weight_of_phragment_vote_is_correct() {
+	// #[weight = 100_000_000]
+	let expected_weight = 100_000_000;
+	let weight = PhragmenCall::vote::<Runtime>(Default::default(), Default::default()).get_dispatch_info().weight;
+
+	assert_eq!(weight, expected_weight);
+}
+
+#[test]
+fn weight_of_phragment_submit_candidacy_is_correct() {
+	// #[weight = 500_000_000]
+	let expected_weight = 500_000_000;
+	let weight = PhragmenCall::submit_candidacy::<Runtime>().get_dispatch_info().weight;
+
+	assert_eq!(weight, expected_weight);
+}
+
+#[test]
+fn weight_of_phragment_renounce_candidacy_is_correct() {
+	// #[weight = (2_000_000_000, DispatchClass::Operational)]
+	let expected_weight = 2_000_000_000;
+	let weight = PhragmenCall::renounce_candidacy::<Runtime>().get_dispatch_info().weight;
 
 	assert_eq!(weight, expected_weight);
 }

--- a/runtime/polkadot/tests/weights_and_fees.rs
+++ b/runtime/polkadot/tests/weights_and_fees.rs
@@ -27,6 +27,7 @@ use keyring::AccountKeyring;
 use primitives::AccountId;
 use polkadot_runtime::{self, Runtime};
 use polkadot_runtime::constants::{currency::*, fee::*};
+use staking::Call as StakingCall;
 
 #[test]
 fn sanity_check_weight_per_second_is_as_expected() {
@@ -122,6 +123,71 @@ fn weight_of_transfer_keep_alive_is_correct() {
 	polkadot_runtime::BalancesCall::transfer_keep_alive::<Runtime>(alice, 42 * DOLLARS)
 		.get_dispatch_info()
 		.weight;
+
+	assert_eq!(weight, expected_weight);
+}
+
+#[test]
+fn weight_of_set_timestamp_is_correct() {
+	// #[weight = T::DbWeight::get().reads_writes(2, 1) + 9_000_000]
+	let expected_weight = 159_000_000;
+	let weight = polkadot_runtime::TimestampCall::set::<Runtime>(1234).get_dispatch_info().weight;
+
+	assert_eq!(weight, expected_weight);
+}
+
+#[test]
+fn weight_of_staking_bond_is_correct() {
+	let controller: AccountId = AccountKeyring::Alice.into();
+
+	// #[weight = 500_000_000]
+	let expected_weight = 500_000_000;
+	let weight = StakingCall::bond::<Runtime>(controller, 1 * DOLLARS, Default::default()).get_dispatch_info().weight;
+
+	assert_eq!(weight, expected_weight);
+}
+
+#[test]
+fn weight_of_staking_bond_extra_is_correct() {
+	// #[weight = 500_000_000]
+	let expected_weight = 500_000_000;
+	let weight = StakingCall::bond_extra::<Runtime>(1 * DOLLARS).get_dispatch_info().weight;
+
+	assert_eq!(weight, expected_weight);
+}
+
+#[test]
+fn weight_of_staking_unbond_is_correct() {
+	// #[weight = 400_000_000]
+	let expected_weight = 400_000_000;
+	let weight = StakingCall::unbond::<Runtime>(Default::default()).get_dispatch_info().weight;
+
+	assert_eq!(weight, expected_weight);
+}
+
+#[test]
+fn weight_of_staking_widthdraw_unbonded_is_correct() {
+	// #[weight = 400_000_000]
+	let expected_weight = 400_000_000;
+	let weight = StakingCall::withdraw_unbonded::<Runtime>().get_dispatch_info().weight;
+
+	assert_eq!(weight, expected_weight);
+}
+
+#[test]
+fn weight_of_staking_validate_is_correct() {
+	// #[weight = 750_000_000]
+	let expected_weight = 750_000_000;
+	let weight = StakingCall::validate::<Runtime>(Default::default()).get_dispatch_info().weight;
+
+	assert_eq!(weight, expected_weight);
+}
+
+#[test]
+fn weight_of_staking_nominate_is_correct() {
+	// #[weight = 750_000_000]
+	let expected_weight = 750_000_000;
+	let weight = StakingCall::nominate::<Runtime>(vec![]).get_dispatch_info().weight;
 
 	assert_eq!(weight, expected_weight);
 }

--- a/runtime/polkadot/tests/weights_and_fees.rs
+++ b/runtime/polkadot/tests/weights_and_fees.rs
@@ -22,12 +22,12 @@
 //!  - Read: 25 * WEIGHT_PER_MICROS = 25 * 100_000_000,
 //!  - Write: 100 * WEIGHT_PER_MICROS = 25 * 100_000_000,
 
-use frame_support::weights::{GetDispatchInfo, constants::*};
+use frame_support::weights::{constants::*, GetDispatchInfo};
 use keyring::AccountKeyring;
-use primitives::AccountId;
+use polkadot_runtime::constants::currency::*;
 use polkadot_runtime::{self, Runtime};
-use polkadot_runtime::constants::{currency::*, fee::*};
-use runtime_common::{MaximumBlockWeight, ExtrinsicBaseWeight};
+use primitives::AccountId;
+use runtime_common::MaximumBlockWeight;
 
 use democracy::Call as DemocracyCall;
 use elections_phragmen::Call as PhragmenCall;
@@ -65,69 +65,54 @@ fn sanity_check_weight_per_nanos_is_as_expected() {
 }
 
 #[test]
-fn weight_of_transfer_is_correct() {
-	let alice: AccountId = AccountKeyring::Alice.into();
-
+fn weight_of_balances_transfer_is_correct() {
 	// #[weight = T::DbWeight::get().reads_writes(1, 1) + 70_000_000]
 	let expected_weight = 195_000_000;
 
-	let weight = polkadot_runtime::BalancesCall::transfer::<Runtime>(alice, 42 * DOLLARS).get_dispatch_info().weight;
+	let weight = polkadot_runtime::BalancesCall::transfer::<Runtime>(Default::default(), Default::default())
+		.get_dispatch_info()
+		.weight;
 	assert_eq!(weight, expected_weight);
 }
 
 #[test]
-fn transfer_fees_are_correct() {
-	use sp_runtime::traits::Convert;
-
-	let alice: AccountId = AccountKeyring::Alice.into();
-
-	let expected_fee = 15_600_000;
-
-	let weight = polkadot_runtime::BalancesCall::transfer::<Runtime>(alice, 42 * DOLLARS).get_dispatch_info().weight;
-	let fee = WeightToFee::convert(weight);
-	assert_eq!(fee, expected_fee);
-}
-
-#[test]
-fn weight_of_set_balance_is_correct() {
-	let alice: AccountId = AccountKeyring::Alice.into();
-
+fn weight_of_balances_set_balance_is_correct() {
 	// #[weight = T::DbWeight::get().reads_writes(1, 1) + 35_000_000]
 	let expected_weight = 160_000_000;
 
-	let weight =
-	polkadot_runtime::BalancesCall::set_balance::<Runtime>(alice, 12 * DOLLARS, 34 * DOLLARS)
-		.get_dispatch_info()
-		.weight;
+	let weight = polkadot_runtime::BalancesCall::set_balance::<Runtime>(
+		Default::default(),
+		Default::default(),
+		Default::default(),
+	)
+	.get_dispatch_info()
+	.weight;
 
 	assert_eq!(weight, expected_weight);
 }
 
 #[test]
-fn weight_of_force_transfer_is_correct() {
-	let alice: AccountId = AccountKeyring::Alice.into();
-	let bob: AccountId = AccountKeyring::Alice.into();
-
+fn weight_of_balances_force_transfer_is_correct() {
 	// #[weight = T::DbWeight::get().reads_writes(2, 2) + 70_000_000]
 	let expected_weight = 320_000_000;
 
-	let weight =
-	polkadot_runtime::BalancesCall::force_transfer::<Runtime>(alice, bob, 34 * DOLLARS)
-		.get_dispatch_info()
-		.weight;
+	let weight = polkadot_runtime::BalancesCall::force_transfer::<Runtime>(
+		Default::default(),
+		Default::default(),
+		Default::default(),
+	)
+	.get_dispatch_info()
+	.weight;
 
 	assert_eq!(weight, expected_weight);
 }
 
 #[test]
-fn weight_of_transfer_keep_alive_is_correct() {
-	let alice: AccountId = AccountKeyring::Alice.into();
-
+fn weight_of_balances_transfer_keep_alive_is_correct() {
 	// #[weight = T::DbWeight::get().reads_writes(1, 1) + 50_000_000]
 	let expected_weight = 175_000_000;
 
-	let weight =
-	polkadot_runtime::BalancesCall::transfer_keep_alive::<Runtime>(alice, 42 * DOLLARS)
+	let weight = polkadot_runtime::BalancesCall::transfer_keep_alive::<Runtime>(Default::default(), Default::default())
 		.get_dispatch_info()
 		.weight;
 
@@ -135,10 +120,10 @@ fn weight_of_transfer_keep_alive_is_correct() {
 }
 
 #[test]
-fn weight_of_set_timestamp_is_correct() {
+fn weight_of_timestap_set_is_correct() {
 	// #[weight = T::DbWeight::get().reads_writes(2, 1) + 9_000_000]
 	let expected_weight = 159_000_000;
-	let weight = polkadot_runtime::TimestampCall::set::<Runtime>(1234).get_dispatch_info().weight;
+	let weight = polkadot_runtime::TimestampCall::set::<Runtime>(Default::default()).get_dispatch_info().weight;
 
 	assert_eq!(weight, expected_weight);
 }
@@ -281,10 +266,7 @@ fn weight_of_democracy_propose_is_correct() {
 #[test]
 fn weight_of_democracy_vote_is_correct() {
 	use democracy::AccountVote;
-	let vote = AccountVote::Standard {
-		vote: Default::default(),
-		balance: Default::default(),
-	};
+	let vote = AccountVote::Standard { vote: Default::default(), balance: Default::default() };
 
 	// #[weight = 200_000_000]
 	let expected_weight = 200_000_000;
@@ -297,7 +279,8 @@ fn weight_of_democracy_vote_is_correct() {
 fn weight_of_democracy_enact_proposal_is_correct() {
 	// #[weight = T::MaximumBlockWeight::get()]
 	let expected_weight = MaximumBlockWeight::get();
-	let weight = DemocracyCall::enact_proposal::<Runtime>(Default::default(), Default::default()).get_dispatch_info().weight;
+	let weight =
+		DemocracyCall::enact_proposal::<Runtime>(Default::default(), Default::default()).get_dispatch_info().weight;
 
 	assert_eq!(weight, expected_weight);
 }
@@ -333,7 +316,8 @@ fn weight_of_phragment_renounce_candidacy_is_correct() {
 fn weight_of_treasury_propose_spend_is_correct() {
 	// #[weight = 120_000_000 + T::DbWeight::get().reads_writes(1, 2)]
 	let expected_weight = 345_000_000;
-	let weight = TreasuryCall::propose_spend::<Runtime>(Default::default(), Default::default()).get_dispatch_info().weight;
+	let weight =
+		TreasuryCall::propose_spend::<Runtime>(Default::default(), Default::default()).get_dispatch_info().weight;
 
 	assert_eq!(weight, expected_weight);
 }

--- a/runtime/polkadot/tests/weights_and_fees.rs
+++ b/runtime/polkadot/tests/weights_and_fees.rs
@@ -1,0 +1,127 @@
+// Copyright 2017-2020 Parity Technologies (UK) Ltd.
+// This file is part of Polkadot.
+
+// Polkadot is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Polkadot is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Tests to make sure that Polkadot's weights and fees match what we
+//! expect from Substrate.
+//!
+//! NOTE: All the tests assume RocksDB as the RuntimeDbWeight type
+//! which gives us the following weights:
+//!  - Read: 25 * WEIGHT_PER_MICROS = 25 * 100_000_000,
+//!  - Write: 100 * WEIGHT_PER_MICROS = 25 * 100_000_000,
+
+use frame_support::weights::{GetDispatchInfo, constants::*};
+use keyring::AccountKeyring;
+use primitives::AccountId;
+use polkadot_runtime::{self, Runtime};
+use polkadot_runtime::constants::{currency::*, fee::*};
+
+#[test]
+fn sanity_check_weight_per_second_is_as_expected() {
+	// This value comes from Substrate, we want to make sure that if it
+	// ever changes we don't accidently break Polkadot
+	assert_eq!(WEIGHT_PER_SECOND, 1_000_000_000_000)
+}
+
+#[test]
+fn sanity_check_weight_per_milli_is_as_expected() {
+	// This value comes from Substrate, we want to make sure that if it
+	// ever changes we don't accidently break Polkadot
+	assert_eq!(WEIGHT_PER_MILLIS, 1_000_000_000)
+}
+
+#[test]
+fn sanity_check_weight_per_micros_is_as_expected() {
+	// This value comes from Substrate, we want to make sure that if it
+	// ever changes we don't accidently break Polkadot
+	assert_eq!(WEIGHT_PER_MICROS, 1_000_000)
+}
+
+#[test]
+fn sanity_check_weight_per_nanos_is_as_expected() {
+	// This value comes from Substrate, we want to make sure that if it
+	// ever changes we don't accidently break Polkadot
+	assert_eq!(WEIGHT_PER_NANOS, 1_000)
+}
+
+#[test]
+fn weight_of_transfer_is_correct() {
+	let alice: AccountId = AccountKeyring::Alice.into();
+
+	// #[weight = T::DbWeight::get().reads_writes(1, 1) + 70_000_000]
+	let expected_weight = 195_000_000;
+
+	let weight = polkadot_runtime::BalancesCall::transfer::<Runtime>(alice, 42 * DOLLARS).get_dispatch_info().weight;
+	assert_eq!(weight, expected_weight);
+}
+
+#[test]
+fn transfer_fees_are_correct() {
+	use sp_runtime::traits::Convert;
+
+	let alice: AccountId = AccountKeyring::Alice.into();
+
+	let expected_fee = 15_600_000;
+
+	let weight = polkadot_runtime::BalancesCall::transfer::<Runtime>(alice, 42 * DOLLARS).get_dispatch_info().weight;
+	let fee = WeightToFee::convert(weight);
+	assert_eq!(fee, expected_fee);
+}
+
+#[test]
+fn weight_of_set_balance_is_correct() {
+	let alice: AccountId = AccountKeyring::Alice.into();
+
+	// #[weight = T::DbWeight::get().reads_writes(1, 1) + 35_000_000]
+	let expected_weight = 160_000_000;
+
+	let weight =
+	polkadot_runtime::BalancesCall::set_balance::<Runtime>(alice, 12 * DOLLARS, 34 * DOLLARS)
+		.get_dispatch_info()
+		.weight;
+
+	assert_eq!(weight, expected_weight);
+}
+
+#[test]
+fn weight_of_force_transfer_is_correct() {
+	let alice: AccountId = AccountKeyring::Alice.into();
+	let bob: AccountId = AccountKeyring::Alice.into();
+
+	// #[weight = T::DbWeight::get().reads_writes(2, 2) + 70_000_000]
+	let expected_weight = 320_000_000;
+
+	let weight =
+	polkadot_runtime::BalancesCall::force_transfer::<Runtime>(alice, bob, 34 * DOLLARS)
+		.get_dispatch_info()
+		.weight;
+
+	assert_eq!(weight, expected_weight);
+}
+
+#[test]
+fn weight_of_transfer_keep_alive_is_correct() {
+	let alice: AccountId = AccountKeyring::Alice.into();
+
+	// #[weight = T::DbWeight::get().reads_writes(1, 1) + 50_000_000]
+	let expected_weight = 175_000_000;
+
+	let weight =
+	polkadot_runtime::BalancesCall::transfer_keep_alive::<Runtime>(alice, 42 * DOLLARS)
+		.get_dispatch_info()
+		.weight;
+
+	assert_eq!(weight, expected_weight);
+}

--- a/runtime/polkadot/tests/weights_and_fees.rs
+++ b/runtime/polkadot/tests/weights_and_fees.rs
@@ -34,6 +34,7 @@ use elections_phragmen::Call as PhragmenCall;
 use session::Call as SessionCall;
 use staking::Call as StakingCall;
 use system::Call as SystemCall;
+use treasury::Call as TreasuryCall;
 
 #[test]
 fn sanity_check_weight_per_second_is_as_expected() {
@@ -324,6 +325,34 @@ fn weight_of_phragment_renounce_candidacy_is_correct() {
 	// #[weight = (2_000_000_000, DispatchClass::Operational)]
 	let expected_weight = 2_000_000_000;
 	let weight = PhragmenCall::renounce_candidacy::<Runtime>().get_dispatch_info().weight;
+
+	assert_eq!(weight, expected_weight);
+}
+
+#[test]
+fn weight_of_treasury_propose_spend_is_correct() {
+	// #[weight = 120_000_000 + T::DbWeight::get().reads_writes(1, 2)]
+	let expected_weight = 345_000_000;
+	let weight = TreasuryCall::propose_spend::<Runtime>(Default::default(), Default::default()).get_dispatch_info().weight;
+
+	assert_eq!(weight, expected_weight);
+}
+
+#[test]
+fn weight_of_treasury_approve_proposal_is_correct() {
+	// #[weight = (34_000_000 + T::DbWeight::get().reads_writes(2, 1), DispatchClass::Operational)]
+	let expected_weight = 184_000_000;
+	let weight = TreasuryCall::approve_proposal::<Runtime>(Default::default()).get_dispatch_info().weight;
+
+	assert_eq!(weight, expected_weight);
+}
+
+#[test]
+fn weight_of_treasury_tip_is_correct() {
+	// #[weight = 68_000_000 + 2_000_000 * T::Tippers::max_len() as Weight
+	// 	+ T::DbWeight::get().reads_writes(2, 1)]
+	let expected_weight = 244_000_000;
+	let weight = TreasuryCall::tip::<Runtime>(Default::default(), Default::default()).get_dispatch_info().weight;
 
 	assert_eq!(weight, expected_weight);
 }

--- a/runtime/polkadot/tests/weights_and_fees.rs
+++ b/runtime/polkadot/tests/weights_and_fees.rs
@@ -28,6 +28,8 @@ use primitives::AccountId;
 use polkadot_runtime::{self, Runtime};
 use polkadot_runtime::constants::{currency::*, fee::*};
 use runtime_common::{MaximumBlockWeight, ExtrinsicBaseWeight};
+
+use democracy::Call as DemocracyCall;
 use session::Call as SessionCall;
 use staking::Call as StakingCall;
 use system::Call as SystemCall;
@@ -261,6 +263,39 @@ fn weight_of_session_purge_keys_is_correct() {
 	// Polkadot has five possible session keys, so we default to key_ids.len() = 5
 	let expected_weight = 770_000_000;
 	let weight = SessionCall::purge_keys::<Runtime>().get_dispatch_info().weight;
+
+	assert_eq!(weight, expected_weight);
+}
+
+#[test]
+fn weight_of_democracy_propose_is_correct() {
+	// #[weight = 5_000_000_000]
+	let expected_weight = 5_000_000_000;
+	let weight = DemocracyCall::propose::<Runtime>(Default::default(), Default::default()).get_dispatch_info().weight;
+
+	assert_eq!(weight, expected_weight);
+}
+
+#[test]
+fn weight_of_democracy_vote_is_correct() {
+	use democracy::AccountVote;
+	let vote = AccountVote::Standard {
+		vote: Default::default(),
+		balance: Default::default(),
+	};
+
+	// #[weight = 200_000_000]
+	let expected_weight = 200_000_000;
+	let weight = DemocracyCall::vote::<Runtime>(Default::default(), vote).get_dispatch_info().weight;
+
+	assert_eq!(weight, expected_weight);
+}
+
+#[test]
+fn weight_of_democracy_enact_proposal_is_correct() {
+	// #[weight = T::MaximumBlockWeight::get()]
+	let expected_weight = MaximumBlockWeight::get();
+	let weight = DemocracyCall::enact_proposal::<Runtime>(Default::default(), Default::default()).get_dispatch_info().weight;
 
 	assert_eq!(weight, expected_weight);
 }

--- a/runtime/polkadot/tests/weights_and_fees.rs
+++ b/runtime/polkadot/tests/weights_and_fees.rs
@@ -28,6 +28,7 @@ use primitives::AccountId;
 use polkadot_runtime::{self, Runtime};
 use polkadot_runtime::constants::{currency::*, fee::*};
 use runtime_common::{MaximumBlockWeight, ExtrinsicBaseWeight};
+use session::Call as SessionCall;
 use staking::Call as StakingCall;
 use system::Call as SystemCall;
 
@@ -235,6 +236,31 @@ fn weight_of_system_remark_is_correct() {
 	// #[weight = 700_000]
 	let expected_weight = 700_000;
 	let weight = SystemCall::remark::<Runtime>(vec![]).get_dispatch_info().weight;
+
+	assert_eq!(weight, expected_weight);
+}
+
+#[test]
+fn weight_of_session_set_keys_is_correct() {
+	// #[weight = 200_000_000
+	// 	+ T::DbWeight::get().reads(2 + T::Keys::key_ids().len() as Weight)
+	// 	+ T::DbWeight::get().writes(1 + T::Keys::key_ids().len() as Weight)]
+	//
+	// Polkadot has five possible session keys, so we default to key_ids.len() = 5
+	let expected_weight = 975_000_000;
+	let weight = SessionCall::set_keys::<Runtime>(Default::default(), Default::default()).get_dispatch_info().weight;
+
+	assert_eq!(weight, expected_weight);
+}
+
+#[test]
+fn weight_of_session_purge_keys_is_correct() {
+	// #[weight = 120_000_000
+	// 	+ T::DbWeight::get().reads_writes(2, 1 + T::Keys::key_ids().len() as Weight)]
+	//
+	// Polkadot has five possible session keys, so we default to key_ids.len() = 5
+	let expected_weight = 770_000_000;
+	let weight = SessionCall::purge_keys::<Runtime>().get_dispatch_info().weight;
 
 	assert_eq!(weight, expected_weight);
 }


### PR DESCRIPTION
This PR tackles part of #1069, specifically it will verify that the weight and fee assumption from Substrate continue to hold in Polkadot. I'd like to have tests for the Kusama and Westend runtimes as well, but depending on how big this PR gets those could be done in follow ups.