### PR TITLE
[CI] Docker image updates

### DIFF
--- a/.github/workflows/publish-docker-release.yml
+++ b/.github/workflows/publish-docker-release.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Build
         id:   docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/publish-docker-release.yml
+++ b/.github/workflows/publish-docker-release.yml
@@ -10,10 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
       - name: Build
         id:   docker_build
         uses: docker/build-push-action@v2

--- a/.github/workflows/publish-docker-release.yml
+++ b/.github/workflows/publish-docker-release.yml
@@ -23,6 +23,8 @@ jobs:
         with:
           push: true
           file: scripts/docker/Dockerfile.release
-          tags: martinparity/polkadot:latest
+          tags: |
+            martinparity/polkadot:latest
+            martinparity/polkadot:${{ github.event.release.tag_name }}
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/publish-docker-release.yml
+++ b/.github/workflows/publish-docker-release.yml
@@ -10,17 +10,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Login to Dockerhub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build
         id:   docker_build
         uses: docker/build-push-action@v2
         with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          path: ./scripts/docker
+          file: ./scripts/docker/Dockerfile.release
+          repository: ${{ secrets.DOCKERHUB_USERNAME }}/polkadot
+          tags: latest
           push: true
-          file: scripts/docker/Dockerfile.release
-          tags: martinparity/polkadot:latest
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/publish-docker-release.yml
+++ b/.github/workflows/publish-docker-release.yml
@@ -10,12 +10,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Login to Dockerhub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build
         id:   docker_build
         uses: docker/build-push-action@v2
         with:
-          push: false
+          push: true
           file: scripts/docker/Dockerfile.release
-          tags: s3krit/polkadot:latest
+          tags: martinparity/polkadot:latest
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/publish-docker-release.yml
+++ b/.github/workflows/publish-docker-release.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
       - name: Login to Dockerhub
         uses: docker/login-action@v1
         with:

--- a/.github/workflows/publish-docker-release.yml
+++ b/.github/workflows/publish-docker-release.yml
@@ -9,6 +9,7 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
@@ -18,6 +19,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: false
+          file: scripts/docker/Dockerfile.release
           tags: s3krit/polkadot:latest
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/publish-docker-release.yml
+++ b/.github/workflows/publish-docker-release.yml
@@ -1,0 +1,23 @@
+name: Publish Docker image for new releases
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Build
+        id:   docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: false
+          tags: s3krit/polkadot:latest
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/publish-docker-release.yml
+++ b/.github/workflows/publish-docker-release.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Build
         id:   docker_build
-        uses: docker/build-push-action@v1
+        uses: docker/build-push-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/publish-docker-release.yml
+++ b/.github/workflows/publish-docker-release.yml
@@ -24,7 +24,7 @@ jobs:
           push: true
           file: scripts/docker/Dockerfile.release
           tags: |
-            martinparity/polkadot:latest
-            martinparity/polkadot:${{ github.event.release.tag_name }}
+            parity/polkadot:latest
+            parity/polkadot:${{ github.event.release.tag_name }}
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/publish-docker-release.yml
+++ b/.github/workflows/publish-docker-release.yml
@@ -12,12 +12,19 @@ jobs:
       - uses: actions/checkout@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
+      - name: Cache Docker layers
+        uses: actions/cache@v2
       - name: Login to Dockerhub
+        with:
+         path: /tmp/.buildx-cache
+         key: ${{ runner.os }}-buildx-${{ github.sha }}
+         restore-keys: |
+           ${{ runner.os }}-buildx-
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build
+      - name: Build and push
         id:   docker_build
         uses: docker/build-push-action@v2
         with:
@@ -26,5 +33,7 @@ jobs:
           tags: |
             parity/polkadot:latest
             parity/polkadot:${{ github.event.release.tag_name }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/publish-docker-release.yml
+++ b/.github/workflows/publish-docker-release.yml
@@ -10,16 +10,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Login to Dockerhub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build
         id:   docker_build
         uses: docker/build-push-action@v2
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-          path: ./scripts/docker
-          file: ./scripts/docker/Dockerfile.release
-          repository: ${{ secrets.DOCKERHUB_USERNAME }}/polkadot
-          tags: latest
           push: true
+          file: scripts/docker/Dockerfile.release
+          tags: martinparity/polkadot:latest
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -212,12 +212,16 @@ generate-impl-guide:
     - EXTRATAG="$(cat ./artifacts/EXTRATAG)"
     - echo "Polkadot version = ${VERSION} (EXTRATAG ${EXTRATAG})"
 
-publish-docker-release:
+publish-docker:
   <<:                              *publish-build
   image:                           docker:stable
   services:
     - docker:dind
   <<:                              *collect-artifacts
+  # Don't run on releases - this is handled by the Github Action here:
+  # TODO: Fill this in
+  rules:
+    - if: $CI_COMMIT_REF_NAME !~ /^v[0-9]+\.[0-9]+\.[0-9]+$/ # i.e., v1.2.3 but NOT v1.2.3-rc1
   variables:
     DOCKER_HOST:                   tcp://localhost:2375
     DOCKER_DRIVER:                 overlay2

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -219,7 +219,7 @@ publish-docker:
     - docker:dind
   <<:                              *collect-artifacts
   # Don't run on releases - this is handled by the Github Action here:
-  # TODO: Fill this in
+  # .github/workflows/publish-docker-release.yml
   rules:
     - if: $CI_COMMIT_REF_NAME !~ /^v[0-9]+\.[0-9]+\.[0-9]+$/ # i.e., v1.2.3 but NOT v1.2.3-rc1
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -221,7 +221,9 @@ publish-docker:
   # Don't run on releases - this is handled by the Github Action here:
   # .github/workflows/publish-docker-release.yml
   rules:
-    - if: $CI_COMMIT_REF_NAME !~ /^v[0-9]+\.[0-9]+\.[0-9]+$/ # i.e., v1.2.3 but NOT v1.2.3-rc1
+    - if: $CI_PIPELINE_SOURCE == "web"
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+    - if: $CI_COMMIT_REF_NAME == "master"
   variables:
     DOCKER_HOST:                   tcp://localhost:2375
     DOCKER_DRIVER:                 overlay2

--- a/doc/docker.md
+++ b/doc/docker.md
@@ -1,36 +1,38 @@
 ### The easiest way
 
-The easiest/faster option is to use the latest image.
+The easiest/faster option to run Polkadot in docker is to use the latest
+release images. These are small images that use the latest official release of
+the polkadot binary, pulled from our package repository.
 
 Let´s first check the version we have. The first time you run this command, the polkadot docker image will be downloaded. This takes a bit of time and bandwidth, be patient:
 
 ```bash
-docker run --rm -it chevdor/polkadot:latest polkadot --version
+docker run --rm -it parity/polkadot:latest polkadot --version
 ```
 
 You can also pass any argument/flag that polkadot supports:
 
 ```bash
-docker run --rm -it chevdor/polkadot:latest polkadot --chain westend --name "PolkaDocker"
+docker run --rm -it parity/polkadot:latest polkadot --chain westend --name "PolkaDocker"
 ```
 
 Once you are done experimenting and picking the best node name :) you can start polkadot as daemon, exposes the polkadot ports and mount a volume that will keep your blockchain data locally:
 
 ```bash
-docker run -d -p 30333:30333 -p 9933:9933 -v /my/local/folder:/data chevdor/polkadot:latest polkadot --chain westend
+docker run -d -p 30333:30333 -p 9933:9933 -v /my/local/folder:/data parity/polkadot:latest polkadot --chain westend
 ```
 
 Additionally if you want to have custom node name you can add the `--name "YourName"` at the end
 
 ```bash
-docker run -d -p 30333:30333 -p 9933:9933 -v /my/local/folder:/data chevdor/polkadot:latest polkadot --chain westend --name "PolkaDocker"
+docker run -d -p 30333:30333 -p 9933:9933 -v /my/local/folder:/data parity/polkadot:latest polkadot --chain westend --name "PolkaDocker"
 ```
 
 ```bash
-docker run -d -p 30333:30333 -p 9933:9933 -v /my/local/folder:/data chevdor/polkadot:latest polkadot --rpc-external --chain westend
+docker run -d -p 30333:30333 -p 9933:9933 -v /my/local/folder:/data parity/polkadot:latest polkadot --rpc-external --chain westend
 ```
 
-if you want to connect to rpc port 9933, then must add polkadot startup parameter: `--rpc-external`.
+If you want to connect to rpc port 9933, then must add polkadot startup parameter: `--rpc-external`.
 
 **Note:** The `--chain westend` argument is important and you need to add it to the command line. If you are running older node versions (pre 0.3) you don't need it.
 
@@ -68,7 +70,7 @@ If you run into issues with polkadot when using docker, please run the following
 (replace the tag with the appropriate one if you do not use latest):
 
 ```bash
-docker run --rm -it chevdor/polkadot:latest polkadot --version
+docker run --rm -it parity/polkadot:latest polkadot --version
 ```
 
 This will show you the polkadot version as well as the git commit ref that was used to build your container.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,4 @@
-FROM phusion/baseimage:0.11 as builder
-LABEL maintainer "chevdor@gmail.com"
+FROM paritytech/ci-linux:production as builder
 LABEL description="This is the build stage for Polkadot. Here we create the binary."
 
 ARG PROFILE=release
@@ -7,27 +6,16 @@ WORKDIR /polkadot
 
 COPY . /polkadot
 
-RUN apt-get update && \
-	apt-get upgrade -y && \
-	apt-get install -y cmake pkg-config libssl-dev git clang
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y && \
-        export PATH=$PATH:$HOME/.cargo/bin && \
-        scripts/init.sh && \
-        cargo build --$PROFILE
+RUN cargo build --$PROFILE
 
 # ===== SECOND STAGE ======
 
-FROM phusion/baseimage:0.11
-LABEL maintainer "chevdor@gmail.com"
+FROM debian:buster-slim
 LABEL description="This is the 2nd stage: a very small image where we copy the Polkadot binary."
 ARG PROFILE=release
 COPY --from=builder /polkadot/target/$PROFILE/polkadot /usr/local/bin
 
-RUN mv /usr/share/ca* /tmp && \
-	rm -rf /usr/share/*  && \
-	mv /tmp/ca-certificates /usr/share/ && \
-	rm -rf /usr/lib/python* && \
-	useradd -m -u 1000 -U -s /bin/sh -d /polkadot polkadot && \
+RUN useradd -m -u 1000 -U -s /bin/sh -d /polkadot polkadot && \
 	mkdir -p /polkadot/.local/share/polkadot && \
 	chown -R polkadot:polkadot /polkadot/.local && \
 	ln -s /polkadot/.local/share/polkadot /data && \

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -9,12 +9,12 @@ cd $PROJECT_ROOT
 
 # Find the current version from Cargo.toml
 VERSION=`grep "^version" ./Cargo.toml | egrep -o "([0-9\.]+)"`
-GITUSER=chevdor
+GITUSER=parity
 GITREPO=polkadot
 
 # Build the image
 echo "Building ${GITUSER}/${GITREPO}:latest docker image, hang on!"
-time docker build -f ./docker/Dockerfile --build-arg PROFILE=release -t ${GITUSER}/${GITREPO}:latest .
+time docker build -f ./docker/Dockerfile --build-arg RUSTC_WRAPPER= --build-arg PROFILE=release -t ${GITUSER}/${GITREPO}:latest .
 
 # Show the list of available images for this repo
 echo "Image is ready"

--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch-slim
+FROM debian:buster-slim
 
 # metadata
 ARG VCS_REF

--- a/scripts/docker/Dockerfile.release
+++ b/scripts/docker/Dockerfile.release
@@ -1,0 +1,46 @@
+FROM debian:buster-slim
+
+# metadata
+ARG VCS_REF
+ARG BUILD_DATE
+
+LABEL io.parity.image.authors="devops-team@parity.io" \
+	io.parity.image.vendor="Parity Technologies" \
+	io.parity.image.title="parity/polkadot" \
+	io.parity.image.description="polkadot: a platform for web3" \
+	io.parity.image.source="https://github.com/paritytech/polkadot/blob/${VCS_REF}/scripts/docker/Dockerfile" \
+	io.parity.image.revision="${VCS_REF}" \
+	io.parity.image.created="${BUILD_DATE}" \
+	io.parity.image.documentation="https://github.com/paritytech/polkadot/"
+
+# show backtraces
+ENV RUST_BACKTRACE 1
+
+# install tools and dependencies
+RUN apt-get update && \
+	DEBIAN_FRONTEND=noninteractive apt-get upgrade -y && \
+	DEBIAN_FRONTEND=noninteractive apt-get install -y \
+		libssl1.1 \
+		ca-certificates \
+		curl \
+    gnupg && \
+    gpg --recv-keys --keyserver hkps://keys.mailvelope.com 9D4B2B6EB8F97156D19669A9FF0812D491B96798 && \
+    gpg --export 9D4B2B6EB8F97156D19669A9FF0812D491B96798 > /usr/share/keyrings/parity.gpg && \
+    echo 'deb [signed-by=/usr/share/keyrings/parity.gpg] https://releases.parity.io/deb release main' > /etc/apt/sources.list.d/parity.list && \
+    apt update && \
+    apt install polkadot && \
+# apt cleanup
+	apt-get autoremove -y && \
+	apt-get clean && \
+	find /var/lib/apt/lists/ -type f -not -name lock -delete
+
+USER polkadot
+
+# check if executable works in this container
+RUN /usr/bin/polkadot --version
+
+EXPOSE 30333 9933 9944
+VOLUME ["/polkadot"]
+
+ENTRYPOINT ["/usr/bin/polkadot"]
+

--- a/scripts/docker/release.Dockerfile
+++ b/scripts/docker/release.Dockerfile
@@ -30,9 +30,9 @@ RUN apt-get update && \
     apt update && \
     apt install polkadot && \
 # apt cleanup
-	apt-get autoremove -y && \
-	apt-get clean && \
-	find /var/lib/apt/lists/ -type f -not -name lock -delete
+    apt-get autoremove -y && \
+    apt-get clean && \
+    find /var/lib/apt/lists/ -type f -not -name lock -delete
 
 USER polkadot
 

--- a/scripts/docker/release.Dockerfile
+++ b/scripts/docker/release.Dockerfile
@@ -18,21 +18,21 @@ ENV RUST_BACKTRACE 1
 
 # install tools and dependencies
 RUN apt-get update && \
-	DEBIAN_FRONTEND=noninteractive apt-get upgrade -y && \
-	DEBIAN_FRONTEND=noninteractive apt-get install -y \
-		libssl1.1 \
-		ca-certificates \
-		curl \
-    gnupg && \
-    gpg --recv-keys --keyserver hkps://keys.mailvelope.com 9D4B2B6EB8F97156D19669A9FF0812D491B96798 && \
-    gpg --export 9D4B2B6EB8F97156D19669A9FF0812D491B96798 > /usr/share/keyrings/parity.gpg && \
-    echo 'deb [signed-by=/usr/share/keyrings/parity.gpg] https://releases.parity.io/deb release main' > /etc/apt/sources.list.d/parity.list && \
-    apt update && \
-    apt install polkadot && \
+		DEBIAN_FRONTEND=noninteractive apt-get upgrade -y && \
+		DEBIAN_FRONTEND=noninteractive apt-get install -y \
+			libssl1.1 \
+			ca-certificates \
+			curl \
+			gnupg && \
+		gpg --recv-keys --keyserver hkps://keys.mailvelope.com 9D4B2B6EB8F97156D19669A9FF0812D491B96798 && \
+		gpg --export 9D4B2B6EB8F97156D19669A9FF0812D491B96798 > /usr/share/keyrings/parity.gpg && \
+		echo 'deb [signed-by=/usr/share/keyrings/parity.gpg] https://releases.parity.io/deb release main' > /etc/apt/sources.list.d/parity.list && \
+		apt update && \
+		apt install polkadot && \
 # apt cleanup
-    apt-get autoremove -y && \
-    apt-get clean && \
-    find /var/lib/apt/lists/ -type f -not -name lock -delete
+		apt-get autoremove -y && \
+		apt-get clean && \
+		find /var/lib/apt/lists/ -type f -not -name lock -delete
 
 USER polkadot
 


### PR DESCRIPTION
This PR makes a number of changes:

1. Do not push the parity/polkadot:latest docker image on new *tag* pushes
2. Introduce a new Github Action that will push to parity/polkadot:latest when a new release is *published*, that will build the image based on our deb package repo (this is done with `scripts/docker/Dockerfile.release`
3. Update the documentation in `doc/docker.md` to specify using our official docker images, rather than ones based on phusion. As per our [Docker images maintenance policy](https://github.com/paritytech/devops/wiki/Docker-images-maintenance-policy): Use only official (in the _ namespace) third-party DockerHub images are allowed, both in direct use and inherited with FROM.
4. Update `docker/Dockerfile` to be based on `paritytech/ci-linux:production` as per the aforementioned Docker images maintenance policy.