### PR TITLE
Simplify subsystem jobs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4939,7 +4939,6 @@ dependencies = [
 name = "polkadot-node-core-bitfield-signing"
 version = "0.1.0"
 dependencies = [
- "derive_more",
  "futures 0.3.8",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",

--- a/node/core/bitfield-signing/Cargo.toml
+++ b/node/core/bitfield-signing/Cargo.toml
@@ -14,4 +14,3 @@ polkadot-node-subsystem-util = { path = "../../subsystem-util" }
 sp-keystore = { git = "https://github.com/paritytech/substrate", branch = "master" }
 wasm-timer = "0.2.5"
 thiserror = "1.0.22"
-derive_more = "0.99.11"

--- a/node/core/bitfield-signing/src/lib.rs
+++ b/node/core/bitfield-signing/src/lib.rs
@@ -49,16 +49,12 @@ pub struct BitfieldSigningJob;
 #[allow(missing_docs)]
 pub enum ToJob {
 	BitfieldSigning(BitfieldSigningMessage),
-	Stop,
 }
 
 impl ToJobTrait for ToJob {
-	const STOP: Self = ToJob::Stop;
-
-	fn relay_parent(&self) -> Option<Hash> {
+	fn relay_parent(&self) -> Hash {
 		match self {
 			Self::BitfieldSigning(bsm) => bsm.relay_parent(),
-			Self::Stop => None,
 		}
 	}
 }

--- a/node/subsystem/src/messages.rs
+++ b/node/subsystem/src/messages.rs
@@ -57,11 +57,11 @@ pub enum CandidateSelectionMessage {
 }
 
 impl CandidateSelectionMessage {
-	/// If the current variant contains the relay parent hash, return it.
-	pub fn relay_parent(&self) -> Option<Hash> {
+	/// Returns the relay parent this message is assigned to.
+	pub fn relay_parent(&self) -> Hash {
 		match self {
-			Self::Collation(hash, ..) => Some(*hash),
-			Self::Invalid(hash, _) => Some(*hash),
+			Self::Collation(hash, ..) => *hash,
+			Self::Invalid(hash, _) => *hash,
 		}
 	}
 }
@@ -87,12 +87,12 @@ pub enum CandidateBackingMessage {
 }
 
 impl CandidateBackingMessage {
-	/// If the current variant contains the relay parent hash, return it.
-	pub fn relay_parent(&self) -> Option<Hash> {
+	/// Retuns the relay parent this message is assigned to.
+	pub fn relay_parent(&self) -> Hash {
 		match self {
-			Self::GetBackedCandidates(hash, _) => Some(*hash),
-			Self::Second(hash, _, _) => Some(*hash),
-			Self::Statement(hash, _) => Some(*hash),
+			Self::GetBackedCandidates(hash, _) => *hash,
+			Self::Second(hash, _, _) => *hash,
+			Self::Statement(hash, _) => *hash,
 		}
 	}
 }
@@ -274,9 +274,9 @@ impl BitfieldDistributionMessage {
 pub enum BitfieldSigningMessage {}
 
 impl BitfieldSigningMessage {
-	/// If the current variant contains the relay parent hash, return it.
-	pub fn relay_parent(&self) -> Option<Hash> {
-		None
+	/// Retuns the relay parent this message is assigned to.
+	pub fn relay_parent(&self) -> Hash {
+		match *self {}
 	}
 }
 
@@ -526,12 +526,12 @@ pub enum ProvisionerMessage {
 }
 
 impl ProvisionerMessage {
-	/// If the current variant contains the relay parent hash, return it.
-	pub fn relay_parent(&self) -> Option<Hash> {
+	/// Returns the relay parent this message is assigned to.
+	pub fn relay_parent(&self) -> Hash {
 		match self {
-			Self::RequestBlockAuthorshipData(hash, _) => Some(*hash),
-			Self::RequestInherentData(hash, _) => Some(*hash),
-			Self::ProvisionableData(hash, _) => Some(*hash),
+			Self::RequestBlockAuthorshipData(hash, _) => *hash,
+			Self::RequestInherentData(hash, _) => *hash,
+			Self::ProvisionableData(hash, _) => *hash,
 		}
 	}
 }

--- a/node/subsystem/src/messages.rs
+++ b/node/subsystem/src/messages.rs
@@ -39,8 +39,13 @@ use polkadot_primitives::v1::{
 	ValidationCode, ValidatorId, ValidationData, CandidateHash,
 	ValidatorIndex, ValidatorSignature, InboundDownwardMessage, InboundHrmpMessage,
 };
-use std::sync::Arc;
-use std::collections::btree_map::BTreeMap;
+use std::{sync::Arc, collections::btree_map::BTreeMap};
+
+/// Subsystem messages where each message is always bound to a relay parent.
+pub trait BoundToRelayParent {
+	/// Returns the relay parent this message is bound to.
+	fn relay_parent(&self) -> Hash;
+}
 
 /// A notification of a new backed candidate.
 #[derive(Debug)]
@@ -56,9 +61,8 @@ pub enum CandidateSelectionMessage {
 	Invalid(Hash, CandidateReceipt),
 }
 
-impl CandidateSelectionMessage {
-	/// Returns the relay parent this message is assigned to.
-	pub fn relay_parent(&self) -> Hash {
+impl BoundToRelayParent for CandidateSelectionMessage {
+	fn relay_parent(&self) -> Hash {
 		match self {
 			Self::Collation(hash, ..) => *hash,
 			Self::Invalid(hash, _) => *hash,
@@ -86,9 +90,8 @@ pub enum CandidateBackingMessage {
 	Statement(Hash, SignedFullStatement),
 }
 
-impl CandidateBackingMessage {
-	/// Retuns the relay parent this message is assigned to.
-	pub fn relay_parent(&self) -> Hash {
+impl BoundToRelayParent for CandidateBackingMessage {
+	fn relay_parent(&self) -> Hash {
 		match self {
 			Self::GetBackedCandidates(hash, _) => *hash,
 			Self::Second(hash, _, _) => *hash,
@@ -273,9 +276,8 @@ impl BitfieldDistributionMessage {
 #[derive(Debug)]
 pub enum BitfieldSigningMessage {}
 
-impl BitfieldSigningMessage {
-	/// Retuns the relay parent this message is assigned to.
-	pub fn relay_parent(&self) -> Hash {
+impl BoundToRelayParent for BitfieldSigningMessage {
+	fn relay_parent(&self) -> Hash {
 		match *self {}
 	}
 }
@@ -525,9 +527,8 @@ pub enum ProvisionerMessage {
 	ProvisionableData(Hash, ProvisionableData),
 }
 
-impl ProvisionerMessage {
-	/// Returns the relay parent this message is assigned to.
-	pub fn relay_parent(&self) -> Hash {
+impl BoundToRelayParent for ProvisionerMessage {
+	fn relay_parent(&self) -> Hash {
 		match self {
 			Self::RequestBlockAuthorshipData(hash, _) => *hash,
 			Self::RequestInherentData(hash, _) => *hash,


### PR DESCRIPTION
This pr simplifies the subsystem jobs interface. Instead of requiring an
extra message that is used to signal that a job should be ended, a job
now ends when the receiver returns `None`. Besides that it changes the
interface to enforce that messages to a job provide a relay parent.