### PR TITLE
Update .editorconfig to what we have in practice

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,12 +1,13 @@
 root = true
-[*]
+
+[*.rs]
 indent_style=tab
 indent_size=tab
 tab_width=4
+max_line_length=120
 end_of_line=lf
 charset=utf-8
 trim_trailing_whitespace=true
-max_line_length=120
 insert_final_newline=true
 
 [*.yml]
@@ -14,3 +15,6 @@ indent_style=space
 indent_size=2
 tab_width=8
 end_of_line=lf
+charset=utf-8
+trim_trailing_whitespace=true
+insert_final_newline=true


### PR DESCRIPTION
While editing the impl guide markdowns I tried to be inline with what seemingly more
common way to indent them: spaces. However, despite that I changed it kept reseting.
Turned out the culprit is the .editorconfig file.

This commit addresses this issue. I didn't try to deduplicate the rules since
I found that the formal specification is a bit ambigious and it is not a big
deal anyway.