### PR TITLE
Backport: Make ValidationPool accepts execution mode to run custom command or in process validation (#1622)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8623,8 +8623,11 @@ dependencies = [
  "polkadot-collator",
  "polkadot-parachain",
  "polkadot-primitives",
+ "polkadot-service",
  "sc-client-api",
+ "sp-api",
  "sp-core",
+ "sp-runtime",
  "test-parachain-adder",
 ]
 

--- a/collator/src/lib.rs
+++ b/collator/src/lib.rs
@@ -76,7 +76,7 @@ use polkadot_service_new::{
 use sc_service::SpawnTaskHandle;
 use sp_core::traits::SpawnNamed;
 use sp_runtime::traits::BlakeTwo256;
-use consensus_common::SyncOracle;
+pub use consensus_common::SyncOracle;
 use sc_client_api::Backend as BackendT;
 
 const COLLATION_TIMEOUT: Duration = Duration::from_secs(30);
@@ -118,11 +118,11 @@ pub trait BuildParachainContext {
 	type ParachainContext: self::ParachainContext;
 
 	/// Build the `ParachainContext`.
-	fn build<SP, Client, Backend>(
+	fn build<SP, Client, Backend, PNetwork>(
 		self,
 		client: Arc<Client>,
 		spawner: SP,
-		network: impl Network + SyncOracle + Clone + 'static,
+		network: PNetwork,
 	) -> Result<Self::ParachainContext, ()>
 		where
 			SP: SpawnNamed + Clone + Send + Sync + 'static,
@@ -130,6 +130,7 @@ pub trait BuildParachainContext {
 			Backend::State: sp_api::StateBackend<BlakeTwo256>,
 			Client: polkadot_service::AbstractClient<Block, Backend> + 'static,
 			Client::Api: RuntimeApiCollection<StateBackend = Backend::State>,
+			PNetwork: Network + SyncOracle + Clone + 'static,
 		;
 }
 
@@ -460,11 +461,11 @@ mod tests {
 	impl BuildParachainContext for BuildDummyParachainContext {
 		type ParachainContext = DummyParachainContext;
 
-		fn build<SP, Client, Backend>(
+		fn build<SP, Client, Backend, PNetwork>(
 			self,
 			_: Arc<Client>,
 			_: SP,
-			_: impl Network + Clone + 'static,
+			_: PNetwork,
 		) -> Result<Self::ParachainContext, ()>
 		where
 			SP: SpawnNamed + Clone + Send + Sync + 'static,
@@ -472,6 +473,7 @@ mod tests {
 			Backend::State: sp_api::StateBackend<BlakeTwo256>,
 			Client: polkadot_service::AbstractClient<Block, Backend> + 'static,
 			Client::Api: RuntimeApiCollection<StateBackend = Backend::State>,
+			PNetwork: Network + SyncOracle + Clone + 'static,
 		{
 			Ok(DummyParachainContext)
 		}

--- a/node/core/candidate-validation/src/lib.rs
+++ b/node/core/candidate-validation/src/lib.rs
@@ -33,8 +33,10 @@ use polkadot_primitives::v1::{
 	ValidationCode, OmittedValidationData, PoV, CandidateDescriptor, LocalValidationData,
 	GlobalValidationData, OccupiedCoreAssumption, Hash, validation_data_hash,
 };
-use polkadot_parachain::wasm_executor::{self, ValidationPool, ExecutionMode, ValidationError,
-	InvalidCandidate as WasmInvalidCandidate};
+use polkadot_parachain::wasm_executor::{
+	self, ValidationPool, ExecutionMode, ValidationError,
+	InvalidCandidate as WasmInvalidCandidate, ValidationExecutionMode,
+};
 use polkadot_parachain::primitives::{ValidationResult as WasmValidationResult, ValidationParams};
 
 use parity_scale_codec::Encode;
@@ -73,7 +75,7 @@ async fn run(
 )
 	-> SubsystemResult<()>
 {
-	let pool = ValidationPool::new();
+	let pool = ValidationPool::new(ValidationExecutionMode::ExternalProcessSelfHost);
 
 	loop {
 		match ctx.recv().await? {

--- a/parachain/Cargo.toml
+++ b/parachain/Cargo.toml
@@ -19,7 +19,7 @@ polkadot-core-primitives = { path = "../core-primitives", default-features = fal
 derive_more = { version = "0.99.2", optional = true }
 serde = { version = "1.0.102", default-features = false, features = [ "derive" ], optional = true }
 sp-externalities = { git = "https://github.com/paritytech/substrate", branch = "rococo-branch", optional = true }
-sc-executor = { git = "https://github.com/paritytech/substrate", branch = "rococo-branch", optional = true, features = ["wasmtime"] }
+sc-executor = { git = "https://github.com/paritytech/substrate", branch = "rococo-branch", optional = true }
 sp-io = { git = "https://github.com/paritytech/substrate", branch = "rococo-branch", optional = true }
 parking_lot = { version = "0.10.0", optional = true }
 log = { version = "0.4.8", optional = true }

--- a/parachain/src/wasm_executor/mod.rs
+++ b/parachain/src/wasm_executor/mod.rs
@@ -28,7 +28,7 @@ use sp_externalities::Extensions;
 use sp_wasm_interface::HostFunctions as _;
 
 #[cfg(not(any(target_os = "android", target_os = "unknown")))]
-pub use validation_host::{run_worker, ValidationPool, EXECUTION_TIMEOUT_SEC};
+pub use validation_host::{run_worker, ValidationPool, EXECUTION_TIMEOUT_SEC, ValidationExecutionMode};
 
 mod validation_host;
 
@@ -66,8 +66,6 @@ pub enum ExecutionMode<'a> {
 	Local,
 	/// Remote execution in a spawned process.
 	Remote(&'a ValidationPool),
-	/// Remote execution in a spawned test runner.
-	RemoteTest(&'a ValidationPool),
 }
 
 #[derive(Debug, derive_more::Display, derive_more::From)]
@@ -143,21 +141,10 @@ pub fn validate_candidate(
 		},
 		#[cfg(not(any(target_os = "android", target_os = "unknown")))]
 		ExecutionMode::Remote(pool) => {
-			pool.validate_candidate(validation_code, params, false)
-		},
-		#[cfg(not(any(target_os = "android", target_os = "unknown")))]
-		ExecutionMode::RemoteTest(pool) => {
-			pool.validate_candidate(validation_code, params, true)
+			pool.validate_candidate(validation_code, params)
 		},
 		#[cfg(any(target_os = "android", target_os = "unknown"))]
 		ExecutionMode::Remote(_pool) =>
-			Err(ValidationError::Internal(InternalError::System(
-				Box::<dyn std::error::Error + Send + Sync>::from(
-					"Remote validator not available".to_string()
-				) as Box<_>
-			))),
-		#[cfg(any(target_os = "android", target_os = "unknown"))]
-		ExecutionMode::RemoteTest(_pool) =>
 			Err(ValidationError::Internal(InternalError::System(
 				Box::<dyn std::error::Error + Send + Sync>::from(
 					"Remote validator not available".to_string()

--- a/parachain/test-parachains/adder/collator/Cargo.toml
+++ b/parachain/test-parachains/adder/collator/Cargo.toml
@@ -9,8 +9,11 @@ adder = { package = "test-parachain-adder", path = ".." }
 parachain = { package = "polkadot-parachain", path = "../../.." }
 collator = { package = "polkadot-collator", path = "../../../../collator" }
 primitives = { package = "polkadot-primitives", path = "../../../../primitives" }
+service = { package = "polkadot-service", path = "../../../../service" }
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "rococo-branch" }
 client-api = { package = "sc-client-api", git = "https://github.com/paritytech/substrate", branch = "rococo-branch" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "rococo-branch" }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "rococo-branch" }
 parking_lot = "0.10.0"
 codec = { package = "parity-scale-codec", version = "1.3.4" }
 futures = "0.3.4"

--- a/parachain/test-parachains/adder/collator/src/main.rs
+++ b/parachain/test-parachains/adder/collator/src/main.rs
@@ -20,15 +20,17 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use adder::{HeadData as AdderHead, BlockData as AdderBody};
-use sp_core::Pair;
+use sp_core::{traits::SpawnNamed, Pair};
 use codec::{Encode, Decode};
 use primitives::v0::{
-	Hash, DownwardMessage,
+	Block, Hash, DownwardMessage,
 	HeadData, BlockData, Id as ParaId, LocalValidationData, GlobalValidationData,
 };
 use collator::{ParachainContext, Network, BuildParachainContext, Cli, SubstrateCli};
 use parking_lot::Mutex;
 use futures::future::{Ready, ready, FutureExt};
+use sp_runtime::traits::BlakeTwo256;
+use client_api::Backend as BackendT;
 
 const GENESIS: AdderHead = AdderHead {
 	number: 0,
@@ -103,12 +105,19 @@ impl ParachainContext for AdderContext {
 impl BuildParachainContext for AdderContext {
 	type ParachainContext = Self;
 
-	fn build<SP>(
+	fn build<SP, Client, Backend>(
 		self,
-		_: collator::Client,
+		_: Arc<Client>,
 		_: SP,
 		network: impl Network + Clone + 'static,
-	) -> Result<Self::ParachainContext, ()> {
+	) -> Result<Self::ParachainContext, ()>
+	where
+		SP: SpawnNamed + Clone + Send + Sync + 'static,
+		Backend: BackendT<Block>,
+		Backend::State: sp_api::StateBackend<BlakeTwo256>,
+		Client: service::AbstractClient<Block, Backend> + 'static,
+		Client::Api: service::RuntimeApiCollection<StateBackend = Backend::State>,
+	{
 		Ok(Self { _network: Some(Arc::new(network)), ..self })
 	}
 }

--- a/parachain/test-parachains/adder/collator/src/main.rs
+++ b/parachain/test-parachains/adder/collator/src/main.rs
@@ -26,7 +26,7 @@ use primitives::v0::{
 	Block, Hash, DownwardMessage,
 	HeadData, BlockData, Id as ParaId, LocalValidationData, GlobalValidationData,
 };
-use collator::{ParachainContext, Network, BuildParachainContext, Cli, SubstrateCli};
+use collator::{ParachainContext, Network, BuildParachainContext, Cli, SubstrateCli, SyncOracle};
 use parking_lot::Mutex;
 use futures::future::{Ready, ready, FutureExt};
 use sp_runtime::traits::BlakeTwo256;
@@ -105,11 +105,11 @@ impl ParachainContext for AdderContext {
 impl BuildParachainContext for AdderContext {
 	type ParachainContext = Self;
 
-	fn build<SP, Client, Backend>(
+	fn build<SP, Client, Backend, PNetwork>(
 		self,
 		_: Arc<Client>,
 		_: SP,
-		network: impl Network + Clone + 'static,
+		network: PNetwork,
 	) -> Result<Self::ParachainContext, ()>
 	where
 		SP: SpawnNamed + Clone + Send + Sync + 'static,
@@ -117,6 +117,7 @@ impl BuildParachainContext for AdderContext {
 		Backend::State: sp_api::StateBackend<BlakeTwo256>,
 		Client: service::AbstractClient<Block, Backend> + 'static,
 		Client::Api: service::RuntimeApiCollection<StateBackend = Backend::State>,
+		PNetwork: Network + SyncOracle + Clone + 'static,
 	{
 		Ok(Self { _network: Some(Arc::new(network)), ..self })
 	}

--- a/parachain/test-parachains/tests/code_upgrader/mod.rs
+++ b/parachain/test-parachains/tests/code_upgrader/mod.rs
@@ -16,6 +16,7 @@
 
 //! Basic parachain that adds a number as part of its state.
 
+use parachain::wasm_executor::{ValidationPool, ValidationExecutionMode};
 use parachain::primitives::{
 	BlockData as GenericBlockData,
 	HeadData as GenericHeadData,
@@ -24,9 +25,20 @@ use parachain::primitives::{
 use codec::{Decode, Encode};
 use code_upgrader::{hash_state, HeadData, BlockData, State};
 
+const WORKER_ARGS_TEST: &[&'static str] = &["--nocapture", "validation_worker"];
+
+fn validation_pool() -> ValidationPool {
+	let execution_mode = ValidationExecutionMode::ExternalProcessCustomHost {
+		binary: std::env::current_exe().unwrap(),
+		args: WORKER_ARGS_TEST.iter().map(|x| x.to_string()).collect(),
+	};
+
+	ValidationPool::new(execution_mode)
+}
+
 #[test]
 pub fn execute_good_no_upgrade() {
-	let pool = parachain::wasm_executor::ValidationPool::new();
+	let pool = validation_pool();
 
 	let parent_head = HeadData {
 		number: 0,
@@ -49,7 +61,7 @@ pub fn execute_good_no_upgrade() {
 			relay_chain_height: 1,
 			code_upgrade_allowed: None,
 		},
-		parachain::wasm_executor::ExecutionMode::RemoteTest(&pool),
+		parachain::wasm_executor::ExecutionMode::Remote(&pool),
 		sp_core::testing::TaskExecutor::new(),
 	).unwrap();
 
@@ -63,7 +75,7 @@ pub fn execute_good_no_upgrade() {
 
 #[test]
 pub fn execute_good_with_upgrade() {
-	let pool = parachain::wasm_executor::ValidationPool::new();
+	let pool = validation_pool();
 
 	let parent_head = HeadData {
 		number: 0,
@@ -86,7 +98,7 @@ pub fn execute_good_with_upgrade() {
 			relay_chain_height: 1,
 			code_upgrade_allowed: Some(20),
 		},
-		parachain::wasm_executor::ExecutionMode::RemoteTest(&pool),
+		parachain::wasm_executor::ExecutionMode::Remote(&pool),
 		sp_core::testing::TaskExecutor::new(),
 	).unwrap();
 
@@ -107,7 +119,7 @@ pub fn execute_good_with_upgrade() {
 #[test]
 #[should_panic]
 pub fn code_upgrade_not_allowed() {
-	let pool = parachain::wasm_executor::ValidationPool::new();
+	let pool = validation_pool();
 
 	let parent_head = HeadData {
 		number: 0,
@@ -130,14 +142,14 @@ pub fn code_upgrade_not_allowed() {
 			relay_chain_height: 1,
 			code_upgrade_allowed: None,
 		},
-		parachain::wasm_executor::ExecutionMode::RemoteTest(&pool),
+		parachain::wasm_executor::ExecutionMode::Remote(&pool),
 		sp_core::testing::TaskExecutor::new(),
 	).unwrap();
 }
 
 #[test]
 pub fn applies_code_upgrade_after_delay() {
-	let pool = parachain::wasm_executor::ValidationPool::new();
+	let pool = validation_pool();
 
 	let (new_head, state) = {
 		let parent_head = HeadData {
@@ -161,7 +173,7 @@ pub fn applies_code_upgrade_after_delay() {
 				relay_chain_height: 1,
 				code_upgrade_allowed: Some(2),
 			},
-			parachain::wasm_executor::ExecutionMode::RemoteTest(&pool),
+			parachain::wasm_executor::ExecutionMode::Remote(&pool),
 			sp_core::testing::TaskExecutor::new(),
 		).unwrap();
 
@@ -197,7 +209,7 @@ pub fn applies_code_upgrade_after_delay() {
 				relay_chain_height: 2,
 				code_upgrade_allowed: None,
 			},
-			parachain::wasm_executor::ExecutionMode::RemoteTest(&pool),
+			parachain::wasm_executor::ExecutionMode::Remote(&pool),
 			sp_core::testing::TaskExecutor::new(),
 		).unwrap();
 

--- a/parachain/test-parachains/tests/wasm_executor/mod.rs
+++ b/parachain/test-parachains/tests/wasm_executor/mod.rs
@@ -16,15 +16,26 @@
 
 //! Basic parachain that adds a number as part of its state.
 
+const WORKER_ARGS_TEST: &[&'static str] = &["--nocapture", "validation_worker"];
+
 use crate::adder;
 use parachain::{
 	primitives::{BlockData, ValidationParams},
-	wasm_executor::{ValidationError, InvalidCandidate, EXECUTION_TIMEOUT_SEC},
+	wasm_executor::{ValidationError, InvalidCandidate, EXECUTION_TIMEOUT_SEC, ValidationExecutionMode, ValidationPool},
 };
+
+fn validation_pool() -> ValidationPool {
+	let execution_mode = ValidationExecutionMode::ExternalProcessCustomHost {
+		binary: std::env::current_exe().unwrap(),
+		args: WORKER_ARGS_TEST.iter().map(|x| x.to_string()).collect(),
+	};
+
+	ValidationPool::new(execution_mode)
+}
 
 #[test]
 fn terminates_on_timeout() {
-	let pool = parachain::wasm_executor::ValidationPool::new();
+	let pool = validation_pool();
 
 	let result = parachain::wasm_executor::validate_candidate(
 		halt::wasm_binary_unwrap(),
@@ -36,7 +47,7 @@ fn terminates_on_timeout() {
 			relay_chain_height: 1,
 			code_upgrade_allowed: None,
 		},
-		parachain::wasm_executor::ExecutionMode::RemoteTest(&pool),
+		parachain::wasm_executor::ExecutionMode::Remote(&pool),
 		sp_core::testing::TaskExecutor::new(),
 	);
 	match result {
@@ -45,12 +56,12 @@ fn terminates_on_timeout() {
 	}
 
 	// check that another parachain can validate normaly
-	adder::execute_good_on_parent();
+	adder::execute_good_on_parent_with_external_process_validation();
 }
 
 #[test]
 fn parallel_execution() {
-	let pool = parachain::wasm_executor::ValidationPool::new();
+	let pool = validation_pool();
 
 	let start = std::time::Instant::now();
 
@@ -66,7 +77,7 @@ fn parallel_execution() {
 			relay_chain_height: 1,
 			code_upgrade_allowed: None,
 		},
-		parachain::wasm_executor::ExecutionMode::RemoteTest(&pool2),
+		parachain::wasm_executor::ExecutionMode::Remote(&pool2),
 		sp_core::testing::TaskExecutor::new(),
 	).ok());
 	let _ = parachain::wasm_executor::validate_candidate(
@@ -79,7 +90,7 @@ fn parallel_execution() {
 			relay_chain_height: 1,
 			code_upgrade_allowed: None,
 		},
-		parachain::wasm_executor::ExecutionMode::RemoteTest(&pool),
+		parachain::wasm_executor::ExecutionMode::Remote(&pool),
 		sp_core::testing::TaskExecutor::new(),
 	);
 	thread.join().unwrap();

--- a/service/src/client.rs
+++ b/service/src/client.rs
@@ -118,6 +118,19 @@ pub trait ExecuteWithClient {
 			Client: AbstractClient<Block, Backend, Api = Api> + 'static;
 }
 
+/// A handle to a Polkadot client instance.
+///
+/// The Polkadot service supports multiple different runtimes (Westend, Polkadot itself, etc). As each runtime has a
+/// specialized client, we need to hide them behind a trait. This is this trait.
+///
+/// When wanting to work with the inner client, you need to use `execute_with`.
+///
+/// See [`ExecuteWithClient`](trait.ExecuteWithClient.html) for more information.
+pub trait ClientHandle {
+	/// Execute the given something with the client.
+	fn execute_with<T: ExecuteWithClient>(&self, t: T) -> T::Output;
+}
+
 /// A client instance of Polkadot.
 ///
 /// See [`ExecuteWithClient`] for more information.
@@ -129,9 +142,8 @@ pub enum Client {
 	Rococo(Arc<crate::FullClient<rococo_runtime::RuntimeApi, crate::RococoExecutor>>),
 }
 
-impl Client {
-	/// Execute the given something with the client.
-	pub fn execute_with<T: ExecuteWithClient>(&self, t: T) -> T::Output {
+impl ClientHandle for Client {
+	fn execute_with<T: ExecuteWithClient>(&self, t: T) -> T::Output {
 		match self {
 			Self::Polkadot(client) => {
 				T::execute_with_client::<_, _, crate::FullBackend>(t, client.clone())

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -111,16 +111,25 @@ impl IdentifyVariant for Box<dyn ChainSpec> {
 	}
 }
 
-type FullBackend = service::TFullBackend<Block>;
-type FullSelectChain = sc_consensus::LongestChain<FullBackend, Block>;
-type FullClient<RuntimeApi, Executor> = service::TFullClient<Block, RuntimeApi, Executor>;
-type FullGrandpaBlockImport<RuntimeApi, Executor> = grandpa::GrandpaBlockImport<
+/// Polkadot's full backend.
+pub type FullBackend = service::TFullBackend<Block>;
+
+/// Polkadot's select chain.
+pub type FullSelectChain = sc_consensus::LongestChain<FullBackend, Block>;
+
+/// Polkadot's full client.
+pub type FullClient<RuntimeApi, Executor> = service::TFullClient<Block, RuntimeApi, Executor>;
+
+/// Polkadot's full Grandpa block import.
+pub type FullGrandpaBlockImport<RuntimeApi, Executor> = grandpa::GrandpaBlockImport<
 	FullBackend, Block, FullClient<RuntimeApi, Executor>, FullSelectChain
 >;
 
-type LightBackend = service::TLightBackendWithHash<Block, sp_runtime::traits::BlakeTwo256>;
+/// Polkadot's light backend.
+pub type LightBackend = service::TLightBackendWithHash<Block, sp_runtime::traits::BlakeTwo256>;
 
-type LightClient<RuntimeApi, Executor> =
+/// Polkadot's light client.
+pub type LightClient<RuntimeApi, Executor> =
 	service::TLightClientWithBackend<Block, RuntimeApi, Executor, LightBackend>;
 
 #[cfg(feature = "full-node")]

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -31,6 +31,7 @@ use sc_executor::native_executor_instance;
 use log::info;
 use sp_trie::PrefixedMemoryDB;
 use prometheus_endpoint::Registry;
+#[cfg(feature = "full-node")]
 use consensus::pipeline::ValidationExecutionMode;
 pub use service::{
 	Role, PruningMode, TransactionPoolOptions, Error, RuntimeGenesis, RpcHandlers,

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -31,6 +31,7 @@ use sc_executor::native_executor_instance;
 use log::info;
 use sp_trie::PrefixedMemoryDB;
 use prometheus_endpoint::Registry;
+use consensus::pipeline::ValidationExecutionMode;
 pub use service::{
 	Role, PruningMode, TransactionPoolOptions, Error, RuntimeGenesis, RpcHandlers,
 	TFullClient, TLightClient, TFullBackend, TLightBackend, TFullCallExecutor, TLightCallExecutor,
@@ -402,6 +403,11 @@ pub fn new_full<RuntimeApi, Executor>(
 			select_chain: select_chain.clone(),
 			keystore: keystore.clone(),
 			max_block_data_size,
+			validation_execution_mode: if test {
+				ValidationExecutionMode::InProcess
+			} else {
+				ValidationExecutionMode::ExternalProcessSelfHost
+			},
 		}.build();
 
 		task_manager.spawn_essential_handle().spawn("validation-service", Box::pin(validation_service));

--- a/validation/src/pipeline.rs
+++ b/validation/src/pipeline.rs
@@ -34,7 +34,7 @@ use sp_api::ProvideRuntimeApi;
 use crate::Error;
 use primitives::traits::SpawnNamed;
 
-pub use parachain::wasm_executor::ValidationPool;
+pub use parachain::wasm_executor::{ValidationPool, ValidationExecutionMode};
 
 /// Does basic checks of a collation. Provide the encoded PoV-block.
 pub fn basic_checks(

--- a/validation/src/validation_service/mod.rs
+++ b/validation/src/validation_service/mod.rs
@@ -48,7 +48,7 @@ use log::{warn, info, debug, trace};
 
 use super::{Network, Collators, SharedTable, TableRouter};
 use crate::Error;
-use crate::pipeline::ValidationPool;
+use crate::pipeline::{ValidationPool, ValidationExecutionMode};
 
 // Remote processes may request for a validation instance to be cloned or instantiated.
 // They send a oneshot channel.
@@ -163,7 +163,7 @@ impl<C, N, P, SC, SP> ServiceBuilder<C, N, P, SC, SP> where
 			NotifyImport(sc_client_api::BlockImportNotification<Block>),
 		}
 
-		let validation_pool = Some(ValidationPool::new());
+		let validation_pool = Some(ValidationPool::new(ValidationExecutionMode::ExternalProcessSelfHost));
 		let mut parachain_validation = ParachainValidationInstances {
 			client: self.client.clone(),
 			network: self.network,

--- a/validation/src/validation_service/mod.rs
+++ b/validation/src/validation_service/mod.rs
@@ -132,6 +132,8 @@ pub struct ServiceBuilder<C, N, P, SC, SP> {
 	pub keystore: KeyStorePtr,
 	/// The maximum block-data size in bytes.
 	pub max_block_data_size: Option<u64>,
+	/// Validation execution mode.
+	pub validation_execution_mode: ValidationExecutionMode,
 }
 
 impl<C, N, P, SC, SP> ServiceBuilder<C, N, P, SC, SP> where
@@ -163,7 +165,7 @@ impl<C, N, P, SC, SP> ServiceBuilder<C, N, P, SC, SP> where
 			NotifyImport(sc_client_api::BlockImportNotification<Block>),
 		}
 
-		let validation_pool = Some(ValidationPool::new(ValidationExecutionMode::ExternalProcessSelfHost));
+		let validation_pool = Some(ValidationPool::new(self.validation_execution_mode));
 		let mut parachain_validation = ParachainValidationInstances {
 			client: self.client.clone(),
 			network: self.network,


### PR DESCRIPTION
Related to #1622 
Related to https://github.com/paritytech/cumulus/issues/199
Also related to https://github.com/paritytech/cumulus/pull/201 for the actual use

This change will make the polkadot test service use the "in-process" mode of the validation pool.

Also:
* backporting: Allow using any polkadot client instead of enum Client (#1575)
* Replace impl Trait by generic parameter (code does not exist in master anymore)