### PR TITLE
Add CI job to verify extrinsic ordering

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -147,8 +147,8 @@ check-runtime-benchmarks:          &test
 check-transaction-versions:
   image:                          node:15
   stage:                          build
-  dependencies:
-    - test-linux-stable
+  needs:
+    - job:                        test-linux-stable
   before_script:
     - npm install -g @polkadot/metadata-cmp
     - git fetch origin release

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -198,7 +198,7 @@ generate-impl-guide:
     - mdbook build roadmap/implementers-guide
 
 check-transaction-versions:
-  stage:                          build
+  stage:                          publish
   dependencies:
     - build-linux-release
   script: "scripts/gitlab/check_extrinsics_ordering.sh"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -200,9 +200,13 @@ generate-impl-guide:
     - mdbook build roadmap/implementers-guide
 
 check-transaction-versions:
-  stage:                          test
-    # dependencies:
-    # - build-linux-release
+  image:                          node:15
+  stage:                          publish
+  dependencies:
+    - build-linux-release
+  before_script:
+    - npm install -g @polkadot/metadata-cmp
+    - git fetch origin release
   script: "scripts/gitlab/check_extrinsics_ordering.sh"
 
 .publish-build:                    &publish-build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -66,8 +66,6 @@ variables:
 
 .test-refs:                        &test-refs
   rules:
-    # FIXME: Remove before opening PR
-    - if: $CI_COMMIT_REF_NAME == "mp-check-extrinsics-job"
     - if: $CI_PIPELINE_SOURCE == "web"
     - if: $CI_PIPELINE_SOURCE == "schedule"
     - if: $CI_COMMIT_REF_NAME == "master"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -163,6 +163,8 @@ build-linux-release:               &build
   <<:                              *compiler_info
   rules:
     # .build-refs with manual on PRs
+    # TODO: REMOVE this branch before opening PR
+    - if: $CI_COMMIT_REF_NAME == "mp-check-extrinsics-job"
     - if: $CI_PIPELINE_SOURCE == "web"
     - if: $CI_PIPELINE_SOURCE == "schedule"
     - if: $CI_COMMIT_REF_NAME == "master"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -197,6 +197,12 @@ generate-impl-guide:
   script:
     - mdbook build roadmap/implementers-guide
 
+check-transaction-versions:
+  stage:                          build
+  dependencies:
+    - build-linux-release
+  script: "scripts/gitlab/check_extrinsics_ordering.sh"
+
 .publish-build:                    &publish-build
   stage:                           publish
   dependencies:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -163,8 +163,6 @@ build-linux-release:               &build
   <<:                              *compiler_info
   rules:
     # .build-refs with manual on PRs
-    # TODO: REMOVE this branch before opening PR
-    - if: $CI_COMMIT_REF_NAME == "mp-check-extrinsics-job"
     - if: $CI_PIPELINE_SOURCE == "web"
     - if: $CI_PIPELINE_SOURCE == "schedule"
     - if: $CI_COMMIT_REF_NAME == "master"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -200,9 +200,9 @@ generate-impl-guide:
     - mdbook build roadmap/implementers-guide
 
 check-transaction-versions:
-  stage:                          publish
-  dependencies:
-    - build-linux-release
+  stage:                          test
+    # dependencies:
+    # - build-linux-release
   script: "scripts/gitlab/check_extrinsics_ordering.sh"
 
 .publish-build:                    &publish-build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -66,6 +66,8 @@ variables:
 
 .test-refs:                        &test-refs
   rules:
+    # FIXME: Remove before opening PR
+    - if: $CI_COMMIT_REF_NAME == "mp-check-extrinsics-job"
     - if: $CI_PIPELINE_SOURCE == "web"
     - if: $CI_PIPELINE_SOURCE == "schedule"
     - if: $CI_COMMIT_REF_NAME == "master"
@@ -116,6 +118,9 @@ test-linux-stable:                 &test
     # but still want to have debug assertions.
     RUSTFLAGS: "-Cdebug-assertions=y -Dwarnings"
     TARGET: native
+  artifacts:
+    paths:
+      - ./target/release/polkadot
   script:
     - ./scripts/gitlab/test_linux_stable.sh
     - sccache -s
@@ -140,6 +145,16 @@ check-runtime-benchmarks:          &test
     # Check that the node will compile with `runtime-benchmarks` feature flag.
     - ./scripts/gitlab/check_runtime_benchmarks.sh
     - sccache -s
+
+check-transaction-versions:
+  image:                          node:15
+  stage:                          build
+  dependencies:
+    - test-linux-stable
+  before_script:
+    - npm install -g @polkadot/metadata-cmp
+    - git fetch origin release
+  script: "scripts/gitlab/check_extrinsics_ordering.sh"
 
 build-wasm-release:
   stage:                          build
@@ -196,16 +211,6 @@ generate-impl-guide:
     entrypoint: [""]
   script:
     - mdbook build roadmap/implementers-guide
-
-check-transaction-versions:
-  image:                          node:15
-  stage:                          publish
-  dependencies:
-    - build-linux-release
-  before_script:
-    - npm install -g @polkadot/metadata-cmp
-    - git fetch origin release
-  script: "scripts/gitlab/check_extrinsics_ordering.sh"
 
 .publish-build:                    &publish-build
   stage:                           publish

--- a/scripts/gitlab/check_extrinsics_ordering.sh
+++ b/scripts/gitlab/check_extrinsics_ordering.sh
@@ -6,6 +6,8 @@ LOCAL_WS=ws://localhost:9944
 # Kill the polkadot client before exiting
 trap 'kill "$(jobs -p)"' EXIT
 
+git fetch origin release
+
 runtimes=(
   "westend"
   "kusama"
@@ -16,7 +18,7 @@ for RUNTIME in "${runtimes[@]}"; do
   echo "[+] Checking runtime: ${RUNTIME}"
 
   release_transaction_version=$(
-    git show "release:runtime/${RUNTIME}/src/lib.rs" | \
+    git show "origin/release:runtime/${RUNTIME}/src/lib.rs" | \
     grep 'transaction_version'
   )
 

--- a/scripts/gitlab/check_extrinsics_ordering.sh
+++ b/scripts/gitlab/check_extrinsics_ordering.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-BIN=./artifacts/polkadot
+BIN=./target/release/polkadot
 LIVE_WS=wss://rpc.polkadot.io
 LOCAL_WS=ws://localhost:9944
 

--- a/scripts/gitlab/check_extrinsics_ordering.sh
+++ b/scripts/gitlab/check_extrinsics_ordering.sh
@@ -6,8 +6,6 @@ LOCAL_WS=ws://localhost:9944
 # Kill the polkadot client before exiting
 trap 'kill "$(jobs -p)"' EXIT
 
-git fetch origin release
-
 runtimes=(
   "westend"
   "kusama"
@@ -25,6 +23,9 @@ for RUNTIME in "${runtimes[@]}"; do
   current_transaction_version=$(
     grep 'transaction_version' "./runtime/${RUNTIME}/src/lib.rs"
   )
+
+  echo "[+] Release: ${release_transaction_version}"
+  echo "[+] Ours: ${current_transaction_version}"
 
   if [ ! "$release_transaction_version" = "$current_transaction_version" ]; then
     echo "[+] Transaction version for ${RUNTIME} has been bumped since last release."

--- a/scripts/gitlab/check_extrinsics_ordering.sh
+++ b/scripts/gitlab/check_extrinsics_ordering.sh
@@ -33,7 +33,8 @@ for RUNTIME in "${runtimes[@]}"; do
   fi
 
   if [ "$RUNTIME" = 'polkadot' ]; then
-    LIVE_WS="wss://rpc.polkadot.io"
+    # FIXME: change this back to rpc.polkadot.io before opening PR
+    LIVE_WS="wss://kusama-rpc.polkadot.io"
   else
     LIVE_WS="wss://${RUNTIME}-rpc.polkadot.io"
   fi

--- a/scripts/gitlab/check_extrinsics_ordering.sh
+++ b/scripts/gitlab/check_extrinsics_ordering.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+BIN=polkadot
+LIVE_WS=wss://rpc.polkadot.io
+LOCAL_WS=ws://localhost:9944
+
+runtimes=(
+  "westend"
+  "kusama"
+  "polkadot"
+)
+
+for RUNTIME in "${runtimes[@]}"; do
+  # TODO: Write early exit if the transaction_version in runtime/$RUNTIME/src/lib.rs has
+  # changed since the last release (use same technique as check_runtime.sh)
+  # Start running the local polkadot node in the background
+  $BIN --chain="$RUNTIME-local" > /dev/null 2>&1 &
+
+  changed_extrinsics=$(
+  # TODO: select websocket based on runtime
+    polkadot-js-metadata-cmp "$LIVE_WS" "$LOCAL_WS" \
+    | sed 's/^ \+//g' | grep -e 'idx: [0-9]\+ -> [0-9]\+'
+  )
+
+  if [ -n "$changed_extrinsics" ]; then
+    echo "[!] Extrinsics indexing/ordering has changed! If this change is 
+  intentional, please bump transaction_version in lib.rs. Changed extrinsics:"
+    echo "$changed_extrinsics"
+    exit 1
+  fi
+done
+
+kill %1

--- a/scripts/gitlab/check_extrinsics_ordering.sh
+++ b/scripts/gitlab/check_extrinsics_ordering.sh
@@ -40,7 +40,6 @@ for RUNTIME in "${runtimes[@]}"; do
   jobs
 
   changed_extrinsics=$(
-  # TODO: select websocket based on runtime
     polkadot-js-metadata-cmp "$LIVE_WS" "$LOCAL_WS" \
     | sed 's/^ \+//g' | grep -e 'idx: [0-9]\+ -> [0-9]\+'
   )

--- a/scripts/gitlab/check_extrinsics_ordering.sh
+++ b/scripts/gitlab/check_extrinsics_ordering.sh
@@ -33,8 +33,7 @@ for RUNTIME in "${runtimes[@]}"; do
   fi
 
   if [ "$RUNTIME" = 'polkadot' ]; then
-    # FIXME: change this back to rpc.polkadot.io before opening PR
-    LIVE_WS="wss://kusama-rpc.polkadot.io"
+    LIVE_WS="wss://rpc.polkadot.io"
   else
     LIVE_WS="wss://${RUNTIME}-rpc.polkadot.io"
   fi

--- a/scripts/gitlab/check_extrinsics_ordering.sh
+++ b/scripts/gitlab/check_extrinsics_ordering.sh
@@ -17,7 +17,7 @@ for RUNTIME in "${runtimes[@]}"; do
 
   release_transaction_version=$(
     git show "origin/release:runtime/${RUNTIME}/src/lib.rs" | \
-    grep 'transaction_version'
+      grep 'transaction_version'
   )
 
   current_transaction_version=$(
@@ -44,7 +44,7 @@ for RUNTIME in "${runtimes[@]}"; do
 
   changed_extrinsics=$(
     polkadot-js-metadata-cmp "$LIVE_WS" "$LOCAL_WS" \
-    | sed 's/^ \+//g' | grep -e 'idx: [0-9]\+ -> [0-9]\+'
+      | sed 's/^ \+//g' | grep -e 'idx: [0-9]\+ -> [0-9]\+'
   )
 
   if [ -n "$changed_extrinsics" ]; then


### PR DESCRIPTION
**What?**: This PR adds a job that uses @jacogr 's `polkadot-js-metadata-cmp` tool to verify that if the ordering/indexing of the extrinsics of a runtime have changed since the last release, `transaction_version` for that runtime has been bumped.

**How?**: We grab the polkadot binary produced in the `test-linux-stable` job, and for each runtime, we run the client in the background with `--chain=$RUNTIME-local`. Then we use `polkadot-js-metadata-cmp` to compare the metadata with the live chain.

This essentially automates [this](https://github.com/paritytech/polkadot/blob/master/.github/ISSUE_TEMPLATE/release.md#extrinsic-ordering) check that is completed as part of our release process - but on a per-PR basis. In design and implementation it's somewhat similar to our [`check_runtime.sh`](https://github.com/paritytech/polkadot/blob/master/scripts/gitlab/check_runtime.sh) CI job.

After merging, we should add this check as a must-pass to our branch protection rules for `master`

An example of a passing job can be found [here](https://gitlab.parity.io/parity/polkadot/-/jobs/714696)
An example of a failing job can be found [here](https://gitlab.parity.io/parity/polkadot/-/jobs/714605) (to cause it to fail, I had it compare the metadata between kusama and polkadot)