### PR TITLE
`locked` flag added to building section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ dnf install polkadot
 If you want to install Polkadot in your PATH, you can do so with with:
 
 ```bash
-cargo install --git https://github.com/paritytech/polkadot --tag <version> polkadot
+cargo install --git https://github.com/paritytech/polkadot --tag <version> polkadot --locked
 ```
 
 ### Build from Source


### PR DESCRIPTION
As described in #1717 running `cargo install` without `--locked` flag may end up with build fails.