### PR TITLE
[CI] Switch to using paritytech/srtool

### DIFF
--- a/.github/workflows/publish-draft-release.yml
+++ b/.github/workflows/publish-draft-release.yml
@@ -13,12 +13,12 @@ jobs:
       matrix:
         runtime: ['polkadot', 'kusama']
     container:
-      image: chevdor/srtool:nightly-2020-07-20
+      image: paritytech/srtool:nightly-2020-10-27
       volumes:
         - ${{ github.workspace }}:/build
       env:
         PACKAGE: ${{ matrix.runtime }}-runtime
-        RUSTC_VERSION: nightly-2020-07-20
+        RUSTC_VERSION: nightly-2020-10-27
     steps:
       - uses: actions/checkout@v2
       - name: Cache target dir

--- a/scripts/github/polkadot_release.erb
+++ b/scripts/github/polkadot_release.erb
@@ -11,7 +11,7 @@ This release was tested against the following versions of `rustc`. Other version
 - <%= rustc_stable %>
 - <%= rustc_nightly %>
 
-WASM runtimes built with [srtool](https://gitlab.com/chevdor/srtool) using `<%= polkadot_json['rustc'] %>`.
+WASM runtimes built with [srtool](https://github.com/paritytech/srtool) using `<%= polkadot_json['rustc'] %>`.
 
 Proposal hashes:
 * `polkadot_runtime-v<%= polkadot_runtime %>.compact.wasm - <%= polkadot_json['prop'] %>`


### PR DESCRIPTION
Currently we use chevdor's [srtool](https://gitlab.com/chevdor/srtool), which is mostly fine. However, due to its use of phusion as its base image, it doesn't meet our [Docker images maintenance policy](https://github.com/paritytech/devops/wiki/Docker-images-maintenance-policy).

In addition, due to its older version of nightly, chevdor/srtool doesn't currently seem to be able to build our Wasm blobs.

This works towards resolving paritytech/devops#618