### PR TITLE
Bump Kusama spec version to 2000

### DIFF
--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -84,7 +84,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("kusama"),
 	impl_name: create_runtime_str!("parity-kusama"),
 	authoring_version: 2,
-	spec_version: 1065,
+	spec_version: 2000,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
When we introduced `transaction_version` into the signed payload, we've agreed to bump the `spec_version` to 2000 to indicate that change to Parity Signer and other offline signing tools.

This PR does just that, bumps the `spec_version` so we won't forget it during the next release.