### PR TITLE
Expose more benchmarks (Scheduler, Elections)

### DIFF
--- a/runtime/kusama/Cargo.toml
+++ b/runtime/kusama/Cargo.toml
@@ -155,6 +155,7 @@ runtime-benchmarks = [
 	"elections-phragmen/runtime-benchmarks",
 	"identity/runtime-benchmarks",
 	"im-online/runtime-benchmarks",
+	"scheduler/runtime-benchmarks",
 	"society/runtime-benchmarks",
 	"staking/runtime-benchmarks",
 	"timestamp/runtime-benchmarks",

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -1095,7 +1095,7 @@ sp_api::impl_runtime_apis! {
 			add_benchmark!(params, batches, b"balances", Balances);
 			add_benchmark!(params, batches, b"collective", Council);
 			add_benchmark!(params, batches, b"democracy", Democracy);
-			add_benchmark!(params, batches, b"elections", Elections);
+			add_benchmark!(params, batches, b"elections-phragmen", ElectionsPhragmen);
 			add_benchmark!(params, batches, b"identity", Identity);
 			add_benchmark!(params, batches, b"im-online", ImOnline);
 			add_benchmark!(params, batches, b"offences", OffencesBench::<Runtime>);

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -1095,9 +1095,11 @@ sp_api::impl_runtime_apis! {
 			add_benchmark!(params, batches, b"balances", Balances);
 			add_benchmark!(params, batches, b"collective", Council);
 			add_benchmark!(params, batches, b"democracy", Democracy);
+			add_benchmark!(params, batches, b"elections", Elections);
 			add_benchmark!(params, batches, b"identity", Identity);
 			add_benchmark!(params, batches, b"im-online", ImOnline);
 			add_benchmark!(params, batches, b"offences", OffencesBench::<Runtime>);
+			add_benchmark!(params, batches, b"scheduler", Scheduler);
 			add_benchmark!(params, batches, b"session", SessionBench::<Runtime>);
 			add_benchmark!(params, batches, b"staking", Staking);
 			add_benchmark!(params, batches, b"system", SystemBench::<Runtime>);

--- a/runtime/polkadot/Cargo.toml
+++ b/runtime/polkadot/Cargo.toml
@@ -148,6 +148,7 @@ runtime-benchmarks = [
 	"democracy/runtime-benchmarks",
 	"elections-phragmen/runtime-benchmarks",
 	"im-online/runtime-benchmarks",
+	"scheduler/runtime-benchmarks",
 	"staking/runtime-benchmarks",
 	"timestamp/runtime-benchmarks",
 	"treasury/runtime-benchmarks",

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -1012,7 +1012,7 @@ sp_api::impl_runtime_apis! {
 			add_benchmark!(params, batches, b"balances", Balances);
 			add_benchmark!(params, batches, b"collective", Council);
 			add_benchmark!(params, batches, b"democracy", Democracy);
-			add_benchmark!(params, batches, b"elections", Elections);
+			add_benchmark!(params, batches, b"elections-phragmen", ElectionsPhragmen);
 			add_benchmark!(params, batches, b"im-online", ImOnline);
 			add_benchmark!(params, batches, b"offences", OffencesBench::<Runtime>);
 			add_benchmark!(params, batches, b"scheduler", Scheduler);

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -1012,8 +1012,10 @@ sp_api::impl_runtime_apis! {
 			add_benchmark!(params, batches, b"balances", Balances);
 			add_benchmark!(params, batches, b"collective", Council);
 			add_benchmark!(params, batches, b"democracy", Democracy);
+			add_benchmark!(params, batches, b"elections", Elections);
 			add_benchmark!(params, batches, b"im-online", ImOnline);
 			add_benchmark!(params, batches, b"offences", OffencesBench::<Runtime>);
+			add_benchmark!(params, batches, b"scheduler", Scheduler);
 			add_benchmark!(params, batches, b"session", SessionBench::<Runtime>);
 			add_benchmark!(params, batches, b"staking", Staking);
 			add_benchmark!(params, batches, b"system", SystemBench::<Runtime>);

--- a/runtime/westend/Cargo.toml
+++ b/runtime/westend/Cargo.toml
@@ -158,6 +158,7 @@ runtime-benchmarks = [
 	"elections-phragmen/runtime-benchmarks",
 	"identity/runtime-benchmarks",
 	"im-online/runtime-benchmarks",
+	"scheduler/runtime-benchmarks",
 	"society/runtime-benchmarks",
 	"staking/runtime-benchmarks",
 	"timestamp/runtime-benchmarks",

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -890,6 +890,7 @@ sp_api::impl_runtime_apis! {
 			add_benchmark!(params, batches, b"identity", Identity);
 			add_benchmark!(params, batches, b"im-online", ImOnline);
 			add_benchmark!(params, batches, b"offences", OffencesBench::<Runtime>);
+			add_benchmark!(params, batches, b"scheduler", Scheduler);
 			add_benchmark!(params, batches, b"session", SessionBench::<Runtime>);
 			add_benchmark!(params, batches, b"staking", Staking);
 			add_benchmark!(params, batches, b"system", SystemBench::<Runtime>);


### PR DESCRIPTION
This PR simply exposes more benchmarks that were created upstream in Substrate master.

AFAIK these are the last two for Polkadot and Substrate to be 1:1