### PR TITLE
[CI] Add github token to generate-release-text

### DIFF
--- a/.github/workflows/publish-draft-release.yml
+++ b/.github/workflows/publish-draft-release.yml
@@ -85,6 +85,7 @@ jobs:
       env:
         RUSTC_STABLE: ${{ needs.get-rust-versions.outputs.rustc-stable }}
         RUSTC_NIGHTLY: ${{ needs.get-rust-versions.outputs.rustc-nightly }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         gem install changelogerator git toml
         ruby $GITHUB_WORKSPACE/polkadot/scripts/github/generate_release_text.rb | tee release_text.md


### PR DESCRIPTION
Without giving `GITHUB_TOKEN` to the generate-release-text job we were running out of free github API calls on releases with lots of changes.