### PR TITLE
[CI] Allow check-labels to fail

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -79,6 +79,7 @@ check-labels:
     - /^[0-9]+$/
   script:
     - ./scripts/gitlab/check_tags.sh
+  allow_failure:                   true
 
 #### stage:                        test
 


### PR DESCRIPTION
Quick fix to allow the check-labels CI job to fail without blocking the rest of the pipeline