### PR TITLE
[CI] Auto-label new PRs depending on status

### DIFF
--- a/.github/workflows/auto-label-prs.yml
+++ b/.github/workflows/auto-label-prs.yml
@@ -2,10 +2,10 @@ name: Label new PRs
 on:
   pull_request:
     types: [opened,ready_for_review]
-    
+
 jobs:
   label-new-prs:
-    runs-on: ubuntu:latest
+    runs-on: ubuntu-latest
     steps:
       - name: Label new drafts
         uses: andymckay/labeler@master

--- a/.github/workflows/auto-label-prs.yml
+++ b/.github/workflows/auto-label-prs.yml
@@ -1,0 +1,31 @@
+name: Label new PRs
+on:
+  pull_request:
+    types: [opened]
+jobs:
+  label-new-prs:
+    runs-on: ubuntu:latest
+    steps:
+      - name: Label new drafts
+        uses: andymckay/labeler@master
+        if: github.event.pull_request.draft == true
+        with:
+          add-labels: 'A3-inprogress'
+      - name: Label new PRs
+        uses: andymckay/labeler@master
+        if: github.event.pull_request.draft == false
+        with:
+          add-labels: 'A0-pleasereview'
+---
+name: Relabel draft PRs when ready for review
+on:
+  pull_request:
+    types: [ready_for_review]
+jobs:
+  relabel-drafts:
+    runs-on: ubuntu:latest
+      - name: Relabel drafts that are ready for review
+        uses: andymckay/labeler@master
+        with:
+          add-labels: 'A0-pleasereview'
+          remove-labels: 'A3-inprogress'

--- a/.github/workflows/auto-label-prs.yml
+++ b/.github/workflows/auto-label-prs.yml
@@ -16,16 +16,3 @@ jobs:
         if: github.event.pull_request.draft == false
         with:
           add-labels: 'A0-pleasereview'
----
-name: Relabel draft PRs when ready for review
-on:
-  pull_request:
-    types: [ready_for_review]
-jobs:
-  relabel-drafts:
-    runs-on: ubuntu:latest
-      - name: Relabel drafts that are ready for review
-        uses: andymckay/labeler@master
-        with:
-          add-labels: 'A0-pleasereview'
-          remove-labels: 'A3-inprogress'

--- a/.github/workflows/auto-label-prs.yml
+++ b/.github/workflows/auto-label-prs.yml
@@ -1,7 +1,8 @@
 name: Label new PRs
 on:
   pull_request:
-    types: [opened]
+    types: [opened,ready_for_review]
+    
 jobs:
   label-new-prs:
     runs-on: ubuntu:latest


### PR DESCRIPTION
If a new PR is created as a draft, gets auto-labeled with A3-inprogress.
If a new PR is created and is not a draft, gets auto-labeled with A0-pleasereview
If 'ready for review' is clicked, the A3-inprogress label is removed and A0-pleasereview is added.