### PR TITLE
Validation: don't detect STDIN closing when running in process 

### DIFF
--- a/network/src/protocol/tests.rs
+++ b/network/src/protocol/tests.rs
@@ -24,7 +24,7 @@ use polkadot_primitives::v0::{
 	GlobalValidationData, LocalValidationData, SigningContext,
 	PoVBlock, BlockData, ValidationCode,
 };
-use polkadot_validation::{SharedTable, TableRouter};
+use polkadot_validation::{SharedTable, TableRouter, pipeline::ExecutionMode};
 
 use av_store::Store as AvailabilityStore;
 use sc_network_gossip::TopicNotification;
@@ -298,7 +298,7 @@ fn consensus_instances_cleaned_up() {
 		signing_context,
 		AvailabilityStore::new_in_memory(service.clone()),
 		None,
-		None,
+		ExecutionMode::InProcess,
 	));
 
 	pool.spawner().spawn_local(worker_task).unwrap();
@@ -329,7 +329,7 @@ fn collation_is_received_with_dropped_router() {
 		signing_context,
 		AvailabilityStore::new_in_memory(service.clone()),
 		None,
-		None,
+		ExecutionMode::InProcess,
 	));
 
 	pool.spawner().spawn_local(worker_task).unwrap();
@@ -489,7 +489,7 @@ fn fetches_pov_block_from_gossip() {
 		signing_context,
 		AvailabilityStore::new_in_memory(service.clone()),
 		None,
-		None,
+		ExecutionMode::InProcess,
 	));
 
 	let spawner = pool.spawner();

--- a/parachain/Cargo.toml
+++ b/parachain/Cargo.toml
@@ -19,7 +19,7 @@ polkadot-core-primitives = { path = "../core-primitives", default-features = fal
 derive_more = { version = "0.99.2", optional = true }
 serde = { version = "1.0.102", default-features = false, features = [ "derive" ], optional = true }
 sp-externalities = { git = "https://github.com/paritytech/substrate", branch = "rococo-branch", optional = true }
-sc-executor = { git = "https://github.com/paritytech/substrate", branch = "rococo-branch", optional = true }
+sc-executor = { git = "https://github.com/paritytech/substrate", branch = "rococo-branch", optional = true, features = ["wasmtime"] }
 sp-io = { git = "https://github.com/paritytech/substrate", branch = "rococo-branch", optional = true }
 parking_lot = { version = "0.10.0", optional = true }
 log = { version = "0.4.8", optional = true }

--- a/parachain/src/wasm_executor/mod.rs
+++ b/parachain/src/wasm_executor/mod.rs
@@ -184,7 +184,7 @@ pub fn validate_candidate_internal(
 ) -> Result<ValidationResult, ValidationError> {
 	let executor = sc_executor::WasmExecutor::new(
 		#[cfg(not(any(target_os = "android", target_os = "unknown")))]
-		sc_executor::WasmExecutionMethod::Interpreted,
+		sc_executor::WasmExecutionMethod::Compiled,
 		#[cfg(any(target_os = "android", target_os = "unknown"))]
 		Default::default(),
 		// TODO: Make sure we don't use more than 1GB: https://github.com/paritytech/polkadot/issues/699

--- a/parachain/src/wasm_executor/mod.rs
+++ b/parachain/src/wasm_executor/mod.rs
@@ -28,7 +28,7 @@ use sp_externalities::Extensions;
 use sp_wasm_interface::HostFunctions as _;
 
 #[cfg(not(any(target_os = "android", target_os = "unknown")))]
-pub use validation_host::{run_worker, ValidationPool, EXECUTION_TIMEOUT_SEC};
+pub use validation_host::{run_worker, ValidationPool, EXECUTION_TIMEOUT_SEC, WORKER_ARGS};
 
 mod validation_host;
 
@@ -161,7 +161,7 @@ pub fn validate_candidate(
 			pool.validate_candidate_custom(validation_code, params, binary, &args)
 		},
 		#[cfg(any(target_os = "android", target_os = "unknown"))]
-		ExecutionMode::Remote(_pool) => // TODO
+		ExecutionMode::ExternalProcessSelfHost(_pool) | ExecutionMode::ExternalProcessCustomHost { .. } =>
 			Err(ValidationError::Internal(InternalError::System(
 				Box::<dyn std::error::Error + Send + Sync>::from(
 					"Remote validator not available".to_string()

--- a/parachain/src/wasm_executor/mod.rs
+++ b/parachain/src/wasm_executor/mod.rs
@@ -59,7 +59,8 @@ pub fn run_worker(_: &str) -> Result<(), String> {
 }
 
 /// The execution mode for the `ValidationPool`.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
+#[cfg_attr(not(any(target_os = "android", target_os = "unknown")), derive(Debug)]
 pub enum ExecutionMode {
 	/// The validation worker is ran in a thread inside the same process.
 	InProcess,
@@ -161,7 +162,7 @@ pub fn validate_candidate(
 			pool.validate_candidate_custom(validation_code, params, binary, &args)
 		},
 		#[cfg(any(target_os = "android", target_os = "unknown"))]
-		ExecutionMode::ExternalProcessSelfHost(_pool) | ExecutionMode::ExternalProcessCustomHost { .. } =>
+		ExecutionMode::ExternalProcessSelfHost(_) | ExecutionMode::ExternalProcessCustomHost { .. } =>
 			Err(ValidationError::Internal(InternalError::System(
 				Box::<dyn std::error::Error + Send + Sync>::from(
 					"Remote validator not available".to_string()
@@ -183,7 +184,7 @@ pub fn validate_candidate_internal(
 ) -> Result<ValidationResult, ValidationError> {
 	let executor = sc_executor::WasmExecutor::new(
 		#[cfg(not(any(target_os = "android", target_os = "unknown")))]
-		sc_executor::WasmExecutionMethod::Compiled,
+		sc_executor::WasmExecutionMethod::Interpreted,
 		#[cfg(any(target_os = "android", target_os = "unknown"))]
 		Default::default(),
 		// TODO: Make sure we don't use more than 1GB: https://github.com/paritytech/polkadot/issues/699

--- a/parachain/src/wasm_executor/mod.rs
+++ b/parachain/src/wasm_executor/mod.rs
@@ -58,18 +58,6 @@ pub fn run_worker(_: &str) -> Result<(), String> {
 	Err("Cannot run validation worker on this platform".to_string())
 }
 
-/*
-/// WASM code execution mode.
-///
-/// > Note: When compiling for WASM, the `Remote` variants are not available.
-pub enum ExecutionMode<'a> {
-	/// Execute in-process. The execution can not be interrupted or aborted.
-	Local,
-	/// Remote execution in a spawned process.
-	Remote(&'a ValidationPool),
-}
-*/
-
 /// The execution mode for the `ValidationPool`.
 #[derive(Debug, Clone)]
 pub enum ExecutionMode {
@@ -77,10 +65,12 @@ pub enum ExecutionMode {
 	InProcess,
 	/// The validation worker is ran using the process' executable and the subcommand `validation-worker` is passed
 	/// following by the address of the shared memory.
-	ExternalProcessSelfHost,
+	ExternalProcessSelfHost(ValidationPool),
 	/// The validation worker is ran using the command provided and the argument provided. The address of the shared
 	/// memory is added at the end of the arguments.
 	ExternalProcessCustomHost {
+		/// Validation pool.
+		pool: ValidationPool,
 		/// Path to the validation worker. The file must exists and be executable.
 		binary: PathBuf,
 		/// List of arguments passed to the validation worker. The address of the shared memory will be automatically
@@ -155,7 +145,6 @@ pub fn validate_candidate(
 	validation_code: &[u8],
 	params: ValidationParams,
 	execution_mode: &ExecutionMode,
-	pool: Option<&ValidationPool>,
 	spawner: impl SpawnNamed + 'static,
 ) -> Result<ValidationResult, ValidationError> {
 	match execution_mode {
@@ -163,13 +152,13 @@ pub fn validate_candidate(
 			validate_candidate_internal(validation_code, &params.encode(), spawner)
 		},
 		#[cfg(not(any(target_os = "android", target_os = "unknown")))]
-		ExecutionMode::ExternalProcessSelfHost => {
-			pool.expect("todo").validate_candidate(validation_code, params)
+		ExecutionMode::ExternalProcessSelfHost(pool) => {
+			pool.validate_candidate(validation_code, params)
 		},
 		#[cfg(not(any(target_os = "android", target_os = "unknown")))]
-		ExecutionMode::ExternalProcessCustomHost { binary, args } => {
+		ExecutionMode::ExternalProcessCustomHost { pool, binary, args } => {
 			let args: Vec<&str> = args.iter().map(|x| x.as_str()).collect();
-			pool.expect("todo").validate_candidate_custom(validation_code, params, binary, &args)
+			pool.validate_candidate_custom(validation_code, params, binary, &args)
 		},
 		#[cfg(any(target_os = "android", target_os = "unknown"))]
 		ExecutionMode::Remote(_pool) => // TODO

--- a/parachain/src/wasm_executor/mod.rs
+++ b/parachain/src/wasm_executor/mod.rs
@@ -20,7 +20,7 @@
 //! Assuming the parameters are correct, this module provides a wrapper around
 //! a WASM VM for re-execution of a parachain candidate.
 
-use std::any::{TypeId, Any};
+use std::{any::{TypeId, Any}, path::PathBuf};
 use crate::primitives::{ValidationParams, ValidationResult};
 use codec::{Decode, Encode};
 use sp_core::{storage::ChildInfo, traits::{CallInWasm, SpawnNamed}};
@@ -28,7 +28,7 @@ use sp_externalities::Extensions;
 use sp_wasm_interface::HostFunctions as _;
 
 #[cfg(not(any(target_os = "android", target_os = "unknown")))]
-pub use validation_host::{run_worker, ValidationPool, EXECUTION_TIMEOUT_SEC, ValidationExecutionMode};
+pub use validation_host::{run_worker, ValidationPool, EXECUTION_TIMEOUT_SEC};
 
 mod validation_host;
 
@@ -58,6 +58,7 @@ pub fn run_worker(_: &str) -> Result<(), String> {
 	Err("Cannot run validation worker on this platform".to_string())
 }
 
+/*
 /// WASM code execution mode.
 ///
 /// > Note: When compiling for WASM, the `Remote` variants are not available.
@@ -67,6 +68,27 @@ pub enum ExecutionMode<'a> {
 	/// Remote execution in a spawned process.
 	Remote(&'a ValidationPool),
 }
+*/
+
+/// The execution mode for the `ValidationPool`.
+#[derive(Debug, Clone)]
+pub enum ExecutionMode {
+	/// The validation worker is ran in a thread inside the same process.
+	InProcess,
+	/// The validation worker is ran using the process' executable and the subcommand `validation-worker` is passed
+	/// following by the address of the shared memory.
+	ExternalProcessSelfHost,
+	/// The validation worker is ran using the command provided and the argument provided. The address of the shared
+	/// memory is added at the end of the arguments.
+	ExternalProcessCustomHost {
+		/// Path to the validation worker. The file must exists and be executable.
+		binary: PathBuf,
+		/// List of arguments passed to the validation worker. The address of the shared memory will be automatically
+		/// added after the arguments.
+		args: Vec<String>,
+	},
+}
+
 
 #[derive(Debug, derive_more::Display, derive_more::From)]
 /// Candidate validation error.
@@ -132,19 +154,25 @@ impl std::error::Error for ValidationError {
 pub fn validate_candidate(
 	validation_code: &[u8],
 	params: ValidationParams,
-	options: ExecutionMode<'_>,
+	execution_mode: &ExecutionMode,
+	pool: Option<&ValidationPool>,
 	spawner: impl SpawnNamed + 'static,
 ) -> Result<ValidationResult, ValidationError> {
-	match options {
-		ExecutionMode::Local => {
+	match execution_mode {
+		ExecutionMode::InProcess => {
 			validate_candidate_internal(validation_code, &params.encode(), spawner)
 		},
 		#[cfg(not(any(target_os = "android", target_os = "unknown")))]
-		ExecutionMode::Remote(pool) => {
-			pool.validate_candidate(validation_code, params)
+		ExecutionMode::ExternalProcessSelfHost => {
+			pool.expect("todo").validate_candidate(validation_code, params)
+		},
+		#[cfg(not(any(target_os = "android", target_os = "unknown")))]
+		ExecutionMode::ExternalProcessCustomHost { binary, args } => {
+			let args: Vec<&str> = args.iter().map(|x| x.as_str()).collect();
+			pool.expect("todo").validate_candidate_custom(validation_code, params, binary, &args)
 		},
 		#[cfg(any(target_os = "android", target_os = "unknown"))]
-		ExecutionMode::Remote(_pool) =>
+		ExecutionMode::Remote(_pool) => // TODO
 			Err(ValidationError::Internal(InternalError::System(
 				Box::<dyn std::error::Error + Send + Sync>::from(
 					"Remote validator not available".to_string()

--- a/parachain/src/wasm_executor/mod.rs
+++ b/parachain/src/wasm_executor/mod.rs
@@ -60,7 +60,7 @@ pub fn run_worker(_: &str) -> Result<(), String> {
 
 /// The execution mode for the `ValidationPool`.
 #[derive(Clone)]
-#[cfg_attr(not(any(target_os = "android", target_os = "unknown")), derive(Debug)]
+#[cfg_attr(not(any(target_os = "android", target_os = "unknown")), derive(Debug))]
 pub enum ExecutionMode {
 	/// The validation worker is ran in a thread inside the same process.
 	InProcess,

--- a/parachain/src/wasm_executor/validation_host.rs
+++ b/parachain/src/wasm_executor/validation_host.rs
@@ -282,9 +282,6 @@ impl ValidationHost {
 				return Ok(());
 			}
 		}
-		if self.worker_thread.is_some() {
-			return Ok(());
-		}
 
 		let memory = Self::create_memory()?;
 

--- a/parachain/src/wasm_executor/validation_host.rs
+++ b/parachain/src/wasm_executor/validation_host.rs
@@ -249,7 +249,6 @@ impl std::ops::DerefMut for ValidationHostMemory {
 #[derive(Default, Debug)]
 struct ValidationHost {
 	worker: Option<process::Child>,
-	worker_thread: Option<std::thread::JoinHandle<Result<(), String>>>,
 	memory: Option<ValidationHostMemory>,
 	id: u32,
 }

--- a/parachain/test-parachains/tests/adder/mod.rs
+++ b/parachain/test-parachains/tests/adder/mod.rs
@@ -25,7 +25,7 @@ use parachain::{
 		HeadData as GenericHeadData,
 		ValidationParams,
 	},
-	wasm_executor::{ValidationPool, ValidationExecutionMode}
+	wasm_executor::{ValidationPool, ExecutionMode}
 };
 use codec::{Decode, Encode};
 
@@ -57,28 +57,27 @@ fn hash_head(head: &HeadData) -> [u8; 32] {
 	tiny_keccak::keccak256(head.encode().as_slice())
 }
 
-fn validation_pool() -> ValidationPool {
-	let execution_mode = ValidationExecutionMode::ExternalProcessCustomHost {
+fn execution_mode() -> ExecutionMode {
+	ExecutionMode::ExternalProcessCustomHost {
+		pool: ValidationPool::new(),
 		binary: std::env::current_exe().unwrap(),
 		args: WORKER_ARGS_TEST.iter().map(|x| x.to_string()).collect(),
-	};
-
-	ValidationPool::new(execution_mode)
+	}
 }
 
 #[test]
 fn execute_good_on_parent_with_inprocess_validation() {
-	let pool = ValidationPool::new(ValidationExecutionMode::InProcess);
-	execute_good_on_parent(pool);
+	let execution_mode = ExecutionMode::InProcess;
+	execute_good_on_parent(execution_mode);
 }
 
 #[test]
 pub fn execute_good_on_parent_with_external_process_validation() {
-	let pool = validation_pool();
-	execute_good_on_parent(pool);
+	let execution_mode = execution_mode();
+	execute_good_on_parent(execution_mode);
 }
 
-fn execute_good_on_parent(pool: ValidationPool) {
+fn execute_good_on_parent(execution_mode: ExecutionMode) {
 	let parent_head = HeadData {
 		number: 0,
 		parent_hash: [0; 32],
@@ -101,7 +100,7 @@ fn execute_good_on_parent(pool: ValidationPool) {
 			relay_chain_height: 1,
 			code_upgrade_allowed: None,
 		},
-		parachain::wasm_executor::ExecutionMode::Remote(&pool),
+		&execution_mode,
 		sp_core::testing::TaskExecutor::new(),
 	).unwrap();
 
@@ -117,7 +116,7 @@ fn execute_good_chain_on_parent() {
 	let mut number = 0;
 	let mut parent_hash = [0; 32];
 	let mut last_state = 0;
-	let pool = validation_pool();
+	let execution_mode = execution_mode();
 
 	for add in 0..10 {
 		let parent_head = HeadData {
@@ -141,7 +140,7 @@ fn execute_good_chain_on_parent() {
 				relay_chain_height: number as RelayChainBlockNumber + 1,
 				code_upgrade_allowed: None,
 			},
-			parachain::wasm_executor::ExecutionMode::Remote(&pool),
+			&execution_mode,
 			sp_core::testing::TaskExecutor::new(),
 		).unwrap();
 
@@ -159,7 +158,7 @@ fn execute_good_chain_on_parent() {
 
 #[test]
 fn execute_bad_on_parent() {
-	let pool = validation_pool();
+	let execution_mode = execution_mode();
 
 	let parent_head = HeadData {
 		number: 0,
@@ -182,7 +181,7 @@ fn execute_bad_on_parent() {
 			relay_chain_height: 1,
 			code_upgrade_allowed: None,
 		},
-		parachain::wasm_executor::ExecutionMode::Remote(&pool),
+		&execution_mode,
 		sp_core::testing::TaskExecutor::new(),
 	).unwrap_err();
 }

--- a/parachain/test-parachains/tests/wasm_executor/mod.rs
+++ b/parachain/test-parachains/tests/wasm_executor/mod.rs
@@ -21,21 +21,20 @@ const WORKER_ARGS_TEST: &[&'static str] = &["--nocapture", "validation_worker"];
 use crate::adder;
 use parachain::{
 	primitives::{BlockData, ValidationParams},
-	wasm_executor::{ValidationError, InvalidCandidate, EXECUTION_TIMEOUT_SEC, ValidationExecutionMode, ValidationPool},
+	wasm_executor::{ValidationError, InvalidCandidate, EXECUTION_TIMEOUT_SEC, ExecutionMode, ValidationPool},
 };
 
-fn validation_pool() -> ValidationPool {
-	let execution_mode = ValidationExecutionMode::ExternalProcessCustomHost {
+fn execution_mode() -> ExecutionMode {
+	ExecutionMode::ExternalProcessCustomHost {
+		pool: ValidationPool::new(),
 		binary: std::env::current_exe().unwrap(),
 		args: WORKER_ARGS_TEST.iter().map(|x| x.to_string()).collect(),
-	};
-
-	ValidationPool::new(execution_mode)
+	}
 }
 
 #[test]
 fn terminates_on_timeout() {
-	let pool = validation_pool();
+	let execution_mode = execution_mode();
 
 	let result = parachain::wasm_executor::validate_candidate(
 		halt::wasm_binary_unwrap(),
@@ -47,7 +46,7 @@ fn terminates_on_timeout() {
 			relay_chain_height: 1,
 			code_upgrade_allowed: None,
 		},
-		parachain::wasm_executor::ExecutionMode::Remote(&pool),
+		&execution_mode,
 		sp_core::testing::TaskExecutor::new(),
 	);
 	match result {
@@ -61,11 +60,11 @@ fn terminates_on_timeout() {
 
 #[test]
 fn parallel_execution() {
-	let pool = validation_pool();
+	let execution_mode = execution_mode();
 
 	let start = std::time::Instant::now();
 
-	let pool2 = pool.clone();
+	let execution_mode2 = execution_mode.clone();
 	let thread = std::thread::spawn(move ||
 		parachain::wasm_executor::validate_candidate(
 		halt::wasm_binary_unwrap(),
@@ -77,7 +76,7 @@ fn parallel_execution() {
 			relay_chain_height: 1,
 			code_upgrade_allowed: None,
 		},
-		parachain::wasm_executor::ExecutionMode::Remote(&pool2),
+		&execution_mode,
 		sp_core::testing::TaskExecutor::new(),
 	).ok());
 	let _ = parachain::wasm_executor::validate_candidate(
@@ -90,7 +89,7 @@ fn parallel_execution() {
 			relay_chain_height: 1,
 			code_upgrade_allowed: None,
 		},
-		parachain::wasm_executor::ExecutionMode::Remote(&pool),
+		&execution_mode2,
 		sp_core::testing::TaskExecutor::new(),
 	);
 	thread.join().unwrap();

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -31,8 +31,6 @@ use sc_executor::native_executor_instance;
 use log::info;
 use sp_trie::PrefixedMemoryDB;
 use prometheus_endpoint::Registry;
-#[cfg(feature = "full-node")]
-use consensus::pipeline::ValidationExecutionMode;
 pub use service::{
 	Role, PruningMode, TransactionPoolOptions, Error, RuntimeGenesis, RpcHandlers,
 	TFullClient, TLightClient, TFullBackend, TLightBackend, TFullCallExecutor, TLightCallExecutor,
@@ -413,11 +411,7 @@ pub fn new_full<RuntimeApi, Executor>(
 			select_chain: select_chain.clone(),
 			keystore: keystore.clone(),
 			max_block_data_size,
-			validation_execution_mode: if test {
-				ValidationExecutionMode::InProcess
-			} else {
-				ValidationExecutionMode::ExternalProcessSelfHost
-			},
+			local_validation: test,
 		}.build();
 
 		task_manager.spawn_essential_handle().spawn("validation-service", Box::pin(validation_service));

--- a/validation/src/collation.rs
+++ b/validation/src/collation.rs
@@ -58,7 +58,6 @@ pub trait Collators: Clone {
 
 /// A future which resolves when a collation is available.
 pub async fn collation_fetch<C: Collators, P>(
-	validation_pool: Option<crate::pipeline::ValidationPool>,
 	execution_mode: crate::pipeline::ExecutionMode,
 	parachain: ParaId,
 	relay_parent: Hash,
@@ -78,7 +77,6 @@ pub async fn collation_fetch<C: Collators, P>(
 		let collation = collators.collate(parachain, relay_parent).await?;
 		let Collation { info, pov } = collation;
 		let res = crate::pipeline::full_output_validation_with_api(
-			validation_pool.as_ref(),
 			&execution_mode,
 			&*client,
 			&info,

--- a/validation/src/collation.rs
+++ b/validation/src/collation.rs
@@ -59,6 +59,7 @@ pub trait Collators: Clone {
 /// A future which resolves when a collation is available.
 pub async fn collation_fetch<C: Collators, P>(
 	validation_pool: Option<crate::pipeline::ValidationPool>,
+	execution_mode: crate::pipeline::ExecutionMode,
 	parachain: ParaId,
 	relay_parent: Hash,
 	collators: C,
@@ -78,6 +79,7 @@ pub async fn collation_fetch<C: Collators, P>(
 		let Collation { info, pov } = collation;
 		let res = crate::pipeline::full_output_validation_with_api(
 			validation_pool.as_ref(),
+			&execution_mode,
 			&*client,
 			&info,
 			&pov,

--- a/validation/src/pipeline.rs
+++ b/validation/src/pipeline.rs
@@ -189,7 +189,6 @@ fn validate_upward_messages(
 /// Does full checks of a collation, with provided PoV-block and contextual data.
 pub fn validate<'a>(
 	execution_mode: &'a ExecutionMode,
-	validation_pool: Option<&ValidationPool>,
 	collation: &'a CollationInfo,
 	pov_block: &'a PoVBlock,
 	local_validation: &'a LocalValidationData,
@@ -223,7 +222,6 @@ pub fn validate<'a>(
 		&validation_code.0,
 		params,
 		execution_mode,
-		validation_pool,
 		spawner,
 	) {
 		Ok(result) => {
@@ -274,7 +272,6 @@ where
 
 /// Does full-pipeline validation of a collation with provided contextual parameters.
 pub fn full_output_validation_with_api<P>(
-	validation_pool: Option<&ValidationPool>,
 	execution_mode: &ExecutionMode,
 	api: &P,
 	collation: &CollationInfo,
@@ -303,7 +300,6 @@ pub fn full_output_validation_with_api<P>(
 		.and_then(|()| {
 			let res = validate(
 				execution_mode,
-				validation_pool,
 				&collation,
 				&pov_block,
 				&local_validation,

--- a/validation/src/shared_table/mod.rs
+++ b/validation/src/shared_table/mod.rs
@@ -711,7 +711,7 @@ mod tests {
 			signing_context.clone(),
 			AvailabilityStore::new_in_memory(DummyErasureNetworking),
 			None,
-			None,
+			ExecutionMode::InProcess,
 		);
 
 		let mut candidate = AbridgedCandidateReceipt::default();
@@ -768,7 +768,7 @@ mod tests {
 			signing_context.clone(),
 			AvailabilityStore::new_in_memory(DummyErasureNetworking),
 			None,
-			None,
+			ExecutionMode::InProcess,
 		);
 
 		let mut candidate = AbridgedCandidateReceipt::default();
@@ -826,7 +826,7 @@ mod tests {
 			availability_store: store.clone(),
 			max_block_data_size: None,
 			n_validators,
-			validation_pool: None,
+			execution_mode: ExecutionMode::InProcess,
 		};
 
 		for i in 0..n_validators {
@@ -896,7 +896,7 @@ mod tests {
 			availability_store: store.clone(),
 			max_block_data_size: None,
 			n_validators,
-			validation_pool: None,
+			execution_mode: ExecutionMode::InProcess,
 		};
 
 		let validated = block_on(producer.prime_with(|_, _| Ok(
@@ -951,7 +951,7 @@ mod tests {
 			signing_context.clone(),
 			AvailabilityStore::new_in_memory(DummyErasureNetworking),
 			None,
-			None,
+			ExecutionMode::InProcess,
 		);
 
 		let mut candidate = AbridgedCandidateReceipt::default();
@@ -1019,7 +1019,7 @@ mod tests {
 			signing_context.clone(),
 			AvailabilityStore::new_in_memory(DummyErasureNetworking),
 			None,
-			None,
+			ExecutionMode::InProcess,
 		);
 
 		let mut candidate = AbridgedCandidateReceipt::default();

--- a/validation/src/validation_service/mod.rs
+++ b/validation/src/validation_service/mod.rs
@@ -749,7 +749,7 @@ mod tests {
 			spawner: executor.clone(),
 			availability_store: AvailabilityStore::new_in_memory(MockErasureNetworking),
 			live_instances: HashMap::new(),
-			validation_pool: None,
+			execution_mode: ExecutionMode::InProcess,
 		};
 
 		executor::block_on(parachain_validation.get_or_instantiate(Default::default(), &keystore, None))
@@ -789,7 +789,7 @@ mod tests {
 			spawner: executor.clone(),
 			availability_store: AvailabilityStore::new_in_memory(MockErasureNetworking),
 			live_instances: HashMap::new(),
-			validation_pool: None,
+			execution_mode: ExecutionMode::InProcess,
 		};
 
 		executor::block_on(parachain_validation.get_or_instantiate(Default::default(), &keystore, None))

--- a/validation/src/validation_service/mod.rs
+++ b/validation/src/validation_service/mod.rs
@@ -335,9 +335,7 @@ pub(crate) struct ParachainValidationInstances<N: Network, P, SP, CF> {
 	/// Live agreements. Maps relay chain parent hashes to attestation
 	/// instances.
 	live_instances: HashMap<Hash, LiveInstance<N::TableRouter>>,
-	/// The underlying validation pool of processes to use.
-	/// Only `None` in tests.
-	/// TODO
+	/// The underlying validation execution mode.
 	execution_mode: ExecutionMode,
 	/// Used to fetch a collation.
 	collation_fetch: CF,


### PR DESCRIPTION
I had an issue in https://github.com/paritytech/cumulus/pull/201 because the test was working locally but not on CI and I couldn't figure out why. I finally found out why: when running in a CI, the STDIN is actually closed. Because of that, the exit detection mechanism was triggered and the validation was never run.

This PR proposes to fix this by adding a flag that activates this exit mechanism. So when the validation is ran "in process", it will disable the flag and let the validation run indefinitely.

Related to #1622 