### PR TITLE
Make sure we clear the freed the availability cores

### DIFF
--- a/runtime/parachains/src/inclusion.rs
+++ b/runtime/parachains/src/inclusion.rs
@@ -312,7 +312,7 @@ impl<T: Trait> Module<T> {
 		{
 			if pending_availability.availability_votes.count_ones() >= threshold {
 				<PendingAvailability<T>>::remove(&para_id);
-				let commitments = match <PendingAvailabilityCommitments>::take(&para_id) {
+				let commitments = match PendingAvailabilityCommitments::take(&para_id) {
 					Some(commitments) => commitments,
 					None => {
 						debug::warn!(r#"

--- a/runtime/parachains/src/inclusion_inherent.rs
+++ b/runtime/parachains/src/inclusion_inherent.rs
@@ -104,7 +104,7 @@ decl_module! {
 			let freed = freed_concluded.into_iter().map(|c| (c, FreedReason::Concluded))
 				.chain(freed_timeout.into_iter().map(|c| (c, FreedReason::TimedOut)));
 
-			<scheduler::Module<T>>::schedule(freed.collect());
+			<scheduler::Module<T>>::schedule(freed);
 
 			// Process backed candidates according to scheduled cores.
 			let occupied = <inclusion::Module<T>>::process_candidates(


### PR DESCRIPTION
If a core is freed, we need to make sure it is inserted as free into
availability cores, because we can not be sure that the core is occupied
directly again.