### PR TITLE
Increase Westend `spec_version`

### DIFF
--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -85,7 +85,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("westend"),
 	impl_name: create_runtime_str!("parity-westend"),
 	authoring_version: 2,
-	spec_version: 44,
+	spec_version: 45,
 	impl_version: 1,
 	#[cfg(not(feature = "disable-runtime-api"))]
 	apis: RUNTIME_API_VERSIONS,


### PR DESCRIPTION
This is required to ensure that on chain isn't seen as compatible to
current master.