### PR TITLE
Implementer's Guide: Flesh out more details for upward messages

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,12 +1,13 @@
 root = true
-[*]
+
+[*.rs]
 indent_style=tab
 indent_size=tab
 tab_width=4
+max_line_length=120
 end_of_line=lf
 charset=utf-8
 trim_trailing_whitespace=true
-max_line_length=120
 insert_final_newline=true
 
 [*.yml]
@@ -14,6 +15,9 @@ indent_style=space
 indent_size=2
 tab_width=8
 end_of_line=lf
+charset=utf-8
+trim_trailing_whitespace=true
+insert_final_newline=true
 
 [*.sh]
 indent_style=space

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,13 +1,12 @@
 root = true
-
-[*.rs]
+[*]
 indent_style=tab
 indent_size=tab
 tab_width=4
-max_line_length=120
 end_of_line=lf
 charset=utf-8
 trim_trailing_whitespace=true
+max_line_length=120
 insert_final_newline=true
 
 [*.yml]
@@ -15,9 +14,6 @@ indent_style=space
 indent_size=2
 tab_width=8
 end_of_line=lf
-charset=utf-8
-trim_trailing_whitespace=true
-insert_final_newline=true
 
 [*.sh]
 indent_style=space

--- a/roadmap/implementers-guide/src/messaging.md
+++ b/roadmap/implementers-guide/src/messaging.md
@@ -36,7 +36,7 @@ The weight that processing of the dispatchables can consume is limited by a prec
 that some dispatchables will be left for later blocks. To make the dispatching more fair, the queues are processed turn-by-turn
 in a round robin fashion.
 
-Other kinds of upward messages can be introduced in the future as well. Most likely the HRMP channel managem
+Other kinds of upward messages can be introduced in the future as well. Most likely the HRMP channel management.
 
 ## Horizontal Message Passing
 

--- a/roadmap/implementers-guide/src/messaging.md
+++ b/roadmap/implementers-guide/src/messaging.md
@@ -17,9 +17,7 @@ digraph {
 }
 ```
 
-Downward Message Passing (DMP) is a mechanism for delivering messages to parachains from the relay chain. Downward
-messages may originate not from the relay chain, but rather from another parachain via a mechanism
-called HRMP (Will be described later).
+Downward Message Passing (DMP) is a mechanism for delivering messages to parachains from the relay chain.
 
 Each parachain has its own queue that stores all pending inbound downward messages. A parachain
 doesn't have to process all messages at once, however, there are rules as to how the downward message queue
@@ -28,16 +26,17 @@ The downward message queue doesn't have a cap on its size and it is up to the re
 that prevent spamming in place.
 
 Upward Message Passing (UMP) is a mechanism responsible for delivering messages in the opposite direction:
-from a parachain up to the relay chain. Upward messages are dispatched to Runtime entrypoints and
-typically used for invoking some actions on the relay chain on behalf of the parachain.
+from a parachain up to the relay chain. Upward messagess can serve different purposes and can be of different
+ kinds.
 
-> NOTE: It is conceivable that upward messages will be divided to more fine-grained kinds with a dispatchable upward message
-being only one kind of multiple. That would make upward messages inspectable and therefore would allow imposing additional
-validity criteria for the candidates that contain these messages.
+One kind of messages is `Dispatchable`. They could be thought of similar to extrinsics sent to a relay chain: they also
+invoke exposed runtime entrypoints, they consume weight and require fees. The difference is that they originate from
+a parachain. Each parachain has a queue of dispatchables to be executed. There can be only so many dispatchables at a time.
+The weight that processing of the dispatchables can consume is limited by a preconfigured value. Therefore, it is possible
+that some dispatchables will be left for later blocks. To make the dispatching more fair, the queues are processed turn-by-turn
+in a round robin fashion.
 
-Semantically, there is a queue of upward messages queue where messages from each parachain are stored. Each parachain
-can have a limited number of messages and the total sum of pending messages is also limited. Each parachain can dispatch
-multiple upward messages per candidate.
+Other kinds of upward messages can be introduced in the future as well. Most likely the HRMP channel managem
 
 ## Horizontal Message Passing
 

--- a/roadmap/implementers-guide/src/messaging.md
+++ b/roadmap/implementers-guide/src/messaging.md
@@ -36,7 +36,9 @@ The weight that processing of the dispatchables can consume is limited by a prec
 that some dispatchables will be left for later blocks. To make the dispatching more fair, the queues are processed turn-by-turn
 in a round robin fashion.
 
-Other kinds of upward messages can be introduced in the future as well. Most likely the HRMP channel management.
+Other kinds of upward messages can be introduced in the future as well. Potential candidates are channel management for
+horizontal message passing (XCMP and HRMP, both are to be described later), new validation code signalling, or other
+requests to the relay chain.
 
 ## Horizontal Message Passing
 

--- a/roadmap/implementers-guide/src/messaging.md
+++ b/roadmap/implementers-guide/src/messaging.md
@@ -37,7 +37,7 @@ that some dispatchables will be left for later blocks. To make the dispatching m
 in a round robin fashion.
 
 Other kinds of upward messages can be introduced in the future as well. Potential candidates are channel management for
-horizontal message passing (XCMP and HRMP, both are to be described later), new validation code signalling, or other
+horizontal message passing (XCMP and HRMP, both are to be described below), new validation code signalling, or other
 requests to the relay chain.
 
 ## Horizontal Message Passing

--- a/roadmap/implementers-guide/src/messaging.md
+++ b/roadmap/implementers-guide/src/messaging.md
@@ -26,10 +26,10 @@ The downward message queue doesn't have a cap on its size and it is up to the re
 that prevent spamming in place.
 
 Upward Message Passing (UMP) is a mechanism responsible for delivering messages in the opposite direction:
-from a parachain up to the relay chain. Upward messagess can serve different purposes and can be of different
+from a parachain up to the relay chain. Upward messages can serve different purposes and can be of different
  kinds.
 
-One kind of messages is `Dispatchable`. They could be thought of similar to extrinsics sent to a relay chain: they also
+One kind of message is `Dispatchable`. They could be thought of similarly to extrinsics sent to a relay chain: they also
 invoke exposed runtime entrypoints, they consume weight and require fees. The difference is that they originate from
 a parachain. Each parachain has a queue of dispatchables to be executed. There can be only so many dispatchables at a time.
 The weight that processing of the dispatchables can consume is limited by a preconfigured value. Therefore, it is possible

--- a/roadmap/implementers-guide/src/runtime/inclusion.md
+++ b/roadmap/implementers-guide/src/runtime/inclusion.md
@@ -68,7 +68,7 @@ All failed checks should lead to an unrecoverable error making the block invalid
   1. Ensure that any code upgrade scheduled by the candidate does not happen within `config.validation_upgrade_frequency` of `Paras::last_code_upgrade(para_id, true)`, if any, comparing against the value of `Paras::FutureCodeUpgrades` for the given para ID.
   1. Check the collator's signature on the candidate data.
   1. check the backing of the candidate using the signatures and the bitfields, comparing against the validators assigned to the groups, fetched with the `group_validators` lookup.
-  1. check that the upward messages, when combined with the existing queue size, are not exceeding `config.max_upward_queue_count` and `config.watermark_upward_queue_size` parameters.
+  1. call `Router::check_upward_messages(para, commitments.upward_messages)` to check that the upward messages are valid.
   1. call `Router::check_processed_downward_messages(para, commitments.processed_downward_messages)` to check that the DMQ is properly drained.
   1. call `Router::check_hrmp_watermark(para, commitments.hrmp_watermark)` for each candidate to check rules of processing the HRMP watermark.
   1. check that in the commitments of each candidate the horizontal messages are sorted by ascending recipient ParaId and there is no two horizontal messages have the same recipient.
@@ -79,7 +79,7 @@ All failed checks should lead to an unrecoverable error making the block invalid
 * `enact_candidate(relay_parent_number: BlockNumber, CommittedCandidateReceipt)`:
   1. If the receipt contains a code upgrade, Call `Paras::schedule_code_upgrade(para_id, code, relay_parent_number + config.validationl_upgrade_delay)`.
     > TODO: Note that this is safe as long as we never enact candidates where the relay parent is across a session boundary. In that case, which we should be careful to avoid with contextual execution, the configuration might have changed and the para may de-sync from the host's understanding of it.
-  1. call `Router::queue_upward_messages` for each backed candidate, using the [`UpwardMessage`s](../types/messages.md#upward-message) from the [`CandidateCommitments`](../types/candidate.md#candidate-commitments).
+  1. call `Router::enact_upward_messages` for each backed candidate, using the [`UpwardMessage`s](../types/messages.md#upward-message) from the [`CandidateCommitments`](../types/candidate.md#candidate-commitments).
   1. call `Router::queue_outbound_hrmp` with the para id of the candidate and the list of horizontal messages taken from the commitment,
   1. call `Router::prune_hrmp` with the para id of the candiate and the candidate's `hrmp_watermark`.
   1. call `Router::prune_dmq` with the para id of the candidate and the candidate's `processed_downward_messages`.

--- a/roadmap/implementers-guide/src/runtime/inclusioninherent.md
+++ b/roadmap/implementers-guide/src/runtime/inclusioninherent.md
@@ -22,4 +22,5 @@ Included: Option<()>,
     1. Invoke `Scheduler::schedule(freed)`
 	1. Invoke the `Inclusion::process_candidates` routine with the parameters `(backed_candidates, Scheduler::scheduled(), Scheduler::group_validators)`.
     1. Call `Scheduler::occupied` using the return value of the `Inclusion::process_candidates` call above, first sorting the list of assigned core indices.
+    1. Call the `Router::process_upward_dispatchables` routine to execute all messages in upward dispatch queues.
     1. If all of the above succeeds, set `Included` to `Some(())`.

--- a/roadmap/implementers-guide/src/runtime/router.md
+++ b/roadmap/implementers-guide/src/runtime/router.md
@@ -10,7 +10,7 @@ Storage layout:
 /// Paras that are to be cleaned up at the end of the session.
 /// The entries are sorted ascending by the para id.
 OutgoingParas: Vec<ParaId>;
-/// Messages ready to be dispatched onto the relay chain. The messages are processed in FIFO order.
+/// Dispatchable objects ready to be dispatched onto the relay chain. The messages are processed in FIFO order.
 /// This is subject to `max_upward_queue_count` and
 /// `watermark_queue_size` from `HostConfiguration`.
 RelayDispatchQueues: map ParaId => Vec<RawDispatchable>;

--- a/roadmap/implementers-guide/src/runtime/router.md
+++ b/roadmap/implementers-guide/src/runtime/router.md
@@ -224,6 +224,8 @@ any of dispatchables return an error.
           1. If `weight_of(D) > config.dispatchable_upward_message_critical_weight` then append `DispatchResult::CriticalWeightExceeded` into `R` for `P`. Otherwise:
             1. Execute `D` and add the actual amount of weight consumed to `T`. Add the `DispatchResult` into `R` for `P`.
       1. If `weight_of(D) + T > config.preferred_dispatchable_upward_messages_step_weight`, set `NextDispatchRoundStartWith` to `P` and finish processing.
+      > NOTE that in practice we would need to approach the weight calculation more thoroughly, i.e. incorporate all operations
+      > that could take place on the course of handling these dispatchables.
       1. If `RelayDispatchQueues` for `P` became empty, remove `P` from `NeedsDispatch`.
       1. If `NeedsDispatch` became empty then finish processing and set `NextDispatchRoundStartWith` to `None`.
   1. Then, for each `P` and the vector of `DispatchResult` in `R`:

--- a/roadmap/implementers-guide/src/runtime/router.md
+++ b/roadmap/implementers-guide/src/runtime/router.md
@@ -162,7 +162,7 @@ The following routines are intended to be invoked by paras' upward messages.
 Candidate Acceptance Function:
 
 * `check_upward_messages(P: ParaId, Vec<UpwardMessage>`:
-  1. Checks that there are at most `config.max_upward_msg_num_per_candidate` messages.
+  1. Checks that there are at most `config.max_upward_message_num_per_candidate` messages.
   1. Checks each upward message individually depending on its kind:
   1. If the message kind is `Dispatchable`:
       1. Verify that `RelayDispatchQueueSize` for `P` has enough capacity for the message (NOTE that should include all processed

--- a/roadmap/implementers-guide/src/runtime/router.md
+++ b/roadmap/implementers-guide/src/runtime/router.md
@@ -239,7 +239,6 @@ any of dispatchables return an error.
   1. Remove `P` if it exists in `NeedsDispatch`.
   1. If `P` is in `NextDispatchRoundStartWith`, then reset it to `None`
   - Note that we don't remove the open/close requests since they are gon die out naturally.
-TODO: What happens with the deposits in channels or open requests?
 1. For each request `R` in `HrmpOpenChannelRequests`:
     1. if `R.confirmed = false`:
         1. increment `R.age` by 1.
@@ -265,7 +264,3 @@ To remove a channel `C` identified with a tuple `(sender, recipient)`:
 1. Remove `C` from `HrmpChannelContents`.
 1. Remove `recipient` from the set `HrmpEgressChannelsIndex` for `sender`.
 1. Remove `sender` from the set `HrmpIngressChannelsIndex` for `recipient`.
-
-## Finalization
-
-  1. Dispatch queued upward messages from `RelayDispatchQueues` in a FIFO order applying the `config.max_upward_queue_size` and `config.max_upward_queue_count` limits.

--- a/roadmap/implementers-guide/src/runtime/router.md
+++ b/roadmap/implementers-guide/src/runtime/router.md
@@ -224,7 +224,7 @@ any of dispatchables return an error.
       1. If `weight_of(D) + T > config.max_parachain_ump_dispatch_weight`, set `NextDispatchRoundStartWith` to `P` and finish processing.
       1. Dequeue `D`
       1. Decrement the size of the message from `RelayDispatchQueueSize` for `P`
-      1. In case `D` doesn't deserialize as a proper call - drop it (this can happen if an upgrade took place after the acceptance check)
+      1. In case `D` doesn't deserialize as a proper entrypoint - drop it (this can happen if an upgrade took place after the acceptance check)
       1. Execute `D` and add the actual amount of weight consumed to `T`.
       1. If `RelayDispatchQueues` for `P` became empty, remove `P` from `NeedsDispatch`. If `NeedsDispatch` became empty then finish processing.
 

--- a/roadmap/implementers-guide/src/types/messages.md
+++ b/roadmap/implementers-guide/src/types/messages.md
@@ -22,14 +22,20 @@ enum ParachainDispatchOrigin {
 	Root,
 }
 
+/// An opaque byte buffer that encodes an entrypoint and the arguments that should be
+/// provided to it upon the dispatch.
+///
+/// NOTE In order to be executable the byte buffer should be decoded which potentially can fail if
+/// the encoding was changed.
+type RawDispatchable = Vec<u8>;
+
 enum UpwardMessage {
-	/// This upward message is meant to be dispatched to the entrypoint specified.
+	/// This upward message is meant to schedule execution of a provided dispatchable.
 	Dispatchable {
-		/// The origin for the message to be sent from.
+		/// The origin with which the dispatchable should be executed.
 		origin: ParachainDispatchOrigin,
-		/// An opaque byte buffer that encodes an enrtypoint and the arguments that should be
-		/// provided to it upon the dispatch.
-		data: Vec<u8>,
+		/// The dispatchable to be executed in its raw form.
+		dispatchable: RawDispatchable,
 	},
 	// Examples:
 	// HrmpOpenChannel { .. },
@@ -64,7 +70,19 @@ A message that go down from the relay chain to a parachain. Such a message could
 as a result of an operation took place on the relay chain.
 
 ```rust,ignore
+enum DispatchResult {
+	Executed {
+		success: bool,
+	},
+	/// Decoding `RawDispatchable` into an executable runtime representation has failed.
+	DecodeFailed,
+	CriticalWeightExceeded,
+}
+
 enum DownwardMessage {
+	/// The parachain receives a dispatch result for each sent dispatchable upward message in order
+	/// they were sent.
+	DispatchResult(Vec<DispatchResult>),
 	/// Some funds were transferred into the parachain's account. The hash is the identifier that
 	/// was given with the transfer.
 	TransferInto(AccountId, Balance, Remark),

--- a/roadmap/implementers-guide/src/types/messages.md
+++ b/roadmap/implementers-guide/src/types/messages.md
@@ -66,8 +66,9 @@ struct InboundHrmpMessage {
 
 ## Downward Message
 
-A message that go down from the relay chain to a parachain. Such a message could be initiated either
-as a result of an operation took place on the relay chain.
+`DownwardMessage`- is a message that go down from the relay chain to a parachain. Such a message
+could be seen as a notification, however, it is concievable that they might be used by the relay
+chain to send a request to the parachain (likely, through the `ParachainSpecific` variant).
 
 ```rust,ignore
 enum DispatchResult {

--- a/roadmap/implementers-guide/src/types/messages.md
+++ b/roadmap/implementers-guide/src/types/messages.md
@@ -76,6 +76,7 @@ enum DispatchResult {
 	},
 	/// Decoding `RawDispatchable` into an executable runtime representation has failed.
 	DecodeFailed,
+	/// A dispatchable in question exceeded the maximum amount of weight allowed.
 	CriticalWeightExceeded,
 }
 

--- a/roadmap/implementers-guide/src/types/messages.md
+++ b/roadmap/implementers-guide/src/types/messages.md
@@ -22,11 +22,17 @@ enum ParachainDispatchOrigin {
 	Root,
 }
 
-struct UpwardMessage {
-	/// The origin for the message to be sent from.
-	pub origin: ParachainDispatchOrigin,
-	/// The message data.
-	pub data: Vec<u8>,
+enum UpwardMessage {
+	/// This upward message is meant to be dispatched to the entrypoint specified.
+	Dispatchable {
+		/// The origin for the message to be sent from.
+		origin: ParachainDispatchOrigin,
+		/// An opaque byte buffer that encodes an enrtypoint and the arguments that should be
+		/// provided to it upon the dispatch.
+		data: Vec<u8>,
+	},
+	/// HrmpOpenChannel { .. },
+	/// HrmpCloseChannel { .. },
 }
 ```
 

--- a/roadmap/implementers-guide/src/types/messages.md
+++ b/roadmap/implementers-guide/src/types/messages.md
@@ -31,8 +31,9 @@ enum UpwardMessage {
 		/// provided to it upon the dispatch.
 		data: Vec<u8>,
 	},
-	/// HrmpOpenChannel { .. },
-	/// HrmpCloseChannel { .. },
+	// Examples:
+	// HrmpOpenChannel { .. },
+	// HrmpCloseChannel { .. },
 }
 ```
 

--- a/roadmap/implementers-guide/src/types/messages.md
+++ b/roadmap/implementers-guide/src/types/messages.md
@@ -66,8 +66,8 @@ struct InboundHrmpMessage {
 
 ## Downward Message
 
-`DownwardMessage`- is a message that go down from the relay chain to a parachain. Such a message
-could be seen as a notification, however, it is concievable that they might be used by the relay
+`DownwardMessage`- is a message that goes down from the relay chain to a parachain. Such a message
+could be seen as a notification, however, it is conceivable that they might be used by the relay
 chain to send a request to the parachain (likely, through the `ParachainSpecific` variant).
 
 ```rust,ignore

--- a/roadmap/implementers-guide/src/types/runtime.md
+++ b/roadmap/implementers-guide/src/types/runtime.md
@@ -40,9 +40,20 @@ struct HostConfiguration {
 	/// no further messages may be added to it. If it exceeds this then the queue may contain only
 	/// a single message.
 	pub max_upward_queue_size: u32,
-	/// Maximum amount of weight that we wish to devote on processing of the dispatchable upward
-	/// messages.
-	pub max_parachain_ump_dispatch_weight: u32,
+	/// The amount of weight we wish to devote to the processing the dispatchable upward messages
+	/// stage.
+	///
+	/// NOTE that this is a soft limit and could be exceeded.
+	pub preferred_dispatchable_upward_messages_step_weight: u32,
+	/// Any dispatchable upward message that requests more than the critical amount is rejected
+	/// with `DispatchResult::CriticalWeightExceeded`.
+	///
+	/// The parameter value is picked up so that no dispatchable can make the block weight exceed
+	/// the total budget. I.e. that the sum of `preferred_dispatchable_upward_messages_step_weight`
+	/// and `dispatchable_upward_message_critical_weight` doesn't exceed the amount of weight left
+	/// under a typical worst case (e.g. no upgrades, etc) weight consumed by the required phases of
+	/// block execution (i.e. initialization, finalization and inherents).
+	pub dispatchable_upward_message_critical_weight: u32,
 	/// The maximum number of messages that a candidate can contain.
 	pub max_upward_msg_num_per_candidate: u32,
 	/// Number of sessions after which an HRMP open channel request expires.

--- a/roadmap/implementers-guide/src/types/runtime.md
+++ b/roadmap/implementers-guide/src/types/runtime.md
@@ -39,7 +39,12 @@ struct HostConfiguration {
 	/// Total size of messages allowed in the parachain -> relay-chain message queue before which
 	/// no further messages may be added to it. If it exceeds this then the queue may contain only
 	/// a single message.
-	pub watermark_upward_queue_size: u32,
+	pub max_upward_queue_size: u32,
+	/// Maximum amount of weight that we wish to devote on processing of the dispatchable upward
+    /// messages.
+	pub max_parachain_ump_dispatch_weight: u32,
+	/// The maximum number of messages that a candidate can contain.
+    pub max_upward_msg_num_per_candidate: u32,
 	/// Number of sessions after which an HRMP open channel request expires.
 	pub hrmp_open_request_ttl: u32,
 	/// The deposit that the sender should provide for opening an HRMP channel.

--- a/roadmap/implementers-guide/src/types/runtime.md
+++ b/roadmap/implementers-guide/src/types/runtime.md
@@ -55,7 +55,7 @@ struct HostConfiguration {
 	/// block execution (i.e. initialization, finalization and inherents).
 	pub dispatchable_upward_message_critical_weight: u32,
 	/// The maximum number of messages that a candidate can contain.
-	pub max_upward_msg_num_per_candidate: u32,
+	pub max_upward_message_num_per_candidate: u32,
 	/// Number of sessions after which an HRMP open channel request expires.
 	pub hrmp_open_request_ttl: u32,
 	/// The deposit that the sender should provide for opening an HRMP channel.

--- a/roadmap/implementers-guide/src/types/runtime.md
+++ b/roadmap/implementers-guide/src/types/runtime.md
@@ -41,10 +41,10 @@ struct HostConfiguration {
 	/// a single message.
 	pub max_upward_queue_size: u32,
 	/// Maximum amount of weight that we wish to devote on processing of the dispatchable upward
-    /// messages.
+	/// messages.
 	pub max_parachain_ump_dispatch_weight: u32,
 	/// The maximum number of messages that a candidate can contain.
-    pub max_upward_msg_num_per_candidate: u32,
+	pub max_upward_msg_num_per_candidate: u32,
 	/// Number of sessions after which an HRMP open channel request expires.
 	pub hrmp_open_request_ttl: u32,
 	/// The deposit that the sender should provide for opening an HRMP channel.


### PR DESCRIPTION
Closes #1534 

This PR changes the way how we process the upward messages.

### Upward Message Kind

Upward messages are split to different kinds, with `Dispatchable` being only one of them. The upside is that the unlike plain opaque dispatchables, explicit message kinds allows us to impose some validity criteria upon the upward messages. E.g. we can reject candidates that we know will fail upfront.

However, we only introduce the scaffolding for different upward message kinds without actually introducing any new.

### Weight

Then, in the current construction the weight consumed by messages is not limited. In the proposed changes, each upward message of dispatchable kind consumes some predefined weight and the total weight consumed during dispatching messages is limited, leaving a guaranteed amount of weight to other extrinsics. 

This proposal doesn't yet address charging fees for the weight.

### Round-robin dispatching

Since it can happen that some messages won't fit in the weight budget devoted for a block, we need to fairly distribute the weight among the pending dispatchables.

To address this, we go over all queues in a round robin fashion dequeuing a message each time. When we reach the weight budget for executing dispatchables or there are none left we finish processing. There can be multiple iterations. If any unused weight left it can be leveraged by signed extrinsics.

### Dispatch order

The current construction dispatches messages during finalization. The proposed construction moves this processing to be just right at the end of inclusion inherent giving the dispatchables an advantage over the regular signed extrinsics. That alleviates the front-running the parachain upward messages by the validators to some degree.

Optionally, perhaps we can add another round of dispatching during the finalization stage to leverage unused weight, but that would worsen the property against front-running