### PR TITLE
Companion PR for #7136 (WeightInfo for Session / Offences)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1429,7 +1429,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -1437,7 +1437,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1455,7 +1455,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-benchmarking",
  "parity-scale-codec",
@@ -1473,7 +1473,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1489,7 +1489,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata"
 version = "11.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -1500,7 +1500,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "bitmask",
  "frame-metadata",
@@ -1525,7 +1525,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-support-procedural-tools",
  "proc-macro2 1.0.18",
@@ -1536,7 +1536,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -1548,7 +1548,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
@@ -1558,7 +1558,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -1574,7 +1574,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -1588,7 +1588,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -3756,7 +3756,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3772,7 +3772,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3787,7 +3787,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3812,7 +3812,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3826,7 +3826,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3842,7 +3842,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3857,7 +3857,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3872,7 +3872,7 @@ dependencies = [
 [[package]]
 name = "pallet-finality-tracker"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3888,7 +3888,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3910,7 +3910,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -3926,7 +3926,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3946,7 +3946,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3962,7 +3962,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3976,7 +3976,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3991,7 +3991,7 @@ dependencies = [
 [[package]]
 name = "pallet-nicks"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4005,7 +4005,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4020,7 +4020,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4041,7 +4041,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4056,7 +4056,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4069,7 +4069,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "enumflags2",
  "frame-support",
@@ -4084,7 +4084,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4099,7 +4099,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4119,7 +4119,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4135,7 +4135,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4149,7 +4149,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4171,7 +4171,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.18",
@@ -4182,7 +4182,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4196,7 +4196,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4214,7 +4214,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4231,7 +4231,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -4249,7 +4249,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -4262,7 +4262,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4277,7 +4277,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4293,7 +4293,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -6480,7 +6480,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "bytes 0.5.6",
  "derive_more 0.99.9",
@@ -6508,7 +6508,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -6532,7 +6532,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -6549,7 +6549,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -6566,7 +6566,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.18",
@@ -6577,7 +6577,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
@@ -6626,7 +6626,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "derive_more 0.99.9",
  "fnv",
@@ -6662,7 +6662,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "blake2-rfc",
  "hash-db",
@@ -6692,7 +6692,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "sc-client-api",
  "sp-blockchain",
@@ -6703,7 +6703,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "derive_more 0.99.9",
  "fork-tree",
@@ -6747,7 +6747,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "derive_more 0.99.9",
  "futures 0.3.5",
@@ -6771,7 +6771,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -6784,7 +6784,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -6807,7 +6807,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-uncles"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "log 0.4.11",
  "sc-client-api",
@@ -6821,7 +6821,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "derive_more 0.99.9",
  "lazy_static",
@@ -6849,7 +6849,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "derive_more 0.99.9",
  "log 0.4.11",
@@ -6866,7 +6866,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "log 0.4.11",
  "parity-scale-codec",
@@ -6881,7 +6881,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "log 0.4.11",
  "parity-scale-codec",
@@ -6899,7 +6899,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "derive_more 0.99.9",
  "finality-grandpa",
@@ -6936,7 +6936,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa-rpc"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "derive_more 0.99.9",
  "finality-grandpa",
@@ -6960,7 +6960,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "ansi_term 0.12.1",
  "futures 0.3.5",
@@ -6978,7 +6978,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "derive_more 0.99.9",
  "hex",
@@ -6994,7 +6994,7 @@ dependencies = [
 [[package]]
 name = "sc-light"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "hash-db",
  "lazy_static",
@@ -7013,7 +7013,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "async-std",
  "async-trait",
@@ -7067,7 +7067,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -7082,7 +7082,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "bytes 0.5.6",
  "fnv",
@@ -7109,7 +7109,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "futures 0.3.5",
  "libp2p",
@@ -7122,7 +7122,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "log 0.4.11",
  "substrate-prometheus-endpoint",
@@ -7131,7 +7131,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "futures 0.3.5",
  "hash-db",
@@ -7163,7 +7163,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "derive_more 0.99.9",
  "futures 0.3.5",
@@ -7187,7 +7187,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "futures 0.1.29",
  "jsonrpc-core",
@@ -7205,7 +7205,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "derive_more 0.99.9",
  "directories",
@@ -7267,7 +7267,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "log 0.4.11",
  "parity-scale-codec",
@@ -7281,7 +7281,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -7302,7 +7302,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "erased-serde",
  "log 0.4.11",
@@ -7321,7 +7321,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-graph"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "derive_more 0.99.9",
  "futures 0.3.5",
@@ -7342,7 +7342,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "derive_more 0.99.9",
  "futures 0.3.5",
@@ -7809,7 +7809,7 @@ dependencies = [
 [[package]]
 name = "sp-allocator"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "derive_more 0.99.9",
  "log 0.4.11",
@@ -7821,7 +7821,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
@@ -7836,7 +7836,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate",
@@ -7848,7 +7848,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -7860,7 +7860,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "integer-sqrt",
  "num-traits 0.2.12",
@@ -7873,7 +7873,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7885,7 +7885,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -7896,7 +7896,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7908,7 +7908,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "derive_more 0.99.9",
  "log 0.4.11",
@@ -7925,7 +7925,7 @@ dependencies = [
 [[package]]
 name = "sp-chain-spec"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "serde",
  "serde_json",
@@ -7934,7 +7934,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "derive_more 0.99.9",
  "futures 0.3.5",
@@ -7960,7 +7960,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "merlin",
  "parity-scale-codec",
@@ -7979,7 +7979,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -7988,7 +7988,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "parity-scale-codec",
  "schnorrkel",
@@ -8000,7 +8000,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "base58",
  "blake2-rfc",
@@ -8044,7 +8044,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "kvdb",
  "parking_lot 0.10.2",
@@ -8053,7 +8053,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
@@ -8063,7 +8063,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -8074,7 +8074,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "finality-grandpa",
  "log 0.4.11",
@@ -8090,7 +8090,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-tracker"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -8100,7 +8100,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "derive_more 0.99.9",
  "parity-scale-codec",
@@ -8112,7 +8112,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "futures 0.3.5",
  "hash-db",
@@ -8135,7 +8135,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -8146,7 +8146,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -8158,7 +8158,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections-compact"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.18",
@@ -8169,7 +8169,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -8179,7 +8179,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "backtrace",
  "log 0.4.11",
@@ -8188,7 +8188,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "serde",
  "sp-core",
@@ -8197,7 +8197,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -8219,7 +8219,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "parity-scale-codec",
  "primitive-types",
@@ -8235,7 +8235,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -8247,7 +8247,7 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "serde",
  "serde_json",
@@ -8256,7 +8256,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -8269,7 +8269,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -8279,7 +8279,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "hash-db",
  "log 0.4.11",
@@ -8300,12 +8300,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 
 [[package]]
 name = "sp-storage"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -8318,7 +8318,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -8332,7 +8332,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "log 0.4.11",
  "parity-scale-codec",
@@ -8345,7 +8345,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "derive_more 0.99.9",
  "futures 0.3.5",
@@ -8360,7 +8360,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -8374,7 +8374,7 @@ dependencies = [
 [[package]]
 name = "sp-utils"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "futures 0.3.5",
  "futures-core",
@@ -8386,7 +8386,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -8398,7 +8398,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -8539,7 +8539,7 @@ dependencies = [
 [[package]]
 name = "substrate-browser-utils"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "chrono",
  "console_error_panic_hook",
@@ -8565,7 +8565,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "platforms",
 ]
@@ -8573,7 +8573,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.5",
@@ -8596,7 +8596,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "async-std",
  "derive_more 0.99.9",
@@ -8610,7 +8610,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "futures 0.1.29",
  "futures 0.3.5",
@@ -8636,7 +8636,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-utils"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "futures 0.3.5",
  "substrate-test-utils-derive",
@@ -8646,7 +8646,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-utils-derive"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#75d987ba6bc4317f3f9783a1524f68904f282970"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "proc-macro-crate",
  "quote 1.0.7",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1429,7 +1429,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -1437,7 +1437,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1455,7 +1455,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-benchmarking",
  "parity-scale-codec",
@@ -1473,7 +1473,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1489,7 +1489,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata"
 version = "11.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -1500,7 +1500,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "bitmask",
  "frame-metadata",
@@ -1525,7 +1525,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-support-procedural-tools",
  "proc-macro2 1.0.18",
@@ -1536,7 +1536,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -1548,7 +1548,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
@@ -1558,7 +1558,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -1574,7 +1574,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -1588,7 +1588,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -3769,7 +3769,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3785,7 +3785,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3800,7 +3800,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3825,7 +3825,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3839,7 +3839,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3855,7 +3855,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3870,7 +3870,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3885,7 +3885,7 @@ dependencies = [
 [[package]]
 name = "pallet-finality-tracker"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3901,7 +3901,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3923,7 +3923,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -3939,7 +3939,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3959,7 +3959,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3975,7 +3975,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3989,7 +3989,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4004,7 +4004,7 @@ dependencies = [
 [[package]]
 name = "pallet-nicks"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4018,7 +4018,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4033,7 +4033,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4054,7 +4054,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4069,7 +4069,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4082,7 +4082,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "enumflags2",
  "frame-support",
@@ -4097,7 +4097,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4112,7 +4112,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4132,7 +4132,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4148,7 +4148,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4162,7 +4162,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4184,7 +4184,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.18",
@@ -4195,7 +4195,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4209,7 +4209,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4227,7 +4227,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4244,7 +4244,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "jsonrpc-core 15.0.0",
  "jsonrpc-core-client",
@@ -4262,7 +4262,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -4275,7 +4275,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4290,7 +4290,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4306,7 +4306,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -6493,7 +6493,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "bytes 0.5.6",
  "derive_more 0.99.9",
@@ -6521,7 +6521,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -6545,7 +6545,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -6562,7 +6562,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -6579,7 +6579,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.18",
@@ -6590,7 +6590,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
@@ -6639,7 +6639,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "derive_more 0.99.9",
  "fnv",
@@ -6675,7 +6675,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "blake2-rfc",
  "hash-db",
@@ -6705,7 +6705,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "sc-client-api",
  "sp-blockchain",
@@ -6716,7 +6716,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "derive_more 0.99.9",
  "fork-tree",
@@ -6760,7 +6760,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "derive_more 0.99.9",
  "futures 0.3.5",
@@ -6784,7 +6784,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -6797,7 +6797,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -6820,7 +6820,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-uncles"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "log 0.4.11",
  "sc-client-api",
@@ -6834,7 +6834,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "derive_more 0.99.9",
  "lazy_static",
@@ -6862,7 +6862,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "derive_more 0.99.9",
  "log 0.4.11",
@@ -6879,7 +6879,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "log 0.4.11",
  "parity-scale-codec",
@@ -6894,7 +6894,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "log 0.4.11",
  "parity-scale-codec",
@@ -6912,7 +6912,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "derive_more 0.99.9",
  "finality-grandpa",
@@ -6949,7 +6949,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa-rpc"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "derive_more 0.99.9",
  "finality-grandpa",
@@ -6973,7 +6973,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "ansi_term 0.12.1",
  "futures 0.3.5",
@@ -6991,7 +6991,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "derive_more 0.99.9",
  "hex",
@@ -7007,7 +7007,7 @@ dependencies = [
 [[package]]
 name = "sc-light"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "hash-db",
  "lazy_static",
@@ -7026,7 +7026,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "async-std",
  "async-trait",
@@ -7080,7 +7080,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -7095,7 +7095,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "bytes 0.5.6",
  "fnv",
@@ -7122,7 +7122,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "futures 0.3.5",
  "libp2p",
@@ -7135,7 +7135,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "log 0.4.11",
  "substrate-prometheus-endpoint",
@@ -7144,7 +7144,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "futures 0.3.5",
  "hash-db",
@@ -7176,7 +7176,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "derive_more 0.99.9",
  "futures 0.3.5",
@@ -7200,7 +7200,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "futures 0.1.29",
  "jsonrpc-core 15.0.0",
@@ -7218,7 +7218,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "derive_more 0.99.9",
  "directories",
@@ -7280,7 +7280,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "log 0.4.11",
  "parity-scale-codec",
@@ -7294,7 +7294,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -7315,7 +7315,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "erased-serde",
  "log 0.4.11",
@@ -7334,7 +7334,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-graph"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "derive_more 0.99.9",
  "futures 0.3.5",
@@ -7355,7 +7355,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "derive_more 0.99.9",
  "futures 0.3.5",
@@ -7822,7 +7822,7 @@ dependencies = [
 [[package]]
 name = "sp-allocator"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "derive_more 0.99.9",
  "log 0.4.11",
@@ -7834,7 +7834,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
@@ -7849,7 +7849,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate",
@@ -7861,7 +7861,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -7873,7 +7873,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "integer-sqrt",
  "num-traits 0.2.12",
@@ -7886,7 +7886,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7898,7 +7898,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -7909,7 +7909,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7921,7 +7921,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "derive_more 0.99.9",
  "log 0.4.11",
@@ -7938,7 +7938,7 @@ dependencies = [
 [[package]]
 name = "sp-chain-spec"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "serde",
  "serde_json",
@@ -7947,7 +7947,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "derive_more 0.99.9",
  "futures 0.3.5",
@@ -7973,7 +7973,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "merlin",
  "parity-scale-codec",
@@ -7992,7 +7992,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -8001,7 +8001,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "parity-scale-codec",
  "schnorrkel",
@@ -8013,7 +8013,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "base58",
  "blake2-rfc",
@@ -8057,7 +8057,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "kvdb",
  "parking_lot 0.10.2",
@@ -8066,7 +8066,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
@@ -8076,7 +8076,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -8087,7 +8087,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "finality-grandpa",
  "log 0.4.11",
@@ -8103,7 +8103,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-tracker"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -8113,7 +8113,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "derive_more 0.99.9",
  "parity-scale-codec",
@@ -8125,7 +8125,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "futures 0.3.5",
  "hash-db",
@@ -8148,7 +8148,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -8159,7 +8159,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -8171,7 +8171,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections-compact"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.18",
@@ -8182,7 +8182,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -8192,7 +8192,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "backtrace",
  "log 0.4.11",
@@ -8201,7 +8201,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "serde",
  "sp-core",
@@ -8210,7 +8210,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -8232,7 +8232,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "parity-scale-codec",
  "primitive-types",
@@ -8248,7 +8248,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -8260,7 +8260,7 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "serde",
  "serde_json",
@@ -8269,7 +8269,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -8282,7 +8282,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -8292,7 +8292,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "hash-db",
  "log 0.4.11",
@@ -8313,12 +8313,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 
 [[package]]
 name = "sp-storage"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -8331,7 +8331,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -8345,7 +8345,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "log 0.4.11",
  "parity-scale-codec",
@@ -8358,7 +8358,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "derive_more 0.99.9",
  "futures 0.3.5",
@@ -8373,7 +8373,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -8387,7 +8387,7 @@ dependencies = [
 [[package]]
 name = "sp-utils"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "futures 0.3.5",
  "futures-core",
@@ -8399,7 +8399,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -8411,7 +8411,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -8552,7 +8552,7 @@ dependencies = [
 [[package]]
 name = "substrate-browser-utils"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "chrono",
  "console_error_panic_hook",
@@ -8578,7 +8578,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "platforms",
 ]
@@ -8586,7 +8586,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.5",
@@ -8609,7 +8609,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "async-std",
  "derive_more 0.99.9",
@@ -8623,7 +8623,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "futures 0.1.29",
  "futures 0.3.5",
@@ -8649,7 +8649,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-utils"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "futures 0.3.5",
  "substrate-test-utils-derive",
@@ -8659,7 +8659,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-utils-derive"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
+source = "git+https://github.com/paritytech/substrate#8f19521d3ac1487afa7f1ceb2c64627faf7b9102"
 dependencies = [
  "proc-macro-crate",
  "quote 1.0.7",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1429,7 +1429,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -1437,7 +1437,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1455,7 +1455,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "frame-benchmarking",
  "parity-scale-codec",
@@ -1473,7 +1473,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1489,7 +1489,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata"
 version = "11.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -1500,7 +1500,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "bitmask",
  "frame-metadata",
@@ -1525,7 +1525,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "frame-support-procedural-tools",
  "proc-macro2 1.0.18",
@@ -1536,7 +1536,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -1548,7 +1548,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
@@ -1558,7 +1558,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -1574,7 +1574,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -1588,7 +1588,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -2408,13 +2408,13 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-client-transports"
-version = "14.2.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecbdaacc17243168d9d1fa6b2bd7556a27e1e60a621d8a2a6e590ae2b145d158"
+checksum = "c6f7b1cdf66312002e15682a24430728bd13036c641163c016bc53fb686a7c2d"
 dependencies = [
  "failure",
  "futures 0.1.29",
- "jsonrpc-core",
+ "jsonrpc-core 15.0.0",
  "jsonrpc-pubsub",
  "log 0.4.11",
  "serde",
@@ -2436,19 +2436,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonrpc-core-client"
-version = "14.2.0"
+name = "jsonrpc-core"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34221123bc79b66279a3fde2d3363553835b43092d629b34f2e760c44dc94713"
+checksum = "f30b12567a31d48588a65b6cf870081e6ba1d7b2ae353977cb9820d512e69c70"
+dependencies = [
+ "futures 0.1.29",
+ "log 0.4.11",
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
+name = "jsonrpc-core-client"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d175ca0cf77439b5495612bf216c650807d252d665b4b70ab2eebd895a88fac1"
 dependencies = [
  "jsonrpc-client-transports",
 ]
 
 [[package]]
 name = "jsonrpc-derive"
-version = "14.2.1"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fadf6945e227246825a583514534d864554e9f23d80b3c77d034b10983db5ef"
+checksum = "c2cc6ea7f785232d9ca8786a44e9fa698f92149dcdc1acc4aa1fc69c4993d79e"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.18",
@@ -2458,12 +2471,12 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-http-server"
-version = "14.2.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0da906d682799df05754480dac1b9e70ec92e12c19ebafd2662a5ea1c9fd6522"
+checksum = "9996b26c0c7a59626d0ed6c5ec8bf06218e62ce1474bd2849f9b9fd38a0158c0"
 dependencies = [
  "hyper 0.12.35",
- "jsonrpc-core",
+ "jsonrpc-core 15.0.0",
  "jsonrpc-server-utils",
  "log 0.4.11",
  "net2",
@@ -2473,11 +2486,11 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-ipc-server"
-version = "14.2.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dedccd693325d833963b549e959137f30a7a0ea650cde92feda81dc0c1393cb5"
+checksum = "b8e8f2278fb2b277175b6e21b23e7ecf30e78daff5ee301d0a2a411d9a821a0a"
 dependencies = [
- "jsonrpc-core",
+ "jsonrpc-core 15.0.0",
  "jsonrpc-server-utils",
  "log 0.4.11",
  "parity-tokio-ipc",
@@ -2487,11 +2500,11 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-pubsub"
-version = "14.2.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d44f5602a11d657946aac09357956d2841299ed422035edf140c552cb057986"
+checksum = "f389c5cd1f3db258a99296892c21047e21ae73ff4c0e2d39650ea86fe994b4c7"
 dependencies = [
- "jsonrpc-core",
+ "jsonrpc-core 15.0.0",
  "log 0.4.11",
  "parking_lot 0.10.2",
  "rand 0.7.3",
@@ -2500,13 +2513,13 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-server-utils"
-version = "14.2.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56cbfb462e7f902e21121d9f0d1c2b77b2c5b642e1a4e8f4ebfa2e15b94402bb"
+checksum = "c623e1895d0d9110cb0ea7736cfff13191ff52335ad33b21bd5c775ea98b27af"
 dependencies = [
  "bytes 0.4.12",
  "globset",
- "jsonrpc-core",
+ "jsonrpc-core 15.0.0",
  "lazy_static",
  "log 0.4.11",
  "tokio 0.1.22",
@@ -2516,16 +2529,16 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-ws-server"
-version = "14.2.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "903d3109fe7c4acb932b567e1e607e0f524ed04741b09fb0e61841bc40a022fc"
+checksum = "436a92034d0137ab3e3c64a7a6350b428f31cb4d7d1a89f284bcdbcd98a7bc56"
 dependencies = [
- "jsonrpc-core",
+ "jsonrpc-core 15.0.0",
  "jsonrpc-server-utils",
  "log 0.4.11",
+ "parity-ws",
  "parking_lot 0.10.2",
  "slab",
- "ws",
 ]
 
 [[package]]
@@ -3756,7 +3769,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3772,7 +3785,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3787,7 +3800,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3812,7 +3825,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3826,7 +3839,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3842,7 +3855,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3857,7 +3870,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3872,7 +3885,7 @@ dependencies = [
 [[package]]
 name = "pallet-finality-tracker"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3888,7 +3901,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3910,7 +3923,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -3926,7 +3939,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3946,7 +3959,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3962,7 +3975,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3976,7 +3989,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3991,7 +4004,7 @@ dependencies = [
 [[package]]
 name = "pallet-nicks"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4005,7 +4018,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4020,7 +4033,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4041,7 +4054,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4056,7 +4069,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4069,7 +4082,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "enumflags2",
  "frame-support",
@@ -4084,7 +4097,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4099,7 +4112,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4119,7 +4132,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4135,7 +4148,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4149,7 +4162,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4171,7 +4184,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.18",
@@ -4182,7 +4195,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4196,7 +4209,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4214,7 +4227,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4231,9 +4244,9 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
- "jsonrpc-core",
+ "jsonrpc-core 15.0.0",
  "jsonrpc-core-client",
  "jsonrpc-derive",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -4249,7 +4262,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -4262,7 +4275,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4277,7 +4290,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4293,7 +4306,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -4420,6 +4433,24 @@ name = "parity-wasm"
 version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc878dac00da22f8f61e7af3157988424567ab01d9920b962ef7dcbd7cd865"
+
+[[package]]
+name = "parity-ws"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e02a625dd75084c2a7024f07c575b61b782f729d18702dabb3cdbf31911dc61"
+dependencies = [
+ "byteorder 1.3.4",
+ "bytes 0.4.12",
+ "httparse",
+ "log 0.4.11",
+ "mio",
+ "mio-extras",
+ "rand 0.7.3",
+ "sha-1",
+ "slab",
+ "url 2.1.1",
+]
 
 [[package]]
 name = "parking"
@@ -5154,7 +5185,7 @@ dependencies = [
 name = "polkadot-rpc"
 version = "0.8.24"
 dependencies = [
- "jsonrpc-core",
+ "jsonrpc-core 14.2.0",
  "pallet-transaction-payment-rpc",
  "parity-scale-codec",
  "polkadot-primitives",
@@ -6462,7 +6493,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "bytes 0.5.6",
  "derive_more 0.99.9",
@@ -6490,7 +6521,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -6514,7 +6545,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -6531,7 +6562,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -6548,7 +6579,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.18",
@@ -6559,7 +6590,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
@@ -6608,7 +6639,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "derive_more 0.99.9",
  "fnv",
@@ -6644,7 +6675,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "blake2-rfc",
  "hash-db",
@@ -6674,7 +6705,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "sc-client-api",
  "sp-blockchain",
@@ -6685,7 +6716,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "derive_more 0.99.9",
  "fork-tree",
@@ -6729,11 +6760,11 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "derive_more 0.99.9",
  "futures 0.3.5",
- "jsonrpc-core",
+ "jsonrpc-core 15.0.0",
  "jsonrpc-core-client",
  "jsonrpc-derive",
  "sc-consensus-babe",
@@ -6753,7 +6784,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -6766,7 +6797,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -6789,7 +6820,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-uncles"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "log 0.4.11",
  "sc-client-api",
@@ -6803,7 +6834,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "derive_more 0.99.9",
  "lazy_static",
@@ -6831,7 +6862,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "derive_more 0.99.9",
  "log 0.4.11",
@@ -6848,7 +6879,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "log 0.4.11",
  "parity-scale-codec",
@@ -6863,7 +6894,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "log 0.4.11",
  "parity-scale-codec",
@@ -6881,7 +6912,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "derive_more 0.99.9",
  "finality-grandpa",
@@ -6918,12 +6949,12 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa-rpc"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "derive_more 0.99.9",
  "finality-grandpa",
  "futures 0.3.5",
- "jsonrpc-core",
+ "jsonrpc-core 15.0.0",
  "jsonrpc-core-client",
  "jsonrpc-derive",
  "jsonrpc-pubsub",
@@ -6942,7 +6973,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "ansi_term 0.12.1",
  "futures 0.3.5",
@@ -6960,7 +6991,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "derive_more 0.99.9",
  "hex",
@@ -6976,7 +7007,7 @@ dependencies = [
 [[package]]
 name = "sc-light"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "hash-db",
  "lazy_static",
@@ -6995,7 +7026,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "async-std",
  "async-trait",
@@ -7049,7 +7080,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -7064,7 +7095,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "bytes 0.5.6",
  "fnv",
@@ -7091,7 +7122,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "futures 0.3.5",
  "libp2p",
@@ -7104,7 +7135,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "log 0.4.11",
  "substrate-prometheus-endpoint",
@@ -7113,11 +7144,11 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "futures 0.3.5",
  "hash-db",
- "jsonrpc-core",
+ "jsonrpc-core 15.0.0",
  "jsonrpc-pubsub",
  "log 0.4.11",
  "parity-scale-codec",
@@ -7145,11 +7176,11 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "derive_more 0.99.9",
  "futures 0.3.5",
- "jsonrpc-core",
+ "jsonrpc-core 15.0.0",
  "jsonrpc-core-client",
  "jsonrpc-derive",
  "jsonrpc-pubsub",
@@ -7169,10 +7200,10 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "futures 0.1.29",
- "jsonrpc-core",
+ "jsonrpc-core 15.0.0",
  "jsonrpc-http-server",
  "jsonrpc-ipc-server",
  "jsonrpc-pubsub",
@@ -7187,7 +7218,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "derive_more 0.99.9",
  "directories",
@@ -7196,7 +7227,7 @@ dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
  "hash-db",
- "jsonrpc-core",
+ "jsonrpc-core 15.0.0",
  "jsonrpc-pubsub",
  "lazy_static",
  "log 0.4.11",
@@ -7249,7 +7280,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "log 0.4.11",
  "parity-scale-codec",
@@ -7263,7 +7294,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -7284,7 +7315,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "erased-serde",
  "log 0.4.11",
@@ -7303,7 +7334,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-graph"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "derive_more 0.99.9",
  "futures 0.3.5",
@@ -7324,7 +7355,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "derive_more 0.99.9",
  "futures 0.3.5",
@@ -7791,7 +7822,7 @@ dependencies = [
 [[package]]
 name = "sp-allocator"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "derive_more 0.99.9",
  "log 0.4.11",
@@ -7803,7 +7834,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
@@ -7818,7 +7849,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate",
@@ -7830,7 +7861,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -7842,7 +7873,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "integer-sqrt",
  "num-traits 0.2.12",
@@ -7855,7 +7886,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7867,7 +7898,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -7878,7 +7909,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7890,7 +7921,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "derive_more 0.99.9",
  "log 0.4.11",
@@ -7907,7 +7938,7 @@ dependencies = [
 [[package]]
 name = "sp-chain-spec"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "serde",
  "serde_json",
@@ -7916,7 +7947,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "derive_more 0.99.9",
  "futures 0.3.5",
@@ -7942,7 +7973,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "merlin",
  "parity-scale-codec",
@@ -7961,7 +7992,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -7970,7 +8001,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "parity-scale-codec",
  "schnorrkel",
@@ -7982,7 +8013,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "base58",
  "blake2-rfc",
@@ -8026,7 +8057,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "kvdb",
  "parking_lot 0.10.2",
@@ -8035,7 +8066,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
@@ -8045,7 +8076,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -8056,7 +8087,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "finality-grandpa",
  "log 0.4.11",
@@ -8072,7 +8103,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-tracker"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -8082,7 +8113,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "derive_more 0.99.9",
  "parity-scale-codec",
@@ -8094,7 +8125,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "futures 0.3.5",
  "hash-db",
@@ -8117,7 +8148,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -8128,7 +8159,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -8140,7 +8171,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections-compact"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.18",
@@ -8151,7 +8182,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -8161,7 +8192,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "backtrace",
  "log 0.4.11",
@@ -8170,7 +8201,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "serde",
  "sp-core",
@@ -8179,7 +8210,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -8201,7 +8232,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "parity-scale-codec",
  "primitive-types",
@@ -8217,7 +8248,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -8229,7 +8260,7 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "serde",
  "serde_json",
@@ -8238,7 +8269,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -8251,7 +8282,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -8261,7 +8292,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "hash-db",
  "log 0.4.11",
@@ -8282,12 +8313,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 
 [[package]]
 name = "sp-storage"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -8300,7 +8331,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -8314,7 +8345,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "log 0.4.11",
  "parity-scale-codec",
@@ -8327,7 +8358,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "derive_more 0.99.9",
  "futures 0.3.5",
@@ -8342,7 +8373,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -8356,7 +8387,7 @@ dependencies = [
 [[package]]
 name = "sp-utils"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "futures 0.3.5",
  "futures-core",
@@ -8368,7 +8399,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -8380,7 +8411,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -8521,7 +8552,7 @@ dependencies = [
 [[package]]
 name = "substrate-browser-utils"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "chrono",
  "console_error_panic_hook",
@@ -8547,7 +8578,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "platforms",
 ]
@@ -8555,11 +8586,11 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.5",
- "jsonrpc-core",
+ "jsonrpc-core 15.0.0",
  "jsonrpc-core-client",
  "jsonrpc-derive",
  "log 0.4.11",
@@ -8578,7 +8609,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "async-std",
  "derive_more 0.99.9",
@@ -8592,7 +8623,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "futures 0.1.29",
  "futures 0.3.5",
@@ -8618,7 +8649,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-utils"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "futures 0.3.5",
  "substrate-test-utils-derive",
@@ -8628,7 +8659,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-utils-derive"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate#16474ee9ed8f75ad578f4539ae4fc016ecf8b3d1"
+source = "git+https://github.com/paritytech/substrate#4a6b0ae28eaafaae7fa09abd958c20518cd01c3f"
 dependencies = [
  "proc-macro-crate",
  "quote 1.0.7",
@@ -9975,24 +10006,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "ws"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51a2c47b5798ccc774ffb93ff536aec7c4275d722fd9c740c83cdd1af1f2d94"
-dependencies = [
- "byteorder 1.3.4",
- "bytes 0.4.12",
- "httparse",
- "log 0.4.11",
- "mio",
- "mio-extras",
- "rand 0.7.3",
- "sha-1",
- "slab",
- "url 2.1.1",
-]
 
 [[package]]
 name = "ws2_32-sys"

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -549,7 +549,6 @@ impl pallet_offences::Trait for Runtime {
 	type IdentificationTuple = pallet_session::historical::IdentificationTuple<Self>;
 	type OnOffenceHandler = Staking;
 	type WeightSoftLimit = OffencesWeightSoftLimit;
-	type WeightInfo = ();
 }
 
 impl pallet_authority_discovery::Trait for Runtime {}

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -605,7 +605,6 @@ impl pallet_offences::Trait for Runtime {
 	type IdentificationTuple = pallet_session::historical::IdentificationTuple<Self>;
 	type OnOffenceHandler = Staking;
 	type WeightSoftLimit = OffencesWeightSoftLimit;
-	type WeightInfo = ();
 }
 
 impl pallet_authority_discovery::Trait for Runtime {}

--- a/runtime/polkadot/tests/weights.rs
+++ b/runtime/polkadot/tests/weights.rs
@@ -33,7 +33,6 @@ use polkadot_runtime::{self, Runtime};
 use runtime_common::MaximumBlockWeight;
 
 use pallet_elections_phragmen::Call as PhragmenCall;
-use pallet_session::Call as SessionCall;
 use frame_system::Call as SystemCall;
 
 type DbWeight = <Runtime as frame_system::Trait>::DbWeight;

--- a/runtime/polkadot/tests/weights.rs
+++ b/runtime/polkadot/tests/weights.rs
@@ -58,31 +58,6 @@ fn weight_of_system_set_code_is_correct() {
 }
 
 #[test]
-fn weight_of_session_set_keys_is_correct() {
-	// #[weight = 200_000_000
-	// 	+ T::DbWeight::get().reads(2 + T::Keys::key_ids().len() as Weight)
-	// 	+ T::DbWeight::get().writes(1 + T::Keys::key_ids().len() as Weight)]
-	//
-	// Polkadot has five possible session keys, so we default to key_ids.len() = 5
-	let expected_weight = 200_000_000 + (DbWeight::get().read * (2 + 5)) + (DbWeight::get().write * (1 + 5));
-	let weight = SessionCall::set_keys::<Runtime>(Default::default(), Default::default()).get_dispatch_info().weight;
-
-	assert_eq!(weight, expected_weight);
-}
-
-#[test]
-fn weight_of_session_purge_keys_is_correct() {
-	// #[weight = 120_000_000
-	// 	+ T::DbWeight::get().reads_writes(2, 1 + T::Keys::key_ids().len() as Weight)]
-	//
-	// Polkadot has five possible session keys, so we default to key_ids.len() = 5
-	let expected_weight = 120_000_000 + (DbWeight::get().read * 2) + (DbWeight::get().write * (1 + 5));
-	let weight = SessionCall::purge_keys::<Runtime>().get_dispatch_info().weight;
-
-	assert_eq!(weight, expected_weight);
-}
-
-#[test]
 fn weight_of_phragmen_vote_is_correct() {
 	// #[weight = 100_000_000]
 	let expected_weight = 350_000_000;

--- a/runtime/rococo-v1/src/lib.rs
+++ b/runtime/rococo-v1/src/lib.rs
@@ -598,7 +598,6 @@ impl pallet_offences::Trait for Runtime {
 	type IdentificationTuple = pallet_session::historical::IdentificationTuple<Self>;
 	type OnOffenceHandler = Staking;
 	type WeightSoftLimit = OffencesWeightSoftLimit;
-	type WeightInfo = ();
 }
 
 impl pallet_authority_discovery::Trait for Runtime {}

--- a/runtime/test-runtime/src/lib.rs
+++ b/runtime/test-runtime/src/lib.rs
@@ -378,7 +378,6 @@ impl pallet_offences::Trait for Runtime {
 	type IdentificationTuple = pallet_session::historical::IdentificationTuple<Self>;
 	type OnOffenceHandler = Staking;
 	type WeightSoftLimit = OffencesWeightSoftLimit;
-	type WeightInfo = ();
 }
 
 impl pallet_authority_discovery::Trait for Runtime {}

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -356,7 +356,6 @@ impl pallet_offences::Trait for Runtime {
 	type IdentificationTuple = pallet_session::historical::IdentificationTuple<Self>;
 	type OnOffenceHandler = Staking;
 	type WeightSoftLimit = OffencesWeightSoftLimit;
-	type WeightInfo = ();
 }
 
 impl pallet_authority_discovery::Trait for Runtime {}


### PR DESCRIPTION
This is a simple PR that removes the `WeightInfo` trade for pallet_offences (as the weight information should come from the different implementations of `OnOffence`.

paritytech/substrate#7136