### PR TITLE
Move candidate validation to the background

### DIFF
--- a/node/core/backing/src/lib.rs
+++ b/node/core/backing/src/lib.rs
@@ -88,10 +88,22 @@ enum Error {
 }
 
 enum ValidatedCandidateCommand {
-	// We were instructed to second the candidate, and the outcome is represented by the provided bool.
+	// We were instructed to second the candidate.
 	Second(BackgroundValidationResult),
-	// We were instructed to validate the candidate, and the outcome is represented by the provided bool.
+	// We were instructed to validate the candidate.
 	Attest(BackgroundValidationResult),
+}
+
+impl std::fmt::Debug for ValidatedCandidateCommand {
+	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+		let candidate_hash = self.candidate_hash();
+		match *self {
+			ValidatedCandidateCommand::Second(_) =>
+				write!(f, "Second({})", candidate_hash),
+			ValidatedCandidateCommand::Attest(_) =>
+				write!(f, "Attest({})", candidate_hash),
+		}
+	}
 }
 
 impl ValidatedCandidateCommand {
@@ -436,7 +448,7 @@ impl CandidateBackingJob {
 		Ok(())
 	}
 
-	#[tracing::instrument(level = "trace", skip(self, command), fields(subsystem = LOG_TARGET))]
+	#[tracing::instrument(level = "trace", skip(self), fields(subsystem = LOG_TARGET))]
 	async fn handle_validated_candidate_command(
 		&mut self,
 		command: ValidatedCandidateCommand,

--- a/node/core/backing/src/lib.rs
+++ b/node/core/backing/src/lib.rs
@@ -218,19 +218,22 @@ enum FromJob {
 	Provisioner(ProvisionerMessage),
 	PoVDistribution(PoVDistributionMessage),
 	StatementDistribution(StatementDistributionMessage),
+	Spawn(&'static str, Pin<Box<dyn Future<Output = ()> + Send>>),
 }
 
 impl From<FromJob> for FromJobCommand {
 	fn from(f: FromJob) -> FromJobCommand {
-		FromJobCommand::SendMessage(match f {
-			FromJob::AvailabilityStore(msg) => AllMessages::AvailabilityStore(msg),
-			FromJob::RuntimeApiMessage(msg) => AllMessages::RuntimeApi(msg),
-			FromJob::CandidateValidation(msg) => AllMessages::CandidateValidation(msg),
-			FromJob::CandidateSelection(msg) => AllMessages::CandidateSelection(msg),
-			FromJob::StatementDistribution(msg) => AllMessages::StatementDistribution(msg),
-			FromJob::PoVDistribution(msg) => AllMessages::PoVDistribution(msg),
-			FromJob::Provisioner(msg) => AllMessages::Provisioner(msg),
-		})
+		let send_msg = |msg| FromJobCommand::SendMessage(msg);
+		match f {
+			FromJob::AvailabilityStore(msg) => send_msg(AllMessages::AvailabilityStore(msg)),
+			FromJob::RuntimeApiMessage(msg) => send_msg(AllMessages::RuntimeApi(msg)),
+			FromJob::CandidateValidation(msg) => send_msg(AllMessages::CandidateValidation(msg)),
+			FromJob::CandidateSelection(msg) => send_msg(AllMessages::CandidateSelection(msg)),
+			FromJob::StatementDistribution(msg) => send_msg(AllMessages::StatementDistribution(msg)),
+			FromJob::PoVDistribution(msg) => send_msg(AllMessages::PoVDistribution(msg)),
+			FromJob::Provisioner(msg) => send_msg(AllMessages::Provisioner(msg)),
+			FromJob::Spawn(name, task) => FromJobCommand::Spawn(name, task),
+		}
 	}
 }
 


### PR DESCRIPTION
Currently, candidate validation and PoV distribution stalls the backing job, meaning that it can't handle other incoming votes or requests for block data while it's validating a candidate. This PR does refactoring of candidate backing to introduce a function `fn background_validate_and_make_available` which can be updated to spawn an abortable background task. 

The goal here is that fetching PoV and doing candidate validation doesn't block the main message-processing loop of the subsystem, so we can handle multiple candidates at a time and answer requests for backed candidates while waiting for those results.

I added a test that a candidate validation request that never concludes should not interrupt the quorum logic.