### PR TITLE
impl ProvideInherent for InclusionInherent

### DIFF
--- a/primitives/src/inclusion_inherent.rs
+++ b/primitives/src/inclusion_inherent.rs
@@ -1,3 +1,19 @@
+// Copyright 2017-2020 Parity Technologies (UK) Ltd.
+// This file is part of Polkadot.
+
+// Polkadot is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Polkadot is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
+
 //! Inclusion Inherent primitives define types and constants which can be imported
 //! without needing to import the entire inherent module.
 

--- a/primitives/src/inclusion_inherent.rs
+++ b/primitives/src/inclusion_inherent.rs
@@ -1,0 +1,7 @@
+//! Inclusion Inherent primitives define types and constants which can be imported
+//! without needing to import the entire inherent module.
+
+use inherents::InherentIdentifier;
+
+/// Unique identifier for the Inclusion Inherent
+pub const INHERENT_IDENTIFIER: InherentIdentifier = *b"inclusn0";

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -23,6 +23,7 @@
 use runtime_primitives::{generic, MultiSignature};
 pub use runtime_primitives::traits::{BlakeTwo256, Hash as HashT, Verify, IdentifyAccount};
 
+pub mod inclusion_inherent;
 pub mod parachain;
 
 pub use parity_scale_codec::Compact;

--- a/primitives/src/parachain.rs
+++ b/primitives/src/parachain.rs
@@ -722,6 +722,12 @@ pub type SignedAvailabilityBitfield = Signed<AvailabilityBitfield>;
 #[derive(Encode, Decode, Clone, PartialEq, Eq, RuntimeDebug)]
 pub struct SignedAvailabilityBitfields(pub Vec<SignedAvailabilityBitfield>);
 
+impl From<Vec<SignedAvailabilityBitfield>> for SignedAvailabilityBitfields {
+	fn from(fields: Vec<SignedAvailabilityBitfield>) -> SignedAvailabilityBitfields {
+		SignedAvailabilityBitfields(fields)
+	}
+}
+
 /// A backed (or backable, depending on context) candidate.
 // TODO: yes, this is roughly the same as AttestedCandidate.
 // After https://github.com/paritytech/polkadot/issues/1250

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -86,7 +86,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("kusama"),
 	impl_name: create_runtime_str!("parity-kusama"),
 	authoring_version: 2,
-	spec_version: 2012,
+	spec_version: 2013,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/runtime/parachains/src/inclusion_inherent.rs
+++ b/runtime/parachains/src/inclusion_inherent.rs
@@ -22,7 +22,10 @@
 //! this module.
 
 use sp_std::prelude::*;
-use primitives::parachain::{BackedCandidate, SignedAvailabilityBitfields};
+use primitives::{
+	inclusion_inherent,
+	parachain::{BackedCandidate, SignedAvailabilityBitfields},
+};
 use frame_support::{
 	decl_error, decl_module, decl_storage, ensure,
 	dispatch::DispatchResult,
@@ -124,7 +127,7 @@ decl_module! {
 impl<T: Trait> ProvideInherent for Module<T> {
 	type Call = Call<T>;
 	type Error = MakeFatalError<()>;
-	const INHERENT_IDENTIFIER: InherentIdentifier = *b"inclusn0";
+	const INHERENT_IDENTIFIER: InherentIdentifier = inclusion_inherent::INHERENT_IDENTIFIER;
 
 	fn create_inherent(data: &InherentData) -> Option<Self::Call> {
 		data.get_data(&Self::INHERENT_IDENTIFIER)

--- a/runtime/parachains/src/inclusion_inherent.rs
+++ b/runtime/parachains/src/inclusion_inherent.rs
@@ -21,20 +21,19 @@
 //! as it has no initialization logic and its finalization logic depends only on the details of
 //! this module.
 
+use sp_std::prelude::*;
+use primitives::parachain::{BackedCandidate, SignedAvailabilityBitfields};
+use frame_support::{
+	decl_error, decl_module, decl_storage, ensure,
+	dispatch::DispatchResult,
+	weights::{DispatchClass, Weight},
+	traits::Get,
+};
+use system::ensure_none;
 use crate::{
 	inclusion,
 	scheduler::{self, FreedReason},
 };
-use frame_support::{
-	decl_error, decl_module, decl_storage,
-	dispatch::DispatchResult,
-	ensure,
-	traits::Get,
-	weights::{DispatchClass, Weight},
-};
-use primitives::parachain::{BackedCandidate, SignedAvailabilityBitfields};
-use sp_std::prelude::*;
-use system::ensure_none;
 use inherents::{InherentIdentifier, InherentData, MakeFatalError, ProvideInherent};
 
 pub trait Trait: inclusion::Trait + scheduler::Trait {}
@@ -129,7 +128,7 @@ impl<T: Trait> ProvideInherent for Module<T> {
 
 	fn create_inherent(data: &InherentData) -> Option<Self::Call> {
 		data.get_data(&Self::INHERENT_IDENTIFIER)
-			.expect("inherent identifier data failed to decode")
+			.expect("inclusion inherent data failed to decode")
 			.map(|(signed_bitfields, backed_candidates)| {
 				Call::inclusion(signed_bitfields, backed_candidates)
 			})


### PR DESCRIPTION
Closes #1268.

Modeled on [this `ProvideInherent` implementation](https://github.com/paritytech/cumulus/blob/05a83e8bdbcf4c216e8632431aa49dd996ce4c3f/message-broker/src/lib.rs#L141-L151). 

It's not obvious where the data is actually injected into `InherentData`, but presumably this is the responsibility of the runtime?