### PR TITLE
fix `availability_cores`

### DIFF
--- a/runtime/parachains/src/runtime_api_impl/v1.rs
+++ b/runtime/parachains/src/runtime_api_impl/v1.rs
@@ -151,7 +151,12 @@ pub fn availability_cores<T: initializer::Config>() -> Vec<CoreState<T::Hash, T:
 
 	// This will overwrite only `Free` cores if the scheduler module is working as intended.
 	for scheduled in <scheduler::Module<T>>::scheduled() {
-		core_states[scheduled.core.0 as usize] = CoreState::Scheduled(ScheduledCore {
+		let core_index = scheduled.core.0 as usize;
+		if core_index >= core_states.len() {
+			break
+		}
+
+		core_states[core_index] = CoreState::Scheduled(ScheduledCore {
 			para_id: scheduled.para_id,
 			collator: scheduled.required_collator().map(|c| c.clone()),
 		});


### PR DESCRIPTION
When `schedule_para_cleanup` become effective, an error will occur. The log as follows:
`Thread 'tokio-runtime-worker' panicked at 'index out of bounds: the len is 1 but the index is 1', /xxx/polkadot-4038f27d5e4ea2e8/0df0195/runtime/parachains/src/runtime_api_impl/v1.rs:154`.
