### PR TITLE
Sudo wrapper for paras

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4945,6 +4945,7 @@ dependencies = [
  "pallet-vesting",
  "parity-scale-codec",
  "polkadot-primitives",
+ "polkadot-runtime-parachains",
  "rustc-hex",
  "serde",
  "serde_derive",

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -36,6 +36,7 @@ frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch =
 
 primitives = { package = "polkadot-primitives", path = "../../primitives", default-features = false }
 libsecp256k1 = { version = "0.3.2", default-features = false, optional = true }
+runtime-parachains = { package = "polkadot-runtime-parachains", path = "../parachains", default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.2.1"

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -27,6 +27,7 @@ pub mod slots;
 pub mod crowdfund;
 pub mod purchase;
 pub mod impls;
+pub mod paras_sudo_wrapper;
 
 use primitives::v0::BlockNumber;
 use sp_runtime::{Perquintill, Perbill, FixedPointNumber, traits::Saturating};

--- a/runtime/common/src/paras_sudo_wrapper.rs
+++ b/runtime/common/src/paras_sudo_wrapper.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
+//! A simple wrapper allowing `Sudo` to call into `paras` routines.
+
 use frame_support::{
 	decl_error, decl_module,
 	dispatch::DispatchResult,
@@ -26,6 +28,7 @@ use runtime_parachains::paras::{
 };
 use primitives::v1::Id as ParaId;
 
+/// The module's configuration trait.
 pub trait Trait: paras::Trait { }
 
 decl_error! {

--- a/runtime/common/src/paras_sudo_wrapper.rs
+++ b/runtime/common/src/paras_sudo_wrapper.rs
@@ -1,0 +1,60 @@
+// Copyright 2020 Parity Technologies (UK) Ltd.
+// This file is part of Polkadot.
+
+// Polkadot is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Polkadot is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
+
+use frame_support::{
+	decl_error, decl_module,
+	dispatch::DispatchResult,
+	weights::DispatchClass,
+};
+use system::ensure_root;
+use runtime_parachains::paras::{
+	self,
+	ParaGenesisArgs,
+};
+use primitives::v1::Id as ParaId;
+
+pub trait Trait: paras::Trait { }
+
+decl_error! {
+	pub enum Error for Module<T: Trait> { }
+}
+
+decl_module! {
+	/// A sudo wrapper to call into v1 paras module.
+	pub struct Module<T: Trait> for enum Call where origin: <T as system::Trait>::Origin, system = system {
+		type Error = Error<T>;
+
+		/// Schedule a para to be initialized at the start of the next session.
+		#[weight = (1_000, DispatchClass::Operational)]
+		pub fn sudo_schedule_para_initialize(
+			origin,
+			id: ParaId,
+			genesis: ParaGenesisArgs,
+		) -> DispatchResult {
+			ensure_root(origin)?;
+			paras::Module::<T>::schedule_para_initialize(id, genesis);
+			Ok(())
+		}
+
+		/// Schedule a para to be cleaned up at the start of the next session.
+		#[weight = (1_000, DispatchClass::Operational)]
+		pub fn sudo_schedule_para_cleanup(origin, id: ParaId) -> DispatchResult {
+			ensure_root(origin)?;
+			paras::Module::<T>::schedule_para_cleanup(id);
+			Ok(())
+		}
+	}
+}

--- a/runtime/rococo-v1/src/lib.rs
+++ b/runtime/rococo-v1/src/lib.rs
@@ -61,6 +61,7 @@ use sp_core::OpaqueMetadata;
 use sp_staking::SessionIndex;
 use session::historical as session_historical;
 use system::EnsureRoot;
+use runtime_common::paras_sudo_wrapper as paras_sudo_wrapper;
 
 use runtime_parachains::configuration as parachains_configuration;
 use runtime_parachains::inclusion as parachains_inclusion;
@@ -369,6 +370,8 @@ construct_runtime! {
 		Scheduler: parachains_scheduler::{Module, Call, Storage},
 		Paras: parachains_paras::{Module, Call, Storage},
 		Initializer: parachains_initializer::{Module, Call, Storage},
+
+		ParasSudoWrapper: paras_sudo_wrapper::{Module, Call},
 	}
 }
 
@@ -722,3 +725,5 @@ impl parachains_scheduler::Trait for Runtime { }
 impl parachains_initializer::Trait for Runtime {
 	type Randomness = Babe;
 }
+
+impl paras_sudo_wrapper::Trait for Runtime { }


### PR DESCRIPTION
A sudo wrapper for paras was forgotten. Should constant weights be here and return values from the functions be ignored? If not how do we go from `Weight` to `DispatchResult`?