### PR TITLE
Make `CandidateHash` a real type

### DIFF
--- a/core-primitives/src/lib.rs
+++ b/core-primitives/src/lib.rs
@@ -52,6 +52,8 @@ pub type Hash = sp_core::H256;
 
 /// Unit type wrapper around [`Hash`] that represents a candidate hash.
 ///
+/// This type is produced by [`CandidateReceipt::hash`].
+///
 /// This type makes it easy to enforce that a hash is a candidate hash on the type level.
 #[derive(Clone, Copy, codec::Encode, codec::Decode, Hash, Eq, PartialEq, Debug, Default)]
 pub struct CandidateHash(pub Hash);

--- a/core-primitives/src/lib.rs
+++ b/core-primitives/src/lib.rs
@@ -50,6 +50,12 @@ pub type ChainId = u32;
 /// A hash of some data used by the relay chain.
 pub type Hash = sp_core::H256;
 
+/// Unit type wrapper around [`Hash`] that represents a candidate hash.
+///
+/// This type makes it easy to enforce that a hash is a candidate hash on the type level.
+#[derive(Clone, Copy, codec::Encode, codec::Decode, Hash, Eq, PartialEq, Debug, Default)]
+pub struct CandidateHash(pub Hash);
+
 /// Index of a transaction in the relay chain. 32-bit should be plenty.
 pub type Nonce = u32;
 

--- a/node/core/av-store/src/lib.rs
+++ b/node/core/av-store/src/lib.rs
@@ -729,7 +729,10 @@ where
 	Ok(())
 }
 
-fn available_data(db: &Arc<dyn KeyValueDB>, candidate_hash: &CandidateHash) -> Option<StoredAvailableData> {
+fn available_data(
+	db: &Arc<dyn KeyValueDB>,
+	candidate_hash: &CandidateHash,
+) -> Option<StoredAvailableData> {
 	query_inner(db, columns::DATA, &available_data_key(candidate_hash))
 }
 
@@ -981,7 +984,11 @@ fn get_chunk(
 	Ok(None)
 }
 
-fn query_inner<D: Decode>(db: &Arc<dyn KeyValueDB>, column: u32, key: &[u8]) -> Option<D> {
+fn query_inner<D: Decode>(
+	db: &Arc<dyn KeyValueDB>,
+	column: u32,
+	key: &[u8],
+) -> Option<D> {
 	match db.get(column, key) {
 		Ok(Some(raw)) => {
 			let res = D::decode(&mut &raw[..]).expect("all stored data serialized correctly; qed");

--- a/node/core/av-store/src/lib.rs
+++ b/node/core/av-store/src/lib.rs
@@ -33,7 +33,7 @@ use kvdb_rocksdb::{Database, DatabaseConfig};
 use kvdb::{KeyValueDB, DBTransaction};
 
 use polkadot_primitives::v1::{
-	Hash, AvailableData, BlockNumber, CandidateEvent, ErasureChunk, ValidatorIndex,
+	Hash, AvailableData, BlockNumber, CandidateEvent, ErasureChunk, ValidatorIndex, CandidateHash,
 };
 use polkadot_subsystem::{
 	FromOverseer, OverseerSignal, SubsystemError, Subsystem, SubsystemContext, SpawnedSubsystem,
@@ -242,7 +242,7 @@ enum CandidateState {
 
 #[derive(Debug, Decode, Encode, Eq)]
 struct PoVPruningRecord {
-	candidate_hash: Hash,
+	candidate_hash: CandidateHash,
 	block_number: BlockNumber,
 	candidate_state: CandidateState,
 	prune_at: PruningDelay,
@@ -272,7 +272,7 @@ impl PartialOrd for PoVPruningRecord {
 
 #[derive(Debug, Decode, Encode, Eq)]
 struct ChunkPruningRecord {
-	candidate_hash: Hash,
+	candidate_hash: CandidateHash,
 	block_number: BlockNumber,
 	candidate_state: CandidateState,
 	chunk_index: u32,
@@ -387,11 +387,11 @@ impl AvailabilityStoreSubsystem {
 	}
 }
 
-fn available_data_key(candidate_hash: &Hash) -> Vec<u8> {
+fn available_data_key(candidate_hash: &CandidateHash) -> Vec<u8> {
 	(candidate_hash, 0i8).encode()
 }
 
-fn erasure_chunk_key(candidate_hash: &Hash, index: u32) -> Vec<u8> {
+fn erasure_chunk_key(candidate_hash: &CandidateHash, index: u32) -> Vec<u8> {
 	(candidate_hash, index, 0i8).encode()
 }
 
@@ -564,7 +564,7 @@ where
 				log::trace!(
 					target: LOG_TARGET,
 					"Updating pruning record for finalized block {}",
-					record.candidate_hash,
+					record.block_number,
 				);
 
 				record.prune_at = PruningDelay::into_the_future(
@@ -583,7 +583,7 @@ where
 				log::trace!(
 					target: LOG_TARGET,
 					"Updating chunk pruning record for finalized block {}",
-					record.candidate_hash,
+					record.block_number,
 				);
 
 				record.prune_at = PruningDelay::into_the_future(
@@ -620,7 +620,7 @@ where
 
 	for event in events.into_iter() {
 		if let CandidateEvent::CandidateIncluded(receipt, _) = event {
-			log::trace!(target: LOG_TARGET, "Candidate {} was included", receipt.hash());
+			log::trace!(target: LOG_TARGET, "Candidate {:?} was included", receipt.hash());
 			included.insert(receipt.hash());
 		}
 	}
@@ -729,7 +729,7 @@ where
 	Ok(())
 }
 
-fn available_data(db: &Arc<dyn KeyValueDB>, candidate_hash: &Hash) -> Option<StoredAvailableData> {
+fn available_data(db: &Arc<dyn KeyValueDB>, candidate_hash: &CandidateHash) -> Option<StoredAvailableData> {
 	query_inner(db, columns::DATA, &available_data_key(candidate_hash))
 }
 
@@ -835,7 +835,7 @@ where
 
 fn store_available_data(
 	subsystem: &mut AvailabilityStoreSubsystem,
-	candidate_hash: &Hash,
+	candidate_hash: &CandidateHash,
 	id: Option<ValidatorIndex>,
 	n_validators: u32,
 	available_data: AvailableData,
@@ -872,7 +872,7 @@ fn store_available_data(
 	}
 
 	let pruning_record = PoVPruningRecord {
-		candidate_hash: candidate_hash.clone(),
+		candidate_hash: *candidate_hash,
 		block_number,
 		candidate_state: CandidateState::Stored,
 		prune_at,
@@ -901,7 +901,7 @@ fn store_available_data(
 
 fn store_chunk(
 	subsystem: &mut AvailabilityStoreSubsystem,
-	candidate_hash: &Hash,
+	candidate_hash: &CandidateHash,
 	_n_validators: u32,
 	chunk: ErasureChunk,
 	block_number: BlockNumber,
@@ -952,7 +952,7 @@ fn store_chunk(
 
 fn get_chunk(
 	subsystem: &mut AvailabilityStoreSubsystem,
-	candidate_hash: &Hash,
+	candidate_hash: &CandidateHash,
 	index: u32,
 ) -> Result<Option<ErasureChunk>, Error> {
 	if let Some(chunk) = query_inner(

--- a/node/core/av-store/src/tests.rs
+++ b/node/core/av-store/src/tests.rs
@@ -27,7 +27,7 @@ use smallvec::smallvec;
 
 use polkadot_primitives::v1::{
 	AvailableData, BlockData, CandidateDescriptor, CandidateReceipt, HeadData,
-	PersistedValidationData, PoV, Id as ParaId,
+	PersistedValidationData, PoV, Id as ParaId, CandidateHash,
 };
 use polkadot_node_subsystem_util::TimeoutExt;
 use polkadot_subsystem::{
@@ -199,7 +199,7 @@ fn runtime_api_error_does_not_stop_the_subsystem() {
 
 		// but that's fine, we're still alive
 		let (tx, rx) = oneshot::channel();
-		let candidate_hash = Hash::repeat_byte(33);
+		let candidate_hash = CandidateHash(Hash::repeat_byte(33));
 		let validator_index = 5;
 		let query_chunk = AvailabilityStoreMessage::QueryChunk(
 			candidate_hash,
@@ -220,7 +220,7 @@ fn store_chunk_works() {
 	test_harness(PruningConfig::default(), store.clone(), |test_harness| async move {
 		let TestHarness { mut virtual_overseer } = test_harness;
 		let relay_parent = Hash::repeat_byte(32);
-		let candidate_hash = Hash::repeat_byte(33);
+		let candidate_hash = CandidateHash(Hash::repeat_byte(33));
 		let validator_index = 5;
 
 		let chunk = ErasureChunk {
@@ -273,7 +273,7 @@ fn store_block_works() {
 	let test_state = TestState::default();
 	test_harness(test_state.pruning_config.clone(), store.clone(), |test_harness| async move {
 		let TestHarness { mut virtual_overseer } = test_harness;
-		let candidate_hash = Hash::from([1; 32]);
+		let candidate_hash = CandidateHash(Hash::from([1; 32]));
 		let validator_index = 5;
 		let n_validators = 10;
 
@@ -327,7 +327,7 @@ fn store_pov_and_query_chunk_works() {
 
 	test_harness(test_state.pruning_config.clone(), store.clone(), |test_harness| async move {
 		let TestHarness { mut virtual_overseer } = test_harness;
-		let candidate_hash = Hash::from([1; 32]);
+		let candidate_hash = CandidateHash(Hash::from([1; 32]));
 		let n_validators = 10;
 
 		let pov = PoV {
@@ -370,7 +370,7 @@ fn stored_but_not_included_chunk_is_pruned() {
 
 	test_harness(test_state.pruning_config.clone(), store.clone(), |test_harness| async move {
 		let TestHarness { mut virtual_overseer } = test_harness;
-		let candidate_hash = Hash::repeat_byte(1);
+		let candidate_hash = CandidateHash(Hash::repeat_byte(1));
 		let relay_parent = Hash::repeat_byte(2);
 		let validator_index = 5;
 
@@ -425,7 +425,7 @@ fn stored_but_not_included_data_is_pruned() {
 
 	test_harness(test_state.pruning_config.clone(), store.clone(), |test_harness| async move {
 		let TestHarness { mut virtual_overseer } = test_harness;
-		let candidate_hash = Hash::repeat_byte(1);
+		let candidate_hash = CandidateHash(Hash::repeat_byte(1));
 		let n_validators = 10;
 
 		let pov = PoV {
@@ -852,7 +852,7 @@ fn forkfullness_works() {
 
 async fn query_available_data(
 	virtual_overseer: &mut test_helpers::TestSubsystemContextHandle<AvailabilityStoreMessage>,
-	candidate_hash: Hash,
+	candidate_hash: CandidateHash,
 ) -> Option<AvailableData> {
 	let (tx, rx) = oneshot::channel();
 
@@ -864,7 +864,7 @@ async fn query_available_data(
 
 async fn query_chunk(
 	virtual_overseer: &mut test_helpers::TestSubsystemContextHandle<AvailabilityStoreMessage>,
-	candidate_hash: Hash,
+	candidate_hash: CandidateHash,
 	index: u32,
 ) -> Option<ErasureChunk> {
 	let (tx, rx) = oneshot::channel();

--- a/node/core/bitfield-signing/src/lib.rs
+++ b/node/core/bitfield-signing/src/lib.rs
@@ -182,7 +182,7 @@ async fn get_core_availability(
 		let (tx, rx) = oneshot::channel();
 		sender
 			.send(AvailabilityStore(QueryChunkAvailability(
-				committed_candidate_receipt.descriptor.pov_hash,
+				committed_candidate_receipt.hash(),
 				validator_idx,
 				tx,
 			)))

--- a/node/network/availability-distribution/src/tests.rs
+++ b/node/network/availability-distribution/src/tests.rs
@@ -254,7 +254,7 @@ fn make_erasure_root(test: &TestState, pov: PoV) -> Hash {
 
 fn make_valid_availability_gossip(
 	test: &TestState,
-	candidate_hash: Hash,
+	candidate_hash: CandidateHash,
 	erasure_chunk_index: u32,
 	pov: PoV,
 ) -> AvailabilityGossipMessage {
@@ -320,7 +320,7 @@ fn helper_integrity() {
 	.build();
 
 	let message =
-		make_valid_availability_gossip(&test_state, dbg!(candidate.hash()), 2, pov_block.clone());
+		make_valid_availability_gossip(&test_state, candidate.hash(), 2, pov_block.clone());
 
 	let root = dbg!(&candidate.commitments.erasure_root);
 

--- a/node/network/protocol/src/lib.rs
+++ b/node/network/protocol/src/lib.rs
@@ -186,7 +186,7 @@ impl View {
 pub mod v1 {
 	use polkadot_primitives::v1::{
 		Hash, CollatorId, Id as ParaId, ErasureChunk, CandidateReceipt,
-		SignedAvailabilityBitfield, PoV,
+		SignedAvailabilityBitfield, PoV, CandidateHash,
 	};
 	use polkadot_node_primitives::SignedFullStatement;
 	use parity_scale_codec::{Encode, Decode};
@@ -198,7 +198,7 @@ pub mod v1 {
 	pub enum AvailabilityDistributionMessage {
 		/// An erasure chunk for a given candidate hash.
 		#[codec(index = "0")]
-		Chunk(Hash, ErasureChunk),
+		Chunk(CandidateHash, ErasureChunk),
 	}
 
 	/// Network messages used by the bitfield distribution subsystem.

--- a/node/overseer/src/lib.rs
+++ b/node/overseer/src/lib.rs
@@ -1635,7 +1635,7 @@ mod tests {
 	use std::collections::HashMap;
 	use futures::{executor, pin_mut, select, channel::mpsc, FutureExt};
 
-	use polkadot_primitives::v1::{BlockData, CollatorPair, PoV};
+	use polkadot_primitives::v1::{BlockData, CollatorPair, PoV, CandidateHash};
 	use polkadot_subsystem::messages::RuntimeApiRequest;
 	use polkadot_node_primitives::{Collation, CollationGenerationConfig};
 	use polkadot_node_network_protocol::{PeerId, ReputationChange, NetworkBridgeEvent};
@@ -2273,7 +2273,7 @@ mod tests {
 
 	fn test_availability_store_msg() -> AvailabilityStoreMessage {
 		let (sender, _) = oneshot::channel();
-		AvailabilityStoreMessage::QueryAvailableData(Default::default(), sender)
+		AvailabilityStoreMessage::QueryAvailableData(CandidateHash(Default::default()), sender)
 	}
 
 	fn test_network_bridge_msg() -> NetworkBridgeMessage {

--- a/node/primitives/src/lib.rs
+++ b/node/primitives/src/lib.rs
@@ -28,7 +28,7 @@ use polkadot_primitives::v1::{
 	Hash, CommittedCandidateReceipt, CandidateReceipt, CompactStatement,
 	EncodeAs, Signed, SigningContext, ValidatorIndex, ValidatorId,
 	UpwardMessage, ValidationCode, PersistedValidationData, ValidationData,
-	HeadData, PoV, CollatorPair, Id as ParaId, ValidationOutputs,
+	HeadData, PoV, CollatorPair, Id as ParaId, ValidationOutputs, CandidateHash,
 };
 use polkadot_statement_table::{
 	generic::{
@@ -54,10 +54,10 @@ pub enum Statement {
 	Seconded(CommittedCandidateReceipt),
 	/// A statement that a validator has deemed a candidate valid.
 	#[codec(index = "2")]
-	Valid(Hash),
+	Valid(CandidateHash),
 	/// A statement that a validator has deemed a candidate invalid.
 	#[codec(index = "3")]
-	Invalid(Hash),
+	Invalid(CandidateHash),
 }
 
 impl Statement {

--- a/node/subsystem/src/messages.rs
+++ b/node/subsystem/src/messages.rs
@@ -36,7 +36,7 @@ use polkadot_primitives::v1::{
 	CollatorId, CommittedCandidateReceipt, CoreState, ErasureChunk,
 	GroupRotationInfo, Hash, Id as ParaId, OccupiedCoreAssumption,
 	PersistedValidationData, PoV, SessionIndex, SignedAvailabilityBitfield,
-	ValidationCode, ValidatorId, ValidationData,
+	ValidationCode, ValidatorId, ValidationData, CandidateHash,
 	ValidatorIndex, ValidatorSignature, InboundDownwardMessage,
 };
 use std::sync::Arc;
@@ -289,31 +289,31 @@ impl BitfieldSigningMessage {
 #[derive(Debug)]
 pub enum AvailabilityStoreMessage {
 	/// Query a `AvailableData` from the AV store.
-	QueryAvailableData(Hash, oneshot::Sender<Option<AvailableData>>),
+	QueryAvailableData(CandidateHash, oneshot::Sender<Option<AvailableData>>),
 
 	/// Query whether a `AvailableData` exists within the AV Store.
 	///
 	/// This is useful in cases when existence
 	/// matters, but we don't want to necessarily pass around multiple
 	/// megabytes of data to get a single bit of information.
-	QueryDataAvailability(Hash, oneshot::Sender<bool>),
+	QueryDataAvailability(CandidateHash, oneshot::Sender<bool>),
 
 	/// Query an `ErasureChunk` from the AV store by the candidate hash and validator index.
-	QueryChunk(Hash, ValidatorIndex, oneshot::Sender<Option<ErasureChunk>>),
+	QueryChunk(CandidateHash, ValidatorIndex, oneshot::Sender<Option<ErasureChunk>>),
 
 	/// Query whether an `ErasureChunk` exists within the AV Store.
 	///
 	/// This is useful in cases like bitfield signing, when existence
 	/// matters, but we don't want to necessarily pass around large
 	/// quantities of data to get a single bit of information.
-	QueryChunkAvailability(Hash, ValidatorIndex, oneshot::Sender<bool>),
+	QueryChunkAvailability(CandidateHash, ValidatorIndex, oneshot::Sender<bool>),
 
 	/// Store an `ErasureChunk` in the AV store.
 	///
 	/// Return `Ok(())` if the store operation succeeded, `Err(())` if it failed.
 	StoreChunk {
 		/// A hash of the candidate this chunk belongs to.
-		candidate_hash: Hash,
+		candidate_hash: CandidateHash,
 		/// A relevant relay parent.
 		relay_parent: Hash,
 		/// The index of the validator this chunk belongs to.
@@ -328,7 +328,7 @@ pub enum AvailabilityStoreMessage {
 	/// If `ValidatorIndex` is present store corresponding chunk also.
 	///
 	/// Return `Ok(())` if the store operation succeeded, `Err(())` if it failed.
-	StoreAvailableData(Hash, Option<ValidatorIndex>, u32, AvailableData, oneshot::Sender<Result<(), ()>>),
+	StoreAvailableData(CandidateHash, Option<ValidatorIndex>, u32, AvailableData, oneshot::Sender<Result<(), ()>>),
 }
 
 impl AvailabilityStoreMessage {

--- a/primitives/src/v0.rs
+++ b/primitives/src/v0.rs
@@ -633,18 +633,18 @@ pub struct ErasureChunk {
 pub enum CompactStatement {
 	/// Proposal of a parachain candidate.
 	#[codec(index = "1")]
-	Candidate(Hash),
+	Candidate(CandidateHash),
 	/// State that a parachain candidate is valid.
 	#[codec(index = "2")]
-	Valid(Hash),
+	Valid(CandidateHash),
 	/// State that a parachain candidate is invalid.
 	#[codec(index = "3")]
-	Invalid(Hash),
+	Invalid(CandidateHash),
 }
 
 impl CompactStatement {
 	/// Get the underlying candidate hash this references.
-	pub fn candidate_hash(&self) -> &Hash {
+	pub fn candidate_hash(&self) -> &CandidateHash {
 		match *self {
 			CompactStatement::Candidate(ref h)
 				| CompactStatement::Valid(ref h)
@@ -684,7 +684,7 @@ impl ValidityAttestation {
 	/// which should be known in context.
 	pub fn signed_payload<H: Encode>(
 		&self,
-		candidate_hash: Hash,
+		candidate_hash: CandidateHash,
 		signing_context: &SigningContext<H>,
 	) -> Vec<u8> {
 		match *self {

--- a/primitives/src/v1.rs
+++ b/primitives/src/v1.rs
@@ -31,7 +31,7 @@ pub use runtime_primitives::traits::{BlakeTwo256, Hash as HashT};
 pub use polkadot_core_primitives::v1::{
 	BlockNumber, Moment, Signature, AccountPublic, AccountId, AccountIndex,
 	ChainId, Hash, Nonce, Balance, Header, Block, BlockId, UncheckedExtrinsic,
-	Remark, DownwardMessage, InboundDownwardMessage,
+	Remark, DownwardMessage, InboundDownwardMessage, CandidateHash,
 };
 
 // Export some polkadot-parachain primitives
@@ -148,8 +148,8 @@ impl<H> CandidateReceipt<H> {
 	}
 
 	/// Computes the blake2-256 hash of the receipt.
-	pub fn hash(&self) -> Hash where H: Encode {
-		BlakeTwo256::hash_of(self)
+	pub fn hash(&self) -> CandidateHash where H: Encode {
+		CandidateHash(BlakeTwo256::hash_of(self))
 	}
 }
 
@@ -196,7 +196,7 @@ impl<H: Clone> CommittedCandidateReceipt<H> {
 	///
 	/// This computes the canonical hash, not the hash of the directly encoded data.
 	/// Thus this is a shortcut for `candidate.to_plain().hash()`.
-	pub fn hash(&self) -> Hash where H: Encode {
+	pub fn hash(&self) -> CandidateHash where H: Encode {
 		self.to_plain().hash()
 	}
 }
@@ -421,7 +421,7 @@ pub fn check_candidate_backing<H: AsRef<[u8]> + Clone + Encode>(
 	}
 
 	// this is known, even in runtime, to be blake2-256.
-	let hash: Hash = backed.candidate.hash();
+	let hash = backed.candidate.hash();
 
 	let mut signed = 0;
 	for ((val_in_group_idx, _), attestation) in backed.validator_indices.iter().enumerate()

--- a/roadmap/implementers-guide/src/types/network.md
+++ b/roadmap/implementers-guide/src/types/network.md
@@ -23,7 +23,7 @@ enum ObservedRole {
 ```rust
 enum AvailabilityDistributionV1Message {
 	/// An erasure chunk for a given candidate hash.
-	Chunk(Hash, ErasureChunk),
+	Chunk(CandidateHash, ErasureChunk),
 }
 ```
 

--- a/roadmap/implementers-guide/src/types/overseer-protocol.md
+++ b/roadmap/implementers-guide/src/types/overseer-protocol.md
@@ -136,18 +136,18 @@ Messages to and from the availability store.
 ```rust
 enum AvailabilityStoreMessage {
 	/// Query the `AvailableData` of a candidate by hash.
-	QueryAvailableData(Hash, ResponseChannel<Option<AvailableData>>),
+	QueryAvailableData(CandidateHash, ResponseChannel<Option<AvailableData>>),
 	/// Query whether an `AvailableData` exists within the AV Store.
-	QueryDataAvailability(Hash, ResponseChannel<bool>),
+	QueryDataAvailability(CandidateHash, ResponseChannel<bool>),
 	/// Query a specific availability chunk of the candidate's erasure-coding by validator index.
 	/// Returns the chunk and its inclusion proof against the candidate's erasure-root.
-	QueryChunk(Hash, ValidatorIndex, ResponseChannel<Option<AvailabilityChunkAndProof>>),
+	QueryChunk(CandidateHash, ValidatorIndex, ResponseChannel<Option<AvailabilityChunkAndProof>>),
 	/// Store a specific chunk of the candidate's erasure-coding by validator index, with an
 	/// accompanying proof.
-	StoreChunk(Hash, ValidatorIndex, AvailabilityChunkAndProof, ResponseChannel<Result<()>>),
+	StoreChunk(CandidateHash, ValidatorIndex, AvailabilityChunkAndProof, ResponseChannel<Result<()>>),
 	/// Store `AvailableData`. If `ValidatorIndex` is provided, also store this validator's
 	/// `AvailabilityChunkAndProof`.
-	StoreAvailableData(Hash, Option<ValidatorIndex>, u32, AvailableData, ResponseChannel<Result<()>>),
+	StoreAvailableData(CandidateHash, Option<ValidatorIndex>, u32, AvailableData, ResponseChannel<Result<()>>),
 }
 ```
 

--- a/statement-table/src/lib.rs
+++ b/statement-table/src/lib.rs
@@ -18,63 +18,21 @@ pub mod generic;
 
 pub use generic::{Table, Context};
 
-/// Concrete instantiations suitable for v0 primitives.
-pub mod v0 {
-	use crate::generic;
-	use primitives::v0::{
-		Hash,
-		Id, AbridgedCandidateReceipt, CompactStatement as PrimitiveStatement, ValidatorSignature, ValidatorIndex,
-	};
-
-	/// Statements about candidates on the network.
-	pub type Statement = generic::Statement<AbridgedCandidateReceipt, Hash>;
-
-	/// Signed statements about candidates.
-	pub type SignedStatement = generic::SignedStatement<
-		AbridgedCandidateReceipt,
-		Hash,
-		ValidatorIndex,
-		ValidatorSignature,
-	>;
-
-	/// Kinds of misbehavior, along with proof.
-	pub type Misbehavior = generic::Misbehavior<
-		AbridgedCandidateReceipt,
-		Hash,
-		ValidatorIndex,
-		ValidatorSignature,
-	>;
-
-	/// A summary of import of a statement.
-	pub type Summary = generic::Summary<Hash, Id>;
-
-	impl<'a> From<&'a Statement> for PrimitiveStatement {
-		fn from(s: &'a Statement) -> PrimitiveStatement {
-			match *s {
-				generic::Statement::Valid(s) => PrimitiveStatement::Valid(s),
-				generic::Statement::Invalid(s) => PrimitiveStatement::Invalid(s),
-				generic::Statement::Candidate(ref s) => PrimitiveStatement::Candidate(s.hash()),
-			}
-		}
-	}
-}
-
 /// Concrete instantiations suitable for v1 primitives.
 pub mod v1 {
 	use crate::generic;
 	use primitives::v1::{
-		Hash,
-		Id, CommittedCandidateReceipt, CompactStatement as PrimitiveStatement,
+		CandidateHash, Id, CommittedCandidateReceipt, CompactStatement as PrimitiveStatement,
 		ValidatorSignature, ValidatorIndex,
 	};
 
 	/// Statements about candidates on the network.
-	pub type Statement = generic::Statement<CommittedCandidateReceipt, Hash>;
+	pub type Statement = generic::Statement<CommittedCandidateReceipt, CandidateHash>;
 
 	/// Signed statements about candidates.
 	pub type SignedStatement = generic::SignedStatement<
 		CommittedCandidateReceipt,
-		Hash,
+		CandidateHash,
 		ValidatorIndex,
 		ValidatorSignature,
 	>;
@@ -82,13 +40,13 @@ pub mod v1 {
 	/// Kinds of misbehavior, along with proof.
 	pub type Misbehavior = generic::Misbehavior<
 		CommittedCandidateReceipt,
-		Hash,
+		CandidateHash,
 		ValidatorIndex,
 		ValidatorSignature,
 	>;
 
 	/// A summary of import of a statement.
-	pub type Summary = generic::Summary<Hash, Id>;
+	pub type Summary = generic::Summary<CandidateHash, Id>;
 
 	impl<'a> From<&'a Statement> for PrimitiveStatement {
 		fn from(s: &'a Statement) -> PrimitiveStatement {


### PR DESCRIPTION
This pr adds a new type `CandidateHash` that is used instead of the
opaque `Hash` type. This helps to ensure on the type system level that
we are passing the correct types.

This pr also fixes wrong usage of `relay_parent` as `candidate_hash`
when communicating with the av storage.