### PR TITLE
Fail test on warnings

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -132,7 +132,7 @@ test-linux-stable:                 &test
     RUST_TOOLCHAIN: stable
     # Enable debug assertions since we are running optimized builds for testing
     # but still want to have debug assertions.
-    RUSTFLAGS: -Cdebug-assertions=y
+    RUSTFLAGS: "-Cdebug-assertions=y -Dwarnings"
     TARGET: native
   script:
     - time cargo test --all --release --verbose --locked --features runtime-benchmarks


### PR DESCRIPTION
Fails the linux test on warnings,
removed the check for warnings since it does not make sense now.

substrate companion: https://github.com/paritytech/substrate/pull/6043