### PR TITLE
[CI] bump matrix-message-action to v0.0.3

### DIFF
--- a/.github/workflows/burnin-label-notification.yml
+++ b/.github/workflows/burnin-label-notification.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - name: Notify devops
         if: github.event.label.name == 'A1-needsburnin'
-        uses: s3krit/matrix-message-action@v0.0.2
+        uses: s3krit/matrix-message-action@v0.0.3
         with:
           room_id: ${{ secrets.POLKADOT_DEVOPS_MATRIX_ROOM_ID }}
           access_token: ${{ secrets.POLKADOT_DEVOPS_MATRIX_ACCESS_TOKEN }}

--- a/.github/workflows/publish-draft-release.yml
+++ b/.github/workflows/publish-draft-release.yml
@@ -105,7 +105,7 @@ jobs:
     needs: publish-draft-release
     steps:
       - name: Internal polkadot channel
-        uses: s3krit/matrix-message-action@v0.0.2
+        uses: s3krit/matrix-message-action@v0.0.3
         with:
           room_id: ${{ secrets.INTERNAL_POLKADOT_MATRIX_ROOM_ID }}
           access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}

--- a/.github/workflows/release-bot.yml
+++ b/.github/workflows/release-bot.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Internal Release Notes Channel
-        uses: s3krit/matrix-message-action@v0.0.2
+        uses: s3krit/matrix-message-action@v0.0.3
         with:
           room_id: ${{ secrets.MATRIX_ROOM_ID }}
           access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
@@ -16,7 +16,7 @@ jobs:
           server: "matrix.parity.io"
 
       - name: Validator Lounge
-        uses: s3krit/matrix-message-action@v0.0.2
+        uses: s3krit/matrix-message-action@v0.0.3
         with:
           room_id: ${{ secrets.VALIDATOR_LOUNGE_MATRIX_ROOM_ID }}
           access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
@@ -24,7 +24,7 @@ jobs:
           server: "matrix.parity.io"
 
       - name: Polkadot Announcements
-        uses: s3krit/matrix-message-action@v0.0.2
+        uses: s3krit/matrix-message-action@v0.0.3
         with:
           room_id: ${{ secrets.KUSAMA_ANNOUNCEMENTS_MATRIX_ROOM_ID }}
           access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}


### PR DESCRIPTION
Required for Github actions that send messages to Matrix/Element to continue working.