### PR TITLE
Add manual action to build PR binary

### DIFF
--- a/.github/workflows/burnin-label-notification.yml
+++ b/.github/workflows/burnin-label-notification.yml
@@ -4,16 +4,6 @@ on:
     types: [labeled]
 
 jobs:
-  build-pr:
-    runs-on: ubuntu-latest
-      - name: Notify devops
-        if: github.event.label.name == 'A1-needsburnin'
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-      - run: cargo build --release --all-features
   notify-devops:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/burnin-label-notification.yml
+++ b/.github/workflows/burnin-label-notification.yml
@@ -4,6 +4,15 @@ on:
     types: [labeled]
 
 jobs:
+  build-pr:
+    runs-on: ubuntu-latest
+      - name: Notify devops
+        if: github.event.label.name == 'A1-needsburnin'
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - run: cargo build --release --all-features
   notify-devops:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/burnin-label-notification.yml
+++ b/.github/workflows/burnin-label-notification.yml
@@ -8,6 +8,7 @@ jobs:
     runs-on: ubuntu-latest
       - name: Notify devops
         if: github.event.label.name == 'A1-needsburnin'
+    steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -205,6 +205,18 @@ build-linux-release:               &build
     - cp -r scripts/docker/* ./artifacts
     - sccache -s
 
+build-linux-release-pr:            &build
+  stage:                           build
+  <<:                              *collect-artifacts
+  <<:                              *build-refs
+  <<:                              *docker-env
+  <<:                              *compiler_info
+  script:
+    - time cargo build --release --verbose
+    - mkdir -p ./artifacts
+    - mv ./target/release/polkadot ./artifacts/.
+    - sha256sum ./artifacts/polkadot | tee ./artifacts/polkadot.sha256
+  when: manual
 
 generate-impl-guide:
   stage:                          build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -208,7 +208,7 @@ build-linux-release:               &build
 build-linux-release-pr:            &build
   stage:                           build
   <<:                              *collect-artifacts
-  <<:                              *build-refs
+  <<:                              *test-refs
   <<:                              *docker-env
   <<:                              *compiler_info
   script:


### PR DESCRIPTION
Add a manual action to allow other services trigger a build and extract the binary file for open PR's.