### PR TITLE
*: Enable authority discovery by default

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -59,7 +59,12 @@ pub struct RunCmd {
 	#[structopt(long = "force-westend")]
 	pub force_westend: bool,
 
-	/// Enable the authority discovery module.
+	/// Disable the authority discovery module on validator or sentry nodes.
+	///
+	/// Enabled by default on validator and sentry nodes. Always disabled on
+	/// non validator or sentry nodes.
+	///
+	/// When enabled:
 	///
 	/// (1) As a validator node: Make oneself discoverable by publishing either
 	///     ones own network addresses, or the ones of ones sentry nodes
@@ -68,8 +73,8 @@ pub struct RunCmd {
 	/// (2) As a validator or sentry node: Discover addresses of validators or
 	///     addresses of their sentry nodes and maintain a permanent connection
 	///     to a subset.
-	#[structopt(long = "enable-authority-discovery")]
-	pub authority_discovery_enabled: bool,
+	#[structopt(long = "disable-authority-discovery")]
+	pub authority_discovery_disabled: bool,
 
 	/// Setup a GRANDPA scheduled voting pause.
 	///

--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -111,7 +111,7 @@ pub fn run() -> Result<()> {
 
 			set_default_ss58_version(chain_spec);
 
-			let authority_discovery_enabled = cli.run.authority_discovery_enabled;
+			let authority_discovery_disabled = cli.run.authority_discovery_disabled;
 			let grandpa_pause = if cli.run.grandpa_pause.is_empty() {
 				None
 			} else {
@@ -132,7 +132,7 @@ pub fn run() -> Result<()> {
 						config,
 						None,
 						None,
-						authority_discovery_enabled,
+						authority_discovery_disabled,
 						6000,
 						grandpa_pause,
 					).map(|(components, _, _)| components)
@@ -145,7 +145,7 @@ pub fn run() -> Result<()> {
 						config,
 						None,
 						None,
-						authority_discovery_enabled,
+						authority_discovery_disabled,
 						6000,
 						grandpa_pause,
 					).map(|(components, _, _)| components)
@@ -158,7 +158,7 @@ pub fn run() -> Result<()> {
 						config,
 						None,
 						None,
-						authority_discovery_enabled,
+						authority_discovery_disabled,
 						6000,
 						grandpa_pause,
 					).map(|(components, _, _)| components)

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -287,7 +287,7 @@ fn real_overseer<S: futures::task::Spawn>(
 		network_bridge: DummySubsystem,
 	};
 	Overseer::new(
-		leaves, 
+		leaves,
 		all_subsystems,
 		s,
 	).map_err(|e| ServiceError::Other(format!("Failed to create an Overseer: {:?}", e)))
@@ -299,7 +299,7 @@ macro_rules! new_full {
 	(
 		$config:expr,
 		$collating_for:expr,
-		$authority_discovery_enabled:expr,
+		$authority_discovery_disabled:expr,
 		$grandpa_pause:expr,
 		$runtime:ty,
 		$dispatch:ty,
@@ -600,7 +600,7 @@ pub fn polkadot_new_full(
 	mut config: Configuration,
 	collating_for: Option<(CollatorId, ParaId)>,
 	_max_block_data_size: Option<u64>,
-	_authority_discovery_enabled: bool,
+	_authority_discovery_disabled: bool,
 	_slot_duration: u64,
 	grandpa_pause: Option<(u32, u32)>,
 )
@@ -617,7 +617,7 @@ pub fn polkadot_new_full(
 	let (components, client) = new_full!(
 		config,
 		collating_for,
-		authority_discovery_enabled,
+		authority_discovery_disabled,
 		grandpa_pause,
 		polkadot_runtime::RuntimeApi,
 		PolkadotExecutor,
@@ -632,7 +632,7 @@ pub fn kusama_new_full(
 	mut config: Configuration,
 	collating_for: Option<(CollatorId, ParaId)>,
 	_max_block_data_size: Option<u64>,
-	_authority_discovery_enabled: bool,
+	_authority_discovery_disabled: bool,
 	_slot_duration: u64,
 	grandpa_pause: Option<(u32, u32)>,
 ) -> Result<(
@@ -649,7 +649,7 @@ pub fn kusama_new_full(
 	let (components, client) = new_full!(
 		config,
 		collating_for,
-		authority_discovery_enabled,
+		authority_discovery_disabled,
 		grandpa_pause,
 		kusama_runtime::RuntimeApi,
 		KusamaExecutor,
@@ -664,7 +664,7 @@ pub fn westend_new_full(
 	mut config: Configuration,
 	collating_for: Option<(CollatorId, ParaId)>,
 	_max_block_data_size: Option<u64>,
-	_authority_discovery_enabled: bool,
+	_authority_discovery_disabled: bool,
 	_slot_duration: u64,
 	grandpa_pause: Option<(u32, u32)>,
 )
@@ -681,7 +681,7 @@ pub fn westend_new_full(
 	let (components, client) = new_full!(
 		config,
 		collating_for,
-		authority_discovery_enabled,
+		authority_discovery_disabled,
 		grandpa_pause,
 		westend_runtime::RuntimeApi,
 		WestendExecutor,

--- a/node/test-service/src/lib.rs
+++ b/node/test-service/src/lib.rs
@@ -69,7 +69,7 @@ pub fn polkadot_test_new_full(
 	config: Configuration,
 	collating_for: Option<(CollatorId, ParaId)>,
 	max_block_data_size: Option<u64>,
-	authority_discovery_enabled: bool,
+	authority_discovery_disabled: bool,
 	slot_duration: u64,
 ) -> Result<
 	(
@@ -85,7 +85,7 @@ pub fn polkadot_test_new_full(
 		config,
 		collating_for,
 		max_block_data_size,
-		authority_discovery_enabled,
+		authority_discovery_disabled,
 		slot_duration,
 		polkadot_test_runtime::RuntimeApi,
 		PolkadotTestExecutor,
@@ -204,9 +204,9 @@ pub fn run_test_node(
 > {
 	let config = node_config(storage_update_func, task_executor, key, boot_nodes);
 	let multiaddr = config.network.listen_addresses[0].clone();
-	let authority_discovery_enabled = false;
+	let authority_discovery_disabled = true;
 	let (task_manager, client, handles, network, rpc_handlers) =
-		polkadot_test_new_full(config, None, None, authority_discovery_enabled, 6000)
+		polkadot_test_new_full(config, None, None, authority_discovery_disabled, 6000)
 			.expect("could not create Polkadot test service");
 
 	let peer_id = network.local_peer_id().clone();

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -297,7 +297,7 @@ macro_rules! new_full {
 		$config:expr,
 		$collating_for:expr,
 		$max_block_data_size:expr,
-		$authority_discovery_enabled:expr,
+		$authority_discovery_disabled:expr,
 		$slot_duration:expr,
 		$grandpa_pause:expr,
 		$new_full_start:expr $(,)?
@@ -318,7 +318,7 @@ macro_rules! new_full {
 		let max_block_data_size = $max_block_data_size;
 		let disable_grandpa = $config.disable_grandpa;
 		let name = $config.network.node_name.clone();
-		let authority_discovery_enabled = $authority_discovery_enabled;
+		let authority_discovery_disabled = $authority_discovery_disabled;
 		let slot_duration = $slot_duration;
 
 		let (builder, mut import_setup, inherent_data_providers, mut rpc_setup) = $new_full_start;
@@ -459,7 +459,7 @@ macro_rules! new_full {
 		}
 
 		if matches!(role, Role::Authority{..} | Role::Sentry{..}) {
-			if authority_discovery_enabled {
+			if !authority_discovery_disabled {
 				let (sentries, authority_discovery_role) = match role {
 					Role::Authority { ref sentry_nodes } => (
 						sentry_nodes.clone(),
@@ -568,7 +568,7 @@ macro_rules! new_full {
 		$config:expr,
 		$collating_for:expr,
 		$max_block_data_size:expr,
-		$authority_discovery_enabled:expr,
+		$authority_discovery_disabled:expr,
 		$slot_duration:expr,
 		$grandpa_pause:expr,
 		$runtime:ty,
@@ -578,7 +578,7 @@ macro_rules! new_full {
 			$config,
 			$collating_for,
 			$max_block_data_size,
-			$authority_discovery_enabled,
+			$authority_discovery_disabled,
 			$slot_duration,
 			$grandpa_pause,
 			new_full_start!($config, $runtime, $dispatch),
@@ -589,7 +589,7 @@ macro_rules! new_full {
 		$config:expr,
 		$collating_for:expr,
 		$max_block_data_size:expr,
-		$authority_discovery_enabled:expr,
+		$authority_discovery_disabled:expr,
 		$slot_duration:expr,
 		$runtime:ty,
 		$dispatch:ty,
@@ -598,7 +598,7 @@ macro_rules! new_full {
 			$config,
 			$collating_for,
 			$max_block_data_size,
-			$authority_discovery_enabled,
+			authority_discovery_disabled,
 			$slot_duration,
 			None,
 			new_full_start!(test $config, $runtime, $dispatch),
@@ -734,7 +734,7 @@ pub fn polkadot_new_full(
 	mut config: Configuration,
 	collating_for: Option<(CollatorId, parachain::Id)>,
 	max_block_data_size: Option<u64>,
-	authority_discovery_enabled: bool,
+	authority_discovery_disabled: bool,
 	slot_duration: u64,
 	grandpa_pause: Option<(u32, u32)>,
 )
@@ -752,7 +752,7 @@ pub fn polkadot_new_full(
 		config,
 		collating_for,
 		max_block_data_size,
-		authority_discovery_enabled,
+		authority_discovery_disabled,
 		slot_duration,
 		grandpa_pause,
 		polkadot_runtime::RuntimeApi,
@@ -768,7 +768,7 @@ pub fn kusama_new_full(
 	mut config: Configuration,
 	collating_for: Option<(CollatorId, parachain::Id)>,
 	max_block_data_size: Option<u64>,
-	authority_discovery_enabled: bool,
+	authority_discovery_disabled: bool,
 	slot_duration: u64,
 	grandpa_pause: Option<(u32, u32)>,
 ) -> Result<(
@@ -786,7 +786,7 @@ pub fn kusama_new_full(
 		config,
 		collating_for,
 		max_block_data_size,
-		authority_discovery_enabled,
+		authority_discovery_disabled,
 		slot_duration,
 		grandpa_pause,
 		kusama_runtime::RuntimeApi,
@@ -802,7 +802,7 @@ pub fn westend_new_full(
 	mut config: Configuration,
 	collating_for: Option<(CollatorId, parachain::Id)>,
 	max_block_data_size: Option<u64>,
-	authority_discovery_enabled: bool,
+	authority_discovery_disabled: bool,
 	slot_duration: u64,
 	grandpa_pause: Option<(u32, u32)>,
 )
@@ -820,7 +820,7 @@ pub fn westend_new_full(
 		config,
 		collating_for,
 		max_block_data_size,
-		authority_discovery_enabled,
+		authority_discovery_disabled,
 		slot_duration,
 		grandpa_pause,
 		westend_runtime::RuntimeApi,

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -598,7 +598,7 @@ macro_rules! new_full {
 			$config,
 			$collating_for,
 			$max_block_data_size,
-			authority_discovery_disabled,
+			$authority_discovery_disabled,
 			$slot_duration,
 			None,
 			new_full_start!(test $config, $runtime, $dispatch),


### PR DESCRIPTION
Instead of having to explicitly enable the authority discovery module on
validator and sentry nodes, this commit enables the module by default.

Today there is no way for non validator or sentry nodes to run the
module. That might change in the future.

Closes https://github.com/paritytech/polkadot/issues/1392