### PR TITLE
Implementer's Guide: Promote `HrmpChannelId` and supply more docs

### DIFF
--- a/roadmap/implementers-guide/src/runtime/router.md
+++ b/roadmap/implementers-guide/src/runtime/router.md
@@ -32,12 +32,6 @@ DownwardMessageQueues: map ParaId => Vec<DownwardMessage>;
 HRMP related structs:
 
 ```rust,ignore
-/// A type used to designate a HRMP channel between a (sender, recipient).
-struct HrmpChannelId {
-    sender: ParaId,
-    recipient: ParaId,
-}
-
 /// A description of a request to open an HRMP channel.
 struct HrmpOpenChannelRequest {
     /// The sender and the initiator of this request.

--- a/roadmap/implementers-guide/src/types/messages.md
+++ b/roadmap/implementers-guide/src/types/messages.md
@@ -5,6 +5,22 @@ Types of messages that are passed between parachains and the relay chain: UMP, D
 There is also HRMP (Horizontally Relay-routed Message Passing) which provides the same functionality
 although with smaller scalability potential.
 
+## HrmpChannelId
+
+A type that uniquely identifies a HRMP channel. A HRMP channel is established between two paras.
+In text, we use the notation `(A, B)` to specify a channel between A and B. The channels are
+unidirectional, meaning that `(A, B)` and `(B, A)` refer to different channels. The convention is
+that we use the first item tuple for the sender and the second for the recipient. Only one channel
+is allowed between two participants in one direction, i.e. there cannot be 2 different channels
+identified by `(A, B)`.
+
+```rust,ignore
+struct HrmpChannelId {
+    sender: ParaId,
+    recipient: ParaId,
+}
+```
+
 ## Upward Message
 
 A type of messages dispatched from a parachain to the relay chain.


### PR DESCRIPTION
A small one, I believe insubstantial.

Expands the documentation of channel.