### PR TITLE
Implementer's Guide: Integrate DMP into PersistentValidationData + DMQ watermarks

### DIFF
--- a/roadmap/implementers-guide/src/runtime/inclusion.md
+++ b/roadmap/implementers-guide/src/runtime/inclusion.md
@@ -69,7 +69,7 @@ All failed checks should lead to an unrecoverable error making the block invalid
   1. Check the collator's signature on the candidate data.
   1. check the backing of the candidate using the signatures and the bitfields, comparing against the validators assigned to the groups, fetched with the `group_validators` lookup.
   1. call `Router::check_upward_messages(para, commitments.upward_messages)` to check that the upward messages are valid.
-  1. call `Router::check_processed_downward_messages(para, commitments.processed_downward_messages)` to check that the DMQ is properly drained.
+  1. call `Router::check_dmq_watermark(para, commitments.dmq_watermark)` for each canddiate to check rules of processing the DMQ watermark.
   1. call `Router::check_hrmp_watermark(para, commitments.hrmp_watermark)` for each candidate to check rules of processing the HRMP watermark.
   1. check that in the commitments of each candidate the horizontal messages are sorted by ascending recipient ParaId and there is no two horizontal messages have the same recipient.
   1. using `Router::verify_outbound_hrmp(sender, commitments.horizontal_messages)` ensure that the each candidate send a valid set of horizontal messages
@@ -82,7 +82,7 @@ All failed checks should lead to an unrecoverable error making the block invalid
   1. call `Router::enact_upward_messages` for each backed candidate, using the [`UpwardMessage`s](../types/messages.md#upward-message) from the [`CandidateCommitments`](../types/candidate.md#candidate-commitments).
   1. call `Router::queue_outbound_hrmp` with the para id of the candidate and the list of horizontal messages taken from the commitment,
   1. call `Router::prune_hrmp` with the para id of the candiate and the candidate's `hrmp_watermark`.
-  1. call `Router::prune_dmq` with the para id of the candidate and the candidate's `processed_downward_messages`.
+  1. call `Router::prune_dmq` with the para id of the candidate and the candidate's `dmq_watermark`.
   1. Call `Paras::note_new_head` using the `HeadData` from the receipt and `relay_parent_number`.
 * `collect_pending`:
 

--- a/roadmap/implementers-guide/src/runtime/inclusion.md
+++ b/roadmap/implementers-guide/src/runtime/inclusion.md
@@ -69,7 +69,7 @@ All failed checks should lead to an unrecoverable error making the block invalid
   1. Check the collator's signature on the candidate data.
   1. check the backing of the candidate using the signatures and the bitfields, comparing against the validators assigned to the groups, fetched with the `group_validators` lookup.
   1. call `Router::check_upward_messages(para, commitments.upward_messages)` to check that the upward messages are valid.
-  1. call `Router::check_dmq_watermark(para, commitments.dmq_watermark)` for each canddiate to check rules of processing the DMQ watermark.
+  1. call `Router::check_dmq_watermark(para, commitments.dmq_watermark)` for each candidate to check rules of processing the DMQ watermark.
   1. call `Router::check_hrmp_watermark(para, commitments.hrmp_watermark)` for each candidate to check rules of processing the HRMP watermark.
   1. check that in the commitments of each candidate the horizontal messages are sorted by ascending recipient ParaId and there is no two horizontal messages have the same recipient.
   1. using `Router::verify_outbound_hrmp(sender, commitments.horizontal_messages)` ensure that the each candidate send a valid set of horizontal messages

--- a/roadmap/implementers-guide/src/runtime/router.md
+++ b/roadmap/implementers-guide/src/runtime/router.md
@@ -25,7 +25,7 @@ NeedsDispatch: Vec<ParaId>;
 NextDispatchRoundStartWith: Option<ParaId>;
 ```
 
-### DMP
+### Downward Message Passing (DMP)
 
 Storage layout required for implementation of DMP.
 

--- a/roadmap/implementers-guide/src/runtime/router.md
+++ b/roadmap/implementers-guide/src/runtime/router.md
@@ -204,6 +204,7 @@ Candidate Enactment:
   1. Set `HrmpWatermarks` for `P` to be equal to `new_hrmp_watermark`
 * `prune_dmq(P: ParaId, new_dmq_watermark)`:
   1. Remove all messages in `DownwardMessageQueues` for `P` up to (including) a message with `sent_at` equal to `new_dmq_watermark`.
+  1. Remove all block numbers up to (including) `new_dmq_watermark` in `DownwardMessagesDigest` for `P`
 * `enact_upward_messages(P: ParaId, Vec<UpwardMessage>)`:
   1. Process all upward messages in order depending on their kinds:
   1. If the message kind is `Dispatchable`:

--- a/roadmap/implementers-guide/src/types/candidate.md
+++ b/roadmap/implementers-guide/src/types/candidate.md
@@ -173,7 +173,7 @@ struct TransientValidationData {
 	/// This informs a relay-chain backing check and the parachain logic.
 	code_upgrade_allowed: Option<BlockNumber>,
 	/// A copy of `config.max_upward_message_num_per_candidate` for checking that a candidate doesn't
-	/// send more messages that permitted.
+	/// send more messages than permitted.
 	config_max_upward_message_num_per_candidate: u32,
 	/// A vector that enumerates the list of blocks in which there was at least one DMQ messages
 	/// enqueued.

--- a/roadmap/implementers-guide/src/types/candidate.md
+++ b/roadmap/implementers-guide/src/types/candidate.md
@@ -181,7 +181,7 @@ struct TransientValidationData {
 	/// The first number in the vector, if any, is always greater than the DMQ watermark. The
 	/// elements are ordered by ascending the block number. The vector doesn't contain duplicates.
 	dmq_digest: Vec<BlockNumber>,
-	/// A part of transient validaiton data related to HRMP.
+	/// A part of transient validation data related to HRMP.
 	hrmp: HrmpTransientValidationData,
 }
 

--- a/roadmap/implementers-guide/src/types/candidate.md
+++ b/roadmap/implementers-guide/src/types/candidate.md
@@ -129,9 +129,14 @@ struct PersistedValidationData {
 	/// vector is sorted ascending by the para id and doesn't contain multiple entries with the same
 	/// sender.
 	///
-	/// The MQC heads will be used by the validation function to authorize the input messages passed
+	/// The HRMP MQC heads will be used by the validation function to authorize the input messages passed
 	/// by the collator.
 	hrmp_mqc_heads: Vec<(ParaId, Hash)>,
+	/// The MQC head for the DMQ.
+	///
+	/// The DMQ MQC head will be used by the validation fnction to authorize the downward messages
+	/// passed by the collator.
+	dmq_mqc_head: Hash,
 }
 ```
 
@@ -170,9 +175,13 @@ struct TransientValidationData {
 	/// A copy of `config.max_upward_message_num_per_candidate` for checking that a candidate doesn't
 	/// send more messages that permitted.
 	config_max_upward_message_num_per_candidate: u32,
-	/// The number of messages pending of the downward message queue.
-	dmq_length: u32,
-	/// A part of transient validation data related to HRMP.
+	/// A vector that enumerates the list of blocks in which there was at least one DMQ messages
+	/// enqueued.
+	///
+	/// The first number in the vector, if any, is always greater than the DMQ watermark. The
+	/// elements are ordered by ascending the block number. The vector doesn't contain duplicates.
+	dmq_digest: Vec<BlockNumber>,
+	/// A part of transient validaiton data related to HRMP.
 	hrmp: HrmpTransientValidationData,
 }
 
@@ -246,8 +255,8 @@ struct CandidateCommitments {
 	new_validation_code: Option<ValidationCode>,
 	/// The head-data produced as a result of execution.
 	head_data: HeadData,
-	/// The number of messages processed from the DMQ.
-	processed_downward_messages: u32,
+	/// The mark which specifies the block number up to which all inbound DMP messages are processed.
+	dmq_watermark: BlockNumber,
 	/// The mark which specifies the block number up to which all inbound HRMP messages are processed.
 	hrmp_watermark: BlockNumber,
 }
@@ -284,8 +293,8 @@ struct ValidationOutputs {
 	fees: Balance,
 	/// The new validation code submitted by the execution, if any.
 	new_validation_code: Option<ValidationCode>,
-	/// The number of messages processed from the DMQ.
-	processed_downward_messages: u32,
+	/// The mark which specifies the block number up to which all inbound DMP messages are processed.
+	dmq_watermark: BlockNumber,
 	/// The mark which specifies the block number up to which all inbound HRMP messages are processed.
 	hrmp_watermark: BlockNumber,
 }

--- a/roadmap/implementers-guide/src/types/messages.md
+++ b/roadmap/implementers-guide/src/types/messages.md
@@ -90,6 +90,9 @@ struct OutboundHrmpMessage {
 }
 
 struct InboundHrmpMessage {
+	/// The block number at which this message was sent.
+	/// Specifically, it is the block number at which the candidate that sends this message was
+	/// enacted.
 	pub sent_at: BlockNumber,
 	/// The message payload.
 	pub data: Vec<u8>,
@@ -124,5 +127,14 @@ enum DownwardMessage {
 	/// to be used as a basis for special protocols between the relay chain and, typically system,
 	/// paras.
 	ParachainSpecific(Vec<u8>),
+}
+
+/// A wrapped version of `DownwardMessage`. The difference is that it has attached the block number when
+/// the message was sent.
+struct InboundDownwardMessage {
+	/// The block number at which this messages was put into the downward message queue.
+	pub sent_at: BlockNumber,
+	/// The actual downward message to processes.
+	pub msg: DownwardMessage,
 }
 ```


### PR DESCRIPTION
Based on top of https://github.com/paritytech/polkadot/pull/1588
Closes #1643 

### Summary

- Main theme of this PR is integration of DMP into the `PersistentValidationData` ("ground truth") through a DMQ MQC head.
- Introduce DMQ watermarks

This PR is accompanied by some drive-by wording fixes here and there.

### Description

I decided to take the approach of putting only the MQC head into `PersistentValidationData` to allow the authorization of the messages that a collator provides while building a parablock. 

<details>
<summary>Background</summary>
The alternative is to put the DMQ contents, all messages, into `PersistentValidationData`. We need to put all messages in because `PersistentValidationData` is used to form the inputs and is collected before the execution of the PVF.
Putting only data to authorize the sequence of messages into `PersistentValidationData` allows the collator to include the messages that were actually consumed into the PoV.

All in all, this should positively affect the amount of data made available.
</details>

While working on it I realized that it might be useful to supply the block number in which a particular downward message was put in the DMQ. That also makes it similar to HRMP/XCMP MQC which may be good from the implementation standpoint.

It seemed to me that it would be harder for the PVF to return `processed_downward_messages` and trying to keep track of the on-the-relay-chain state of DMQ rather than dealing with watermarks. So, i finally introduced **DMQ watermarks**. They cost a bit more, since we need to keep track the digest (the list of all blocks where the DMP messages were sent to correctly check the DMQ watermark)

Those DMQ watermarks, however, are still different from HRMP watermarks. I am still not confident about merging them.

### What to look for

Here are some clues how to approach this PR

- The `TransientValidationData` has all data to check if the resulting candidate passes the acceptance criteria (by collator or primary checker)
- The acceptance criteria establishes sensible invariants
    - That the enactment function can rely on
    - Won't change in between backing and the enactment
- Unused data is properly cleaned and doesn't pile up
- Among other things from areas of safety, consistency, etc