### PR TITLE
Implement HRMP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5478,6 +5478,7 @@ dependencies = [
  "sp-std",
  "sp-trie",
  "sp-version",
+ "xcm",
 ]
 
 [[package]]

--- a/core-primitives/src/lib.rs
+++ b/core-primitives/src/lib.rs
@@ -113,6 +113,7 @@ pub struct InboundHrmpMessage<BlockNumber = crate::BlockNumber> {
 	pub data: sp_std::vec::Vec<u8>,
 }
 
+/// An HRMP message seen from the perspective of a sender.
 #[derive(codec::Encode, codec::Decode, Clone, sp_runtime::RuntimeDebug, PartialEq, Eq, Hash)]
 pub struct OutboundHrmpMessage<Id> {
 	/// The para that will get this message in its downward message queue.

--- a/core-primitives/src/lib.rs
+++ b/core-primitives/src/lib.rs
@@ -102,6 +102,25 @@ pub struct InboundDownwardMessage<BlockNumber = crate::BlockNumber> {
 	pub msg: DownwardMessage,
 }
 
+/// An HRMP message seen from the perspective of a recipient.
+#[derive(codec::Encode, codec::Decode, Clone, sp_runtime::RuntimeDebug, PartialEq)]
+pub struct InboundHrmpMessage<BlockNumber = crate::BlockNumber> {
+	/// The block number at which this message was sent.
+	/// Specifically, it is the block number at which the candidate that sends this message was
+	/// enacted.
+	pub sent_at: BlockNumber,
+	/// The message payload.
+	pub data: sp_std::vec::Vec<u8>,
+}
+
+#[derive(codec::Encode, codec::Decode, Clone, sp_runtime::RuntimeDebug, PartialEq, Eq, Hash)]
+pub struct OutboundHrmpMessage<Id> {
+	/// The para that will get this message in its downward message queue.
+	pub recipient: Id,
+	/// The message payload.
+	pub data: sp_std::vec::Vec<u8>,
+}
+
 /// V1 primitives.
 pub mod v1 {
 	pub use super::*;

--- a/node/collation-generation/src/lib.rs
+++ b/node/collation-generation/src/lib.rs
@@ -274,10 +274,12 @@ async fn handle_new_activations<Context: SubsystemContext>(
 
 				let commitments = CandidateCommitments {
 					upward_messages: collation.upward_messages,
+					horizontal_messages: collation.horizontal_messages,
 					new_validation_code: collation.new_validation_code,
 					head_data: collation.head_data,
 					erasure_root,
 					processed_downward_messages: collation.processed_downward_messages,
+					hrmp_watermark: collation.hrmp_watermark,
 				};
 
 				let ccr = CandidateReceipt {
@@ -382,12 +384,14 @@ mod tests {
 		fn test_collation() -> Collation {
 			Collation {
 				upward_messages: Default::default(),
+				horizontal_messages: Default::default(),
 				new_validation_code: Default::default(),
 				head_data: Default::default(),
 				proof_of_validity: PoV {
 					block_data: BlockData(Vec::new()),
 				},
 				processed_downward_messages: Default::default(),
+				hrmp_watermark: Default::default(),
 			}
 		}
 

--- a/node/core/backing/src/lib.rs
+++ b/node/core/backing/src/lib.rs
@@ -717,10 +717,12 @@ impl CandidateBackingJob {
 
 		let commitments = CandidateCommitments {
 			upward_messages: outputs.upward_messages,
+			horizontal_messages: outputs.horizontal_messages,
 			erasure_root,
 			new_validation_code: outputs.new_validation_code,
 			head_data: outputs.head_data,
 			processed_downward_messages: outputs.processed_downward_messages,
+			hrmp_watermark: outputs.hrmp_watermark,
 		};
 
 		let res = match with_commitments(commitments) {
@@ -1200,9 +1202,11 @@ mod tests {
 					tx.send(Ok(
 						ValidationResult::Valid(ValidationOutputs {
 							head_data: expected_head_data.clone(),
+							horizontal_messages: Vec::new(),
 							upward_messages: Vec::new(),
 							new_validation_code: None,
 							processed_downward_messages: 0,
+							hrmp_watermark: 0,
 						}, test_state.validation_data.persisted),
 					)).unwrap();
 				}
@@ -1328,8 +1332,10 @@ mod tests {
 						ValidationResult::Valid(ValidationOutputs {
 							head_data: expected_head_data.clone(),
 							upward_messages: Vec::new(),
+							horizontal_messages: Vec::new(),
 							new_validation_code: None,
 							processed_downward_messages: 0,
+							hrmp_watermark: 0,
 						}, test_state.validation_data.persisted),
 					)).unwrap();
 				}
@@ -1477,8 +1483,10 @@ mod tests {
 						ValidationResult::Valid(ValidationOutputs {
 							head_data: expected_head_data.clone(),
 							upward_messages: Vec::new(),
+							horizontal_messages: Vec::new(),
 							new_validation_code: None,
 							processed_downward_messages: 0,
+							hrmp_watermark: 0,
 						}, test_state.validation_data.persisted),
 					)).unwrap();
 				}
@@ -1660,8 +1668,10 @@ mod tests {
 						ValidationResult::Valid(ValidationOutputs {
 							head_data: expected_head_data.clone(),
 							upward_messages: Vec::new(),
+							horizontal_messages: Vec::new(),
 							new_validation_code: None,
 							processed_downward_messages: 0,
+							hrmp_watermark: 0,
 						}, test_state.validation_data.persisted),
 					)).unwrap();
 				}

--- a/node/core/candidate-validation/src/lib.rs
+++ b/node/core/candidate-validation/src/lib.rs
@@ -489,8 +489,10 @@ fn validate_candidate_exhaustive<B: ValidationBackend, S: SpawnNamed + 'static>(
 			let outputs = ValidationOutputs {
 				head_data: res.head_data,
 				upward_messages: res.upward_messages,
+				horizontal_messages: res.horizontal_messages,
 				new_validation_code: res.new_validation_code,
 				processed_downward_messages: res.processed_downward_messages,
+				hrmp_watermark: res.hrmp_watermark,
 			};
 			Ok(ValidationResult::Valid(outputs, persisted_validation_data))
 		}
@@ -833,7 +835,9 @@ mod tests {
 			head_data: HeadData(vec![1, 1, 1]),
 			new_validation_code: Some(vec![2, 2, 2].into()),
 			upward_messages: Vec::new(),
+			horizontal_messages: Vec::new(),
 			processed_downward_messages: 0,
+			hrmp_watermark: 0,
 		};
 
 		let v = validate_candidate_exhaustive::<MockValidationBackend, _>(
@@ -848,7 +852,9 @@ mod tests {
 		assert_matches!(v, ValidationResult::Valid(outputs, used_validation_data) => {
 			assert_eq!(outputs.head_data, HeadData(vec![1, 1, 1]));
 			assert_eq!(outputs.upward_messages, Vec::<UpwardMessage>::new());
+			assert_eq!(outputs.horizontal_messages, Vec::new());
 			assert_eq!(outputs.new_validation_code, Some(vec![2, 2, 2].into()));
+			assert_eq!(outputs.hrmp_watermark, 0);
 			assert_eq!(used_validation_data, validation_data);
 		});
 	}

--- a/node/primitives/src/lib.rs
+++ b/node/primitives/src/lib.rs
@@ -28,7 +28,7 @@ use polkadot_primitives::v1::{
 	Hash, CommittedCandidateReceipt, CandidateReceipt, CompactStatement,
 	EncodeAs, Signed, SigningContext, ValidatorIndex, ValidatorId,
 	UpwardMessage, ValidationCode, PersistedValidationData, ValidationData,
-	HeadData, PoV, CollatorPair, Id as ParaId, ValidationOutputs, CandidateHash,
+	HeadData, PoV, CollatorPair, Id as ParaId, OutboundHrmpMessage, ValidationOutputs, CandidateHash,
 };
 use polkadot_statement_table::{
 	generic::{
@@ -252,9 +252,11 @@ impl std::convert::TryFrom<FromTableMisbehavior> for MisbehaviorReport {
 /// - does not contain the erasure root; that's computed at the Polkadot level, not at Cumulus
 /// - contains a proof of validity.
 #[derive(Clone, Encode, Decode)]
-pub struct Collation {
+pub struct Collation<BlockNumber = polkadot_primitives::v1::BlockNumber> {
 	/// Messages destined to be interpreted by the Relay chain itself.
 	pub upward_messages: Vec<UpwardMessage>,
+	/// The horizontal messages sent by the parachain.
+	pub horizontal_messages: Vec<OutboundHrmpMessage<ParaId>>,
 	/// New validation code.
 	pub new_validation_code: Option<ValidationCode>,
 	/// The head-data produced as a result of execution.
@@ -263,6 +265,8 @@ pub struct Collation {
 	pub proof_of_validity: PoV,
 	/// The number of messages processed from the DMQ.
 	pub processed_downward_messages: u32,
+	/// The mark which specifies the block number up to which all inbound HRMP messages are processed.
+	pub hrmp_watermark: BlockNumber,
 }
 
 /// Configuration for the collation generator

--- a/node/subsystem/src/messages.rs
+++ b/node/subsystem/src/messages.rs
@@ -37,9 +37,10 @@ use polkadot_primitives::v1::{
 	GroupRotationInfo, Hash, Id as ParaId, OccupiedCoreAssumption,
 	PersistedValidationData, PoV, SessionIndex, SignedAvailabilityBitfield,
 	ValidationCode, ValidatorId, ValidationData, CandidateHash,
-	ValidatorIndex, ValidatorSignature, InboundDownwardMessage,
+	ValidatorIndex, ValidatorSignature, InboundDownwardMessage, InboundHrmpMessage,
 };
 use std::sync::Arc;
+use std::collections::btree_map::BTreeMap;
 
 /// A notification of a new backed candidate.
 #[derive(Debug)]
@@ -451,6 +452,12 @@ pub enum RuntimeApiRequest {
 	DmqContents(
 		ParaId,
 		RuntimeApiSender<Vec<InboundDownwardMessage<BlockNumber>>>,
+	),
+	/// Get the contents of all channels addressed to the given recipient. Channels that have no
+	/// messages in them are also included.
+	InboundHrmpChannelsContents(
+		ParaId,
+		RuntimeApiSender<BTreeMap<ParaId, Vec<InboundHrmpMessage<BlockNumber>>>>,
 	),
 }
 

--- a/parachain/src/primitives.rs
+++ b/parachain/src/primitives.rs
@@ -186,7 +186,14 @@ impl<T: Encode + Decode + Default> AccountIdConversion<T> for Id {
 	}
 }
 
-/// A type that uniquely identifies an HRMP channel. An HRMP channel is unidirectional
+/// A type that uniquely identifies an HRMP channel. An HRMP channel is established between two paras.
+/// In text, we use the notation `(A, B)` to specify a channel between A and B. The channels are
+/// unidirectional, meaning that `(A, B)` and `(B, A)` refer to different channels. The convention is
+/// that we use the first item tuple for the sender and the second for the recipient. Only one channel
+/// is allowed between two participants in one direction, i.e. there cannot be 2 different channels
+/// identified by `(A, B)`.
+///
+/// `HrmpChannelId` has a defined ordering: first `sender` and tie is resolved by `recipient`.
 #[derive(Clone, PartialEq, Eq, Encode, Decode, RuntimeDebug)]
 #[cfg_attr(feature = "std", derive(Hash))]
 pub struct HrmpChannelId {

--- a/parachain/src/primitives.rs
+++ b/parachain/src/primitives.rs
@@ -28,7 +28,7 @@ use serde::{Serialize, Deserialize};
 #[cfg(feature = "std")]
 use sp_core::bytes;
 
-use polkadot_core_primitives::Hash;
+use polkadot_core_primitives::{Hash, OutboundHrmpMessage};
 
 /// Block number type used by the relay chain.
 pub use polkadot_core_primitives::BlockNumber as RelayChainBlockNumber;
@@ -186,6 +186,16 @@ impl<T: Encode + Decode + Default> AccountIdConversion<T> for Id {
 	}
 }
 
+/// A type that uniquely identifies an HRMP channel. An HRMP channel is unidirectional
+#[derive(Clone, PartialEq, Eq, Encode, Decode, RuntimeDebug)]
+#[cfg_attr(feature = "std", derive(Hash))]
+pub struct HrmpChannelId {
+	/// The para that acts as the sender in this channel.
+	pub sender: Id,
+	/// The para that acts as the recipient in this channel.
+	pub recipient: Id,
+}
+
 /// A message from a parachain to its Relay Chain.
 pub type UpwardMessage = Vec<u8>;
 
@@ -212,7 +222,7 @@ pub struct ValidationParams {
 }
 
 /// The result of parachain validation.
-// TODO: egress and balance uploads (https://github.com/paritytech/polkadot/issues/220)
+// TODO: balance uploads (https://github.com/paritytech/polkadot/issues/220)
 #[derive(PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Debug, Decode))]
 pub struct ValidationResult {
@@ -222,8 +232,12 @@ pub struct ValidationResult {
 	pub new_validation_code: Option<ValidationCode>,
 	/// Upward messages send by the Parachain.
 	pub upward_messages: Vec<UpwardMessage>,
+	/// Outbound horizontal messages sent by the parachain.
+	pub horizontal_messages: Vec<OutboundHrmpMessage<Id>>,
 	/// Number of downward messages that were processed by the Parachain.
 	///
 	/// It is expected that the Parachain processes them from first to last.
 	pub processed_downward_messages: u32,
+	/// The mark which specifies the block number up to which all inbound HRMP messages are processed.
+	pub hrmp_watermark: RelayChainBlockNumber,
 }

--- a/parachain/src/primitives.rs
+++ b/parachain/src/primitives.rs
@@ -192,8 +192,6 @@ impl<T: Encode + Decode + Default> AccountIdConversion<T> for Id {
 /// that we use the first item tuple for the sender and the second for the recipient. Only one channel
 /// is allowed between two participants in one direction, i.e. there cannot be 2 different channels
 /// identified by `(A, B)`.
-///
-/// `HrmpChannelId` has a defined ordering: first `sender` and tie is resolved by `recipient`.
 #[derive(Clone, PartialEq, Eq, Encode, Decode, RuntimeDebug)]
 #[cfg_attr(feature = "std", derive(Hash))]
 pub struct HrmpChannelId {

--- a/parachain/test-parachains/adder/collator/src/lib.rs
+++ b/parachain/test-parachains/adder/collator/src/lib.rs
@@ -114,10 +114,12 @@ impl Collator {
 
 			let collation = Collation {
 				upward_messages: Vec::new(),
+				horizontal_messages: Vec::new(),
 				new_validation_code: None,
 				head_data: head_data.encode().into(),
 				proof_of_validity: PoV { block_data: block_data.encode().into() },
 				processed_downward_messages: 0,
+				hrmp_watermark: validation_data.persisted.block_number,
 			};
 
 			async move { Some(collation) }.boxed()

--- a/parachain/test-parachains/adder/src/wasm_validation.rs
+++ b/parachain/test-parachains/adder/src/wasm_validation.rs
@@ -17,12 +17,13 @@
 //! WASM validation for adder parachain.
 
 use crate::{HeadData, BlockData};
-use core::{intrinsics, panic};
+use core::panic;
+use sp_std::vec::Vec;
 use parachain::primitives::{ValidationResult, HeadData as GenericHeadData};
 use codec::{Encode, Decode};
 
 #[no_mangle]
-pub extern fn validate_block(params: *const u8, len: usize) -> u64 {
+pub extern "C" fn validate_block(params: *const u8, len: usize) -> u64 {
 	let params = unsafe { parachain::load_params(params, len) };
 	let parent_head = HeadData::decode(&mut &params.parent_head.0[..])
 		.expect("invalid parent head format.");
@@ -38,7 +39,9 @@ pub extern fn validate_block(params: *const u8, len: usize) -> u64 {
 			head_data: GenericHeadData(new_head.encode()),
 			new_validation_code: None,
 			upward_messages: sp_std::vec::Vec::new(),
+			horizontal_messages: sp_std::vec::Vec::new(),
 			processed_downward_messages: 0,
+			hrmp_watermark: params.relay_chain_height,
 		}
 	)
 }

--- a/primitives/src/v1.rs
+++ b/primitives/src/v1.rs
@@ -29,14 +29,14 @@ pub use runtime_primitives::traits::{BlakeTwo256, Hash as HashT};
 
 // Export some core primitives.
 pub use polkadot_core_primitives::v1::{
-	BlockNumber, Moment, Signature, AccountPublic, AccountId, AccountIndex,
-	ChainId, Hash, Nonce, Balance, Header, Block, BlockId, UncheckedExtrinsic,
-	Remark, DownwardMessage, InboundDownwardMessage, CandidateHash,
+	BlockNumber, Moment, Signature, AccountPublic, AccountId, AccountIndex, ChainId, Hash, Nonce,
+	Balance, Header, Block, BlockId, UncheckedExtrinsic, Remark, DownwardMessage,
+	InboundDownwardMessage, CandidateHash, InboundHrmpMessage, OutboundHrmpMessage,
 };
 
 // Export some polkadot-parachain primitives
 pub use polkadot_parachain::primitives::{
-	Id, LOWEST_USER_ID, UpwardMessage, HeadData, BlockData, ValidationCode,
+	Id, LOWEST_USER_ID, HrmpChannelId, UpwardMessage, HeadData, BlockData, ValidationCode,
 };
 
 // Export some basic parachain primitives from v0.
@@ -317,18 +317,24 @@ pub struct ValidationOutputs {
 	pub head_data: HeadData,
 	/// Upward messages to the relay chain.
 	pub upward_messages: Vec<UpwardMessage>,
+	/// The horizontal messages sent by the parachain.
+	pub horizontal_messages: Vec<OutboundHrmpMessage<Id>>,
 	/// The new validation code submitted by the execution, if any.
 	pub new_validation_code: Option<ValidationCode>,
 	/// The number of messages processed from the DMQ.
 	pub processed_downward_messages: u32,
+	/// The mark which specifies the block number up to which all inbound HRMP messages are processed.
+	pub hrmp_watermark: BlockNumber,
 }
 
 /// Commitments made in a `CandidateReceipt`. Many of these are outputs of validation.
 #[derive(PartialEq, Eq, Clone, Encode, Decode)]
 #[cfg_attr(feature = "std", derive(Debug, Default, Hash))]
-pub struct CandidateCommitments {
+pub struct CandidateCommitments<N = BlockNumber> {
 	/// Messages destined to be interpreted by the Relay chain itself.
 	pub upward_messages: Vec<UpwardMessage>,
+	/// Horizontal messages sent by the parachain.
+	pub horizontal_messages: Vec<OutboundHrmpMessage<Id>>,
 	/// The root of a block's erasure encoding Merkle tree.
 	pub erasure_root: Hash,
 	/// New validation code.
@@ -337,6 +343,8 @@ pub struct CandidateCommitments {
 	pub head_data: HeadData,
 	/// The number of messages processed from the DMQ.
 	pub processed_downward_messages: u32,
+	/// The mark which specifies the block number up to which all inbound HRMP messages are processed.
+	pub hrmp_watermark: N,
 }
 
 impl CandidateCommitments {

--- a/primitives/src/v1.rs
+++ b/primitives/src/v1.rs
@@ -17,6 +17,7 @@
 //! V1 Primitives.
 
 use sp_std::prelude::*;
+use sp_std::collections::btree_map::BTreeMap;
 use parity_scale_codec::{Encode, Decode};
 use bitvec::vec::BitVec;
 
@@ -743,6 +744,10 @@ sp_api::decl_runtime_apis! {
 		fn dmq_contents(
 			recipient: Id,
 		) -> Vec<InboundDownwardMessage<N>>;
+
+		/// Get the contents of all channels addressed to the given recipient. Channels that have no
+		/// messages in them are also included.
+		fn inbound_hrmp_channels_contents(recipient: Id) -> BTreeMap<Id, Vec<InboundHrmpMessage<N>>>;
 	}
 }
 

--- a/roadmap/implementers-guide/src/runtime/inclusion.md
+++ b/roadmap/implementers-guide/src/runtime/inclusion.md
@@ -70,8 +70,7 @@ All failed checks should lead to an unrecoverable error making the block invalid
   1. call `Router::check_upward_messages(para, commitments.upward_messages)` to check that the upward messages are valid.
   1. call `Router::check_processed_downward_messages(para, commitments.processed_downward_messages)` to check that the DMQ is properly drained.
   1. call `Router::check_hrmp_watermark(para, commitments.hrmp_watermark)` for each candidate to check rules of processing the HRMP watermark.
-  1. check that in the commitments of each candidate the horizontal messages are sorted by ascending recipient ParaId and there is no two horizontal messages have the same recipient.
-  1. using `Router::verify_outbound_hrmp(sender, commitments.horizontal_messages)` ensure that the each candidate send a valid set of horizontal messages
+  1. using `Router::check_outbound_hrmp(sender, commitments.horizontal_messages)` ensure that the each candidate send a valid set of horizontal messages
   1. create an entry in the `PendingAvailability` map for each backed candidate with a blank `availability_votes` bitfield.
   1. create a corresponding entry in the `PendingAvailabilityCommitments` with the commitments.
   1. Return a `Vec<CoreIndex>` of all scheduled cores of the list of passed assignments that a candidate was successfully backed for, sorted ascending by CoreIndex.
@@ -79,9 +78,9 @@ All failed checks should lead to an unrecoverable error making the block invalid
   1. If the receipt contains a code upgrade, Call `Paras::schedule_code_upgrade(para_id, code, relay_parent_number + config.validationl_upgrade_delay)`.
     > TODO: Note that this is safe as long as we never enact candidates where the relay parent is across a session boundary. In that case, which we should be careful to avoid with contextual execution, the configuration might have changed and the para may de-sync from the host's understanding of it.
   1. call `Router::enact_upward_messages` for each backed candidate, using the [`UpwardMessage`s](../types/messages.md#upward-message) from the [`CandidateCommitments`](../types/candidate.md#candidate-commitments).
-  1. call `Router::queue_outbound_hrmp` with the para id of the candidate and the list of horizontal messages taken from the commitment,
-  1. call `Router::prune_hrmp` with the para id of the candiate and the candidate's `hrmp_watermark`.
   1. call `Router::prune_dmq` with the para id of the candidate and the candidate's `processed_downward_messages`.
+  1. call `Router::prune_hrmp` with the para id of the candiate and the candidate's `hrmp_watermark`.
+  1. call `Router::queue_outbound_hrmp` with the para id of the candidate and the list of horizontal messages taken from the commitment,
   1. Call `Paras::note_new_head` using the `HeadData` from the receipt and `relay_parent_number`.
 * `collect_pending`:
 

--- a/roadmap/implementers-guide/src/runtime/inclusion.md
+++ b/roadmap/implementers-guide/src/runtime/inclusion.md
@@ -70,7 +70,7 @@ All failed checks should lead to an unrecoverable error making the block invalid
   1. call `Router::check_upward_messages(para, commitments.upward_messages)` to check that the upward messages are valid.
   1. call `Router::check_processed_downward_messages(para, commitments.processed_downward_messages)` to check that the DMQ is properly drained.
   1. call `Router::check_hrmp_watermark(para, commitments.hrmp_watermark)` for each candidate to check rules of processing the HRMP watermark.
-  1. using `Router::check_outbound_hrmp(sender, commitments.horizontal_messages)` ensure that the each candidate send a valid set of horizontal messages
+  1. using `Router::check_outbound_hrmp(sender, commitments.horizontal_messages)` ensure that the each candidate sent a valid set of horizontal messages
   1. create an entry in the `PendingAvailability` map for each backed candidate with a blank `availability_votes` bitfield.
   1. create a corresponding entry in the `PendingAvailabilityCommitments` with the commitments.
   1. Return a `Vec<CoreIndex>` of all scheduled cores of the list of passed assignments that a candidate was successfully backed for, sorted ascending by CoreIndex.

--- a/roadmap/implementers-guide/src/runtime/paras.md
+++ b/roadmap/implementers-guide/src/runtime/paras.md
@@ -111,6 +111,7 @@ OutgoingParas: Vec<ParaId>;
 * `note_new_head(ParaId, HeadData, BlockNumber)`: note that a para has progressed to a new head, where the new head was executed in the context of a relay-chain block with given number. This will apply pending code upgrades based on the block number provided.
 * `validation_code_at(ParaId, at: BlockNumber, assume_intermediate: Option<BlockNumber>)`: Fetches the validation code to be used when validating a block in the context of the given relay-chain height. A second block number parameter may be used to tell the lookup to proceed as if an intermediate parablock has been included at the given relay-chain height. This may return past, current, or (with certain choices of `assume_intermediate`) future code. `assume_intermediate`, if provided, must be before `at`. If the validation code has been pruned, this will return `None`.
 * `is_parathread(ParaId) -> bool`: Returns true if the para ID references any live parathread.
+* `is_valid_para(ParaId) -> bool`: Returns true if the para ID references either a live parathread or live parachain.
 
 * `last_code_upgrade(id: ParaId, include_future: bool) -> Option<BlockNumber>`: The block number of the last scheduled upgrade of the requested para. Includes future upgrades if the flag is set. This is the `expected_at` number, not the `activated_at` number.
 * `persisted_validation_data(id: ParaId) -> Option<PersistedValidationData>`: Get the PersistedValidationData of the given para, assuming the context is the parent block. Returns `None` if the para is not known.

--- a/roadmap/implementers-guide/src/runtime/router.md
+++ b/roadmap/implementers-guide/src/runtime/router.md
@@ -287,6 +287,12 @@ the parachain executed the message.
         1. Set `limit_used_places` to `max_places`
         1. Set `limit_message_size` to `max_message_size`
         1. Set `limit_used_bytes` to `config.hrmp_channel_max_size`
+    1. Send a downward message to `recipient` notifying about an inbound HRMP channel request.
+        - The DM is sent using `queue_downward_message`.
+        - The DM is represented by the `HrmpNewChannelOpenRequest`  XCM message.
+            - `sender` is set to `origin`,
+            - `max_message_size` is set to `max_message_size`,
+            - `max_capacity` is set to `max_places`.
 * `hrmp_accept_open_channel(sender)`:
     1. Check that there is an existing request between (`sender`, `origin`) in `HrmpOpenChannelRequests`
         1. Check that it is not confirmed.
@@ -299,12 +305,23 @@ the parachain executed the message.
     1. Reserve the deposit for the `origin` according to `config.hrmp_recipient_deposit`
     1. For the request in `HrmpOpenChannelRequests` identified by `(sender, P)`, set `confirmed` flag to `true`.
     1. Increase `HrmpAcceptedChannelRequestCount` by 1 for `origin`.
+    1. Send a downward message to `sender` notifying that the channel request was accepted.
+        - The DM is sent using `queue_downward_message`.
+        - The DM is represented by the `HrmpChannelAccepted` XCM message.
+            - `recipient` is set to `origin`.
 * `hrmp_close_channel(ch)`:
     1. Check that `origin` is either `ch.sender` or `ch.recipient`
     1. Check that `HrmpChannels` for `ch` exists.
     1. Check that `ch` is not in the `HrmpCloseChannelRequests` set.
     1. If not already there, insert a new entry `Some(())` to `HrmpCloseChannelRequests` for `ch`
     and append `ch` to `HrmpCloseChannelRequestsList`.
+    1. Send a downward message to the opposite party notifying about the channel closing.
+        - The DM is sent using `queue_downward_message`.
+        - The DM is represented by the `HrmpChannelClosing` XCM message with:
+            - `initator` is set to `origin`,
+            - `sender` is set to `ch.sender`,
+            - `recipient` is set to `ch.recipient`.
+        - The opposite party is `ch.sender` if `origin` is `ch.recipient` and `ch.recipient` if `origin` is `ch.sender`.
 
 ## Session Change
 

--- a/roadmap/implementers-guide/src/runtime/router.md
+++ b/roadmap/implementers-guide/src/runtime/router.md
@@ -172,7 +172,10 @@ HrmpEgressChannelsIndex: map ParaId => Vec<ParaId>;
 HrmpChannelContents: map HrmpChannelId => Vec<InboundHrmpMessage>;
 /// Maintains a mapping that can be used to answer the question:
 /// What paras sent a message at the given block number for a given reciever.
-/// Invariant: The para ids vector is never empty.
+/// Invariants:
+/// - The para ids vector is never empty.
+/// - The para ids vector doesn't contain duplicates.
+/// - The outer vector is sorted ascending by block number and there are no duplicates.
 HrmpChannelDigests: map ParaId => Vec<(BlockNumber, Vec<ParaId>)>;
 ```
 

--- a/roadmap/implementers-guide/src/runtime/router.md
+++ b/roadmap/implementers-guide/src/runtime/router.md
@@ -92,8 +92,6 @@ struct HrmpChannel {
     sender_deposit: Balance,
     /// The amount that the recipient supplied as a deposit when accepting opening this channel.
     recipient_deposit: Balance,
-    /// The maximum message size that could be put into the channel.
-    limit_message_size: u32,
     /// The maximum number of messages that can be pending in the channel at once.
     max_capacity: u32,
     /// The maximum total size of the messages that can be pending in the channel at once.
@@ -173,7 +171,7 @@ HrmpChannelContents: map HrmpChannelId => Vec<InboundHrmpMessage>;
 /// Maintains a mapping that can be used to answer the question:
 /// What paras sent a message at the given block number for a given reciever.
 /// Invariants:
-/// - The para ids vector is never empty.
+/// - The inner `Vec<ParaId>` is never empty.
 /// - The para ids vector doesn't contain duplicates.
 /// - The outer vector is sorted ascending by block number and there are no duplicates.
 HrmpChannelDigests: map ParaId => Vec<(BlockNumber, Vec<ParaId>)>;

--- a/roadmap/implementers-guide/src/runtime/router.md
+++ b/roadmap/implementers-guide/src/runtime/router.md
@@ -198,6 +198,7 @@ Candidate Acceptance Function:
         1. equal to the context's block number
         1. or in `HrmpChannelDigests` for `P` an entry with the block number should exist
 * `check_outbound_hrmp(sender: ParaId, Vec<OutboundHrmpMessage>)`:
+    1. Checks that there are at most `config.hrmp_max_message_num_per_candidate` messages.
     1. Checks that horizontal messages are sorted by ascending recipient ParaId and there is no two horizontal messages have the same recipient.
     1. For each horizontal message `M` with the channel `C` identified by `(sender, M.recipient)` check:
         1. exists

--- a/roadmap/implementers-guide/src/runtime/router.md
+++ b/roadmap/implementers-guide/src/runtime/router.md
@@ -146,9 +146,12 @@ HrmpCloseChannelRequests: map HrmpChannelId => Option<()>;
 HrmpCloseChannelRequestsList: Vec<HrmpChannelId>;
 
 /// The HRMP watermark associated with each para.
-/// Invariant: every para should be onboarded.
+/// Invariant:
+/// - each para `P` used here as a key should satisfy `Paras::is_valid_para(P)` within a session.
 HrmpWatermarks: map ParaId => Option<BlockNumber>;
 /// HRMP channel data associated with each para.
+/// Invariant:
+/// - each participant in the channel should satisfy `Paras::is_valid_para(P)` within a session.
 HrmpChannels: map HrmpChannelId => Option<HrmpChannel>;
 /// Ingress/egress indexes allow to find all the senders and receivers given the opposite
 /// side. I.e.

--- a/roadmap/implementers-guide/src/runtime/router.md
+++ b/roadmap/implementers-guide/src/runtime/router.md
@@ -172,8 +172,9 @@ HrmpChannelContents: map HrmpChannelId => Vec<InboundHrmpMessage>;
 /// What paras sent a message at the given block number for a given reciever.
 /// Invariants:
 /// - The inner `Vec<ParaId>` is never empty.
-/// - The para ids vector doesn't contain duplicates.
-/// - The outer vector is sorted ascending by block number and there are no duplicates.
+/// - The inner `Vec<ParaId>` cannot store two same `ParaId`.
+/// - The outer vector is sorted ascending by block number and cannot store two items with the same
+///   block number.
 HrmpChannelDigests: map ParaId => Vec<(BlockNumber, Vec<ParaId>)>;
 ```
 

--- a/roadmap/implementers-guide/src/types/messages.md
+++ b/roadmap/implementers-guide/src/types/messages.md
@@ -42,8 +42,6 @@ that we use the first item tuple for the sender and the second for the recipient
 is allowed between two participants in one direction, i.e. there cannot be 2 different channels
 identified by `(A, B)`.
 
-`HrmpChannelId` has a defined ordering: first `sender` and tie is resolved by `recipient`.
-
 ```rust,ignore
 struct HrmpChannelId {
     sender: ParaId,

--- a/roadmap/implementers-guide/src/types/runtime.md
+++ b/roadmap/implementers-guide/src/types/runtime.md
@@ -77,9 +77,9 @@ struct HostConfiguration {
 	/// The deposit that the recipient should provide for accepting opening an HRMP channel.
 	pub hrmp_recipient_deposit: u32,
 	/// The maximum number of messages allowed in an HRMP channel at once.
-	pub hrmp_channel_max_places: u32,
+	pub hrmp_channel_max_capacity: u32,
 	/// The maximum total size of messages in bytes allowed in an HRMP channel at once.
-	pub hrmp_channel_max_size: u32,
+	pub hrmp_channel_max_total_size: u32,
 	/// The maximum number of inbound HRMP channels a parachain is allowed to accept.
 	pub hrmp_max_parachain_inbound_channels: u32,
 	/// The maximum number of inbound HRMP channels a parathread is allowed to accept.

--- a/roadmap/implementers-guide/src/types/runtime.md
+++ b/roadmap/implementers-guide/src/types/runtime.md
@@ -85,10 +85,16 @@ struct HostConfiguration {
 	/// The maximum number of inbound HRMP channels a parathread is allowed to accept.
 	pub hrmp_max_parathread_inbound_channels: u32,
 	/// The maximum size of a message that could ever be put into an HRMP channel.
+	///
+	/// This parameter affects the upper bound of size of `CandidateCommitments`.
 	pub hrmp_channel_max_message_size: u32,
 	/// The maximum number of outbound HRMP channels a parachain is allowed to open.
 	pub hrmp_max_parachain_outbound_channels: u32,
 	/// The maximum number of outbound HRMP channels a parathread is allowed to open.
 	pub hrmp_max_parathread_outbound_channels: u32,
+	/// The maximum number of outbound HRMP messages can be sent by a candidate.
+	///
+	/// This parameter affects the upper bound of size of `CandidateCommitments`.
+	pub hrmp_max_message_num_per_candidate: u32,
 }
 ```

--- a/runtime/common/src/paras_registrar.rs
+++ b/runtime/common/src/paras_registrar.rs
@@ -427,6 +427,7 @@ mod tests {
 
 	impl router::Trait for Test {
 		type UmpSink = ();
+		type Origin = Origin;
 	}
 
 	impl pallet_session::historical::Trait for Test {

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -22,12 +22,14 @@
 
 use pallet_transaction_payment::CurrencyAdapter;
 use sp_std::prelude::*;
+use sp_std::collections::btree_map::BTreeMap;
 use sp_core::u32_trait::{_1, _2, _3, _5};
 use codec::{Encode, Decode};
 use primitives::v1::{
 	AccountId, AccountIndex, Balance, BlockNumber, CandidateEvent, CommittedCandidateReceipt,
 	CoreState, GroupRotationInfo, Hash, Id, Moment, Nonce, OccupiedCoreAssumption,
 	PersistedValidationData, Signature, ValidationCode, ValidationData, ValidatorId, ValidatorIndex,
+	InboundDownwardMessage, InboundHrmpMessage,
 };
 use runtime_common::{
 	claims, SlowAdjustingFeeUpdate, CurrencyToVote,
@@ -1112,8 +1114,14 @@ sp_api::impl_runtime_apis! {
 
 		fn dmq_contents(
 			_recipient: Id,
-		) -> Vec<primitives::v1::InboundDownwardMessage<BlockNumber>> {
+		) -> Vec<InboundDownwardMessage<BlockNumber>> {
 			Vec::new()
+		}
+
+		fn inbound_hrmp_channels_contents(
+			_recipient: Id
+		) -> BTreeMap<Id, Vec<InboundHrmpMessage<BlockNumber>>> {
+			BTreeMap::new()
 		}
 	}
 

--- a/runtime/parachains/Cargo.toml
+++ b/runtime/parachains/Cargo.toml
@@ -33,6 +33,7 @@ pallet-vesting = { git = "https://github.com/paritytech/substrate", branch = "ma
 pallet-offences = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false, optional = true }
 
+xcm = { package = "xcm", path = "../../xcm", default-features = false }
 primitives = { package = "polkadot-primitives", path = "../../primitives", default-features = false }
 libsecp256k1 = { version = "0.3.2", default-features = false, optional = true }
 
@@ -81,6 +82,7 @@ std = [
 	"frame-system/std",
 	"pallet-timestamp/std",
 	"pallet-vesting/std",
+	"xcm/std",
 ]
 runtime-benchmarks = [
 	"libsecp256k1/hmac",

--- a/runtime/parachains/src/configuration.rs
+++ b/runtime/parachains/src/configuration.rs
@@ -19,7 +19,7 @@
 //! Configuration can change only at session boundaries and is buffered until then.
 
 use sp_std::prelude::*;
-use primitives::v1::ValidatorId;
+use primitives::v1::{Balance, ValidatorId};
 use frame_support::{
 	decl_storage, decl_module, decl_error,
 	dispatch::DispatchResult,
@@ -84,6 +84,32 @@ pub struct HostConfiguration<BlockNumber> {
 	///
 	/// This parameter affects the size upper bound of the `CandidateCommitments`.
 	pub max_upward_message_num_per_candidate: u32,
+	/// Number of sessions after which an HRMP open channel request expires.
+	pub hrmp_open_request_ttl: u32,
+	/// The deposit that the sender should provide for opening an HRMP channel.
+	pub hrmp_sender_deposit: Balance,
+	/// The deposit that the recipient should provide for accepting opening an HRMP channel.
+	pub hrmp_recipient_deposit: Balance,
+	/// The maximum number of messages allowed in an HRMP channel at once.
+	pub hrmp_channel_max_capacity: u32,
+	/// The maximum total size of messages in bytes allowed in an HRMP channel at once.
+	pub hrmp_channel_max_total_size: u32,
+	/// The maximum number of inbound HRMP channels a parachain is allowed to accept.
+	pub hrmp_max_parachain_inbound_channels: u32,
+	/// The maximum number of inbound HRMP channels a parathread is allowed to accept.
+	pub hrmp_max_parathread_inbound_channels: u32,
+	/// The maximum size of a message that could ever be put into an HRMP channel.
+	///
+	/// This parameter affects the upper bound of size of `CandidateCommitments`.
+	pub hrmp_channel_max_message_size: u32,
+	/// The maximum number of outbound HRMP channels a parachain is allowed to open.
+	pub hrmp_max_parachain_outbound_channels: u32,
+	/// The maximum number of outbound HRMP channels a parathread is allowed to open.
+	pub hrmp_max_parathread_outbound_channels: u32,
+	/// The maximum number of outbound HRMP messages can be sent by a candidate.
+	///
+	/// This parameter affects the upper bound of size of `CandidateCommitments`.
+	pub hrmp_max_message_num_per_candidate: u32,
 }
 
 pub trait Trait: frame_system::Trait { }
@@ -276,6 +302,105 @@ decl_module! {
 			});
 			Ok(())
 		}
+
+		#[weight = (1_000, DispatchClass::Operational)]
+		pub fn set_hrmp_open_request_ttl(origin, new: u32) -> DispatchResult {
+			ensure_root(origin)?;
+			Self::update_config_member(|config| {
+				sp_std::mem::replace(&mut config.hrmp_open_request_ttl, new) != new
+			});
+			Ok(())
+		}
+
+		#[weight = (1_000, DispatchClass::Operational)]
+		pub fn set_hrmp_sender_deposit(origin, new: Balance) -> DispatchResult {
+			ensure_root(origin)?;
+			Self::update_config_member(|config| {
+				sp_std::mem::replace(&mut config.hrmp_sender_deposit, new) != new
+			});
+			Ok(())
+		}
+
+		#[weight = (1_000, DispatchClass::Operational)]
+		pub fn set_hrmp_recipient_deposit(origin, new: Balance) -> DispatchResult {
+			ensure_root(origin)?;
+			Self::update_config_member(|config| {
+				sp_std::mem::replace(&mut config.hrmp_recipient_deposit, new) != new
+			});
+			Ok(())
+		}
+
+		#[weight = (1_000, DispatchClass::Operational)]
+		pub fn set_hrmp_channel_max_capacity(origin, new: u32) -> DispatchResult {
+			ensure_root(origin)?;
+			Self::update_config_member(|config| {
+				sp_std::mem::replace(&mut config.hrmp_channel_max_capacity, new) != new
+			});
+			Ok(())
+		}
+
+		#[weight = (1_000, DispatchClass::Operational)]
+		pub fn set_hrmp_channel_max_total_size(origin, new: u32) -> DispatchResult {
+			ensure_root(origin)?;
+			Self::update_config_member(|config| {
+				sp_std::mem::replace(&mut config.hrmp_channel_max_total_size, new) != new
+			});
+			Ok(())
+		}
+
+		#[weight = (1_000, DispatchClass::Operational)]
+		pub fn set_hrmp_max_parachain_inbound_channels(origin, new: u32) -> DispatchResult {
+			ensure_root(origin)?;
+			Self::update_config_member(|config| {
+				sp_std::mem::replace(&mut config.hrmp_max_parachain_inbound_channels, new) != new
+			});
+			Ok(())
+		}
+
+		#[weight = (1_000, DispatchClass::Operational)]
+		pub fn set_hrmp_max_parathread_inbound_channels(origin, new: u32) -> DispatchResult {
+			ensure_root(origin)?;
+			Self::update_config_member(|config| {
+				sp_std::mem::replace(&mut config.hrmp_max_parathread_inbound_channels, new) != new
+			});
+			Ok(())
+		}
+
+		#[weight = (1_000, DispatchClass::Operational)]
+		pub fn set_hrmp_channel_max_message_size(origin, new: u32) -> DispatchResult {
+			ensure_root(origin)?;
+			Self::update_config_member(|config| {
+				sp_std::mem::replace(&mut config.hrmp_channel_max_message_size, new) != new
+			});
+			Ok(())
+		}
+
+		#[weight = (1_000, DispatchClass::Operational)]
+		pub fn set_hrmp_max_parachain_outbound_channels(origin, new: u32) -> DispatchResult {
+			ensure_root(origin)?;
+			Self::update_config_member(|config| {
+				sp_std::mem::replace(&mut config.hrmp_max_parachain_outbound_channels, new) != new
+			});
+			Ok(())
+		}
+
+		#[weight = (1_000, DispatchClass::Operational)]
+		pub fn set_hrmp_max_parathread_outbound_channels(origin, new: u32) -> DispatchResult {
+			ensure_root(origin)?;
+			Self::update_config_member(|config| {
+				sp_std::mem::replace(&mut config.hrmp_max_parathread_outbound_channels, new) != new
+			});
+			Ok(())
+		}
+
+		#[weight = (1_000, DispatchClass::Operational)]
+		pub fn set_hrmp_max_message_num_per_candidate(origin, new: u32) -> DispatchResult {
+			ensure_root(origin)?;
+			Self::update_config_member(|config| {
+				sp_std::mem::replace(&mut config.hrmp_max_message_num_per_candidate, new) != new
+			});
+			Ok(())
+		}
 	}
 }
 
@@ -360,6 +485,17 @@ mod tests {
 				preferred_dispatchable_upward_messages_step_weight: 20000,
 				max_upward_message_size: 448,
 				max_upward_message_num_per_candidate: 5,
+				hrmp_open_request_ttl: 1312,
+				hrmp_sender_deposit: 22,
+				hrmp_recipient_deposit: 4905,
+				hrmp_channel_max_capacity: 3921,
+				hrmp_channel_max_total_size: 7687,
+				hrmp_max_parachain_inbound_channels: 3722,
+				hrmp_max_parathread_inbound_channels: 1967,
+				hrmp_channel_max_message_size: 8192,
+				hrmp_max_parachain_outbound_channels: 100,
+				hrmp_max_parathread_outbound_channels: 200,
+				hrmp_max_message_num_per_candidate: 20,
 			};
 
 			assert!(<Configuration as Store>::PendingConfig::get().is_none());
@@ -414,6 +550,50 @@ mod tests {
 			).unwrap();
 			Configuration::set_max_upward_message_num_per_candidate(
 				Origin::root(), new_config.max_upward_message_num_per_candidate,
+			).unwrap();
+			Configuration::set_hrmp_open_request_ttl(
+				Origin::root(),
+				new_config.hrmp_open_request_ttl,
+			).unwrap();
+			Configuration::set_hrmp_sender_deposit(
+				Origin::root(),
+				new_config.hrmp_sender_deposit,
+			).unwrap();
+			Configuration::set_hrmp_recipient_deposit(
+				Origin::root(),
+				new_config.hrmp_recipient_deposit,
+			).unwrap();
+			Configuration::set_hrmp_channel_max_capacity(
+				Origin::root(),
+				new_config.hrmp_channel_max_capacity,
+			).unwrap();
+			Configuration::set_hrmp_channel_max_total_size(
+				Origin::root(),
+				new_config.hrmp_channel_max_total_size,
+			).unwrap();
+			Configuration::set_hrmp_max_parachain_inbound_channels(
+				Origin::root(),
+				new_config.hrmp_max_parachain_inbound_channels,
+			).unwrap();
+			Configuration::set_hrmp_max_parathread_inbound_channels(
+				Origin::root(),
+				new_config.hrmp_max_parathread_inbound_channels,
+			).unwrap();
+			Configuration::set_hrmp_channel_max_message_size(
+				Origin::root(),
+				new_config.hrmp_channel_max_message_size,
+			).unwrap();
+			Configuration::set_hrmp_max_parachain_outbound_channels(
+				Origin::root(),
+				new_config.hrmp_max_parachain_outbound_channels,
+			).unwrap();
+			Configuration::set_hrmp_max_parathread_outbound_channels(
+				Origin::root(),
+				new_config.hrmp_max_parathread_outbound_channels,
+			).unwrap();
+			Configuration::set_hrmp_max_message_num_per_candidate(
+				Origin::root(),
+				new_config.hrmp_max_message_num_per_candidate,
 			).unwrap();
 
 			assert_eq!(<Configuration as Store>::PendingConfig::get(), Some(new_config));

--- a/runtime/parachains/src/configuration.rs
+++ b/runtime/parachains/src/configuration.rs
@@ -303,6 +303,7 @@ decl_module! {
 			Ok(())
 		}
 
+		/// Sets the number of sessions after which an HRMP open channel request expires.
 		#[weight = (1_000, DispatchClass::Operational)]
 		pub fn set_hrmp_open_request_ttl(origin, new: u32) -> DispatchResult {
 			ensure_root(origin)?;
@@ -312,6 +313,7 @@ decl_module! {
 			Ok(())
 		}
 
+		/// Sets the amount of funds that the sender should provide for opening an HRMP channel.
 		#[weight = (1_000, DispatchClass::Operational)]
 		pub fn set_hrmp_sender_deposit(origin, new: Balance) -> DispatchResult {
 			ensure_root(origin)?;
@@ -321,6 +323,8 @@ decl_module! {
 			Ok(())
 		}
 
+		/// Sets the amount of funds that the recipient should provide for accepting opening an HRMP
+		/// channel.
 		#[weight = (1_000, DispatchClass::Operational)]
 		pub fn set_hrmp_recipient_deposit(origin, new: Balance) -> DispatchResult {
 			ensure_root(origin)?;
@@ -330,6 +334,7 @@ decl_module! {
 			Ok(())
 		}
 
+		/// Sets the maximum number of messages allowed in an HRMP channel at once.
 		#[weight = (1_000, DispatchClass::Operational)]
 		pub fn set_hrmp_channel_max_capacity(origin, new: u32) -> DispatchResult {
 			ensure_root(origin)?;
@@ -339,6 +344,7 @@ decl_module! {
 			Ok(())
 		}
 
+		/// Sets the maximum total size of messages in bytes allowed in an HRMP channel at once.
 		#[weight = (1_000, DispatchClass::Operational)]
 		pub fn set_hrmp_channel_max_total_size(origin, new: u32) -> DispatchResult {
 			ensure_root(origin)?;
@@ -348,6 +354,7 @@ decl_module! {
 			Ok(())
 		}
 
+		/// Sets the maximum number of inbound HRMP channels a parachain is allowed to accept.
 		#[weight = (1_000, DispatchClass::Operational)]
 		pub fn set_hrmp_max_parachain_inbound_channels(origin, new: u32) -> DispatchResult {
 			ensure_root(origin)?;
@@ -357,6 +364,7 @@ decl_module! {
 			Ok(())
 		}
 
+		/// Sets the maximum number of inbound HRMP channels a parathread is allowed to accept.
 		#[weight = (1_000, DispatchClass::Operational)]
 		pub fn set_hrmp_max_parathread_inbound_channels(origin, new: u32) -> DispatchResult {
 			ensure_root(origin)?;
@@ -366,6 +374,7 @@ decl_module! {
 			Ok(())
 		}
 
+		/// Sets the maximum size of a message that could ever be put into an HRMP channel.
 		#[weight = (1_000, DispatchClass::Operational)]
 		pub fn set_hrmp_channel_max_message_size(origin, new: u32) -> DispatchResult {
 			ensure_root(origin)?;
@@ -375,6 +384,7 @@ decl_module! {
 			Ok(())
 		}
 
+		/// Sets the maximum number of outbound HRMP channels a parachain is allowed to open.
 		#[weight = (1_000, DispatchClass::Operational)]
 		pub fn set_hrmp_max_parachain_outbound_channels(origin, new: u32) -> DispatchResult {
 			ensure_root(origin)?;
@@ -384,6 +394,7 @@ decl_module! {
 			Ok(())
 		}
 
+		/// Sets the maximum number of outbound HRMP channels a parathread is allowed to open.
 		#[weight = (1_000, DispatchClass::Operational)]
 		pub fn set_hrmp_max_parathread_outbound_channels(origin, new: u32) -> DispatchResult {
 			ensure_root(origin)?;
@@ -393,6 +404,7 @@ decl_module! {
 			Ok(())
 		}
 
+		/// Sets the maximum number of outbound HRMP messages can be sent by a candidate.
 		#[weight = (1_000, DispatchClass::Operational)]
 		pub fn set_hrmp_max_message_num_per_candidate(origin, new: u32) -> DispatchResult {
 			ensure_root(origin)?;

--- a/runtime/parachains/src/inclusion.rs
+++ b/runtime/parachains/src/inclusion.rs
@@ -157,6 +157,10 @@ decl_error! {
 		IncorrectDownwardMessageHandling,
 		/// At least one upward message sent does not pass the acceptance criteria.
 		InvalidUpwardMessages,
+		/// The candidate didn't follow the rules of HRMP watermark advancement.
+		HrmpWatermarkMishandling,
+		/// The HRMP messages sent by the candidate is not valid.
+		InvalidOutboundHrmp,
 	}
 }
 
@@ -415,6 +419,8 @@ impl<T: Trait> Module<T> {
 					&candidate.candidate.commitments.new_validation_code,
 					candidate.candidate.commitments.processed_downward_messages,
 					&candidate.candidate.commitments.upward_messages,
+					candidate.candidate.commitments.hrmp_watermark,
+					&candidate.candidate.commitments.horizontal_messages,
 				)?;
 
 				for (i, assignment) in scheduled[skip..].iter().enumerate() {
@@ -548,6 +554,8 @@ impl<T: Trait> Module<T> {
 			&validation_outputs.new_validation_code,
 			validation_outputs.processed_downward_messages,
 			&validation_outputs.upward_messages,
+			validation_outputs.hrmp_watermark,
+			&validation_outputs.horizontal_messages,
 		)
 	}
 
@@ -577,6 +585,14 @@ impl<T: Trait> Module<T> {
 		weight += <router::Module<T>>::enact_upward_messages(
 			receipt.descriptor.para_id,
 			commitments.upward_messages,
+		);
+		weight += <router::Module<T>>::prune_hrmp(
+			receipt.descriptor.para_id,
+			T::BlockNumber::from(commitments.hrmp_watermark),
+		);
+		weight += <router::Module<T>>::queue_outbound_hrmp(
+			receipt.descriptor.para_id,
+			commitments.horizontal_messages,
 		);
 
 		Self::deposit_event(
@@ -702,6 +718,8 @@ impl<T: Trait> CandidateCheckContext<T> {
 		new_validation_code: &Option<primitives::v1::ValidationCode>,
 		processed_downward_messages: u32,
 		upward_messages: &[primitives::v1::UpwardMessage],
+		hrmp_watermark: primitives::v1::BlockNumber,
+		horizontal_messages: &[primitives::v1::OutboundHrmpMessage<ParaId>],
 	) -> Result<(), DispatchError> {
 		ensure!(
 			head_data.0.len() <= self.config.max_head_data_size as _,
@@ -738,6 +756,23 @@ impl<T: Trait> CandidateCheckContext<T> {
 				upward_messages,
 			),
 			Error::<T>::InvalidUpwardMessages,
+		);
+		ensure!(
+			<router::Module<T>>::check_hrmp_watermark(
+				para_id,
+				self.relay_parent_number,
+				// TODO: Hmm, we should settle on a single represenation of T::BlockNumber
+				T::BlockNumber::from(hrmp_watermark),
+			),
+			Error::<T>::HrmpWatermarkMishandling,
+		);
+		ensure!(
+			<router::Module<T>>::check_outbound_hrmp(
+				&self.config,
+				para_id,
+				horizontal_messages,
+			),
+			Error::<T>::InvalidOutboundHrmp,
 		);
 
 		Ok(())
@@ -946,6 +981,7 @@ mod tests {
 		relay_parent: Hash,
 		persisted_validation_data_hash: Hash,
 		new_validation_code: Option<ValidationCode>,
+		hrmp_watermark: BlockNumber,
 	}
 
 	impl TestCandidateBuilder {
@@ -961,6 +997,7 @@ mod tests {
 				commitments: CandidateCommitments {
 					head_data: self.head_data,
 					new_validation_code: self.new_validation_code,
+					hrmp_watermark: self.hrmp_watermark,
 					..Default::default()
 				},
 			}
@@ -1359,6 +1396,9 @@ mod tests {
 		let chain_b = ParaId::from(2);
 		let thread_a = ParaId::from(3);
 
+		// The block number of the relay-parent for testing.
+		const RELAY_PARENT_NUM: BlockNumber = 4;
+
 		let paras = vec![(chain_a, true), (chain_b, true), (thread_a, false)];
 		let validators = vec![
 			Sr25519Keyring::Alice,
@@ -1421,6 +1461,7 @@ mod tests {
 					relay_parent: System::parent_hash(),
 					pov_hash: Hash::from([1; 32]),
 					persisted_validation_data_hash: make_vdata_hash(chain_a).unwrap(),
+					hrmp_watermark: RELAY_PARENT_NUM,
 					..Default::default()
 				}.build();
 				collator_sign_candidate(
@@ -1454,6 +1495,7 @@ mod tests {
 					relay_parent: System::parent_hash(),
 					pov_hash: Hash::from([1; 32]),
 					persisted_validation_data_hash: make_vdata_hash(chain_a).unwrap(),
+					hrmp_watermark: RELAY_PARENT_NUM,
 					..Default::default()
 				}.build();
 				let mut candidate_b = TestCandidateBuilder {
@@ -1461,6 +1503,7 @@ mod tests {
 					relay_parent: System::parent_hash(),
 					pov_hash: Hash::from([2; 32]),
 					persisted_validation_data_hash: make_vdata_hash(chain_b).unwrap(),
+					hrmp_watermark: RELAY_PARENT_NUM,
 					..Default::default()
 				}.build();
 
@@ -1510,6 +1553,7 @@ mod tests {
 					relay_parent: System::parent_hash(),
 					pov_hash: Hash::from([1; 32]),
 					persisted_validation_data_hash: make_vdata_hash(chain_a).unwrap(),
+					hrmp_watermark: RELAY_PARENT_NUM,
 					..Default::default()
 				}.build();
 				collator_sign_candidate(
@@ -1579,6 +1623,7 @@ mod tests {
 					relay_parent: System::parent_hash(),
 					pov_hash: Hash::from([1; 32]),
 					persisted_validation_data_hash: make_vdata_hash(thread_a).unwrap(),
+					hrmp_watermark: RELAY_PARENT_NUM,
 					..Default::default()
 				}.build();
 
@@ -1618,6 +1663,7 @@ mod tests {
 					relay_parent: System::parent_hash(),
 					pov_hash: Hash::from([1; 32]),
 					persisted_validation_data_hash: make_vdata_hash(thread_a).unwrap(),
+					hrmp_watermark: RELAY_PARENT_NUM,
 					..Default::default()
 				}.build();
 
@@ -1656,6 +1702,7 @@ mod tests {
 					relay_parent: System::parent_hash(),
 					pov_hash: Hash::from([1; 32]),
 					persisted_validation_data_hash: make_vdata_hash(chain_a).unwrap(),
+					hrmp_watermark: RELAY_PARENT_NUM,
 					..Default::default()
 				}.build();
 
@@ -1703,6 +1750,7 @@ mod tests {
 					relay_parent: System::parent_hash(),
 					pov_hash: Hash::from([1; 32]),
 					persisted_validation_data_hash: make_vdata_hash(chain_a).unwrap(),
+					hrmp_watermark: RELAY_PARENT_NUM,
 					..Default::default()
 				}.build();
 
@@ -1743,6 +1791,7 @@ mod tests {
 					pov_hash: Hash::from([1; 32]),
 					new_validation_code: Some(vec![5, 6, 7, 8].into()),
 					persisted_validation_data_hash: make_vdata_hash(chain_a).unwrap(),
+					hrmp_watermark: RELAY_PARENT_NUM,
 					..Default::default()
 				}.build();
 
@@ -1785,6 +1834,7 @@ mod tests {
 					relay_parent: System::parent_hash(),
 					pov_hash: Hash::from([1; 32]),
 					persisted_validation_data_hash: [42u8; 32].into(),
+					hrmp_watermark: RELAY_PARENT_NUM,
 					..Default::default()
 				}.build();
 
@@ -1819,6 +1869,9 @@ mod tests {
 		let chain_a = ParaId::from(1);
 		let chain_b = ParaId::from(2);
 		let thread_a = ParaId::from(3);
+
+		// The block number of the relay-parent for testing.
+        const RELAY_PARENT_NUM: BlockNumber = 4;
 
 		let paras = vec![(chain_a, true), (chain_b, true), (thread_a, false)];
 		let validators = vec![
@@ -1880,6 +1933,7 @@ mod tests {
 				relay_parent: System::parent_hash(),
 				pov_hash: Hash::from([1; 32]),
 				persisted_validation_data_hash: make_vdata_hash(chain_a).unwrap(),
+				hrmp_watermark: RELAY_PARENT_NUM,
 				..Default::default()
 			}.build();
 			collator_sign_candidate(
@@ -1892,6 +1946,7 @@ mod tests {
 				relay_parent: System::parent_hash(),
 				pov_hash: Hash::from([2; 32]),
 				persisted_validation_data_hash: make_vdata_hash(chain_b).unwrap(),
+				hrmp_watermark: RELAY_PARENT_NUM,
 				..Default::default()
 			}.build();
 			collator_sign_candidate(
@@ -1904,6 +1959,7 @@ mod tests {
 				relay_parent: System::parent_hash(),
 				pov_hash: Hash::from([3; 32]),
 				persisted_validation_data_hash: make_vdata_hash(thread_a).unwrap(),
+				hrmp_watermark: RELAY_PARENT_NUM,
 				..Default::default()
 			}.build();
 			collator_sign_candidate(
@@ -2001,6 +2057,9 @@ mod tests {
 	fn can_include_candidate_with_ok_code_upgrade() {
 		let chain_a = ParaId::from(1);
 
+		// The block number of the relay-parent for testing.
+		const RELAY_PARENT_NUM: BlockNumber = 4;
+
 		let paras = vec![(chain_a, true)];
 		let validators = vec![
 			Sr25519Keyring::Alice,
@@ -2044,6 +2103,7 @@ mod tests {
 				pov_hash: Hash::from([1; 32]),
 				persisted_validation_data_hash: make_vdata_hash(chain_a).unwrap(),
 				new_validation_code: Some(vec![1, 2, 3].into()),
+				hrmp_watermark: RELAY_PARENT_NUM,
 				..Default::default()
 			}.build();
 			collator_sign_candidate(

--- a/runtime/parachains/src/inclusion.rs
+++ b/runtime/parachains/src/inclusion.rs
@@ -419,7 +419,7 @@ impl<T: Trait> Module<T> {
 					&candidate.candidate.commitments.new_validation_code,
 					candidate.candidate.commitments.processed_downward_messages,
 					&candidate.candidate.commitments.upward_messages,
-					candidate.candidate.commitments.hrmp_watermark,
+					T::BlockNumber::from(candidate.candidate.commitments.hrmp_watermark),
 					&candidate.candidate.commitments.horizontal_messages,
 				)?;
 
@@ -554,7 +554,7 @@ impl<T: Trait> Module<T> {
 			&validation_outputs.new_validation_code,
 			validation_outputs.processed_downward_messages,
 			&validation_outputs.upward_messages,
-			validation_outputs.hrmp_watermark,
+			T::BlockNumber::from(validation_outputs.hrmp_watermark),
 			&validation_outputs.horizontal_messages,
 		)
 	}
@@ -718,7 +718,7 @@ impl<T: Trait> CandidateCheckContext<T> {
 		new_validation_code: &Option<primitives::v1::ValidationCode>,
 		processed_downward_messages: u32,
 		upward_messages: &[primitives::v1::UpwardMessage],
-		hrmp_watermark: primitives::v1::BlockNumber,
+		hrmp_watermark: T::BlockNumber,
 		horizontal_messages: &[primitives::v1::OutboundHrmpMessage<ParaId>],
 	) -> Result<(), DispatchError> {
 		ensure!(
@@ -761,8 +761,7 @@ impl<T: Trait> CandidateCheckContext<T> {
 			<router::Module<T>>::check_hrmp_watermark(
 				para_id,
 				self.relay_parent_number,
-				// TODO: Hmm, we should settle on a single represenation of T::BlockNumber
-				T::BlockNumber::from(hrmp_watermark),
+				hrmp_watermark,
 			),
 			Error::<T>::HrmpWatermarkMishandling,
 		);

--- a/runtime/parachains/src/mock.rs
+++ b/runtime/parachains/src/mock.rs
@@ -109,6 +109,7 @@ impl crate::paras::Trait for Test {
 }
 
 impl crate::router::Trait for Test {
+	type Origin = Origin;
 	type UmpSink = crate::router::MockUmpSink;
 }
 

--- a/runtime/parachains/src/paras.rs
+++ b/runtime/parachains/src/paras.rs
@@ -541,6 +541,12 @@ impl<T: Trait> Module<T> {
 		}
 	}
 
+	/// Returns whether the given ID refers to a valid para.
+	pub(crate) fn is_valid_para(id: ParaId) -> bool {
+		Self::parachains().binary_search(&id).is_ok()
+			|| Self::is_parathread(id)
+	}
+
 	/// Whether a para ID corresponds to any live parathread.
 	pub(crate) fn is_parathread(id: ParaId) -> bool {
 		Parathreads::get(&id).is_some()

--- a/runtime/parachains/src/router.rs
+++ b/runtime/parachains/src/router.rs
@@ -144,9 +144,12 @@ decl_storage! {
 		HrmpCloseChannelRequestsList: Vec<HrmpChannelId>;
 
 		/// The HRMP watermark associated with each para.
-		/// Invariant: every para should be onboarded.
+		/// Invariant:
+		/// - each para `P` used here as a key should satisfy `Paras::is_valid_para(P)` within a session.
 		HrmpWatermarks: map hasher(twox_64_concat) ParaId => Option<T::BlockNumber>;
 		/// HRMP channel data associated with each para.
+		/// Invariant:
+		/// - each participant in the channel should satisfy `Paras::is_valid_para(P)` within a session.
 		HrmpChannels: map hasher(twox_64_concat) HrmpChannelId => Option<HrmpChannel>;
 		/// Ingress/egress indexes allow to find all the senders and receivers given the opposite
 		/// side. I.e.

--- a/runtime/parachains/src/router.rs
+++ b/runtime/parachains/src/router.rs
@@ -20,18 +20,19 @@
 //! routing the messages at their destinations and informing the parachains about the incoming
 //! messages.
 
-use crate::{
-	configuration,
-	initializer,
-};
+use crate::{configuration, initializer};
 use sp_std::prelude::*;
 use frame_support::{decl_error, decl_module, decl_storage, weights::Weight};
 use sp_std::collections::vec_deque::VecDeque;
-use primitives::v1::{Id as ParaId, InboundDownwardMessage, Hash, UpwardMessage};
+use primitives::v1::{
+	Id as ParaId, InboundDownwardMessage, Hash, UpwardMessage, HrmpChannelId, InboundHrmpMessage,
+};
 
+mod hrmp;
 mod dmp;
 mod ump;
 
+use hrmp::{HrmpOpenChannelRequest, HrmpChannel};
 pub use dmp::QueueDownwardMessageError;
 pub use ump::UmpSink;
 
@@ -103,6 +104,68 @@ decl_storage! {
 		/// Invariant:
 		/// - If `Some(para)`, then `para` must be present in `NeedsDispatch`.
 		NextDispatchRoundStartWith: Option<ParaId>;
+
+		/*
+		 * Horizontally Relay-routed Message Passing (HRMP)
+		 *
+		 * HRMP related storage layout
+		 */
+
+		/// The set of pending HRMP open channel requests.
+		///
+		/// The set is accompanied by a list for iteration.
+		///
+		/// Invariant:
+		/// - There are no channels that exists in list but not in the set and vice versa.
+		HrmpOpenChannelRequests: map hasher(twox_64_concat) HrmpChannelId => Option<HrmpOpenChannelRequest>;
+		HrmpOpenChannelRequestsList: Vec<HrmpChannelId>;
+
+		/// This mapping tracks how many open channel requests are inititated by a given sender para.
+		/// Invariant: `HrmpOpenChannelRequests` should contain the same number of items that has `(X, _)`
+		/// as the number of `HrmpOpenChannelRequestCount` for `X`.
+		HrmpOpenChannelRequestCount: map hasher(twox_64_concat) ParaId => u32;
+		/// This mapping tracks how many open channel requests were accepted by a given recipient para.
+		/// Invariant: `HrmpOpenChannelRequests` should contain the same number of items `(_, X)` with
+		/// `confirmed` set to true, as the number of `HrmpAcceptedChannelRequestCount` for `X`.
+		HrmpAcceptedChannelRequestCount: map hasher(twox_64_concat) ParaId => u32;
+
+		/// A set of pending HRMP close channel requests that are going to be closed during the session change.
+		/// Used for checking if a given channel is registered for closure.
+		///
+		/// The set is accompanied by a list for iteration.
+		///
+		/// Invariant:
+		/// - There are no channels that exists in list but not in the set and vice versa.
+		HrmpCloseChannelRequests: map hasher(twox_64_concat) HrmpChannelId => Option<()>;
+		HrmpCloseChannelRequestsList: Vec<HrmpChannelId>;
+
+		/// The HRMP watermark associated with each para.
+		/// Invariant: every para should be onboarded.
+		HrmpWatermarks: map hasher(twox_64_concat) ParaId => Option<T::BlockNumber>;
+		/// HRMP channel data associated with each para.
+		HrmpChannels: map hasher(twox_64_concat) HrmpChannelId => Option<HrmpChannel>;
+		/// Ingress/egress indexes allow to find all the senders and receivers given the opposite
+		/// side. I.e.
+		///
+		/// (a) ingress index allows to find all the senders for a given recipient.
+		/// (b) egress index allows to find all the recipients for a given sender.
+		///
+		/// Invariants:
+		/// - for each ingress index entry for `P` each item `I` in the index should present in `HrmpChannels`
+		///   as `(I, P)`.
+		/// - for each egress index entry for `P` each item `E` in the index should present in `HrmpChannels`
+		///   as `(P, E)`.
+		/// - there should be no other dangling channels in `HrmpChannels`.
+		/// - the vectors are sorted.
+		HrmpIngressChannelsIndex: map hasher(twox_64_concat) ParaId => Vec<ParaId>;
+		HrmpEgressChannelsIndex: map hasher(twox_64_concat) ParaId => Vec<ParaId>;
+		/// Storage for the messages for each channel.
+		/// Invariant: cannot be non-empty if the corresponding channel in `HrmpChannels` is `None`.
+		HrmpChannelContents: map hasher(twox_64_concat) HrmpChannelId => Vec<InboundHrmpMessage<T::BlockNumber>>;
+		/// Maintains a mapping that can be used to answer the question:
+		/// What paras sent a message at the given block number for a given reciever.
+		/// Invariant: The para ids vector is never empty.
+		HrmpChannelDigests: map hasher(twox_64_concat) ParaId => Vec<(T::BlockNumber, Vec<ParaId>)>;
 	}
 }
 

--- a/runtime/parachains/src/router.rs
+++ b/runtime/parachains/src/router.rs
@@ -168,7 +168,10 @@ decl_storage! {
 		HrmpChannelContents: map hasher(twox_64_concat) HrmpChannelId => Vec<InboundHrmpMessage<T::BlockNumber>>;
 		/// Maintains a mapping that can be used to answer the question:
 		/// What paras sent a message at the given block number for a given reciever.
-		/// Invariant: The para ids vector is never empty.
+		/// Invariants:
+		/// - The para ids vector is never empty.
+		/// - The para ids vector doesn't contain duplicates.
+		/// - The outer vector is sorted ascending by block number and there are no duplicates.
 		HrmpChannelDigests: map hasher(twox_64_concat) ParaId => Vec<(T::BlockNumber, Vec<ParaId>)>;
 	}
 }

--- a/runtime/parachains/src/router.rs
+++ b/runtime/parachains/src/router.rs
@@ -169,9 +169,10 @@ decl_storage! {
 		/// Maintains a mapping that can be used to answer the question:
 		/// What paras sent a message at the given block number for a given reciever.
 		/// Invariants:
-		/// - The para ids vector is never empty.
-		/// - The para ids vector doesn't contain duplicates.
-		/// - The outer vector is sorted ascending by block number and there are no duplicates.
+		/// - The inner `Vec<ParaId>` is never empty.
+		/// - The inner `Vec<ParaId>` cannot store two same `ParaId`.
+		/// - The outer vector is sorted ascending by block number and cannot store two items with the same
+		///   block number.
 		HrmpChannelDigests: map hasher(twox_64_concat) ParaId => Vec<(T::BlockNumber, Vec<ParaId>)>;
 	}
 }

--- a/runtime/parachains/src/router/hrmp.rs
+++ b/runtime/parachains/src/router/hrmp.rs
@@ -1,0 +1,64 @@
+// Copyright 2020 Parity Technologies (UK) Ltd.
+// This file is part of Polkadot.
+
+// Polkadot is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Polkadot is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
+
+use primitives::v1::{Balance, Hash, SessionIndex};
+use codec::{Encode, Decode};
+
+/// A description of a request to open an HRMP channel.
+#[derive(Encode, Decode)]
+pub struct HrmpOpenChannelRequest {
+	/// Indicates if this request was confirmed by the recipient.
+	pub confirmed: bool,
+	/// How many session boundaries ago this request was seen.
+	pub age: SessionIndex,
+	/// The amount that the sender supplied at the time of creation of this request.
+	pub sender_deposit: Balance,
+	/// The maximum message size that could be put into the channel.
+	pub max_message_size: u32,
+	/// The maximum number of messages that can be pending in the channel at once.
+	pub max_capacity: u32,
+	/// The maximum total size of the messages that can be pending in the channel at once.
+	pub max_total_size: u32,
+}
+
+/// A metadata of an HRMP channel.
+#[derive(Encode, Decode)]
+pub struct HrmpChannel {
+	/// The amount that the sender supplied as a deposit when opening this channel.
+	pub sender_deposit: Balance,
+	/// The amount that the recipient supplied as a deposit when accepting opening this channel.
+	pub recipient_deposit: Balance,
+	/// The maximum number of messages that can be pending in the channel at once.
+	pub max_capacity: u32,
+	/// The maximum total size of the messages that can be pending in the channel at once.
+	pub max_total_size: u32,
+	/// The maximum message size that could be put into the channel.
+	pub max_message_size: u32,
+	/// The current number of messages pending in the channel.
+    /// Invariant: should be less or equal to `max_capacity`.s`.
+	pub msg_count: u32,
+	/// The total size in bytes of all message payloads in the channel.
+    /// Invariant: should be less or equal to `max_total_size`.
+	pub total_size: u32,
+	/// A head of the Message Queue Chain for this channel. Each link in this chain has a form:
+	/// `(prev_head, B, H(M))`, where
+	/// - `prev_head`: is the previous value of `mqc_head` or zero if none.
+	/// - `B`: is the [relay-chain] block number in which a message was appended
+	/// - `H(M)`: is the hash of the message being appended.
+	/// This value is initialized to a special value that consists of all zeroes which indicates
+	/// that no messages were previously added.
+	pub mqc_head: Option<Hash>,
+}

--- a/runtime/parachains/src/router/hrmp.rs
+++ b/runtime/parachains/src/router/hrmp.rs
@@ -14,8 +14,21 @@
 // You should have received a copy of the GNU General Public License
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
-use primitives::v1::{Balance, Hash, SessionIndex};
-use codec::{Encode, Decode};
+use super::{Module, Store, Trait, Error as DispatchError, dmp};
+use crate::{
+	configuration::{self, HostConfiguration},
+	paras,
+};
+use codec::{Decode, Encode};
+use frame_support::{traits::Get, weights::Weight, StorageMap, StorageValue, ensure};
+use primitives::v1::{
+	Balance, Hash, HrmpChannelId, Id as ParaId, InboundHrmpMessage, OutboundHrmpMessage,
+	SessionIndex,
+};
+use sp_runtime::traits::{BlakeTwo256, Hash as HashT};
+use sp_std::collections::btree_set::BTreeSet;
+use sp_std::mem;
+use sp_std::prelude::*;
 
 /// A description of a request to open an HRMP channel.
 #[derive(Encode, Decode)]
@@ -36,6 +49,7 @@ pub struct HrmpOpenChannelRequest {
 
 /// A metadata of an HRMP channel.
 #[derive(Encode, Decode)]
+#[cfg_attr(test, derive(Debug))]
 pub struct HrmpChannel {
 	/// The amount that the sender supplied as a deposit when opening this channel.
 	pub sender_deposit: Balance,
@@ -61,4 +75,593 @@ pub struct HrmpChannel {
 	/// This value is initialized to a special value that consists of all zeroes which indicates
 	/// that no messages were previously added.
 	pub mqc_head: Option<Hash>,
+}
+
+/// Routines and getters related to HRMP.
+impl<T: Trait> Module<T> {
+	/// Remove all storage entries associated with the given para.
+	pub(super) fn clean_hrmp_after_outgoing(outgoing_para: ParaId) {
+		<Self as Store>::HrmpOpenChannelRequestCount::remove(&outgoing_para);
+		<Self as Store>::HrmpAcceptedChannelRequestCount::remove(&outgoing_para);
+
+		// close all channels where the outgoing para acts as the recipient.
+		for sender in <Self as Store>::HrmpIngressChannelsIndex::take(&outgoing_para) {
+			Self::close_hrmp_channel(&HrmpChannelId {
+				sender,
+				recipient: outgoing_para.clone(),
+			});
+		}
+		// close all channels where the outgoing para acts as the sender.
+		for recipient in <Self as Store>::HrmpEgressChannelsIndex::take(&outgoing_para) {
+			Self::close_hrmp_channel(&HrmpChannelId {
+				sender: outgoing_para.clone(),
+				recipient,
+			});
+		}
+	}
+
+	/// Iterate over all open channel requests and:
+	///
+	/// - prune the stale requests
+	/// - enact the confirmed requests
+	pub(super) fn process_hrmp_open_channel_requests(config: &HostConfiguration<T::BlockNumber>) {
+		let mut open_req_channels = <Self as Store>::HrmpOpenChannelRequestsList::get();
+		if open_req_channels.is_empty() {
+			return;
+		}
+
+		// iterate the vector starting from the end making our way to the beginning. This way we
+		// can leverage `swap_remove` to efficiently remove an item during iteration.
+		let mut idx = open_req_channels.len();
+		loop {
+			// bail if we've iterated over all items.
+			if idx == 0 {
+				break;
+			}
+
+			idx -= 1;
+			let channel_id = open_req_channels[idx].clone();
+			let mut request = <Self as Store>::HrmpOpenChannelRequests::get(&channel_id)
+				.expect(
+					"can't be `None` due to the invariant that the list contains the same items as the set; qed"
+				);
+
+			if request.confirmed {
+				if <paras::Module<T>>::is_valid_para(channel_id.sender)
+					&& <paras::Module<T>>::is_valid_para(channel_id.recipient)
+				{
+					<Self as Store>::HrmpChannels::insert(
+						&channel_id,
+						HrmpChannel {
+							sender_deposit: request.sender_deposit,
+							recipient_deposit: config.hrmp_recipient_deposit,
+							max_capacity: request.max_capacity,
+							max_total_size: request.max_total_size,
+							max_message_size: request.max_message_size,
+							msg_count: 0,
+							total_size: 0,
+							mqc_head: None,
+						},
+					);
+
+					<Self as Store>::HrmpIngressChannelsIndex::mutate(&channel_id.recipient, |v| {
+						if let Err(i) = v.binary_search(&channel_id.sender) {
+							v.insert(i, channel_id.sender);
+						}
+					});
+					<Self as Store>::HrmpEgressChannelsIndex::mutate(&channel_id.sender, |v| {
+						if let Err(i) = v.binary_search(&channel_id.recipient) {
+							v.insert(i, channel_id.recipient);
+						}
+					});
+				}
+
+				let new_open_channel_req_cnt =
+					<Self as Store>::HrmpOpenChannelRequestCount::get(&channel_id.sender)
+						.saturating_sub(1);
+				if new_open_channel_req_cnt != 0 {
+					<Self as Store>::HrmpOpenChannelRequestCount::insert(
+						&channel_id.sender,
+						new_open_channel_req_cnt,
+					);
+				} else {
+					<Self as Store>::HrmpOpenChannelRequestCount::remove(&channel_id.sender);
+				}
+
+				let new_accepted_channel_req_cnt =
+					<Self as Store>::HrmpAcceptedChannelRequestCount::get(&channel_id.recipient)
+						.saturating_sub(1);
+				if new_accepted_channel_req_cnt != 0 {
+					<Self as Store>::HrmpAcceptedChannelRequestCount::insert(
+						&channel_id.recipient,
+						new_accepted_channel_req_cnt,
+					);
+				} else {
+					<Self as Store>::HrmpAcceptedChannelRequestCount::remove(&channel_id.recipient);
+				}
+
+				let _ = open_req_channels.swap_remove(idx);
+				<Self as Store>::HrmpOpenChannelRequests::remove(&channel_id);
+			} else {
+				request.age += 1;
+				if request.age == config.hrmp_open_request_ttl {
+					// got stale
+
+					<Self as Store>::HrmpOpenChannelRequestCount::mutate(&channel_id.sender, |v| {
+						*v -= 1;
+					});
+
+					// TODO: return deposit https://github.com/paritytech/polkadot/issues/1907
+
+					let _ = open_req_channels.swap_remove(idx);
+					<Self as Store>::HrmpOpenChannelRequests::remove(&channel_id);
+				}
+			}
+		}
+
+		<Self as Store>::HrmpOpenChannelRequestsList::put(open_req_channels);
+	}
+
+	/// Iterate over all close channel requests unconditionally closing the channels.
+	pub(super) fn process_hrmp_close_channel_requests() {
+		let close_reqs = <Self as Store>::HrmpCloseChannelRequestsList::take();
+		for condemned_ch_id in close_reqs {
+			<Self as Store>::HrmpCloseChannelRequests::remove(&condemned_ch_id);
+			Self::close_hrmp_channel(&condemned_ch_id);
+
+			// clean up the indexes.
+			<Self as Store>::HrmpEgressChannelsIndex::mutate(&condemned_ch_id.sender, |v| {
+				if let Ok(i) = v.binary_search(&condemned_ch_id.recipient) {
+					v.remove(i);
+				}
+			});
+			<Self as Store>::HrmpIngressChannelsIndex::mutate(&condemned_ch_id.recipient, |v| {
+				if let Ok(i) = v.binary_search(&condemned_ch_id.sender) {
+					v.remove(i);
+				}
+			});
+		}
+	}
+
+	/// Close and remove the designated HRMP channel.
+	///
+	/// This includes returning the deposits. However, it doesn't include updating the ingress/egress
+	/// indicies.
+	pub(super) fn close_hrmp_channel(channel_id: &HrmpChannelId) {
+		// TODO: return deposit https://github.com/paritytech/polkadot/issues/1907
+
+		<Self as Store>::HrmpChannels::remove(channel_id);
+		<Self as Store>::HrmpChannelContents::remove(channel_id);
+	}
+
+	/// Check that the candidate of the given recipient controls the HRMP watermark properly.
+	pub(crate) fn check_hrmp_watermark(
+		recipient: ParaId,
+		relay_chain_parent_number: T::BlockNumber,
+		new_hrmp_watermark: T::BlockNumber,
+	) -> bool {
+		// First, check where the watermark CANNOT legally land.
+		//
+		// (a) For ensuring that messages are eventually, a rule requires each parablock new
+		//     watermark should be greater than the last one.
+		//
+		// (b) However, a parachain cannot read into "the future", therefore the watermark should
+		//     not be greater than the relay-chain context block which the parablock refers to.
+		if let Some(last_watermark) = <Self as Store>::HrmpWatermarks::get(&recipient) {
+			if new_hrmp_watermark <= last_watermark {
+				return false;
+			}
+		}
+		if new_hrmp_watermark > relay_chain_parent_number {
+			return false;
+		}
+
+		// Second, check where the watermark CAN land. It's one of the following:
+		//
+		// (a) The relay parent block number.
+		// (b) A relay-chain block in which this para received at least one message.
+		if new_hrmp_watermark == relay_chain_parent_number {
+			true
+		} else {
+			let digest = <Self as Store>::HrmpChannelDigests::get(&recipient);
+			digest
+				.binary_search_by_key(&new_hrmp_watermark, |(block_no, _)| *block_no)
+				.is_ok()
+		}
+	}
+
+	pub(crate) fn check_outbound_hrmp(
+		config: &HostConfiguration<T::BlockNumber>,
+		sender: ParaId,
+		out_hrmp_msgs: &[OutboundHrmpMessage<ParaId>],
+	) -> bool {
+		if out_hrmp_msgs.len() as u32 > config.hrmp_max_message_num_per_candidate {
+			return false;
+		}
+
+		let mut last_recipient = None::<ParaId>;
+
+		for out_msg in out_hrmp_msgs {
+			match last_recipient {
+				// the messages must be sorted in ascending order and there must be no two messages sent
+				// to the same recipient. Thus we can check that every recipient is strictly greater than
+				// the previous one.
+				Some(last_recipient) if out_msg.recipient <= last_recipient => {
+					return false;
+				}
+				_ => last_recipient = Some(out_msg.recipient),
+			}
+
+			let channel_id = HrmpChannelId {
+				sender,
+				recipient: out_msg.recipient,
+			};
+
+			let channel = match <Self as Store>::HrmpChannels::get(&channel_id) {
+				Some(channel) => channel,
+				None => return false,
+			};
+
+			if out_msg.data.len() as u32 > channel.max_message_size {
+				return false;
+			}
+
+			if channel.total_size + out_msg.data.len() as u32 > channel.max_total_size {
+				return false;
+			}
+
+			if channel.msg_count + 1 > channel.max_capacity {
+				return false;
+			}
+		}
+
+		true
+	}
+
+	pub(crate) fn prune_hrmp(recipient: ParaId, new_hrmp_watermark: T::BlockNumber) -> Weight {
+		let mut weight = 0;
+
+		// sift through the incoming messages digest to collect the paras that sent at least one
+		// message to this parachain between the old and new watermarks.
+		let senders = <Self as Store>::HrmpChannelDigests::mutate(&recipient, |digest| {
+			let mut senders = BTreeSet::new();
+			let mut residue = Vec::with_capacity(digest.len());
+			for (block_no, paras_sent_msg) in mem::replace(digest, Vec::new()) {
+				if block_no <= new_hrmp_watermark {
+					senders.extend(paras_sent_msg);
+				} else {
+					residue.push((block_no, paras_sent_msg));
+				}
+			}
+			*digest = residue;
+			senders
+		});
+		weight += T::DbWeight::get().reads_writes(1, 1);
+
+		// having all senders we can trivially find out the channels which we need to prune.
+		let channels_to_prune = senders
+			.into_iter()
+			.map(|sender| HrmpChannelId { sender, recipient });
+		for channel_id in channels_to_prune {
+			// prune each channel up to the new watermark keeping track how many messages we removed
+			// and what is the total byte size of them.
+			let (cnt, size) =
+				<Self as Store>::HrmpChannelContents::mutate(&channel_id, |outbound_messages| {
+					let (mut cnt, mut size) = (0, 0);
+
+					let mut residue = Vec::with_capacity(outbound_messages.len());
+					for msg in mem::replace(outbound_messages, Vec::new()).into_iter() {
+						if msg.sent_at <= new_hrmp_watermark {
+							cnt += 1;
+							size += msg.data.len();
+						} else {
+							residue.push(msg);
+						}
+					}
+					*outbound_messages = residue;
+
+					(cnt, size)
+				});
+
+			// update the channel metadata.
+			<Self as Store>::HrmpChannels::mutate(&channel_id, |channel| {
+				if let Some(ref mut channel) = channel {
+					channel.msg_count -= cnt as u32;
+					channel.total_size -= size as u32;
+				}
+			});
+
+			weight += T::DbWeight::get().reads_writes(2, 2);
+		}
+
+		<Self as Store>::HrmpWatermarks::insert(&recipient, new_hrmp_watermark);
+		weight += T::DbWeight::get().reads_writes(0, 1);
+
+		weight
+	}
+
+	/// Process the outbound HRMP messages by putting them into the appropriate recipient queues.
+	///
+	/// Returns the amount of weight consumed.
+	pub(crate) fn queue_outbound_hrmp(
+		sender: ParaId,
+		out_hrmp_msgs: Vec<OutboundHrmpMessage<ParaId>>,
+	) -> Weight {
+		let mut weight = 0;
+		let now = <frame_system::Module<T>>::block_number();
+
+		for out_msg in out_hrmp_msgs {
+			let channel_id = HrmpChannelId {
+				sender,
+				recipient: out_msg.recipient,
+			};
+
+			let mut channel = match <Self as Store>::HrmpChannels::get(&channel_id) {
+				Some(channel) => channel,
+				None => {
+					// apparently, that since acceptance of this candidate the recipient was
+					// offboarded and the channel no longer exists.
+					continue;
+				}
+			};
+
+			let inbound = InboundHrmpMessage {
+				sent_at: now,
+				data: out_msg.data,
+			};
+
+			// book keeping
+			channel.msg_count += 1;
+			channel.total_size += inbound.data.len() as u32;
+
+			// compute the new MQC head of the channel
+			let prev_head = channel.mqc_head.clone().unwrap_or(Default::default());
+			let new_head = BlakeTwo256::hash_of(&(
+				prev_head,
+				inbound.sent_at,
+				T::Hashing::hash_of(&inbound.data),
+			));
+			channel.mqc_head = Some(new_head);
+
+			<Self as Store>::HrmpChannels::insert(&channel_id, channel);
+			<Self as Store>::HrmpChannelContents::append(&channel_id, inbound);
+
+			weight += T::DbWeight::get().reads_writes(2, 2);
+		}
+
+		weight
+	}
+
+	pub(super) fn init_open_channel(
+		origin: ParaId,
+		recipient: ParaId,
+		proposed_max_capacity: u32,
+		proposed_max_message_size: u32,
+	) -> Result<(), DispatchError<T>> {
+		ensure!(
+			origin != recipient,
+			DispatchError::<T>::OpenHrmpChannelToSelf
+		);
+		ensure!(
+			<paras::Module<T>>::is_valid_para(recipient),
+			DispatchError::<T>::OpenHrmpChannelInvalidRecipient,
+		);
+
+		let config = <configuration::Module<T>>::config();
+		ensure!(
+			proposed_max_capacity > 0,
+			DispatchError::<T>::OpenHrmpChannelZeroCapacity,
+		);
+		ensure!(
+			proposed_max_capacity <= config.hrmp_channel_max_capacity,
+			DispatchError::<T>::OpenHrmpChannelCapacityExceedsLimit,
+		);
+		ensure!(
+			proposed_max_message_size > 0,
+			DispatchError::<T>::OpenHrmpChannelZeroMessageSize,
+		);
+		ensure!(
+			proposed_max_message_size <= config.hrmp_channel_max_message_size,
+			DispatchError::<T>::OpenHrmpChannelMessageSizeExceedsLimit,
+		);
+
+		let channel_id = HrmpChannelId {
+			sender: origin,
+			recipient,
+		};
+		ensure!(
+			<Self as Store>::HrmpOpenChannelRequests::get(&channel_id).is_none(),
+			DispatchError::<T>::OpenHrmpChannelAlreadyExists,
+		);
+		ensure!(
+			<Self as Store>::HrmpChannels::get(&channel_id).is_none(),
+			DispatchError::<T>::OpenHrmpChannelAlreadyRequested,
+		);
+
+		let egress_cnt =
+			<Self as Store>::HrmpEgressChannelsIndex::decode_len(&origin).unwrap_or(0) as u32;
+		let open_req_cnt = <Self as Store>::HrmpOpenChannelRequestCount::get(&origin);
+		let channel_num_limit = if <paras::Module<T>>::is_parathread(origin) {
+			config.hrmp_max_parathread_outbound_channels
+		} else {
+			config.hrmp_max_parachain_outbound_channels
+		};
+		ensure!(
+			egress_cnt + open_req_cnt < channel_num_limit,
+			DispatchError::<T>::OpenHrmpChannelLimitExceeded,
+		);
+
+		// TODO: Deposit https://github.com/paritytech/polkadot/issues/1907
+
+		<Self as Store>::HrmpOpenChannelRequestCount::insert(&origin, open_req_cnt + 1);
+		<Self as Store>::HrmpOpenChannelRequests::insert(
+			&channel_id,
+			HrmpOpenChannelRequest {
+				confirmed: false,
+				age: 0,
+				sender_deposit: config.hrmp_sender_deposit,
+				max_capacity: proposed_max_capacity,
+				max_message_size: proposed_max_message_size,
+				max_total_size: config.hrmp_channel_max_total_size,
+			},
+		);
+		<Self as Store>::HrmpOpenChannelRequestsList::append(channel_id);
+
+		let notification_bytes = {
+			use xcm::v0::Xcm;
+			use codec::Encode as _;
+
+			Xcm::HrmpNewChannelOpenRequest {
+				sender: u32::from(origin),
+				max_capacity: proposed_max_capacity,
+				max_message_size: proposed_max_message_size,
+			}
+			.encode()
+		};
+		if let Err(dmp::QueueDownwardMessageError::ExceedsMaxMessageSize) =
+			Self::queue_downward_message(&config, recipient, notification_bytes)
+		{
+			// this should never happen unless the max downward message size is configured to an
+			// jokingly small number.
+			debug_assert!(false);
+		}
+
+		Ok(())
+	}
+
+	pub(super) fn accept_open_channel(
+		origin: ParaId,
+		sender: ParaId,
+	) -> Result<(), DispatchError<T>> {
+		let channel_id = HrmpChannelId {
+			sender,
+			recipient: origin,
+		};
+		let mut channel_req = <Self as Store>::HrmpOpenChannelRequests::get(&channel_id)
+			.ok_or(DispatchError::<T>::AcceptHrmpChannelDoesntExist)?;
+		ensure!(
+			!channel_req.confirmed,
+			DispatchError::<T>::AcceptHrmpChannelAlreadyConfirmed,
+		);
+
+		// check if by accepting this open channel request, this parachain would exceed the
+		// number of inbound channels.
+		let config = <configuration::Module<T>>::config();
+		let channel_num_limit = if <paras::Module<T>>::is_parathread(origin) {
+			config.hrmp_max_parathread_inbound_channels
+		} else {
+			config.hrmp_max_parachain_inbound_channels
+		};
+		let ingress_cnt =
+			<Self as Store>::HrmpIngressChannelsIndex::decode_len(&origin).unwrap_or(0) as u32;
+		let accepted_cnt = <Self as Store>::HrmpAcceptedChannelRequestCount::get(&origin);
+		ensure!(
+			ingress_cnt + accepted_cnt < channel_num_limit,
+			DispatchError::<T>::AcceptHrmpChannelLimitExceeded,
+		);
+
+		// TODO: Deposit https://github.com/paritytech/polkadot/issues/1907
+
+		// persist the updated open channel request and then increment the number of accepted
+		// channels.
+		channel_req.confirmed = true;
+		<Self as Store>::HrmpOpenChannelRequests::insert(&channel_id, channel_req);
+		<Self as Store>::HrmpAcceptedChannelRequestCount::insert(&origin, accepted_cnt + 1);
+
+		let notification_bytes = {
+			use xcm::v0::Xcm;
+			use codec::Encode as _;
+
+			Xcm::HrmpChannelAccepted {
+				recipient: u32::from(origin),
+			}
+			.encode()
+		};
+		if let Err(dmp::QueueDownwardMessageError::ExceedsMaxMessageSize) =
+			Self::queue_downward_message(&config, sender, notification_bytes)
+		{
+			// this should never happen unless the max downward message size is configured to an
+			// jokingly small number.
+			debug_assert!(false);
+		}
+
+		Ok(())
+	}
+
+	pub(super) fn close_channel(
+		origin: ParaId,
+		channel_id: HrmpChannelId,
+	) -> Result<(), DispatchError<T>> {
+		// check if the origin is allowed to close the channel.
+		ensure!(
+			origin == channel_id.sender || origin == channel_id.recipient,
+			DispatchError::<T>::CloseHrmpChannelUnauthorized,
+		);
+
+		// check if the channel requested to close does exist.
+		ensure!(
+			<Self as Store>::HrmpChannels::get(&channel_id).is_some(),
+			DispatchError::<T>::CloseHrmpChannelDoesntExist,
+		);
+
+		// check that there is no outstanding close request for this channel
+		ensure!(
+			<Self as Store>::HrmpCloseChannelRequests::get(&channel_id).is_none(),
+			DispatchError::<T>::CloseHrmpChannelAlreadyUnderway,
+		);
+
+		<Self as Store>::HrmpCloseChannelRequests::insert(&channel_id, ());
+		<Self as Store>::HrmpCloseChannelRequestsList::append(channel_id.clone());
+
+		let config = <configuration::Module<T>>::config();
+		let notification_bytes = {
+			use xcm::v0::Xcm;
+			use codec::Encode as _;
+
+			Xcm::HrmpChannelClosing {
+				initiator: u32::from(origin),
+				sender: u32::from(channel_id.sender),
+				recipient: u32::from(channel_id.recipient),
+			}
+			.encode()
+		};
+		let opposite_party = if origin == channel_id.sender {
+			channel_id.recipient
+		} else {
+			channel_id.sender
+		};
+		if let Err(dmp::QueueDownwardMessageError::ExceedsMaxMessageSize) =
+			Self::queue_downward_message(&config, opposite_party, notification_bytes)
+		{
+			// this should never happen unless the max downward message size is configured to an
+			// jokingly small number.
+			debug_assert!(false);
+		}
+
+		Ok(())
+	}
+
+	/// Returns the list of MQC heads for the inbound channels of the given recipient para paired
+	/// with the sender para ids. This vector is sorted ascending by the para id and doesn't contain
+	/// multiple entries with the same sender.
+	pub(crate) fn hrmp_mqc_heads(recipient: ParaId) -> Vec<(ParaId, Hash)> {
+		let sender_set = <Self as Store>::HrmpIngressChannelsIndex::get(&recipient);
+
+		// The ingress channels vector is sorted, thus `mqc_heads` is sorted as well.
+		let mut mqc_heads = Vec::with_capacity(sender_set.len());
+		for sender in sender_set {
+			let channel_metadata =
+				<Self as Store>::HrmpChannels::get(&HrmpChannelId { sender, recipient });
+			let mqc_head = channel_metadata
+				.and_then(|metadata| metadata.mqc_head)
+				.unwrap_or(Hash::default());
+			mqc_heads.push((sender, mqc_head));
+		}
+
+		mqc_heads
+	}
+}
+
+#[cfg(test)]
+mod tests {
 }

--- a/runtime/parachains/src/router/hrmp.rs
+++ b/runtime/parachains/src/router/hrmp.rs
@@ -1097,7 +1097,7 @@ mod tests {
 			// On Block 7:
 			// B receives the message sent by A. B sets the watermark to 6.
 			run_to_block(7, None);
-			assert!(Router::check_hrmp_watermark(para_b, 7, 6,));
+			assert!(Router::check_hrmp_watermark(para_b, 7, 6));
 			let _ = Router::prune_hrmp(para_b, 6);
 			assert_storage_consistency_exhaustive();
 		});

--- a/runtime/parachains/src/router/hrmp.rs
+++ b/runtime/parachains/src/router/hrmp.rs
@@ -973,7 +973,7 @@ mod tests {
 		//   (a, x)         (a, x)
 		//   (a, y)         (a, y)
 		//   (b, x)         (b, x)
-		//   (b, y)         (b, y)
+		//   (b, z)         (b, z)
 		//
 		// and then that we compare that to the channel list in the `HrmpChannels`.
 		let channel_set_derived_from_ingress = <Router as Store>::HrmpIngressChannelsIndex::iter()

--- a/runtime/parachains/src/router/hrmp.rs
+++ b/runtime/parachains/src/router/hrmp.rs
@@ -824,9 +824,6 @@ mod tests {
 		}
 	}
 
-	// TODO:
-	// - rename: schedule_initialize
-	// - impl Iterator
 	fn register_parachain(id: ParaId) {
 		Paras::schedule_para_initialize(
 			id,

--- a/runtime/parachains/src/router/hrmp.rs
+++ b/runtime/parachains/src/router/hrmp.rs
@@ -289,6 +289,7 @@ impl<T: Trait> Module<T> {
 					"the HRMP watermark ({}) doesn't land on a block with messages received",
 					new_hrmp_watermark,
 				);
+				return false;
 			}
 			true
 		}

--- a/runtime/parachains/src/runtime_api_impl/v1.rs
+++ b/runtime/parachains/src/runtime_api_impl/v1.rs
@@ -18,12 +18,13 @@
 //! functions.
 
 use sp_std::prelude::*;
+use sp_std::collections::btree_map::BTreeMap;
 use primitives::v1::{
 	ValidatorId, ValidatorIndex, GroupRotationInfo, CoreState, ValidationData,
 	Id as ParaId, OccupiedCoreAssumption, SessionIndex, ValidationCode,
 	CommittedCandidateReceipt, ScheduledCore, OccupiedCore, CoreOccupied, CoreIndex,
 	GroupIndex, CandidateEvent, PersistedValidationData, AuthorityDiscoveryId,
-	InboundDownwardMessage,
+	InboundDownwardMessage, InboundHrmpMessage,
 };
 use sp_runtime::traits::Zero;
 use frame_support::debug;
@@ -327,4 +328,11 @@ pub fn dmq_contents<T: router::Trait>(
 	recipient: ParaId,
 ) -> Vec<InboundDownwardMessage<T::BlockNumber>> {
 	<router::Module<T>>::dmq_contents(recipient)
+}
+
+/// Implementation for the `inbound_hrmp_channels_contents` function of the runtime API.
+pub fn inbound_hrmp_channels_contents<T: router::Trait>(
+	recipient: ParaId,
+) -> BTreeMap<ParaId, Vec<InboundHrmpMessage<T::BlockNumber>>> {
+	<router::Module<T>>::inbound_hrmp_channels_contents(recipient)
 }

--- a/runtime/parachains/src/util.rs
+++ b/runtime/parachains/src/util.rs
@@ -19,7 +19,6 @@
 
 use sp_runtime::traits::{One, Saturating};
 use primitives::v1::{Id as ParaId, PersistedValidationData, TransientValidationData};
-use sp_std::prelude::*;
 
 use crate::{configuration, paras, router};
 
@@ -34,7 +33,7 @@ pub fn make_persisted_validation_data<T: paras::Trait + router::Trait>(
 	Some(PersistedValidationData {
 		parent_head: <paras::Module<T>>::para_head(&para_id)?,
 		block_number: relay_parent_number,
-		hrmp_mqc_heads: Vec::new(),
+		hrmp_mqc_heads: <router::Module<T>>::hrmp_mqc_heads(para_id),
 		dmq_mqc_head: <router::Module<T>>::dmq_mqc_head(para_id),
 	})
 }

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -30,12 +30,14 @@ use runtime_common::{
 };
 
 use sp_std::prelude::*;
+use sp_std::collections::btree_map::BTreeMap;
 use sp_core::u32_trait::{_1, _2, _3, _4, _5};
 use codec::{Encode, Decode};
 use primitives::v1::{
 	AccountId, AccountIndex, Balance, BlockNumber, CandidateEvent, CommittedCandidateReceipt,
 	CoreState, GroupRotationInfo, Hash, Id, Moment, Nonce, OccupiedCoreAssumption,
 	PersistedValidationData, Signature, ValidationCode, ValidationData, ValidatorId, ValidatorIndex,
+	InboundDownwardMessage, InboundHrmpMessage,
 };
 use sp_runtime::{
 	create_runtime_str, generic, impl_opaque_keys, ModuleId, ApplyExtrinsicResult,
@@ -1106,9 +1108,16 @@ sp_api::impl_runtime_apis! {
 
 		fn dmq_contents(
 			_recipient: Id,
-		) -> Vec<primitives::v1::InboundDownwardMessage<BlockNumber>> {
+		) -> Vec<InboundDownwardMessage<BlockNumber>> {
 			Vec::new()
 		}
+
+		fn inbound_hrmp_channels_contents(
+			_recipient: Id
+		) -> BTreeMap<Id, Vec<InboundHrmpMessage<BlockNumber>>> {
+			BTreeMap::new()
+		}
+
 	}
 
 	impl fg_primitives::GrandpaApi<Block> for Runtime {

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -22,12 +22,13 @@
 
 use pallet_transaction_payment::CurrencyAdapter;
 use sp_std::prelude::*;
+use sp_std::collections::btree_map::BTreeMap;
 use codec::Encode;
 use primitives::v1::{
 	AccountId, AccountIndex, Balance, BlockNumber, Hash, Nonce, Signature, Moment,
 	GroupRotationInfo, CoreState, Id, ValidationData, ValidationCode, CandidateEvent,
 	ValidatorId, ValidatorIndex, CommittedCandidateReceipt, OccupiedCoreAssumption,
-	PersistedValidationData,
+	PersistedValidationData, InboundDownwardMessage, InboundHrmpMessage,
 };
 use runtime_common::{
 	SlowAdjustingFeeUpdate,
@@ -682,8 +683,14 @@ sp_api::impl_runtime_apis! {
 			runtime_api_impl::validator_discovery::<Runtime>(validators)
 		}
 
-		fn dmq_contents(recipient: Id) -> Vec<primitives::v1::InboundDownwardMessage<BlockNumber>> {
+		fn dmq_contents(recipient: Id) -> Vec<InboundDownwardMessage<BlockNumber>> {
 			runtime_api_impl::dmq_contents::<Runtime>(recipient)
+		}
+
+		fn inbound_hrmp_channels_contents(
+			recipient: Id
+		) -> BTreeMap<Id, Vec<InboundHrmpMessage<BlockNumber>>> {
+			runtime_api_impl::inbound_hrmp_channels_contents::<Runtime>(recipient)
 		}
 	}
 

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -532,6 +532,7 @@ impl parachains_paras::Trait for Runtime {
 }
 
 impl parachains_router::Trait for Runtime {
+	type Origin = Origin;
 	type UmpSink = (); // TODO: #1873 To be handled by the XCM receiver.
 }
 

--- a/runtime/test-runtime/src/lib.rs
+++ b/runtime/test-runtime/src/lib.rs
@@ -453,6 +453,7 @@ impl paras::Trait for Runtime {
 }
 
 impl router::Trait for Runtime {
+	type Origin = Origin;
 	type UmpSink = ();
 }
 

--- a/runtime/test-runtime/src/lib.rs
+++ b/runtime/test-runtime/src/lib.rs
@@ -22,6 +22,7 @@
 
 use pallet_transaction_payment::CurrencyAdapter;
 use sp_std::prelude::*;
+use sp_std::collections::btree_map::BTreeMap;
 use codec::Encode;
 use polkadot_runtime_parachains::{
 	configuration,
@@ -36,6 +37,7 @@ use primitives::v1::{
 	AccountId, AccountIndex, Balance, BlockNumber, CandidateEvent, CommittedCandidateReceipt,
 	CoreState, GroupRotationInfo, Hash as HashT, Id as ParaId, Moment, Nonce, OccupiedCoreAssumption,
 	PersistedValidationData, Signature, ValidationCode, ValidationData, ValidatorId, ValidatorIndex,
+	InboundDownwardMessage, InboundHrmpMessage,
 };
 use runtime_common::{
 	claims, SlowAdjustingFeeUpdate, paras_sudo_wrapper,
@@ -669,8 +671,14 @@ sp_api::impl_runtime_apis! {
 
 		fn dmq_contents(
 			recipient: ParaId,
-		) -> Vec<primitives::v1::InboundDownwardMessage<BlockNumber>> {
+		) -> Vec<InboundDownwardMessage<BlockNumber>> {
 			runtime_impl::dmq_contents::<Runtime>(recipient)
+		}
+
+		fn inbound_hrmp_channels_contents(
+			recipient: ParaId,
+		) -> BTreeMap<ParaId, Vec<InboundHrmpMessage<BlockNumber>>> {
+			runtime_impl::inbound_hrmp_channels_contents::<Runtime>(recipient)
 		}
 	}
 

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -22,11 +22,13 @@
 
 use pallet_transaction_payment::CurrencyAdapter;
 use sp_std::prelude::*;
+use sp_std::collections::btree_map::BTreeMap;
 use codec::{Encode, Decode};
 use primitives::v1::{
 	AccountId, AccountIndex, Balance, BlockNumber, CandidateEvent, CommittedCandidateReceipt,
 	CoreState, GroupRotationInfo, Hash, Id, Moment, Nonce, OccupiedCoreAssumption,
 	PersistedValidationData, Signature, ValidationCode, ValidationData, ValidatorId, ValidatorIndex,
+	InboundDownwardMessage, InboundHrmpMessage,
 };
 use runtime_common::{
 	SlowAdjustingFeeUpdate, CurrencyToVote,
@@ -856,8 +858,14 @@ sp_api::impl_runtime_apis! {
 
 		fn dmq_contents(
 			_recipient: Id,
-		) -> Vec<primitives::v1::InboundDownwardMessage<BlockNumber>> {
+		) -> Vec<InboundDownwardMessage<BlockNumber>> {
 			Vec::new()
+		}
+
+		fn inbound_hrmp_channels_contents(
+			_recipient: Id
+		) -> BTreeMap<Id, Vec<InboundHrmpMessage<BlockNumber>>> {
+			BTreeMap::new()
 		}
 	}
 

--- a/xcm/src/v0/mod.rs
+++ b/xcm/src/v0/mod.rs
@@ -158,6 +158,51 @@ pub enum Xcm {
 	///
 	/// Errors:
 	RelayedFrom { superorigin: MultiLocation, inner: Box<VersionedXcm> },
+
+	/// A message to notify about a new incoming HRMP channel. This message is meant to be sent by the
+	/// relay-chain to a para.
+	///
+	/// - `sender`: The sender in the to-be opened channel. Also, the initiator of the channel opening.
+	/// - `max_message_size`: The maximum size of a message proposed by the sender.
+	/// - `max_capacity`: The maximum number of messages that can be queued in the channel.
+	///
+	/// Safety: The message should originate directly from the relay-chain.
+	///
+	/// Kind: *System Notification*
+	HrmpNewChannelOpenRequest {
+		#[codec(compact)] sender: u32,
+		#[codec(compact)] max_message_size: u32,
+		#[codec(compact)] max_capacity: u32,
+	},
+
+	/// A message to notify about that a previously sent open channel request has been accepted by
+	/// the recipient. That means that the channel will be opened during the next relay-chain session
+	/// change. This message is meant to be sent by the relay-chain to a para.
+	///
+	/// Safety: The message should originate directly from the relay-chain.
+	///
+	/// Kind: *System Notification*
+	///
+	/// Errors:
+	HrmpChannelAccepted {
+		#[codec(compact)] recipient: u32,
+	},
+
+	/// A message to notify that the other party in an open channel decided to close it. In particular,
+	/// `inititator` is going to close the channel opened from `sender` to the `recipient`. The close
+	/// will be enacted at the next relay-chain session change. This message is meant to be sent by
+	/// the relay-chain to a para.
+	///
+	/// Safety: The message should originate directly from the relay-chain.
+	///
+	/// Kind: *System Notification*
+	///
+	/// Errors:
+	HrmpChannelClosing {
+		#[codec(compact)] initiator: u32,
+		#[codec(compact)] sender: u32,
+		#[codec(compact)] recipient: u32,
+	},
 }
 
 impl From<Xcm> for VersionedXcm {


### PR DESCRIPTION
This PR subsumes the Router PR: #1679 

Closes #1400
Closes #1642 
Closes #1663 
Closes #1704
Closes #1806
Closes #1869

- [x] #1806
- [x] #1869
- [x] the router module HRMP tests

Regarding #1663 I decided to go with a simple implementation: just to send a DM to notify paras. For now, it makes sense to start with a simpler approach to see how it works and then extend it as needed. My concern about this solution was that these notifications should be processed in a timely manner but a downward message queue can be clogged. Well, that's a bit too forward looking since most likely the queues won't be filled in the foreseeable future (assuming we can upgrade later). Apart from that, if that becomes an issue, it is possible for the PVF to enact messages out-of-order therefore getting some sort of QoS. But again I doubt that this will be required for now.