### PR TITLE
Fix Jaeger service name

### DIFF
--- a/node/subsystem/src/jaeger.rs
+++ b/node/subsystem/src/jaeger.rs
@@ -205,7 +205,7 @@ impl Jaeger {
 		log::info!("🐹 Collecting jaeger spans for {:?}", &jaeger_agent);
 
 		let (traces_in, mut traces_out) = mick_jaeger::init(mick_jaeger::Config {
-			service_name: format!("{}-{}", cfg.node_name, cfg.node_name),
+			service_name: format!("polkadot-{}", cfg.node_name),
 		});
 
 		// Spawn a background task that pulls span information and sends them on the network.


### PR DESCRIPTION
Services would no longer be named `rococo-3-validator-5-rococo-3-validator-5` but `polkadot-rococo-3-validator-5`.
`polkadot` prefix is there in order to not create confusion if someone wants to connect additional non-Polkadot services to the same Jaeger agent.