### PR TITLE
Remove Purchase Pallet from Polkadot + Westend

### DIFF
--- a/runtime/common/src/dummy.rs
+++ b/runtime/common/src/dummy.rs
@@ -16,9 +16,11 @@
 
 //! A dummy module for holding place of modules in a runtime.
 
-use frame_support::{decl_module, decl_storage};
+use frame_support::{decl_module, decl_storage, decl_event};
 
-pub trait Trait<I: Instance = DefaultInstance>: frame_system::Trait { }
+pub trait Trait<I: Instance = DefaultInstance>: frame_system::Trait {
+	type Event: Into<<Self as frame_system::Trait>::Event>;
+}
 
 decl_module! {
 	pub struct Module<T: Trait<I>, I: Instance = DefaultInstance> for enum Call where origin: T::Origin {
@@ -27,4 +29,12 @@ decl_module! {
 
 decl_storage! {
 	trait Store for Module<T: Trait<I>, I: Instance = DefaultInstance> as Dummy { }
+}
+
+decl_event!{
+	pub enum Event<T, I: Instance = DefaultInstance> where
+		<T as frame_system::Trait>::AccountId
+	{
+		Dummy(AccountId),
+	}
 }

--- a/runtime/common/src/purchase.rs
+++ b/runtime/common/src/purchase.rs
@@ -361,7 +361,7 @@ impl<T: Trait> Module<T> {
 
 	/// WARNING: Executing this function will clear all storage used by this pallet.
 	/// Be sure this is what you want...
-	fn remove_pallet() -> Weight{
+	pub fn remove_pallet() -> Weight{
 		Accounts::<T>::remove_all();
 		PaymentAccount::<T>::remove();
 		Statement::remove();

--- a/runtime/common/src/purchase.rs
+++ b/runtime/common/src/purchase.rs
@@ -358,17 +358,6 @@ impl<T: Trait> Module<T> {
 			false => Err(Error::<T>::InvalidSignature)?,
 		}
 	}
-
-	/// WARNING: Executing this function will clear all storage used by this pallet.
-	/// Be sure this is what you want...
-	pub fn remove_pallet() -> Weight{
-		Accounts::<T>::remove_all();
-		PaymentAccount::<T>::remove();
-		Statement::remove();
-		UnlockBlock::<T>::remove();
-
-		T::MaximumBlockWeight::get()
-	}
 }
 
 // This function converts a 32 byte AccountId to its byte-array equivalent form.
@@ -380,6 +369,20 @@ fn account_to_bytes<AccountId>(account: &AccountId) -> Result<[u8; 32], Dispatch
 	let mut bytes = [0u8; 32];
 	bytes.copy_from_slice(&account_vec);
 	Ok(bytes)
+}
+
+/// WARNING: Executing this function will clear all storage used by this pallet.
+/// Be sure this is what you want...
+pub fn remove_pallet<T>() -> frame_support::weights::Weight
+	where T: frame_system::Trait
+{
+	use frame_support::migration::remove_storage_prefix;
+	remove_storage_prefix(b"Purchase", b"Accounts", b"");
+	remove_storage_prefix(b"Purchase", b"PaymentAccount", b"");
+	remove_storage_prefix(b"Purchase", b"Statement", b"");
+	remove_storage_prefix(b"Purchase", b"UnlockBlock", b"");
+
+	T::MaximumBlockWeight::get()
 }
 
 #[cfg(test)]
@@ -1020,6 +1023,42 @@ mod tests {
 				Origin::signed(payment_account()),
 				alice(),
 			), BalancesError::<Test, _>::InsufficientBalance);
+		});
+	}
+
+	#[test]
+	fn remove_pallet_works() {
+		new_test_ext().execute_with(|| {
+			let account_status = AccountStatus {
+				validity: AccountValidity::Completed,
+				free_balance: 1234,
+				locked_balance: 4321,
+				signature: b"my signature".to_vec(),
+				vat: Permill::from_percent(50),
+			};
+
+			// Add some storage.
+			Accounts::<Test>::insert(alice(), account_status.clone());
+			Accounts::<Test>::insert(bob(), account_status);
+			PaymentAccount::<Test>::put(alice());
+			Statement::put(b"hello, world!".to_vec());
+			UnlockBlock::<Test>::put(4);
+
+			// Verify storage exists.
+			assert_eq!(Accounts::<Test>::iter().count(), 2);
+			assert!(PaymentAccount::<Test>::exists());
+			assert!(Statement::exists());
+			assert!(UnlockBlock::<Test>::exists());
+
+			// Remove storage.
+			remove_pallet::<Test>();
+
+			// Verify storage is gone.
+			assert_eq!(Accounts::<Test>::iter().count(), 0);
+			assert!(!PaymentAccount::<Test>::exists());
+			assert!(!Statement::exists());
+			assert!(!UnlockBlock::<Test>::exists());
+
 		});
 	}
 }

--- a/runtime/common/src/purchase.rs
+++ b/runtime/common/src/purchase.rs
@@ -358,6 +358,17 @@ impl<T: Trait> Module<T> {
 			false => Err(Error::<T>::InvalidSignature)?,
 		}
 	}
+
+	/// WARNING: Executing this function will clear all storage used by this pallet.
+	/// Be sure this is what you want...
+	fn remove_pallet() -> Weight{
+		Accounts::<T>::remove_all();
+		PaymentAccount::<T>::remove();
+		Statement::remove();
+		UnlockBlock::<T>::remove();
+
+		T::MaximumBlockWeight::get()
+	}
 }
 
 // This function converts a 32 byte AccountId to its byte-array equivalent form.

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -757,7 +757,9 @@ parameter_types! {
 	pub const MaxPending: u16 = 32;
 }
 
-impl<I: frame_support::traits::Instance> dummy::Trait<I> for Runtime { }
+impl<I: frame_support::traits::Instance> dummy::Trait<I> for Runtime {
+	type Event = Event;
+}
 
 /// The type used to represent the kinds of proxying allowed.
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, RuntimeDebug)]
@@ -909,10 +911,10 @@ construct_runtime! {
 		Claims: claims::{Module, Call, Storage, Event<T>, Config<T>, ValidateUnsigned},
 
 		// Old parachains stuff. All dummies to avoid messing up the transaction indices.
-		DummyParachains: dummy::<Instance0>::{Module, Call},
-		DummyAttestations: dummy::<Instance1>::{Module, Call},
-		DummySlots: dummy::<Instance2>::{Module, Call},
-		DummyRegistrar: dummy::<Instance3>::{Module, Call},
+		DummyParachains: dummy::<Instance0>::{Module, Call, Event<T>},
+		DummyAttestations: dummy::<Instance1>::{Module, Call, Event<T>},
+		DummySlots: dummy::<Instance2>::{Module, Call, Event<T>},
+		DummyRegistrar: dummy::<Instance3>::{Module, Call, Event<T>},
 
 		// Utility module.
 		Utility: pallet_utility::{Module, Call, Event},

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -911,8 +911,8 @@ construct_runtime! {
 		Claims: claims::{Module, Call, Storage, Event<T>, Config<T>, ValidateUnsigned},
 
 		// Old parachains stuff. All dummies to avoid messing up the transaction indices.
-		DummyParachains: dummy::<Instance0>::{Module, Call, Event<T>},
-		DummyAttestations: dummy::<Instance1>::{Module, Call, Event<T>},
+		DummyParachains: dummy::<Instance0>::{Module, Call},
+		DummyAttestations: dummy::<Instance1>::{Module, Call},
 		DummySlots: dummy::<Instance2>::{Module, Call, Event<T>},
 		DummyRegistrar: dummy::<Instance3>::{Module, Call, Event<T>},
 

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -746,7 +746,9 @@ parameter_types! {
 	pub const MaxPending: u16 = 32;
 }
 
-impl<I: frame_support::traits::Instance> dummy::Trait<I> for Runtime { }
+impl<I: frame_support::traits::Instance> dummy::Trait<I> for Runtime {
+	type Event = Event;
+}
 
 /// The type used to represent the kinds of proxying allowed.
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, RuntimeDebug)]
@@ -915,10 +917,10 @@ construct_runtime! {
 		Treasury: pallet_treasury::{Module, Call, Storage, Event<T>},
 
 		// Old parachains stuff. All dummies to avoid messing up the transaction indices.
-		DummyParachains: dummy::<Instance0>::{Module, Call},
-		DummyAttestations: dummy::<Instance1>::{Module, Call},
-		DummySlots: dummy::<Instance2>::{Module, Call},
-		DummyRegistrar: dummy::<Instance3>::{Module, Call},
+		DummyParachains: dummy::<Instance0>::{Module, Call, Event<T>},
+		DummyAttestations: dummy::<Instance1>::{Module, Call, Event<T>},
+		DummySlots: dummy::<Instance2>::{Module, Call, Event<T>},
+		DummyRegistrar: dummy::<Instance3>::{Module, Call, Event<T>},
 
 		// Claims. Usable initially.
 		Claims: claims::{Module, Call, Storage, Event<T>, Config<T>, ValidateUnsigned},
@@ -928,7 +930,7 @@ construct_runtime! {
 		Utility: pallet_utility::{Module, Call, Event},
 
 		// Old spot for the purchase pallet. Can be replaced later by a new pallet.
-		DummyPurchase: dummy::<Instance4>::{Module, Call},
+		DummyPurchase: dummy::<Instance4>::{Module, Call, Event<T>},
 
 		// Identity. Late addition.
 		Identity: pallet_identity::{Module, Call, Storage, Event<T>},

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -872,148 +872,8 @@ impl pallet_proxy::Trait for Runtime {
 pub struct CustomOnRuntimeUpgrade;
 impl frame_support::traits::OnRuntimeUpgrade for CustomOnRuntimeUpgrade {
 	fn on_runtime_upgrade() -> frame_support::weights::Weight {
-		use frame_support::storage::{StorageMap, IterableStorageMap};
-		use pallet_democracy::{VotingOf, Conviction, Voting::Direct, AccountVote::Standard};
-		// Cancel convictions for Referendum Zero (for removing Sudo - this is something we would
-		// have done anyway).
-		for (who, mut voting) in VotingOf::<Runtime>::iter() {
-			if let Direct { ref mut votes, .. } = voting {
-				if let Some((0, Standard { ref mut vote, .. })) = votes.first_mut() {
-					vote.conviction = Conviction::None
-				}
-			}
-			VotingOf::<Runtime>::insert(who, voting);
-		}
-
-		<Runtime as frame_system::Trait>::MaximumBlockWeight::get()
+		purchase::Module::<Runtime>::remove_pallet()
 	}
-}
-
-#[test]
-fn test_rm_ref_0() {
-	use sp_runtime::AccountId32;
-	use frame_support::{traits::OnRuntimeUpgrade, storage::StorageMap};
-	use pallet_democracy::{VotingOf, Vote, Voting::{Direct, Delegating}, AccountVote::{Standard, Split}};
-	use pallet_democracy::Conviction::{Locked1x, Locked2x, Locked3x, None as NoConviction};
-	let t = frame_system::GenesisConfig::default().build_storage::<Runtime>().unwrap();
-	let mut ext = sp_io::TestExternalities::new(t);
-	ext.execute_with(|| {
-		let a = |i| AccountId32::from([i; 32]);
-		VotingOf::<Runtime>::insert(a(1), Direct {
-			votes: vec![(0, Standard {
-				vote: Vote { aye: true, conviction: Locked1x },
-				balance: 1,
-			})],
-			delegations: Default::default(),
-			prior: Default::default(),
-		});
-		VotingOf::<Runtime>::insert(a(2), Direct {
-			votes: vec![
-				(0, Standard { vote: Vote { aye: true, conviction: Locked2x }, balance: 2 }),
-				(1, Standard { vote: Vote { aye: true, conviction: Locked2x }, balance: 2 })
-			],
-			delegations: Default::default(),
-			prior: Default::default(),
-		});
-		VotingOf::<Runtime>::insert(a(3), Direct {
-			votes: vec![(1, Standard { vote: Vote { aye: true, conviction: Locked3x }, balance: 3 })],
-			delegations: Default::default(),
-			prior: Default::default(),
-		});
-		VotingOf::<Runtime>::insert(a(4), Direct {
-			votes: vec![],
-			delegations: Default::default(),
-			prior: Default::default(),
-		});
-		VotingOf::<Runtime>::insert(a(5), Delegating {
-			balance: 5,
-			target: a(0),
-			conviction: Locked1x,
-			delegations: Default::default(),
-			prior: Default::default(),
-		});
-		VotingOf::<Runtime>::insert(a(6), Direct {
-			votes: vec![(0, Split { aye: 6, nay: 6 }), (1, Split { aye: 6, nay: 6 })],
-			delegations: Default::default(),
-			prior: Default::default(),
-		});
-		CustomOnRuntimeUpgrade::on_runtime_upgrade();
-		assert_eq!(VotingOf::<Runtime>::get(a(1)), Direct {
-			votes: vec![(0, Standard { vote: Vote { aye: true, conviction: NoConviction }, balance: 1, })],
-			delegations: Default::default(),
-			prior: Default::default(),
-		});
-		assert_eq!(VotingOf::<Runtime>::get(a(2)), Direct {
-			votes: vec![
-				(0, Standard { vote: Vote { aye: true, conviction: NoConviction }, balance: 2, }),
-				(1, Standard { vote: Vote { aye: true, conviction: Locked2x }, balance: 2, })
-			],
-			delegations: Default::default(),
-			prior: Default::default(),
-		});
-		assert_eq!(VotingOf::<Runtime>::get(a(3)), Direct {
-			votes: vec![(1, Standard { vote: Vote { aye: true, conviction: Locked3x }, balance: 3, })],
-			delegations: Default::default(),
-			prior: Default::default(),
-		});
-		assert_eq!(VotingOf::<Runtime>::get(a(4)), Direct {
-			votes: vec![],
-			delegations: Default::default(),
-			prior: Default::default(),
-		});
-		assert_eq!(VotingOf::<Runtime>::get(a(5)), Delegating {
-			balance: 5,
-			target: a(0),
-			conviction: Locked1x,
-			delegations: Default::default(),
-			prior: Default::default(),
-		});
-		assert_eq!(VotingOf::<Runtime>::get(a(6)), Direct {
-			votes: vec![(0, Split { aye: 6, nay: 6 }), (1, Split { aye: 6, nay: 6 })],
-			delegations: Default::default(),
-			prior: Default::default(),
-		});
-	});
-}
-
-parameter_types! {
-	pub const MaxStatementLength: usize = 1_000;
-	pub const UnlockedProportion: Permill = Permill::zero();
-	pub const MaxUnlocked: Balance = 0;
-}
-
-ord_parameter_types! {
-	pub const W3FValidity: AccountId = AccountId::from(
-		// 142wAF65SK7PxhyzzrWz5m5PXDtooehgePBd7rc2NWpfc8Wa
-		hex_literal::hex!("862e432e0cf75693899c62691ac0f48967f815add97ae85659dcde8332708551")
-	);
-	pub const W3FConfiguration: AccountId = AccountId::from(
-		// 1KvKReVmUiTc2LW2a4qyHsaJJ9eE9LRsywZkMk5hyBeyHgw
-		hex_literal::hex!("0e6de68b13b82479fbe988ab9ecb16bad446b67b993cdd9198cd41c7c6259c49")
-	);
-}
-
-type ValidityOrigin = EnsureOneOf<
-	AccountId,
-	EnsureRoot<AccountId>,
-	EnsureSignedBy<W3FValidity, AccountId>,
->;
-
-type ConfigurationOrigin = EnsureOneOf<
-	AccountId,
-	EnsureRoot<AccountId>,
-	EnsureSignedBy<W3FConfiguration, AccountId>,
->;
-
-impl purchase::Trait for Runtime {
-	type Event = Event;
-	type Currency = Balances;
-	type VestingSchedule = Vesting;
-	type ValidityOrigin = ValidityOrigin;
-	type ConfigurationOrigin = ConfigurationOrigin;
-	type MaxStatementLength = MaxStatementLength;
-	type UnlockedProportion = UnlockedProportion;
-	type MaxUnlocked = MaxUnlocked;
 }
 
 construct_runtime! {
@@ -1067,8 +927,8 @@ construct_runtime! {
 		// Cunning utilities. Usable initially.
 		Utility: pallet_utility::{Module, Call, Event},
 
-		// DOT Purchase module. Late addition; this is in place of Sudo.
-		Purchase: purchase::{Module, Call, Storage, Event<T>},
+		// Old spot for the purchase pallet. Can be replaced later by a new pallet.
+		DummyPurchase: dummy::<Instance4>::{Module, Call},
 
 		// Identity. Late addition.
 		Identity: pallet_identity::{Module, Call, Storage, Event<T>},

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -50,11 +50,11 @@ use sp_version::NativeVersion;
 use sp_core::OpaqueMetadata;
 use sp_staking::SessionIndex;
 use frame_support::{
-	parameter_types, ord_parameter_types, construct_runtime, debug, RuntimeDebug,
+	parameter_types, construct_runtime, debug, RuntimeDebug,
 	traits::{KeyOwnerProofSystem, SplitTwoWays, Randomness, LockIdentifier, Filter},
 	weights::Weight,
 };
-use frame_system::{EnsureRoot, EnsureOneOf, EnsureSignedBy};
+use frame_system::{EnsureRoot, EnsureOneOf};
 use pallet_im_online::sr25519::AuthorityId as ImOnlineId;
 use authority_discovery_primitives::AuthorityId as AuthorityDiscoveryId;
 use pallet_transaction_payment_rpc_runtime_api::RuntimeDispatchInfo;
@@ -109,7 +109,8 @@ impl Filter<Call> for BaseFilter {
 	fn filter(call: &Call) -> bool {
 		match call {
 			// Parachains stuff
-			Call::DummyParachains(_) | Call::DummyAttestations(_) | Call::DummySlots(_) | Call::DummyRegistrar(_) =>
+			Call::DummyParachains(_) | Call::DummyAttestations(_) | Call::DummySlots(_) | Call::DummyRegistrar(_) |
+			Call::DummyPurchase(_) =>
 				false,
 
 			// These modules are all allowed to be called by transactions:
@@ -121,9 +122,8 @@ impl Filter<Call> for BaseFilter {
 			Call::Session(_) | Call::FinalityTracker(_) | Call::Grandpa(_) | Call::ImOnline(_) |
 			Call::AuthorityDiscovery(_) |
 			Call::Utility(_) | Call::Claims(_) | Call::Vesting(_) |
-			Call::Identity(_) | Call::Proxy(_) | Call::Multisig(_) |
-			Call::Purchase(_) =>
-				true,
+			Call::Identity(_) | Call::Proxy(_) | Call::Multisig(_)
+			=> true,
 		}
 	}
 }
@@ -872,7 +872,7 @@ impl pallet_proxy::Trait for Runtime {
 pub struct CustomOnRuntimeUpgrade;
 impl frame_support::traits::OnRuntimeUpgrade for CustomOnRuntimeUpgrade {
 	fn on_runtime_upgrade() -> frame_support::weights::Weight {
-		purchase::Module::<Runtime>::remove_pallet()
+		purchase::remove_pallet::<Runtime>()
 	}
 }
 

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -917,8 +917,8 @@ construct_runtime! {
 		Treasury: pallet_treasury::{Module, Call, Storage, Event<T>},
 
 		// Old parachains stuff. All dummies to avoid messing up the transaction indices.
-		DummyParachains: dummy::<Instance0>::{Module, Call, Event<T>},
-		DummyAttestations: dummy::<Instance1>::{Module, Call, Event<T>},
+		DummyParachains: dummy::<Instance0>::{Module, Call},
+		DummyAttestations: dummy::<Instance1>::{Module, Call},
 		DummySlots: dummy::<Instance2>::{Module, Call, Event<T>},
 		DummyRegistrar: dummy::<Instance3>::{Module, Call, Event<T>},
 

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -639,46 +639,6 @@ impl pallet_proxy::Trait for Runtime {
 	type AnnouncementDepositFactor = AnnouncementDepositFactor;
 }
 
-parameter_types! {
-	pub const MaxStatementLength: usize = 1_000;
-	pub const UnlockedProportion: Permill = Permill::zero();
-	pub const MaxUnlocked: Balance = 0;
-}
-
-ord_parameter_types! {
-	pub const PurchaseValidity: AccountId = AccountId::from(
-		// 5CqSB6zNHcp3mvTAyh5Vr2MbSdb7DgLi9yWoAppHRveGcYQh
-		hex_literal::hex!("221d409ba60508368d4448ccda40182aca2744bcdfa0881944c08108a9fd966d")
-	);
-	pub const PurchaseConfiguration: AccountId = AccountId::from(
-		// 5FUP4BwQzi8F5WBTmaHsoobGbMSUTiX7Exwb7QzTjgNQypo1
-		hex_literal::hex!("96c34c8c60b3690701176bdbc9b16aced2898d754385a84ee0cfe7fb015db800")
-	);
-}
-
-type ValidityOrigin = EnsureOneOf<
-	AccountId,
-	EnsureRoot<AccountId>,
-	EnsureSignedBy<PurchaseValidity, AccountId>,
->;
-
-type ConfigurationOrigin = EnsureOneOf<
-	AccountId,
-	EnsureRoot<AccountId>,
-	EnsureSignedBy<PurchaseConfiguration, AccountId>,
->;
-
-impl purchase::Trait for Runtime {
-	type Event = Event;
-	type Currency = Balances;
-	type VestingSchedule = Vesting;
-	type ValidityOrigin = ValidityOrigin;
-	type ConfigurationOrigin = ConfigurationOrigin;
-	type MaxStatementLength = MaxStatementLength;
-	type UnlockedProportion = UnlockedProportion;
-	type MaxUnlocked = MaxUnlocked;
-}
-
 impl<I: frame_support::traits::Instance> dummy::Trait<I> for Runtime { }
 
 construct_runtime! {
@@ -738,9 +698,6 @@ construct_runtime! {
 
 		// Multisig module. Late addition.
 		Multisig: pallet_multisig::{Module, Call, Storage, Event<T>},
-
-		// Purchase module. Late addition.
-		Purchase: purchase::{Module, Call, Storage, Event<T>},
 	}
 }
 
@@ -769,9 +726,23 @@ pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<Address, Call, Signatu
 /// Extrinsic type that has already been checked.
 pub type CheckedExtrinsic = generic::CheckedExtrinsic<AccountId, Nonce, Call>;
 /// Executive: handles dispatch to the various modules.
-pub type Executive = frame_executive::Executive<Runtime, Block, frame_system::ChainContext<Runtime>, Runtime, AllModules>;
+pub type Executive = frame_executive::Executive<
+	Runtime,
+	Block,
+	frame_system::ChainContext<Runtime>,
+	Runtime,
+	AllModules,
+	CustomOnRuntimeUpgrade,
+>;
 /// The payload being signed in transactions.
 pub type SignedPayload = generic::SignedPayload<Call, SignedExtra>;
+
+pub struct CustomOnRuntimeUpgrade;
+impl frame_support::traits::OnRuntimeUpgrade for CustomOnRuntimeUpgrade {
+	fn on_runtime_upgrade() -> frame_support::weights::Weight {
+		purchase::Module::<Runtime>::remove_pallet()
+	}
+}
 
 #[cfg(not(feature = "disable-runtime-api"))]
 sp_api::impl_runtime_apis! {

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -673,8 +673,8 @@ construct_runtime! {
 		AuthorityDiscovery: pallet_authority_discovery::{Module, Call, Config},
 
 		// Old Parachains stuff. All dummies to avoid messing up the transaction indices.
-		DummyParachains: dummy::<Instance0>::{Module, Call, Event<T>},
-		DummyAttestations: dummy::<Instance1>::{Module, Call, Event<T>},
+		DummyParachains: dummy::<Instance0>::{Module, Call},
+		DummyAttestations: dummy::<Instance1>::{Module, Call},
 		DummyRegistrar: dummy::<Instance2>::{Module, Call, Event<T>},
 
 		// Utility module.

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -35,7 +35,7 @@ use runtime_common::{
 };
 use sp_runtime::{
 	create_runtime_str, generic, impl_opaque_keys,
-	ApplyExtrinsicResult, KeyTypeId, Permill, Perbill, curve::PiecewiseLinear,
+	ApplyExtrinsicResult, KeyTypeId, Perbill, curve::PiecewiseLinear,
 	transaction_validity::{TransactionValidity, TransactionSource, TransactionPriority},
 	traits::{
 		BlakeTwo256, Block as BlockT, OpaqueKeys, ConvertInto, IdentityLookup,
@@ -51,7 +51,7 @@ use sp_version::NativeVersion;
 use sp_core::OpaqueMetadata;
 use sp_staking::SessionIndex;
 use frame_support::{
-	parameter_types, ord_parameter_types, construct_runtime, debug, RuntimeDebug,
+	parameter_types, construct_runtime, debug, RuntimeDebug,
 	traits::{KeyOwnerProofSystem, Randomness, Filter, InstanceFilter},
 	weights::Weight,
 };
@@ -59,7 +59,7 @@ use pallet_im_online::sr25519::AuthorityId as ImOnlineId;
 use authority_discovery_primitives::AuthorityId as AuthorityDiscoveryId;
 use pallet_transaction_payment_rpc_runtime_api::RuntimeDispatchInfo;
 use pallet_session::historical as session_historical;
-use frame_system::{EnsureRoot, EnsureSignedBy, EnsureOneOf};
+use frame_system::{EnsureRoot};
 
 #[cfg(feature = "std")]
 pub use pallet_staking::StakerStatus;
@@ -740,7 +740,7 @@ pub type SignedPayload = generic::SignedPayload<Call, SignedExtra>;
 pub struct CustomOnRuntimeUpgrade;
 impl frame_support::traits::OnRuntimeUpgrade for CustomOnRuntimeUpgrade {
 	fn on_runtime_upgrade() -> frame_support::weights::Weight {
-		purchase::Module::<Runtime>::remove_pallet()
+		purchase::remove_pallet::<Runtime>()
 	}
 }
 

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -639,7 +639,9 @@ impl pallet_proxy::Trait for Runtime {
 	type AnnouncementDepositFactor = AnnouncementDepositFactor;
 }
 
-impl<I: frame_support::traits::Instance> dummy::Trait<I> for Runtime { }
+impl<I: frame_support::traits::Instance> dummy::Trait<I> for Runtime {
+	type Event = Event;
+}
 
 construct_runtime! {
 	pub enum Runtime where
@@ -671,9 +673,9 @@ construct_runtime! {
 		AuthorityDiscovery: pallet_authority_discovery::{Module, Call, Config},
 
 		// Old Parachains stuff. All dummies to avoid messing up the transaction indices.
-		DummyParachains: dummy::<Instance0>::{Module, Call},
-		DummyAttestations: dummy::<Instance1>::{Module, Call},
-		DummyRegistrar: dummy::<Instance2>::{Module, Call},
+		DummyParachains: dummy::<Instance0>::{Module, Call, Event<T>},
+		DummyAttestations: dummy::<Instance1>::{Module, Call, Event<T>},
+		DummyRegistrar: dummy::<Instance2>::{Module, Call, Event<T>},
 
 		// Utility module.
 		Utility: pallet_utility::{Module, Call, Event},


### PR DESCRIPTION
This PR removes the Purchase pallet from Polkadot + Westend.

* A new function is introduced in the Purchase pallet that simply removes all storage items.
* The purchase pallet is replaced with the `dummy` runtime.
* The `remove_pallet` function is called on the next `CustomOnRuntimeUpgrade`.