### PR TITLE
Fix EnsureOrigin trait impl

### DIFF
--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -682,6 +682,7 @@ impl EnsureOrigin<Origin> for PriviledgedOrigin {
 		}
 	}
 
+	#[cfg(feature = "runtime-benchmarks")]
 	fn successful_origin() -> OuterOrigin { Origin::root() }
 }
 


### PR DESCRIPTION
Adds benchmarks feature to fix trait implementation in Rococo.