### PR TITLE
Support `build-spec` for other chains than Polkadot

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -59,6 +59,10 @@ pub struct RunCmd {
 	#[structopt(long = "force-westend")]
 	pub force_westend: bool,
 
+	/// Force using Rococo native runtime.
+	#[structopt(long = "force-westend")]
+	pub force_rococo: bool,
+
 	/// Enable the authority discovery module on validator or sentry nodes.
 	///
 	/// When enabled:

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -60,7 +60,7 @@ pub struct RunCmd {
 	pub force_westend: bool,
 
 	/// Force using Rococo native runtime.
-	#[structopt(long = "force-westend")]
+	#[structopt(long)]
 	pub force_rococo: bool,
 
 	/// Enable the authority discovery module on validator or sentry nodes.

--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -78,13 +78,13 @@ impl SubstrateCli for Cli {
 				// When `force_*` is given or the file name starts with the name of one of the known chains,
 				// we use the chain spec for the specific chain.
 				if self.run.force_rococo || starts_with("rococo") {
-					Box::new(service::RococoChainSpec::from_json_file(std::path::PathBuf::from(path))?)
+					Box::new(service::RococoChainSpec::from_json_file(path)?)
 				} else if self.run.force_kusama || starts_with("kusama") {
-					Box::new(service::KusamaChainSpec::from_json_file(std::path::PathBuf::from(path))?)
+					Box::new(service::KusamaChainSpec::from_json_file(path)?)
 				} else if self.run.force_westend || starts_with("westend") {
-					Box::new(service::WestendChainSpec::from_json_file(std::path::PathBuf::from(path))?)
+					Box::new(service::WestendChainSpec::from_json_file(path)?)
 				} else {
-					Box::new(service::PolkadotChainSpec::from_json_file(std::path::PathBuf::from(path))?)
+					Box::new(service::PolkadotChainSpec::from_json_file(path)?)
 				}
 			},
 		})

--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -68,13 +68,25 @@ impl SubstrateCli for Cli {
 			"rococo-staging" => Box::new(service::chain_spec::rococo_staging_testnet_config()?),
 			"rococo-local" => Box::new(service::chain_spec::rococo_local_testnet_config()?),
 			"rococo" => Box::new(service::chain_spec::rococo_config()?),
-			path if self.run.force_kusama => {
-				Box::new(service::KusamaChainSpec::from_json_file(std::path::PathBuf::from(path))?)
+			path => {
+				let path = std::path::PathBuf::from(path);
+
+				let starts_with = |prefix: &str| {
+					path.file_name().map(|f| f.to_str().map(|s| s.starts_with(&prefix))).flatten().unwrap_or(false)
+				};
+
+				// When `force_*` is given or the file name starts with the name of one of the known chains,
+				// we use the chain spec for the specific chain.
+				if self.run.force_rococo || starts_with("rococo") {
+					Box::new(service::RococoChainSpec::from_json_file(std::path::PathBuf::from(path))?)
+				} else if self.run.force_kusama || starts_with("kusama") {
+					Box::new(service::KusamaChainSpec::from_json_file(std::path::PathBuf::from(path))?)
+				} else if self.run.force_westend || starts_with("westend") {
+					Box::new(service::WestendChainSpec::from_json_file(std::path::PathBuf::from(path))?)
+				} else {
+					Box::new(service::PolkadotChainSpec::from_json_file(std::path::PathBuf::from(path))?)
+				}
 			},
-			path if self.run.force_westend => {
-				Box::new(service::WestendChainSpec::from_json_file(std::path::PathBuf::from(path))?)
-			},
-			path => Box::new(service::PolkadotChainSpec::from_json_file(std::path::PathBuf::from(path))?),
 		})
 	}
 
@@ -83,6 +95,8 @@ impl SubstrateCli for Cli {
 			&service::kusama_runtime::VERSION
 		} else if spec.is_westend() {
 			&service::westend_runtime::VERSION
+		} else if spec.is_rococo() {
+			&service::rococo_runtime::VERSION
 		} else {
 			&service::polkadot_runtime::VERSION
 		}

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -25,11 +25,12 @@ use std::time::Duration;
 use polkadot_primitives::v0::{self as parachain, Hash, BlockId};
 #[cfg(feature = "full-node")]
 use polkadot_network::{legacy::gossip::Known, protocol as network_protocol};
-use service::{error::Error as ServiceError};
+use service::error::Error as ServiceError;
 use grandpa::{self, FinalityProofProvider as GrandpaFinalityProofProvider};
 use sc_executor::native_executor_instance;
 use log::info;
 use sp_trie::PrefixedMemoryDB;
+use prometheus_endpoint::Registry;
 pub use service::{
 	Role, PruningMode, TransactionPoolOptions, Error, RuntimeGenesis, RpcHandlers,
 	TFullClient, TLightClient, TFullBackend, TLightBackend, TFullCallExecutor, TLightCallExecutor,
@@ -44,14 +45,14 @@ pub use sp_runtime::traits::{HashFor, NumberFor};
 pub use consensus_common::{SelectChain, BlockImport, block_validation::Chain};
 pub use polkadot_primitives::v0::{Block, CollatorId, ParachainHost};
 pub use sp_runtime::traits::{Block as BlockT, self as runtime_traits, BlakeTwo256};
-pub use chain_spec::{PolkadotChainSpec, KusamaChainSpec, WestendChainSpec};
+pub use chain_spec::{PolkadotChainSpec, KusamaChainSpec, WestendChainSpec, RococoChainSpec};
 #[cfg(feature = "full-node")]
 pub use consensus::run_validation_worker;
 pub use codec::Codec;
 pub use polkadot_runtime;
 pub use kusama_runtime;
 pub use westend_runtime;
-use prometheus_endpoint::Registry;
+pub use rococo_runtime;
 pub use self::client::*;
 
 native_executor_instance!(
@@ -364,7 +365,7 @@ pub fn new_full<RuntimeApi, Executor>(
 	let polkadot_network_service = network_protocol::start(
 		network.clone(),
 		network_protocol::Config {
-			collating_for: collating_for,
+			collating_for,
 		},
 		(is_known, client.clone()),
 		client.clone(),


### PR DESCRIPTION
The problem when building a chain specification is that you require the
native runtime to parse the json file (assuming the chain spec is not
raw yet). Before this pr we could only overwrite the native runtime when
running the node using `force_*`. This pr now adds support to load the
native runtime when the filename starts with the name of the chain. So,
when usng `build-spec --chain rococo-something-else.jon` it will use the
rococo native runtime to load the chain spec.

Fixes: https://github.com/paritytech/polkadot/issues/1565