### PR TITLE
Companion PR for #6215

### DIFF
--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -166,7 +166,10 @@ fn new_partial<RuntimeApi, Executor>(config: &mut Configuration) -> Result<
 				grandpa::LinkHalf<Block, FullClient<RuntimeApi, Executor>, FullSelectChain>,
 				babe::BabeLink<Block>
 			),
-			grandpa::SharedVoterState,
+			(
+				grandpa::SharedVoterState,
+				Arc<GrandpaFinalityProofProvider<FullBackend, Block>>,
+			),
 		)
 	>,
 	Error
@@ -232,9 +235,11 @@ fn new_partial<RuntimeApi, Executor>(config: &mut Configuration) -> Result<
 	let justification_stream = grandpa_link.justification_stream();
 	let shared_authority_set = grandpa_link.shared_authority_set().clone();
 	let shared_voter_state = grandpa::SharedVoterState::empty();
+	let finality_proof_provider =
+		GrandpaFinalityProofProvider::new_for_service(backend.clone(), client.clone());
 
 	let import_setup = (block_import.clone(), grandpa_link, babe_link.clone());
-	let rpc_setup = shared_voter_state.clone();
+	let rpc_setup = (shared_voter_state.clone(), finality_proof_provider.clone());
 
 	let babe_config = babe_link.config().clone();
 	let shared_epoch_changes = babe_link.epoch_changes().clone();
@@ -261,6 +266,7 @@ fn new_partial<RuntimeApi, Executor>(config: &mut Configuration) -> Result<
 					shared_authority_set: shared_authority_set.clone(),
 					justification_stream: justification_stream.clone(),
 					subscriptions,
+					finality_provider: finality_proof_provider.clone(),
 				},
 			};
 
@@ -341,8 +347,7 @@ fn new_full<RuntimeApi, Executor>(
 
 	let prometheus_registry = config.prometheus_registry().cloned();
 
-	let finality_proof_provider =
-		GrandpaFinalityProofProvider::new_for_service(backend.clone(), client.clone());
+	let (shared_voter_state, finality_proof_provider) = rpc_setup;
 
 	let (network, network_status_sinks, system_rpc_tx, network_starter) =
 		service::build_network(service::BuildNetworkParams {
@@ -381,8 +386,6 @@ fn new_full<RuntimeApi, Executor>(
 	})?;
 
 	let (block_import, link_half, babe_link) = import_setup;
-
-	let shared_voter_state = rpc_setup;
 
 	let overseer_client = client.clone();
 	let spawner = task_manager.spawn_handle();

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -14,6 +14,7 @@ sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master
 sp-api = { git = "https://github.com/paritytech/substrate", branch = "master"  }
 sp-consensus = { git = "https://github.com/paritytech/substrate", branch = "master"  }
 sp-consensus-babe = { git = "https://github.com/paritytech/substrate", branch = "master"  }
+sp-state-machine = { git = "https://github.com/paritytech/substrate", branch = "master"}
 sc-rpc = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sc-consensus-babe = { git = "https://github.com/paritytech/substrate", branch = "master"}
 sc-consensus-babe-rpc = { git = "https://github.com/paritytech/substrate", branch = "master"}

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -129,7 +129,10 @@ pub fn new_partial<RuntimeApi, Executor>(config: &mut Configuration, test: bool)
 				grandpa::LinkHalf<Block, FullClient<RuntimeApi, Executor>, FullSelectChain>,
 				babe::BabeLink<Block>
 			),
-			grandpa::SharedVoterState,
+			(
+				grandpa::SharedVoterState,
+				Arc<GrandpaFinalityProofProvider<FullBackend, Block>>,
+			),
 		)
 	>,
 	Error
@@ -200,9 +203,11 @@ pub fn new_partial<RuntimeApi, Executor>(config: &mut Configuration, test: bool)
 	let justification_stream = grandpa_link.justification_stream();
 	let shared_authority_set = grandpa_link.shared_authority_set().clone();
 	let shared_voter_state = grandpa::SharedVoterState::empty();
+	let finality_proof_provider =
+		GrandpaFinalityProofProvider::new_for_service(backend.clone(), client.clone());
 
 	let import_setup = (block_import.clone(), grandpa_link, babe_link.clone());
-	let rpc_setup = shared_voter_state.clone();
+	let rpc_setup = (shared_voter_state.clone(), finality_proof_provider.clone());
 
 	let babe_config = babe_link.config().clone();
 	let shared_epoch_changes = babe_link.epoch_changes().clone();
@@ -229,6 +234,7 @@ pub fn new_partial<RuntimeApi, Executor>(config: &mut Configuration, test: bool)
 					shared_authority_set: shared_authority_set.clone(),
 					justification_stream: justification_stream.clone(),
 					subscriptions,
+					finality_provider: finality_proof_provider.clone(),
 				},
 			};
 
@@ -282,8 +288,7 @@ pub fn new_full<RuntimeApi, Executor>(
 
 	let prometheus_registry = config.prometheus_registry().cloned();
 
-	let finality_proof_provider =
-		GrandpaFinalityProofProvider::new_for_service(backend.clone(), client.clone());
+	let (shared_voter_state, finality_proof_provider) = rpc_setup;
 
 	let (network, network_status_sinks, system_rpc_tx, network_starter) =
 		service::build_network(service::BuildNetworkParams {
@@ -322,8 +327,6 @@ pub fn new_full<RuntimeApi, Executor>(
 	})?;
 
 	let (block_import, link_half, babe_link) = import_setup;
-
-	let shared_voter_state = rpc_setup;
 
 	if role.is_authority() {
 		let proposer = consensus::ProposerFactory::new(


### PR DESCRIPTION
Add an on-demand API that clients can call to catch up on the stream of proofs if they need to fill in missing proofs. For example after a period of being offline.

companion PR for: https://github.com/paritytech/substrate/pull/6215