### PR TITLE
Update latest substrate master

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -762,7 +762,8 @@ checksum = "6d375c433320f6c5057ae04a04376eef4d04ce2801448cf8863a78da99107be4"
 [[package]]
 name = "cranelift-bforest"
 version = "0.66.0"
-source = "git+https://github.com/paritytech/wasmtime?branch=update-upstream#f744c4e564b40a4cfce6a7090f093ec1726c68e9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dcc286b052ee24a1e5a222e7c1125e6010ad35b0f248709b9b3737a8fedcfdf"
 dependencies = [
  "cranelift-entity",
 ]
@@ -770,7 +771,8 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen"
 version = "0.66.0"
-source = "git+https://github.com/paritytech/wasmtime?branch=update-upstream#f744c4e564b40a4cfce6a7090f093ec1726c68e9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d9badfe36176cb653506091693bc2bb1970c9bddfcd6ec7fac404f7eaec6f38"
 dependencies = [
  "byteorder",
  "cranelift-bforest",
@@ -789,7 +791,8 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen-meta"
 version = "0.66.0"
-source = "git+https://github.com/paritytech/wasmtime?branch=update-upstream#f744c4e564b40a4cfce6a7090f093ec1726c68e9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3f460031861e4f4ad510be62b2ae50bba6cc886b598a36f9c0a970feab9598"
 dependencies = [
  "cranelift-codegen-shared",
  "cranelift-entity",
@@ -798,12 +801,14 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen-shared"
 version = "0.66.0"
-source = "git+https://github.com/paritytech/wasmtime?branch=update-upstream#f744c4e564b40a4cfce6a7090f093ec1726c68e9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ad12409e922e7697cd0bdc7dc26992f64a77c31880dfe5e3c7722f4710206d"
 
 [[package]]
 name = "cranelift-entity"
 version = "0.66.0"
-source = "git+https://github.com/paritytech/wasmtime?branch=update-upstream#f744c4e564b40a4cfce6a7090f093ec1726c68e9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d97cdc58972ea065d107872cfb9079f4c92ade78a8af85aaff519a65b5d13f71"
 dependencies = [
  "serde",
 ]
@@ -811,7 +816,8 @@ dependencies = [
 [[package]]
 name = "cranelift-frontend"
 version = "0.66.0"
-source = "git+https://github.com/paritytech/wasmtime?branch=update-upstream#f744c4e564b40a4cfce6a7090f093ec1726c68e9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ef419efb4f94ecc02e5d9fbcc910d2bb7f0040e2de570e63a454f883bc891d6"
 dependencies = [
  "cranelift-codegen",
  "log 0.4.8",
@@ -822,7 +828,8 @@ dependencies = [
 [[package]]
 name = "cranelift-native"
 version = "0.66.0"
-source = "git+https://github.com/paritytech/wasmtime?branch=update-upstream#f744c4e564b40a4cfce6a7090f093ec1726c68e9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e69d44d59826eef6794066ac2c0f4ad3975f02d97030c60dbc04e3886adf36e"
 dependencies = [
  "cranelift-codegen",
  "raw-cpuid",
@@ -832,7 +839,8 @@ dependencies = [
 [[package]]
 name = "cranelift-wasm"
 version = "0.66.0"
-source = "git+https://github.com/paritytech/wasmtime?branch=update-upstream#f744c4e564b40a4cfce6a7090f093ec1726c68e9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "979df666b1304624abe99738e9e0e7c7479ee5523ba4b8b237df9ff49996acbb"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1335,7 +1343,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -1343,7 +1351,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1360,7 +1368,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "Inflector",
  "frame-benchmarking",
@@ -1379,7 +1387,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1394,7 +1402,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata"
 version = "11.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -1405,7 +1413,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "bitmask",
  "frame-metadata",
@@ -1430,7 +1438,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "frame-support-procedural-tools",
  "proc-macro2 1.0.18",
@@ -1441,7 +1449,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -1453,7 +1461,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
@@ -1463,7 +1471,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -1479,7 +1487,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -1493,7 +1501,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -3507,7 +3515,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3523,7 +3531,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3538,7 +3546,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3563,7 +3571,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3577,7 +3585,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3593,7 +3601,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3608,7 +3616,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3623,7 +3631,7 @@ dependencies = [
 [[package]]
 name = "pallet-finality-tracker"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3639,7 +3647,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3661,7 +3669,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -3677,7 +3685,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3697,7 +3705,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3713,7 +3721,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3727,7 +3735,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3742,7 +3750,7 @@ dependencies = [
 [[package]]
 name = "pallet-nicks"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3756,7 +3764,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3771,7 +3779,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3792,7 +3800,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3807,7 +3815,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3820,7 +3828,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "enumflags2",
  "frame-support",
@@ -3835,7 +3843,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3850,7 +3858,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3870,7 +3878,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3886,7 +3894,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3900,7 +3908,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3922,7 +3930,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.18",
@@ -3933,7 +3941,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3947,7 +3955,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3965,7 +3973,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3982,7 +3990,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -4000,7 +4008,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -4013,7 +4021,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4028,7 +4036,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4044,7 +4052,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -5793,9 +5801,9 @@ dependencies = [
 
 [[package]]
 name = "regalloc"
-version = "0.0.28"
+version = "0.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3598bed0895fe0f72a9e0b00ef9e3a3c8af978a8401b2f2046dec5927de6364a"
+checksum = "b9ba8aaf5fe7cf307c6dbdaeed85478961d29e25e3bee5169e11b92fa9f027a8"
 dependencies = [
  "log 0.4.8",
  "rustc-hash",
@@ -6008,7 +6016,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "bytes 0.5.5",
  "derive_more 0.99.9",
@@ -6035,7 +6043,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -6059,7 +6067,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -6076,7 +6084,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "impl-trait-for-tuples",
  "sc-chain-spec-derive",
@@ -6092,7 +6100,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.18",
@@ -6103,7 +6111,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
@@ -6144,7 +6152,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "derive_more 0.99.9",
  "fnv",
@@ -6180,7 +6188,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "blake2-rfc",
  "hash-db",
@@ -6209,7 +6217,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "sc-client-api",
  "sp-blockchain",
@@ -6220,7 +6228,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "derive_more 0.99.9",
  "fork-tree",
@@ -6262,7 +6270,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "derive_more 0.99.9",
  "futures 0.3.5",
@@ -6286,7 +6294,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -6299,7 +6307,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -6322,7 +6330,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-uncles"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "log 0.4.8",
  "sc-client-api",
@@ -6336,7 +6344,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "derive_more 0.99.9",
  "lazy_static",
@@ -6364,7 +6372,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "derive_more 0.99.9",
  "log 0.4.8",
@@ -6381,7 +6389,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "log 0.4.8",
  "parity-scale-codec",
@@ -6396,7 +6404,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "cranelift-codegen",
  "cranelift-wasm",
@@ -6417,7 +6425,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "assert_matches",
  "derive_more 0.99.9",
@@ -6455,7 +6463,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa-rpc"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "derive_more 0.99.9",
  "finality-grandpa",
@@ -6472,7 +6480,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "ansi_term 0.12.1",
  "futures 0.3.5",
@@ -6490,7 +6498,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "derive_more 0.99.9",
  "hex",
@@ -6506,7 +6514,7 @@ dependencies = [
 [[package]]
 name = "sc-light"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "hash-db",
  "lazy_static",
@@ -6525,7 +6533,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "bitflags",
  "bs58",
@@ -6577,7 +6585,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -6592,7 +6600,7 @@ dependencies = [
 [[package]]
 name = "sc-network-test"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "env_logger",
  "futures 0.3.5",
@@ -6619,7 +6627,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "bytes 0.5.5",
  "fnv",
@@ -6646,7 +6654,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "futures 0.3.5",
  "libp2p",
@@ -6659,7 +6667,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "log 0.4.8",
  "substrate-prometheus-endpoint",
@@ -6668,7 +6676,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "futures 0.3.5",
  "hash-db",
@@ -6700,7 +6708,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "derive_more 0.99.9",
  "futures 0.3.5",
@@ -6724,7 +6732,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-http-server",
@@ -6740,7 +6748,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "derive_more 0.99.9",
  "directories",
@@ -6802,7 +6810,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "log 0.4.8",
  "parity-scale-codec",
@@ -6816,7 +6824,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -6837,7 +6845,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "erased-serde",
  "log 0.4.8",
@@ -6854,7 +6862,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-graph"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "derive_more 0.99.9",
  "futures 0.3.5",
@@ -6875,7 +6883,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "derive_more 0.99.9",
  "futures 0.3.5",
@@ -7330,7 +7338,7 @@ dependencies = [
 [[package]]
 name = "sp-allocator"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "derive_more 0.99.9",
  "log 0.4.8",
@@ -7342,7 +7350,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
@@ -7357,7 +7365,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate",
@@ -7369,7 +7377,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -7381,7 +7389,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "integer-sqrt",
  "num-traits 0.2.12",
@@ -7394,7 +7402,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7406,7 +7414,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -7417,7 +7425,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7429,7 +7437,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "derive_more 0.99.9",
  "log 0.4.8",
@@ -7446,7 +7454,7 @@ dependencies = [
 [[package]]
 name = "sp-chain-spec"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "serde",
  "serde_json",
@@ -7455,7 +7463,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "derive_more 0.99.9",
  "futures 0.3.5",
@@ -7480,7 +7488,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7494,7 +7502,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "merlin",
  "parity-scale-codec",
@@ -7513,7 +7521,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -7522,7 +7530,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "parity-scale-codec",
  "schnorrkel",
@@ -7534,7 +7542,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "base58",
  "blake2-rfc",
@@ -7577,7 +7585,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "kvdb",
  "parking_lot 0.10.2",
@@ -7586,7 +7594,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
@@ -7596,7 +7604,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -7607,7 +7615,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "finality-grandpa",
  "log 0.4.8",
@@ -7623,7 +7631,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-tracker"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -7633,7 +7641,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "derive_more 0.99.9",
  "parity-scale-codec",
@@ -7645,7 +7653,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "futures 0.3.5",
  "hash-db",
@@ -7666,7 +7674,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -7677,7 +7685,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -7689,7 +7697,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections-compact"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.18",
@@ -7700,7 +7708,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -7710,7 +7718,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "backtrace",
  "log 0.4.8",
@@ -7719,7 +7727,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "serde",
  "sp-core",
@@ -7728,7 +7736,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -7750,7 +7758,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "parity-scale-codec",
  "primitive-types",
@@ -7765,7 +7773,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -7777,7 +7785,7 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "serde",
  "serde_json",
@@ -7786,7 +7794,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7799,7 +7807,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -7809,7 +7817,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "hash-db",
  "itertools 0.9.0",
@@ -7830,12 +7838,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 
 [[package]]
 name = "sp-storage"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "impl-serde 0.2.3",
  "ref-cast",
@@ -7847,7 +7855,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -7861,7 +7869,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "log 0.4.8",
  "rental",
@@ -7871,7 +7879,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "derive_more 0.99.9",
  "futures 0.3.5",
@@ -7886,7 +7894,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -7900,7 +7908,7 @@ dependencies = [
 [[package]]
 name = "sp-utils"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "futures 0.3.5",
  "futures-core",
@@ -7912,7 +7920,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "impl-serde 0.2.3",
  "parity-scale-codec",
@@ -7924,7 +7932,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -8055,7 +8063,7 @@ dependencies = [
 [[package]]
 name = "substrate-browser-utils"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "chrono",
  "console_error_panic_hook",
@@ -8081,7 +8089,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "platforms",
 ]
@@ -8089,7 +8097,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.5",
@@ -8112,7 +8120,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "async-std",
  "derive_more 0.99.9",
@@ -8126,7 +8134,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "futures 0.1.29",
  "futures 0.3.5",
@@ -8152,7 +8160,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "cfg-if",
  "frame-executive",
@@ -8185,14 +8193,14 @@ dependencies = [
  "sp-transaction-pool",
  "sp-trie",
  "sp-version",
- "substrate-wasm-builder-runner 1.0.6 (git+https://github.com/paritytech/substrate)",
+ "substrate-wasm-builder-runner 1.0.6 (git+https://github.com/paritytech/substrate?branch=master)",
  "trie-db",
 ]
 
 [[package]]
 name = "substrate-test-runtime-client"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 dependencies = [
  "futures 0.3.5",
  "parity-scale-codec",
@@ -8213,7 +8221,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder-runner"
 version = "1.0.6"
-source = "git+https://github.com/paritytech/substrate#ae579a841587919bc12940388e994ef799c37e6c"
+source = "git+https://github.com/paritytech/substrate?branch=master#bf0e1ec1006e55b080b6d7314107a6ee571072e2"
 
 [[package]]
 name = "substrate-wasm-builder-runner"
@@ -8224,7 +8232,8 @@ checksum = "d2a965994514ab35d3893e9260245f2947fd1981cdd4fffd2c6e6d1a9ce02e6a"
 [[package]]
 name = "substrate-wasmtime"
 version = "0.19.0"
-source = "git+https://github.com/paritytech/wasmtime?branch=update-upstream#f744c4e564b40a4cfce6a7090f093ec1726c68e9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d75a69f5b3afef86e3e372529bf3fb1f7219b20287c4490e4cb4b4e91970f4f5"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -9251,7 +9260,8 @@ checksum = "a950e6a618f62147fd514ff445b2a0b53120d382751960797f85f058c7eda9b9"
 [[package]]
 name = "wasmtime-debug"
 version = "0.19.0"
-source = "git+https://github.com/paritytech/wasmtime?branch=update-upstream#f744c4e564b40a4cfce6a7090f093ec1726c68e9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e634af9067a3af6cf2c7d33dc3b84767ddaf5d010ba68e80eecbcea73d4a349"
 dependencies = [
  "anyhow",
  "gimli 0.21.0",
@@ -9266,7 +9276,8 @@ dependencies = [
 [[package]]
 name = "wasmtime-environ"
 version = "0.19.0"
-source = "git+https://github.com/paritytech/wasmtime?branch=update-upstream#f744c4e564b40a4cfce6a7090f093ec1726c68e9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08f85619a94ee4034bd5bb87fc3dcf71fd2237b81c840809da1201061eec9ab3"
 dependencies = [
  "anyhow",
  "base64 0.12.3",
@@ -9296,7 +9307,8 @@ dependencies = [
 [[package]]
 name = "wasmtime-jit"
 version = "0.19.0"
-source = "git+https://github.com/paritytech/wasmtime?branch=update-upstream#f744c4e564b40a4cfce6a7090f093ec1726c68e9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e914c013c7a9f15f4e429d5431f2830fb8adb56e40567661b69c5ec1d645be23"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -9324,7 +9336,8 @@ dependencies = [
 [[package]]
 name = "wasmtime-obj"
 version = "0.19.0"
-source = "git+https://github.com/paritytech/wasmtime?branch=update-upstream#f744c4e564b40a4cfce6a7090f093ec1726c68e9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e81d8e02e9bc9fe2da9b6d48bbc217f96e089f7df613f11a28a3958abc44641e"
 dependencies = [
  "anyhow",
  "more-asserts",
@@ -9337,7 +9350,8 @@ dependencies = [
 [[package]]
 name = "wasmtime-profiling"
 version = "0.19.0"
-source = "git+https://github.com/paritytech/wasmtime?branch=update-upstream#f744c4e564b40a4cfce6a7090f093ec1726c68e9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e8d4d1af8dd5f7096cfcc89dd668d358e52980c38cce199643372ffd6590e27"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -9355,7 +9369,8 @@ dependencies = [
 [[package]]
 name = "wasmtime-runtime"
 version = "0.19.0"
-source = "git+https://github.com/paritytech/wasmtime?branch=update-upstream#f744c4e564b40a4cfce6a7090f093ec1726c68e9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a25f140bbbaadb07c531cba99ce1a966dba216138dc1b2a0ddecec851a01a93"
 dependencies = [
  "backtrace",
  "cc",

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -87,8 +87,8 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("kusama"),
 	impl_name: create_runtime_str!("parity-kusama"),
 	authoring_version: 2,
-	spec_version: 2020,
-	impl_version: 1,
+	spec_version: 2021,
+	impl_version: 0,
 	#[cfg(not(feature = "disable-runtime-api"))]
 	apis: RUNTIME_API_VERSIONS,
 	#[cfg(feature = "disable-runtime-api")]

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -86,8 +86,8 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("polkadot"),
 	impl_name: create_runtime_str!("parity-polkadot"),
 	authoring_version: 0,
-	spec_version: 20,
-	impl_version: 1,
+	spec_version: 21,
+	impl_version: 0,
 	#[cfg(not(feature = "disable-runtime-api"))]
 	apis: RUNTIME_API_VERSIONS,
 	#[cfg(feature = "disable-runtime-api")]

--- a/runtime/test-runtime/src/lib.rs
+++ b/runtime/test-runtime/src/lib.rs
@@ -77,13 +77,13 @@ use constants::{time::*, currency::*, fee::*};
 #[cfg(feature = "std")]
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
-/// Runtime version (Kusama).
+/// Runtime version (Test).
 pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("polkadot-test-runtime"),
 	impl_name: create_runtime_str!("parity-polkadot-test-runtime"),
 	authoring_version: 2,
-	spec_version: 1053,
-	impl_version: 1,
+	spec_version: 1054,
+	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,
 };

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -78,13 +78,13 @@ use constants::{time::*, currency::*, fee::*};
 #[cfg(feature = "std")]
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
-/// Runtime version (Kusama).
+/// Runtime version (Westend).
 pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("westend"),
 	impl_name: create_runtime_str!("parity-westend"),
 	authoring_version: 2,
-	spec_version: 40,
-	impl_version: 1,
+	spec_version: 41,
+	impl_version: 0,
 	#[cfg(not(feature = "disable-runtime-api"))]
 	apis: RUNTIME_API_VERSIONS,
 	#[cfg(feature = "disable-runtime-api")]


### PR DESCRIPTION
Mainly to get https://github.com/paritytech/substrate/pull/6725 in and deploy a runtime upgrade on Westend.