### PR TITLE
Patch Approve Origin Requirements

### DIFF
--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -506,7 +506,7 @@ parameter_types! {
 type ApproveOrigin = EnsureOneOf<
 	AccountId,
 	EnsureRoot<AccountId>,
-	collective::EnsureProportionAtLeast<_3, _4, AccountId, CouncilCollective>
+	collective::EnsureProportionAtLeast<_3, _5, AccountId, CouncilCollective>
 >;
 
 impl treasury::Trait for Runtime {


### PR DESCRIPTION
A small typo got introduced in #1222 that changed the amount of council required for ApproveOrigin