### PR TITLE
Remove treasury retract tip upgrade

### DIFF
--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -891,8 +891,8 @@ impl proxy::Trait for Runtime {
 pub struct CustomOnRuntimeUpgrade;
 impl frame_support::traits::OnRuntimeUpgrade for CustomOnRuntimeUpgrade {
 	fn on_runtime_upgrade() -> frame_support::weights::Weight {
-		treasury::Module::<Runtime>::migrate_retract_tip_for_tip_new();
-		500_000_000
+		// No upgrades queued
+		0
 	}
 }
 


### PR DESCRIPTION
This is a cleanup of the runtime upgrade code for https://github.com/paritytech/polkadot/pull/1321