### PR TITLE
rename storage Config to ActiveConfig

### DIFF
--- a/runtime/parachains/src/configuration.rs
+++ b/runtime/parachains/src/configuration.rs
@@ -23,7 +23,6 @@ use primitives::v1::{Balance, ValidatorId, SessionIndex};
 use frame_support::{
 	decl_storage, decl_module, decl_error,
 	ensure,
-	storage::migration,
 	dispatch::DispatchResult,
 	weights::{DispatchClass, Weight},
 };
@@ -538,9 +537,9 @@ impl<T: Trait> Module<T> {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::mock::{new_test_ext, Initializer, Configuration, Origin, Test};
+	use crate::mock::{new_test_ext, Initializer, Configuration, Origin};
 
-	use frame_support::traits::{OnFinalize, OnInitialize, OnRuntimeUpgrade};
+	use frame_support::traits::{OnFinalize, OnInitialize};
 
 	#[test]
 	fn config_changes_on_session_boundary() {

--- a/runtime/parachains/src/configuration.rs
+++ b/runtime/parachains/src/configuration.rs
@@ -745,25 +745,4 @@ mod tests {
 			assert!(<Configuration as Store>::PendingConfig::get().is_none())
 		});
 	}
-
-	#[test]
-	fn test_migration_config_to_active_config() {
-		new_test_ext(Default::default()).execute_with(|| {
-			let mut config: HostConfiguration<<Test as frame_system::Trait>::BlockNumber>
-				= Default::default();
-			config.max_code_size = 99;
-
-			migration::put_storage_value(b"Configuration", b"Config", b"", &config);
-
-			Configuration::on_runtime_upgrade();
-
-			assert_eq!(ActiveConfig::<Test>::get(), config);
-			assert_eq!(migration::have_storage_value(b"Configuration", b"Config", b""), false);
-
-			Configuration::on_runtime_upgrade();
-
-			assert_eq!(ActiveConfig::<Test>::get(), config);
-			assert_eq!(migration::have_storage_value(b"Configuration", b"Config", b""), false);
-		});
-	}
 }

--- a/runtime/parachains/src/configuration.rs
+++ b/runtime/parachains/src/configuration.rs
@@ -151,20 +151,6 @@ decl_module! {
 	pub struct Module<T: Trait> for enum Call where origin: <T as frame_system::Trait>::Origin {
 		type Error = Error<T>;
 
-		fn on_runtime_upgrade() -> Weight {
-			let value = migration::take_storage_value::<HostConfiguration<T::BlockNumber>>(
-				b"Configuration",
-				b"Config",
-				b"",
-			);
-
-			if let Some(value) = value {
-				ActiveConfig::<T>::put(value)
-			}
-
-			0
-		}
-
 		/// Set the validation upgrade frequency.
 		#[weight = (1_000, DispatchClass::Operational)]
 		pub fn set_validation_upgrade_frequency(origin, new: T::BlockNumber) -> DispatchResult {


### PR DESCRIPTION
This PR rename the storage `Config` in Configuration pallet to `ActiveConfig`.

This is to prevent name collision with incoming renaming of `Trait` into `Config`.

I think this pallet is used in some tests chains, thus I implemented the migration. Note that I don't think the migration needs any version check and bump because it only needs to migrate a value whenever it exist.

related: https://github.com/paritytech/polkadot/pull/2014