### PR TITLE
Update parity-multiaddr.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4407,9 +4407,9 @@ dependencies = [
 
 [[package]]
 name = "parity-multiaddr"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc20af3143a62c16e7c9e92ea5c6ae49f7d271d97d4d8fe73afc28f0514a3d0f"
+checksum = "2165a93382a93de55868dcbfa11e4a8f99676a9164eee6a2b4a9479ad319c257"
 dependencies = [
  "arrayref",
  "bs58",


### PR DESCRIPTION
Companion PR for https://github.com/paritytech/substrate/pull/7077.