### PR TITLE
Companion for #6695 make impl_outer_origin default to use frame_system

### DIFF
--- a/runtime/common/src/claims.rs
+++ b/runtime/common/src/claims.rs
@@ -646,7 +646,7 @@ mod tests {
 	use super::Call as ClaimsCall;
 
 	impl_outer_origin! {
-		pub enum Origin for Test {}
+		pub enum Origin for Test where system = system {}
 	}
 
 	impl_outer_dispatch! {

--- a/runtime/common/src/crowdfund.rs
+++ b/runtime/common/src/crowdfund.rs
@@ -578,7 +578,7 @@ mod tests {
 	use crate::registrar::Registrar;
 
 	impl_outer_origin! {
-		pub enum Origin for Test {}
+		pub enum Origin for Test where system = system {}
 	}
 
 	// For testing the module, we construct most of a mock runtime. This means

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -106,7 +106,7 @@ mod multiplier_tests {
 	pub struct Runtime;
 
 	impl_outer_origin!{
-		pub enum Origin for Runtime {}
+		pub enum Origin for Runtime where system = system {}
 	}
 
 	parameter_types! {

--- a/runtime/common/src/parachains.rs
+++ b/runtime/common/src/parachains.rs
@@ -1702,7 +1702,7 @@ mod tests {
 	];
 
 	impl_outer_origin! {
-		pub enum Origin for Test {
+		pub enum Origin for Test where system = system {
 			parachains
 		}
 	}

--- a/runtime/common/src/purchase.rs
+++ b/runtime/common/src/purchase.rs
@@ -391,7 +391,7 @@ mod tests {
 	use balances::Error as BalancesError;
 
 	impl_outer_origin! {
-		pub enum Origin for Test {}
+		pub enum Origin for Test where system = system {}
 	}
 
 	impl_outer_dispatch! {

--- a/runtime/common/src/registrar.rs
+++ b/runtime/common/src/registrar.rs
@@ -688,7 +688,7 @@ mod tests {
 	use crate::attestations;
 
 	impl_outer_origin! {
-		pub enum Origin for Test {
+		pub enum Origin for Test where system = system {
 			parachains,
 		}
 	}

--- a/runtime/common/src/slots.rs
+++ b/runtime/common/src/slots.rs
@@ -893,7 +893,7 @@ mod tests {
 	use primitives::v0::{BlockNumber, Header, Id as ParaId, Info as ParaInfo, Scheduling};
 
 	impl_outer_origin! {
-		pub enum Origin for Test {}
+		pub enum Origin for Test where system = system {}
 	}
 
 	// For testing the module, we construct most of a mock runtime. This means

--- a/runtime/parachains/src/mock.rs
+++ b/runtime/parachains/src/mock.rs
@@ -36,7 +36,7 @@ use crate::inclusion;
 pub struct Test;
 
 impl_outer_origin! {
-	pub enum Origin for Test { }
+	pub enum Origin for Test where system = system { }
 }
 
 impl_outer_dispatch! {


### PR DESCRIPTION
Companion for: https://github.com/paritytech/substrate/pull/6695