### PR TITLE
Remove `collating_for` argument from service

### DIFF
--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -148,7 +148,6 @@ pub fn run() -> Result<()> {
 					Role::Light => service::build_light(config).map(|(task_manager, _)| task_manager),
 					_ => service::build_full(
 						config,
-						None,
 						authority_discovery_enabled,
 						grandpa_pause,
 					).map(|full| full.task_manager),
@@ -189,7 +188,7 @@ pub fn run() -> Result<()> {
 					network_status_sinks,
 					..
 				} = service::build_full(
-					config, None, authority_discovery_enabled, grandpa_pause,
+					config, authority_discovery_enabled, grandpa_pause,
 				)?;
 				let client = Arc::new(client);
 

--- a/node/test-service/src/lib.rs
+++ b/node/test-service/src/lib.rs
@@ -23,9 +23,7 @@ mod chain_spec;
 pub use chain_spec::*;
 use futures::future::Future;
 use polkadot_overseer::OverseerHandler;
-use polkadot_primitives::v0::{
-	Block, CollatorId, Id as ParaId,
-};
+use polkadot_primitives::v1::Block;
 use polkadot_runtime_common::BlockHashCount;
 use polkadot_service::{
 	new_full, NewFull, FullClient, AbstractClient, ClientHandle, ExecuteWithClient,
@@ -63,7 +61,6 @@ native_executor_instance!(
 /// Create a new Polkadot test service for a full node.
 pub fn polkadot_test_new_full(
 	config: Configuration,
-	collating_for: Option<(CollatorId, ParaId)>,
 	authority_discovery_enabled: bool,
 ) -> Result<
 	NewFull<Arc<FullClient<polkadot_test_runtime::RuntimeApi, PolkadotTestExecutor>>>,
@@ -71,7 +68,6 @@ pub fn polkadot_test_new_full(
 > {
 	new_full::<polkadot_test_runtime::RuntimeApi, PolkadotTestExecutor>(
 		config,
-		collating_for,
 		authority_discovery_enabled,
 		None,
 	).map_err(Into::into)
@@ -198,7 +194,7 @@ pub fn run_test_node(
 	let multiaddr = config.network.listen_addresses[0].clone();
 	let authority_discovery_enabled = false;
 	let NewFull {task_manager, client, network, rpc_handlers, node_handles, ..} =
-		polkadot_test_new_full(config, None, authority_discovery_enabled)
+		polkadot_test_new_full(config, authority_discovery_enabled)
 			.expect("could not create Polkadot test service");
 
 	let peer_id = network.local_peer_id().clone();


### PR DESCRIPTION
The collator is now enabled in a different way and we don't require this
argument anymore.