### PR TITLE
Pass relay parent as argument when collating

### DIFF
--- a/node/collation-generation/src/lib.rs
+++ b/node/collation-generation/src/lib.rs
@@ -233,7 +233,7 @@ async fn handle_new_activations<Context: SubsystemContext>(
 			ctx.spawn("collation generation collation builder", Box::pin(async move {
 				let persisted_validation_data_hash = validation_data.persisted.hash();
 
-				let collation = match (task_config.collator)(&validation_data).await {
+				let collation = match (task_config.collator)(relay_parent, &validation_data).await {
 					Some(collation) => collation,
 					None => {
 						log::debug!(
@@ -406,7 +406,7 @@ mod tests {
 		fn test_config<Id: Into<ParaId>>(para_id: Id) -> Arc<CollationGenerationConfig> {
 			Arc::new(CollationGenerationConfig {
 				key: CollatorPair::generate().0,
-				collator: Box::new(|_vd: &ValidationData| {
+				collator: Box::new(|_: Hash, _vd: &ValidationData| {
 					Box::new(TestCollator)
 				}),
 				para_id: para_id.into(),

--- a/node/overseer/src/lib.rs
+++ b/node/overseer/src/lib.rs
@@ -1876,7 +1876,7 @@ mod tests {
 	fn test_collator_generation_msg() -> CollationGenerationMessage {
 		CollationGenerationMessage::Initialize(CollationGenerationConfig {
 			key: CollatorPair::generate().0,
-			collator: Box::new(|_| Box::new(TestCollator)),
+			collator: Box::new(|_, _| Box::new(TestCollator)),
 			para_id: Default::default(),
 		})
 	}

--- a/node/primitives/src/lib.rs
+++ b/node/primitives/src/lib.rs
@@ -285,7 +285,11 @@ pub struct CollationGenerationConfig {
 	/// Collator's authentication key, so it can sign things.
 	pub key: CollatorPair,
 	/// Collation function.
-	pub collator: Box<dyn Fn(&ValidationData) -> Box<dyn Future<Output = Option<Collation>> + Unpin + Send> + Send + Sync>,
+	///
+	/// Will be called with the hash of the relay chain block the parachain
+	/// block should be build on and the [`ValidationData`] that provides
+	/// information about the state of the parachain on the relay chain.
+	pub collator: Box<dyn Fn(Hash, &ValidationData) -> Box<dyn Future<Output = Option<Collation>> + Unpin + Send> + Send + Sync>,
 	/// The parachain that this collator collates for
 	pub para_id: ParaId,
 }

--- a/roadmap/implementers-guide/src/node/collators/collation-generation.md
+++ b/roadmap/implementers-guide/src/node/collators/collation-generation.md
@@ -36,7 +36,10 @@ pub struct Collation {
 
 struct CollationGenerationConfig {
   key: CollatorPair,
-  collator: Box<dyn Fn(&ValidationData) -> Box<dyn Future<Output = Option<Collation>>>>
+  /// Collate will be called with the relay chain hash the parachain should build 
+  /// a block on and the `ValidationData` that provides information about the state
+  /// of the parachain on the relay chain.
+  collator: Box<dyn Fn(Hash, &ValidationData) -> Box<dyn Future<Output = Option<Collation>>>>
   para_id: ParaId,
 }
 ```


### PR DESCRIPTION
This pr changes the collation function to also pass the current relay
parent the parachain block should be build on.