### PR TITLE
Align for "Starting parachain attestation session"

### DIFF
--- a/validation/src/validation_service/mod.rs
+++ b/validation/src/validation_service/mod.rs
@@ -383,13 +383,13 @@ impl<N, P, SP, CF> ParachainValidationInstances<N, P, SP, CF> where
 
 		if let Some(ref duty) = local_duty {
 			info!(
-				"✍️ Starting parachain attestation session (parent: {}) with active duty {}",
+				"✍️  Starting parachain attestation session (parent: {}) with active duty {}",
 				parent_hash,
 				Colour::Red.bold().paint(format!("{:?}", duty)),
 			);
 		} else {
 			debug!(
-				"✍️ Starting parachain attestation session (parent: {}). No local duty..",
+				"✍️  Starting parachain attestation session (parent: {}). No local duty..",
 				parent_hash,
 			);
 		}


### PR DESCRIPTION
This is not a big problem.

You can find "✍️ Starting parachain attestation" isn't alignment with other output

![image](https://user-images.githubusercontent.com/1024162/89658198-d1b8d480-d900-11ea-9882-430ae9befc33.png)

I do a little experiment, I copy this string to terminal and I found the space between `✍️` and `Starting` disappeared, so give one more space would help for alignment