### PR TITLE
Reward validators for participating in parachains

### DIFF
--- a/roadmap/implementers-guide/src/runtime/inclusion.md
+++ b/roadmap/implementers-guide/src/runtime/inclusion.md
@@ -17,6 +17,7 @@ struct CandidatePendingAvailability {
   descriptor: CandidateDescriptor,
   availability_votes: Bitfield, // one bit per validator.
   relay_parent_number: BlockNumber, // number of the relay-parent.
+  backers: Bitfield, // one bit per validator, set for those who backed the candidate.
   backed_in_number: BlockNumber,
 }
 ```
@@ -77,6 +78,7 @@ All failed checks should lead to an unrecoverable error making the block invalid
 * `enact_candidate(relay_parent_number: BlockNumber, CommittedCandidateReceipt)`:
   1. If the receipt contains a code upgrade, Call `Paras::schedule_code_upgrade(para_id, code, relay_parent_number + config.validationl_upgrade_delay)`.
     > TODO: Note that this is safe as long as we never enact candidates where the relay parent is across a session boundary. In that case, which we should be careful to avoid with contextual execution, the configuration might have changed and the para may de-sync from the host's understanding of it.
+  1. Reward all backing validators of each candidate, contained within the `backers` field.
   1. call `Ump::enact_upward_messages` for each backed candidate, using the [`UpwardMessage`s](../types/messages.md#upward-message) from the [`CandidateCommitments`](../types/candidate.md#candidate-commitments).
   1. call `Dmp::prune_dmq` with the para id of the candidate and the candidate's `processed_downward_messages`.
   1. call `Hrmp::prune_hrmp` with the para id of the candiate and the candidate's `hrmp_watermark`.

--- a/runtime/common/src/paras_registrar.rs
+++ b/runtime/common/src/paras_registrar.rs
@@ -262,7 +262,7 @@ mod tests {
 		}, testing::{UintAuthorityId, TestXt}, Perbill, curve::PiecewiseLinear,
 	};
 	use primitives::v1::{
-		Balance, BlockNumber, Header, Signature, AuthorityDiscoveryId,
+		Balance, BlockNumber, Header, Signature, AuthorityDiscoveryId, ValidatorIndex,
 	};
 	use frame_support::{
 		traits::{Randomness, OnInitialize, OnFinalize},
@@ -473,8 +473,16 @@ mod tests {
 
 	impl configuration::Config for Test { }
 
+	pub struct TestRewardValidators;
+
+	impl inclusion::RewardValidators for TestRewardValidators {
+		fn reward_backing(_: impl IntoIterator<Item = ValidatorIndex>) { }
+		fn reward_bitfields(_: impl IntoIterator<Item = ValidatorIndex>) { }
+	}
+
 	impl inclusion::Config for Test {
 		type Event = ();
+		type RewardValidators = TestRewardValidators;
 	}
 
 	impl session_info::AuthorityDiscoveryConfig for Test {

--- a/runtime/parachains/src/inclusion.rs
+++ b/runtime/parachains/src/inclusion.rs
@@ -1394,7 +1394,7 @@ mod tests {
 				availability_votes: default_availability_votes(),
 				relay_parent_number: 0,
 				backed_in_number: 0,
-				backers: default_backing_bitfield(),
+				backers: backing_bitfield(&[3, 4]),
 			});
 			PendingAvailabilityCommitments::insert(chain_a, candidate_a.commitments);
 
@@ -1410,7 +1410,7 @@ mod tests {
 				availability_votes: default_availability_votes(),
 				relay_parent_number: 0,
 				backed_in_number: 0,
-				backers: default_backing_bitfield(),
+				backers: backing_bitfield(&[0, 2]),
 			});
 			PendingAvailabilityCommitments::insert(chain_b, candidate_b.commitments);
 
@@ -1481,6 +1481,25 @@ mod tests {
 
 			// and check that chain head was enacted.
 			assert_eq!(Paras::para_head(&chain_a), Some(vec![1, 2, 3, 4].into()));
+
+			// Check that rewards are applied.
+			{
+				let rewards = crate::mock::availability_rewards();
+
+				assert_eq!(rewards.len(), 4);
+				assert_eq!(rewards.get(&0).unwrap(), &1);
+				assert_eq!(rewards.get(&1).unwrap(), &1);
+				assert_eq!(rewards.get(&2).unwrap(), &1);
+				assert_eq!(rewards.get(&3).unwrap(), &1);
+			}
+
+			{
+				let rewards = crate::mock::backing_rewards();
+
+				assert_eq!(rewards.len(), 2);
+				assert_eq!(rewards.get(&3).unwrap(), &1);
+				assert_eq!(rewards.get(&4).unwrap(), &1);
+			}
 		});
 	}
 

--- a/runtime/parachains/src/inclusion.rs
+++ b/runtime/parachains/src/inclusion.rs
@@ -87,10 +87,13 @@ impl<H, N> CandidatePendingAvailability<H, N> {
 	}
 }
 
+/// A hook for applying validator rewards
 pub trait RewardValidators {
 	// Reward the validators with the given indices for issuing backing statements.
 	fn reward_backing(validators: impl IntoIterator<Item=ValidatorIndex>);
 	// Reward the validators with the given indices for issuing availability bitfields.
+	// Validators are sent to this hook when they have contributed to the availability
+	// of a candidate by setting a bit in their bitfield.
 	fn reward_bitfields(validators: impl IntoIterator<Item=ValidatorIndex>);
 }
 

--- a/runtime/parachains/src/inclusion.rs
+++ b/runtime/parachains/src/inclusion.rs
@@ -1093,6 +1093,7 @@ mod tests {
 				availability_votes: default_availability_votes(),
 				relay_parent_number: 0,
 				backed_in_number: 0,
+				backers: default_availability_votes(),
 			});
 			PendingAvailabilityCommitments::insert(chain_a, default_candidate.commitments.clone());
 
@@ -1102,6 +1103,7 @@ mod tests {
 				availability_votes: default_availability_votes(),
 				relay_parent_number: 0,
 				backed_in_number: 0,
+				backers: default_availability_votes(),
 			});
 			PendingAvailabilityCommitments::insert(chain_b, default_candidate.commitments);
 
@@ -1265,6 +1267,7 @@ mod tests {
 					availability_votes: default_availability_votes(),
 					relay_parent_number: 0,
 					backed_in_number: 0,
+					backers: default_availability_votes(),
 				});
 				PendingAvailabilityCommitments::insert(chain_a, default_candidate.commitments);
 
@@ -1299,6 +1302,7 @@ mod tests {
 					availability_votes: default_availability_votes(),
 					relay_parent_number: 0,
 					backed_in_number: 0,
+					backers: default_availability_votes(),
 				});
 
 				*bare_bitfield.0.get_mut(0).unwrap() = true;
@@ -1370,6 +1374,7 @@ mod tests {
 				availability_votes: default_availability_votes(),
 				relay_parent_number: 0,
 				backed_in_number: 0,
+				backers: default_availability_votes(),
 			});
 			PendingAvailabilityCommitments::insert(chain_a, candidate_a.commitments);
 
@@ -1385,6 +1390,7 @@ mod tests {
 				availability_votes: default_availability_votes(),
 				relay_parent_number: 0,
 				backed_in_number: 0,
+				backers: default_availability_votes(),
 			});
 			PendingAvailabilityCommitments::insert(chain_b, candidate_b.commitments);
 
@@ -1795,6 +1801,7 @@ mod tests {
 					availability_votes: default_availability_votes(),
 					relay_parent_number: 3,
 					backed_in_number: 4,
+					backers: default_availability_votes(),
 				});
 				<PendingAvailabilityCommitments>::insert(&chain_a, candidate.commitments);
 
@@ -2082,6 +2089,7 @@ mod tests {
 					availability_votes: default_availability_votes(),
 					relay_parent_number: System::block_number() - 1,
 					backed_in_number: System::block_number(),
+					backers: default_availability_votes(),
 				})
 			);
 			assert_eq!(
@@ -2097,6 +2105,7 @@ mod tests {
 					availability_votes: default_availability_votes(),
 					relay_parent_number: System::block_number() - 1,
 					backed_in_number: System::block_number(),
+					backers: default_availability_votes(),
 				})
 			);
 			assert_eq!(
@@ -2112,6 +2121,7 @@ mod tests {
 					availability_votes: default_availability_votes(),
 					relay_parent_number: System::block_number() - 1,
 					backed_in_number: System::block_number(),
+					backers: default_availability_votes(),
 				})
 			);
 			assert_eq!(
@@ -2206,6 +2216,7 @@ mod tests {
 					availability_votes: default_availability_votes(),
 					relay_parent_number: System::block_number() - 1,
 					backed_in_number: System::block_number(),
+					backers: default_availability_votes(),
 				})
 			);
 			assert_eq!(
@@ -2280,6 +2291,7 @@ mod tests {
 				availability_votes: default_availability_votes(),
 				relay_parent_number: 5,
 				backed_in_number: 6,
+				backers: default_availability_votes(),
 			});
 			<PendingAvailabilityCommitments>::insert(&chain_a, candidate.commitments.clone());
 
@@ -2289,6 +2301,7 @@ mod tests {
 				availability_votes: default_availability_votes(),
 				relay_parent_number: 6,
 				backed_in_number: 7,
+				backers: default_availability_votes(),
 			});
 			<PendingAvailabilityCommitments>::insert(&chain_b, candidate.commitments);
 

--- a/runtime/parachains/src/inclusion.rs
+++ b/runtime/parachains/src/inclusion.rs
@@ -1019,6 +1019,18 @@ mod tests {
 		bitvec::bitvec![BitOrderLsb0, u8; 0; Validators::get().len()]
 	}
 
+	fn default_backing_bitfield() -> BitVec<BitOrderLsb0, u8> {
+		bitvec::bitvec![BitOrderLsb0, u8; 0; Validators::get().len()]
+	}
+
+	fn backing_bitfield(v: &[usize]) -> BitVec<BitOrderLsb0, u8> {
+		let mut b = default_backing_bitfield();
+		for i in v {
+			b.set(*i, true);
+		}
+		b
+	}
+
 	fn validator_pubkeys(val_ids: &[Sr25519Keyring]) -> Vec<ValidatorId> {
 		val_ids.iter().map(|v| v.public().into()).collect()
 	}
@@ -1093,7 +1105,7 @@ mod tests {
 				availability_votes: default_availability_votes(),
 				relay_parent_number: 0,
 				backed_in_number: 0,
-				backers: default_availability_votes(),
+				backers: default_backing_bitfield(),
 			});
 			PendingAvailabilityCommitments::insert(chain_a, default_candidate.commitments.clone());
 
@@ -1103,7 +1115,7 @@ mod tests {
 				availability_votes: default_availability_votes(),
 				relay_parent_number: 0,
 				backed_in_number: 0,
-				backers: default_availability_votes(),
+				backers: default_backing_bitfield(),
 			});
 			PendingAvailabilityCommitments::insert(chain_b, default_candidate.commitments);
 
@@ -1267,7 +1279,7 @@ mod tests {
 					availability_votes: default_availability_votes(),
 					relay_parent_number: 0,
 					backed_in_number: 0,
-					backers: default_availability_votes(),
+					backers: default_backing_bitfield(),
 				});
 				PendingAvailabilityCommitments::insert(chain_a, default_candidate.commitments);
 
@@ -1302,7 +1314,7 @@ mod tests {
 					availability_votes: default_availability_votes(),
 					relay_parent_number: 0,
 					backed_in_number: 0,
-					backers: default_availability_votes(),
+					backers: default_backing_bitfield(),
 				});
 
 				*bare_bitfield.0.get_mut(0).unwrap() = true;
@@ -1374,7 +1386,7 @@ mod tests {
 				availability_votes: default_availability_votes(),
 				relay_parent_number: 0,
 				backed_in_number: 0,
-				backers: default_availability_votes(),
+				backers: default_backing_bitfield(),
 			});
 			PendingAvailabilityCommitments::insert(chain_a, candidate_a.commitments);
 
@@ -1390,7 +1402,7 @@ mod tests {
 				availability_votes: default_availability_votes(),
 				relay_parent_number: 0,
 				backed_in_number: 0,
-				backers: default_availability_votes(),
+				backers: default_backing_bitfield(),
 			});
 			PendingAvailabilityCommitments::insert(chain_b, candidate_b.commitments);
 
@@ -1801,7 +1813,7 @@ mod tests {
 					availability_votes: default_availability_votes(),
 					relay_parent_number: 3,
 					backed_in_number: 4,
-					backers: default_availability_votes(),
+					backers: default_backing_bitfield(),
 				});
 				<PendingAvailabilityCommitments>::insert(&chain_a, candidate.commitments);
 
@@ -2089,7 +2101,7 @@ mod tests {
 					availability_votes: default_availability_votes(),
 					relay_parent_number: System::block_number() - 1,
 					backed_in_number: System::block_number(),
-					backers: default_availability_votes(),
+					backers: backing_bitfield(&[0, 1]),
 				})
 			);
 			assert_eq!(
@@ -2105,7 +2117,7 @@ mod tests {
 					availability_votes: default_availability_votes(),
 					relay_parent_number: System::block_number() - 1,
 					backed_in_number: System::block_number(),
-					backers: default_availability_votes(),
+					backers: backing_bitfield(&[2, 3]),
 				})
 			);
 			assert_eq!(
@@ -2121,7 +2133,7 @@ mod tests {
 					availability_votes: default_availability_votes(),
 					relay_parent_number: System::block_number() - 1,
 					backed_in_number: System::block_number(),
-					backers: default_availability_votes(),
+					backers: backing_bitfield(&[4]),
 				})
 			);
 			assert_eq!(
@@ -2216,7 +2228,7 @@ mod tests {
 					availability_votes: default_availability_votes(),
 					relay_parent_number: System::block_number() - 1,
 					backed_in_number: System::block_number(),
-					backers: default_availability_votes(),
+					backers: backing_bitfield(&[0, 1, 2]),
 				})
 			);
 			assert_eq!(
@@ -2291,7 +2303,7 @@ mod tests {
 				availability_votes: default_availability_votes(),
 				relay_parent_number: 5,
 				backed_in_number: 6,
-				backers: default_availability_votes(),
+				backers: default_backing_bitfield(),
 			});
 			<PendingAvailabilityCommitments>::insert(&chain_a, candidate.commitments.clone());
 
@@ -2301,7 +2313,7 @@ mod tests {
 				availability_votes: default_availability_votes(),
 				relay_parent_number: 6,
 				backed_in_number: 7,
-				backers: default_availability_votes(),
+				backers: default_backing_bitfield(),
 			});
 			<PendingAvailabilityCommitments>::insert(&chain_b, candidate.commitments);
 

--- a/runtime/parachains/src/inclusion.rs
+++ b/runtime/parachains/src/inclusion.rs
@@ -352,6 +352,7 @@ impl<T: Config> Module<T> {
 					pending_availability.relay_parent_number,
 					receipt,
 					pending_availability.backers,
+					pending_availability.availability_votes,
 				);
 
 				freed_cores.push(pending_availability.core);
@@ -614,6 +615,7 @@ impl<T: Config> Module<T> {
 		relay_parent_number: T::BlockNumber,
 		receipt: CommittedCandidateReceipt<T::Hash>,
 		backers: BitVec<BitOrderLsb0, u8>,
+		availability_votes: BitVec<BitOrderLsb0, u8>,
 	) -> Weight {
 		let plain = receipt.to_plain();
 		let commitments = receipt.commitments;
@@ -621,6 +623,11 @@ impl<T: Config> Module<T> {
 
 		T::RewardValidators::reward_backing(backers.iter().enumerate()
 			.filter(|(_, backed)| **backed)
+			.map(|(i, _)| i as _)
+		);
+
+		T::RewardValidators::reward_bitfields(availability_votes.iter().enumerate()
+			.filter(|(_, voted)| **voted)
 			.map(|(i, _)| i as _)
 		);
 
@@ -721,6 +728,7 @@ impl<T: Config> Module<T> {
 				pending.relay_parent_number,
 				candidate,
 				pending.backers,
+				pending.availability_votes,
 			);
 		}
 	}

--- a/runtime/parachains/src/lib.rs
+++ b/runtime/parachains/src/lib.rs
@@ -33,6 +33,7 @@ pub mod origin;
 pub mod dmp;
 pub mod ump;
 pub mod hrmp;
+pub mod reward_points;
 
 pub mod runtime_api_impl;
 

--- a/runtime/parachains/src/mock.rs
+++ b/runtime/parachains/src/mock.rs
@@ -148,7 +148,7 @@ pub fn backing_rewards() -> HashMap<ValidatorIndex, usize> {
 }
 
 pub fn availability_rewards() -> HashMap<ValidatorIndex, usize> {
-	BACKING_REWARDS.with(|r| r.borrow().clone())
+	AVAILABILITY_REWARDS.with(|r| r.borrow().clone())
 }
 
 pub struct TestRewardValidators;

--- a/runtime/parachains/src/mock.rs
+++ b/runtime/parachains/src/mock.rs
@@ -24,7 +24,7 @@ use sp_runtime::{
 		BlakeTwo256, IdentityLookup,
 	},
 };
-use primitives::v1::{AuthorityDiscoveryId, BlockNumber, Header};
+use primitives::v1::{AuthorityDiscoveryId, BlockNumber, Header, ValidatorIndex};
 use frame_support::{
 	impl_outer_origin, impl_outer_dispatch, impl_outer_event, parameter_types,
 	weights::Weight, traits::Randomness as RandomnessT,
@@ -122,6 +122,7 @@ impl crate::scheduler::Config for Test { }
 
 impl crate::inclusion::Config for Test {
 	type Event = TestEvent;
+	type RewardValidators = TestRewardValidators;
 }
 
 impl crate::session_info::Config for Test { }
@@ -130,6 +131,13 @@ impl crate::session_info::AuthorityDiscoveryConfig for Test {
 	fn authorities() -> Vec<AuthorityDiscoveryId> {
 		Vec::new()
 	}
+}
+
+pub struct TestRewardValidators;
+
+impl inclusion::RewardValidators for TestRewardValidators {
+	fn reward_backing(_: impl IntoIterator<Item = ValidatorIndex>) { }
+	fn reward_bitfields(_: impl IntoIterator<Item = ValidatorIndex>) { }
 }
 
 pub type System = frame_system::Module<Test>;

--- a/runtime/parachains/src/reward_points.rs
+++ b/runtime/parachains/src/reward_points.rs
@@ -18,18 +18,14 @@
 //! `pallet-staking` to compute the rewards.
 //!
 //! Based on https://w3f-research.readthedocs.io/en/latest/polkadot/Token%20Economics.html
-//! which doesn't currently mention availability bitfields. Since those are not a huge amount
-//! of work and every validator will be doing a lot of availability networking, we set the
-//! availability rewards to be very small relative to backing.
+//! which doesn't currently mention availability bitfields. As such, we don't reward them
+//! for the time being, although we will build schemes to do so in the future.
 
 use primitives::v1::ValidatorIndex;
 use pallet_staking::SessionInterface;
 
 /// The amount of era points given by backing a candidate that is included.
 pub const BACKING_POINTS: u32 = 20;
-
-/// The amount of era points given by contributing to the availability of a candidate.
-pub const AVAILABILITY_POINTS: u32 = 1;
 
 /// Rewards validators for participating in parachains with era points in pallet-staking.
 pub struct RewardValidatorsWithEraPoints<C>(sp_std::marker::PhantomData<C>);
@@ -55,7 +51,5 @@ impl<C> crate::inclusion::RewardValidators for RewardValidatorsWithEraPoints<C>
 		reward_by_indices::<C, _>(BACKING_POINTS, validators);
 	}
 
-	fn reward_bitfields(validators: impl IntoIterator<Item=ValidatorIndex>) {
-		reward_by_indices::<C, _>(AVAILABILITY_POINTS, validators);
-	}
+	fn reward_bitfields(_validators: impl IntoIterator<Item=ValidatorIndex>) { }
 }

--- a/runtime/parachains/src/reward_points.rs
+++ b/runtime/parachains/src/reward_points.rs
@@ -1,0 +1,56 @@
+// Copyright 2020 Parity Technologies (UK) Ltd.
+// This file is part of Polkadot.
+
+// Polkadot is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Polkadot is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
+
+//! An implementation of the `RewardValidators` trait used by `inclusion` that employs
+//! `pallet-staking` to compute the rewards.
+
+use primitives::v1::ValidatorIndex;
+use pallet_staking::SessionInterface;
+
+/// The amount of era points given by backing a candidate that is included.
+pub const BACKING_POINTS: u32 = 20;
+
+/// The amount of era points given by contributing to the availability of a candidate.
+pub const AVAILABILITY_POINTS: u32 = 1;
+
+/// Rewards validators for participating in parachains with era points in pallet-staking.
+pub struct RewardValidatorsWithEraPoints<C>(sp_std::marker::PhantomData<C>);
+
+fn reward_by_indices<C, I>(points: u32, indices: I) where
+	C: pallet_staking::Config,
+	I: IntoIterator<Item = ValidatorIndex>
+{
+	// Fetch the validators from the _session_ because sessions are offset from eras
+	// and we are rewarding for behavior in current session.
+	let validators = C::SessionInterface::validators();
+	let rewards = indices.into_iter()
+		.filter_map(|i| validators.get(i as usize).map(|v| v.clone()))
+		.map(|v| (v, points));
+
+	<pallet_staking::Module<C>>::reward_by_ids(rewards);
+}
+
+impl<C> crate::inclusion::RewardValidators for RewardValidatorsWithEraPoints<C>
+	where C: pallet_staking::Config
+{
+	fn reward_backing(validators: impl IntoIterator<Item=ValidatorIndex>) {
+		reward_by_indices::<C, _>(BACKING_POINTS, validators);
+	}
+
+	fn reward_bitfields(validators: impl IntoIterator<Item=ValidatorIndex>) {
+		reward_by_indices::<C, _>(AVAILABILITY_POINTS, validators);
+	}
+}

--- a/runtime/parachains/src/reward_points.rs
+++ b/runtime/parachains/src/reward_points.rs
@@ -16,6 +16,11 @@
 
 //! An implementation of the `RewardValidators` trait used by `inclusion` that employs
 //! `pallet-staking` to compute the rewards.
+//!
+//! Based on https://w3f-research.readthedocs.io/en/latest/polkadot/Token%20Economics.html
+//! which doesn't currently mention availability bitfields. Since those are not a huge amount
+//! of work and every validator will be doing a lot of availability networking, we set the
+//! availability rewards to be very small relative to backing.
 
 use primitives::v1::ValidatorIndex;
 use pallet_staking::SessionInterface;

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -78,6 +78,7 @@ use runtime_parachains::dmp as parachains_dmp;
 use runtime_parachains::ump as parachains_ump;
 use runtime_parachains::hrmp as parachains_hrmp;
 use runtime_parachains::scheduler as parachains_scheduler;
+use runtime_parachains::reward_points::RewardValidatorsWithEraPoints;
 
 pub use pallet_balances::Call as BalancesCall;
 pub use pallet_staking::StakerStatus;
@@ -531,6 +532,7 @@ impl parachains_configuration::Config for Runtime {}
 
 impl parachains_inclusion::Config for Runtime {
 	type Event = Event;
+	type RewardValidators = RewardValidatorsWithEraPoints<Runtime>,
 }
 
 impl parachains_paras::Config for Runtime {

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -532,7 +532,7 @@ impl parachains_configuration::Config for Runtime {}
 
 impl parachains_inclusion::Config for Runtime {
 	type Event = Event;
-	type RewardValidators = RewardValidatorsWithEraPoints<Runtime>,
+	type RewardValidators = RewardValidatorsWithEraPoints<Runtime>;
 }
 
 impl parachains_paras::Config for Runtime {

--- a/runtime/test-runtime/src/lib.rs
+++ b/runtime/test-runtime/src/lib.rs
@@ -74,6 +74,7 @@ use frame_support::{
 use authority_discovery_primitives::AuthorityId as AuthorityDiscoveryId;
 use pallet_transaction_payment_rpc_runtime_api::RuntimeDispatchInfo;
 use pallet_session::historical as session_historical;
+use polkadot_runtime_parachains::reward_points::RewardValidatorsWithEraPoints;
 
 #[cfg(feature = "std")]
 pub use pallet_staking::StakerStatus;
@@ -450,6 +451,7 @@ impl parachains_configuration::Config for Runtime {}
 
 impl parachains_inclusion::Config for Runtime {
 	type Event = Event;
+	type RewardValidators = RewardValidatorsWithEraPoints<Runtime>,
 }
 
 impl parachains_inclusion_inherent::Config for Runtime {}

--- a/runtime/test-runtime/src/lib.rs
+++ b/runtime/test-runtime/src/lib.rs
@@ -451,7 +451,7 @@ impl parachains_configuration::Config for Runtime {}
 
 impl parachains_inclusion::Config for Runtime {
 	type Event = Event;
-	type RewardValidators = RewardValidatorsWithEraPoints<Runtime>,
+	type RewardValidators = RewardValidatorsWithEraPoints<Runtime>;
 }
 
 impl parachains_inclusion_inherent::Config for Runtime {}


### PR DESCRIPTION
We want to give reward points according to the schedule here: https://w3f-research.readthedocs.io/en/latest/polkadot/Token%20Economics.html 

That document doesn't yet account for bitfields, but I imagine we want to record every '1' bit set in candidates that actually get included. Likewise, I only rewarded validators backing candidates that became available later on.

TODO:
  - [x] Fix tests
  - [x] Test backing rewards
  - [x] Add bitfield rewards
  - [x] Test bitfield rewards
  - [x] Add an implementation of `RewardValidators` that uses `pallet-staking` and real values under the hood