### PR TITLE
be more careful about fusing in `select!`

### DIFF
--- a/node/collation-generation/src/lib.rs
+++ b/node/collation-generation/src/lib.rs
@@ -84,8 +84,9 @@ impl CollationGenerationSubsystem {
 		// at any point waiting for them all, so instead, we create a channel on which they can
 		// send those messages. We can then just monitor the channel and forward messages on it
 		// to the overseer here, via the context.
-		let (sender, mut receiver) = mpsc::channel(0);
+		let (sender, receiver) = mpsc::channel(0);
 
+		let mut receiver = receiver.fuse();
 		loop {
 			select! {
 				incoming = ctx.recv().fuse() => {
@@ -93,7 +94,7 @@ impl CollationGenerationSubsystem {
 						break;
 					}
 				},
-				msg = receiver.next().fuse() => {
+				msg = receiver.next() => {
 					if let Some(msg) = msg {
 						ctx.send_message(msg).await;
 					}

--- a/node/network/collator-protocol/src/collator_side.rs
+++ b/node/network/collator-protocol/src/collator_side.rs
@@ -695,7 +695,7 @@ pub(crate) async fn run(
 				let (relay_parent, validator_id, peer_id) = match res {
 					Some(res) => res,
 					// Will never happen, but better to be safe.
-					None => continue,
+					None => return Ok(()),
 				};
 
 				let _timer = state.metrics.time_handle_connection_request();


### PR DESCRIPTION
I went through our `select!` implementations in subsystems and tweaked a few of them. Others, I made sure that a `None` result on a stream leads to the loop breaking.