### PR TITLE
CI images were moved

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,7 +11,7 @@ stages:
   - publish
   - deploy
 
-image:                             parity/rust-builder:latest
+image:                             paritytech/substrate-ci-linux:production
 
 variables:
   GIT_STRATEGY:                    fetch
@@ -73,7 +73,7 @@ variables:
 
 check-runtime:
   stage:                           test
-  image:                           parity/tools:latest
+  image:                           paritytech/tools:latest
   <<:                              *kubernetes-env
   only:
     - /^[0-9]+$/
@@ -87,7 +87,7 @@ check-runtime:
 
 check-line-width:
   stage:                           test
-  image:                           parity/tools:latest
+  image:                           paritytech/tools:latest
   <<:                              *kubernetes-env
   only:
     - /^[0-9]+$/
@@ -98,7 +98,7 @@ check-line-width:
 
 publish-draft-release:
   stage:                           test
-  image:                           parity/tools:latest
+  image:                           paritytech/tools:latest
   only:
     - tags
     - /^v[0-9]+\.[0-9]+\.[0-9]+.*$/        # i.e. v1.0.1, v2.1.0rc1
@@ -239,7 +239,7 @@ publish-docker-release:
 
 publish-s3-release:
   <<:                              *publish-build
-  image:                           parity/awscli:latest
+  image:                           paritytech/awscli:latest
   variables:
     GIT_STRATEGY:                  none
     BUCKET:                        "releases.parity.io"
@@ -280,7 +280,7 @@ deploy-polkasync-kusama:
 
 check-labels:
   stage:                          .post
-  image:                          parity/tools:latest
+  image:                          paritytech/tools:latest
   <<:                             *kubernetes-env
   only:
     - /^[0-9]+$/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,7 +11,7 @@ stages:
   - publish
   - deploy
 
-image:                             paritytech/substrate-ci-linux:production
+image:                             paritytech/ci-linux:production
 
 variables:
   GIT_STRATEGY:                    fetch


### PR DESCRIPTION
- we've moved our CI images to `paritytech` registry.
- new, main CI image `paritytech/substrate-ci-linux` is now tested against Substrate before publishing.

substrate companion: https://github.com/paritytech/substrate/pull/6223