### PR TITLE
Rollback spec_version and fix check_runtime

### DIFF
--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -88,7 +88,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("kusama"),
 	impl_name: create_runtime_str!("parity-kusama"),
 	authoring_version: 2,
-	spec_version: 2027,
+	spec_version: 2026,
 	impl_version: 0,
 	#[cfg(not(feature = "disable-runtime-api"))]
 	apis: RUNTIME_API_VERSIONS,

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -90,7 +90,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("polkadot"),
 	impl_name: create_runtime_str!("parity-polkadot"),
 	authoring_version: 0,
-	spec_version: 27,
+	spec_version: 26,
 	impl_version: 0,
 	#[cfg(not(feature = "disable-runtime-api"))]
 	apis: RUNTIME_API_VERSIONS,

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -85,7 +85,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("westend"),
 	impl_name: create_runtime_str!("parity-westend"),
 	authoring_version: 2,
-	spec_version: 47,
+	spec_version: 46,
 	impl_version: 0,
 	#[cfg(not(feature = "disable-runtime-api"))]
 	apis: RUNTIME_API_VERSIONS,

--- a/scripts/gitlab/check_runtime.sh
+++ b/scripts/gitlab/check_runtime.sh
@@ -24,7 +24,7 @@ SUBSTRATE_REPO_CARGO="git\+${SUBSTRATE_REPO}"
 SUBSTRATE_VERSIONS_FILE="bin/node/runtime/src/lib.rs"
 
 # figure out the latest release tag
-LATEST_TAG="$(git tag -l | sort -V | tail -n 1)"
+LATEST_TAG="$(git tag -l | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n 1)"
 boldprint "latest release tag ${LATEST_TAG}"
 
 boldprint "latest 10 commits of ${CI_COMMIT_REF_NAME}"


### PR DESCRIPTION
`spec_version` for polkadot, kusama and westend were bumped in #1775 erroneously, due to a bug in the check_runtime CI job. It didn't account for release-candidate-style tags (i.e., `v0.8.26-rc1`). We only need to bump the `spec_version` on a new *release*, not every time there's a new tag. Since there has not yet been a new release, `spec_version` does not yet need to be bumped. This PR rolls back `spec_version` and fixes the bug to only pick up tags like `^v1.2.3$`