### PR TITLE
[CI] Expose WASM binaries on publish

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -216,12 +216,11 @@ build-linux-release:               &build
     - sccache -s
 
 
-
-
 .publish-build:                    &publish-build
   stage:                           publish
   dependencies:
     - build-linux-release
+    - build-wasm-release
   cache:                           {}
   <<:                              *build-refs
   <<:                              *kubernetes-env
@@ -232,6 +231,10 @@ build-linux-release:               &build
     - EXTRATAG="$(cat ./artifacts/EXTRATAG)"
     - echo "Polkadot version = ${VERSION} (EXTRATAG ${EXTRATAG})"
 
+list-all-artifacts:
+  <<: *publish-build
+  script:
+    - find ./artifacts
 
 
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -158,6 +158,26 @@ check-runtime-benchmarks:          &test
     - time cargo check --features runtime-benchmarks
     - sccache -s
 
+build-wasm-release:
+  stage:                          build
+  <<:                             *collect-artifacts
+  <<:                             *docker-env
+  <<:                             *compiler_info
+  only:
+    - /^v[0-9]+\.[0-9]+.*$/        # i.e. v1.0, v2.1rc1
+  script:
+    - time cargo build --locked --target=wasm32-unknown-unknown --manifest-path cli/Cargo.toml --no-default-features --features browser --release
+    - mkdir -p ./artifacts
+    - mv ./target/wasm32-unknown-unknown/release/polkadot_cli.wasm ./artifacts/.
+    - sha256sum ./artifacts/polkadot_cli.wasm |
+      tee ./artifacts/polkadot_cli.wasm.sha256
+    - VERSION="${CI_COMMIT_TAG}"
+    - EXTRATAG="latest"
+    - echo "Polkadot version = ${VERSION} (EXTRATAG ${EXTRATAG})"
+    # Probably don't need these since build-linux-release will do it
+    # - echo -n ${VERSION} > ./artifacts/VERSION
+    # - echo -n ${EXTRATAG} > ./artifacts/EXTRATAG
+
 
 build-linux-release:               &build
   stage:                           build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -168,11 +168,15 @@ build-wasm-release:
   <<:                             *compiler_info
   # Note: We likely only want to do this for tagged releases, hence the 'only:'
   only:
-    - /^v[0-9]+\.[0-9]+.*$/        # i.e. v1.0, v2.1rc1
+    # FIXME remove when ready to merge
+    - /^[0-9]+$/
+    # - /^v[0-9]+\.[0-9]+.*$/        # i.e. v1.0, v2.1rc1
   script:
-    - time cargo build --locked --target=wasm32-unknown-unknown --manifest-path cli/Cargo.toml --no-default-features --features browser --release
+    - cargo install wasm-pack
+    - time wasm-pack build --target web --out-dir wasm --release cli -- --no-default-features --features browser
     - mkdir -p ./artifacts
-    - mv ./target/wasm32-unknown-unknown/release/polkadot_cli.wasm ./artifacts/.
+    - mv ./cli/wasm/polkadot_cli* ./artifacts/.
+    - find ./artifacts/
     - sha256sum ./artifacts/polkadot_cli.wasm |
       tee ./artifacts/polkadot_cli.wasm.sha256
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,6 @@
 # pipelines can be triggered manually in the web
 # setting DEPLOY_TAG will only deploy the tagged image
 
-
 stages:
   - test
   - build
@@ -22,7 +21,6 @@ variables:
   CI_SERVER_NAME:                  "GitLab CI"
   DOCKER_OS:                       "debian:stretch"
   ARCH:                            "x86_64"
-
 
 .collect-artifacts:                &collect-artifacts
   artifacts:
@@ -55,8 +53,6 @@ variables:
     - rustup show
     - cargo --version
     - sccache -s
-
-
 
 .build-refs:                       &build-refs
   only:
@@ -100,7 +96,6 @@ check-runtime:
   interruptible:                   true
   allow_failure:                   true
 
-
 check-line-width:
   stage:                           test
   image:                           parity/tools:latest
@@ -137,7 +132,6 @@ test-linux-stable:                 &test
   script:
     - time cargo test --all --release --verbose --locked --features runtime-benchmarks
     - sccache -s
-
 
 check-web-wasm:                    &test
   stage:                           test
@@ -182,13 +176,10 @@ build-wasm-release:
     - mv ./target/wasm32-unknown-unknown/release/polkadot_cli.wasm ./artifacts/.
     - sha256sum ./artifacts/polkadot_cli.wasm |
       tee ./artifacts/polkadot_cli.wasm.sha256
-    - VERSION="${CI_COMMIT_TAG}"
-    - EXTRATAG="latest"
     - echo "Polkadot version = ${VERSION} (EXTRATAG ${EXTRATAG})"
     # Probably don't need these since build-linux-release will do it
     # - echo -n ${VERSION} > ./artifacts/VERSION
     # - echo -n ${EXTRATAG} > ./artifacts/EXTRATAG
-
 
 build-linux-release:               &build
   stage:                           build
@@ -218,7 +209,6 @@ build-linux-release:               &build
     - cp -r scripts/docker/* ./artifacts
     - sccache -s
 
-
 .publish-build:                    &publish-build
   stage:                           publish
   dependencies:
@@ -233,13 +223,6 @@ build-linux-release:               &build
     - VERSION="$(cat ./artifacts/VERSION)"
     - EXTRATAG="$(cat ./artifacts/EXTRATAG)"
     - echo "Polkadot version = ${VERSION} (EXTRATAG ${EXTRATAG})"
-
-list-all-artifacts:
-  <<: *publish-build
-  only:
-    - /^[0-9]+$/
-  script:
-    - find ./artifacts
 
 publish-docker-release:
   <<:                              *publish-build
@@ -271,9 +254,6 @@ publish-docker-release:
     # only VERSION information is needed for the deployment
     - find ./artifacts/ -depth -not -name VERSION -not -name artifacts -delete
 
-
-
-
 publish-s3-release:
   <<:                              *publish-build
   image:                           parity/awscli:latest
@@ -303,12 +283,6 @@ publish-s3-release:
   after_script:
     - aws s3 ls s3://${BUCKET}/${PREFIX}/${EXTRATAG}/
         --recursive --human-readable --summarize
-
-
-
-
-
-
 
 deploy-polkasync-kusama:
   stage:                           deploy

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -174,11 +174,11 @@ build-wasm-release:
   script:
     - cargo install wasm-pack
     - time wasm-pack build --target web --out-dir wasm --release cli -- --no-default-features --features browser
-    - mkdir -p ./artifacts
+    - mkdir -p ./artifacts/wasm
     - cd ./cli/wasm/
     - for f in polkadot_cli*; do sha256sum "${f}" > "${f}.sha256"; done
-    - mv ./polkadot_cli* ../../artifacts/.
-    - find ../../artifacts/
+    - mv ./polkadot_cli* ../../artifacts/wasm/.
+    - cd ../../
 
 build-linux-release:               &build
   stage:                           build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -164,7 +164,9 @@ build-wasm-release:
   <<:                             *docker-env
   <<:                             *compiler_info
   only:
-    - /^v[0-9]+\.[0-9]+.*$/        # i.e. v1.0, v2.1rc1
+    #FIXME: Remove before merging
+    - /^[0-9]+$/
+    #- /^v[0-9]+\.[0-9]+.*$/        # i.e. v1.0, v2.1rc1
   script:
     - time cargo build --locked --target=wasm32-unknown-unknown --manifest-path cli/Cargo.toml --no-default-features --features browser --release
     - mkdir -p ./artifacts

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -193,9 +193,12 @@ build-wasm-release:
 build-linux-release:               &build
   stage:                           build
   <<:                              *collect-artifacts
-  <<:                              *build-refs
   <<:                              *docker-env
   <<:                              *compiler_info
+  only:
+    #FIXME: Remove before merging
+    - /^[0-9]+$/
+    #- /^v[0-9]+\.[0-9]+.*$/        # i.e. v1.0, v2.1rc1
   script:
     - time cargo build --release --verbose
     - mkdir -p ./artifacts

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -175,7 +175,6 @@ build-wasm-release:
     - mv ./target/wasm32-unknown-unknown/release/polkadot_cli.wasm ./artifacts/.
     - sha256sum ./artifacts/polkadot_cli.wasm |
       tee ./artifacts/polkadot_cli.wasm.sha256
-    - echo "Polkadot version = ${VERSION} (EXTRATAG ${EXTRATAG})"
 
 build-linux-release:               &build
   stage:                           build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -172,13 +172,11 @@ build-wasm-release:
     - /^[0-9]+$/
     # - /^v[0-9]+\.[0-9]+.*$/        # i.e. v1.0, v2.1rc1
   script:
-    - cargo install wasm-pack
     - time wasm-pack build --target web --out-dir wasm --release cli -- --no-default-features --features browser
     - mkdir -p ./artifacts/wasm
     - cd ./cli/wasm/
     - for f in polkadot_cli*; do sha256sum "${f}" > "${f}.sha256"; done
     - mv ./polkadot_cli* ../../artifacts/wasm/.
-    - cd ../../
 
 build-linux-release:               &build
   stage:                           build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -233,10 +233,10 @@ build-linux-release:               &build
 
 list-all-artifacts:
   <<: *publish-build
+  only:
+    - /^[0-9]+$/
   script:
     - find ./artifacts
-
-
 
 publish-docker-release:
   <<:                              *publish-build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -175,10 +175,10 @@ build-wasm-release:
     - cargo install wasm-pack
     - time wasm-pack build --target web --out-dir wasm --release cli -- --no-default-features --features browser
     - mkdir -p ./artifacts
-    - mv ./cli/wasm/polkadot_cli* ./artifacts/.
-    - find ./artifacts/
-    - sha256sum ./artifacts/polkadot_cli.wasm |
-      tee ./artifacts/polkadot_cli.wasm.sha256
+    - cd ./cli/wasm/
+    - for f in polkadot_cli*; do sha256sum "${f}" > "${f}.sha256"; done
+    - mv ./polkadot_cli* ../../artifacts/.
+    - find ../../artifacts/
 
 build-linux-release:               &build
   stage:                           build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -166,10 +166,9 @@ build-wasm-release:
   <<:                             *collect-artifacts
   <<:                             *docker-env
   <<:                             *compiler_info
+  # Note: We likely only want to do this for tagged releases, hence the 'only:'
   only:
-    #FIXME: Remove before merging
-    - /^[0-9]+$/
-    #- /^v[0-9]+\.[0-9]+.*$/        # i.e. v1.0, v2.1rc1
+    - /^v[0-9]+\.[0-9]+.*$/        # i.e. v1.0, v2.1rc1
   script:
     - time cargo build --locked --target=wasm32-unknown-unknown --manifest-path cli/Cargo.toml --no-default-features --features browser --release
     - mkdir -p ./artifacts
@@ -177,19 +176,13 @@ build-wasm-release:
     - sha256sum ./artifacts/polkadot_cli.wasm |
       tee ./artifacts/polkadot_cli.wasm.sha256
     - echo "Polkadot version = ${VERSION} (EXTRATAG ${EXTRATAG})"
-    # Probably don't need these since build-linux-release will do it
-    # - echo -n ${VERSION} > ./artifacts/VERSION
-    # - echo -n ${EXTRATAG} > ./artifacts/EXTRATAG
 
 build-linux-release:               &build
   stage:                           build
   <<:                              *collect-artifacts
+  <<:                              *build-refs
   <<:                              *docker-env
   <<:                              *compiler_info
-  only:
-    #FIXME: Remove before merging
-    - /^[0-9]+$/
-    #- /^v[0-9]+\.[0-9]+.*$/        # i.e. v1.0, v2.1rc1
   script:
     - time cargo build --release --verbose
     - mkdir -p ./artifacts


### PR DESCRIPTION
This is to address paritytech/devops/issues/401 and publish the WASM CLI binary blobs built in the CI to S3.

(note: this is unrelated to the plan to embed the runtime WASM as part of the release process)