### PR TITLE
Revert "revert enabling authority discovery by default (#1532)"

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -83,7 +83,10 @@ pub struct RunCmd {
 	#[structopt(long = "force-rococo")]
 	pub force_rococo: bool,
 
-	/// Enable the authority discovery module on validator or sentry nodes.
+	/// Disable the authority discovery module on validator or sentry nodes.
+	///
+	/// Enabled by default on validator and sentry nodes. Always disabled on non
+	/// validator or sentry nodes.
 	///
 	/// When enabled:
 	///
@@ -94,8 +97,8 @@ pub struct RunCmd {
 	/// (2) As a validator or sentry node: Discover addresses of validators or
 	///     addresses of their sentry nodes and maintain a permanent connection
 	///     to a subset.
-	#[structopt(long = "enable-authority-discovery")]
-	pub authority_discovery_enabled: bool,
+	#[structopt(long = "disable-authority-discovery")]
+	pub authority_discovery_disabled: bool,
 
 	/// Setup a GRANDPA scheduled voting pause.
 	///

--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -126,7 +126,7 @@ pub fn run() -> Result<()> {
 
 			set_default_ss58_version(chain_spec);
 
-			let authority_discovery_enabled = cli.run.authority_discovery_enabled;
+			let authority_discovery_disabled = cli.run.authority_discovery_disabled;
 			let grandpa_pause = if cli.run.grandpa_pause.is_empty() {
 				None
 			} else {
@@ -148,7 +148,7 @@ pub fn run() -> Result<()> {
 					Role::Light => service::build_light(config).map(|(task_manager, _)| task_manager),
 					_ => service::build_full(
 						config,
-						authority_discovery_enabled,
+						authority_discovery_disabled,
 						grandpa_pause,
 					).map(|full| full.task_manager),
 				}
@@ -164,7 +164,7 @@ pub fn run() -> Result<()> {
 
 			set_default_ss58_version(chain_spec);
 
-			let authority_discovery_enabled = cli.run.authority_discovery_enabled;
+			let authority_discovery_disabled = cli.run.authority_discovery_disabled;
 			let grandpa_pause = if cli.run.grandpa_pause.is_empty() {
 				None
 			} else {
@@ -188,7 +188,7 @@ pub fn run() -> Result<()> {
 					network_status_sinks,
 					..
 				} = service::build_full(
-					config, authority_discovery_enabled, grandpa_pause,
+					config, authority_discovery_disabled, grandpa_pause,
 				)?;
 				let client = Arc::new(client);
 

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -328,7 +328,7 @@ impl<C> NewFull<C> {
 #[cfg(feature = "full-node")]
 pub fn new_full<RuntimeApi, Executor>(
 	mut config: Configuration,
-	authority_discovery_enabled: bool,
+	authority_discovery_disabled: bool,
 	grandpa_pause: Option<(u32, u32)>,
 ) -> Result<NewFull<Arc<FullClient<RuntimeApi, Executor>>>, Error>
 	where
@@ -536,7 +536,7 @@ pub fn new_full<RuntimeApi, Executor>(
 		use sc_network::Event;
 		use futures::StreamExt;
 
-		if authority_discovery_enabled {
+		if !authority_discovery_disabled {
 			let (sentries, authority_discovery_role) = match role {
 				Role::Authority { ref sentry_nodes } => (
 					sentry_nodes.clone(),
@@ -743,31 +743,31 @@ pub fn build_light(config: Configuration) -> Result<(TaskManager, RpcHandlers), 
 #[cfg(feature = "full-node")]
 pub fn build_full(
 	config: Configuration,
-	authority_discovery_enabled: bool,
+	authority_discovery_disabled: bool,
 	grandpa_pause: Option<(u32, u32)>,
 ) -> Result<NewFull<Client>, ServiceError> {
 	if config.chain_spec.is_rococo() {
 		new_full::<rococo_runtime::RuntimeApi, RococoExecutor>(
 			config,
-			authority_discovery_enabled,
+			authority_discovery_disabled,
 			grandpa_pause,
 		).map(|full| full.with_client(Client::Rococo))
 	} else if config.chain_spec.is_kusama() {
 		new_full::<kusama_runtime::RuntimeApi, KusamaExecutor>(
 			config,
-			authority_discovery_enabled,
+			authority_discovery_disabled,
 			grandpa_pause,
 		).map(|full| full.with_client(Client::Kusama))
 	} else if config.chain_spec.is_westend() {
 		new_full::<westend_runtime::RuntimeApi, WestendExecutor>(
 			config,
-			authority_discovery_enabled,
+			authority_discovery_disabled,
 			grandpa_pause,
 		).map(|full| full.with_client(Client::Westend))
 	} else {
 		new_full::<polkadot_runtime::RuntimeApi, PolkadotExecutor>(
 			config,
-			authority_discovery_enabled,
+			authority_discovery_disabled,
 			grandpa_pause,
 		).map(|full| full.with_client(Client::Polkadot))
 	}

--- a/node/test-service/src/lib.rs
+++ b/node/test-service/src/lib.rs
@@ -61,14 +61,14 @@ native_executor_instance!(
 /// Create a new Polkadot test service for a full node.
 pub fn polkadot_test_new_full(
 	config: Configuration,
-	authority_discovery_enabled: bool,
+	authority_discovery_disabled: bool,
 ) -> Result<
 	NewFull<Arc<FullClient<polkadot_test_runtime::RuntimeApi, PolkadotTestExecutor>>>,
 	ServiceError,
 > {
 	new_full::<polkadot_test_runtime::RuntimeApi, PolkadotTestExecutor>(
 		config,
-		authority_discovery_enabled,
+		authority_discovery_disabled,
 		None,
 	).map_err(Into::into)
 }
@@ -192,9 +192,9 @@ pub fn run_test_node(
 > {
 	let config = node_config(storage_update_func, task_executor, key, boot_nodes);
 	let multiaddr = config.network.listen_addresses[0].clone();
-	let authority_discovery_enabled = false;
+	let authority_discovery_disabled = true;
 	let NewFull {task_manager, client, network, rpc_handlers, overseer_handler, ..} =
-		polkadot_test_new_full(config, authority_discovery_enabled)
+		polkadot_test_new_full(config, authority_discovery_disabled)
 			.expect("could not create Polkadot test service");
 
 	let peer_id = network.local_peer_id().clone();


### PR DESCRIPTION
This reverts commit 671cc75c4dcc8e05bdf3b722ddd63880f8166d8a.

The authority discovery module was initially enabled by default on validator and sentry nodes with commit bc6e1e7. This change was later on reverted in 671cc75. With this commit the authority discovery module is again enabled by default.

With https://github.com/libp2p/rust-libp2p/pull/1698 the amount of file descriptors needed for the authority discovery Kademlia DHT activities has been drastically reduced. With https://github.com/paritytech/substrate/pull/7018 lookups are spread out instead of done all at once removing any spikes in number of file descriptors, network traffic or CPU usage.

After a testing phase on a couple of our Kusama validator and sentry nodes the authority discovery module is now enabled on the majority of Parity Kusama nodes. For details see either https://github.com/paritytech/substrate/pull/7018#issuecomment-687043009 or consult the corresponding authority discovery Grafana dashboard.

Closes https://github.com/paritytech/polkadot/issues/1544.

Release note suggestion:

> The authority discovery module enables Polkadot authorities to discover and directly connect to other authorities. Instead of having to explicitly enable the authority discovery module on validator and sentry nodes, with this release the module is enabled by default. For those not interested in running the authority module please pass the `---disable-authority-discovery` flag. As one would expect the `--enable-authority-discovery` flag is replaced by the the `--disable-authority-discovery` flag.