### PR TITLE
Remove `as_sub` capability from `NonTransfer`

### DIFF
--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -828,7 +828,9 @@ impl InstanceFilter<Call> for ProxyType {
 				Call::Attestations(..) |
 				Call::Slots(..) |
 				Call::Registrar(..) |
-				Call::Utility(..) |
+				Call::Utility(utility::Call::batch(..)) |
+				Call::Utility(utility::Call::as_limited_sub(..)) |
+				// Specifically omitting Utility `as_sub`
 				Call::Identity(..) |
 				Call::Society(..) |
 				Call::Recovery(recovery::Call::as_recovered(..)) |

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -816,7 +816,9 @@ impl InstanceFilter<Call> for ProxyType {
 				Call::Vesting(vesting::Call::vest(..)) |
 				Call::Vesting(vesting::Call::vest_other(..)) |
 				// Specifically omitting Vesting `vested_transfer`, and `force_vested_transfer`
-				Call::Utility(..) |
+				Call::Utility(utility::Call::batch(..)) |
+				Call::Utility(utility::Call::as_limited_sub(..)) |
+				// Specifically omitting Utility `as_sub`
 				// Specifically omitting Sudo pallet
 				Call::Identity(..) |
 				Call::Proxy(..) |

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -607,7 +607,9 @@ impl InstanceFilter<Call> for ProxyType {
 				Call::Parachains(..) |
 				Call::Attestations(..) |
 				Call::Registrar(..) |
-				Call::Utility(..) |
+				Call::Utility(utility::Call::batch(..)) |
+				Call::Utility(utility::Call::as_limited_sub(..)) |
+				// Specifically omitting Utility `as_sub`
 				Call::Identity(..) |
 				Call::Recovery(recovery::Call::as_recovered(..)) |
 				Call::Recovery(recovery::Call::vouch_recovery(..)) |


### PR DESCRIPTION
One more precaution against proxies being able to transfer from sub accounts.