### PR TITLE
add simple name derivation heuristic for JobManager Subsystem impl

### DIFF
--- a/node/subsystem/src/util.rs
+++ b/node/subsystem/src/util.rs
@@ -711,7 +711,7 @@ where
 		});
 
 		SpawnedSubsystem {
-			name: "JobManager",
+			name: Job::NAME.strip_suffix("Job").unwrap_or(Job::NAME),
 			future,
 		}
 	}
@@ -733,6 +733,8 @@ mod tests {
 		ActiveLeavesUpdate,
 		FromOverseer,
 		OverseerSignal,
+		SpawnedSubsystem,
+		Subsystem,
 	};
 	use futures::{
 		channel::mpsc,
@@ -954,5 +956,17 @@ mod tests {
 				JobsError::Utility(util::Error::JobNotFound(match_relay_parent)) if relay_parent == match_relay_parent
 			);
 		});
+	}
+
+	#[test]
+	fn test_subsystem_impl_and_name_derivation() {
+		let pool = sp_core::testing::TaskExecutor::new();
+		let (context, _) = make_subsystem_context::<CandidateSelectionMessage, _>(pool.clone());
+
+		let SpawnedSubsystem { name, .. } = FakeCandidateSelectionSubsystem::new(
+			pool,
+			HashMap::new(),
+		).start(context);
+		assert_eq!(name, "FakeCandidateSelection");
 	}
 }


### PR DESCRIPTION
Subsystems are encouraged to either typedef themselves as appropriate
`JobManager` instances for their job type, or wrap a `JobManager`
instance and delegate the `Subsystem` impl. In both cases, we want
to use a sensible, non-repeated subsystem name for appropriate
logging and debugging.

This PR adds a heuristic: if the job name ends in the literal
"Job", then that gets stripped. Otherwise, the job name is used.
This improves on the previous situation, in which subsystems
typedef'd to or wrapping `JobManager` all got the same constant (!)
name.