### PR TITLE
Bump ‘spec_version’ in Westend

### DIFF
--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -82,7 +82,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("westend"),
 	impl_name: create_runtime_str!("parity-westend"),
 	authoring_version: 2,
-	spec_version: 11,
+	spec_version: 2000,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
This lets offline signers know that the transaction format has changed,
due to the addition of `transaction_version` to the signed payload.