### PR TITLE
Include audit status of runtime changes in release notes

### DIFF
--- a/scripts/github/generate_release_text.rb
+++ b/scripts/github/generate_release_text.rb
@@ -49,13 +49,33 @@ substrate_cl = Changelog.new(
   prefix: true
 )
 
-all_changes = polkadot_cl.changes + substrate_cl.changes
+# Combine all changes into a single array and filter out companions
+all_changes = (polkadot_cl.changes + substrate_cl.changes).reject do |c|
+  c[:title] =~ /[Cc]ompanion/
+end
 
 # Set all the variables needed for a release
 
 misc_changes = Changelog.changes_with_label(all_changes, 'B1-releasenotes')
 client_changes = Changelog.changes_with_label(all_changes, 'B5-clientnoteworthy')
 runtime_changes = Changelog.changes_with_label(all_changes, 'B7-runtimenoteworthy')
+
+# Add the audit status for runtime changes
+runtime_changes.each do |c|
+  if c.labels.any? { |l| l[:name] == 'D1-audited👍' }
+    c[:pretty_title] = "✅ `audited` #{c[:pretty_title]}"
+    next
+  end
+  if c.labels.any? { |l| l[:name] == 'D9-needsaudit👮' }
+    c[:pretty_title] = "❌ `AWAITING AUDIT` #{c[:pretty_title]}"
+    next
+  end
+  if c.labels.any? { |l| l[:name] == 'D5-nicetohaveaudit⚠️' }
+    c[:pretty_title] = "⏳ `pending non-critical audit` #{c[:pretty_title]}"
+    next
+  end
+  c[:pretty_title] = "✅ `trivial` #{c[:pretty_title]}"
+end
 
 release_priority = Changelog.highest_priority_for_changes(all_changes)
 


### PR DESCRIPTION
All runtime-noteworthy changes will now have their audit status prepended to their line in the release notes (as per the current release notes for v0.8.25) - If a runtime change does not have an auditing-related D-label, it will be marked as trivial.

In addition, this PR stops companion PRs from being mentioned in the release notes.