### PR TITLE
[CI] Fix release notification message, and add rustc version to release notes

### DIFF
--- a/.github/workflows/release-bot.yml
+++ b/.github/workflows/release-bot.yml
@@ -20,13 +20,13 @@ jobs:
         with:
           room_id: ${{ secrets.VALIDATOR_LOUNGE_MATRIX_ROOM_ID }}
           access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
-          message: "***Kusama ${{github.event.release.tag_name}} has been released!***<br/>Please update at your earliest convenience.<br/>${{github.event.release.html_url}}<br/><br/>${{github.event.release.body}}<br/>"
+          message: "***Polkadot ${{github.event.release.tag_name}} has been released!***<br/>Please update at your earliest convenience.<br/>${{github.event.release.html_url}}<br/><br/>${{github.event.release.body}}<br/>"
           server: "matrix.parity.io"
 
-      - name: Kusama Announcements
+      - name: Polkadot Announcements
         uses: s3krit/matrix-message-action@v0.0.2
         with:
           room_id: ${{ secrets.KUSAMA_ANNOUNCEMENTS_MATRIX_ROOM_ID }}
           access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
-          message: "***Kusama ${{github.event.release.tag_name}} has been released!***<br/>Please update at your earliest convenience.<br/>${{github.event.release.html_url}}<br/><br/>${{github.event.release.body}}<br/>"
+          message: "***Polkadot ${{github.event.release.tag_name}} has been released!***<br/>Please update at your earliest convenience.<br/>${{github.event.release.html_url}}<br/><br/>${{github.event.release.body}}<br/>"
           server: "matrix.parity.io"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -100,8 +100,9 @@ publish-draft-release:
   stage:                           test
   image:                           parity/tools:latest
   only:
-    - tags
-    - /^v[0-9]+\.[0-9]+\.[0-9]+.*$/        # i.e. v1.0.1, v2.1.0rc1
+    #- tags
+    #- /^v[0-9]+\.[0-9]+\.[0-9]+.*$/        # i.e. v1.0.1, v2.1.0rc1
+    - /^[0-9]+$/
   script:
     - ./scripts/gitlab/publish_draft_release.sh
   interruptible:                   true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -98,11 +98,9 @@ check-line-width:
 
 publish-draft-release:
   stage:                           test
-  #image:                           parity/tools:latest
   only:
-    #- tags
-    #- /^v[0-9]+\.[0-9]+\.[0-9]+.*$/        # i.e. v1.0.1, v2.1.0rc1
-    - /^[0-9]+$/
+    - tags
+    - /^v[0-9]+\.[0-9]+\.[0-9]+.*$/        # i.e. v1.0.1, v2.1.0rc1
   script:
     - apt-get -y update; apt-get -y install jq
     - ./scripts/gitlab/publish_draft_release.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -98,12 +98,13 @@ check-line-width:
 
 publish-draft-release:
   stage:                           test
-  image:                           parity/tools:latest
+  #image:                           parity/tools:latest
   only:
     #- tags
     #- /^v[0-9]+\.[0-9]+\.[0-9]+.*$/        # i.e. v1.0.1, v2.1.0rc1
     - /^[0-9]+$/
   script:
+    - apt-get -y update; apt-get -y install jq
     - ./scripts/gitlab/publish_draft_release.sh
   interruptible:                   true
   allow_failure:                   true

--- a/scripts/gitlab/lib.sh
+++ b/scripts/gitlab/lib.sh
@@ -31,6 +31,7 @@ check_tag () {
   if [ "$tag_sha" = "null" ]; then
     return 2
   fi
+  echo "[+] Tag object SHA: $tag_sha"
   verified_str=$(curl -H "Authorization: token $GITHUB_RELEASE_TOKEN" -s "$object_url" | jq -r .verification.verified)
   if [ "$verified_str" = "true" ]; then
     # Verified, everything is good

--- a/scripts/gitlab/lib.sh
+++ b/scripts/gitlab/lib.sh
@@ -22,8 +22,10 @@ check_tag () {
   repo=$1
   tagver=$2
   if [ -n "$GITHUB_RELEASE_TOKEN" ]; then
+    echo '[+] Fetching tag using privileged token'
     tag_out=$(curl -H "Authorization: token $GITHUB_RELEASE_TOKEN" -s "$api_base/$repo/git/refs/tags/$tagver")
   else
+    echo '[+] Fetching tag using unprivileged token'
     tag_out=$(curl -H "Authorization: token $GITHUB_PR_TOKEN" -s "$api_base/$repo/git/refs/tags/$tagver")
   fi
   tag_sha=$(echo "$tag_out" | jq -r .object.sha)

--- a/scripts/gitlab/publish_draft_release.sh
+++ b/scripts/gitlab/publish_draft_release.sh
@@ -24,7 +24,7 @@ case $? in
     ;;
   1) echo '[!] Tag found but has not been signed. Aborting release.'; exit 1
     ;;
-  2) echo '[!] Tag not found. Aborting release.'; exit
+  2) echo '[!] Tag not found. Aborting release.'; exit 1
 esac
 
 # Start with referencing current native runtime

--- a/scripts/gitlab/publish_draft_release.sh
+++ b/scripts/gitlab/publish_draft_release.sh
@@ -30,8 +30,8 @@ echo '[+] Checking tag has been signed'
 #esac
 
 # Pull rustc version used by rust-builder for stable and nightly
-stable_rustc="$(podman run -ti parity/rust-builder:latest rustc +stable --version)"
-nightly_rustc="$(podman run -ti parity/rust-builder:latest rustc +nightly --version)"
+stable_rustc="$(docker run -ti parity/rust-builder:latest rustc +stable --version)"
+nightly_rustc="$(docker run -ti parity/rust-builder:latest rustc +nightly --version)"
 
 # Start with referencing current native runtime
 # and find any referenced PRs since last release

--- a/scripts/gitlab/publish_draft_release.sh
+++ b/scripts/gitlab/publish_draft_release.sh
@@ -12,22 +12,20 @@ echo "[+] Cloning substrate to generate list of changes"
 git clone $substrate_repo $substrate_dir
 echo "[+] Finished cloning substrate into $substrate_dir"
 
-# TODO: Undo before opening PR (replace CI_COMMIT_SHA with CI_COMMIT_TAG)
-version="$CI_COMMIT_SHA"
-last_version=$(git tag -l | sort -V | grep -B 1 -x "$CI_COMMIT_SHA" | head -n 1)
+version="$CI_COMMIT_TAG"
+last_version=$(git tag -l | sort -V | grep -B 1 -x "$CI_COMMIT_TAG" | head -n 1)
 echo "[+] Version: $version; Previous version: $last_version"
 
 # Check that a signed tag exists on github for this version
 echo '[+] Checking tag has been signed'
-# TODO: Uncomment before opening PR
-#check_tag "paritytech/polkadot" "$version"
-#case $? in
-#  0) echo '[+] Tag found and has been signed'
-#    ;;
-#  1) echo '[!] Tag found but has not been signed. Aborting release.'; exit 1
-#    ;;
-#  2) echo '[!] Tag not found. Aborting release.'; exit 1
-#esac
+check_tag "paritytech/polkadot" "$version"
+case $? in
+  0) echo '[+] Tag found and has been signed'
+    ;;
+  1) echo '[!] Tag found but has not been signed. Aborting release.'; exit 1
+    ;;
+  2) echo '[!] Tag not found. Aborting release.'; exit 1
+esac
 
 # Pull rustc version used by rust-builder for stable and nightly
 stable_rustc="$(rustc +stable --version)"
@@ -156,9 +154,6 @@ fi
 
 echo "[+] Release text generated: "
 echo "$release_text"
-
-# TODO: Undo before opening PR
-exit
 
 echo "[+] Pushing release to github"
 # Create release on github

--- a/scripts/gitlab/publish_draft_release.sh
+++ b/scripts/gitlab/publish_draft_release.sh
@@ -30,8 +30,8 @@ echo '[+] Checking tag has been signed'
 #esac
 
 # Pull rustc version used by rust-builder for stable and nightly
-stable_rustc="$(docker run -ti parity/rust-builder:latest rustc +stable --version)"
-nightly_rustc="$(docker run -ti parity/rust-builder:latest rustc +nightly --version)"
+stable_rustc="$(rustc +stable --version)"
+nightly_rustc="$(rustc +nightly --version)"
 
 # Start with referencing current native runtime
 # and find any referenced PRs since last release

--- a/scripts/gitlab/publish_draft_release.sh
+++ b/scripts/gitlab/publish_draft_release.sh
@@ -19,21 +19,19 @@ echo "[+] Version: $version; Previous version: $last_version"
 
 # Check that a signed tag exists on github for this version
 echo '[+] Checking tag has been signed'
-check_tag "paritytech/polkadot" "$version"
-case $? in
-  0) echo '[+] Tag found and has been signed'
-    ;;
-  1) echo '[!] Tag found but has not been signed. Aborting release.'; exit 1
-    ;;
-  2) echo '[!] Tag not found. Aborting release.'; exit 1
-esac
+# TODO: Uncomment before opening PR
+#check_tag "paritytech/polkadot" "$version"
+#case $? in
+#  0) echo '[+] Tag found and has been signed'
+#    ;;
+#  1) echo '[!] Tag found but has not been signed. Aborting release.'; exit 1
+#    ;;
+#  2) echo '[!] Tag not found. Aborting release.'; exit 1
+#esac
 
-# Pull rustc version used by rust-builder
-stable_rustc="$(docker run -ti parity/rust-builder:latest \
-  'rustup default stable > /dev/null 2>&1; rustc --version')"
-
-nightly_rustc="$(docker run -ti parity/rust-builder:latest \
-  'rustup default nightly > /dev/null 2>&1; rustc --version')"
+# Pull rustc version used by rust-builder for stable and nightly
+stable_rustc="$(podman run -ti parity/rust-builder:latest rustc +stable --version)"
+nightly_rustc="$(podman run -ti parity/rust-builder:latest rustc +nightly --version)"
 
 # Start with referencing current native runtime
 # and find any referenced PRs since last release
@@ -50,7 +48,7 @@ Kusama native runtime: $kusama_spec
 
 Westend native runtime: $westend_spec
 
-Building this project requires the following rustc versions to be installed:
+This release was built with the following versions of \`rustc\`. Other versions may work.
 - $stable_rustc
 - $nightly_rustc
 "


### PR DESCRIPTION
Changes 'kusama' to 'polkadot' in the release notes, and now adds the version of `rustc` used to build this version in the release notes. Forms part of #1163 