### PR TITLE
Add ParasSudoWrapper to test-runtime and bring back register_parachain to test-service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5592,6 +5592,7 @@ dependencies = [
  "polkadot-primitives",
  "polkadot-rpc",
  "polkadot-runtime-common",
+ "polkadot-runtime-parachains",
  "polkadot-service",
  "polkadot-test-runtime",
  "rand 0.7.3",

--- a/node/test-service/Cargo.toml
+++ b/node/test-service/Cargo.toml
@@ -19,6 +19,7 @@ polkadot-rpc = { path = "../../rpc" }
 polkadot-runtime-common = { path = "../../runtime/common" }
 polkadot-service = { path = "../service" }
 polkadot-test-runtime = { path = "../../runtime/test-runtime" }
+polkadot-runtime-parachains = { path = "../../runtime/parachains" }
 
 # Substrate dependencies
 authority-discovery = { package = "sc-authority-discovery", git = "https://github.com/paritytech/substrate", branch = "master" }

--- a/node/test-service/src/lib.rs
+++ b/node/test-service/src/lib.rs
@@ -28,7 +28,8 @@ use polkadot_runtime_common::BlockHashCount;
 use polkadot_service::{
 	new_full, NewFull, FullClient, AbstractClient, ClientHandle, ExecuteWithClient,
 };
-use polkadot_test_runtime::{Runtime, SignedExtra, SignedPayload, VERSION};
+use polkadot_test_runtime::{Runtime, SignedExtra, SignedPayload, VERSION, ParasSudoWrapperCall};
+use polkadot_runtime_parachains::paras::ParaGenesisArgs;
 use sc_chain_spec::ChainSpec;
 use sc_client_api::{execution_extensions::ExecutionStrategies, BlockchainEvents};
 use sc_executor::native_executor_instance;
@@ -289,12 +290,15 @@ where
 		&self,
 		id: ParaId,
 		validation_code: ValidationCode,
-		initial_head_data: HeadData,
+		genesis_head: HeadData,
 	) -> Result<(), RpcTransactionError> {
-		let call = polkadot_test_runtime::RegistrarCall::register_parachain(
+		let call = ParasSudoWrapperCall::sudo_schedule_para_initialize(
 			id,
-			initial_head_data,
-			validation_code,
+			ParaGenesisArgs {
+				genesis_head,
+				validation_code,
+				parachain: true,
+			},
 		);
 
 		self.call_function(call, Sr25519Keyring::Alice).await.map(drop)

--- a/node/test-service/src/lib.rs
+++ b/node/test-service/src/lib.rs
@@ -23,7 +23,7 @@ mod chain_spec;
 pub use chain_spec::*;
 use futures::future::Future;
 use polkadot_overseer::OverseerHandler;
-use polkadot_primitives::v1::Block;
+use polkadot_primitives::v1::{Block, Id as ParaId, HeadData, ValidationCode};
 use polkadot_runtime_common::BlockHashCount;
 use polkadot_service::{
 	new_full, NewFull, FullClient, AbstractClient, ClientHandle, ExecuteWithClient,
@@ -82,9 +82,13 @@ impl ClientHandle for TestClient {
 	}
 }
 
-/// Create a Polkadot `Configuration`. By default an in-memory socket will be used, therefore you need to provide boot
-/// nodes if you want the future node to be connected to other nodes. The `storage_update_func` can be used to make
-/// adjustements to the runtime before the node starts.
+/// Create a Polkadot `Configuration`.
+///
+/// By default an in-memory socket will be used, therefore you need to provide boot
+/// nodes if you want the future node to be connected to other nodes.
+///
+/// The `storage_update_func` function will be executed in an externalities provided environment
+/// and can be used to make adjustements to the runtime genesis storage.
 pub fn node_config(
 	storage_update_func: impl Fn(),
 	task_executor: TaskExecutor,
@@ -178,9 +182,13 @@ pub fn node_config(
 	}
 }
 
-/// Run a Polkadot test node using the Polkadot test runtime. The node will be using an in-memory socket, therefore you
-/// need to provide boot nodes if you want it to be connected to other nodes. The `storage_update_func` can be used to
-/// make adjustements to the runtime before the node starts.
+/// Run a Polkadot test node using the Polkadot test runtime.
+///
+/// The node will be using an in-memory socket, therefore you need to provide boot nodes if you
+/// want it to be connected to other nodes.
+///
+/// The `storage_update_func` function will be executed in an externalities provided environment
+/// and can be used to make adjustements to the runtime genesis storage.
 pub fn run_test_node(
 	task_executor: TaskExecutor,
 	key: Sr25519Keyring,
@@ -230,9 +238,10 @@ where
 	/// Send a transaction through RPCHandlers to call a function.
 	pub async fn call_function(
 		&self,
-		function: polkadot_test_runtime::Call,
+		function: impl Into<polkadot_test_runtime::Call>,
 		caller: Sr25519Keyring,
 	) -> Result<RpcTransactionOutput, RpcTransactionError> {
+		let function = function.into();
 		let current_block_hash = self.client.info().best_hash;
 		let current_block = self.client.info().best_number.saturated_into();
 		let genesis_block = self.client.hash(0).unwrap().unwrap();
@@ -273,6 +282,22 @@ where
 		);
 
 		self.rpc_handlers.send_transaction(extrinsic.into()).await
+	}
+
+	/// Register a parachain at this relay chain.
+	pub async fn register_parachain(
+		&self,
+		id: ParaId,
+		validation_code: ValidationCode,
+		initial_head_data: HeadData,
+	) -> Result<(), RpcTransactionError> {
+		let call = polkadot_test_runtime::RegistrarCall::register_parachain(
+			id,
+			initial_head_data,
+			validation_code,
+		);
+
+		self.call_function(call, Sr25519Keyring::Alice).await.map(drop)
 	}
 }
 

--- a/runtime/common/src/paras_registrar.rs
+++ b/runtime/common/src/paras_registrar.rs
@@ -604,6 +604,7 @@ mod tests {
 			run_to_block(2);
 
 			assert_ok!(Registrar::register_parachain(
+				Origin::root(),
 				2u32.into(),
 				vec![3; 3].into(),
 				vec![3; 3].into(),
@@ -625,7 +626,7 @@ mod tests {
 
 			run_to_block(3);
 
-			assert_ok!(Registrar::deregister_parachain(2u32.into()));
+			assert_ok!(Registrar::deregister_parachain(Origin::root(), 2u32.into()));
 
 			assert_ok!(Registrar::deregister_parathread(
 				runtime_parachains::Origin::Parachain(8u32.into()).into()
@@ -659,6 +660,7 @@ mod tests {
 			));
 
 			assert_ok!(Registrar::register_parachain(
+				Origin::root(),
 				2u32.into(),
 				vec![1; 3].into(),
 				vec![1; 3].into(),
@@ -687,6 +689,7 @@ mod tests {
 			run_to_block(2);
 
 			assert_ok!(Registrar::register_parachain(
+				Origin::root(),
 				1u32.into(),
 				vec![1; 3].into(),
 				vec![1; 3].into(),
@@ -694,10 +697,11 @@ mod tests {
 
 			run_to_block(4);
 
-			assert_ok!(Registrar::deregister_parachain(1u32.into()));
+			assert_ok!(Registrar::deregister_parachain(Origin::root(), 1u32.into()));
 			run_to_block(5);
 
 			assert!(Registrar::register_parachain(
+				Origin::root(),
 				1u32.into(),
 				vec![1; 3].into(),
 				vec![1; 3].into(),
@@ -706,6 +710,7 @@ mod tests {
 			run_to_block(6);
 
 			assert_ok!(Registrar::register_parachain(
+				Origin::root(),
 				1u32.into(),
 				vec![1; 3].into(),
 				vec![1; 3].into(),

--- a/runtime/parachains/src/paras.rs
+++ b/runtime/parachains/src/paras.rs
@@ -176,7 +176,6 @@ pub struct ParaGenesisArgs {
 	pub parachain: bool,
 }
 
-
 decl_storage! {
 	trait Store for Module<T: Trait> as Paras {
 		/// All parachains. Ordered ascending by ParaId. Parathreads are not included.

--- a/runtime/rococo-v1/src/lib.rs
+++ b/runtime/rococo-v1/src/lib.rs
@@ -63,8 +63,7 @@ use sp_core::OpaqueMetadata;
 use sp_staking::SessionIndex;
 use pallet_session::historical as session_historical;
 use frame_system::EnsureRoot;
-use runtime_common::paras_sudo_wrapper as paras_sudo_wrapper;
-use runtime_common::paras_registrar;
+use runtime_common::{paras_sudo_wrapper, paras_registrar};
 
 use runtime_parachains::origin as parachains_origin;
 use runtime_parachains::configuration as parachains_configuration;
@@ -740,9 +739,9 @@ impl pallet_authorship::Trait for Runtime {
 	type EventHandler = (Staking, ImOnline);
 }
 
-impl parachains_origin::Trait for Runtime { }
+impl parachains_origin::Trait for Runtime {}
 
-impl parachains_configuration::Trait for Runtime { }
+impl parachains_configuration::Trait for Runtime {}
 
 impl parachains_inclusion::Trait for Runtime {
 	type Event = Event;
@@ -752,17 +751,17 @@ impl parachains_paras::Trait for Runtime {
 	type Origin = Origin;
 }
 
-impl parachains_router::Trait for Runtime { }
+impl parachains_router::Trait for Runtime {}
 
-impl parachains_inclusion_inherent::Trait for Runtime { }
+impl parachains_inclusion_inherent::Trait for Runtime {}
 
-impl parachains_scheduler::Trait for Runtime { }
+impl parachains_scheduler::Trait for Runtime {}
 
 impl parachains_initializer::Trait for Runtime {
 	type Randomness = Babe;
 }
 
-impl paras_sudo_wrapper::Trait for Runtime { }
+impl paras_sudo_wrapper::Trait for Runtime {}
 
 impl paras_registrar::Trait for Runtime {
 	type Currency = Balances;

--- a/runtime/test-runtime/src/lib.rs
+++ b/runtime/test-runtime/src/lib.rs
@@ -37,7 +37,7 @@ use primitives::v1::{
 	PersistedValidationData, Signature, ValidationCode, ValidationData, ValidatorId, ValidatorIndex,
 };
 use runtime_common::{
-	claims, SlowAdjustingFeeUpdate,
+	claims, SlowAdjustingFeeUpdate, paras_registrar,
 	BlockHashCount, MaximumBlockWeight, AvailableBlockRatio,
 	MaximumBlockLength, BlockExecutionWeight, ExtrinsicBaseWeight, ParachainSessionKeyPlaceholder,
 };
@@ -74,6 +74,7 @@ pub use pallet_staking::StakerStatus;
 pub use sp_runtime::BuildStorage;
 pub use pallet_timestamp::Call as TimestampCall;
 pub use pallet_balances::Call as BalancesCall;
+pub use paras_registrar::Call as RegistrarCall;
 
 /// Constant values used within the runtime.
 pub mod constants;
@@ -448,6 +449,16 @@ impl router::Trait for Runtime {}
 
 impl scheduler::Trait for Runtime {}
 
+impl paras_registrar::Trait for Runtime {
+	type Currency = Balances;
+	type ParathreadDeposit = ParathreadDeposit;
+	type Origin = Origin;
+}
+
+parameter_types! {
+	pub const ParathreadDeposit: Balance = 5 * DOLLARS;
+}
+
 construct_runtime! {
 	pub enum Runtime where
 		Block = Block,
@@ -487,6 +498,7 @@ construct_runtime! {
 		Initializer: initializer::{Module, Call, Storage},
 		Paras: paras::{Module, Call, Storage, Origin},
 		Scheduler: scheduler::{Module, Call, Storage},
+		Registrar: paras_registrar::{Module, Call, Storage},
 
 		// Sudo. Last module.
 		Sudo: pallet_sudo::{Module, Call, Storage, Config<T>, Event<T>},

--- a/runtime/test-runtime/src/lib.rs
+++ b/runtime/test-runtime/src/lib.rs
@@ -37,7 +37,7 @@ use primitives::v1::{
 	PersistedValidationData, Signature, ValidationCode, ValidationData, ValidatorId, ValidatorIndex,
 };
 use runtime_common::{
-	claims, SlowAdjustingFeeUpdate, paras_registrar,
+	claims, SlowAdjustingFeeUpdate, paras_sudo_wrapper,
 	BlockHashCount, MaximumBlockWeight, AvailableBlockRatio,
 	MaximumBlockLength, BlockExecutionWeight, ExtrinsicBaseWeight, ParachainSessionKeyPlaceholder,
 };
@@ -74,7 +74,7 @@ pub use pallet_staking::StakerStatus;
 pub use sp_runtime::BuildStorage;
 pub use pallet_timestamp::Call as TimestampCall;
 pub use pallet_balances::Call as BalancesCall;
-pub use paras_registrar::Call as RegistrarCall;
+pub use paras_sudo_wrapper::Call as ParasSudoWrapperCall;
 
 /// Constant values used within the runtime.
 pub mod constants;
@@ -449,15 +449,7 @@ impl router::Trait for Runtime {}
 
 impl scheduler::Trait for Runtime {}
 
-impl paras_registrar::Trait for Runtime {
-	type Currency = Balances;
-	type ParathreadDeposit = ParathreadDeposit;
-	type Origin = Origin;
-}
-
-parameter_types! {
-	pub const ParathreadDeposit: Balance = 5 * DOLLARS;
-}
+impl paras_sudo_wrapper::Trait for Runtime {}
 
 construct_runtime! {
 	pub enum Runtime where
@@ -498,9 +490,8 @@ construct_runtime! {
 		Initializer: initializer::{Module, Call, Storage},
 		Paras: paras::{Module, Call, Storage, Origin},
 		Scheduler: scheduler::{Module, Call, Storage},
-		Registrar: paras_registrar::{Module, Call, Storage},
+		ParasSudoWrapper: paras_sudo_wrapper::{Module, Call},
 
-		// Sudo. Last module.
 		Sudo: pallet_sudo::{Module, Call, Storage, Config<T>, Event<T>},
 	}
 }


### PR DESCRIPTION
Adds the ParasSudoWrapper to the test-runtime to support registration of parachains.

Besides that it brings back the functionality of the test node to
register a parachain.