### PR TITLE
Move erasure root out of candidate commitments and into descriptor

### DIFF
--- a/node/collation-generation/src/lib.rs
+++ b/node/collation-generation/src/lib.rs
@@ -702,6 +702,7 @@ mod tests {
 				collator: config.key.public(),
 				persisted_validation_data_hash: expect_validation_data_hash,
 				pov_hash: expect_pov_hash,
+				erasure_root: Default::default(), // this isn't something we're checking right now
 			};
 
 			assert_eq!(sent_messages.len(), 1);
@@ -728,6 +729,7 @@ mod tests {
 					let expect_descriptor = {
 						let mut expect_descriptor = expect_descriptor;
 						expect_descriptor.signature = descriptor.signature.clone();
+						expect_descriptor.erasure_root = descriptor.erasure_root.clone();
 						expect_descriptor
 					};
 					assert_eq!(descriptor, &expect_descriptor);

--- a/node/collation-generation/src/lib.rs
+++ b/node/collation-generation/src/lib.rs
@@ -284,7 +284,6 @@ async fn handle_new_activations<Context: SubsystemContext>(
 					horizontal_messages: collation.horizontal_messages,
 					new_validation_code: collation.new_validation_code,
 					head_data: collation.head_data,
-					erasure_root,
 					processed_downward_messages: collation.processed_downward_messages,
 					hrmp_watermark: collation.hrmp_watermark,
 				};
@@ -298,6 +297,7 @@ async fn handle_new_activations<Context: SubsystemContext>(
 						collator: task_config.key.public(),
 						persisted_validation_data_hash,
 						pov_hash,
+						erasure_root,
 					},
 				};
 

--- a/node/core/backing/src/lib.rs
+++ b/node/core/backing/src/lib.rs
@@ -377,7 +377,7 @@ impl CandidateBackingJob {
 							Some(Statement::Seconded(candidate))
 						}
 						Err(InvalidErasureRoot) => {
-							self.issue_candidate_invalid_message(candidate.clone()).await?;
+							self.issue_candidate_invalid_message(candidate).await?;
 							None
 						}
 					}

--- a/node/core/backing/src/lib.rs
+++ b/node/core/backing/src/lib.rs
@@ -377,7 +377,7 @@ impl CandidateBackingJob {
 							Some(Statement::Seconded(candidate))
 						}
 						Err(InvalidErasureRoot) => {
-							self.issue_candidate_invalid_message(candidate).await?;
+							self.issue_candidate_invalid_message(candidate.clone()).await?;
 							None
 						}
 					}

--- a/node/core/candidate-validation/src/lib.rs
+++ b/node/core/candidate-validation/src/lib.rs
@@ -36,7 +36,7 @@ use polkadot_subsystem::errors::RuntimeApiError;
 use polkadot_node_primitives::{ValidationResult, InvalidCandidate};
 use polkadot_primitives::v1::{
 	ValidationCode, PoV, CandidateDescriptor, PersistedValidationData,
-	OccupiedCoreAssumption, Hash, ValidationOutputs,
+	OccupiedCoreAssumption, Hash, CandidateCommitments,
 };
 use polkadot_parachain::wasm_executor::{
 	self, IsolationStrategy, ValidationError, InvalidCandidate as WasmInvalidCandidate
@@ -458,7 +458,7 @@ fn validate_candidate_exhaustive<B: ValidationBackend, S: SpawnNamed + 'static>(
 			Ok(ValidationResult::Invalid(InvalidCandidate::ExecutionError(e.to_string()))),
 		Err(ValidationError::Internal(e)) => Err(ValidationFailed(e.to_string())),
 		Ok(res) => {
-			let outputs = ValidationOutputs {
+			let outputs = CandidateCommitments {
 				head_data: res.head_data,
 				upward_messages: res.upward_messages,
 				horizontal_messages: res.horizontal_messages,

--- a/node/core/runtime-api/src/lib.rs
+++ b/node/core/runtime-api/src/lib.rs
@@ -275,7 +275,7 @@ mod tests {
 			fn check_validation_outputs(
 				&self,
 				para_id: ParaId,
-				_commitments: polkadot_primitives::v1::ValidationOutputs,
+				_commitments: polkadot_primitives::v1::CandidateCommitments,
 			) -> bool {
 				self.validation_outputs_results
 					.get(&para_id)
@@ -497,7 +497,7 @@ mod tests {
 		let relay_parent = [1; 32].into();
 		let para_a = 5.into();
 		let para_b = 6.into();
-		let commitments = polkadot_primitives::v1::ValidationOutputs::default();
+		let commitments = polkadot_primitives::v1::CandidateCommitments::default();
 
 		runtime_api.validation_outputs_results.insert(para_a, false);
 		runtime_api.validation_outputs_results.insert(para_b, true);

--- a/node/network/availability-distribution/src/lib.rs
+++ b/node/network/availability-distribution/src/lib.rs
@@ -640,7 +640,7 @@ where
 	};
 
 	// check the merkle proof
-	let root = &live_candidate.commitments.erasure_root;
+	let root = &live_candidate.descriptor.erasure_root;
 	let anticipated_hash = if let Ok(hash) = branch_hash(
 		root,
 		&message.erasure_chunk.proof,

--- a/node/network/availability-distribution/src/tests.rs
+++ b/node/network/availability-distribution/src/tests.rs
@@ -290,11 +290,11 @@ impl TestCandidateBuilder {
 				para_id: self.para_id,
 				pov_hash: self.pov_hash,
 				relay_parent: self.relay_parent,
+				erasure_root: self.erasure_root,
 				..Default::default()
 			},
 			commitments: CandidateCommitments {
 				head_data: self.head_data,
-				erasure_root: self.erasure_root,
 				..Default::default()
 			},
 		}
@@ -323,7 +323,7 @@ fn helper_integrity() {
 	let message =
 		make_valid_availability_gossip(&test_state, candidate.hash(), 2, pov_block.clone());
 
-	let root = dbg!(&candidate.commitments.erasure_root);
+	let root = dbg!(&candidate.descriptor.erasure_root);
 
 	let anticipated_hash = branch_hash(
 		root,

--- a/node/primitives/src/lib.rs
+++ b/node/primitives/src/lib.rs
@@ -28,7 +28,7 @@ use polkadot_primitives::v1::{
 	Hash, CommittedCandidateReceipt, CandidateReceipt, CompactStatement,
 	EncodeAs, Signed, SigningContext, ValidatorIndex, ValidatorId,
 	UpwardMessage, ValidationCode, PersistedValidationData, ValidationData,
-	HeadData, PoV, CollatorPair, Id as ParaId, OutboundHrmpMessage, ValidationOutputs, CandidateHash,
+	HeadData, PoV, CollatorPair, Id as ParaId, OutboundHrmpMessage, CandidateCommitments, CandidateHash,
 };
 use polkadot_statement_table::{
 	generic::{
@@ -144,7 +144,7 @@ pub enum InvalidCandidate {
 pub enum ValidationResult {
 	/// Candidate is valid. The validation process yields these outputs and the persisted validation
 	/// data used to form inputs.
-	Valid(ValidationOutputs, PersistedValidationData),
+	Valid(CandidateCommitments, PersistedValidationData),
 	/// Candidate is invalid.
 	Invalid(InvalidCandidate),
 }

--- a/node/subsystem/src/messages.rs
+++ b/node/subsystem/src/messages.rs
@@ -406,7 +406,7 @@ pub enum RuntimeApiRequest {
 	/// Sends back `true` if the validation outputs pass all acceptance criteria checks.
 	CheckValidationOutputs(
 		ParaId,
-		polkadot_primitives::v1::ValidationOutputs,
+		polkadot_primitives::v1::CandidateCommitments,
 		RuntimeApiSender<bool>,
 	),
 	/// Get the session index that a child of the block will have.

--- a/primitives/src/v1.rs
+++ b/primitives/src/v1.rs
@@ -113,6 +113,8 @@ pub struct CandidateDescriptor<H = Hash> {
 	pub persisted_validation_data_hash: Hash,
 	/// The blake2-256 hash of the pov.
 	pub pov_hash: Hash,
+	/// The root of a block's erasure encoding Merkle tree.
+	pub erasure_root: Hash,
 	/// Signature on blake2-256 of components of this receipt:
 	/// The parachain index, the relay parent, the validation data hash, and the pov_hash.
 	pub signature: CollatorSignature,
@@ -338,8 +340,6 @@ pub struct CandidateCommitments<N = BlockNumber> {
 	pub upward_messages: Vec<UpwardMessage>,
 	/// Horizontal messages sent by the parachain.
 	pub horizontal_messages: Vec<OutboundHrmpMessage<Id>>,
-	/// The root of a block's erasure encoding Merkle tree.
-	pub erasure_root: Hash,
 	/// New validation code.
 	pub new_validation_code: Option<ValidationCode>,
 	/// The head-data produced as a result of execution.

--- a/primitives/src/v1.rs
+++ b/primitives/src/v1.rs
@@ -685,7 +685,7 @@ sp_api::decl_runtime_apis! {
 			-> Option<PersistedValidationData<N>>;
 
 		/// Checks if the given validation outputs pass the acceptance criteria.
-		fn check_validation_outputs(para_id: Id, outputs: ValidationOutputs) -> bool;
+		fn check_validation_outputs(para_id: Id, outputs: CandidateCommitments) -> bool;
 
 		/// Returns the session index expected at a child of the block.
 		///

--- a/primitives/src/v1.rs
+++ b/primitives/src/v1.rs
@@ -314,24 +314,6 @@ pub struct TransientValidationData<N = BlockNumber> {
 	pub dmq_length: u32,
 }
 
-/// Outputs of validating a candidate.
-#[derive(Encode, Decode)]
-#[cfg_attr(feature = "std", derive(Clone, Debug, Default))]
-pub struct ValidationOutputs {
-	/// The head-data produced by validation.
-	pub head_data: HeadData,
-	/// Upward messages to the relay chain.
-	pub upward_messages: Vec<UpwardMessage>,
-	/// The horizontal messages sent by the parachain.
-	pub horizontal_messages: Vec<OutboundHrmpMessage<Id>>,
-	/// The new validation code submitted by the execution, if any.
-	pub new_validation_code: Option<ValidationCode>,
-	/// The number of messages processed from the DMQ.
-	pub processed_downward_messages: u32,
-	/// The mark which specifies the block number up to which all inbound HRMP messages are processed.
-	pub hrmp_watermark: BlockNumber,
-}
-
 /// Commitments made in a `CandidateReceipt`. Many of these are outputs of validation.
 #[derive(PartialEq, Eq, Clone, Encode, Decode)]
 #[cfg_attr(feature = "std", derive(Debug, Default, Hash))]

--- a/roadmap/implementers-guide/src/types/candidate.md
+++ b/roadmap/implementers-guide/src/types/candidate.md
@@ -276,26 +276,3 @@ struct SigningContext {
 	session_index: SessionIndex,
 }
 ```
-
-## Validation Outputs
-
-This struct encapsulates the outputs of candidate validation.
-
-```rust
-struct ValidationOutputs {
-	/// The head-data produced by validation.
-	head_data: HeadData,
-	/// The validation data, persisted.
-	validation_data: PersistedValidationData,
-	/// Messages directed to other paras routed via the relay chain.
-	horizontal_messages: Vec<OutboundHrmpMessage>,
-	/// Upwards messages to the relay chain.
-	upwards_messages: Vec<UpwardsMessage>,
-	/// The new validation code submitted by the execution, if any.
-	new_validation_code: Option<ValidationCode>,
-	/// The number of messages processed from the DMQ.
-	processed_downward_messages: u32,
-	/// The mark which specifies the block number up to which all inbound HRMP messages are processed.
-	hrmp_watermark: BlockNumber,
-}
-```

--- a/roadmap/implementers-guide/src/types/candidate.md
+++ b/roadmap/implementers-guide/src/types/candidate.md
@@ -80,6 +80,8 @@ struct CandidateDescriptor {
 	persisted_validation_data_hash: Hash,
 	/// The blake2-256 hash of the pov-block.
 	pov_hash: Hash,
+	/// The root of a block's erasure encoding Merkle tree.
+	erasure_root: Hash,
 	/// Signature on blake2-256 of components of this receipt:
 	/// The parachain index, the relay parent, the validation data hash, and the pov_hash.
 	signature: CollatorSignature,
@@ -251,8 +253,6 @@ struct CandidateCommitments {
 	horizontal_messages: Vec<OutboundHrmpMessage>,
 	/// Messages destined to be interpreted by the Relay chain itself.
 	upward_messages: Vec<UpwardMessage>,
-	/// The root of a block's erasure encoding Merkle tree.
-	erasure_root: Hash,
 	/// New validation code.
 	new_validation_code: Option<ValidationCode>,
 	/// The head-data produced as a result of execution.

--- a/roadmap/implementers-guide/src/types/overseer-protocol.md
+++ b/roadmap/implementers-guide/src/types/overseer-protocol.md
@@ -470,7 +470,7 @@ Various modules request that the [Candidate Validation subsystem](../node/utilit
 enum ValidationResult {
 	/// Candidate is valid, and here are the outputs and the validation data used to form inputs.
 	/// In practice, this should be a shared type so that validation caching can be done.
-	Valid(ValidationOutputs, PersistedValidationData),
+	Valid(CandidateCommitments, PersistedValidationData),
 	/// Candidate is invalid.
 	Invalid,
 }

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -1083,7 +1083,7 @@ sp_api::impl_runtime_apis! {
 		}
 		fn check_validation_outputs(
 			_: Id,
-			_: primitives::v1::ValidationOutputs,
+			_: primitives::v1::CandidateCommitments,
 		) -> bool {
 			false
 		}

--- a/runtime/parachains/src/inclusion.rs
+++ b/runtime/parachains/src/inclusion.rs
@@ -562,7 +562,7 @@ impl<T: Trait> Module<T> {
 	/// Run the acceptance criteria checks on the given candidate commitments.
 	pub(crate) fn check_validation_outputs(
 		para_id: ParaId,
-		validation_outputs: primitives::v1::ValidationOutputs,
+		validation_outputs: primitives::v1::CandidateCommitments,
 	) -> bool {
 		if let Err(err) = CandidateCheckContext::<T>::new().check_validation_outputs(
 			para_id,

--- a/runtime/parachains/src/runtime_api_impl/v1.rs
+++ b/runtime/parachains/src/runtime_api_impl/v1.rs
@@ -221,7 +221,7 @@ pub fn persisted_validation_data<T: initializer::Trait>(
 /// Implementation for the `check_validation_outputs` function of the runtime API.
 pub fn check_validation_outputs<T: initializer::Trait>(
 	para_id: ParaId,
-	outputs: primitives::v1::ValidationOutputs,
+	outputs: primitives::v1::CandidateCommitments,
 ) -> bool {
 	<inclusion::Module<T>>::check_validation_outputs(para_id, outputs)
 }

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -1078,7 +1078,7 @@ sp_api::impl_runtime_apis! {
 			None
 		}
 
-		fn check_validation_outputs(_: Id, _: primitives::v1::ValidationOutputs) -> bool {
+		fn check_validation_outputs(_: Id, _: primitives::v1::CandidateCommitments) -> bool {
 			false
 		}
 

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -654,7 +654,7 @@ sp_api::impl_runtime_apis! {
 
 		fn check_validation_outputs(
 			para_id: Id,
-			outputs: primitives::v1::ValidationOutputs,
+			outputs: primitives::v1::CandidateCommitments,
 		) -> bool {
 			runtime_api_impl::check_validation_outputs::<Runtime>(para_id, outputs)
 		}

--- a/runtime/test-runtime/src/lib.rs
+++ b/runtime/test-runtime/src/lib.rs
@@ -647,7 +647,7 @@ sp_api::impl_runtime_apis! {
 
 		fn check_validation_outputs(
 			para_id: ParaId,
-			outputs: primitives::v1::ValidationOutputs,
+			outputs: primitives::v1::CandidateCommitments,
 		) -> bool {
 			runtime_impl::check_validation_outputs::<Runtime>(para_id, outputs)
 		}

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -831,7 +831,7 @@ sp_api::impl_runtime_apis! {
 
 		fn check_validation_outputs(
 			_: Id,
-			_: primitives::v1::ValidationOutputs
+			_: primitives::v1::CandidateCommitments
 		) -> bool {
 			false
 		}


### PR DESCRIPTION
Only descriptors are available at the point where we do availability recovery, so we needed this to be in the descriptor.

It also made it easier to reason about commitments as stuff that the chain needs to be notified of. In fact, it made the `ValidationOutputs` struct completely redundant, so I removed it and used `CandidateCommitments` everywhere it used to be.

Candidate backing has the largest changeset. I made sure we are still checking:
  1. That the validated commitments match the ones sent to us by a collator / another validator
  1. That the erasure root matches the ones sent to us by a collator / another validator.

Previously, these checks were the same, but now they are separate.