### PR TITLE
Update Kusama Council seats & Runners Up number

### DIFF
--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -424,8 +424,8 @@ parameter_types! {
 	pub const VotingBond: Balance = 5 * CENTS;
 	/// Daily council elections.
 	pub const TermDuration: BlockNumber = 24 * HOURS;
-	pub const DesiredMembers: u32 = 17;
-	pub const DesiredRunnersUp: u32 = 7;
+	pub const DesiredMembers: u32 = 19;
+	pub const DesiredRunnersUp: u32 = 19;
 	pub const ElectionsPhragmenModuleId: LockIdentifier = *b"phrelect";
 }
 // Make sure that there are no more than MAX_MEMBERS members elected via phragmen.


### PR DESCRIPTION
Update Kusama council seats to 19 and `DesiredRunnersUp` to 19 as well, increasing representation of passive stakeholders in the council and giving more visibility to runners up in Kusama Network (from 7 to 19): this will be more visibility to new candidates passing the threshold to expand options for stakeholders when voting.