### PR TITLE
test-runtime: use sp-std instead of rstd

### DIFF
--- a/runtime/test-runtime/Cargo.toml
+++ b/runtime/test-runtime/Cargo.toml
@@ -19,7 +19,7 @@ babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/par
 sp-api = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 offchain-primitives = { package = "sp-offchain", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-rstd = { package = "sp-std", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 sp-io = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 sp-staking = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
@@ -85,7 +85,7 @@ std = [
 	"tx-pool-api/std",
 	"block-builder-api/std",
 	"offchain-primitives/std",
-	"rstd/std",
+	"sp-std/std",
 	"sp-io/std",
 	"frame-support/std",
 	"pallet-authorship/std",

--- a/runtime/test-runtime/src/lib.rs
+++ b/runtime/test-runtime/src/lib.rs
@@ -20,7 +20,7 @@
 // `construct_runtime!` does a lot of recursion and requires us to increase the limit to 256.
 #![recursion_limit="256"]
 
-use rstd::prelude::*;
+use sp_std::prelude::*;
 use codec::Encode;
 use polkadot_runtime_parachains::{
 	configuration,


### PR DESCRIPTION
At some point we had aliases for all the substrate crates but at some point we've switched to the full names to avoid confusion. It seems that we missed this instance.

Was split off #1679 