### PR TITLE
ci: fix subdirectory upload to s3

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -253,8 +253,8 @@ publish-s3-release:
     - echo "uploading objects to https://${BUCKET}/${PREFIX}/${VERSION}"
     - aws s3 sync ./artifacts/ s3://${BUCKET}/${PREFIX}/${VERSION}/
     - echo "update objects at https://${BUCKET}/${PREFIX}/${EXTRATAG}"
-    - for file in ./artifacts/*; do
-      name="$(basename ${file})";
+    - find ./artifacts -type f | while read file; do
+      name="${file#./artifacts/}";
       aws s3api copy-object
         --copy-source ${BUCKET}/${PREFIX}/${VERSION}/${name}
         --bucket ${BUCKET} --key ${PREFIX}/${EXTRATAG}/${name};


### PR DESCRIPTION
the ci s3 artifacts upload currently [fails](https://gitlab.parity.io/parity/polkadot/-/jobs/589169) since the wasm subdirectory has been [added](https://github.com/paritytech/polkadot/pull/1093).

 

ref https://github.com/paritytech/devops/issues/591