### PR TITLE
Registrar v1 follow-ups

### DIFF
--- a/runtime/common/src/paras_registrar.rs
+++ b/runtime/common/src/paras_registrar.rs
@@ -33,6 +33,7 @@ use runtime_parachains::{
 		self,
 		ParaGenesisArgs,
 	},
+	router,
 	ensure_parachain,
 	Origin,
 };
@@ -40,7 +41,7 @@ use runtime_parachains::{
 type BalanceOf<T> =
 	<<T as Trait>::Currency as Currency<<T as frame_system::Trait>::AccountId>>::Balance;
 
-pub trait Trait: paras::Trait {
+pub trait Trait: paras::Trait + router::Trait {
 	/// The aggregated origin type must support the `parachains` origin. We require that we can
 	/// infallibly convert between this origin and the system origin, but in reality, they're the
 	/// same type, we just can't express that to the Rust type system without writing a `where`
@@ -269,7 +270,7 @@ mod tests {
 
 	impl_outer_origin! {
 		pub enum Origin for Test {
-			paras,
+			runtime_parachains,
 		}
 	}
 

--- a/runtime/common/src/paras_registrar.rs
+++ b/runtime/common/src/paras_registrar.rs
@@ -151,6 +151,7 @@ decl_module! {
 			let _ = <T as Trait>::Currency::unreserve(&debtor, T::ParathreadDeposit::get());
 
 			<paras::Module<T>>::schedule_para_cleanup(id);
+			<router::Module::<T>>::schedule_para_cleanup(id);
 
 			Ok(())
 		}

--- a/runtime/common/src/paras_registrar.rs
+++ b/runtime/common/src/paras_registrar.rs
@@ -243,6 +243,7 @@ impl<T: Trait> Module<T> {
 		ensure!(is_parachain, Error::<T>::InvalidChainId);
 
 		<paras::Module<T>>::schedule_para_cleanup(id);
+		<router::Module::<T>>::schedule_para_cleanup(id);
 
 		Ok(())
 	}

--- a/runtime/parachains/src/mock.rs
+++ b/runtime/parachains/src/mock.rs
@@ -30,7 +30,7 @@ use frame_support::{
 	weights::Weight, traits::Randomness as RandomnessT,
 };
 use crate::inclusion;
-use crate::paras;
+use crate as parachains;
 
 /// A test runtime struct.
 #[derive(Clone, Eq, PartialEq)]
@@ -38,7 +38,7 @@ pub struct Test;
 
 impl_outer_origin! {
 	pub enum Origin for Test {
-		paras
+		parachains
 	}
 }
 

--- a/runtime/parachains/src/origin.rs
+++ b/runtime/parachains/src/origin.rs
@@ -22,8 +22,7 @@ use primitives::v1::Id as ParaId;
 use codec::{Decode, Encode};
 
 /// Origin for the parachains.
-#[derive(PartialEq, Eq, Clone, Encode, Decode)]
-#[cfg_attr(feature = "std", derive(Debug))]
+#[derive(PartialEq, Eq, Clone, Encode, Decode, sp_core::RuntimeDebug)]
 pub enum Origin {
 	/// It comes from a parachain.
 	Parachain(ParaId),

--- a/runtime/parachains/src/paras.rs
+++ b/runtime/parachains/src/paras.rs
@@ -43,7 +43,7 @@ use sp_core::RuntimeDebug;
 #[cfg(feature = "std")]
 use serde::{Serialize, Deserialize};
 
-pub use crate::Origin;
+use crate::Origin;
 
 pub trait Trait: frame_system::Trait + configuration::Trait {
 	/// The outer origin type.


### PR DESCRIPTION
A follow-up to recently merged https://github.com/paritytech/polkadot/pull/1559

This PR comprised of two changes:

1. Do not add alias for `polkadot-runtime-parachains::Origin` to `polkadot-runtime-parachains::paras::Origin`. 
1. Call the `schedule_para_cleanup` for the router module as well.

Re: origin. TBH, I am not sure why it was made this way, but I don't see a reason why we should not use the original declaration directly. Otherwise, it spawns questions like: why do we add this origin into the mock but not into the runtime, are there any edge-cases if you register the essentially the same origin twice but using different paths, and so on.

I actually made it this way first in #1679, but failed to land the mock part in https://github.com/paritytech/polkadot/pull/1749.

Re: `schedule_para_cleanup`. Right now, you are expected to call all `schedule_para_cleanup`. I don't remember the reasons why we decided to go with additional function instead of introducing a single entrypoint (i.e. call the router module from paras) or introducing another top-level entrypoint, but this PR might be a sign that we might need to reconsider this. Although I don't think it's critical though. cc @rphmeier 

This PR was split from https://github.com/paritytech/polkadot/pull/1679