### PR TITLE
[CI] Fix release Docker github action

### DIFF
--- a/.github/workflows/publish-docker-release.yml
+++ b/.github/workflows/publish-docker-release.yml
@@ -14,12 +14,12 @@ jobs:
         uses: docker/setup-buildx-action@v1
       - name: Cache Docker layers
         uses: actions/cache@v2
-      - name: Login to Dockerhub
         with:
          path: /tmp/.buildx-cache
          key: ${{ runner.os }}-buildx-${{ github.sha }}
          restore-keys: |
            ${{ runner.os }}-buildx-
+      - name: Login to Dockerhub
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -29,7 +29,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          file: scripts/docker/Dockerfile.release
+          file: scripts/docker/release.Dockerfile
           tags: |
             parity/polkadot:latest
             parity/polkadot:${{ github.event.release.tag_name }}

--- a/.github/workflows/publish-docker-release.yml
+++ b/.github/workflows/publish-docker-release.yml
@@ -31,8 +31,10 @@ jobs:
           push: true
           file: scripts/docker/release.Dockerfile
           tags: |
-            parity/polkadot:latest
-            parity/polkadot:${{ github.event.release.tag_name }}
+            martinparity/polkadot:latest
+            martinparity/polkadot:${{ github.event.release.tag_name }}
+          build-args: |
+            POLKADOT_VERSION=${{ github.event.release.tag_name }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
       - name: Image digest

--- a/.github/workflows/publish-docker-release.yml
+++ b/.github/workflows/publish-docker-release.yml
@@ -31,8 +31,8 @@ jobs:
           push: true
           file: scripts/docker/release.Dockerfile
           tags: |
-            martinparity/polkadot:latest
-            martinparity/polkadot:${{ github.event.release.tag_name }}
+            parity/polkadot:latest
+            parity/polkadot:${{ github.event.release.tag_name }}
           build-args: |
             POLKADOT_VERSION=${{ github.event.release.tag_name }}
             VCS_REF=${{ github.ref }}

--- a/.github/workflows/publish-docker-release.yml
+++ b/.github/workflows/publish-docker-release.yml
@@ -35,6 +35,8 @@ jobs:
             martinparity/polkadot:${{ github.event.release.tag_name }}
           build-args: |
             POLKADOT_VERSION=${{ github.event.release.tag_name }}
+            VCS_REF=${{ github.ref }}
+            BUILD_DATE=${{ github.event.release.published_at }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
       - name: Image digest

--- a/scripts/docker/release.Dockerfile
+++ b/scripts/docker/release.Dockerfile
@@ -3,6 +3,7 @@ FROM debian:buster-slim
 # metadata
 ARG VCS_REF
 ARG BUILD_DATE
+ARG POLKADOT_VERSION
 
 LABEL io.parity.image.authors="devops-team@parity.io" \
 	io.parity.image.vendor="Parity Technologies" \
@@ -18,8 +19,7 @@ ENV RUST_BACKTRACE 1
 
 # install tools and dependencies
 RUN apt-get update && \
-		DEBIAN_FRONTEND=noninteractive apt-get upgrade -y && \
-		DEBIAN_FRONTEND=noninteractive apt-get install -y \
+		DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
 			libssl1.1 \
 			ca-certificates \
 			curl \
@@ -28,12 +28,12 @@ RUN apt-get update && \
 		gpg --recv-keys --keyserver hkps://keys.mailvelope.com 9D4B2B6EB8F97156D19669A9FF0812D491B96798 && \
 		gpg --export 9D4B2B6EB8F97156D19669A9FF0812D491B96798 > /usr/share/keyrings/parity.gpg && \
 		echo 'deb [signed-by=/usr/share/keyrings/parity.gpg] https://releases.parity.io/deb release main' > /etc/apt/sources.list.d/parity.list && \
-		apt update && \
-		apt install polkadot && \
+		apt-get update && \
+		apt-get install -y --no-install-recommends polkadot=${POLKADOT_VERSION#?} && \
 # apt cleanup
 		apt-get autoremove -y && \
 		apt-get clean && \
-		find /var/lib/apt/lists/ -type f -not -name lock -delete
+		rm -rf /var/lib/apt/lists/*
 
 USER polkadot
 

--- a/scripts/docker/release.Dockerfile
+++ b/scripts/docker/release.Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get update && \
 			ca-certificates \
 			curl \
 			gnupg && \
+		useradd -m -u 1000 -U -s /bin/sh -d /polkadot polkadot && \
 		gpg --recv-keys --keyserver hkps://keys.mailvelope.com 9D4B2B6EB8F97156D19669A9FF0812D491B96798 && \
 		gpg --export 9D4B2B6EB8F97156D19669A9FF0812D491B96798 > /usr/share/keyrings/parity.gpg && \
 		echo 'deb [signed-by=/usr/share/keyrings/parity.gpg] https://releases.parity.io/deb release main' > /etc/apt/sources.list.d/parity.list && \


### PR DESCRIPTION
* Add some package metadata
* Fix the errors in the Github Action that were causing [this](https://github.com/paritytech/polkadot/actions/runs/352786916) issue
* Fix a few [hadolint](https://github.com/hadolint/hadolint) nags
* Now pins the version installed from the Docker image - will fail if the specific version of Polkadot is not present in our Deb repository