### PR TITLE
Cleanups 

### DIFF
--- a/node/primitives/src/lib.rs
+++ b/node/primitives/src/lib.rs
@@ -284,7 +284,7 @@ pub type CollatorFn = Box<
 pub struct CollationGenerationConfig {
 	/// Collator's authentication key, so it can sign things.
 	pub key: CollatorPair,
-	/// Collation function. See [CollatorFn] for more details.
+	/// Collation function. See [`CollatorFn`] for more details.
 	pub collator: CollatorFn,
 	/// The parachain that this collator collates for
 	pub para_id: ParaId,

--- a/node/primitives/src/lib.rs
+++ b/node/primitives/src/lib.rs
@@ -269,16 +269,23 @@ pub struct Collation<BlockNumber = polkadot_primitives::v1::BlockNumber> {
 	pub hrmp_watermark: BlockNumber,
 }
 
+/// Collation function.
+///
+/// Will be called with the hash of the relay chain block the parachain
+/// block should be build on and the [`ValidationData`] that provides
+/// information about the state of the parachain on the relay chain.
+pub type CollatorFn = Box<
+	dyn Fn(Hash, &ValidationData) -> Pin<Box<dyn Future<Output = Option<Collation>> + Send>>
+		+ Send
+		+ Sync,
+>;
+
 /// Configuration for the collation generator
 pub struct CollationGenerationConfig {
 	/// Collator's authentication key, so it can sign things.
 	pub key: CollatorPair,
-	/// Collation function.
-	///
-	/// Will be called with the hash of the relay chain block the parachain
-	/// block should be build on and the [`ValidationData`] that provides
-	/// information about the state of the parachain on the relay chain.
-	pub collator: Box<dyn Fn(Hash, &ValidationData) -> Pin<Box<dyn Future<Output = Option<Collation>> + Send>> + Send + Sync>,
+	/// Collation function. See [CollatorFn] for more details.
+	pub collator: CollatorFn,
 	/// The parachain that this collator collates for
 	pub para_id: ParaId,
 }

--- a/node/test/service/src/lib.rs
+++ b/node/test/service/src/lib.rs
@@ -24,7 +24,7 @@ pub use chain_spec::*;
 use futures::future::Future;
 use polkadot_overseer::OverseerHandler;
 use polkadot_primitives::v1::{
-	Id as ParaId, HeadData, ValidationCode, Balance, CollatorPair, CollatorId, ValidationData, Hash,
+	Id as ParaId, HeadData, ValidationCode, Balance, CollatorPair, CollatorId,
 };
 use polkadot_runtime_common::BlockHashCount;
 use polkadot_service::{
@@ -34,7 +34,7 @@ use polkadot_node_subsystem::messages::{CollatorProtocolMessage, CollationGenera
 use polkadot_test_runtime::{
 	Runtime, SignedExtra, SignedPayload, VERSION, ParasSudoWrapperCall, SudoCall, UncheckedExtrinsic,
 };
-use polkadot_node_primitives::{Collation, CollatorFn, CollationGenerationConfig};
+use polkadot_node_primitives::{CollatorFn, CollationGenerationConfig};
 use polkadot_runtime_parachains::paras::ParaGenesisArgs;
 use sc_chain_spec::ChainSpec;
 use sc_client_api::execution_extensions::ExecutionStrategies;
@@ -54,7 +54,7 @@ use sp_blockchain::HeaderBackend;
 use sp_keyring::Sr25519Keyring;
 use sp_runtime::{codec::Encode, generic, traits::IdentifyAccount, MultiSigner};
 use sp_state_machine::BasicExternalities;
-use std::{sync::Arc, time::Duration, pin::Pin};
+use std::{sync::Arc, time::Duration};
 use substrate_test_client::{BlockchainEventsExt, RpcHandlersExt, RpcTransactionOutput, RpcTransactionError};
 
 native_executor_instance!(

--- a/parachain/test-parachains/adder/collator/src/lib.rs
+++ b/parachain/test-parachains/adder/collator/src/lib.rs
@@ -16,11 +16,10 @@
 
 //! Collator for the adder test parachain.
 
-use std::{pin::Pin, sync::{Arc, Mutex}, collections::HashMap, time::Duration};
+use std::{sync::{Arc, Mutex}, collections::HashMap, time::Duration};
 use test_parachain_adder::{hash_state, BlockData, HeadData, execute};
-use futures::{Future, FutureExt};
 use futures_timer::Delay;
-use polkadot_primitives::v1::{ValidationData, PoV, Hash, CollatorId, CollatorPair};
+use polkadot_primitives::v1::{PoV, CollatorId, CollatorPair};
 use polkadot_node_primitives::{Collation, CollatorFn};
 use codec::{Encode, Decode};
 use sp_core::Pair;
@@ -117,6 +116,8 @@ impl Collator {
 	pub fn create_collation_function(
 		&self,
 	) -> CollatorFn {
+		use futures::FutureExt as _;
+
 		let state = self.state.clone();
 
 		Box::new(move |relay_parent, validation_data| {
@@ -166,7 +167,7 @@ mod tests {
 
 	use futures::executor::block_on;
 	use polkadot_parachain::{primitives::ValidationParams, wasm_executor::ExecutionMode};
-	use polkadot_primitives::v1::PersistedValidationData;
+	use polkadot_primitives::v1::{ValidationData, PersistedValidationData};
 	use codec::Decode;
 
 	#[test]

--- a/parachain/test-parachains/adder/collator/src/lib.rs
+++ b/parachain/test-parachains/adder/collator/src/lib.rs
@@ -21,7 +21,7 @@ use test_parachain_adder::{hash_state, BlockData, HeadData, execute};
 use futures::{Future, FutureExt};
 use futures_timer::Delay;
 use polkadot_primitives::v1::{ValidationData, PoV, Hash, CollatorId, CollatorPair};
-use polkadot_node_primitives::Collation;
+use polkadot_node_primitives::{Collation, CollatorFn};
 use codec::{Encode, Decode};
 use sp_core::Pair;
 
@@ -116,7 +116,7 @@ impl Collator {
 	/// This collation function can be plugged into the overseer to generate collations for the adder parachain.
 	pub fn create_collation_function(
 		&self,
-	) -> Box<dyn Fn(Hash, &ValidationData) -> Pin<Box<dyn Future<Output = Option<Collation>> + Send>> + Send + Sync> {
+	) -> CollatorFn {
 		let state = self.state.clone();
 
 		Box::new(move |relay_parent, validation_data| {

--- a/roadmap/implementers-guide/src/node/collators/collation-generation.md
+++ b/roadmap/implementers-guide/src/node/collators/collation-generation.md
@@ -32,12 +32,16 @@ pub struct Collation {
   pub proof_of_validity: PoV,
 }
 
+type CollatorFn = Box<
+  dyn Fn(Hash, &ValidationData) -> Pin<Box<dyn Future<Output = Option<Collation>>>>
+>;
+
 struct CollationGenerationConfig {
   key: CollatorPair,
-  /// Collate will be called with the relay chain hash the parachain should build 
+  /// Collate will be called with the relay chain hash the parachain should build
   /// a block on and the `ValidationData` that provides information about the state
   /// of the parachain on the relay chain.
-  collator: Box<dyn Fn(Hash, &ValidationData) -> Pin<Box<dyn Future<Output = Option<Collation>>>>>
+  collator: CollatorFn,
   para_id: ParaId,
 }
 ```

--- a/runtime/test-runtime/src/lib.rs
+++ b/runtime/test-runtime/src/lib.rs
@@ -24,16 +24,16 @@ use pallet_transaction_payment::CurrencyAdapter;
 use sp_std::prelude::*;
 use sp_std::collections::btree_map::BTreeMap;
 use codec::Encode;
-use polkadot_runtime_parachains::{
-	configuration as parachains_configuration,
-	inclusion,
-	inclusion_inherent,
-	initializer,
-	paras,
-	router,
-	runtime_api_impl::v1 as runtime_impl,
-	scheduler,
-};
+
+use polkadot_runtime_parachains::configuration as parachains_configuration;
+use polkadot_runtime_parachains::inclusion as parachains_inclusion;
+use polkadot_runtime_parachains::inclusion_inherent as parachains_inclusion_inherent;
+use polkadot_runtime_parachains::initializer as parachains_initializer;
+use polkadot_runtime_parachains::paras as parachains_paras;
+use polkadot_runtime_parachains::router as parachains_router;
+use polkadot_runtime_parachains::scheduler as parachains_scheduler;
+use polkadot_runtime_parachains::runtime_api_impl::v1 as runtime_impl;
+
 use primitives::v1::{
 	AccountId, AccountIndex, Balance, BlockNumber, CandidateEvent, CommittedCandidateReceipt,
 	CoreState, GroupRotationInfo, Hash as HashT, Id as ParaId, Moment, Nonce, OccupiedCoreAssumption,
@@ -445,26 +445,26 @@ impl pallet_sudo::Trait for Runtime {
 
 impl parachains_configuration::Trait for Runtime {}
 
-impl inclusion::Trait for Runtime {
+impl parachains_inclusion::Trait for Runtime {
 	type Event = Event;
 }
 
-impl inclusion_inherent::Trait for Runtime {}
+impl parachains_inclusion_inherent::Trait for Runtime {}
 
-impl initializer::Trait for Runtime {
+impl parachains_initializer::Trait for Runtime {
 	type Randomness = RandomnessCollectiveFlip;
 }
 
-impl paras::Trait for Runtime {
+impl parachains_paras::Trait for Runtime {
 	type Origin = Origin;
 }
 
-impl router::Trait for Runtime {
+impl parachains_router::Trait for Runtime {
 	type Origin = Origin;
 	type UmpSink = ();
 }
 
-impl scheduler::Trait for Runtime {}
+impl parachains_scheduler::Trait for Runtime {}
 
 impl paras_sudo_wrapper::Trait for Runtime {}
 
@@ -503,11 +503,11 @@ construct_runtime! {
 
 		// Parachains runtime modules
 		ParachainsConfiguration: parachains_configuration::{Module, Call, Storage, Config<T>},
-		Inclusion: inclusion::{Module, Call, Storage, Event<T>},
-		InclusionInherent: inclusion_inherent::{Module, Call, Storage, Inherent},
-		Initializer: initializer::{Module, Call, Storage},
-		Paras: paras::{Module, Call, Storage, Origin},
-		Scheduler: scheduler::{Module, Call, Storage},
+		Inclusion: parachains_inclusion::{Module, Call, Storage, Event<T>},
+		InclusionInherent: parachains_inclusion_inherent::{Module, Call, Storage, Inherent},
+		Initializer: parachains_initializer::{Module, Call, Storage},
+		Paras: parachains_paras::{Module, Call, Storage, Origin},
+		Scheduler: parachains_scheduler::{Module, Call, Storage},
 		ParasSudoWrapper: paras_sudo_wrapper::{Module, Call},
 
 		Sudo: pallet_sudo::{Module, Call, Storage, Config<T>, Event<T>},


### PR DESCRIPTION
This is a follow up to https://github.com/paritytech/polkadot/pull/1928

I was too eager to merge it and as a punishment for myself I tackled wrapping the line and also made test-runtime imports more consistent with rococo-runtime