### PR TITLE
Runtime API for historical validation code

### DIFF
--- a/node/core/candidate-validation/src/lib.rs
+++ b/node/core/candidate-validation/src/lib.rs
@@ -258,7 +258,7 @@ async fn check_assumption_validation_data(
 			descriptor.relay_parent,
 			RuntimeApiRequest::ValidationCode(
 				descriptor.para_id,
-				OccupiedCoreAssumption::Included,
+				assumption,
 				code_tx,
 			),
 			code_rx,
@@ -648,7 +648,7 @@ mod tests {
 				ctx_handle.recv().await,
 				AllMessages::RuntimeApi(RuntimeApiMessage::Request(
 					rp,
-					RuntimeApiRequest::ValidationCode(p, OccupiedCoreAssumption::Included, tx)
+					RuntimeApiRequest::ValidationCode(p, OccupiedCoreAssumption::TimedOut, tx)
 				)) => {
 					assert_eq!(rp, relay_parent);
 					assert_eq!(p, para_id);
@@ -756,7 +756,7 @@ mod tests {
 				ctx_handle.recv().await,
 				AllMessages::RuntimeApi(RuntimeApiMessage::Request(
 					rp,
-					RuntimeApiRequest::ValidationCode(p, OccupiedCoreAssumption::Included, tx)
+					RuntimeApiRequest::ValidationCode(p, OccupiedCoreAssumption::TimedOut, tx)
 				)) => {
 					assert_eq!(rp, relay_parent);
 					assert_eq!(p, para_id);

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -503,6 +503,7 @@ pub fn new_full<RuntimeApi, Executor>(
 
 	let (shared_voter_state, finality_proof_provider) = rpc_setup;
 
+	#[cfg(feature = "real-overseer")]
 	config.network.notifications_protocols.extend(polkadot_network_bridge::notifications_protocol_info());
 
 	let (network, network_status_sinks, system_rpc_tx, network_starter) =

--- a/node/subsystem/src/messages.rs
+++ b/node/subsystem/src/messages.rs
@@ -424,6 +424,16 @@ pub enum RuntimeApiRequest {
 		OccupiedCoreAssumption,
 		RuntimeApiSender<Option<ValidationCode>>,
 	),
+	/// Fetch the historical validation code used by a para for candidates executed in the
+	/// context of a given block height in the current chain.
+	///
+	/// `context_height` may be no greater than the height of the block in whose
+	/// state the runtime API is executed.
+	HistoricalValidationCode(
+		ParaId,
+		BlockNumber,
+		RuntimeApiSender<Option<ValidationCode>>,
+	),
 	/// Get a the candidate pending availability for a particular parachain by parachain / core index
 	CandidatePendingAvailability(ParaId, RuntimeApiSender<Option<CommittedCandidateReceipt>>),
 	/// Get all events concerning candidates (backing, inclusion, time-out) in the parent of

--- a/primitives/src/v1.rs
+++ b/primitives/src/v1.rs
@@ -658,7 +658,7 @@ pub enum CandidateEvent<H = Hash> {
 
 sp_api::decl_runtime_apis! {
 	/// The API for querying the state of parachains on-chain.
-	pub trait ParachainHost<H: Decode = Hash, N: Decode = BlockNumber> {
+	pub trait ParachainHost<H: Decode = Hash, N: Encode + Decode = BlockNumber> {
 		/// Get the current validators.
 		fn validators() -> Vec<ValidatorId>;
 
@@ -700,6 +700,14 @@ sp_api::decl_runtime_apis! {
 		/// Returns `None` if either the para is not registered or the assumption is `Freed`
 		/// and the para already occupies a core.
 		fn validation_code(para_id: Id, assumption: OccupiedCoreAssumption)
+			-> Option<ValidationCode>;
+
+		/// Fetch the historical validation code used by a para for candidates executed in the
+		/// context of a given block height in the current chain.
+		///
+		/// `context_height` may be no greater than the height of the block in whose
+		/// state the runtime API is executed.
+		fn historical_validation_code(para_id: Id, context_height: N)
 			-> Option<ValidationCode>;
 
 		/// Get the receipt of a candidate pending availability. This returns `Some` for any paras

--- a/roadmap/implementers-guide/src/node/approval/approval-voting.md
+++ b/roadmap/implementers-guide/src/node/approval/approval-voting.md
@@ -232,7 +232,7 @@ On receiving an `ApprovedAncestor(Hash, BlockNumber, response_channel)`:
 #### `launch_approval(SessionIndex, CandidateDescriptor, ValidatorIndex, block_hash, candidate_index)`:
   * Extract the public key of the `ValidatorIndex` from the `SessionInfo` for the session.
   * Issue an `AvailabilityRecoveryMessage::RecoverAvailableData(candidate, session_index, response_sender)`
-  * Load the historical validation code of the parachain (TODO: https://github.com/paritytech/polkadot/issues/1877)
+  * Load the historical validation code of the parachain by dispatching a `RuntimeApiRequest::HistoricalValidationCode(`descriptor.para_id`, `descriptor.relay_parent`)` against the state of `block_hash`.
   * Spawn a background task with a clone of `approval_vote_tx`
     * Wait for the available data
     * Issue a `CandidateValidationMessage::ValidateFromExhaustive` message

--- a/roadmap/implementers-guide/src/runtime-api/historical_validation_code.md
+++ b/roadmap/implementers-guide/src/runtime-api/historical_validation_code.md
@@ -1,0 +1,7 @@
+# Historical Validation Code
+
+Fetch the historical validation code used by a para for candidates executed in the context of a given block height in the current chain.
+
+```rust
+fn historical_validation_code(at: Block, para_id: ParaId, context_height: BlockNumber) -> Option<ValidationCode>;
+```

--- a/roadmap/implementers-guide/src/types/overseer-protocol.md
+++ b/roadmap/implementers-guide/src/types/overseer-protocol.md
@@ -409,7 +409,9 @@ enum RuntimeApiRequest {
 	SessionIndex(ResponseChannel<SessionIndex>),
 	/// Get the validation code for a specific para, using the given occupied core assumption.
 	ValidationCode(ParaId, OccupiedCoreAssumption, ResponseChannel<Option<ValidationCode>>),
-	/// Get the persisted validation data at the state of a given block for a specific para,
+	/// Fetch the historical validation code used by a para for candidates executed in 
+	/// the context of a given block height in the current chain.
+	HistoricalValidationCode(ParaId, BlockNumber, ResponseChannel<Option<ValidationCode>>),
 	/// with the given occupied core assumption.
 	PersistedValidationData(
 		ParaId,

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -89,7 +89,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("kusama"),
 	impl_name: create_runtime_str!("parity-kusama"),
 	authoring_version: 2,
-	spec_version: 2026,
+	spec_version: 2027,
 	impl_version: 0,
 	#[cfg(not(feature = "disable-runtime-api"))]
 	apis: RUNTIME_API_VERSIONS,
@@ -1112,6 +1112,10 @@ sp_api::impl_runtime_apis! {
 		}
 
 		fn validation_code(_: Id, _: OccupiedCoreAssumption) -> Option<ValidationCode> {
+			None
+		}
+
+		fn historical_validation_code(_: Id, _: BlockNumber) -> Option<ValidationCode> {
 			None
 		}
 

--- a/runtime/parachains/src/runtime_api_impl/v1.rs
+++ b/runtime/parachains/src/runtime_api_impl/v1.rs
@@ -250,6 +250,14 @@ pub fn validation_code<T: initializer::Trait>(
 	)
 }
 
+/// Implementation for the `historical_validation_code` function of the runtime API.
+pub fn historical_validation_code<T: initializer::Trait>(
+	para_id: ParaId,
+	context_height: T::BlockNumber,
+) -> Option<ValidationCode> {
+	<paras::Module<T>>::validation_code_at(para_id, context_height, None)
+}
+
 /// Implementation for the `candidate_pending_availability` function of the runtime API.
 pub fn candidate_pending_availability<T: initializer::Trait>(para_id: ParaId)
 	-> Option<CommittedCandidateReceipt<T::Hash>>

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -1109,6 +1109,10 @@ sp_api::impl_runtime_apis! {
 			None
 		}
 
+		fn historical_validation_code(_: Id, _: BlockNumber) -> Option<ValidationCode> {
+			None
+		}
+
 		fn candidate_pending_availability(_: Id) -> Option<CommittedCandidateReceipt<Hash>> {
 			None
 		}

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -655,6 +655,12 @@ sp_api::impl_runtime_apis! {
 			runtime_api_impl::validation_code::<Runtime>(para_id, assumption)
 		}
 
+		fn historical_validation_code(para_id: Id, context_height: BlockNumber)
+			-> Option<ValidationCode>
+		{
+			runtime_api_impl::historical_validation_code::<Runtime>(para_id, context_height)
+		}
+
 		fn candidate_pending_availability(para_id: Id) -> Option<CommittedCandidateReceipt<Hash>> {
 			runtime_api_impl::candidate_pending_availability::<Runtime>(para_id)
 		}

--- a/runtime/test-runtime/src/lib.rs
+++ b/runtime/test-runtime/src/lib.rs
@@ -644,6 +644,13 @@ sp_api::impl_runtime_apis! {
 			runtime_impl::validation_code::<Runtime>(para_id, assumption)
 		}
 
+		fn historical_validation_code(para_id: ParaId, context_height: BlockNumber)
+			-> Option<ValidationCode>
+		{
+			runtime_impl::historical_validation_code::<Runtime>(para_id, context_height)
+		}
+
+
 		fn candidate_pending_availability(para_id: ParaId) -> Option<CommittedCandidateReceipt<Hash>> {
 			runtime_impl::candidate_pending_availability::<Runtime>(para_id)
 		}

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -821,6 +821,10 @@ sp_api::impl_runtime_apis! {
 			None
 		}
 
+		fn historical_validation_code(_: Id, _: BlockNumber) -> Option<ValidationCode> {
+			None
+		}
+
 		fn check_validation_outputs(
 			_: Id,
 			_: primitives::v1::ValidationOutputs


### PR DESCRIPTION
closes #1877 

The `Paras` module already had a utility for this, so it was just a matter of wiring it up.