### PR TITLE
Move Claim to Existed Address

### DIFF
--- a/runtime/common/src/claims.rs
+++ b/runtime/common/src/claims.rs
@@ -204,11 +204,10 @@ decl_module! {
 		fn deposit_event() = default;
 
 		fn on_runtime_upgrade() -> frame_support::weights::Weight {
-			use frame_support::migrations::*;
+			use frame_support::migration::*;
 
 			let total = <StorageIterator<BalanceOf<T>>>::new(b"Claims", b"Claims")
-				.iter()
-				.fold(0.into(), |acc, x| acc + x);
+				.fold(BalanceOf::<T>::zero(), |acc, (_, x)| acc + x);
 
 			put_storage_value(b"Claims", b"Total", &[], total);
 

--- a/runtime/common/src/claims.rs
+++ b/runtime/common/src/claims.rs
@@ -406,7 +406,7 @@ decl_module! {
 		}
 
 		#[weight = (
-			T::DbWeight::get().reads_writes(4, 4) + 100_000_000_000,
+			T::DbWeight::get().reads_writes(4, 5) + 100_000_000_000,
 			DispatchClass::Normal,
 			Pays::No
 		)]

--- a/runtime/common/src/claims.rs
+++ b/runtime/common/src/claims.rs
@@ -203,6 +203,18 @@ decl_module! {
 		/// Deposit one of this module's events by using the default implementation.
 		fn deposit_event() = default;
 
+		fn on_runtime_upgrade() -> frame_support::weights::Weight {
+			use frame_support::migrations::*;
+
+			let total = <StorageIterator<BalanceOf<T>>>::new(b"Claims", b"Claims")
+				.iter()
+				.fold(0.into(), |acc, x| acc + x);
+
+			put_storage_value(b"Claims", b"Total", &[], total);
+
+			0
+		}
+
 		/// Make a claim to collect your DOTs.
 		///
 		/// The dispatch origin for this call must be _None_.


### PR DESCRIPTION
If we move claim to some existed address, we should also update the `Total`.

Due to the statement, I can't accumulate two addresses' claims. So I decide to overwrite the target address's claim.

And here's another solution: 

```rust
ensure!(Self::claims(address).is_none(), "Can NOT Move Claim to an EXISTED Address");
```

---

- [ ] I set the `on_runtime_upgrade`'s weight to `0`, I don't know how to deal with it.