### PR TITLE
use color_eyre for its backtrace feature and error reporting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -753,6 +753,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "color-eyre"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2a5123db5af8349c41c43ed0e5dca1cd56c911ea0c4ce6e6ff30f159fa5d27e"
+dependencies = [
+ "backtrace",
+ "color-spantrace",
+ "eyre",
+ "indenter",
+ "once_cell 1.4.1",
+ "owo-colors",
+ "tracing-error",
+]
+
+[[package]]
+name = "color-spantrace"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a99aa4aa18448eef4c7d3f86d2720d2d8cad5c860fe9ff9b279293efdc8f5be"
+dependencies = [
+ "ansi_term 0.11.0",
+ "tracing-core",
+ "tracing-error",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1295,6 +1321,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e43f2f1833d64e33f15592464d6fdd70f349dda7b1a53088eb83cd94014008c5"
 dependencies = [
  "futures 0.3.5",
+]
+
+[[package]]
+name = "eyre"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c5cb4dc433c59f09df4b4450f649cbfed61e8a3505abe32e4154066439157e"
+dependencies = [
+ "indenter",
+ "once_cell 1.4.1",
 ]
 
 [[package]]
@@ -2298,6 +2334,12 @@ dependencies = [
  "quote 1.0.7",
  "syn 1.0.33",
 ]
+
+[[package]]
+name = "indenter"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0bd112d44d9d870a6819eb505d04dd92b5e4d94bb8c304924a0872ae7016fb5"
 
 [[package]]
 name = "indexmap"
@@ -3751,6 +3793,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "owo-colors"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a1250cdd103eef6bd542b5ae82989f931fc00a41a27f60377338241594410f3"
+
+[[package]]
 name = "pallet-authority-discovery"
 version = "2.0.0"
 source = "git+https://github.com/paritytech/substrate#d766e229466d63afadd19097e277d85146fee3c9"
@@ -4640,6 +4688,7 @@ name = "polkadot"
 version = "0.8.25"
 dependencies = [
  "assert_cmd",
+ "color-eyre",
  "futures 0.3.5",
  "nix 0.17.0",
  "parity-util-mem",
@@ -9186,6 +9235,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f50de3927f93d202783f4513cda820ab47ef17f624b03c096e86ef00c67e6b5f"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "tracing-error"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4d7c0b83d4a500748fa5879461652b361edf5c9d51ede2a2ac03875ca185e24"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ readme = "README.md"
 
 [dependencies]
 cli = { package = "polkadot-cli", path = "cli" }
+color-eyre = "0.5.6"
 futures = "0.3.4"
 service = { package = "polkadot-service", path = "node/service" }
 parity-util-mem = { version = "*", default-features = false, features = ["jemalloc-global"] }
@@ -71,6 +72,11 @@ members = [
 
 [badges]
 maintenance = { status = "actively-developed" }
+
+# make sure dev builds with backtrace do
+# not slow us down
+[profile.dev.package.backtrace]
+opt-level = 3
 
 [profile.release]
 # Polkadot runtime requires unwinding.

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,9 @@
 
 #![warn(missing_docs)]
 
-fn main() -> cli::Result<()> {
+use color_eyre::eyre;
+
+fn main() -> eyre::Result<()> {
+	color_eyre::install()?;
 	cli::run()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,7 @@ use cli::Error as PolkaError;
 use std::{error, fmt};
 
 /// A helper to satisfy the requirements of `eyre`
-/// comaptible errors, which require `Send + Sync`
+/// compatible errors, which require `Send + Sync`
 /// which are not satisfied by the `sp_*` crates.
 #[derive(Debug)]
 struct ErrorWrapper(std::sync::Arc<PolkaError>);

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ use std::fmt;
 /// comaptible errors, which require `Send + Sync`
 /// which are not satisfied by the `sp_*` crates.
 #[derive(Debug)]
-struct ErrorWrapper(pub std::sync::Arc<PolkaError>);
+struct ErrorWrapper(std::sync::Arc<PolkaError>);
 
 // nothing is going to be sent to another thread
 // it merely exists to glue two distinct error

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,8 +22,7 @@ use color_eyre::eyre;
 
 use cli::Error as PolkaError;
 
-use std::error;
-use std::fmt;
+use std::{error, fmt};
 
 /// A helper to satisfy the requirements of `eyre`
 /// comaptible errors, which require `Send + Sync`

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,7 @@ unsafe impl Send for ErrorWrapper {}
 
 impl error::Error for ErrorWrapper {
 	fn source(&self) -> Option<&(dyn error::Error + 'static)> {
-		(&*self.0).source()
+		(&*self.0).source().and_then(|e| e.source())
 	}
 	fn description(&self) -> &str {
 		"Error Wrapper"


### PR DESCRIPTION
While we do not want to introduce additional error frameworks in polkadot, it's reasonable to introduce an error reporting lib it in the outermost level in `main.rs` to avoid reimplementing formatting and other chores. 
`color_eyre` provides all we need and the change is very very small and non-contagious, since it is only present in the application and does not pollute any libraries.