### PR TITLE
Do not validate a candidate in candidate selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5017,7 +5017,6 @@ version = "0.1.0"
 dependencies = [
  "futures 0.3.5",
  "log 0.4.11",
- "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-primitives",

--- a/node/core/candidate-selection/Cargo.toml
+++ b/node/core/candidate-selection/Cargo.toml
@@ -9,7 +9,6 @@ futures = "0.3.5"
 log = "0.4.11"
 thiserror = "1.0.21"
 polkadot-primitives = { path = "../../../primitives" }
-polkadot-node-primitives = { path = "../../primitives" }
 polkadot-node-subsystem = { path = "../../subsystem" }
 polkadot-node-subsystem-util = { path = "../../subsystem-util" }
 

--- a/roadmap/implementers-guide/src/node/backing/candidate-selection.md
+++ b/roadmap/implementers-guide/src/node/backing/candidate-selection.md
@@ -16,7 +16,6 @@ Input: [`CandidateSelectionMessage`](../../types/overseer-protocol.md#candidate-
 
 Output:
 
-- Validation requests to Validation subsystem
 - [`CandidateBackingMessage`](../../types/overseer-protocol.md#candidate-backing-message)`::Second`
 - Peer set manager: report peers (collators who have misbehaved)
 


### PR DESCRIPTION
The candidate selection subsystem should not validate a candidate, as
this is done by the backing subsystem on a `Second` request. Otherwise
we validate one candidate twice.