### PR TITLE
Add parity-keyring to install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ gpg --export 9D4B2B6EB8F97156D19669A9FF0812D491B96798 > /usr/share/keyrings/pari
 # Add the Parity repository and update the package index
 echo 'deb [signed-by=/usr/share/keyrings/parity.gpg] https://releases.parity.io/deb release main' > /etc/apt/sources.list.d/parity.list
 apt update
+# Install the `parity-keyring` package - This will ensure the GPG key
+# used by APT remains up-to-date
+apt install parity-keyring
 # Install polkadot
 apt install polkadot
 


### PR DESCRIPTION
Background: The signing key for security@parity.io was due to expire on 2020-11-27. This has since been updated and will now expire on 2021-07-16. This signing key is used to sign our RPM and APT packages, as well as the binaries attached to releases.

I created a (currently only) debian package named [parity-keyring](https://github.com/paritytech/parity-keyring) that will ensure this GPG key remains up-to-date in the future. This change simply adds the installation of it to the install instructions.