### PR TITLE
Proof of concept: Jaeger integration to debug parachains

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fc95d1bdb8e6666b2b217308eeeb09f2d6728d104be3e31916cc74d15420331"
 dependencies = [
- "generic-array 0.14.2",
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -98,17 +98,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "043164d8ba5c4c3035fec9bbee8647c0261d788f3474306f93bb65901cae0e86"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "alga"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f823d037a7ec6ea2197046bafd4ae150e6bc36f9ca347404f46a46823fa84f2"
-dependencies = [
- "approx",
- "num-complex",
- "num-traits 0.2.12",
 ]
 
 [[package]]
@@ -280,15 +269,15 @@ dependencies = [
 
 [[package]]
 name = "async-std"
-version = "1.6.5"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9fa76751505e8df1c7a77762f60486f60c71bbd9b8557f4da6ad47d083732ed"
+checksum = "a7e82538bc65a25dbdff70e4c5439d52f068048ab97cdea0acd73f131594caa1"
 dependencies = [
  "async-global-executor",
  "async-io",
  "async-mutex",
  "blocking",
- "crossbeam-utils",
+ "crossbeam-utils 0.8.1",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -321,7 +310,7 @@ dependencies = [
  "futures-io",
  "rustls",
  "webpki",
- "webpki-roots",
+ "webpki-roots 0.20.0",
 ]
 
 [[package]]
@@ -496,17 +485,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "blake2s_simd"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab9e07352b829279624ceb7c64adb4f585dacdb81d35cafae81139ccd617cf44"
-dependencies = [
- "arrayref",
- "arrayvec 0.5.2",
- "constant_time_eq",
-]
-
-[[package]]
 name = "block-buffer"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -525,7 +503,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
  "block-padding 0.2.1",
- "generic-array 0.14.2",
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -534,7 +512,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa136449e765dc7faa244561ccae839c394048667929af599b5d931ebe7b7f10"
 dependencies = [
- "generic-array 0.14.2",
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -543,7 +521,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f337a3e6da609650eb74e02bc9fac7b735049f7623ab12f2e4c719316fcc7e80"
 dependencies = [
- "generic-array 0.14.2",
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -574,12 +552,6 @@ dependencies = [
  "futures-lite",
  "once_cell",
 ]
-
-[[package]]
-name = "bs58"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "476e9cd489f9e121e02ffa6014a8ef220ecb15c05ed23fc34cca13925dc283fb"
 
 [[package]]
 name = "bs58"
@@ -965,7 +937,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285"
 dependencies = [
  "crossbeam-epoch",
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
  "maybe-uninit",
 ]
 
@@ -977,7 +949,7 @@ checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
 dependencies = [
  "autocfg 1.0.0",
  "cfg-if 0.1.10",
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
  "lazy_static",
  "maybe-uninit",
  "memoffset",
@@ -991,7 +963,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "774ba60a54c213d409d5353bda12d49cd68d14e45036a285234c8d6f91f92570"
 dependencies = [
  "cfg-if 0.1.10",
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
  "maybe-uninit",
 ]
 
@@ -1003,6 +975,17 @@ checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 dependencies = [
  "autocfg 1.0.0",
  "cfg-if 0.1.10",
+ "lazy_static",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
+dependencies = [
+ "autocfg 1.0.0",
+ "cfg-if 1.0.0",
  "lazy_static",
 ]
 
@@ -1028,7 +1011,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
- "generic-array 0.14.2",
+ "generic-array 0.14.4",
  "subtle 2.2.3",
 ]
 
@@ -1126,7 +1109,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array 0.14.2",
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -1136,6 +1119,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "551a778172a450d7fc12e629ca3b0428d00f6afa9a43da1b630d54604e97371c"
 dependencies = [
  "cfg-if 0.1.10",
+ "dirs-sys",
+]
+
+[[package]]
+name = "directories"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fed639d60b58d0f53498ab13d26f621fd77569cc6edb031f4cc36a2ad9da0f"
+dependencies = [
  "dirs-sys",
 ]
 
@@ -1480,7 +1472,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -1488,7 +1480,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1506,7 +1498,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "chrono",
  "frame-benchmarking",
@@ -1528,7 +1520,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1544,7 +1536,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata"
 version = "12.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -1555,7 +1547,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "bitflags",
  "frame-metadata",
@@ -1580,7 +1572,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "frame-support-procedural-tools",
  "proc-macro2 1.0.24",
@@ -1591,7 +1583,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -1603,7 +1595,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -1613,7 +1605,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples 0.1.3",
@@ -1629,7 +1621,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -1643,7 +1635,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -1878,9 +1870,18 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.2"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac746a5f3bbfdadd6106868134545e684693d54d9d44f6e9588a7d54af0bf980"
+checksum = "0ed1e761351b56f54eb9dcd0cfaca9fd0daecf93918e1cfc01c8a3d26ee7adcd"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
 dependencies = [
  "typenum",
  "version_check",
@@ -2352,6 +2353,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b141fdc7836c525d4d594027d318c84161ca17aaf8113ab1f81ab93ae897485"
 
 [[package]]
+name = "integer-encoding"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f4ebd0bd29be0f11973e9b3e219005661042a019fd757798c36a47c87852625"
+
+[[package]]
 name = "integer-sqrt"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2771,9 +2778,9 @@ checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 
 [[package]]
 name = "libp2p"
-version = "0.30.1"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c2b4c99f8798be90746fc226acf95d3e6cff0655883634cc30dab1f64f438b"
+checksum = "24966e73cc5624a6cf14b025365f67cb6da436b4d6337ed84d198063ba74451d"
 dependencies = [
  "atomic",
  "bytes 0.5.6",
@@ -2800,7 +2807,6 @@ dependencies = [
  "libp2p-wasm-ext",
  "libp2p-websocket",
  "libp2p-yamux",
- "multihash",
  "parity-multiaddr",
  "parking_lot 0.11.1",
  "pin-project 1.0.2",
@@ -2810,12 +2816,13 @@ dependencies = [
 
 [[package]]
 name = "libp2p-core"
-version = "0.24.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8186060d6bd415e4e928e6cb44c4fe7e7a7dd53437bd936ce7e5f421e45a51"
+checksum = "28d92fab5df60c9705e05750d9ecee6a5af15aed1e3fa86e09fd3dd07ec5dc8e"
 dependencies = [
  "asn1_der",
- "bs58 0.4.0",
+ "bs58",
+ "bytes 0.5.6",
  "ed25519-dalek",
  "either",
  "fnv",
@@ -2837,16 +2844,16 @@ dependencies = [
  "sha2 0.9.1",
  "smallvec 1.5.0",
  "thiserror",
- "unsigned-varint 0.5.1",
+ "unsigned-varint",
  "void",
  "zeroize",
 ]
 
 [[package]]
 name = "libp2p-core-derive"
-version = "0.20.2"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f753d9324cd3ec14bf04b8a8cd0d269c87f294153d6bf2a84497a63a5ad22213"
+checksum = "f4bc40943156e42138d22ed3c57ff0e1a147237742715937622a99b10fbe0156"
 dependencies = [
  "quote 1.0.7",
  "syn 1.0.48",
@@ -2854,9 +2861,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-deflate"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34aea69349e70a58ef9ecd21ac12c5eaa36255ac6986828079d26393f9e618cb"
+checksum = "5a579d7dd506d0620ba88ccc1754436b7de35ed6c884234f9a226bbfce382640"
 dependencies = [
  "flate2",
  "futures 0.3.8",
@@ -2865,9 +2872,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-dns"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0baeff71fb5cb1fe1604f74a712a44b66a8c5900f4022411a1d550f09d6bb776"
+checksum = "15dea5933f570844d7b5222b12b58f7bd52e9ca38cd65a1bd4f35341f053f012"
 dependencies = [
  "futures 0.3.8",
  "libp2p-core",
@@ -2876,9 +2883,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-floodsub"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db0f925a45f310b678e70faf71a10023b829d02eb9cc2628a63de928936f3ade"
+checksum = "23070a0838bd9a8adb27e6eba477eeb650c498f9d139383dd0135d20a8170253"
 dependencies = [
  "cuckoofilter",
  "fnv",
@@ -2894,9 +2901,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-gossipsub"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efeb65567174974f551a91f9f5719445b6695cad56f6a7a47a27111f37efb6b8"
+checksum = "65e8f3aa0906fbad435dac23c177eef3cdfaaf62609791bd7f54f8553edcfdf9"
 dependencies = [
  "base64 0.13.0",
  "byteorder",
@@ -2914,15 +2921,15 @@ dependencies = [
  "rand 0.7.3",
  "sha2 0.9.1",
  "smallvec 1.5.0",
- "unsigned-varint 0.5.1",
+ "unsigned-varint",
  "wasm-timer",
 ]
 
 [[package]]
 name = "libp2p-identify"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e074124669840484de564901d47f2d0892e73f6d8ee7c37e9c2644af1b217bf4"
+checksum = "802fb973a7e0dde3fb9a2113a62bad90338ebe01983b706e1d576d0c2af93cda"
 dependencies = [
  "futures 0.3.8",
  "libp2p-core",
@@ -2936,9 +2943,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-kad"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78a2653b2e3254a3bbeb66bfc3f0dca7d6cba6aa2a96791db114003dec1b5394"
+checksum = "6506b7b7982f7626fc96a91bc61be4b1fe7ae9ac23824f0ecefcce21cb39238c"
 dependencies = [
  "arrayvec 0.5.2",
  "bytes 0.5.6",
@@ -2949,23 +2956,22 @@ dependencies = [
  "libp2p-core",
  "libp2p-swarm",
  "log",
- "multihash",
  "prost",
  "prost-build",
  "rand 0.7.3",
  "sha2 0.9.1",
  "smallvec 1.5.0",
  "uint",
- "unsigned-varint 0.5.1",
+ "unsigned-varint",
  "void",
  "wasm-timer",
 ]
 
 [[package]]
 name = "libp2p-mdns"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786b068098794322239f8f04df88a52daeb7863b2e77501c4d85d32e0a8f2d26"
+checksum = "4458ec36b5ab2662fb4d5c8bb9b6e1591da0ab6efe8881c7a7670ef033bc8937"
 dependencies = [
  "async-std",
  "data-encoding",
@@ -2985,9 +2991,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-mplex"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed764eab613a8fb6b7dcf6c796f55a06fef2270e528329903e25cd3311b99663"
+checksum = "ae2132b14045009b0f8e577a06e1459592ef0a89dedc58f3d4baf4eac956837b"
 dependencies = [
  "bytes 0.5.6",
  "futures 0.3.8",
@@ -2998,14 +3004,14 @@ dependencies = [
  "parking_lot 0.11.1",
  "rand 0.7.3",
  "smallvec 1.5.0",
- "unsigned-varint 0.5.1",
+ "unsigned-varint",
 ]
 
 [[package]]
 name = "libp2p-noise"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb441fb015ec16690099c5d910fcba271d357763b3dcb784db7b27bbb0b68372"
+checksum = "b9610a524bef4db383cd96b4ec3ec4722eafa72c7242fa89990b74166760583d"
 dependencies = [
  "bytes 0.5.6",
  "curve25519-dalek 3.0.0",
@@ -3025,9 +3031,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-ping"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e5c50936cfdbe96a514e8992f304fa44cd3a681b6f779505f1ae62b3474705"
+checksum = "659adf89356e04f65398bb74ee791b269e63da9e41b37f8dc19eaacd12487bfe"
 dependencies = [
  "futures 0.3.8",
  "libp2p-core",
@@ -3040,9 +3046,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-plaintext"
-version = "0.24.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21026557c335d3639591f247b19b7536195772034ec7e9c463137227f95eaaa1"
+checksum = "96dfe26270c91d4ff095030d1fcadd602f3fd84968ebd592829916d0715798a6"
 dependencies = [
  "bytes 0.5.6",
  "futures 0.3.8",
@@ -3051,7 +3057,7 @@ dependencies = [
  "log",
  "prost",
  "prost-build",
- "unsigned-varint 0.5.1",
+ "unsigned-varint",
  "void",
 ]
 
@@ -3071,9 +3077,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-request-response"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dd9a1e0e6563dec1c9e702f7e68bdaa43da62a84536aa06372d3fed3e25d4ca"
+checksum = "1e952dcc9d2d7e7e45ae8bfcff255723091bd43e3e9a7741a0af8a17fe55b3ed"
 dependencies = [
  "async-trait",
  "bytes 0.5.6",
@@ -3085,15 +3091,15 @@ dependencies = [
  "minicbor",
  "rand 0.7.3",
  "smallvec 1.5.0",
- "unsigned-varint 0.5.1",
+ "unsigned-varint",
  "wasm-timer",
 ]
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.24.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "565f0e06674b4033c978471e4083d5aaa8e03cef0719a0ec0905aaeaad39a919"
+checksum = "a6ecee54e85513a7301eb4681b3a6aac5b6d11f60d43097cf7624fd4450d7dfe"
 dependencies = [
  "either",
  "futures 0.3.8",
@@ -3107,9 +3113,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-tcp"
-version = "0.24.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33f3dce259c0d3127af5167f45c275b6c047320efdd0e40fde947482487af0a3"
+checksum = "bc28c9ad6dc43f4c3950411cf808639d90307a076330e7996e5e94e70279bde0"
 dependencies = [
  "async-std",
  "futures 0.3.8",
@@ -3123,9 +3129,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-uds"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e0aba04370a00d8d0236e350bc862926c1b42542a169aa6a481e660e5b990fe"
+checksum = "9d821208d4b9af4b293a56dde470edd9f9fac8bb94a51f4f5327cc29a471b3f3"
 dependencies = [
  "async-std",
  "futures 0.3.8",
@@ -3135,9 +3141,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-wasm-ext"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c703816f4170477a375b49c56d349e535ce68388f81ba1d9a3c8e2517effa82"
+checksum = "1e6ef400b231ba78e866b860445480ca21ee447e03034138c6d57cf2969d6bf4"
 dependencies = [
  "futures 0.3.8",
  "js-sys",
@@ -3149,9 +3155,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-websocket"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d5e7268a959748040a0cf7456ad655be55b87f0ceda03bdb5b53674726b28f7"
+checksum = "a5736e2fccdcea6e728bbaf903bddc113be223313ce2c756ad9fe43b5a2b0f06"
 dependencies = [
  "async-tls",
  "either",
@@ -3164,14 +3170,14 @@ dependencies = [
  "soketto",
  "url 2.1.1",
  "webpki",
- "webpki-roots",
+ "webpki-roots 0.21.0",
 ]
 
 [[package]]
 name = "libp2p-yamux"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a0798cbb58535162c40858493d09af06eac42a26e4966e58de0df701f559348"
+checksum = "3be7ac000fa3e42ac09a6e658e48de34ac8ef9fff64a4e6e6b08dcc8f4b0e5f6"
 dependencies = [
  "futures 0.3.8",
  "libp2p-core",
@@ -3237,11 +3243,10 @@ dependencies = [
 
 [[package]]
 name = "linregress"
-version = "0.1.7"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9290cf6f928576eeb9c096c6fad9d8d452a0a1a70a2bbffa6e36064eedc0aac9"
+checksum = "0d0ad4b5cc8385a881c561fac3501353d63d2a2b7a357b5064d71815c9a92724"
 dependencies = [
- "failure",
  "nalgebra",
  "statrs",
 ]
@@ -3397,6 +3402,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "mick-jaeger"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68c751e6643309568aa78a725b75755c11d866d6d0d0f7209033142007971cdd"
+dependencies = [
+ "futures 0.3.8",
+ "rand 0.7.3",
+ "thrift",
+]
+
+[[package]]
 name = "minicbor"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3509,17 +3525,29 @@ checksum = "0debeb9fcf88823ea64d64e4a815ab1643f33127d995978e099942ce38f25238"
 
 [[package]]
 name = "multihash"
-version = "0.11.4"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567122ab6492f49b59def14ecc36e13e64dca4188196dd0cd41f9f3f979f3df6"
+checksum = "fb63389ee5fcd4df3f8727600f4a0c3df53c541f0ed4e8b50a9ae51a80fc1efe"
 dependencies = [
- "blake2b_simd",
- "blake2s_simd",
  "digest 0.9.0",
- "sha-1 0.9.2",
+ "generic-array 0.14.4",
+ "multihash-derive",
  "sha2 0.9.1",
- "sha3",
- "unsigned-varint 0.5.1",
+ "unsigned-varint",
+]
+
+[[package]]
+name = "multihash-derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f5653449cd45d502a53480ee08d7a599e8f4893d2bacb33c63d65bc20af6c1a"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro-error",
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "syn 1.0.48",
+ "synstructure",
 ]
 
 [[package]]
@@ -3530,32 +3558,33 @@ checksum = "d8883adfde9756c1d30b0f519c9b8c502a94b41ac62f696453c37c7fc0a958ce"
 
 [[package]]
 name = "multistream-select"
-version = "0.8.5"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93faf2e41f9ee62fb01680ed48f3cc26652352327aa2e59869070358f6b7dd75"
+checksum = "46e19fd46149acdd3600780ebaa09f6ae4e7f2ddbafec64aab54cf75aafd1746"
 dependencies = [
  "bytes 0.5.6",
  "futures 0.3.8",
  "log",
  "pin-project 1.0.2",
  "smallvec 1.5.0",
- "unsigned-varint 0.5.1",
+ "unsigned-varint",
 ]
 
 [[package]]
 name = "nalgebra"
-version = "0.18.1"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaa9fddbc34c8c35dd2108515587b8ce0cab396f17977b8c738568e4edb521a2"
+checksum = "d6b6147c3d50b4f3cdabfe2ecc94a0191fd3d6ad58aefd9664cf396285883486"
 dependencies = [
- "alga",
  "approx",
- "generic-array 0.12.3",
+ "generic-array 0.13.2",
  "matrixmultiply",
  "num-complex",
  "num-rational",
  "num-traits 0.2.12",
- "rand 0.6.5",
+ "rand 0.7.3",
+ "rand_distr",
+ "simba",
  "typenum",
 ]
 
@@ -3744,6 +3773,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
+name = "ordered-float"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3741934be594d77de1c8461ebcbbe866f585ea616a9753aa78f2bdc69f0e4579"
+dependencies = [
+ "num-traits 0.2.12",
+]
+
+[[package]]
 name = "output_vt100"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3770,7 +3808,7 @@ checksum = "7a1250cdd103eef6bd542b5ae82989f931fc00a41a27f60377338241594410f3"
 [[package]]
 name = "pallet-authority-discovery"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3786,7 +3824,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3801,7 +3839,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3826,7 +3864,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3840,7 +3878,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3856,7 +3894,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3871,7 +3909,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3886,7 +3924,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3907,7 +3945,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -3923,7 +3961,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3943,7 +3981,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3960,7 +3998,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3974,7 +4012,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3990,7 +4028,7 @@ dependencies = [
 [[package]]
 name = "pallet-nicks"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4004,7 +4042,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4019,7 +4057,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4040,7 +4078,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4056,7 +4094,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4069,7 +4107,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "enumflags2",
  "frame-support",
@@ -4084,7 +4122,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4099,7 +4137,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4119,7 +4157,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4135,7 +4173,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4149,7 +4187,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4171,7 +4209,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.24",
@@ -4182,7 +4220,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4196,7 +4234,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4214,7 +4252,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4231,7 +4269,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -4249,7 +4287,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -4262,7 +4300,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4277,7 +4315,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4293,7 +4331,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -4321,19 +4359,19 @@ dependencies = [
 
 [[package]]
 name = "parity-multiaddr"
-version = "0.9.5"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60d477bda9666bc37e5ac9e7e7ee3684f745ec33e6e86a5b48640e0407acda26"
+checksum = "2f51a30667591b14f96068b2d12f1306d07a41ebd98239d194356d4d9707ac16"
 dependencies = [
  "arrayref",
- "bs58 0.4.0",
+ "bs58",
  "byteorder",
  "data-encoding",
  "multihash",
  "percent-encoding 2.1.0",
  "serde",
  "static_assertions",
- "unsigned-varint 0.5.1",
+ "unsigned-varint",
  "url 2.1.1",
 ]
 
@@ -4443,7 +4481,7 @@ dependencies = [
  "mio",
  "mio-extras",
  "rand 0.7.3",
- "sha-1 0.8.2",
+ "sha-1",
  "slab",
  "url 2.1.1",
 ]
@@ -4632,7 +4670,7 @@ checksum = "54be6e404f5317079812fc8f9f5279de376d8856929e21c184ecf6bbd692a11d"
 dependencies = [
  "maplit",
  "pest",
- "sha-1 0.8.2",
+ "sha-1",
 ]
 
 [[package]]
@@ -5082,10 +5120,13 @@ name = "polkadot-node-subsystem"
 version = "0.1.0"
 dependencies = [
  "assert_matches",
+ "async-std",
  "async-trait",
  "derive_more",
  "futures 0.3.8",
  "futures-timer 3.0.2",
+ "lazy_static",
+ "mick-jaeger",
  "parity-scale-codec",
  "parking_lot 0.11.1",
  "pin-project 1.0.2",
@@ -5809,18 +5850,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10d4b51f154c8a7fb96fd6dad097cb74b863943ec010ac94b9fd1be8861fe1e"
+checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
 dependencies = [
  "toml",
 ]
 
 [[package]]
 name = "proc-macro-error"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc175e9777c3116627248584e8f8b3e2987405cabe1c0adf7d1dd28f09dc7880"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
  "proc-macro2 1.0.24",
@@ -5831,14 +5872,12 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-error-attr"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cc9795ca17eb581285ec44936da7fc2335a3f34f2ddd13118b6f4d515435c50"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.48",
- "syn-mid",
  "version_check",
 ]
 
@@ -6020,19 +6059,6 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c618c47cd3ebd209790115ab837de41425723956ad3ce2e6a7f09890947cacb9"
-dependencies = [
- "cloudabi 0.0.3",
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "rand"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
@@ -6106,6 +6132,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rand_distr"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96977acbdd3a6576fb1d27391900035bf3863d4a16422973a409b488cf29ffb2"
+dependencies = [
+ "rand 0.7.3",
 ]
 
 [[package]]
@@ -6226,7 +6261,7 @@ checksum = "e92e15d89083484e11353891f1af602cc661426deb9564c298b270c726973280"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-queue",
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
  "lazy_static",
  "num_cpus",
 ]
@@ -6427,9 +6462,9 @@ dependencies = [
 
 [[package]]
 name = "rpassword"
-version = "4.0.5"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99371657d3c8e4d816fb6221db98fa408242b0b53bac08f8676a41f8554fe99f"
+checksum = "d755237fc0f99d98641540e66abac8bc46a0652f19148ac9e21de2da06b326c9"
 dependencies = [
  "libc",
  "winapi 0.3.9",
@@ -6444,7 +6479,7 @@ dependencies = [
  "base64 0.11.0",
  "blake2b_simd",
  "constant_time_eq",
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
 ]
 
 [[package]]
@@ -6552,10 +6587,9 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "async-trait",
- "bytes 0.5.6",
  "derive_more",
  "either",
  "futures 0.3.8",
@@ -6567,7 +6601,6 @@ dependencies = [
  "prost-build",
  "rand 0.7.3",
  "sc-client-api",
- "sc-keystore",
  "sc-network",
  "serde_json",
  "sp-api",
@@ -6582,7 +6615,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "futures 0.3.8",
  "futures-timer 3.0.2",
@@ -6605,7 +6638,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -6622,7 +6655,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "impl-trait-for-tuples 0.1.3",
  "parity-scale-codec",
@@ -6643,7 +6676,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.24",
@@ -6654,7 +6687,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
@@ -6699,7 +6732,7 @@ dependencies = [
 [[package]]
 name = "sc-cli-proc-macro"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.24",
@@ -6710,20 +6743,18 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "derive_more",
  "fnv",
  "futures 0.3.8",
  "hash-db",
- "hex-literal",
  "kvdb",
  "lazy_static",
  "log",
  "parity-scale-codec",
  "parking_lot 0.10.2",
  "sc-executor",
- "sc-telemetry",
  "sp-api",
  "sp-blockchain",
  "sp-consensus",
@@ -6731,7 +6762,6 @@ dependencies = [
  "sp-database",
  "sp-externalities",
  "sp-inherents",
- "sp-keyring",
  "sp-keystore",
  "sp-runtime",
  "sp-state-machine",
@@ -6747,7 +6777,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "blake2-rfc",
  "hash-db",
@@ -6777,7 +6807,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "sc-client-api",
  "sp-blockchain",
@@ -6788,7 +6818,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "derive_more",
  "fork-tree",
@@ -6833,7 +6863,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "derive_more",
  "futures 0.3.8",
@@ -6857,7 +6887,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -6870,7 +6900,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "futures 0.3.8",
  "futures-timer 3.0.2",
@@ -6895,7 +6925,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-uncles"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "log",
  "sc-client-api",
@@ -6909,7 +6939,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "derive_more",
  "lazy_static",
@@ -6938,7 +6968,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "derive_more",
  "log",
@@ -6955,7 +6985,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -6970,7 +7000,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -6988,7 +7018,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "derive_more",
  "finality-grandpa",
@@ -7025,7 +7055,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa-rpc"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "derive_more",
  "finality-grandpa",
@@ -7049,7 +7079,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "ansi_term 0.12.1",
  "futures 0.3.8",
@@ -7067,7 +7097,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -7087,7 +7117,7 @@ dependencies = [
 [[package]]
 name = "sc-light"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "hash-db",
  "lazy_static",
@@ -7106,12 +7136,12 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "async-std",
  "async-trait",
  "bitflags",
- "bs58 0.3.1",
+ "bs58",
  "bytes 0.5.6",
  "derive_more",
  "either",
@@ -7130,7 +7160,7 @@ dependencies = [
  "lru",
  "nohash-hasher",
  "parity-scale-codec",
- "parking_lot 0.10.2",
+ "parking_lot 0.11.1",
  "pin-project 0.4.23",
  "prost",
  "prost-build",
@@ -7142,7 +7172,7 @@ dependencies = [
  "serde_json",
  "slog",
  "slog_derive",
- "smallvec 0.6.13",
+ "smallvec 1.5.0",
  "sp-arithmetic",
  "sp-blockchain",
  "sp-consensus",
@@ -7151,7 +7181,7 @@ dependencies = [
  "sp-utils",
  "substrate-prometheus-endpoint",
  "thiserror",
- "unsigned-varint 0.4.0",
+ "unsigned-varint",
  "void",
  "wasm-timer",
  "zeroize",
@@ -7160,7 +7190,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "futures 0.3.8",
  "futures-timer 3.0.2",
@@ -7175,7 +7205,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "bytes 0.5.6",
  "fnv",
@@ -7202,7 +7232,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "futures 0.3.8",
  "libp2p",
@@ -7215,7 +7245,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -7224,7 +7254,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "futures 0.3.8",
  "hash-db",
@@ -7257,7 +7287,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "derive_more",
  "futures 0.3.8",
@@ -7281,7 +7311,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "futures 0.1.29",
  "jsonrpc-core",
@@ -7299,10 +7329,10 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "derive_more",
- "directories",
+ "directories 3.0.1",
  "exit-future",
  "futures 0.1.29",
  "futures 0.3.8",
@@ -7363,7 +7393,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -7377,7 +7407,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -7396,7 +7426,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "futures 0.3.8",
  "futures-timer 3.0.2",
@@ -7417,7 +7447,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "erased-serde",
  "log",
@@ -7436,7 +7466,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-graph"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "derive_more",
  "futures 0.3.8",
@@ -7457,7 +7487,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "derive_more",
  "futures 0.3.8",
@@ -7688,19 +7718,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha-1"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce3cdf1b5e620a498ee6f2a171885ac7e22f0e12089ec4b3d22b84921792507c"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if 1.0.0",
- "cpuid-bool",
- "digest 0.9.0",
- "opaque-debug 0.3.0",
-]
-
-[[package]]
 name = "sha2"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7797,6 +7814,18 @@ name = "signature"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65211b7b6fc3f14ff9fc7a2011a434e3e6880585bd2e9e9396315ae24cbf7852"
+
+[[package]]
+name = "simba"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb931b1367faadea6b1ab1c306a860ec17aaa5fa39f367d0c744e69d971a1fb2"
+dependencies = [
+ "approx",
+ "num-complex",
+ "num-traits 0.2.12",
+ "paste",
+]
 
 [[package]]
 name = "slab"
@@ -7906,13 +7935,13 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.7.3",
- "sha-1 0.8.2",
+ "sha-1",
 ]
 
 [[package]]
 name = "sp-allocator"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "derive_more",
  "log",
@@ -7924,7 +7953,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
@@ -7939,7 +7968,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate",
@@ -7951,7 +7980,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -7963,7 +7992,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "integer-sqrt",
  "num-traits 0.2.12",
@@ -7976,7 +8005,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7988,7 +8017,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -7999,7 +8028,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -8011,13 +8040,12 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "log",
  "lru",
  "parity-scale-codec",
  "parking_lot 0.10.2",
- "sp-block-builder",
  "sp-consensus",
  "sp-database",
  "sp-runtime",
@@ -8028,7 +8056,7 @@ dependencies = [
 [[package]]
 name = "sp-chain-spec"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "serde",
  "serde_json",
@@ -8037,7 +8065,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "futures 0.3.8",
  "futures-timer 3.0.2",
@@ -8063,7 +8091,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "merlin",
  "parity-scale-codec",
@@ -8083,7 +8111,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -8092,7 +8120,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "parity-scale-codec",
  "schnorrkel",
@@ -8104,7 +8132,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "base58",
  "blake2-rfc",
@@ -8148,7 +8176,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "kvdb",
  "parking_lot 0.10.2",
@@ -8157,7 +8185,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -8167,7 +8195,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -8178,7 +8206,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -8195,7 +8223,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.10.2",
@@ -8207,7 +8235,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "futures 0.3.8",
  "hash-db",
@@ -8231,7 +8259,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -8242,7 +8270,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -8258,7 +8286,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -8270,7 +8298,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections-compact"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.24",
@@ -8281,7 +8309,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -8291,16 +8319,15 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "backtrace",
- "log",
 ]
 
 [[package]]
 name = "sp-rpc"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "serde",
  "sp-core",
@@ -8309,7 +8336,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -8323,7 +8350,6 @@ dependencies = [
  "sp-application-crypto",
  "sp-arithmetic",
  "sp-core",
- "sp-inherents",
  "sp-io",
  "sp-std",
 ]
@@ -8331,7 +8357,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "parity-scale-codec",
  "primitive-types",
@@ -8347,7 +8373,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -8359,7 +8385,7 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "serde",
  "serde_json",
@@ -8368,7 +8394,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -8381,7 +8407,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -8391,7 +8417,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "hash-db",
  "log",
@@ -8413,12 +8439,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 
 [[package]]
 name = "sp-storage"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -8431,7 +8457,7 @@ dependencies = [
 [[package]]
 name = "sp-tasks"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "log",
  "sp-core",
@@ -8444,7 +8470,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "impl-trait-for-tuples 0.1.3",
  "parity-scale-codec",
@@ -8458,7 +8484,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -8471,7 +8497,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "derive_more",
  "futures 0.3.8",
@@ -8486,7 +8512,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -8500,7 +8526,7 @@ dependencies = [
 [[package]]
 name = "sp-utils"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "futures 0.3.8",
  "futures-core",
@@ -8512,7 +8538,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -8524,7 +8550,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "impl-trait-for-tuples 0.1.3",
  "parity-scale-codec",
@@ -8552,11 +8578,11 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "statrs"
-version = "0.10.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10102ac8d55e35db2b3fafc26f81ba8647da2e15879ab686a67e6d19af2685e8"
+checksum = "cce16f6de653e88beca7bd13780d08e09d4489dbca1f9210e041bc4852481382"
 dependencies = [
- "rand 0.5.6",
+ "rand 0.7.3",
 ]
 
 [[package]]
@@ -8565,7 +8591,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09f8ed9974042b8c3672ff3030a69fcc03b74c47c3d1ecb7755e8a3626011e88"
 dependencies = [
- "generic-array 0.14.2",
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -8575,7 +8601,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c80e15f898d8d8f25db24c253ea615cc14acf418ff307822995814e7d42cfa89"
 dependencies = [
  "block-cipher 0.8.0",
- "generic-array 0.14.2",
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -8666,7 +8692,7 @@ dependencies = [
 [[package]]
 name = "substrate-browser-utils"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "chrono",
  "console_error_panic_hook",
@@ -8692,7 +8718,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "platforms",
 ]
@@ -8700,7 +8726,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.8",
@@ -8723,7 +8749,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "async-std",
  "derive_more",
@@ -8737,7 +8763,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "futures 0.1.29",
  "futures 0.3.8",
@@ -8764,7 +8790,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-utils"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "futures 0.3.8",
  "substrate-test-utils-derive",
@@ -8774,7 +8800,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-utils-derive"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#0840c58849bc84e7fd72627745bda243741adcd8"
+source = "git+https://github.com/paritytech/substrate#de44c00109ea19de13ef9219f8888f968d484b55"
 dependencies = [
  "proc-macro-crate",
  "quote 1.0.7",
@@ -8829,17 +8855,6 @@ dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
  "unicode-xid 0.2.1",
-]
-
-[[package]]
-name = "syn-mid"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
-dependencies = [
- "proc-macro2 1.0.24",
- "quote 1.0.7",
- "syn 1.0.48",
 ]
 
 [[package]]
@@ -9006,6 +9021,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "thrift"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6d965454947cc7266d22716ebfd07b18d84ebaf35eec558586bbb2a8cb6b5b"
+dependencies = [
+ "byteorder",
+ "integer-encoding",
+ "log",
+ "ordered-float",
+ "threadpool",
+]
+
+[[package]]
 name = "time"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9133,7 +9161,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb2d1b8f4548dbf5e1f7818512e9c406860678f29c300cdf0ebac72d1a3a1671"
 dependencies = [
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
  "futures 0.1.29",
 ]
 
@@ -9189,7 +9217,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09bc590ec4ba8ba87652da2068d150dcada2cfa2e07faae270a5e0409aa51351"
 dependencies = [
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
  "futures 0.1.29",
  "lazy_static",
  "log",
@@ -9255,7 +9283,7 @@ checksum = "df720b6581784c118f0eb4310796b12b1d242a7eb95f716a8367855325c25f89"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-queue",
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
  "futures 0.1.29",
  "lazy_static",
  "log",
@@ -9270,7 +9298,7 @@ version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93044f2d313c95ff1cb7809ce9a7a05735b012288a888b62d4434fd58c94f296"
 dependencies = [
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
  "futures 0.1.29",
  "slab",
  "tokio-executor",
@@ -9557,20 +9585,8 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8326b2c654932e3e4f9196e69d08fdf7cfd718e1dc6f66b347e6024a0c961402"
 dependencies = [
- "generic-array 0.14.2",
+ "generic-array 0.14.4",
  "subtle 2.2.3",
-]
-
-[[package]]
-name = "unsigned-varint"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "669d776983b692a906c881fcd0cfb34271a48e197e4d6cb8df32b05bfc3d3fa5"
-dependencies = [
- "bytes 0.5.6",
- "futures-io",
- "futures-util",
- "futures_codec",
 ]
 
 [[package]]
@@ -9880,7 +9896,7 @@ dependencies = [
  "cranelift-entity",
  "cranelift-frontend",
  "cranelift-wasm",
- "directories",
+ "directories 2.0.2",
  "errno",
  "file-per-thread-logger",
  "indexmap",
@@ -10023,6 +10039,15 @@ name = "webpki-roots"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f20dea7535251981a9670857150d571846545088359b28e4951d350bdaf179f"
+dependencies = [
+ "webpki",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82015b7e0b8bad8185994674a13a93306bea76cf5a16c5a181382fd3a5ec2376"
 dependencies = [
  "webpki",
 ]

--- a/node/network/availability-distribution/src/lib.rs
+++ b/node/network/availability-distribution/src/lib.rs
@@ -354,6 +354,8 @@ where
 				}
 			};
 
+			let mut _span = polkadot_subsystem::hash_span(&gossiped_availability.candidate_hash.0, "availability-message-received");
+
 			process_incoming_peer_message(ctx, state, remote, gossiped_availability, metrics)
 				.await?;
 		}

--- a/node/network/bitfield-distribution/src/lib.rs
+++ b/node/network/bitfield-distribution/src/lib.rs
@@ -483,6 +483,8 @@ where
 		NetworkBridgeEvent::PeerMessage(remote, message) => {
 			match message {
 				protocol_v1::BitfieldDistributionMessage::Bitfield(relay_parent, bitfield) => {
+					let mut _span = polkadot_subsystem::hash_span(&relay_parent, "bitfield-gossip-received");
+					_span.add_string_tag("peer-id", &remote.to_base58());
 					tracing::trace!(target: LOG_TARGET, peer_id = %remote, "received bitfield gossip from peer");
 					let gossiped_bitfield = BitfieldGossipMessage {
 						relay_parent,

--- a/node/network/collator-protocol/src/collator_side.rs
+++ b/node/network/collator-protocol/src/collator_side.rs
@@ -430,6 +430,8 @@ async fn process_msg(
 			state.collating_on = Some(id);
 		}
 		DistributeCollation(receipt, pov) => {
+			let _span1 = polkadot_subsystem::hash_span(&receipt.descriptor.relay_parent, "distributing-collation");
+			let _span2 = polkadot_subsystem::pov_span(&pov, "distributing-collation");
 			match state.collating_on {
 				Some(id) if receipt.descriptor.para_id != id => {
 					// If the ParaId of a collation requested to be distributed does not match
@@ -539,10 +541,12 @@ async fn handle_incoming_peer_message(
 			);
 		}
 		RequestCollation(request_id, relay_parent, para_id) => {
+			let _span = polkadot_subsystem::hash_span(&relay_parent, "rx-collation-request");
 			match state.collating_on {
 				Some(our_para_id) => {
 					if our_para_id == para_id {
 						if let Some(collation) = state.collations.get(&relay_parent).cloned() {
+							let _span = _span.child("sending");
 							send_collation(ctx, state, request_id, origin, collation.0, collation.1).await;
 						}
 					} else {

--- a/node/network/collator-protocol/src/validator_side.rs
+++ b/node/network/collator-protocol/src/validator_side.rs
@@ -504,6 +504,7 @@ where
 			state.peer_views.entry(origin).or_default();
 		}
 		AdvertiseCollation(relay_parent, para_id) => {
+			let _span = polkadot_subsystem::hash_span(&relay_parent, "advertising-collation");
 			state.advertisements.entry(origin.clone()).or_default().insert((para_id, relay_parent));
 
 			if let Some(collator) = state.known_collators.get(&origin) {
@@ -515,6 +516,8 @@ where
 			modify_reputation(ctx, origin, COST_UNEXPECTED_MESSAGE).await;
 		}
 		Collation(request_id, receipt, pov) => {
+			let _span1 = polkadot_subsystem::hash_span(&receipt.descriptor.relay_parent, "received-collation");
+			let _span2 = polkadot_subsystem::pov_span(&pov, "received-collation");
 			received_collation(ctx, state, origin, request_id, receipt, pov).await;
 		}
 	}
@@ -659,6 +662,7 @@ where
 			);
 		}
 		FetchCollation(relay_parent, collator_id, para_id, tx) => {
+			let _span = polkadot_subsystem::hash_span(&relay_parent, "fetching-collation");
 			fetch_collation(ctx, state, relay_parent, collator_id, para_id, tx).await;
 		}
 		ReportCollator(id) => {

--- a/node/network/statement-distribution/src/lib.rs
+++ b/node/network/statement-distribution/src/lib.rs
@@ -828,6 +828,7 @@ async fn handle_network_update(
 					).await;
 
 					if let Some((relay_parent, new)) = new_stored {
+						let mut _span = polkadot_subsystem::hash_span(&relay_parent, "sending-statement");
 						// When we receive a new message from a peer, we forward it to the
 						// candidate backing subsystem.
 						let message = AllMessages::CandidateBacking(
@@ -943,6 +944,7 @@ impl StatementDistribution {
 				FromOverseer::Communication { msg } => match msg {
 					StatementDistributionMessage::Share(relay_parent, statement) => {
 						let _timer = metrics.time_share();
+						let mut _span = polkadot_subsystem::hash_span(&relay_parent, "circulate-statement");
 
 						inform_statement_listeners(
 							&statement,

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -174,6 +174,7 @@ fn new_partial<RuntimeApi, Executor>(config: &mut Configuration) -> Result<
 		Executor: NativeExecutionDispatch + 'static,
 {
 	set_prometheus_registry(config)?;
+	polkadot_subsystem::init_jaeger(&config.network.node_name);
 
 	let inherent_data_providers = inherents::InherentDataProviders::new();
 

--- a/node/subsystem/Cargo.toml
+++ b/node/subsystem/Cargo.toml
@@ -6,10 +6,13 @@ edition = "2018"
 description = "Subsystem traits and message definitions"
 
 [dependencies]
+async-std = "1.7.0"
 async-trait = "0.1.42"
 derive_more = "0.99.11"
 futures = "0.3.8"
 futures-timer = "3.0.2"
+mick-jaeger = "0.1.1"
+lazy_static = "1.0"
 tracing = "0.1.22"
 tracing-futures = "0.2.4"
 parity-scale-codec = { version = "1.3.5", default-features = false, features = ["derive"] }

--- a/node/subsystem/src/lib.rs
+++ b/node/subsystem/src/lib.rs
@@ -28,7 +28,7 @@ use futures::prelude::*;
 use futures::channel::{mpsc, oneshot};
 use futures::future::BoxFuture;
 
-use polkadot_primitives::v1::Hash;
+use polkadot_primitives::v1::{Hash, PoV};
 use async_trait::async_trait;
 use smallvec::SmallVec;
 use thiserror::Error;
@@ -77,7 +77,7 @@ impl PartialEq for ActiveLeavesUpdate {
 	///
 	/// Instead, it means equality when `activated` and `deactivated` are considered as sets.
 	fn eq(&self, other: &Self) -> bool {
-		self.activated.len() == other.activated.len() && self.deactivated.len() == other.deactivated.len() 
+		self.activated.len() == other.activated.len() && self.deactivated.len() == other.deactivated.len()
 			&& self.activated.iter().all(|a| other.activated.contains(a))
 			&& self.deactivated.iter().all(|a| other.deactivated.contains(a))
 	}
@@ -260,4 +260,77 @@ where
 			future,
 		}
 	}
+}
+
+// Jaeger integration.
+//
+// See <https://www.jaegertracing.io/> for an introduction.
+//
+// The easiest way to try Jaeger is:
+//
+// - Start a docker container with the all-in-one docker image (see below).
+// - Open your browser and navigate to <https://localhost:16686> to acces the UI.
+//
+// The all-in-one docker image can be started with:
+//
+// ```not_rust
+// docker run -d --name jaeger \
+//  -e COLLECTOR_ZIPKIN_HTTP_PORT=9411 \
+//  -p 5775:5775/udp \
+//  -p 6831:6831/udp \
+//  -p 6832:6832/udp \
+//  -p 5778:5778 \
+//  -p 16686:16686 \
+//  -p 14268:14268 \
+//  -p 14250:14250 \
+//  -p 9411:9411 \
+//  jaegertracing/all-in-one:1.21
+// ```
+//
+
+/// Shortcut for [`hash_span`] with the hash of the `PoV`.
+pub fn pov_span(pov: &PoV, span_name: &str) -> mick_jaeger::Span {
+	hash_span(&pov.hash(), span_name)
+}
+
+/// Creates a `Span` referring to the given hash. All spans created with [`hash_span`] with the
+/// same hash (even from multiple different nodes) will be visible in the same view on Jaeger.
+pub fn hash_span(hash: &Hash, span_name: &str) -> mick_jaeger::Span {
+	let trace_id = {
+		let mut buf = [0u8; 16];
+		buf.copy_from_slice(&hash.as_ref()[0..16]);
+		std::num::NonZeroU128::new(u128::from_be_bytes(buf)).unwrap()
+	};
+
+	TRACES_IN.lock().unwrap().as_ref().unwrap().span(trace_id, span_name)
+}
+
+/// Must be called otherwise the other jaeger-related functions will panic.
+///
+/// THIS API IS REALLY BAD AND SHOULDN'T BE FOUND IN THE MASTER BRANCH
+pub fn init_jaeger(node_name: &str) {
+	let (traces_in, mut traces_out) = mick_jaeger::init(mick_jaeger::Config {
+		service_name: format!("polkadot-{}", node_name),
+	});
+
+	let jaeger_agent: std::net::SocketAddr = "127.0.0.1:6831".parse().unwrap();
+
+	// Spawn a background task that pulls span information and sends them on the network.
+	async_std::task::spawn(async move {
+		let udp_socket = async_std::net::UdpSocket::bind("0.0.0.0:0").await.unwrap();
+
+		loop {
+			let buf = traces_out.next().await;
+			// UDP sending errors happen only either if the API is misused (in which case
+			// panicking is desirable) or in case of missing priviledge, in which case a
+			// panic is preferable in order to inform the user.
+			udp_socket.send_to(&buf, jaeger_agent).await.unwrap();
+		}
+	});
+
+	*TRACES_IN.lock().unwrap() = Some(traces_in);
+}
+
+lazy_static::lazy_static! {
+	static ref TRACES_IN: std::sync::Mutex<Option<std::sync::Arc<mick_jaeger::TracesIn>>> = std::sync::Mutex::new(None);
 }


### PR DESCRIPTION
This PR isn't intended to be merged but to demonstrate the idea of reporting timelines to Jaeger.

Because I'm not very familiar with the codebase, I've only put spans at a few selected areas and not everywhere, but here is for example the result I obtain for each relay chain block:

![image](https://user-images.githubusercontent.com/1412254/100475355-30d66b00-30e3-11eb-8b8e-37cbfb90f0b9.png)

Each relay chain block has its own individual trace (i.e. the timeline shown on the screenshot) that collects the information reported by every single node regarding this block.

The way you use it is to run:

```sh
docker run -d --name jaeger \
  -e COLLECTOR_ZIPKIN_HTTP_PORT=9411 \
  -p 5775:5775/udp \
  -p 6831:6831/udp \
  -p 6832:6832/udp \
  -p 5778:5778 \
  -p 16686:16686 \
  -p 14268:14268 \
  -p 14250:14250 \
  -p 9411:9411 \
  jaegertracing/all-in-one:1.21
```

Then run the nodes. They will automatically send their spans through UDP to the agent.
The UI (where to see the traces) can be accessed through <https://localhost:16686>.
