### PR TITLE
.github/dependabot: Handle Substrate crates manually

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,5 +3,10 @@ updates:
   - package-ecosystem: "cargo"
     directory: "/"
     labels: ["A2-insubstantial", "B0-silent", "C1-low"]
+    # Handle updates for crates from github.com/paritytech/substrate manually.
+    ignore:
+      - dependency-name: "substrate-*"
+      - dependency-name: "sc-*"
+      - dependency-name: "pallet-*"
     schedule:
       interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,9 @@ updates:
     ignore:
       - dependency-name: "substrate-*"
       - dependency-name: "sc-*"
+      - dependency-name: "sp-*"
+      - dependency-name: "frame-*"
+      - dependency-name: "fork-tree"
       - dependency-name: "pallet-*"
     schedule:
       interval: "daily"


### PR DESCRIPTION
Handle updates for crates from github.com/paritytech/substrate manually.

https://github.com/paritytech/polkadot/pull/1937 introduced Dependabot to the Polkadot repository. Sadly it also tries to update Substrate specific dependencies, e.g. see https://github.com/paritytech/polkadot/pull/1956.

According to the [config validator](https://dependabot.com/docs/config-file/validator/) this is valid syntax. According to the [documentation](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates#ignore) wildcards are allowed.