### PR TITLE
Integrate all (dummy) subsystems with the Overseer

### DIFF
--- a/node/overseer/examples/minimal-example.rs
+++ b/node/overseer/examples/minimal-example.rs
@@ -28,18 +28,14 @@ use futures_timer::Delay;
 use kv_log_macro as log;
 
 use polkadot_primitives::parachain::{BlockData, PoVBlock};
-use polkadot_overseer::Overseer;
+use polkadot_overseer::{Overseer, AllSubsystems};
 
 use polkadot_subsystem::{
 	Subsystem, SubsystemContext, DummySubsystem, 
 	SpawnedSubsystem, FromOverseer,
 };
 use polkadot_subsystem::messages::{
-	CandidateValidationMessage, CandidateBackingMessage,
-	CandidateSelectionMessage, StatementDistributionMessage,
-	AvailabilityDistributionMessage, BitfieldDistributionMessage,
-	ProvisionerMessage, RuntimeApiMessage, AvailabilityStoreMessage, 
-	NetworkBridgeMessage, AllMessages,
+	CandidateValidationMessage, CandidateBackingMessage, AllMessages,
 };
 
 struct Subsystem1;

--- a/node/overseer/examples/minimal-example.rs
+++ b/node/overseer/examples/minimal-example.rs
@@ -30,9 +30,16 @@ use kv_log_macro as log;
 use polkadot_primitives::parachain::{BlockData, PoVBlock};
 use polkadot_overseer::Overseer;
 
-use polkadot_subsystem::{Subsystem, SubsystemContext, SpawnedSubsystem, FromOverseer};
+use polkadot_subsystem::{
+	Subsystem, SubsystemContext, DummySubsystem, 
+	SpawnedSubsystem, FromOverseer,
+};
 use polkadot_subsystem::messages::{
-	AllMessages, CandidateBackingMessage, CandidateValidationMessage
+	CandidateValidationMessage, CandidateBackingMessage,
+	CandidateSelectionMessage, StatementDistributionMessage,
+	AvailabilityDistributionMessage, BitfieldDistributionMessage,
+	ProvisionerMessage, RuntimeApiMessage, AvailabilityStoreMessage, 
+	NetworkBridgeMessage, AllMessages,
 };
 
 struct Subsystem1;
@@ -131,6 +138,14 @@ fn main() {
 			vec![],
 			Subsystem2,
 			Subsystem1,
+			DummySubsystem::<CandidateSelectionMessage>::default(),
+			DummySubsystem::<StatementDistributionMessage>::default(),
+			DummySubsystem::<AvailabilityDistributionMessage>::default(),
+			DummySubsystem::<BitfieldDistributionMessage>::default(),
+			DummySubsystem::<ProvisionerMessage>::default(),
+			DummySubsystem::<RuntimeApiMessage>::default(),
+			DummySubsystem::<AvailabilityStoreMessage>::default(),
+			DummySubsystem::<NetworkBridgeMessage>::default(),
 			spawner,
 		).unwrap();
 		let overseer_fut = overseer.run().fuse();

--- a/node/overseer/examples/minimal-example.rs
+++ b/node/overseer/examples/minimal-example.rs
@@ -134,18 +134,21 @@ fn main() {
 			Delay::new(Duration::from_secs(1)).await;
 		});
 
+		let all_subsystems = AllSubsystems {
+			candidate_validation: Subsystem2,
+			candidate_backing: Subsystem1,
+			candidate_selection: DummySubsystem,
+			statement_distribution: DummySubsystem,
+			availability_distribution: DummySubsystem,
+			bitfield_distribution: DummySubsystem,
+			provisioner: DummySubsystem,
+			runtime_api: DummySubsystem,
+			availability_store: DummySubsystem,
+			network_bridge: DummySubsystem,
+		};
 		let (overseer, _handler) = Overseer::new(
 			vec![],
-			Subsystem2,
-			Subsystem1,
-			DummySubsystem::<CandidateSelectionMessage>::default(),
-			DummySubsystem::<StatementDistributionMessage>::default(),
-			DummySubsystem::<AvailabilityDistributionMessage>::default(),
-			DummySubsystem::<BitfieldDistributionMessage>::default(),
-			DummySubsystem::<ProvisionerMessage>::default(),
-			DummySubsystem::<RuntimeApiMessage>::default(),
-			DummySubsystem::<AvailabilityStoreMessage>::default(),
-			DummySubsystem::<NetworkBridgeMessage>::default(),
+			all_subsystems,
 			spawner,
 		).unwrap();
 		let overseer_fut = overseer.run().fuse();

--- a/node/overseer/examples/minimal-example.rs
+++ b/node/overseer/examples/minimal-example.rs
@@ -138,6 +138,7 @@ fn main() {
 			availability_distribution: DummySubsystem,
 			bitfield_distribution: DummySubsystem,
 			provisioner: DummySubsystem,
+			pov_distribution: DummySubsystem,
 			runtime_api: DummySubsystem,
 			availability_store: DummySubsystem,
 			network_bridge: DummySubsystem,

--- a/node/overseer/src/lib.rs
+++ b/node/overseer/src/lib.rs
@@ -425,8 +425,8 @@ where
 	/// # use futures_timer::Delay;
 	/// # use polkadot_overseer::Overseer;
 	/// # use polkadot_subsystem::{
-	/// #     Subsystem, SpawnedSubsystem, SubsystemContext,
-	/// #     messages::{CandidateValidationMessage, CandidateBackingMessage},
+	/// #     Subsystem, DummySubsystem, SpawnedSubsystem, SubsystemContext,
+	/// #     messages::*,
 	/// # };
 	///
 	/// struct ValidationSubsystem;
@@ -446,28 +446,19 @@ where
 	///     }
 	/// }
 	///
-	/// struct CandidateBackingSubsystem;
-	/// impl<C> Subsystem<C> for CandidateBackingSubsystem
-	/// 	where C: SubsystemContext<Message=CandidateBackingMessage>
-	/// {
-	///     fn start(
-	///         self,
-	///         mut ctx: C,
-	///     ) -> SpawnedSubsystem {
-	///         SpawnedSubsystem(Box::pin(async move {
-	///             loop {
-	///                 Delay::new(Duration::from_secs(1)).await;
-	///             }
-	///         }))
-	///     }
-	/// }
-	///
 	/// # fn main() { executor::block_on(async move {
 	/// let spawner = executor::ThreadPool::new().unwrap();
 	/// let (overseer, _handler) = Overseer::new(
 	///     vec![],
 	///     ValidationSubsystem,
-	///     CandidateBackingSubsystem,
+	///     DummySubsystem::<CandidateSelectionMessage>::default(),
+	///     DummySubsystem::<StatementDistributionMessage>::default(),
+	///     DummySubsystem::<AvailabilityDistributionMessage>::default(),
+	///     DummySubsystem::<BitfieldDistributionMessage>::default(),
+	///     DummySubsystem::<ProvisionerMessage>::default(),
+	///     DummySubsystem::<RuntimeApiMessage>::default(),
+	///     DummySubsystem::<AvailabilityStoreMessage>::default(),
+	///     DummySubsystem::<NetworkBridgeMessage>::default(),
 	///     spawner,
 	/// ).unwrap();
 	///
@@ -877,6 +868,7 @@ fn spawn<S: Spawn, M: Send + 'static>(
 	})
 }
 
+
 #[cfg(test)]
 mod tests {
 	use futures::{executor, pin_mut, select, channel::mpsc, FutureExt};
@@ -884,23 +876,6 @@ mod tests {
 	use polkadot_primitives::parachain::{BlockData, PoVBlock};
 	use super::*;
 
-	struct DummySubsystem<C>(std::marker::PhantomData<C>);
-
-	impl<C> Default for DummySubsystem<C> {
-		fn default() -> Self {
-			Self(std::marker::PhantomData)
-		}
-	} 
-
-	impl<M: Send, C> Subsystem<C> for DummySubsystem<M>
-		where C: SubsystemContext<Message=M>
-	{
-		fn start(self, mut _ctx: C) -> SpawnedSubsystem {
-			SpawnedSubsystem(Box::pin(async move {
-				// Do nothing and exit.
-			}))
-		}
-	}
 
 	struct TestSubsystem1(mpsc::Sender<usize>);
 

--- a/node/overseer/src/lib.rs
+++ b/node/overseer/src/lib.rs
@@ -389,20 +389,7 @@ pub struct Overseer<S: Spawn> {
 ///
 /// [`Subsystem`]: trait.Subsystem.html
 /// [`DummySubsystem`]: struct.DummySubsystem.html
-pub struct AllSubsystems<CV, CB, CS, SD, AD, BD, P, PoVD, RA, AS, NB>
-where
-	CV: Subsystem<OverseerSubsystemContext<CandidateValidationMessage>> + Send,
-	CB: Subsystem<OverseerSubsystemContext<CandidateBackingMessage>> + Send,
-	CS: Subsystem<OverseerSubsystemContext<CandidateSelectionMessage>> + Send,
-	SD: Subsystem<OverseerSubsystemContext<StatementDistributionMessage>> + Send,
-	AD: Subsystem<OverseerSubsystemContext<AvailabilityDistributionMessage>> + Send,
-	BD: Subsystem<OverseerSubsystemContext<BitfieldDistributionMessage>> + Send,
-	P: Subsystem<OverseerSubsystemContext<ProvisionerMessage>> + Send,
-	PoVD: Subsystem<OverseerSubsystemContext<PoVDistributionMessage>> + Send,
-	RA: Subsystem<OverseerSubsystemContext<RuntimeApiMessage>> + Send,
-	AS: Subsystem<OverseerSubsystemContext<AvailabilityStoreMessage>> + Send,
-	NB: Subsystem<OverseerSubsystemContext<NetworkBridgeMessage>> + Send,
-{
+pub struct AllSubsystems<CV, CB, CS, SD, AD, BD, P, PoVD, RA, AS, NB> {
 	/// A candidate validation subsystem.
 	pub candidate_validation: CV,
 	/// A candidate backing subsystem.

--- a/node/overseer/src/lib.rs
+++ b/node/overseer/src/lib.rs
@@ -451,6 +451,7 @@ where
 	/// let (overseer, _handler) = Overseer::new(
 	///     vec![],
 	///     ValidationSubsystem,
+	///     DummySubsystem::<CandidateBackingMessage>::default(),
 	///     DummySubsystem::<CandidateSelectionMessage>::default(),
 	///     DummySubsystem::<StatementDistributionMessage>::default(),
 	///     DummySubsystem::<AvailabilityDistributionMessage>::default(),
@@ -874,6 +875,7 @@ mod tests {
 	use futures::{executor, pin_mut, select, channel::mpsc, FutureExt};
 
 	use polkadot_primitives::parachain::{BlockData, PoVBlock};
+	use polkadot_subsystem::DummySubsystem;
 	use super::*;
 
 

--- a/node/overseer/src/lib.rs
+++ b/node/overseer/src/lib.rs
@@ -459,10 +459,10 @@ where
 	/// # use std::time::Duration;
 	/// # use futures::{executor, pin_mut, select, FutureExt};
 	/// # use futures_timer::Delay;
-	/// # use polkadot_overseer::Overseer;
+	/// # use polkadot_overseer::{Overseer, AllSubsystems};
 	/// # use polkadot_subsystem::{
 	/// #     Subsystem, DummySubsystem, SpawnedSubsystem, SubsystemContext,
-	/// #     messages::*,
+	/// #     messages::CandidateValidationMessage,
 	/// # };
 	///
 	/// struct ValidationSubsystem;

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -29,7 +29,7 @@ use grandpa::{self, FinalityProofProvider as GrandpaFinalityProofProvider};
 use sc_executor::native_executor_instance;
 use log::info;
 use sp_blockchain::HeaderBackend;
-use polkadot_overseer::{self as overseer, BlockInfo, Overseer, OverseerHandler};
+use polkadot_overseer::{self as overseer, AllSubsystems, BlockInfo, Overseer, OverseerHandler};
 use polkadot_subsystem::DummySubsystem;
 use polkadot_subsystem::messages::{
 	CandidateValidationMessage, CandidateBackingMessage,
@@ -278,18 +278,21 @@ fn real_overseer<S: futures::task::Spawn>(
 	leaves: impl IntoIterator<Item = BlockInfo>,
 	s: S,
 ) -> Result<(Overseer<S>, OverseerHandler), ServiceError> {
+	let all_subsystems = AllSubsystems {
+		candidate_validation: DummySubsystem,
+		candidate_backing: DummySubsystem,
+		candidate_selection: DummySubsystem,
+		statement_distribution: DummySubsystem,
+		availability_distribution: DummySubsystem,
+		bitfield_distribution: DummySubsystem,
+		provisioner: DummySubsystem,
+		runtime_api: DummySubsystem,
+		availability_store: DummySubsystem,
+		network_bridge: DummySubsystem,
+	};
 	Overseer::new(
 		leaves, 
-		DummySubsystem::<CandidateValidationMessage>::default(),
-		DummySubsystem::<CandidateBackingMessage>::default(),
-		DummySubsystem::<CandidateSelectionMessage>::default(),
-		DummySubsystem::<StatementDistributionMessage>::default(),
-		DummySubsystem::<AvailabilityDistributionMessage>::default(),
-		DummySubsystem::<BitfieldDistributionMessage>::default(),
-		DummySubsystem::<ProvisionerMessage>::default(),
-		DummySubsystem::<RuntimeApiMessage>::default(),
-		DummySubsystem::<AvailabilityStoreMessage>::default(),
-		DummySubsystem::<NetworkBridgeMessage>::default(),
+		all_subsystems,
 		s,
 	).map_err(|e| ServiceError::Other(format!("Failed to create an Overseer: {:?}", e)))
 }

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -31,13 +31,6 @@ use log::info;
 use sp_blockchain::HeaderBackend;
 use polkadot_overseer::{self as overseer, AllSubsystems, BlockInfo, Overseer, OverseerHandler};
 use polkadot_subsystem::DummySubsystem;
-use polkadot_subsystem::messages::{
-	CandidateValidationMessage, CandidateBackingMessage,
-	CandidateSelectionMessage, StatementDistributionMessage,
-	AvailabilityDistributionMessage, BitfieldDistributionMessage,
-	ProvisionerMessage, RuntimeApiMessage, AvailabilityStoreMessage, 
-	NetworkBridgeMessage,
-};
 use polkadot_node_core_proposer::ProposerFactory;
 use sp_trie::PrefixedMemoryDB;
 pub use service::{

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -289,6 +289,7 @@ fn real_overseer<S: futures::task::Spawn>(
 		availability_distribution: DummySubsystem,
 		bitfield_distribution: DummySubsystem,
 		provisioner: DummySubsystem,
+		pov_distribution: DummySubsystem,
 		runtime_api: DummySubsystem,
 		availability_store: DummySubsystem,
 		network_bridge: DummySubsystem,

--- a/node/subsystem/src/lib.rs
+++ b/node/subsystem/src/lib.rs
@@ -148,3 +148,23 @@ pub trait Subsystem<C: SubsystemContext> {
 	/// Start this `Subsystem` and return `SpawnedSubsystem`.
 	fn start(self, ctx: C) -> SpawnedSubsystem;
 }
+
+/// A dummy subsystem that implements [`Subsystem`] for all
+/// types of messages. Used for tests or as a placeholder.
+pub struct DummySubsystem<C>(core::marker::PhantomData<C>);
+
+impl<C> Default for DummySubsystem<C> {
+	fn default() -> Self {
+		Self(core::marker::PhantomData)
+	}
+} 
+
+impl<M: Send, C> Subsystem<C> for DummySubsystem<M>
+	where C: SubsystemContext<Message=M>
+{
+	fn start(self, mut _ctx: C) -> SpawnedSubsystem {
+		SpawnedSubsystem(Box::pin(async move {
+			// Do nothing and return immediately
+		}))
+	}
+}

--- a/node/subsystem/src/lib.rs
+++ b/node/subsystem/src/lib.rs
@@ -162,9 +162,15 @@ impl<C> Default for DummySubsystem<C> {
 impl<M: Send, C> Subsystem<C> for DummySubsystem<M>
 	where C: SubsystemContext<Message=M>
 {
-	fn start(self, mut _ctx: C) -> SpawnedSubsystem {
+	fn start(self, mut ctx: C) -> SpawnedSubsystem {
 		SpawnedSubsystem(Box::pin(async move {
-			// Do nothing and return immediately
+			loop {
+				match ctx.recv().await {
+					Ok(FromOverseer::Signal(OverseerSignal::Conclude)) => return,
+					Err(_) => return,
+					_ => continue,
+				}
+			}
 		}))
 	}
 }

--- a/node/subsystem/src/lib.rs
+++ b/node/subsystem/src/lib.rs
@@ -151,17 +151,9 @@ pub trait Subsystem<C: SubsystemContext> {
 
 /// A dummy subsystem that implements [`Subsystem`] for all
 /// types of messages. Used for tests or as a placeholder.
-pub struct DummySubsystem<C>(core::marker::PhantomData<C>);
+pub struct DummySubsystem;
 
-impl<C> Default for DummySubsystem<C> {
-	fn default() -> Self {
-		Self(core::marker::PhantomData)
-	}
-} 
-
-impl<M: Send, C> Subsystem<C> for DummySubsystem<M>
-	where C: SubsystemContext<Message=M>
-{
+impl<C: SubsystemContext> Subsystem<C> for DummySubsystem {
 	fn start(self, mut ctx: C) -> SpawnedSubsystem {
 		SpawnedSubsystem(Box::pin(async move {
 			loop {

--- a/node/subsystem/src/messages.rs
+++ b/node/subsystem/src/messages.rs
@@ -224,12 +224,12 @@ pub enum PoVDistributionMessage {
 	///
 	/// This `CandidateDescriptor` should correspond to a candidate seconded under the provided
 	/// relay-parent hash.
-    FetchPoV(Hash, CandidateDescriptor, oneshot::Sender<Arc<PoVBlock>>),
-    /// Distribute a PoV for the given relay-parent and CandidateDescriptor.
-    /// The PoV should correctly hash to the PoV hash mentioned in the CandidateDescriptor
-    DistributePoV(Hash, CandidateDescriptor, Arc<PoVBlock>),
-    /// An update from the network bridge.
-    NetworkBridgeUpdate(NetworkBridgeEvent),
+	FetchPoV(Hash, CandidateDescriptor, oneshot::Sender<Arc<PoVBlock>>),
+	/// Distribute a PoV for the given relay-parent and CandidateDescriptor.
+	/// The PoV should correctly hash to the PoV hash mentioned in the CandidateDescriptor
+	DistributePoV(Hash, CandidateDescriptor, Arc<PoVBlock>),
+	/// An update from the network bridge.
+	NetworkBridgeUpdate(NetworkBridgeEvent),
 }
 
 /// A message type tying together all message types that are used across Subsystems.


### PR DESCRIPTION
Fixes #1317.

Please bear with me while I make these baby steps.
This boilerplate looks ugly so as an experiment I looked at a type map approach 2e934c3662d7abfd956880f94fd7b0da0be72ce7 (instead of storing a bunch of fields, we can store a `HashMap<Type, Box<SomeTrait>>`) but then reverted this change for now. Let me know if it's worth exploring.