### PR TITLE
Parachains: Introduce a dummy module to include the Origin.

### DIFF
--- a/runtime/parachains/src/lib.rs
+++ b/runtime/parachains/src/lib.rs
@@ -22,11 +22,6 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use sp_std::result;
-use sp_runtime::traits::BadOrigin;
-use primitives::v1::Id as ParaId;
-use codec::{Decode, Encode};
-
 pub mod configuration;
 pub mod inclusion;
 pub mod inclusion_inherent;
@@ -35,6 +30,7 @@ pub mod paras;
 pub mod router;
 pub mod scheduler;
 pub mod validity;
+pub mod origin;
 
 pub mod runtime_api_impl;
 
@@ -43,21 +39,4 @@ mod util;
 #[cfg(test)]
 mod mock;
 
-/// Origin for the parachains.
-#[derive(PartialEq, Eq, Clone, Encode, Decode)]
-#[cfg_attr(feature = "std", derive(Debug))]
-pub enum Origin {
-	/// It comes from a parachain.
-	Parachain(ParaId),
-}
-
-/// Ensure that the origin `o` represents a parachain.
-/// Returns `Ok` with the parachain ID that effected the extrinsic or an `Err` otherwise.
-pub fn ensure_parachain<OuterOrigin>(o: OuterOrigin) -> result::Result<ParaId, BadOrigin>
-	where OuterOrigin: Into<result::Result<Origin, OuterOrigin>>
-{
-	match o.into() {
-		Ok(Origin::Parachain(id)) => Ok(id),
-		_ => Err(BadOrigin),
-	}
-}
+pub use origin::{Origin, ensure_parachain};

--- a/runtime/parachains/src/origin.rs
+++ b/runtime/parachains/src/origin.rs
@@ -1,0 +1,54 @@
+// Copyright 2020 Parity Technologies (UK) Ltd.
+// This file is part of Polkadot.
+
+// Polkadot is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Polkadot is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Declaration of the parachain specific origin and a pallet that hosts it.
+
+use sp_std::result;
+use sp_runtime::traits::BadOrigin;
+use primitives::v1::Id as ParaId;
+use codec::{Decode, Encode};
+
+/// Origin for the parachains.
+#[derive(PartialEq, Eq, Clone, Encode, Decode)]
+#[cfg_attr(feature = "std", derive(Debug))]
+pub enum Origin {
+	/// It comes from a parachain.
+	Parachain(ParaId),
+}
+
+/// Ensure that the origin `o` represents a parachain.
+/// Returns `Ok` with the parachain ID that effected the extrinsic or an `Err` otherwise.
+pub fn ensure_parachain<OuterOrigin>(o: OuterOrigin) -> result::Result<ParaId, BadOrigin>
+	where OuterOrigin: Into<result::Result<Origin, OuterOrigin>>
+{
+	match o.into() {
+		Ok(Origin::Parachain(id)) => Ok(id),
+		_ => Err(BadOrigin),
+	}
+}
+
+/// The origin module.
+pub trait Trait: frame_system::Trait {}
+
+frame_support::decl_module! {
+	/// There is no way to register an origin type in `construct_runtime` without a pallet the origin
+	/// belongs to.
+	///
+	/// This module fulfills only the single purpose of housing the `Origin` in `construct_runtime`.
+	///
+	// ideally, though, the `construct_runtime` should support a free-standing origin.
+	pub struct Module<T: Trait> for enum Call where origin: <T as frame_system::Trait>::Origin {}
+}

--- a/runtime/rococo-v1/src/lib.rs
+++ b/runtime/rococo-v1/src/lib.rs
@@ -63,6 +63,7 @@ use pallet_session::historical as session_historical;
 use frame_system::EnsureRoot;
 use runtime_common::paras_sudo_wrapper as paras_sudo_wrapper;
 
+use runtime_parachains::origin as parachains_origin;
 use runtime_parachains::configuration as parachains_configuration;
 use runtime_parachains::inclusion as parachains_inclusion;
 use runtime_parachains::inclusion_inherent as parachains_inclusion_inherent;
@@ -366,6 +367,7 @@ construct_runtime! {
 		AuthorityDiscovery: pallet_authority_discovery::{Module, Call, Config},
 
 		// Parachains modules.
+		ParachainOrigin: parachains_origin::{Module, Origin},
 		Config: parachains_configuration::{Module, Call, Storage},
 		Inclusion: parachains_inclusion::{Module, Call, Storage, Event<T>},
 		InclusionInherent: parachains_inclusion_inherent::{Module, Call, Storage},
@@ -717,6 +719,8 @@ impl pallet_authorship::Trait for Runtime {
 	type FilterUncle = ();
 	type EventHandler = (Staking, ImOnline);
 }
+
+impl parachains_origin::Trait for Runtime { }
 
 impl parachains_configuration::Trait for Runtime { }
 


### PR DESCRIPTION
That's because `construct_runtime` doesn't support a free-standing Origin. See the comment in parachains/src/origin.rs

Split off from #1679 