### PR TITLE
runtime/session_info: avoid heavy loop when introduced on a live chain 

### DIFF
--- a/runtime/parachains/src/session_info.rs
+++ b/runtime/parachains/src/session_info.rs
@@ -216,7 +216,7 @@ mod tests {
 	}
 
 	#[test]
-	fn session_pruning_is_based_on_dispute_deriod() {
+	fn session_pruning_is_based_on_dispute_period() {
 		new_test_ext(genesis_config()).execute_with(|| {
 			run_to_block(100, session_changes);
 			assert_eq!(EarliestStoredSession::get(), 9);

--- a/runtime/parachains/src/session_info.rs
+++ b/runtime/parachains/src/session_info.rs
@@ -101,8 +101,11 @@ impl<T: Config> Module<T> {
 		// update `EarliestStoredSession` based on `config.dispute_period`
 		EarliestStoredSession::set(new_earliest_stored_session);
 		// remove all entries from `Sessions` from the previous value up to the new value
-		for idx in old_earliest_stored_session..new_earliest_stored_session {
-			Sessions::remove(&idx);
+		// avoid a potentially heavy loop when introduced on a live chain
+		if old_earliest_stored_session != 0 || Sessions::get(0).is_some() {
+			for idx in old_earliest_stored_session..new_earliest_stored_session {
+				Sessions::remove(&idx);
+			}
 		}
 		// create a new entry in `Sessions` with information about the current session
 		let new_session_info = SessionInfo {

--- a/runtime/parachains/src/session_info.rs
+++ b/runtime/parachains/src/session_info.rs
@@ -260,7 +260,7 @@ mod tests {
 	#[test]
 	fn session_pruning_avoids_heavy_loop() {
 		new_test_ext(genesis_config()).execute_with(|| {
-			let start = 1_000_000;
+			let start = 1_000_000_000;
 			System::on_initialize(start);
 			System::set_block_number(start);
 


### PR DESCRIPTION
Addresses part 2 of #2093:
> The SessionInfo module will initially have EarliestSession be 0, but when introduced on a live chain that's been around for several thousand sessions (Kusama, Polkadot), it'll end up in a potentially heavy loop trying to prune all session info from 0..some_high_session_number. We should work around this so enabling the SessionInfo module on existing chains is light.