### PR TITLE
Enable CI to build rococo

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -54,11 +54,10 @@ variables:
 
 .build-refs:                       &build-refs
   only:
-    #    - master
-    #    - schedules
-    #    - web
-    - rococo-branch
-      #    - /^v[0-9]+\.[0-9]+.*$/        # i.e. v1.0, v2.1rc1
+    - master
+    - schedules
+    - web
+    - /^v[0-9]+\.[0-9]+.*$/        # i.e. v1.0, v2.1rc1
 
 .test-refs:                        &test-refs
   only:
@@ -194,6 +193,9 @@ build-linux-release:               &build
     - echo -n ${EXTRATAG} > ./artifacts/EXTRATAG
     - cp -r scripts/docker/* ./artifacts
     - sccache -s
+  # only for rococo for this branch
+  only:
+    - rococo-branch
 
 
 generate-impl-guide:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -57,6 +57,7 @@ variables:
     - master
     - schedules
     - web
+    - rococo-branch
     - /^v[0-9]+\.[0-9]+.*$/        # i.e. v1.0, v2.1rc1
 
 .test-refs:                        &test-refs

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -54,11 +54,11 @@ variables:
 
 .build-refs:                       &build-refs
   only:
-    - master
-    - schedules
-    - web
+    #    - master
+    #    - schedules
+    #    - web
     - rococo-branch
-    - /^v[0-9]+\.[0-9]+.*$/        # i.e. v1.0, v2.1rc1
+      #    - /^v[0-9]+\.[0-9]+.*$/        # i.e. v1.0, v2.1rc1
 
 .test-refs:                        &test-refs
   only:

--- a/cli/src/browser.rs
+++ b/cli/src/browser.rs
@@ -46,8 +46,7 @@ async fn start_inner(chain_spec: String, log_level: String) -> Result<Client, Bo
 	info!("👤 Role: {}", config.display_role());
 
 	// Create the service. This is the most heavy initialization step.
-	let builder = service::NodeBuilder::new(config);
-	let (task_manager, rpc_handlers) = builder.build_light().map_err(|e| format!("{:?}", e))?;
+	let (task_manager, rpc_handlers) = service::build_light(config).map_err(|e| format!("{:?}", e))?;
 
 	Ok(browser_utils::start_client(task_manager, rpc_handlers))
 }

--- a/parachain/src/wasm_executor/mod.rs
+++ b/parachain/src/wasm_executor/mod.rs
@@ -178,7 +178,10 @@ pub fn validate_candidate_internal(
 	spawner: impl SpawnNamed + 'static,
 ) -> Result<ValidationResult, ValidationError> {
 	let executor = sc_executor::WasmExecutor::new(
+		#[cfg(not(any(target_os = "android", target_os = "unknown")))]
 		sc_executor::WasmExecutionMethod::Compiled,
+		#[cfg(any(target_os = "android", target_os = "unknown"))]
+		Default::default(),
 		// TODO: Make sure we don't use more than 1GB: https://github.com/paritytech/polkadot/issues/699
 		Some(1024),
 		HostFunctions::host_functions(),

--- a/parachain/test-parachains/halt/src/lib.rs
+++ b/parachain/test-parachains/halt/src/lib.rs
@@ -50,6 +50,6 @@ pub fn oom(_: core::alloc::Layout) -> ! {
 
 #[cfg(not(feature = "std"))]
 #[no_mangle]
-pub extern fn validate_block(params: *const u8, len: usize) -> usize {
+pub extern fn validate_block(params: *const u8, len: usize) -> u64 {
 	loop {}
 }

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -692,7 +692,7 @@ impl EnsureOrigin<Origin> for PriviledgedOrigin {
 	}
 
 	#[cfg(feature = "runtime-benchmarks")]
-	fn successful_origin() -> OuterOrigin { Origin::root() }
+	fn successful_origin() -> Origin { Origin::root() }
 }
 
 impl propose_parachain::Trait for Runtime {
@@ -1019,17 +1019,14 @@ sp_api::impl_runtime_apis! {
 			highest_range_values: Vec<u32>,
 			steps: Vec<u32>,
 			repeat: u32,
+			extra: bool,
 		) -> Result<Vec<frame_benchmarking::BenchmarkBatch>, RuntimeString> {
 			use frame_benchmarking::{Benchmarking, BenchmarkBatch, add_benchmark};
 			// Trying to add benchmarks directly to the Session Pallet caused cyclic dependency issues.
 			// To get around that, we separated the Session benchmarks into its own crate, which is why
 			// we need these two lines below.
-			use pallet_session_benchmarking::Module as SessionBench;
-			use pallet_offences_benchmarking::Module as OffencesBench;
 			use frame_system_benchmarking::Module as SystemBench;
 
-			impl pallet_session_benchmarking::Trait for Runtime {}
-			impl pallet_offences_benchmarking::Trait for Runtime {}
 			impl frame_system_benchmarking::Trait for Runtime {}
 
 			let whitelist: Vec<Vec<u8>> = vec![
@@ -1051,15 +1048,12 @@ sp_api::impl_runtime_apis! {
 			];
 
 			let mut batches = Vec::<BenchmarkBatch>::new();
-			let params = (&pallet, &benchmark, &lowest_range_values, &highest_range_values, &steps, repeat, &whitelist);
+			let params = (&pallet, &benchmark, &lowest_range_values, &highest_range_values, &steps, repeat, &whitelist, extra);
 
-			add_benchmark!(params, batches, balances,Balances);
-			add_benchmark!(params, batches, identity,Identity);
-			add_benchmark!(params, batches, im_online,ImOnline);
-			add_benchmark!(params, batches, offences,OffencesBench::<Runtime>);
+			add_benchmark!(params, batches, balances, Balances);
+			add_benchmark!(params, batches, identity, Identity);
+			add_benchmark!(params, batches, im_online, ImOnline);
 			add_benchmark!(params, batches, scheduler, Scheduler);
-			add_benchmark!(params, batches, session, SessionBench::<Runtime>);
-			add_benchmark!(params, batches, staking, Staking);
 			add_benchmark!(params, batches, system, SystemBench::<Runtime>);
 			add_benchmark!(params, batches, timestamp, Timestamp);
 			add_benchmark!(params, batches, utility, Utility);

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -67,5 +67,10 @@ env_logger = "0.7.0"
 [features]
 default = ["db", "full-node"]
 db = ["service/db"]
-runtime-benchmarks = ["polkadot-runtime/runtime-benchmarks", "kusama-runtime/runtime-benchmarks", "westend-runtime/runtime-benchmarks"]
+runtime-benchmarks = [
+	"polkadot-runtime/runtime-benchmarks",
+	"kusama-runtime/runtime-benchmarks",
+	"westend-runtime/runtime-benchmarks",
+	"rococo-runtime/runtime-benchmarks"
+]
 full-node = ["av_store", "consensus", "polkadot-network"]


### PR DESCRIPTION
this'll tell our CI machines to build the binaries for easier deployment.