### PR TITLE
Implementer's Guide: Allow the watermark to always land on the relay parent

### DIFF
--- a/roadmap/implementers-guide/src/runtime/router.md
+++ b/roadmap/implementers-guide/src/runtime/router.md
@@ -185,7 +185,9 @@ Candidate Acceptance Function:
 * `check_hrmp_watermark(P: ParaId, new_hrmp_watermark)`:
   1. `new_hrmp_watermark` should be strictly greater than the value of `HrmpWatermarks` for `P` (if any).
   1. `new_hrmp_watermark` must not be greater than the context's block number.
-  1. in `HrmpChannelDigests` for `P` an entry with the block number equal to `new_hrmp_watermark` should exist.
+  1. `new_hrmp_watermark` should be either
+      1. equal to the context's block number
+      1. or in `HrmpChannelDigests` for `P` an entry with the block number should exist
 * `verify_outbound_hrmp(sender: ParaId, Vec<OutboundHrmpMessage>)`:
   1. For each horizontal message `M` with the channel `C` identified by `(sender, M.recipient)` check:
       1. exists


### PR DESCRIPTION
Closes #1671 

The HRMP watermark can now land not only on an entry in the digest but also on the relay-parent block.

First, it fixes a problem that there is no way to satisfy the following two rules if there is no pending messages

1. The candidate needs to always move the watermark
1. However, the watermark can only land on a digest.

Implication of these changes is that the watermark now can point on a block where no messages were sent to the para (i.e. no entry in digest). Don't see why this could be a problem.
