### PR TITLE
Distribute a PoV after seconding it

### DIFF
--- a/node/collation-generation/src/lib.rs
+++ b/node/collation-generation/src/lib.rs
@@ -318,7 +318,7 @@ fn erasure_root(
 ) -> crate::error::Result<Hash> {
 	let available_data = AvailableData {
 		validation_data: persisted_validation,
-		pov,
+		pov: Arc::new(pov),
 	};
 
 	let chunks = polkadot_erasure_coding::obtain_chunks_v1(n_validators, &available_data)?;

--- a/node/core/av-store/src/tests.rs
+++ b/node/core/av-store/src/tests.rs
@@ -282,7 +282,7 @@ fn store_block_works() {
 		};
 
 		let available_data = AvailableData {
-			pov,
+			pov: Arc::new(pov),
 			validation_data: test_state.persisted_validation_data,
 		};
 
@@ -335,7 +335,7 @@ fn store_pov_and_query_chunk_works() {
 		};
 
 		let available_data = AvailableData {
-			pov,
+			pov: Arc::new(pov),
 			validation_data: test_state.persisted_validation_data,
 		};
 
@@ -433,7 +433,7 @@ fn stored_but_not_included_data_is_pruned() {
 		};
 
 		let available_data = AvailableData {
-			pov,
+			pov: Arc::new(pov),
 			validation_data: test_state.persisted_validation_data,
 		};
 
@@ -487,7 +487,7 @@ fn stored_data_kept_until_finalized() {
 		let candidate_hash = candidate.hash();
 
 		let available_data = AvailableData {
-			pov,
+			pov: Arc::new(pov),
 			validation_data: test_state.persisted_validation_data,
 		};
 
@@ -726,12 +726,12 @@ fn forkfullness_works() {
 		let candidate_2_hash = candidate_2.hash();
 
 		let available_data_1 = AvailableData {
-			pov: pov_1,
+			pov: Arc::new(pov_1),
 			validation_data: test_state.persisted_validation_data.clone(),
 		};
 
 		let available_data_2 = AvailableData {
-			pov: pov_2,
+			pov: Arc::new(pov_2),
 			validation_data: test_state.persisted_validation_data,
 		};
 

--- a/node/network/availability-distribution/src/tests.rs
+++ b/node/network/availability-distribution/src/tests.rs
@@ -23,7 +23,7 @@ use polkadot_primitives::v1::{
 	AvailableData, BlockData, CandidateCommitments, CandidateDescriptor, GroupIndex,
 	GroupRotationInfo, HeadData, OccupiedCore, PersistedValidationData, PoV, ScheduledCore,
 };
-use polkadot_subsystem_testhelpers::{self as test_helpers};
+use polkadot_subsystem_testhelpers as test_helpers;
 
 use futures::{executor, future, Future};
 use futures_timer::Delay;
@@ -241,7 +241,7 @@ impl Default for TestState {
 fn make_available_data(test: &TestState, pov: PoV) -> AvailableData {
 	AvailableData {
 		validation_data: test.persisted_validation_data.clone(),
-		pov,
+		pov: Arc::new(pov),
 	}
 }
 

--- a/node/network/pov-distribution/src/lib.rs
+++ b/node/network/pov-distribution/src/lib.rs
@@ -30,18 +30,17 @@ use polkadot_subsystem::{
 		PoVDistributionMessage, RuntimeApiMessage, RuntimeApiRequest, AllMessages, NetworkBridgeMessage,
 	},
 };
-use polkadot_node_subsystem_util::{
-	metrics::{self, prometheus},
-};
-use polkadot_node_network_protocol::{
-	v1 as protocol_v1, ReputationChange as Rep, NetworkBridgeEvent, PeerId, View,
-};
+use polkadot_node_subsystem_util::metrics::{self, prometheus};
+use polkadot_node_network_protocol::{v1 as protocol_v1, ReputationChange as Rep, NetworkBridgeEvent, PeerId, View};
 
 use futures::prelude::*;
 use futures::channel::oneshot;
 
 use std::collections::{hash_map::{Entry, HashMap}, HashSet};
 use std::sync::Arc;
+
+#[cfg(test)]
+mod tests;
 
 const COST_APPARENT_FLOOD: Rep = Rep::new(-500, "Peer appears to be flooding us with PoV requests");
 const COST_UNEXPECTED_POV: Rep = Rep::new(-500, "Peer sent us an unexpected PoV");
@@ -616,6 +615,3 @@ impl metrics::Metrics for Metrics {
 		Ok(Metrics(Some(metrics)))
 	}
 }
-
-#[cfg(test)]
-mod tests;

--- a/primitives/src/v1.rs
+++ b/primitives/src/v1.rs
@@ -494,11 +494,11 @@ pub enum CoreOccupied {
 }
 
 /// This is the data we keep available for each candidate included in the relay chain.
-#[derive(Clone, Encode, Decode)]
-#[cfg_attr(feature = "std", derive(PartialEq, Debug))]
+#[cfg(feature = "std")]
+#[derive(Clone, Encode, Decode, PartialEq, Debug)]
 pub struct AvailableData {
 	/// The Proof-of-Validation of the candidate.
-	pub pov: PoV,
+	pub pov: std::sync::Arc<PoV>,
 	/// The persisted validation data needed for secondary checks.
 	pub validation_data: PersistedValidationData,
 }

--- a/roadmap/implementers-guide/src/node/backing/pov-distribution.md
+++ b/roadmap/implementers-guide/src/node/backing/pov-distribution.md
@@ -17,7 +17,7 @@ Output:
 
 ## Functionality
 
-This network protocol is responsible for distributing [`PoV`s](../../types/availability.md#proof-of-validity) by gossip. Since PoVs are heavy in practice, gossip is far from the most efficient way to distribute them. In the future, this should be replaced by a better network protocol that finds validators who have validated the block and connects to them directly. This protocol is descrbied.
+This network protocol is responsible for distributing [`PoV`s](../../types/availability.md#proof-of-validity) by gossip. Since PoVs are heavy in practice, gossip is far from the most efficient way to distribute them. In the future, this should be replaced by a better network protocol that finds validators who have validated the block and connects to them directly. This protocol is described.
 
 This protocol is described in terms of "us" and our peers, with the understanding that this is the procedure that any honest node will run. It has the following goals:
   - We never have to buffer an unbounded amount of data
@@ -25,7 +25,7 @@ This protocol is described in terms of "us" and our peers, with the understandin
 
 As we are gossiping, we need to track which PoVs our peers are waiting for to avoid sending them data that they are not expecting. It is not reasonable to expect our peers to buffer unexpected PoVs, just as we will not buffer unexpected PoVs. So notifying our peers about what is being awaited is key. However it is important that the notifications system is also bounded.
 
-For this, in order to avoid reaching into the internals of the [Statement Distribution](statement-distribution.md) Subsystem, we can rely on an expected propery of candidate backing: that each validator can second up to 2 candidates per chain head. This will typically be only one, because they are only supposed to issue one, but they can equivocate if they are willing to  be slashed. So we can set a cap on the number of PoVs each peer is allowed to notify us that they are waiting for at a given relay-parent. This cap will be twice the number of validators at that relay-parent. In practice, this is a very lax upper bound that can be reduced much further if desired.
+For this, in order to avoid reaching into the internals of the [Statement Distribution](statement-distribution.md) Subsystem, we can rely on an expected property of candidate backing: that each validator can second up to 2 candidates per chain head. This will typically be only one, because they are only supposed to issue one, but they can equivocate if they are willing to  be slashed. So we can set a cap on the number of PoVs each peer is allowed to notify us that they are waiting for at a given relay-parent. This cap will be twice the number of validators at that relay-parent. In practice, this is a very lax upper bound that can be reduced much further if desired.
 
 The view update mechanism of the [Network Bridge](../utility/network-bridge.md) ensures that peers are only allowed to consider a certain set of relay-parents as live. So this bounding mechanism caps the amount of data we need to store per peer at any time at `sum({ 2 * n_validators_at_head(head) * sizeof(hash) for head in view_heads })`. Additionally, peers should only be allowed to notify us of PoV hashes they are waiting for in the context of relay-parents in our own local view, which means that `n_validators_at_head` is implied to be `0` for relay-parents not in our own local view.
 

--- a/roadmap/implementers-guide/src/types/availability.md
+++ b/roadmap/implementers-guide/src/types/availability.md
@@ -40,7 +40,7 @@ This is the data we want to keep available for each [candidate](candidate.md) in
 ```rust
 struct AvailableData {
     /// The Proof-of-Validation of the candidate.
-    pov: PoV,
+    pov: Arc<PoV>,
     /// The persisted validation data used to check the candidate.
     validation_data: PersistedValidationData,
 }


### PR DESCRIPTION
We need to distribute the PoV after we have seconded it. Other nodes
that will receive our `Secondded` statement and want to validate the
candidate another time will request this PoV from us.