### PR TITLE
gaeger integration to debug parachains

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,15 +269,15 @@ dependencies = [
 
 [[package]]
 name = "async-std"
-version = "1.6.5"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9fa76751505e8df1c7a77762f60486f60c71bbd9b8557f4da6ad47d083732ed"
+checksum = "a7e82538bc65a25dbdff70e4c5439d52f068048ab97cdea0acd73f131594caa1"
 dependencies = [
  "async-global-executor",
  "async-io",
  "async-mutex",
  "blocking",
- "crossbeam-utils",
+ "crossbeam-utils 0.8.1",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -937,7 +937,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285"
 dependencies = [
  "crossbeam-epoch",
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
  "maybe-uninit",
 ]
 
@@ -949,7 +949,7 @@ checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
 dependencies = [
  "autocfg 1.0.0",
  "cfg-if 0.1.10",
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
  "lazy_static",
  "maybe-uninit",
  "memoffset",
@@ -963,7 +963,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "774ba60a54c213d409d5353bda12d49cd68d14e45036a285234c8d6f91f92570"
 dependencies = [
  "cfg-if 0.1.10",
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
  "maybe-uninit",
 ]
 
@@ -975,6 +975,17 @@ checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 dependencies = [
  "autocfg 1.0.0",
  "cfg-if 0.1.10",
+ "lazy_static",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
+dependencies = [
+ "autocfg 1.0.0",
+ "cfg-if 1.0.0",
  "lazy_static",
 ]
 
@@ -2342,6 +2353,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b141fdc7836c525d4d594027d318c84161ca17aaf8113ab1f81ab93ae897485"
 
 [[package]]
+name = "integer-encoding"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f4ebd0bd29be0f11973e9b3e219005661042a019fd757798c36a47c87852625"
+
+[[package]]
 name = "integer-sqrt"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3385,6 +3402,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "mick-jaeger"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68c751e6643309568aa78a725b75755c11d866d6d0d0f7209033142007971cdd"
+dependencies = [
+ "futures 0.3.8",
+ "rand 0.7.3",
+ "thrift",
+]
+
+[[package]]
 name = "minicbor"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3743,6 +3771,15 @@ name = "openssl-probe"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
+
+[[package]]
+name = "ordered-float"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3741934be594d77de1c8461ebcbbe866f585ea616a9753aa78f2bdc69f0e4579"
+dependencies = [
+ "num-traits 0.2.12",
+]
 
 [[package]]
 name = "output_vt100"
@@ -5082,10 +5119,13 @@ name = "polkadot-node-subsystem"
 version = "0.1.0"
 dependencies = [
  "assert_matches",
+ "async-std",
  "async-trait",
  "derive_more",
  "futures 0.3.8",
  "futures-timer 3.0.2",
+ "lazy_static",
+ "mick-jaeger",
  "parity-scale-codec",
  "parking_lot 0.11.1",
  "pin-project 1.0.2",
@@ -6217,7 +6257,7 @@ checksum = "e92e15d89083484e11353891f1af602cc661426deb9564c298b270c726973280"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-queue",
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
  "lazy_static",
  "num_cpus",
 ]
@@ -6435,7 +6475,7 @@ dependencies = [
  "base64 0.11.0",
  "blake2b_simd",
  "constant_time_eq",
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
 ]
 
 [[package]]
@@ -8984,6 +9024,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "thrift"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6d965454947cc7266d22716ebfd07b18d84ebaf35eec558586bbb2a8cb6b5b"
+dependencies = [
+ "byteorder",
+ "integer-encoding",
+ "log",
+ "ordered-float",
+ "threadpool",
+]
+
+[[package]]
 name = "time"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9111,7 +9164,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb2d1b8f4548dbf5e1f7818512e9c406860678f29c300cdf0ebac72d1a3a1671"
 dependencies = [
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
  "futures 0.1.29",
 ]
 
@@ -9167,7 +9220,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09bc590ec4ba8ba87652da2068d150dcada2cfa2e07faae270a5e0409aa51351"
 dependencies = [
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
  "futures 0.1.29",
  "lazy_static",
  "log",
@@ -9233,7 +9286,7 @@ checksum = "df720b6581784c118f0eb4310796b12b1d242a7eb95f716a8367855325c25f89"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-queue",
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
  "futures 0.1.29",
  "lazy_static",
  "log",
@@ -9248,7 +9301,7 @@ version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93044f2d313c95ff1cb7809ce9a7a05735b012288a888b62d4434fd58c94f296"
 dependencies = [
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
  "futures 0.1.29",
  "slab",
  "tokio-executor",

--- a/node/network/availability-distribution/src/lib.rs
+++ b/node/network/availability-distribution/src/lib.rs
@@ -354,6 +354,8 @@ where
 				}
 			};
 
+			let mut _span = polkadot_subsystem::hash_span(&gossiped_availability.candidate_hash.0, "availability-message-received");
+
 			process_incoming_peer_message(ctx, state, remote, gossiped_availability, metrics)
 				.await?;
 		}

--- a/node/network/bitfield-distribution/src/lib.rs
+++ b/node/network/bitfield-distribution/src/lib.rs
@@ -483,6 +483,8 @@ where
 		NetworkBridgeEvent::PeerMessage(remote, message) => {
 			match message {
 				protocol_v1::BitfieldDistributionMessage::Bitfield(relay_parent, bitfield) => {
+					let mut _span = polkadot_subsystem::hash_span(&relay_parent, "bitfield-gossip-received");
+					_span.add_string_tag("peer-id", &remote.to_base58());
 					tracing::trace!(target: LOG_TARGET, peer_id = %remote, "received bitfield gossip from peer");
 					let gossiped_bitfield = BitfieldGossipMessage {
 						relay_parent,

--- a/node/network/collator-protocol/src/collator_side.rs
+++ b/node/network/collator-protocol/src/collator_side.rs
@@ -430,6 +430,8 @@ async fn process_msg(
 			state.collating_on = Some(id);
 		}
 		DistributeCollation(receipt, pov) => {
+			let _span1 = polkadot_subsystem::hash_span(&receipt.descriptor.relay_parent, "distributing-collation");
+			let _span2 = polkadot_subsystem::pov_span(&pov, "distributing-collation");
 			match state.collating_on {
 				Some(id) if receipt.descriptor.para_id != id => {
 					// If the ParaId of a collation requested to be distributed does not match
@@ -539,10 +541,12 @@ async fn handle_incoming_peer_message(
 			);
 		}
 		RequestCollation(request_id, relay_parent, para_id) => {
+			let _span = polkadot_subsystem::hash_span(&relay_parent, "rx-collation-request");
 			match state.collating_on {
 				Some(our_para_id) => {
 					if our_para_id == para_id {
 						if let Some(collation) = state.collations.get(&relay_parent).cloned() {
+							let _span = _span.child("sending");
 							send_collation(ctx, state, request_id, origin, collation.0, collation.1).await;
 						}
 					} else {

--- a/node/network/collator-protocol/src/validator_side.rs
+++ b/node/network/collator-protocol/src/validator_side.rs
@@ -504,6 +504,7 @@ where
 			state.peer_views.entry(origin).or_default();
 		}
 		AdvertiseCollation(relay_parent, para_id) => {
+			let _span = polkadot_subsystem::hash_span(&relay_parent, "advertising-collation");
 			state.advertisements.entry(origin.clone()).or_default().insert((para_id, relay_parent));
 
 			if let Some(collator) = state.known_collators.get(&origin) {
@@ -515,6 +516,8 @@ where
 			modify_reputation(ctx, origin, COST_UNEXPECTED_MESSAGE).await;
 		}
 		Collation(request_id, receipt, pov) => {
+			let _span1 = polkadot_subsystem::hash_span(&receipt.descriptor.relay_parent, "received-collation");
+			let _span2 = polkadot_subsystem::pov_span(&pov, "received-collation");
 			received_collation(ctx, state, origin, request_id, receipt, pov).await;
 		}
 	}
@@ -659,6 +662,7 @@ where
 			);
 		}
 		FetchCollation(relay_parent, collator_id, para_id, tx) => {
+			let _span = polkadot_subsystem::hash_span(&relay_parent, "fetching-collation");
 			fetch_collation(ctx, state, relay_parent, collator_id, para_id, tx).await;
 		}
 		ReportCollator(id) => {

--- a/node/network/statement-distribution/src/lib.rs
+++ b/node/network/statement-distribution/src/lib.rs
@@ -828,6 +828,7 @@ async fn handle_network_update(
 					).await;
 
 					if let Some((relay_parent, new)) = new_stored {
+						let mut _span = polkadot_subsystem::hash_span(&relay_parent, "sending-statement");
 						// When we receive a new message from a peer, we forward it to the
 						// candidate backing subsystem.
 						let message = AllMessages::CandidateBacking(
@@ -943,6 +944,7 @@ impl StatementDistribution {
 				FromOverseer::Communication { msg } => match msg {
 					StatementDistributionMessage::Share(relay_parent, statement) => {
 						let _timer = metrics.time_share();
+						let mut _span = polkadot_subsystem::hash_span(&relay_parent, "circulate-statement");
 
 						inform_statement_listeners(
 							&statement,

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -174,6 +174,7 @@ fn new_partial<RuntimeApi, Executor>(config: &mut Configuration) -> Result<
 		Executor: NativeExecutionDispatch + 'static,
 {
 	set_prometheus_registry(config)?;
+	polkadot_subsystem::init_jaeger(&config.network.node_name);
 
 	let inherent_data_providers = inherents::InherentDataProviders::new();
 

--- a/node/subsystem/Cargo.toml
+++ b/node/subsystem/Cargo.toml
@@ -6,10 +6,13 @@ edition = "2018"
 description = "Subsystem traits and message definitions"
 
 [dependencies]
+async-std = "1.7.0"
 async-trait = "0.1.42"
 derive_more = "0.99.11"
 futures = "0.3.8"
 futures-timer = "3.0.2"
+mick-jaeger = "0.1.1"
+lazy_static = "1.0"
 tracing = "0.1.22"
 tracing-futures = "0.2.4"
 parity-scale-codec = { version = "1.3.5", default-features = false, features = ["derive"] }

--- a/node/subsystem/src/lib.rs
+++ b/node/subsystem/src/lib.rs
@@ -28,7 +28,7 @@ use futures::prelude::*;
 use futures::channel::{mpsc, oneshot};
 use futures::future::BoxFuture;
 
-use polkadot_primitives::v1::Hash;
+use polkadot_primitives::v1::{Hash, PoV};
 use async_trait::async_trait;
 use smallvec::SmallVec;
 use thiserror::Error;
@@ -77,7 +77,7 @@ impl PartialEq for ActiveLeavesUpdate {
 	///
 	/// Instead, it means equality when `activated` and `deactivated` are considered as sets.
 	fn eq(&self, other: &Self) -> bool {
-		self.activated.len() == other.activated.len() && self.deactivated.len() == other.deactivated.len() 
+		self.activated.len() == other.activated.len() && self.deactivated.len() == other.deactivated.len()
 			&& self.activated.iter().all(|a| other.activated.contains(a))
 			&& self.deactivated.iter().all(|a| other.deactivated.contains(a))
 	}
@@ -260,4 +260,77 @@ where
 			future,
 		}
 	}
+}
+
+// Jaeger integration.
+//
+// See <https://www.jaegertracing.io/> for an introduction.
+//
+// The easiest way to try Jaeger is:
+//
+// - Start a docker container with the all-in-one docker image (see below).
+// - Open your browser and navigate to <https://localhost:16686> to acces the UI.
+//
+// The all-in-one docker image can be started with:
+//
+// ```not_rust
+// docker run -d --name jaeger \
+//  -e COLLECTOR_ZIPKIN_HTTP_PORT=9411 \
+//  -p 5775:5775/udp \
+//  -p 6831:6831/udp \
+//  -p 6832:6832/udp \
+//  -p 5778:5778 \
+//  -p 16686:16686 \
+//  -p 14268:14268 \
+//  -p 14250:14250 \
+//  -p 9411:9411 \
+//  jaegertracing/all-in-one:1.21
+// ```
+//
+
+/// Shortcut for [`hash_span`] with the hash of the `PoV`.
+pub fn pov_span(pov: &PoV, span_name: &str) -> mick_jaeger::Span {
+	hash_span(&pov.hash(), span_name)
+}
+
+/// Creates a `Span` referring to the given hash. All spans created with [`hash_span`] with the
+/// same hash (even from multiple different nodes) will be visible in the same view on Jaeger.
+pub fn hash_span(hash: &Hash, span_name: &str) -> mick_jaeger::Span {
+	let trace_id = {
+		let mut buf = [0u8; 16];
+		buf.copy_from_slice(&hash.as_ref()[0..16]);
+		std::num::NonZeroU128::new(u128::from_be_bytes(buf)).unwrap()
+	};
+
+	TRACES_IN.lock().unwrap().as_ref().unwrap().span(trace_id, span_name)
+}
+
+/// Must be called otherwise the other jaeger-related functions will panic.
+///
+/// THIS API IS REALLY BAD AND SHOULDN'T BE FOUND IN THE MASTER BRANCH
+pub fn init_jaeger(node_name: &str) {
+	let (traces_in, mut traces_out) = mick_jaeger::init(mick_jaeger::Config {
+		service_name: format!("polkadot-{}", node_name),
+	});
+
+	let jaeger_agent: std::net::SocketAddr = "127.0.0.1:6831".parse().unwrap();
+
+	// Spawn a background task that pulls span information and sends them on the network.
+	async_std::task::spawn(async move {
+		let udp_socket = async_std::net::UdpSocket::bind("0.0.0.0:0").await.unwrap();
+
+		loop {
+			let buf = traces_out.next().await;
+			// UDP sending errors happen only either if the API is misused (in which case
+			// panicking is desirable) or in case of missing priviledge, in which case a
+			// panic is preferable in order to inform the user.
+			udp_socket.send_to(&buf, jaeger_agent).await.unwrap();
+		}
+	});
+
+	*TRACES_IN.lock().unwrap() = Some(traces_in);
+}
+
+lazy_static::lazy_static! {
+	static ref TRACES_IN: std::sync::Mutex<Option<std::sync::Arc<mick_jaeger::TracesIn>>> = std::sync::Mutex::new(None);
 }


### PR DESCRIPTION
Continuation of #2027 

Goal: Integration of `jaeger` as part of the polkadot subsystems.

1. [ ] more jaeger tracing in polkadot for more subsystems
2. [ ] integrate optionally in substrate, and use that instance