### PR TITLE
Adds integration test based on adder collator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1488,7 +1488,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -1496,7 +1496,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1514,7 +1514,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "chrono",
  "frame-benchmarking",
@@ -1536,7 +1536,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1552,7 +1552,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata"
 version = "12.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -1563,7 +1563,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "bitflags",
  "frame-metadata",
@@ -1588,7 +1588,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "frame-support-procedural-tools",
  "proc-macro2 1.0.24",
@@ -1599,7 +1599,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -1611,7 +1611,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -1621,7 +1621,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -1637,7 +1637,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -1651,7 +1651,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -2496,9 +2496,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-client-transports"
-version = "15.0.0"
+version = "15.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6f7b1cdf66312002e15682a24430728bd13036c641163c016bc53fb686a7c2d"
+checksum = "489b9c612e60c766f751ab40fcb43cbb55a1e10bb44a9b4307ed510ca598cbd7"
 dependencies = [
  "failure",
  "futures 0.1.29",
@@ -2512,9 +2512,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-core"
-version = "15.0.0"
+version = "15.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30b12567a31d48588a65b6cf870081e6ba1d7b2ae353977cb9820d512e69c70"
+checksum = "0745a6379e3edc893c84ec203589790774e4247420033e71a76d3ab4687991fa"
 dependencies = [
  "futures 0.1.29",
  "log 0.4.11",
@@ -2525,18 +2525,18 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-core-client"
-version = "15.0.0"
+version = "15.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d175ca0cf77439b5495612bf216c650807d252d665b4b70ab2eebd895a88fac1"
+checksum = "6f764902d7b891344a0acb65625f32f6f7c6db006952143bd650209fbe7d94db"
 dependencies = [
  "jsonrpc-client-transports",
 ]
 
 [[package]]
 name = "jsonrpc-derive"
-version = "15.0.0"
+version = "15.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2cc6ea7f785232d9ca8786a44e9fa698f92149dcdc1acc4aa1fc69c4993d79e"
+checksum = "99a847f9ec7bb52149b2786a17c9cb260d6effc6b8eeb8c16b343a487a7563a3"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.24",
@@ -2546,9 +2546,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-http-server"
-version = "15.0.0"
+version = "15.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9996b26c0c7a59626d0ed6c5ec8bf06218e62ce1474bd2849f9b9fd38a0158c0"
+checksum = "4fb5c4513b7b542f42da107942b7b759f27120b5cc894729f88254b28dff44b7"
 dependencies = [
  "hyper 0.12.35",
  "jsonrpc-core",
@@ -2561,9 +2561,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-ipc-server"
-version = "15.0.0"
+version = "15.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e8f2278fb2b277175b6e21b23e7ecf30e78daff5ee301d0a2a411d9a821a0a"
+checksum = "cf50e53e4eea8f421a7316c5f63e395f7bc7c4e786a6dc54d76fab6ff7aa7ce7"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-server-utils",
@@ -2575,9 +2575,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-pubsub"
-version = "15.0.0"
+version = "15.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f389c5cd1f3db258a99296892c21047e21ae73ff4c0e2d39650ea86fe994b4c7"
+checksum = "639558e0604013be9787ae52f798506ae42bf4220fe587bdc5625871cc8b9c77"
 dependencies = [
  "jsonrpc-core",
  "log 0.4.11",
@@ -2588,9 +2588,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-server-utils"
-version = "15.0.0"
+version = "15.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c623e1895d0d9110cb0ea7736cfff13191ff52335ad33b21bd5c775ea98b27af"
+checksum = "72f1f3990650c033bd8f6bd46deac76d990f9bbfb5f8dc8c4767bf0a00392176"
 dependencies = [
  "bytes 0.4.12",
  "globset",
@@ -2604,9 +2604,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-ws-server"
-version = "15.0.0"
+version = "15.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436a92034d0137ab3e3c64a7a6350b428f31cb4d7d1a89f284bcdbcd98a7bc56"
+checksum = "6596fe75209b73a2a75ebe1dce4e60e03b88a2b25e8807b667597f6315150d22"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-server-utils",
@@ -3841,7 +3841,7 @@ checksum = "7a1250cdd103eef6bd542b5ae82989f931fc00a41a27f60377338241594410f3"
 [[package]]
 name = "pallet-authority-discovery"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3857,7 +3857,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3872,7 +3872,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3897,7 +3897,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3911,7 +3911,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3927,7 +3927,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3942,7 +3942,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3957,7 +3957,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3978,7 +3978,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -3994,7 +3994,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4014,7 +4014,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4031,7 +4031,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4045,7 +4045,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4061,7 +4061,7 @@ dependencies = [
 [[package]]
 name = "pallet-nicks"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4075,7 +4075,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4090,7 +4090,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4111,7 +4111,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4127,7 +4127,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4140,7 +4140,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "enumflags2",
  "frame-support",
@@ -4155,7 +4155,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4170,7 +4170,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4190,7 +4190,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4206,7 +4206,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4220,7 +4220,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4242,7 +4242,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.24",
@@ -4253,7 +4253,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4267,7 +4267,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4285,7 +4285,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4302,7 +4302,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -4320,7 +4320,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -4333,7 +4333,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4348,7 +4348,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4364,7 +4364,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -4855,6 +4855,7 @@ version = "0.8.26"
 dependencies = [
  "frame-benchmarking-cli",
  "log 0.4.11",
+ "polkadot-parachain",
  "polkadot-service",
  "sc-cli",
  "sc-service",
@@ -5597,6 +5598,7 @@ name = "polkadot-test-client"
 version = "0.8.26"
 dependencies = [
  "parity-scale-codec",
+ "polkadot-node-subsystem",
  "polkadot-primitives",
  "polkadot-test-runtime",
  "polkadot-test-service",
@@ -5687,7 +5689,10 @@ dependencies = [
  "pallet-balances",
  "pallet-staking",
  "pallet-transaction-payment",
+ "polkadot-node-primitives",
+ "polkadot-node-subsystem",
  "polkadot-overseer",
+ "polkadot-parachain",
  "polkadot-primitives",
  "polkadot-rpc",
  "polkadot-runtime-common",
@@ -5703,12 +5708,12 @@ dependencies = [
  "sc-consensus-babe",
  "sc-executor",
  "sc-finality-grandpa",
- "sc-informant",
  "sc-network",
  "sc-service",
  "sc-transaction-pool",
  "serde_json",
  "sp-arithmetic",
+ "sp-authority-discovery",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-babe",
@@ -6574,7 +6579,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "async-trait",
  "bytes 0.5.6",
@@ -6604,7 +6609,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -6628,7 +6633,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -6645,7 +6650,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -6666,7 +6671,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.24",
@@ -6677,7 +6682,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
@@ -6721,7 +6726,7 @@ dependencies = [
 [[package]]
 name = "sc-cli-proc-macro"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.24",
@@ -6732,7 +6737,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "derive_more",
  "fnv",
@@ -6769,7 +6774,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "blake2-rfc",
  "hash-db",
@@ -6799,7 +6804,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "sc-client-api",
  "sp-blockchain",
@@ -6810,7 +6815,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "derive_more",
  "fork-tree",
@@ -6855,7 +6860,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -6879,7 +6884,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -6892,7 +6897,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -6916,7 +6921,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-uncles"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "log 0.4.11",
  "sc-client-api",
@@ -6930,7 +6935,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "derive_more",
  "lazy_static",
@@ -6959,7 +6964,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "derive_more",
  "log 0.4.11",
@@ -6976,7 +6981,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "log 0.4.11",
  "parity-scale-codec",
@@ -6991,7 +6996,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "log 0.4.11",
  "parity-scale-codec",
@@ -7009,7 +7014,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "derive_more",
  "finality-grandpa",
@@ -7046,7 +7051,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa-rpc"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "derive_more",
  "finality-grandpa",
@@ -7070,7 +7075,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "ansi_term 0.12.1",
  "futures 0.3.5",
@@ -7088,7 +7093,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -7108,7 +7113,7 @@ dependencies = [
 [[package]]
 name = "sc-light"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "hash-db",
  "lazy_static",
@@ -7127,7 +7132,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "async-std",
  "async-trait",
@@ -7181,7 +7186,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -7196,7 +7201,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "bytes 0.5.6",
  "fnv",
@@ -7223,7 +7228,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "futures 0.3.5",
  "libp2p",
@@ -7236,7 +7241,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "log 0.4.11",
  "substrate-prometheus-endpoint",
@@ -7245,7 +7250,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "futures 0.3.5",
  "hash-db",
@@ -7278,7 +7283,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -7302,7 +7307,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "futures 0.1.29",
  "jsonrpc-core",
@@ -7320,7 +7325,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "derive_more",
  "directories",
@@ -7384,7 +7389,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "log 0.4.11",
  "parity-scale-codec",
@@ -7398,7 +7403,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -7417,7 +7422,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -7438,7 +7443,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "erased-serde",
  "log 0.4.11",
@@ -7457,7 +7462,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-graph"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -7478,7 +7483,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -7916,7 +7921,7 @@ dependencies = [
 [[package]]
 name = "sp-allocator"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "derive_more",
  "log 0.4.11",
@@ -7928,7 +7933,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
@@ -7943,7 +7948,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate",
@@ -7955,7 +7960,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -7967,7 +7972,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "integer-sqrt",
  "num-traits 0.2.12",
@@ -7980,7 +7985,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7992,7 +7997,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -8003,7 +8008,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -8015,7 +8020,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "log 0.4.11",
  "lru 0.4.3",
@@ -8032,7 +8037,7 @@ dependencies = [
 [[package]]
 name = "sp-chain-spec"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "serde",
  "serde_json",
@@ -8041,7 +8046,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -8067,7 +8072,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "merlin",
  "parity-scale-codec",
@@ -8087,7 +8092,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -8096,7 +8101,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "parity-scale-codec",
  "schnorrkel",
@@ -8108,7 +8113,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "base58",
  "blake2-rfc",
@@ -8152,7 +8157,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "kvdb",
  "parking_lot 0.10.2",
@@ -8161,7 +8166,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -8171,7 +8176,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -8182,7 +8187,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "finality-grandpa",
  "log 0.4.11",
@@ -8199,7 +8204,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.10.2",
@@ -8211,7 +8216,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "futures 0.3.5",
  "hash-db",
@@ -8235,7 +8240,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -8246,7 +8251,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -8262,7 +8267,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -8274,7 +8279,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections-compact"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.24",
@@ -8285,7 +8290,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -8295,7 +8300,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "backtrace",
  "log 0.4.11",
@@ -8304,7 +8309,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "serde",
  "sp-core",
@@ -8313,7 +8318,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -8335,7 +8340,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "parity-scale-codec",
  "primitive-types",
@@ -8351,7 +8356,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -8363,7 +8368,7 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "serde",
  "serde_json",
@@ -8372,7 +8377,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -8385,7 +8390,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -8395,7 +8400,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "hash-db",
  "log 0.4.11",
@@ -8417,12 +8422,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 
 [[package]]
 name = "sp-storage"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -8435,7 +8440,7 @@ dependencies = [
 [[package]]
 name = "sp-tasks"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "log 0.4.11",
  "sp-core",
@@ -8448,7 +8453,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -8462,7 +8467,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "log 0.4.11",
  "parity-scale-codec",
@@ -8475,7 +8480,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -8490,7 +8495,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -8504,7 +8509,7 @@ dependencies = [
 [[package]]
 name = "sp-utils"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "futures 0.3.5",
  "futures-core",
@@ -8516,7 +8521,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -8528,7 +8533,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -8670,7 +8675,7 @@ dependencies = [
 [[package]]
 name = "substrate-browser-utils"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "chrono",
  "console_error_panic_hook",
@@ -8696,7 +8701,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "platforms",
 ]
@@ -8704,7 +8709,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.5",
@@ -8727,7 +8732,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "async-std",
  "derive_more",
@@ -8741,7 +8746,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "futures 0.1.29",
  "futures 0.3.5",
@@ -8768,7 +8773,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-utils"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "futures 0.3.5",
  "substrate-test-utils-derive",
@@ -8778,7 +8783,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-utils-derive"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#b7712fed2c58a898f7706e16861d7109c8f585a5"
+source = "git+https://github.com/paritytech/substrate#2e7292cd84121db8bcd2317c1ad70e348ee52f7a"
 dependencies = [
  "proc-macro-crate",
  "quote 1.0.7",
@@ -8901,6 +8906,7 @@ name = "test-parachain-adder-collator"
 version = "0.7.26"
 dependencies = [
  "futures 0.3.5",
+ "futures-timer 3.0.2",
  "log 0.4.11",
  "parity-scale-codec",
  "polkadot-cli",
@@ -8909,11 +8915,16 @@ dependencies = [
  "polkadot-parachain",
  "polkadot-primitives",
  "polkadot-service",
+ "polkadot-test-service",
  "sc-authority-discovery",
  "sc-cli",
+ "sc-service",
  "sp-core",
+ "sp-keyring",
  "structopt",
+ "substrate-test-utils",
  "test-parachain-adder",
+ "tokio 0.2.21",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -17,17 +17,19 @@ crate-type = ["cdylib", "rlib"]
 log = "0.4.11"
 thiserror = "1.0.21"
 structopt = { version = "0.3.8", optional = true }
+wasm-bindgen = { version = "0.2.57", optional = true }
+wasm-bindgen-futures = { version = "0.4.7", optional = true }
+
+service = { package = "polkadot-service", path = "../node/service", default-features = false, optional = true }
+polkadot-parachain = { path = "../parachain", optional = true }
+
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sc-tracing = { git = "https://github.com/paritytech/substrate", branch = "master" }
-service = { package = "polkadot-service", path = "../node/service", default-features = false, optional = true }
-
 frame-benchmarking-cli = { git = "https://github.com/paritytech/substrate", branch = "master", optional = true }
 sc-cli = { git = "https://github.com/paritytech/substrate", branch = "master", optional = true }
 sc-service = { git = "https://github.com/paritytech/substrate", branch = "master", optional = true }
-
-wasm-bindgen = { version = "0.2.57", optional = true }
-wasm-bindgen-futures = { version = "0.4.7", optional = true }
 browser-utils = { package = "substrate-browser-utils", git = "https://github.com/paritytech/substrate", branch = "master", optional = true }
+
 # this crate is used only to enable `trie-memory-tracker` feature
 # see https://github.com/paritytech/substrate/pull/6745
 sp-trie = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
@@ -36,7 +38,7 @@ sp-trie = { git = "https://github.com/paritytech/substrate", branch = "master", 
 substrate-build-script-utils = { git = "https://github.com/paritytech/substrate", branch = "master" }
 
 [features]
-default = [ "wasmtime", "db", "cli", "full-node", "trie-memory-tracker" ]
+default = [ "wasmtime", "db", "cli", "full-node", "trie-memory-tracker", "polkadot-parachain" ]
 wasmtime = [ "sc-cli/wasmtime" ]
 db = [ "service/db" ]
 cli = [

--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -219,11 +219,11 @@ pub fn run() -> Result<()> {
 		Some(Subcommand::ValidationWorker(cmd)) => {
 			let _ = sc_cli::init_logger("", sc_tracing::TracingReceiver::Log, None);
 
-			if cfg!(feature = "browser") {
+			if cfg!(feature = "browser") || cfg!(target_os = "android") {
 				Err(sc_cli::Error::Input("Cannot run validation worker in browser".into()))
 			} else {
-				#[cfg(all(not(feature = "browser"), not(feature = "service-rewr")))]
-				service::run_validation_worker(&cmd.mem_id)?;
+				#[cfg(not(all(target_os = "android", feature = "browser")))]
+				polkadot_parachain::wasm_executor::run_worker(&cmd.mem_id)?;
 				Ok(())
 			}
 		},

--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -222,7 +222,7 @@ pub fn run() -> Result<()> {
 			if cfg!(feature = "browser") || cfg!(target_os = "android") {
 				Err(sc_cli::Error::Input("Cannot run validation worker in browser".into()))
 			} else {
-				#[cfg(not(all(target_os = "android", feature = "browser")))]
+				#[cfg(not(any(target_os = "android", feature = "browser")))]
 				polkadot_parachain::wasm_executor::run_worker(&cmd.mem_id)?;
 				Ok(())
 			}

--- a/node/core/candidate-validation/src/lib.rs
+++ b/node/core/candidate-validation/src/lib.rs
@@ -31,19 +31,14 @@ use polkadot_subsystem::{
 		ValidationFailed, RuntimeApiRequest,
 	},
 };
-use polkadot_node_subsystem_util::{
-	metrics::{self, prometheus},
-};
+use polkadot_node_subsystem_util::metrics::{self, prometheus};
 use polkadot_subsystem::errors::RuntimeApiError;
 use polkadot_node_primitives::{ValidationResult, InvalidCandidate};
 use polkadot_primitives::v1::{
 	ValidationCode, PoV, CandidateDescriptor, PersistedValidationData,
 	OccupiedCoreAssumption, Hash, ValidationOutputs,
 };
-use polkadot_parachain::wasm_executor::{
-	self, ValidationPool, ExecutionMode, ValidationError,
-	InvalidCandidate as WasmInvalidCandidate,
-};
+use polkadot_parachain::wasm_executor::{self, ExecutionMode, ValidationError, InvalidCandidate as WasmInvalidCandidate};
 use polkadot_parachain::primitives::{ValidationResult as WasmValidationResult, ValidationParams};
 
 use parity_scale_codec::Encode;
@@ -60,57 +55,13 @@ const LOG_TARGET: &'static str = "candidate_validation";
 pub struct CandidateValidationSubsystem<S> {
 	spawn: S,
 	metrics: Metrics,
-}
-
-#[derive(Clone)]
-struct MetricsInner {
-	validation_requests: prometheus::CounterVec<prometheus::U64>,
-}
-
-/// Candidate validation metrics.
-#[derive(Default, Clone)]
-pub struct Metrics(Option<MetricsInner>);
-
-impl Metrics {
-	fn on_validation_event(&self, event: &Result<ValidationResult, ValidationFailed>) {
-		if let Some(metrics) = &self.0 {
-			match event {
-				Ok(ValidationResult::Valid(_, _)) => {
-					metrics.validation_requests.with_label_values(&["valid"]).inc();
-				},
-				Ok(ValidationResult::Invalid(_)) => {
-					metrics.validation_requests.with_label_values(&["invalid"]).inc();
-				},
-				Err(_) => {
-					metrics.validation_requests.with_label_values(&["validation failure"]).inc();
-				},
-			}
-		}
-	}
-}
-
-impl metrics::Metrics for Metrics {
-	fn try_register(registry: &prometheus::Registry) -> Result<Self, prometheus::PrometheusError> {
-		let metrics = MetricsInner {
-			validation_requests: prometheus::register(
-				prometheus::CounterVec::new(
-					prometheus::Opts::new(
-						"parachain_validation_requests_total",
-						"Number of validation requests served.",
-					),
-					&["validity"],
-				)?,
-				registry,
-			)?,
-		};
-		Ok(Metrics(Some(metrics)))
-	}
+	execution_mode: ExecutionMode,
 }
 
 impl<S> CandidateValidationSubsystem<S> {
 	/// Create a new `CandidateValidationSubsystem` with the given task spawner.
-	pub fn new(spawn: S, metrics: Metrics) -> Self {
-		CandidateValidationSubsystem { spawn, metrics }
+	pub fn new(spawn: S, metrics: Metrics, execution_mode: ExecutionMode) -> Self {
+		CandidateValidationSubsystem { spawn, metrics, execution_mode }
 	}
 }
 
@@ -119,7 +70,7 @@ impl<S, C> Subsystem<C> for CandidateValidationSubsystem<S> where
 	S: SpawnNamed + Clone + 'static,
 {
 	fn start(self, ctx: C) -> SpawnedSubsystem {
-		let future = run(ctx, self.spawn, self.metrics)
+		let future = run(ctx, self.spawn, self.metrics, self.execution_mode)
 			.map_err(|e| SubsystemError::with_origin("candidate-validation", e))
 			.boxed();
 		SpawnedSubsystem {
@@ -133,11 +84,8 @@ async fn run(
 	mut ctx: impl SubsystemContext<Message = CandidateValidationMessage>,
 	spawn: impl SpawnNamed + Clone + 'static,
 	metrics: Metrics,
-)
-	-> SubsystemResult<()>
-{
-	let execution_mode = ExecutionMode::ExternalProcessSelfHost(ValidationPool::new());
-
+	execution_mode: ExecutionMode,
+) -> SubsystemResult<()> {
 	loop {
 		match ctx.recv().await? {
 			FromOverseer::Signal(OverseerSignal::ActiveLeaves(_)) => {}
@@ -494,6 +442,51 @@ fn validate_candidate_exhaustive<B: ValidationBackend, S: SpawnNamed + 'static>(
 			};
 			Ok(ValidationResult::Valid(outputs, persisted_validation_data))
 		}
+	}
+}
+
+#[derive(Clone)]
+struct MetricsInner {
+	validation_requests: prometheus::CounterVec<prometheus::U64>,
+}
+
+/// Candidate validation metrics.
+#[derive(Default, Clone)]
+pub struct Metrics(Option<MetricsInner>);
+
+impl Metrics {
+	fn on_validation_event(&self, event: &Result<ValidationResult, ValidationFailed>) {
+		if let Some(metrics) = &self.0 {
+			match event {
+				Ok(ValidationResult::Valid(_, _)) => {
+					metrics.validation_requests.with_label_values(&["valid"]).inc();
+				},
+				Ok(ValidationResult::Invalid(_)) => {
+					metrics.validation_requests.with_label_values(&["invalid"]).inc();
+				},
+				Err(_) => {
+					metrics.validation_requests.with_label_values(&["validation failure"]).inc();
+				},
+			}
+		}
+	}
+}
+
+impl metrics::Metrics for Metrics {
+	fn try_register(registry: &prometheus::Registry) -> Result<Self, prometheus::PrometheusError> {
+		let metrics = MetricsInner {
+			validation_requests: prometheus::register(
+				prometheus::CounterVec::new(
+					prometheus::Opts::new(
+						"parachain_validation_requests_total",
+						"Number of validation requests served.",
+					),
+					&["validity"],
+				)?,
+				registry,
+			)?,
+		};
+		Ok(Metrics(Some(metrics)))
 	}
 }
 

--- a/node/service/src/chain_spec.rs
+++ b/node/service/src/chain_spec.rs
@@ -771,7 +771,7 @@ fn rococo_staging_testnet_config_genesis(wasm_binary: &[u8]) -> rococo_runtime::
 		pallet_sudo: Some(rococo_runtime::SudoConfig {
 			key: endowed_accounts[0].clone(),
 		}),
-		parachains_configuration: Some(rococo_runtime::ParachainConfigConfig {
+		parachains_configuration: Some(rococo_runtime::ParachainsConfigurationConfig {
 			config: polkadot_runtime_parachains::configuration::HostConfiguration {
 				validation_upgrade_frequency: 600u32,
 				validation_upgrade_delay: 300,
@@ -1223,7 +1223,7 @@ pub fn rococo_testnet_genesis(
 		}),
 		pallet_staking: Some(Default::default()),
 		pallet_sudo: Some(rococo_runtime::SudoConfig { key: root_key }),
-		parachains_configuration: Some(rococo_runtime::ParachainConfigConfig {
+		parachains_configuration: Some(rococo_runtime::ParachainsConfigurationConfig {
 			config: polkadot_runtime_parachains::configuration::HostConfiguration {
 				validation_upgrade_frequency: 600u32,
 				validation_upgrade_delay: 300,

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -50,7 +50,7 @@ use service::RpcHandlers;
 pub use self::client::{AbstractClient, Client, ClientHandle, ExecuteWithClient, RuntimeApiCollection};
 pub use chain_spec::{PolkadotChainSpec, KusamaChainSpec, WestendChainSpec, RococoChainSpec};
 pub use consensus_common::{Proposal, SelectChain, BlockImport, RecordProof, block_validation::Chain};
-pub use polkadot_parachain::wasm_executor::run_worker as run_validation_worker;
+pub use polkadot_parachain::wasm_executor::ExecutionMode;
 pub use polkadot_primitives::v1::{Block, BlockId, CollatorId, Hash, Id as ParaId};
 pub use sc_client_api::{Backend, ExecutionStrategy, CallExecutor};
 pub use sc_consensus::LongestChain;
@@ -296,6 +296,7 @@ fn real_overseer<Spawner, RuntimeClient>(
 	registry: Option<&Registry>,
 	spawner: Spawner,
 	_: IsCollator,
+	_: ExecutionMode,
 ) -> Result<(Overseer<Spawner>, OverseerHandler), Error>
 where
 	RuntimeClient: 'static + ProvideRuntimeApi<Block> + HeaderBackend<Block>,
@@ -321,6 +322,7 @@ fn real_overseer<Spawner, RuntimeClient>(
 	registry: Option<&Registry>,
 	spawner: Spawner,
 	is_collator: IsCollator,
+	execution_mode: ExecutionMode,
 ) -> Result<(Overseer<Spawner>, OverseerHandler), Error>
 where
 	RuntimeClient: 'static + ProvideRuntimeApi<Block> + HeaderBackend<Block>,
@@ -375,6 +377,7 @@ where
 		candidate_validation: CandidateValidationSubsystem::new(
 			spawner.clone(),
 			Metrics::register(registry)?,
+			execution_mode,
 		),
 		chain_api: ChainApiSubsystem::new(
 			runtime_client.clone(),
@@ -476,6 +479,7 @@ pub fn new_full<RuntimeApi, Executor>(
 	is_collator: IsCollator,
 	grandpa_pause: Option<(u32, u32)>,
 	authority_discovery_config: Option<AuthorityWorkerConfig>,
+	execution_mode: ExecutionMode,
 ) -> Result<NewFull<Arc<FullClient<RuntimeApi, Executor>>>, Error>
 	where
 		RuntimeApi: ConstructRuntimeApi<Block, FullClient<RuntimeApi, Executor>> + Send + Sync + 'static,
@@ -611,6 +615,7 @@ pub fn new_full<RuntimeApi, Executor>(
 			prometheus_registry.as_ref(),
 			spawner,
 			is_collator,
+			execution_mode,
 		)?;
 		let overseer_handler_clone = overseer_handler.clone();
 
@@ -910,6 +915,7 @@ pub fn build_full(
 			is_collator,
 			grandpa_pause,
 			authority_discovery_config,
+			Default::default(),
 		).map(|full| full.with_client(Client::Rococo))
 	} else if config.chain_spec.is_kusama() {
 		new_full::<kusama_runtime::RuntimeApi, KusamaExecutor>(
@@ -917,6 +923,7 @@ pub fn build_full(
 			is_collator,
 			grandpa_pause,
 			authority_discovery_config,
+			Default::default(),
 		).map(|full| full.with_client(Client::Kusama))
 	} else if config.chain_spec.is_westend() {
 		new_full::<westend_runtime::RuntimeApi, WestendExecutor>(
@@ -924,6 +931,7 @@ pub fn build_full(
 			is_collator,
 			grandpa_pause,
 			authority_discovery_config,
+			Default::default(),
 		).map(|full| full.with_client(Client::Westend))
 	} else {
 		new_full::<polkadot_runtime::RuntimeApi, PolkadotExecutor>(
@@ -931,6 +939,7 @@ pub fn build_full(
 			is_collator,
 			grandpa_pause,
 			authority_discovery_config,
+			Default::default(),
 		).map(|full| full.with_client(Client::Polkadot))
 	}
 }

--- a/node/subsystem-util/src/lib.rs
+++ b/node/subsystem-util/src/lib.rs
@@ -292,6 +292,7 @@ pub async fn signing_key(validators: &[ValidatorId], keystore: SyncCryptoStorePt
 ///
 /// It can be created if the local node is a validator in the context of a particular
 /// relay chain block.
+#[derive(Debug)]
 pub struct Validator {
 	signing_context: SigningContext,
 	key: ValidatorId,

--- a/node/test/client/Cargo.toml
+++ b/node/test/client/Cargo.toml
@@ -11,6 +11,7 @@ codec = { package = "parity-scale-codec", version = "1.3.4", default-features = 
 polkadot-test-runtime = { path = "../../../runtime/test-runtime" }
 polkadot-test-service = { path = "../service" }
 polkadot-primitives = { path = "../../../primitives" }
+polkadot-node-subsystem = { path = "../../subsystem" }
 
 # Substrate dependencies
 substrate-test-client = { git = "https://github.com/paritytech/substrate", branch = "master" }

--- a/node/test/client/src/block_builder.rs
+++ b/node/test/client/src/block_builder.rs
@@ -69,7 +69,14 @@ impl InitPolkadotBlockBuilder for Client {
 
 		inherent_data
 			.put_data(sp_timestamp::INHERENT_IDENTIFIER, &timestamp)
-			.expect("Put timestamp failed");
+			.expect("Put timestamp inherent data");
+
+		inherent_data
+			.put_data(
+				polkadot_primitives::v1::INCLUSION_INHERENT_IDENTIFIER,
+				&polkadot_node_subsystem::messages::ProvisionerInherentData::default(),
+			)
+			.expect("Put inclusion inherent data");
 
 		let inherents = block_builder.create_inherents(inherent_data).expect("Creates inherents");
 

--- a/node/test/service/Cargo.toml
+++ b/node/test/service/Cargo.toml
@@ -15,13 +15,17 @@ tempfile = "3.1.0"
 # Polkadot dependencies
 polkadot-overseer = { path = "../../overseer" }
 polkadot-primitives = { path = "../../../primitives" }
+polkadot-parachain = { path = "../../../parachain" }
 polkadot-rpc = { path = "../../../rpc" }
 polkadot-runtime-common = { path = "../../../runtime/common" }
 polkadot-service = { path = "../../service" }
+polkadot-node-subsystem = { path = "../../subsystem" }
+polkadot-node-primitives = { path = "../../primitives" }
 polkadot-test-runtime = { path = "../../../runtime/test-runtime" }
 polkadot-runtime-parachains = { path = "../../../runtime/parachains" }
 
 # Substrate dependencies
+sp-authority-discovery = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sc-authority-discovery = { git = "https://github.com/paritytech/substrate", branch = "master" }
 babe = { package = "sc-consensus-babe", git = "https://github.com/paritytech/substrate", branch = "master" }
 babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/paritytech/substrate", branch = "master" }
@@ -39,7 +43,6 @@ sc-cli = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sc-consensus = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sc-executor = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sc-informant = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sc-network = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sc-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "master" }
 service = { package = "sc-service", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }

--- a/node/test/service/src/chain_spec.rs
+++ b/node/test/service/src/chain_spec.rs
@@ -16,10 +16,11 @@
 
 //! Chain specifications for the test runtime.
 
+use sp_authority_discovery::AuthorityId as AuthorityDiscoveryId;
 use babe_primitives::AuthorityId as BabeId;
 use grandpa::AuthorityId as GrandpaId;
 use pallet_staking::Forcing;
-use polkadot_primitives::v0::{ValidatorId, AccountId};
+use polkadot_primitives::v1::{ValidatorId, AccountId};
 use polkadot_service::chain_spec::{get_account_id_from_seed, get_from_seed, Extensions};
 use polkadot_test_runtime::constants::currency::DOTS;
 use sc_chain_spec::{ChainSpec, ChainType};
@@ -53,7 +54,6 @@ pub fn polkadot_local_testnet_genesis() -> polkadot_test_runtime::GenesisConfig 
 		vec![
 			get_authority_keys_from_seed("Alice"),
 			get_authority_keys_from_seed("Bob"),
-			get_authority_keys_from_seed("Charlie"),
 		],
 		get_account_id_from_seed::<sr25519::Public>("Alice"),
 		None,
@@ -63,13 +63,14 @@ pub fn polkadot_local_testnet_genesis() -> polkadot_test_runtime::GenesisConfig 
 /// Helper function to generate stash, controller and session key from seed
 fn get_authority_keys_from_seed(
 	seed: &str,
-) -> (AccountId, AccountId, BabeId, GrandpaId, ValidatorId) {
+) -> (AccountId, AccountId, BabeId, GrandpaId, ValidatorId, AuthorityDiscoveryId) {
 	(
 		get_account_id_from_seed::<sr25519::Public>(&format!("{}//stash", seed)),
 		get_account_id_from_seed::<sr25519::Public>(seed),
 		get_from_seed::<BabeId>(seed),
 		get_from_seed::<GrandpaId>(seed),
 		get_from_seed::<ValidatorId>(seed),
+		get_from_seed::<AuthorityDiscoveryId>(seed),
 	)
 }
 
@@ -92,46 +93,47 @@ fn testnet_accounts() -> Vec<AccountId> {
 
 /// Helper function to create polkadot GenesisConfig for testing
 fn polkadot_testnet_genesis(
-	initial_authorities: Vec<(AccountId, AccountId, BabeId, GrandpaId, ValidatorId)>,
+	initial_authorities: Vec<(AccountId, AccountId, BabeId, GrandpaId, ValidatorId, AuthorityDiscoveryId)>,
 	root_key: AccountId,
 	endowed_accounts: Option<Vec<AccountId>>,
 ) -> polkadot_test_runtime::GenesisConfig {
-	use polkadot_test_runtime as polkadot;
+	use polkadot_test_runtime as runtime;
 
 	let endowed_accounts: Vec<AccountId> = endowed_accounts.unwrap_or_else(testnet_accounts);
 
 	const ENDOWMENT: u128 = 1_000_000 * DOTS;
 	const STASH: u128 = 100 * DOTS;
 
-	polkadot::GenesisConfig {
-		frame_system: Some(polkadot::SystemConfig {
-			code: polkadot::WASM_BINARY.expect("Wasm binary must be built for testing").to_vec(),
+	runtime::GenesisConfig {
+		frame_system: Some(runtime::SystemConfig {
+			code: runtime::WASM_BINARY.expect("Wasm binary must be built for testing").to_vec(),
 			..Default::default()
 		}),
-		pallet_indices: Some(polkadot::IndicesConfig { indices: vec![] }),
-		pallet_balances: Some(polkadot::BalancesConfig {
+		pallet_indices: Some(runtime::IndicesConfig { indices: vec![] }),
+		pallet_balances: Some(runtime::BalancesConfig {
 			balances: endowed_accounts
 				.iter()
 				.map(|k| (k.clone(), ENDOWMENT))
 				.collect(),
 		}),
-		pallet_session: Some(polkadot::SessionConfig {
+		pallet_session: Some(runtime::SessionConfig {
 			keys: initial_authorities
 				.iter()
 				.map(|x| {
 					(
 						x.0.clone(),
 						x.0.clone(),
-						polkadot_test_runtime::SessionKeys {
+						runtime::SessionKeys {
 							babe: x.2.clone(),
 							grandpa: x.3.clone(),
 							parachain_validator: x.4.clone(),
+							authority_discovery: x.5.clone(),
 						},
 					)
 				})
 				.collect::<Vec<_>>(),
 		}),
-		pallet_staking: Some(polkadot::StakingConfig {
+		pallet_staking: Some(runtime::StakingConfig {
 			minimum_validator_count: 1,
 			validator_count: 2,
 			stakers: initial_authorities
@@ -141,7 +143,7 @@ fn polkadot_testnet_genesis(
 						x.0.clone(),
 						x.1.clone(),
 						STASH,
-						polkadot::StakerStatus::Validator,
+						runtime::StakerStatus::Validator,
 					)
 				})
 				.collect(),
@@ -152,13 +154,24 @@ fn polkadot_testnet_genesis(
 		}),
 		pallet_babe: Some(Default::default()),
 		pallet_grandpa: Some(Default::default()),
-		pallet_authority_discovery: Some(polkadot::AuthorityDiscoveryConfig { keys: vec![] }),
-		claims: Some(polkadot::ClaimsConfig {
+		pallet_authority_discovery: Some(runtime::AuthorityDiscoveryConfig { keys: vec![] }),
+		claims: Some(runtime::ClaimsConfig {
 			claims: vec![],
 			vesting: vec![],
 		}),
-		pallet_vesting: Some(polkadot::VestingConfig { vesting: vec![] }),
-		pallet_sudo: Some(polkadot::SudoConfig { key: root_key }),
+		pallet_vesting: Some(runtime::VestingConfig { vesting: vec![] }),
+		pallet_sudo: Some(runtime::SudoConfig { key: root_key }),
+		parachains_configuration: Some(runtime::ParachainsConfigurationConfig {
+			config: polkadot_runtime_parachains::configuration::HostConfiguration {
+				validation_upgrade_frequency: 10u32,
+				validation_upgrade_delay: 5,
+				acceptance_period: 1200,
+				max_code_size: 5 * 1024 * 1024,
+				max_head_data_size: 32 * 1024,
+				group_rotation_frequency: 10,
+				..Default::default()
+			},
+		}),
 	}
 }
 

--- a/node/test/service/tests/build-blocks.rs
+++ b/node/test/service/tests/build-blocks.rs
@@ -21,13 +21,13 @@ use sp_keyring::Sr25519Keyring;
 
 #[substrate_test_utils::test]
 async fn ensure_test_service_build_blocks(task_executor: TaskExecutor) {
-	let mut alice = run_test_node(
+	let mut alice = run_validator_node(
 		task_executor.clone(),
 		Sr25519Keyring::Alice,
 		|| {},
 		Vec::new(),
 	);
-	let mut bob = run_test_node(
+	let mut bob = run_validator_node(
 		task_executor.clone(),
 		Sr25519Keyring::Bob,
 		|| {},

--- a/node/test/service/tests/call-function.rs
+++ b/node/test/service/tests/call-function.rs
@@ -20,7 +20,7 @@ use sp_keyring::Sr25519Keyring::{Alice, Bob};
 
 #[substrate_test_utils::test]
 async fn call_function_actually_work(task_executor: TaskExecutor) {
-	let alice = run_test_node(task_executor, Alice, || {}, Vec::new());
+	let alice = run_validator_node(task_executor, Alice, || {}, Vec::new());
 
 	let function = polkadot_test_runtime::Call::Balances(pallet_balances::Call::transfer(
 		Default::default(),
@@ -37,7 +37,7 @@ async fn call_function_actually_work(task_executor: TaskExecutor) {
 	assert_eq!(
 		result.as_str().map(|x| x.starts_with("0x")),
 		Some(true),
-		"result starts with 0x"
+		"result starts with 0x",
 	);
 
 	alice.task_manager.clean_shutdown().await;

--- a/parachain/src/wasm_executor/mod.rs
+++ b/parachain/src/wasm_executor/mod.rs
@@ -37,35 +37,14 @@ const MAX_RUNTIME_MEM: usize = 1024 * 1024 * 1024; // 1 GiB
 const MAX_CODE_MEM: usize = 16 * 1024 * 1024; // 16 MiB
 const MAX_VALIDATION_RESULT_HEADER_MEM: usize = MAX_CODE_MEM + 1024; // 16.001 MiB
 
-/// A stub validation-pool defined when compiling for Android or WASM.
-#[cfg(any(target_os = "android", target_os = "unknown"))]
-#[derive(Clone)]
-pub struct ValidationPool {
-	_inner: (), // private field means not publicly-instantiable
-}
-
-#[cfg(any(target_os = "android", target_os = "unknown"))]
-impl ValidationPool {
-	/// Create a new `ValidationPool`.
-	pub fn new() -> Self {
-		ValidationPool { _inner: () }
-	}
-}
-
-/// A stub function defined when compiling for Android or WASM.
-#[cfg(any(target_os = "android", target_os = "unknown"))]
-pub fn run_worker(_: &str) -> Result<(), String> {
-	Err("Cannot run validation worker on this platform".to_string())
-}
-
 /// The execution mode for the `ValidationPool`.
-#[derive(Clone)]
-#[cfg_attr(not(any(target_os = "android", target_os = "unknown")), derive(Debug))]
+#[derive(Clone, Debug)]
 pub enum ExecutionMode {
 	/// The validation worker is ran in a thread inside the same process.
 	InProcess,
 	/// The validation worker is ran using the process' executable and the subcommand `validation-worker` is passed
 	/// following by the address of the shared memory.
+	#[cfg(not(any(target_os = "android", target_os = "unknown")))]
 	ExternalProcessSelfHost(ValidationPool),
 	/// The validation worker is ran using the command provided and the argument provided. The address of the shared
 	/// memory is added at the end of the arguments.
@@ -80,6 +59,19 @@ pub enum ExecutionMode {
 	},
 }
 
+impl Default for ExecutionMode {
+	fn default() -> Self {
+		#[cfg(not(any(target_os = "android", target_os = "unknown")))]
+		{
+			Self::ExternalProcessSelfHost(ValidationPool::new())
+		}
+
+		#[cfg(any(target_os = "android", target_os = "unknown"))]
+		{
+			Self::InProcess
+		}
+	}
+}
 
 #[derive(Debug, thiserror::Error)]
 /// Candidate validation error.

--- a/parachain/src/wasm_executor/mod.rs
+++ b/parachain/src/wasm_executor/mod.rs
@@ -48,6 +48,7 @@ pub enum ExecutionMode {
 	ExternalProcessSelfHost(ValidationPool),
 	/// The validation worker is ran using the command provided and the argument provided. The address of the shared
 	/// memory is added at the end of the arguments.
+	#[cfg(not(any(target_os = "android", target_os = "unknown")))]
 	ExternalProcessCustomHost {
 		/// Validation pool.
 		pool: ValidationPool,
@@ -151,13 +152,6 @@ pub fn validate_candidate(
 			let args: Vec<&str> = args.iter().map(|x| x.as_str()).collect();
 			pool.validate_candidate_custom(validation_code, params, binary, &args)
 		},
-		#[cfg(any(target_os = "android", target_os = "unknown"))]
-		ExecutionMode::ExternalProcessSelfHost(_) | ExecutionMode::ExternalProcessCustomHost { .. } =>
-			Err(ValidationError::Internal(InternalError::System(
-				Box::<dyn std::error::Error + Send + Sync>::from(
-					"Remote validator not available".to_string()
-				) as Box<_>
-			))),
 	}
 }
 

--- a/parachain/test-parachains/adder/collator/Cargo.toml
+++ b/parachain/test-parachains/adder/collator/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/main.rs"
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.3.4", default-features = false, features = ["derive"] }
 futures = "0.3.4"
+futures-timer = "3.0.2"
 log = "0.4.8"
 structopt = "0.3.8"
 
@@ -28,6 +29,13 @@ sc-authority-discovery = { git = "https://github.com/paritytech/substrate", bran
 
 [dev-dependencies]
 polkadot-parachain = { path = "../../.." }
+polkadot-test-service = { path = "../../../../node/test/service" }
+
+substrate-test-utils = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-service = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "master" }
+
+tokio = { version = "0.2", features = ["macros"] }
 
 [features]
 real-overseer = [ "polkadot-service/real-overseer" ]

--- a/parachain/test-parachains/adder/collator/src/lib.rs
+++ b/parachain/test-parachains/adder/collator/src/lib.rs
@@ -143,7 +143,7 @@ impl Collator {
 		})
 	}
 
-	/// Wait that `blocks` are being build and enacted.
+	/// Wait until `blocks` are built and enacted.
 	pub async fn wait_for_blocks(&self, blocks: u64) {
 		let start_block = self.state.lock().unwrap().best_block;
 		loop {

--- a/parachain/test-parachains/adder/collator/src/lib.rs
+++ b/parachain/test-parachains/adder/collator/src/lib.rs
@@ -16,12 +16,14 @@
 
 //! Collator for the adder test parachain.
 
-use std::{pin::Pin, sync::{Arc, Mutex}, collections::HashMap};
+use std::{pin::Pin, sync::{Arc, Mutex}, collections::HashMap, time::Duration};
 use test_parachain_adder::{hash_state, BlockData, HeadData, execute};
 use futures::{Future, FutureExt};
-use polkadot_primitives::v1::{ValidationData, PoV, Hash};
+use futures_timer::Delay;
+use polkadot_primitives::v1::{ValidationData, PoV, Hash, CollatorId, CollatorPair};
 use polkadot_node_primitives::Collation;
 use codec::{Encode, Decode};
+use sp_core::Pair;
 
 /// The amount we add when producing a new block.
 ///
@@ -32,6 +34,8 @@ const ADD: u64 = 2;
 struct State {
 	head_to_state: HashMap<Arc<HeadData>, u64>,
 	number_to_head: HashMap<u64, Arc<HeadData>>,
+	/// Block number of the best block.
+	best_block: u64,
 }
 
 impl State {
@@ -46,6 +50,7 @@ impl State {
 		Self {
 			head_to_state: vec![(genesis_state.clone(), 0)].into_iter().collect(),
 			number_to_head: vec![(0, genesis_state)].into_iter().collect(),
+			best_block: 0,
 		}
 	}
 
@@ -53,6 +58,8 @@ impl State {
 	///
 	/// Returns the new [`BlockData`] and the new [`HeadData`].
 	fn advance(&mut self, parent_head: HeadData) -> (BlockData, HeadData) {
+		self.best_block = parent_head.number;
+
 		let block = BlockData {
 			state: *self.head_to_state.get(&parent_head).expect("Getting state using parent head"),
 			add: ADD,
@@ -72,6 +79,7 @@ impl State {
 /// The collator of the adder parachain.
 pub struct Collator {
 	state: Arc<Mutex<State>>,
+	key: CollatorPair,
 }
 
 impl Collator {
@@ -79,6 +87,7 @@ impl Collator {
 	pub fn new() -> Self {
 		Self {
 			state: Arc::new(Mutex::new(State::genesis())),
+			key: CollatorPair::generate().0,
 		}
 	}
 
@@ -90,6 +99,16 @@ impl Collator {
 	/// Get the validation code of the adder parachain.
 	pub fn validation_code(&self) -> &[u8] {
 		test_parachain_adder::wasm_binary_unwrap()
+	}
+
+	/// Get the collator key.
+	pub fn collator_key(&self) -> CollatorPair {
+		self.key.clone()
+	}
+
+	/// Get the collator id.
+	pub fn collator_id(&self) -> CollatorId {
+		self.key.public()
 	}
 
 	/// Create the collation function.
@@ -122,6 +141,20 @@ impl Collator {
 
 			async move { Some(collation) }.boxed()
 		})
+	}
+
+	/// Wait that `blocks` are being build and enacted.
+	pub async fn wait_for_blocks(&self, blocks: u64) {
+		let start_block = self.state.lock().unwrap().best_block;
+		loop {
+			Delay::new(Duration::from_secs(1)).await;
+
+			let current_block = self.state.lock().unwrap().best_block;
+
+			if start_block + blocks <= current_block {
+				return
+			}
+		}
 	}
 }
 

--- a/parachain/test-parachains/adder/collator/tests/integration.rs
+++ b/parachain/test-parachains/adder/collator/tests/integration.rs
@@ -17,7 +17,7 @@
 //! Integration test that ensures that we can build and include parachain
 //! blocks of the adder parachain.
 
-#[cfg(feature = "real-overseer")]
+// If this test is failing, make sure to run all tests with the `real-overseer` feature being enabled.
 #[substrate_test_utils::test]
 async fn collating_using_adder_collator(task_executor: sc_service::TaskExecutor) {
 	use sp_keyring::AccountKeyring::*;

--- a/parachain/test-parachains/adder/collator/tests/integration.rs
+++ b/parachain/test-parachains/adder/collator/tests/integration.rs
@@ -1,0 +1,73 @@
+// Copyright 2020 Parity Technologies (UK) Ltd.
+// This file is part of Polkadot.
+
+// Polkadot is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Polkadot is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Integration test that ensures that we can build and include parachain
+//! blocks of the adder parachain.
+
+#[cfg(feature = "real-overseer")]
+#[substrate_test_utils::test]
+async fn collating_using_adder_collator(task_executor: sc_service::TaskExecutor) {
+	use sp_keyring::AccountKeyring::*;
+	use futures::join;
+	use polkadot_primitives::v1::Id as ParaId;
+
+	sc_cli::init_logger("", Default::default(), None).expect("Sets up logger");
+
+	let para_id = ParaId::from(100);
+
+	// start alice
+	let alice = polkadot_test_service::run_validator_node(task_executor.clone(), Alice, || {}, vec![]);
+
+	// start bob
+	let bob = polkadot_test_service::run_validator_node(
+		task_executor.clone(),
+		Bob,
+		|| {},
+		vec![alice.addr.clone()],
+	);
+
+	let collator = test_parachain_adder_collator::Collator::new();
+
+	// register parachain
+	alice
+		.register_parachain(
+			para_id,
+			collator.validation_code().to_vec(),
+			collator.genesis_head(),
+		)
+		.await
+		.unwrap();
+
+	// run the collator node
+	let mut charlie = polkadot_test_service::run_collator_node(
+		task_executor.clone(),
+		Charlie,
+		|| {},
+		vec![alice.addr.clone(), bob.addr.clone()],
+		collator.collator_id(),
+	);
+
+	charlie.register_collator(collator.collator_key(), para_id, collator.create_collation_function()).await;
+
+	// Wait until the parachain has 4 blocks produced.
+	collator.wait_for_blocks(4).await;
+
+	join!(
+		alice.task_manager.clean_shutdown(),
+		bob.task_manager.clean_shutdown(),
+		charlie.task_manager.clean_shutdown(),
+	);
+}

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 
 [dependencies]
-jsonrpc-core = "15.0.0"
+jsonrpc-core = "15.1.0"
 polkadot-primitives = { path = "../primitives" }
 sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "master"  }
 sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "master"  }

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -176,8 +176,8 @@ construct_runtime! {
 		AuthorityDiscovery: pallet_authority_discovery::{Module, Call, Config},
 
 		// Parachains modules.
-		ParachainOrigin: parachains_origin::{Module, Origin},
-		ParachainConfig: parachains_configuration::{Module, Call, Storage, Config<T>},
+		ParachainsOrigin: parachains_origin::{Module, Origin},
+		ParachainsConfiguration: parachains_configuration::{Module, Call, Storage, Config<T>},
 		Inclusion: parachains_inclusion::{Module, Call, Storage, Event<T>},
 		InclusionInherent: parachains_inclusion_inherent::{Module, Call, Storage, Inherent},
 		Scheduler: parachains_scheduler::{Module, Call, Storage},

--- a/runtime/test-runtime/src/constants.rs
+++ b/runtime/test-runtime/src/constants.rs
@@ -28,10 +28,10 @@ pub mod currency {
 pub mod time {
 	use primitives::v0::{Moment, BlockNumber};
 	// Testnet
-	pub const MILLISECS_PER_BLOCK: Moment = 1000;
+	pub const MILLISECS_PER_BLOCK: Moment = 6000;
 	pub const SLOT_DURATION: Moment = MILLISECS_PER_BLOCK;
-	// Testnet
-	pub const EPOCH_DURATION_IN_BLOCKS: BlockNumber = 10 * MINUTES;
+	// 30 seconds for now
+	pub const EPOCH_DURATION_IN_BLOCKS: BlockNumber = MINUTES / 2;
 
 	// These time units are defined in number of blocks.
 	pub const MINUTES: BlockNumber = 60_000 / (MILLISECS_PER_BLOCK as BlockNumber);

--- a/runtime/test-runtime/src/lib.rs
+++ b/runtime/test-runtime/src/lib.rs
@@ -24,8 +24,9 @@ use pallet_transaction_payment::CurrencyAdapter;
 use sp_std::prelude::*;
 use codec::Encode;
 use polkadot_runtime_parachains::{
-	configuration,
+	configuration as parachains_configuration,
 	inclusion,
+	inclusion_inherent,
 	initializer,
 	paras,
 	router,
@@ -40,7 +41,7 @@ use primitives::v1::{
 use runtime_common::{
 	claims, SlowAdjustingFeeUpdate, paras_sudo_wrapper,
 	BlockHashCount, MaximumBlockWeight, AvailableBlockRatio,
-	MaximumBlockLength, BlockExecutionWeight, ExtrinsicBaseWeight, ParachainSessionKeyPlaceholder,
+	MaximumBlockLength, BlockExecutionWeight, ExtrinsicBaseWeight,
 };
 use sp_runtime::{
 	create_runtime_str, generic, impl_opaque_keys,
@@ -76,6 +77,7 @@ pub use sp_runtime::BuildStorage;
 pub use pallet_timestamp::Call as TimestampCall;
 pub use pallet_balances::Call as BalancesCall;
 pub use paras_sudo_wrapper::Call as ParasSudoWrapperCall;
+pub use pallet_sudo::Call as SudoCall;
 
 /// Constant values used within the runtime.
 pub mod constants;
@@ -250,7 +252,8 @@ impl_opaque_keys! {
 	pub struct SessionKeys {
 		pub grandpa: Grandpa,
 		pub babe: Babe,
-		pub parachain_validator: ParachainSessionKeyPlaceholder<Runtime>,
+		pub parachain_validator: Initializer,
+		pub authority_discovery: AuthorityDiscovery,
 	}
 }
 
@@ -438,11 +441,13 @@ impl pallet_sudo::Trait for Runtime {
 	type Call = Call;
 }
 
-impl configuration::Trait for Runtime {}
+impl parachains_configuration::Trait for Runtime {}
 
 impl inclusion::Trait for Runtime {
 	type Event = Event;
 }
+
+impl inclusion_inherent::Trait for Runtime {}
 
 impl initializer::Trait for Runtime {
 	type Randomness = RandomnessCollectiveFlip;
@@ -494,8 +499,9 @@ construct_runtime! {
 		Vesting: pallet_vesting::{Module, Call, Storage, Event<T>, Config<T>},
 
 		// Parachains runtime modules
-		Configuration: configuration::{Module, Call, Storage},
+		ParachainsConfiguration: parachains_configuration::{Module, Call, Storage, Config<T>},
 		Inclusion: inclusion::{Module, Call, Storage, Event<T>},
+		InclusionInherent: inclusion_inherent::{Module, Call, Storage, Inherent},
 		Initializer: initializer::{Module, Call, Storage},
 		Paras: paras::{Module, Call, Storage, Origin},
 		Scheduler: scheduler::{Module, Call, Storage},
@@ -600,7 +606,7 @@ sp_api::impl_runtime_apis! {
 
 	impl authority_discovery_primitives::AuthorityDiscoveryApi<Block> for Runtime {
 		fn authorities() -> Vec<AuthorityDiscoveryId> {
-			Vec::new()
+			AuthorityDiscovery::authorities()
 		}
 	}
 

--- a/scripts/gitlab/test_linux_stable.sh
+++ b/scripts/gitlab/test_linux_stable.sh
@@ -3,4 +3,6 @@
 #shellcheck source=lib.sh
 source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/lib.sh"
 
-time cargo test --all --release --verbose --locked --features runtime-benchmarks
+time cargo test --all --release --verbose --locked --features=runtime-benchmarks --features=real-overseer
+# Should be removed after the `real-overseer` feature is removed
+time cargo test --release --verbose --locked -p test-parachain-adder-collator --features=real-overseer

--- a/scripts/gitlab/test_linux_stable.sh
+++ b/scripts/gitlab/test_linux_stable.sh
@@ -4,5 +4,3 @@
 source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/lib.sh"
 
 time cargo test --all --release --verbose --locked --features=runtime-benchmarks --features=real-overseer
-# Should be removed after the `real-overseer` feature is removed
-time cargo test --release --verbose --locked -p test-parachain-adder-collator --features=real-overseer


### PR DESCRIPTION
This adds an integration test for parachains that uses the adder
collator. The test will start two relay chain nodes and one collator and
waits until 4 blocks are build and enacted by the parachain.