### PR TITLE
Patch some features for XCM

### DIFF
--- a/parachain/src/primitives.rs
+++ b/parachain/src/primitives.rs
@@ -135,6 +135,45 @@ impl sp_std::ops::Add<u32> for Id {
 	}
 }
 
+#[derive(Clone, Copy, Default, Encode, Decode, Eq, PartialEq, Ord, PartialOrd, RuntimeDebug)]
+pub struct Sibling(pub Id);
+
+impl From<Id> for Sibling {
+	fn from(i: Id) -> Self {
+		Self(i)
+	}
+}
+
+impl From<Sibling> for Id {
+	fn from(i: Sibling) -> Self {
+		i.0
+	}
+}
+
+impl AsRef<Id> for Sibling {
+	fn as_ref(&self) -> &Id {
+		&self.0
+	}
+}
+
+impl TypeId for Sibling {
+	const TYPE_ID: [u8; 4] = *b"sibl";
+}
+
+impl From<Sibling> for u32 {
+	fn from(x: Sibling) -> Self { x.0.into() }
+}
+
+impl From<u32> for Sibling {
+	fn from(x: u32) -> Self { Sibling(x.into()) }
+}
+
+impl IsSystem for Sibling {
+	fn is_system(&self) -> bool {
+		IsSystem::is_system(&self.0)
+	}
+}
+
 /// This type can be converted into and possibly from an AccountId (which itself is generic).
 pub trait AccountIdConversion<AccountId>: Sized {
 	/// Convert into an account ID. This is infallible.

--- a/runtime/parachains/src/origin.rs
+++ b/runtime/parachains/src/origin.rs
@@ -51,3 +51,9 @@ frame_support::decl_module! {
 	// ideally, though, the `construct_runtime` should support a free-standing origin.
 	pub struct Module<T: Trait> for enum Call where origin: <T as frame_system::Trait>::Origin {}
 }
+
+impl From<u32> for Origin {
+	fn from(id: u32) -> Origin {
+		Origin::Parachain(id.into())
+	}
+}

--- a/xcm/xcm-builder/src/currency_adapter.rs
+++ b/xcm/xcm-builder/src/currency_adapter.rs
@@ -36,7 +36,7 @@ impl<
 
 	fn deposit_asset(what: &MultiAsset, who: &MultiLocation) -> Result {
 		// Check we handle this asset.
-		let amount = Matcher::matches_fungible(&what).ok_or(())?.saturated_into();
+		let amount: u128 = Matcher::matches_fungible(&what).ok_or(())?.saturated_into();
 		let who = AccountIdConverter::from_location(who).ok_or(())?;
 		let balance_amount = amount.try_into().map_err(|_| ())?;
 		let _imbalance = Currency::deposit_creating(&who, balance_amount);
@@ -45,7 +45,7 @@ impl<
 
 	fn withdraw_asset(what: &MultiAsset, who: &MultiLocation) -> result::Result<MultiAsset, Error> {
 		// Check we handle this asset.
-		let amount = Matcher::matches_fungible(&what).ok_or(())?.saturated_into();
+		let amount: u128 = Matcher::matches_fungible(&what).ok_or(())?.saturated_into();
 		let who = AccountIdConverter::from_location(who).ok_or(())?;
 		let balance_amount = amount.try_into().map_err(|_| ())?;
 		Currency::withdraw(&who, balance_amount, WithdrawReasons::TRANSFER, AllowDeath).map_err(|_| ())?;


### PR DESCRIPTION
This patches a few implementations to let us play with XCM a bit more.

Sibling is used for `LocationConverter`

```
pub struct Sibling(pub Id);
```

And explicit types are needed to use the `CurrencyAdapter` trait.

Related #1783 