### PR TITLE
Remove redundant line

### DIFF
--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -13,7 +13,6 @@ sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "mas
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master"  }
 sp-api = { git = "https://github.com/paritytech/substrate", branch = "master"  }
 sp-consensus = { git = "https://github.com/paritytech/substrate", branch = "master"  }
-sp-consensus-babe = { git = "https://github.com/paritytech/substrate", branch = "master"  }
 sc-rpc = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sc-consensus-babe = { git = "https://github.com/paritytech/substrate", branch = "master"}
 sc-consensus-babe-rpc = { git = "https://github.com/paritytech/substrate", branch = "master"}


### PR DESCRIPTION
Line: `sc-consensus-babe = { git = "https://github.com/paritytech/substrate", branch = "master"}` was defined twice.