### PR TITLE
[CI] Add Github Action to notify devops of PRs labelled with A1-needsburnin

### DIFF
--- a/.github/workflows/burnin-label-notification.yml
+++ b/.github/workflows/burnin-label-notification.yml
@@ -1,0 +1,17 @@
+name: Notify devops when burn-in label applied
+on:
+  pull_request:
+    types: [labeled]
+
+jobs:
+  notify-devops:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify devops
+        if: github.event.label.name == 'A1-needsburnin'
+        uses: s3krit/matrix-message-action@v0.0.2
+        with:
+          room_id: ${{ secrets.POLKADOT_DEVOPS_MATRIX_ROOM_ID }}
+          access_token: ${{ secrets.POLKADOT_DEVOPS_MATRIX_ACCESS_TOKEN }}
+          message: "@room Burn-in request received for the following PR: ${{ github.event.pull_request.html_url }}"
+          server: "matrix.parity.io"


### PR DESCRIPTION
This is a temporary/preliminary Github action that will trigger a message in the #polkadot-devops Matrix channel whenever a PR is labelled with A1-needsburnin. The intention is to fully automate the deployment of PRs requiring burn-in, so this is a stand-in until that functionality has been developed.