### PR TITLE
Add registrar proxy

### DIFF
--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -799,6 +799,7 @@ pub enum ProxyType {
 	NonTransfer,
 	Governance,
 	Staking,
+	RegistrarJudgement,
 }
 impl Default for ProxyType { fn default() -> Self { Self::Any } }
 impl InstanceFilter<Call> for ProxyType {
@@ -857,6 +858,9 @@ impl InstanceFilter<Call> for ProxyType {
 			ProxyType::Staking => matches!(c,
 				Call::Staking(..) | Call::Utility(..)
 			),
+			ProxyType::RegistrarJudgement => matches!(c,
+				Call::Identity(identity::Call::provide_judgement(..))
+			)
 		}
 	}
 	fn is_superset(&self, o: &Self) -> bool {

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -799,7 +799,7 @@ pub enum ProxyType {
 	NonTransfer,
 	Governance,
 	Staking,
-	RegistrarJudgement,
+	IdentityJudgement,
 }
 impl Default for ProxyType { fn default() -> Self { Self::Any } }
 impl InstanceFilter<Call> for ProxyType {
@@ -858,8 +858,9 @@ impl InstanceFilter<Call> for ProxyType {
 			ProxyType::Staking => matches!(c,
 				Call::Staking(..) | Call::Utility(..)
 			),
-			ProxyType::RegistrarJudgement => matches!(c,
+			ProxyType::IdentityJudgement => matches!(c,
 				Call::Identity(identity::Call::provide_judgement(..))
+				| Call::Utility(utility::Call::batch(..))
 			)
 		}
 	}

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -783,6 +783,7 @@ pub enum ProxyType {
 	Governance,
 	Staking,
 	SudoBalances,
+	RegistrarJudgement,
 }
 impl Default for ProxyType { fn default() -> Self { Self::Any } }
 impl InstanceFilter<Call> for ProxyType {
@@ -839,6 +840,9 @@ impl InstanceFilter<Call> for ProxyType {
 				Call::Utility(..) => true,
 				_ => false,
 			},
+			ProxyType::RegistrarJudgement => matches!(c,
+				Call::Identity(identity::Call::provide_judgement(..))
+			)
 		}
 	}
 	fn is_superset(&self, o: &Self) -> bool {

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -842,6 +842,7 @@ impl InstanceFilter<Call> for ProxyType {
 			},
 			ProxyType::IdentityJudgement => matches!(c,
 				Call::Identity(identity::Call::provide_judgement(..))
+				| Call::Utility(utility::Call::batch(..))
 			)
 		}
 	}

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -783,7 +783,7 @@ pub enum ProxyType {
 	Governance,
 	Staking,
 	SudoBalances,
-	RegistrarJudgement,
+	IdentityJudgement,
 }
 impl Default for ProxyType { fn default() -> Self { Self::Any } }
 impl InstanceFilter<Call> for ProxyType {
@@ -840,7 +840,7 @@ impl InstanceFilter<Call> for ProxyType {
 				Call::Utility(..) => true,
 				_ => false,
 			},
-			ProxyType::RegistrarJudgement => matches!(c,
+			ProxyType::IdentityJudgement => matches!(c,
 				Call::Identity(identity::Call::provide_judgement(..))
 			)
 		}

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -581,6 +581,7 @@ pub enum ProxyType {
 	NonTransfer,
 	Staking,
 	SudoBalances,
+	RegistrarJudgement,
 }
 impl Default for ProxyType { fn default() -> Self { Self::Any } }
 impl InstanceFilter<Call> for ProxyType {
@@ -632,6 +633,9 @@ impl InstanceFilter<Call> for ProxyType {
 				Call::Utility(..) => true,
 				_ => false,
 			},
+			ProxyType::RegistrarJudgement => matches!(c,
+				Call::Identity(identity::Call::provide_judgement(..))
+			)
 		}
 	}
 	fn is_superset(&self, o: &Self) -> bool {

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -581,7 +581,7 @@ pub enum ProxyType {
 	NonTransfer,
 	Staking,
 	SudoBalances,
-	RegistrarJudgement,
+	IdentityJudgement,
 }
 impl Default for ProxyType { fn default() -> Self { Self::Any } }
 impl InstanceFilter<Call> for ProxyType {
@@ -633,7 +633,7 @@ impl InstanceFilter<Call> for ProxyType {
 				Call::Utility(..) => true,
 				_ => false,
 			},
-			ProxyType::RegistrarJudgement => matches!(c,
+			ProxyType::IdentityJudgement => matches!(c,
 				Call::Identity(identity::Call::provide_judgement(..))
 			)
 		}

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -635,6 +635,7 @@ impl InstanceFilter<Call> for ProxyType {
 			},
 			ProxyType::IdentityJudgement => matches!(c,
 				Call::Identity(identity::Call::provide_judgement(..))
+				| Call::Utility(utility::Call::batch(..))
 			)
 		}
 	}


### PR DESCRIPTION
This PR adds a new ProxyType: `IdentityJudgement`, allowing only `Identity.provideJudgement` either as single call or batched call.

The main usage is for identity registrars who want to automate their process without exposing the registrar's main account.

## Proxy setup:
![image](https://user-images.githubusercontent.com/738724/85919822-08fe8500-b86f-11ea-9660-b145f202732f.png)

## Usage:
![image](https://user-images.githubusercontent.com/738724/85919776-c341bc80-b86e-11ea-9709-02fe961de37b.png)

Fix #1290