### PR TITLE
node/network/bridge: Define protocol names as str

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1485,7 +1485,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -1493,7 +1493,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1511,7 +1511,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "frame-benchmarking",
  "parity-scale-codec",
@@ -1529,7 +1529,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1544,7 +1544,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata"
 version = "11.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -1555,7 +1555,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "bitmask",
  "frame-metadata",
@@ -1580,7 +1580,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "frame-support-procedural-tools",
  "proc-macro2 1.0.18",
@@ -1591,7 +1591,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -1603,7 +1603,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
@@ -1613,7 +1613,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -1629,7 +1629,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -1643,7 +1643,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -3842,7 +3842,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3858,7 +3858,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3873,7 +3873,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3898,7 +3898,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3912,7 +3912,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3928,7 +3928,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3943,7 +3943,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3958,7 +3958,7 @@ dependencies = [
 [[package]]
 name = "pallet-finality-tracker"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3974,7 +3974,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3996,7 +3996,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -4012,7 +4012,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4032,7 +4032,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4048,7 +4048,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4062,7 +4062,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4077,7 +4077,7 @@ dependencies = [
 [[package]]
 name = "pallet-nicks"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4091,7 +4091,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4106,7 +4106,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4127,7 +4127,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4142,7 +4142,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4155,7 +4155,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "enumflags2",
  "frame-support",
@@ -4170,7 +4170,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4185,7 +4185,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4205,7 +4205,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4221,7 +4221,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4235,7 +4235,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4257,7 +4257,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.18",
@@ -4268,7 +4268,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4282,7 +4282,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4300,7 +4300,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4317,7 +4317,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -4335,7 +4335,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -4348,7 +4348,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4363,7 +4363,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4379,7 +4379,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -6525,7 +6525,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "bytes 0.5.5",
  "derive_more 0.99.9",
@@ -6553,7 +6553,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -6577,7 +6577,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -6594,7 +6594,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -6611,7 +6611,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.18",
@@ -6622,7 +6622,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
@@ -6669,7 +6669,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "derive_more 0.99.9",
  "fnv",
@@ -6705,7 +6705,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "blake2-rfc",
  "hash-db",
@@ -6735,7 +6735,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "sc-client-api",
  "sp-blockchain",
@@ -6746,7 +6746,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "derive_more 0.99.9",
  "fork-tree",
@@ -6790,7 +6790,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "derive_more 0.99.9",
  "futures 0.3.5",
@@ -6814,7 +6814,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -6827,7 +6827,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -6850,7 +6850,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-uncles"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "log 0.4.11",
  "sc-client-api",
@@ -6864,7 +6864,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "derive_more 0.99.9",
  "lazy_static",
@@ -6892,7 +6892,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "derive_more 0.99.9",
  "log 0.4.11",
@@ -6909,7 +6909,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "log 0.4.11",
  "parity-scale-codec",
@@ -6924,7 +6924,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "log 0.4.11",
  "parity-scale-codec",
@@ -6942,7 +6942,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "derive_more 0.99.9",
  "finality-grandpa",
@@ -6979,7 +6979,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa-rpc"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "derive_more 0.99.9",
  "finality-grandpa",
@@ -7001,7 +7001,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "ansi_term 0.12.1",
  "futures 0.3.5",
@@ -7019,7 +7019,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "derive_more 0.99.9",
  "hex",
@@ -7035,7 +7035,7 @@ dependencies = [
 [[package]]
 name = "sc-light"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "hash-db",
  "lazy_static",
@@ -7054,7 +7054,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "async-std",
  "async-trait",
@@ -7108,7 +7108,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -7123,7 +7123,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "bytes 0.5.5",
  "fnv",
@@ -7150,7 +7150,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "futures 0.3.5",
  "libp2p",
@@ -7163,7 +7163,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "log 0.4.11",
  "substrate-prometheus-endpoint",
@@ -7172,7 +7172,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "futures 0.3.5",
  "hash-db",
@@ -7204,7 +7204,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "derive_more 0.99.9",
  "futures 0.3.5",
@@ -7228,7 +7228,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-http-server",
@@ -7244,7 +7244,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "derive_more 0.99.9",
  "directories",
@@ -7305,7 +7305,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "log 0.4.11",
  "parity-scale-codec",
@@ -7319,7 +7319,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -7340,7 +7340,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "erased-serde",
  "log 0.4.11",
@@ -7358,7 +7358,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-graph"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "derive_more 0.99.9",
  "futures 0.3.5",
@@ -7379,7 +7379,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "derive_more 0.99.9",
  "futures 0.3.5",
@@ -7842,7 +7842,7 @@ dependencies = [
 [[package]]
 name = "sp-allocator"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "derive_more 0.99.9",
  "log 0.4.11",
@@ -7854,7 +7854,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
@@ -7869,7 +7869,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate",
@@ -7881,7 +7881,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -7893,7 +7893,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "integer-sqrt",
  "num-traits 0.2.12",
@@ -7906,7 +7906,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7918,7 +7918,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -7929,7 +7929,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7941,7 +7941,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "derive_more 0.99.9",
  "log 0.4.11",
@@ -7958,7 +7958,7 @@ dependencies = [
 [[package]]
 name = "sp-chain-spec"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "serde",
  "serde_json",
@@ -7967,7 +7967,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "derive_more 0.99.9",
  "futures 0.3.5",
@@ -7993,7 +7993,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "merlin",
  "parity-scale-codec",
@@ -8012,7 +8012,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -8021,7 +8021,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "parity-scale-codec",
  "schnorrkel",
@@ -8033,7 +8033,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "base58",
  "blake2-rfc",
@@ -8077,7 +8077,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "kvdb",
  "parking_lot 0.10.2",
@@ -8086,7 +8086,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
@@ -8096,7 +8096,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -8107,7 +8107,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "finality-grandpa",
  "log 0.4.11",
@@ -8123,7 +8123,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-tracker"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -8133,7 +8133,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "derive_more 0.99.9",
  "parity-scale-codec",
@@ -8145,7 +8145,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "futures 0.3.5",
  "hash-db",
@@ -8166,7 +8166,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -8177,7 +8177,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -8189,7 +8189,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections-compact"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.18",
@@ -8200,7 +8200,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -8210,7 +8210,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "backtrace",
  "log 0.4.11",
@@ -8219,7 +8219,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "serde",
  "sp-core",
@@ -8228,7 +8228,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -8250,7 +8250,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "parity-scale-codec",
  "primitive-types",
@@ -8266,7 +8266,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -8278,7 +8278,7 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "serde",
  "serde_json",
@@ -8287,7 +8287,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -8300,7 +8300,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -8310,7 +8310,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "hash-db",
  "itertools 0.9.0",
@@ -8331,12 +8331,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 
 [[package]]
 name = "sp-storage"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -8349,7 +8349,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -8363,7 +8363,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "log 0.4.11",
  "rental",
@@ -8373,7 +8373,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "derive_more 0.99.9",
  "futures 0.3.5",
@@ -8388,7 +8388,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -8402,7 +8402,7 @@ dependencies = [
 [[package]]
 name = "sp-utils"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "futures 0.3.5",
  "futures-core",
@@ -8414,7 +8414,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -8426,7 +8426,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -8566,7 +8566,7 @@ dependencies = [
 [[package]]
 name = "substrate-browser-utils"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "chrono",
  "console_error_panic_hook",
@@ -8592,7 +8592,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "platforms",
 ]
@@ -8600,7 +8600,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.5",
@@ -8623,7 +8623,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "async-std",
  "derive_more 0.99.9",
@@ -8637,7 +8637,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "futures 0.1.29",
  "futures 0.3.5",
@@ -8663,7 +8663,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-utils"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "futures 0.3.5",
  "substrate-test-utils-derive",
@@ -8673,7 +8673,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-utils-derive"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#86ae27e0fc829ab5cf269c3a8659e057736f6a9b"
+source = "git+https://github.com/paritytech/substrate#beb74f4923d64447935fa2ce20c2aeb4bbaaf061"
 dependencies = [
  "proc-macro-crate",
  "quote 1.0.7",

--- a/node/network/bridge/src/lib.rs
+++ b/node/network/bridge/src/lib.rs
@@ -52,11 +52,11 @@ const MAX_VIEW_HEADS: usize = 5;
 /// The engine ID of the validation protocol.
 pub const VALIDATION_PROTOCOL_ID: ConsensusEngineId = *b"pvn1";
 /// The protocol name for the validation peer-set.
-pub const VALIDATION_PROTOCOL_NAME: &[u8] = b"/polkadot/validation/1";
+pub const VALIDATION_PROTOCOL_NAME: &'static str = "/polkadot/validation/1";
 /// The engine ID of the collation protocol.
 pub const COLLATION_PROTOCOL_ID: ConsensusEngineId = *b"pcn1";
 /// The protocol name for the collation peer-set.
-pub const COLLATION_PROTOCOL_NAME: &[u8] = b"/polkadot/collation/1";
+pub const COLLATION_PROTOCOL_NAME: &'static str = "/polkadot/collation/1";
 
 const MALFORMED_MESSAGE_COST: ReputationChange
 	= ReputationChange::new(-500, "Malformed Network-bridge message");
@@ -81,7 +81,7 @@ pub enum WireMessage<M> {
 
 /// Information about the notifications protocol. Should be used during network configuration
 /// or shortly after startup to register the protocol with the network service.
-pub fn notifications_protocol_info() -> Vec<(ConsensusEngineId, std::borrow::Cow<'static, [u8]>)> {
+pub fn notifications_protocol_info() -> Vec<(ConsensusEngineId, std::borrow::Cow<'static, str>)> {
 	vec![
 		(VALIDATION_PROTOCOL_ID, VALIDATION_PROTOCOL_NAME.into()),
 		(COLLATION_PROTOCOL_ID, COLLATION_PROTOCOL_NAME.into()),


### PR DESCRIPTION
Companion for https://github.com/paritytech/substrate/pull/6967.

> Notification protocol names are in practice always valid utf8 strings.
Instead of treating them as such in the type system, thus far they were
casted to a [u8] at creation time.
>
> With this commit protocol names are instead treated as valid utf8
strings throughout the codebase and passed as Cow<'static, str>
instead of Cow<'static, [u8]>. Among other things this eliminates the
need for string casting when logging.


As far as I can tell none of these protocol names are used anywhere.
I still think it is worth keeping them in sync.