### PR TITLE
.github: Add dependabot config and thus enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,5 +2,6 @@ version: 2
 updates:
   - package-ecosystem: "cargo"
     directory: "/"
+    labels: ["A2-insubstantial", "B0-silent", "C1-low"]
     schedule:
       interval: "daily"


### PR DESCRIPTION
Just like https://github.com/paritytech/substrate/pull/7509 I am suggesting to enable Dependabot for the Polkadot repository.

> With this pull request I suggest to enable [Dependabot](dependabot.com/) for this repository. Dependabot will scan the dependencies used in Substrate (both `Cargo.toml` and `Cargo.lock`) and create pull requests whenever newer versions of those dependencies are available.
> 
> We are using Dependabot in [rust-libp2p since about 2 months now](https://github.com/libp2p/rust-libp2p/pull/1744). While annoying at first, I think it is well worth it, reducing the long-term toil keeping dependencies up-to-date as well as staying in sync with recent (security) bug fixes.
> 
> Please don't just merge here but signal your consent / dissent for now. Keeping dependencies up-to-date is a lot of work and thus a team effort.