### PR TITLE
Add an Origin to parachains v1

### DIFF
--- a/runtime/parachains/src/lib.rs
+++ b/runtime/parachains/src/lib.rs
@@ -23,6 +23,11 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+use sp_std::result;
+use sp_runtime::traits::BadOrigin;
+use primitives::v1::Id as ParaId;
+use codec::{Decode, Encode};
+
 pub mod configuration;
 pub mod inclusion;
 pub mod inclusion_inherent;
@@ -35,3 +40,22 @@ pub mod runtime_api_impl;
 
 #[cfg(test)]
 mod mock;
+
+/// Origin for the parachains.
+#[derive(PartialEq, Eq, Clone, Encode, Decode)]
+#[cfg_attr(feature = "std", derive(Debug))]
+pub enum Origin {
+	/// It comes from a parachain.
+	Parachain(ParaId),
+}
+
+/// Ensure that the origin `o` represents a parachain.
+/// Returns `Ok` with the parachain ID that effected the extrinsic or an `Err` otherwise.
+pub fn ensure_parachain<OuterOrigin>(o: OuterOrigin) -> result::Result<ParaId, BadOrigin>
+	where OuterOrigin: Into<result::Result<Origin, OuterOrigin>>
+{
+	match o.into() {
+		Ok(Origin::Parachain(id)) => Ok(id),
+		_ => Err(BadOrigin),
+	}
+}


### PR DESCRIPTION
A small one. This origin will later be wired to `Router` and `Registrar`.

Closes #1510 