### PR TITLE
Backing fixes

### DIFF
--- a/node/core/backing/src/lib.rs
+++ b/node/core/backing/src/lib.rs
@@ -262,7 +262,6 @@ fn table_attested_to_backed(
 		.unzip();
 
 	let group = table_context.groups.get(&para_id)?;
-		None => return None,
 
 	let mut validator_indices = BitVec::with_capacity(group.len());
 

--- a/node/core/backing/src/lib.rs
+++ b/node/core/backing/src/lib.rs
@@ -262,7 +262,6 @@ fn table_attested_to_backed(
 		.unzip();
 
 	let group = table_context.groups.get(&para_id)?;
-		Some(group) => group,
 		None => return None,
 	};
 

--- a/node/core/backing/src/lib.rs
+++ b/node/core/backing/src/lib.rs
@@ -455,6 +455,8 @@ impl CandidateBackingJob {
 				&summary.candidate,
 				&self.table_context,
 			) {
+				// `HashSet::insert` returns true if the thing wasn't in there already.
+				// one of the few places the Rust-std folks did a bad job with API
 				if self.backed.insert(summary.candidate) {
 					if let Some(backed) =
 						table_attested_to_backed(attested, &self.table_context)

--- a/node/core/backing/src/lib.rs
+++ b/node/core/backing/src/lib.rs
@@ -257,9 +257,9 @@ fn table_attested_to_backed(
 	let TableAttestedCandidate { candidate, validity_votes, group_id: para_id } = attested;
 
 	let (ids, validity_votes): (Vec<_>, Vec<_>) = validity_votes
-				.into_iter()
-				.map(|(id, vote)| (id, vote.into()))
-				.unzip();
+		.into_iter()
+		.map(|(id, vote)| (id, vote.into()))
+		.unzip();
 
 	let group = match table_context.groups.get(&para_id) {
 		Some(group) => group,

--- a/node/core/backing/src/lib.rs
+++ b/node/core/backing/src/lib.rs
@@ -263,7 +263,6 @@ fn table_attested_to_backed(
 
 	let group = table_context.groups.get(&para_id)?;
 		None => return None,
-	};
 
 	let mut validator_indices = BitVec::with_capacity(group.len());
 

--- a/node/core/backing/src/lib.rs
+++ b/node/core/backing/src/lib.rs
@@ -261,7 +261,7 @@ fn table_attested_to_backed(
 		.map(|(id, vote)| (id, vote.into()))
 		.unzip();
 
-	let group = match table_context.groups.get(&para_id) {
+	let group = table_context.groups.get(&para_id)?;
 		Some(group) => group,
 		None => return None,
 	};

--- a/node/core/provisioner/src/lib.rs
+++ b/node/core/provisioner/src/lib.rs
@@ -368,8 +368,7 @@ async fn select_candidates(
 		let (scheduled_core, assumption) = match core {
 			CoreState::Scheduled(scheduled_core) => (scheduled_core, OccupiedCoreAssumption::Free),
 			CoreState::Occupied(occupied_core) => {
-				if bitfields_indicate_availability(core_idx, bitfields, &occupied_core.availability)
-				{
+				if bitfields_indicate_availability(core_idx, bitfields, &occupied_core.availability) {
 					if let Some(ref scheduled_core) = occupied_core.next_up_on_available {
 						(scheduled_core, OccupiedCoreAssumption::Included)
 					} else {

--- a/statement-table/src/generic.rs
+++ b/statement-table/src/generic.rs
@@ -256,15 +256,14 @@ impl<C: Context> CandidateData<C> {
 	// if it has enough validity votes
 	// and no authorities have called it bad.
 	fn can_be_included(&self, validity_threshold: usize) -> bool {
-		self.indicated_bad_by.is_empty()
-			&& self.validity_votes.len() >= validity_threshold
+		self.validity_votes.len() >= validity_threshold
 	}
 
 	fn summary(&self, digest: C::Digest) -> Summary<C::Digest, C::GroupId> {
 		Summary {
 			candidate: digest,
 			group_id: self.group_id.clone(),
-			validity_votes: self.validity_votes.len() - self.indicated_bad_by.len(),
+			validity_votes: self.validity_votes.len(),
 			signalled_bad: self.indicated_bad(),
 		}
 	}
@@ -1008,7 +1007,7 @@ mod tests {
 
 		candidate.indicated_bad_by.push(AuthorityId(1024));
 
-		assert!(!candidate.can_be_included(validity_threshold));
+		assert!(candidate.can_be_included(validity_threshold));
 	}
 
 	#[test]
@@ -1058,8 +1057,8 @@ mod tests {
 
 		table.import_statement(&context, vote);
 		assert!(!table.detected_misbehavior.contains_key(&AuthorityId(3)));
-		assert!(!table.candidate_includable(&candidate_digest, &context));
-		assert!(table.includable_count.is_empty());
+		assert!(table.candidate_includable(&candidate_digest, &context));
+		assert!(table.includable_count.get(&GroupId(2)).is_some());
 	}
 
 	#[test]

--- a/statement-table/src/generic.rs
+++ b/statement-table/src/generic.rs
@@ -377,6 +377,18 @@ impl<C: Context> Table<C> {
 		})
 	}
 
+	/// Get an `Attested` version of the candidate, if it's includable.
+	pub fn attested_candidate(&self, digest: &C::Digest, context: &C)
+		-> Option<AttestedCandidate<
+			C::GroupId, C::Candidate, C::AuthorityId, C::Signature,
+		>>
+	{
+		self.candidate_votes.get(digest).and_then(|data| {
+			let v_threshold = context.requisite_votes(&data.group_id);
+			data.attested(v_threshold)
+		})
+	}
+
 	/// Import a signed statement. Signatures should be checked for validity, and the
 	/// sender should be checked to actually be an authority.
 	///


### PR DESCRIPTION
* Add `attested_candidate` function to statement table
* fix: Ensure that imported statements always are fed to the statement table
* Issue backed candidates to the provisioner
* fix: construct backed candidates with the correct para_id for the group
* fix: tests