### PR TITLE
[Release backport] Backport substrate#7733 and switch to that branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1460,7 +1460,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -1468,7 +1468,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1486,7 +1486,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "chrono",
  "frame-benchmarking",
@@ -1508,7 +1508,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1524,7 +1524,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata"
 version = "12.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -1535,7 +1535,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "bitflags",
  "frame-metadata",
@@ -1560,7 +1560,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "frame-support-procedural-tools",
  "proc-macro2 1.0.24",
@@ -1571,7 +1571,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -1583,7 +1583,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -1593,7 +1593,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples 0.1.3",
@@ -1609,7 +1609,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -1623,7 +1623,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -3821,7 +3821,7 @@ checksum = "13370dae44474229701bb69b90b4f4dca6404cb0357a2d50d635f1171dc3aa7b"
 [[package]]
 name = "pallet-authority-discovery"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3837,7 +3837,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3852,7 +3852,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3877,7 +3877,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3891,7 +3891,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3907,7 +3907,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3922,7 +3922,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3937,7 +3937,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3958,7 +3958,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -3974,7 +3974,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3994,7 +3994,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4011,7 +4011,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4025,7 +4025,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4041,7 +4041,7 @@ dependencies = [
 [[package]]
 name = "pallet-nicks"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4055,7 +4055,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4070,7 +4070,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4091,7 +4091,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4107,7 +4107,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4120,7 +4120,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "enumflags2",
  "frame-support",
@@ -4135,7 +4135,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4150,7 +4150,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4170,7 +4170,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4186,7 +4186,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4200,7 +4200,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4222,7 +4222,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.24",
@@ -4233,7 +4233,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4247,7 +4247,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4265,7 +4265,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4282,7 +4282,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -4300,7 +4300,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -4313,7 +4313,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4328,7 +4328,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4344,7 +4344,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -6607,7 +6607,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -6635,7 +6635,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "futures 0.3.8",
  "futures-timer 3.0.2",
@@ -6658,7 +6658,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -6675,7 +6675,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "impl-trait-for-tuples 0.1.3",
  "parity-scale-codec",
@@ -6696,7 +6696,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.24",
@@ -6707,7 +6707,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "atty",
  "chrono",
@@ -6750,7 +6750,7 @@ dependencies = [
 [[package]]
 name = "sc-cli-proc-macro"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.24",
@@ -6761,7 +6761,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "derive_more",
  "fnv",
@@ -6795,7 +6795,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "blake2-rfc",
  "hash-db",
@@ -6825,7 +6825,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "sc-client-api",
  "sp-blockchain",
@@ -6836,7 +6836,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "derive_more",
  "fork-tree",
@@ -6881,7 +6881,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "derive_more",
  "futures 0.3.8",
@@ -6905,7 +6905,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -6918,7 +6918,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "futures 0.3.8",
  "futures-timer 3.0.2",
@@ -6944,7 +6944,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-uncles"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "log",
  "sc-client-api",
@@ -6958,7 +6958,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "derive_more",
  "lazy_static",
@@ -6987,7 +6987,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "derive_more",
  "parity-scale-codec",
@@ -7003,7 +7003,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -7018,7 +7018,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -7036,7 +7036,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "derive_more",
  "finality-grandpa",
@@ -7073,7 +7073,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa-rpc"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "derive_more",
  "finality-grandpa",
@@ -7097,7 +7097,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "ansi_term 0.12.1",
  "futures 0.3.8",
@@ -7115,7 +7115,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -7135,7 +7135,7 @@ dependencies = [
 [[package]]
 name = "sc-light"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "hash-db",
  "lazy_static",
@@ -7154,7 +7154,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "async-std",
  "async-trait",
@@ -7208,7 +7208,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "futures 0.3.8",
  "futures-timer 3.0.2",
@@ -7223,7 +7223,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "bytes 0.5.6",
  "fnv",
@@ -7250,7 +7250,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "futures 0.3.8",
  "libp2p",
@@ -7263,7 +7263,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -7272,7 +7272,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "futures 0.3.8",
  "hash-db",
@@ -7306,7 +7306,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "derive_more",
  "futures 0.3.8",
@@ -7330,7 +7330,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "futures 0.1.29",
  "jsonrpc-core",
@@ -7348,7 +7348,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "directories 3.0.1",
  "exit-future",
@@ -7412,7 +7412,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -7427,7 +7427,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -7447,7 +7447,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "futures 0.3.8",
  "futures-timer 3.0.2",
@@ -7468,7 +7468,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "ansi_term 0.12.1",
  "erased-serde",
@@ -7492,7 +7492,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-graph"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "derive_more",
  "futures 0.3.8",
@@ -7514,7 +7514,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "futures 0.3.8",
  "futures-diagnose",
@@ -7970,7 +7970,7 @@ dependencies = [
 [[package]]
 name = "sp-allocator"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "log",
  "sp-core",
@@ -7982,7 +7982,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
@@ -7998,7 +7998,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate",
@@ -8010,7 +8010,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -8022,7 +8022,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "integer-sqrt",
  "num-traits 0.2.12",
@@ -8035,7 +8035,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -8047,7 +8047,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -8058,7 +8058,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -8070,7 +8070,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "futures 0.3.8",
  "log",
@@ -8088,7 +8088,7 @@ dependencies = [
 [[package]]
 name = "sp-chain-spec"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "serde",
  "serde_json",
@@ -8097,7 +8097,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "futures 0.3.8",
  "futures-timer 3.0.2",
@@ -8123,7 +8123,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "merlin",
  "parity-scale-codec",
@@ -8143,7 +8143,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -8152,7 +8152,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "parity-scale-codec",
  "schnorrkel",
@@ -8164,7 +8164,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "base58",
  "blake2-rfc",
@@ -8208,7 +8208,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "kvdb",
  "parking_lot 0.10.2",
@@ -8217,7 +8217,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -8227,7 +8227,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -8238,7 +8238,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -8255,7 +8255,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.10.2",
@@ -8267,7 +8267,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "futures 0.3.8",
  "hash-db",
@@ -8291,7 +8291,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -8302,7 +8302,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -8319,7 +8319,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -8331,7 +8331,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections-compact"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.24",
@@ -8342,7 +8342,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -8352,7 +8352,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "backtrace",
 ]
@@ -8360,7 +8360,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "serde",
  "sp-core",
@@ -8369,7 +8369,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -8390,7 +8390,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "impl-trait-for-tuples 0.1.3",
  "parity-scale-codec",
@@ -8407,7 +8407,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -8419,7 +8419,7 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "serde",
  "serde_json",
@@ -8428,7 +8428,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -8441,7 +8441,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -8451,7 +8451,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "hash-db",
  "log",
@@ -8473,12 +8473,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 
 [[package]]
 name = "sp-storage"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -8491,7 +8491,7 @@ dependencies = [
 [[package]]
 name = "sp-tasks"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "log",
  "sp-core",
@@ -8504,7 +8504,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "impl-trait-for-tuples 0.1.3",
  "parity-scale-codec",
@@ -8518,7 +8518,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -8531,7 +8531,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "derive_more",
  "futures 0.3.8",
@@ -8547,7 +8547,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -8561,7 +8561,7 @@ dependencies = [
 [[package]]
 name = "sp-utils"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "futures 0.3.8",
  "futures-core",
@@ -8573,7 +8573,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -8585,7 +8585,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "impl-trait-for-tuples 0.1.3",
  "parity-scale-codec",
@@ -8727,7 +8727,7 @@ dependencies = [
 [[package]]
 name = "substrate-browser-utils"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "chrono",
  "console_error_panic_hook",
@@ -8753,7 +8753,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "platforms",
 ]
@@ -8761,7 +8761,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.8",
@@ -8784,7 +8784,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "async-std",
  "derive_more",
@@ -8798,7 +8798,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "futures 0.1.29",
  "futures 0.3.8",
@@ -8825,7 +8825,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-utils"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "futures 0.3.8",
  "substrate-test-utils-derive",
@@ -8835,7 +8835,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-utils-derive"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate#6b600cdeb4043e512bc5f342eb02a5a17d26797a"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-release-v0.8.27#8c3b3fb1b0c858cc603444eafab4032caf6795ce"
 dependencies = [
  "proc-macro-crate",
  "quote 1.0.7",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -23,20 +23,20 @@ wasm-bindgen-futures = { version = "0.4.19", optional = true }
 service = { package = "polkadot-service", path = "../node/service", default-features = false, optional = true }
 polkadot-parachain = { path = "../parachain", optional = true }
 
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sc-tracing = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sc-tracing = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
 tracing-futures = "0.2.4"
-frame-benchmarking-cli = { git = "https://github.com/paritytech/substrate", branch = "master", optional = true }
-sc-cli = { git = "https://github.com/paritytech/substrate", branch = "master", optional = true }
-sc-service = { git = "https://github.com/paritytech/substrate", branch = "master", optional = true }
-browser-utils = { package = "substrate-browser-utils", git = "https://github.com/paritytech/substrate", branch = "master", optional = true }
+frame-benchmarking-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", optional = true }
+sc-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", optional = true }
+sc-service = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", optional = true }
+browser-utils = { package = "substrate-browser-utils", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", optional = true }
 
 # this crate is used only to enable `trie-memory-tracker` feature
 # see https://github.com/paritytech/substrate/pull/6745
-sp-trie = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+sp-trie = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
 
 [build-dependencies]
-substrate-build-script-utils = { git = "https://github.com/paritytech/substrate", branch = "master" }
+substrate-build-script-utils = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
 
 [features]
 default = [ "wasmtime", "db", "cli", "full-node", "trie-memory-tracker", "polkadot-parachain" ]

--- a/core-primitives/Cargo.toml
+++ b/core-primitives/Cargo.toml
@@ -5,9 +5,9 @@ authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 
 [dependencies]
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
 parity-scale-codec = { version = "1.3.5", default-features = false, features = [ "derive" ] }
 
 [features]

--- a/erasure-coding/Cargo.toml
+++ b/erasure-coding/Cargo.toml
@@ -8,6 +8,6 @@ edition = "2018"
 primitives = { package = "polkadot-primitives", path = "../primitives" }
 reed_solomon = { package = "reed-solomon-erasure", version = "4.0.2" }
 parity-scale-codec = { version = "1.3.5", default-features = false, features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
-trie = { package = "sp-trie", git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+trie = { package = "sp-trie", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
 thiserror = "1.0.22"

--- a/node/collation-generation/Cargo.toml
+++ b/node/collation-generation/Cargo.toml
@@ -13,7 +13,7 @@ polkadot-node-primitives = { path = "../primitives" }
 polkadot-node-subsystem = { path = "../subsystem" }
 polkadot-node-subsystem-util = { path = "../subsystem-util" }
 polkadot-primitives = { path = "../../primitives" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
 thiserror = "1.0.22"
 
 [dev-dependencies]

--- a/node/core/av-store/Cargo.toml
+++ b/node/core/av-store/Cargo.toml
@@ -20,7 +20,7 @@ polkadot-node-subsystem-util = { path = "../../subsystem-util" }
 polkadot-overseer = { path = "../../overseer" }
 polkadot-primitives = { path = "../../../primitives" }
 
-sc-service = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+sc-service = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
 
 [dev-dependencies]
 log = "0.4.11"
@@ -29,6 +29,6 @@ assert_matches = "1.4.0"
 smallvec = "1.5.1"
 kvdb-memorydb = "0.7.0"
 
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
 polkadot-node-subsystem-util = { path = "../../subsystem-util" }
 polkadot-node-subsystem-test-helpers = { path = "../../subsystem-test-helpers" }

--- a/node/core/backing/Cargo.toml
+++ b/node/core/backing/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 futures = "0.3.8"
-sp-keystore = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-keystore = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
 polkadot-primitives = { path = "../../../primitives" }
 polkadot-node-primitives = { path = "../../primitives" }
 polkadot-subsystem = { package = "polkadot-node-subsystem", path = "../../subsystem" }
@@ -19,10 +19,10 @@ tracing-futures = "0.2.4"
 thiserror = "1.0.22"
 
 [dev-dependencies]
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-application-crypto = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sc-keystore = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sp-application-crypto = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sc-keystore = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
 futures = { version = "0.3.8", features = ["thread-pool"] }
 assert_matches = "1.4.0"
 polkadot-node-subsystem-test-helpers = { path = "../../subsystem-test-helpers" }

--- a/node/core/bitfield-signing/Cargo.toml
+++ b/node/core/bitfield-signing/Cargo.toml
@@ -11,6 +11,6 @@ tracing-futures = "0.2.4"
 polkadot-primitives = { path = "../../../primitives" }
 polkadot-node-subsystem = { path = "../../subsystem" }
 polkadot-node-subsystem-util = { path = "../../subsystem-util" }
-sp-keystore = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-keystore = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
 wasm-timer = "0.2.5"
 thiserror = "1.0.22"

--- a/node/core/candidate-selection/Cargo.toml
+++ b/node/core/candidate-selection/Cargo.toml
@@ -10,11 +10,11 @@ tracing = "0.1.22"
 tracing-futures = "0.2.4"
 thiserror = "1.0.22"
 
-sp-keystore = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-keystore = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
 
 polkadot-primitives = { path = "../../../primitives" }
 polkadot-node-subsystem = { path = "../../subsystem" }
 polkadot-node-subsystem-util = { path = "../../subsystem-util" }
 
 [dev-dependencies]
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }

--- a/node/core/candidate-validation/Cargo.toml
+++ b/node/core/candidate-validation/Cargo.toml
@@ -9,7 +9,7 @@ futures = "0.3.8"
 tracing = "0.1.22"
 tracing-futures = "0.2.4"
 
-sp-core = { package = "sp-core", git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-core = { package = "sp-core", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
 parity-scale-codec = { version = "1.3.5", default-features = false, features = ["bit-vec", "derive"] }
 
 polkadot-primitives = { path = "../../../primitives" }
@@ -19,7 +19,7 @@ polkadot-subsystem = { package = "polkadot-node-subsystem", path = "../../subsys
 polkadot-node-subsystem-util = { path = "../../subsystem-util" }
 
 [dev-dependencies]
-sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
 futures = { version = "0.3.8", features = ["thread-pool"] }
 assert_matches = "1.4.0"
 polkadot-node-subsystem-test-helpers = { path = "../../subsystem-test-helpers" }

--- a/node/core/chain-api/Cargo.toml
+++ b/node/core/chain-api/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 futures = "0.3.8"
 tracing = "0.1.22"
 tracing-futures = "0.2.4"
-sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
 polkadot-primitives = { path = "../../../primitives" }
 polkadot-subsystem = { package = "polkadot-node-subsystem", path = "../../subsystem" }
 polkadot-node-subsystem-util = { path = "../../subsystem-util" }
@@ -17,4 +17,4 @@ polkadot-node-subsystem-util = { path = "../../subsystem-util" }
 futures = { version = "0.3.8", features = ["thread-pool"] }
 maplit = "1.0.2"
 polkadot-node-subsystem-test-helpers = { path = "../../subsystem-test-helpers" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }

--- a/node/core/proposer/Cargo.toml
+++ b/node/core/proposer/Cargo.toml
@@ -11,14 +11,14 @@ tracing = "0.1.22"
 polkadot-node-subsystem = { path = "../../subsystem" }
 polkadot-overseer = { path = "../../overseer" }
 polkadot-primitives = { path = "../../../primitives" }
-sc-basic-authorship = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sc-block-builder = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-consensus = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-inherents = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "master" }
-prometheus-endpoint = { package = "substrate-prometheus-endpoint", git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-basic-authorship = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sc-block-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sp-consensus = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sp-inherents = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sp-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+prometheus-endpoint = { package = "substrate-prometheus-endpoint", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }

--- a/node/core/provisioner/Cargo.toml
+++ b/node/core/provisioner/Cargo.toml
@@ -16,5 +16,5 @@ polkadot-node-subsystem-util = { path = "../../subsystem-util" }
 futures-timer = "3.0.2"
 
 [dev-dependencies]
-sp-application-crypto = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-keystore = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-application-crypto = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sp-keystore = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }

--- a/node/core/runtime-api/Cargo.toml
+++ b/node/core/runtime-api/Cargo.toml
@@ -8,14 +8,14 @@ edition = "2018"
 futures = "0.3.8"
 tracing = "0.1.22"
 tracing-futures = "0.2.4"
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
 
 polkadot-primitives = { path = "../../../primitives" }
 polkadot-subsystem = { package = "polkadot-node-subsystem", path = "../../subsystem" }
 polkadot-node-subsystem-util = { path = "../../subsystem-util" }
 
 [dev-dependencies]
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
 futures = { version = "0.3.8", features = ["thread-pool"] }
 polkadot-node-subsystem-test-helpers = { path = "../../subsystem-test-helpers" }

--- a/node/network/availability-distribution/Cargo.toml
+++ b/node/network/availability-distribution/Cargo.toml
@@ -14,16 +14,16 @@ polkadot-erasure-coding = { path = "../../../erasure-coding" }
 polkadot-subsystem = { package = "polkadot-node-subsystem", path = "../../subsystem" }
 polkadot-node-network-protocol = { path = "../../network/protocol" }
 polkadot-node-subsystem-util = { path = "../../subsystem-util" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "master", features = ["std"]  }
-sp-keystore = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", features = ["std"]  }
+sp-keystore = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
 thiserror = "1.0.22"
 
 [dev-dependencies]
 polkadot-subsystem-testhelpers = { package = "polkadot-node-subsystem-test-helpers", path = "../../subsystem-test-helpers" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "master", features = ["std"] }
-sp-application-crypto = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sc-keystore = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", features = ["std"] }
+sp-application-crypto = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sc-keystore = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
 futures-timer = "3.0.2"
 env_logger = "0.8.2"
 assert_matches = "1.4.0"

--- a/node/network/bitfield-distribution/Cargo.toml
+++ b/node/network/bitfield-distribution/Cargo.toml
@@ -17,9 +17,9 @@ polkadot-node-network-protocol = { path = "../../network/protocol" }
 [dev-dependencies]
 polkadot-node-subsystem-test-helpers = { path = "../../subsystem-test-helpers" }
 bitvec = { version = "0.17.4", default-features = false, features = ["alloc"] }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-application-crypto = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-keystore = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sp-application-crypto = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sp-keystore = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
 maplit = "1.0.2"
 log = "0.4.11"
 env_logger = "0.8.2"

--- a/node/network/bridge/Cargo.toml
+++ b/node/network/bridge/Cargo.toml
@@ -11,8 +11,8 @@ tracing = "0.1.22"
 tracing-futures = "0.2.4"
 polkadot-primitives = { path = "../../../primitives" }
 parity-scale-codec = { version = "1.3.5", default-features = false, features = ["derive"] }
-sc-authority-discovery = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sc-network = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-authority-discovery = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sc-network = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
 polkadot-subsystem = { package = "polkadot-node-subsystem", path = "../../subsystem" }
 polkadot-node-network-protocol = { path = "../protocol" }
 
@@ -20,5 +20,5 @@ polkadot-node-network-protocol = { path = "../protocol" }
 assert_matches = "1.4.0"
 parking_lot = "0.11.1"
 polkadot-node-subsystem-test-helpers = { path = "../../subsystem-test-helpers" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }

--- a/node/network/collator-protocol/Cargo.toml
+++ b/node/network/collator-protocol/Cargo.toml
@@ -23,7 +23,7 @@ assert_matches = "1.4.0"
 smallvec = "1.5.1"
 futures-timer = "3.0.2"
 
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "master", features = ["std"] }
-sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", features = ["std"] }
+sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
 
 polkadot-subsystem-testhelpers = { package = "polkadot-node-subsystem-test-helpers", path = "../../subsystem-test-helpers" }

--- a/node/network/pov-distribution/Cargo.toml
+++ b/node/network/pov-distribution/Cargo.toml
@@ -21,7 +21,7 @@ env_logger = "0.8.1"
 log = "0.4.11"
 smallvec = "1.5.1"
 
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
 
 polkadot-node-subsystem-test-helpers = { path = "../../subsystem-test-helpers" }

--- a/node/network/protocol/Cargo.toml
+++ b/node/network/protocol/Cargo.toml
@@ -9,4 +9,4 @@ description = "Primitives types for the Node-side"
 polkadot-primitives = { path = "../../../primitives" }
 polkadot-node-primitives = { path = "../../primitives" }
 parity-scale-codec = { version = "1.3.5", default-features = false, features = ["derive"] }
-sc-network = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-network = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }

--- a/node/network/statement-distribution/Cargo.toml
+++ b/node/network/statement-distribution/Cargo.toml
@@ -11,7 +11,7 @@ tracing = "0.1.22"
 tracing-futures = "0.2.4"
 polkadot-primitives = { path = "../../../primitives" }
 node-primitives = { package = "polkadot-node-primitives", path = "../../primitives" }
-sp-staking = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+sp-staking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
 polkadot-subsystem = { package = "polkadot-node-subsystem", path = "../../subsystem" }
 polkadot-node-subsystem-util = { path = "../../subsystem-util" }
 polkadot-node-network-protocol = { path = "../../network/protocol" }
@@ -21,8 +21,8 @@ indexmap = "1.6.0"
 [dev-dependencies]
 polkadot-node-subsystem-test-helpers = { path = "../../subsystem-test-helpers" }
 assert_matches = "1.4.0"
-sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-application-crypto = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-keystore = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sc-keystore = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sp-application-crypto = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sp-keystore = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sc-keystore = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }

--- a/node/overseer/Cargo.toml
+++ b/node/overseer/Cargo.toml
@@ -11,14 +11,14 @@ tracing-futures = "0.2.4"
 futures-timer = "3.0.2"
 streamunordered = "0.5.1"
 polkadot-primitives = { path = "../../primitives" }
-client = { package = "sc-client-api", git = "https://github.com/paritytech/substrate", branch = "master" }
+client = { package = "sc-client-api", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
 polkadot-subsystem = { package = "polkadot-node-subsystem", path = "../subsystem" }
 polkadot-node-subsystem-util = { path = "../subsystem-util" }
 polkadot-node-primitives = { package = "polkadot-node-primitives", path = "../primitives" }
 async-trait = "0.1.42"
 
 [dev-dependencies]
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
 polkadot-node-network-protocol = { path = "../network/protocol" }
 futures = { version = "0.3.8", features = ["thread-pool"] }
 futures-timer = "3.0.2"

--- a/node/primitives/Cargo.toml
+++ b/node/primitives/Cargo.toml
@@ -10,5 +10,5 @@ futures = "0.3.8"
 polkadot-primitives = { path = "../../primitives" }
 polkadot-statement-table = { path = "../../statement-table" }
 parity-scale-codec = { version = "1.3.5", default-features = false, features = ["derive"] }
-runtime_primitives = { package = "sp-runtime", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
+runtime_primitives = { package = "sp-runtime", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }

--- a/node/service/Cargo.toml
+++ b/node/service/Cargo.toml
@@ -6,50 +6,50 @@ edition = "2018"
 
 [dependencies]
 # Substrate Client
-sc-authority-discovery = { git = "https://github.com/paritytech/substrate", branch = "master" }
-babe = { package = "sc-consensus-babe", git = "https://github.com/paritytech/substrate", branch = "master" }
-grandpa = { package = "sc-finality-grandpa", git = "https://github.com/paritytech/substrate", branch = "master" }
-sc-block-builder = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sc-chain-spec = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sc-client-db = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sc-consensus = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sc-consensus-slots = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sc-executor = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sc-network = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sc-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "master" }
-service = { package = "sc-service", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-telemetry = { package = "sc-telemetry", git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-authority-discovery = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+babe = { package = "sc-consensus-babe", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+grandpa = { package = "sc-finality-grandpa", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sc-block-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sc-chain-spec = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sc-client-db = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sc-consensus = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sc-consensus-slots = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sc-executor = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sc-network = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sc-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+service = { package = "sc-service", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+telemetry = { package = "sc-telemetry", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
 
 # Substrate Primitives
-sp-authority-discovery = { git = "https://github.com/paritytech/substrate", branch = "master" }
-babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/paritytech/substrate", branch = "master" }
-consensus_common = { package = "sp-consensus", git = "https://github.com/paritytech/substrate", branch = "master" }
-grandpa_primitives = { package = "sp-finality-grandpa", git = "https://github.com/paritytech/substrate", branch = "master" }
-inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-block-builder = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-keystore = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-offchain = { package = "sp-offchain", git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-session = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-storage = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-trie = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-authority-discovery = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+consensus_common = { package = "sp-consensus", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+grandpa_primitives = { package = "sp-finality-grandpa", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sp-block-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sp-keystore = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sp-offchain = { package = "sp-offchain", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sp-session = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sp-storage = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sp-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sp-trie = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
 
 # Substrate Pallets
-pallet-babe = { git = "https://github.com/paritytech/substrate", branch = "master" }
-pallet-im-online = { git = "https://github.com/paritytech/substrate", branch = "master" }
-pallet-staking = { git = "https://github.com/paritytech/substrate", branch = "master" }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "master" }
+pallet-babe = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+pallet-im-online = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+pallet-staking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
 
 # Substrate Other
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "master" }
-frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "master" }
-prometheus-endpoint = { package = "substrate-prometheus-endpoint", git = "https://github.com/paritytech/substrate", branch = "master" }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+prometheus-endpoint = { package = "substrate-prometheus-endpoint", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
 
 # External Crates
 futures = "0.3.8"

--- a/node/subsystem-test-helpers/Cargo.toml
+++ b/node/subsystem-test-helpers/Cargo.toml
@@ -19,9 +19,9 @@ polkadot-node-subsystem = { path = "../subsystem" }
 polkadot-node-subsystem-util = { path = "../subsystem-util" }
 polkadot-primitives = { path = "../../primitives" }
 polkadot-statement-table = { path = "../../statement-table" }
-sc-network = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-network = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
 smallvec = "1.5.1"
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
 
 [dev-dependencies]
 polkadot-overseer = { path = "../overseer" }

--- a/node/subsystem-util/Cargo.toml
+++ b/node/subsystem-util/Cargo.toml
@@ -21,11 +21,11 @@ polkadot-node-primitives = { path = "../primitives" }
 polkadot-node-subsystem = { path = "../subsystem" }
 polkadot-primitives = { path = "../../primitives" }
 
-sc-network = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-application-crypto = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-keystore = { git = "https://github.com/paritytech/substrate", branch = "master" }
-substrate-prometheus-endpoint = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-network = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sp-application-crypto = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sp-keystore = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+substrate-prometheus-endpoint = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
 
 [dev-dependencies]
 assert_matches = "1.4.0"

--- a/node/subsystem/Cargo.toml
+++ b/node/subsystem/Cargo.toml
@@ -19,10 +19,10 @@ polkadot-node-primitives = { path = "../primitives" }
 polkadot-node-network-protocol = { path = "../network/protocol" }
 polkadot-primitives = { path = "../../primitives" }
 polkadot-statement-table = { path = "../../statement-table" }
-sc-network = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-network = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
 smallvec = "1.5.1"
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
-substrate-prometheus-endpoint = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+substrate-prometheus-endpoint = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
 thiserror = "1.0.22"
 
 [dev-dependencies]

--- a/node/test/client/Cargo.toml
+++ b/node/test/client/Cargo.toml
@@ -14,18 +14,18 @@ polkadot-primitives = { path = "../../../primitives" }
 polkadot-node-subsystem = { path = "../../subsystem" }
 
 # Substrate dependencies
-substrate-test-client = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sc-service = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sc-block-builder = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sc-consensus = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-inherents = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-timestamp = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-consensus = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-state-machine = { git = "https://github.com/paritytech/substrate", branch = "master" }
+substrate-test-client = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sc-service = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sc-block-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sc-consensus = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sp-inherents = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sp-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sp-consensus = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sp-state-machine = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
 
 [dev-dependencies]
-sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }

--- a/node/test/service/Cargo.toml
+++ b/node/test/service/Cargo.toml
@@ -26,37 +26,37 @@ polkadot-test-runtime = { path = "../../../runtime/test-runtime" }
 polkadot-runtime-parachains = { path = "../../../runtime/parachains" }
 
 # Substrate dependencies
-sp-authority-discovery = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sc-authority-discovery = { git = "https://github.com/paritytech/substrate", branch = "master" }
-babe = { package = "sc-consensus-babe", git = "https://github.com/paritytech/substrate", branch = "master" }
-babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/paritytech/substrate", branch = "master" }
-consensus_common = { package = "sp-consensus", git = "https://github.com/paritytech/substrate", branch = "master" }
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "master" }
-frame-system = { git = "https://github.com/paritytech/substrate", branch = "master" }
-grandpa = { package = "sc-finality-grandpa", git = "https://github.com/paritytech/substrate", branch = "master" }
-grandpa_primitives = { package = "sp-finality-grandpa", git = "https://github.com/paritytech/substrate", branch = "master" }
-inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "master" }
-pallet-staking = { git = "https://github.com/paritytech/substrate", branch = "master" }
-pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "master" }
-pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sc-chain-spec = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sc-cli = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sc-consensus = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sc-executor = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sc-network = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sc-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "master" }
-service = { package = "sc-service", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-arithmetic = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-state-machine = { git = "https://github.com/paritytech/substrate", branch = "master" }
-substrate-test-client = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-authority-discovery = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sc-authority-discovery = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+babe = { package = "sc-consensus-babe", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+consensus_common = { package = "sp-consensus", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+grandpa = { package = "sc-finality-grandpa", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+grandpa_primitives = { package = "sp-finality-grandpa", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+pallet-staking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sc-chain-spec = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sc-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sc-consensus = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sc-executor = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sc-network = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sc-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+service = { package = "sc-service", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-arithmetic = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sp-state-machine = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+substrate-test-client = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
 
 [dev-dependencies]
-pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
 serde_json = "1.0.60"
-substrate-test-utils = { git = "https://github.com/paritytech/substrate", branch = "master" }
+substrate-test-utils = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
 tokio = { version = "0.2", features = ["macros"] }

--- a/parachain/Cargo.toml
+++ b/parachain/Cargo.toml
@@ -10,19 +10,19 @@ edition = "2018"
 # this crate for WASM. This is critical to avoid forcing all parachain WASM into implementing
 # various unnecessary Substrate-specific endpoints.
 parity-scale-codec = { version = "1.3.5", default-features = false, features = [ "derive" ] }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-wasm-interface = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-wasm-interface = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
 polkadot-core-primitives = { path = "../core-primitives", default-features = false }
 derive_more = "0.99.11"
 
 # all optional crates.
 thiserror = { version = "1.0.22", optional = true }
 serde = { version = "1.0.117", default-features = false, features = [ "derive" ], optional = true }
-sp-externalities = { git = "https://github.com/paritytech/substrate", branch = "master", optional = true }
-sc-executor = { git = "https://github.com/paritytech/substrate", branch = "master", optional = true }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "master", optional = true }
+sp-externalities = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", optional = true }
+sc-executor = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", optional = true }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", optional = true }
 parking_lot = { version = "0.11.0", optional = true }
 log = { version = "0.4.11", optional = true }
 futures = { version = "0.3.8", optional = true }

--- a/parachain/test-parachains/Cargo.toml
+++ b/parachain/test-parachains/Cargo.toml
@@ -14,7 +14,7 @@ adder = { package = "test-parachain-adder", path = "adder" }
 halt = { package = "test-parachain-halt", path = "halt" }
 
 [dev-dependencies]
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
 
 [features]
 default = [ "std" ]

--- a/parachain/test-parachains/adder/Cargo.toml
+++ b/parachain/test-parachains/adder/Cargo.toml
@@ -9,12 +9,12 @@ build = "build.rs"
 [dependencies]
 parachain = { package = "polkadot-parachain", path = "../../", default-features = false, features = [ "wasm-api" ] }
 parity-scale-codec = { version = "1.3.5", default-features = false, features = ["derive"] }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
 tiny-keccak = { version = "2.0.2", features = ["keccak"] }
 dlmalloc = { version = "0.2.1", features = [ "global" ] }
 
 # We need to make sure the global allocator is disabled until we have support of full substrate externalities
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false, features = [ "disable_allocator" ] }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false, features = [ "disable_allocator" ] }
 
 [build-dependencies]
 substrate-wasm-builder = "3.0.0"

--- a/parachain/test-parachains/adder/collator/Cargo.toml
+++ b/parachain/test-parachains/adder/collator/Cargo.toml
@@ -23,18 +23,18 @@ polkadot-service = { path = "../../../../node/service" }
 polkadot-node-primitives = { path = "../../../../node/primitives" }
 polkadot-node-subsystem = { path = "../../../../node/subsystem" }
 
-sc-cli = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sc-authority-discovery = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sc-service = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sc-authority-discovery = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sc-service = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
 
 [dev-dependencies]
 polkadot-parachain = { path = "../../.." }
 polkadot-test-service = { path = "../../../../node/test/service" }
 
-substrate-test-utils = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sc-service = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "master" }
+substrate-test-utils = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sc-service = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
 
 tokio = { version = "0.2", features = ["macros"] }
 

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -7,25 +7,25 @@ edition = "2018"
 [dependencies]
 serde = { version = "1.0.118", optional = true, features = ["derive"] }
 parity-scale-codec = { version = "1.3.5", default-features = false, features = ["bit-vec", "derive"] }
-primitives = { package = "sp-core", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-application-crypto = { package = "sp-application-crypto", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-keystore = { git = "https://github.com/paritytech/substrate", branch = "master", optional = true }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-version = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-std = { package = "sp-std", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-staking = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-arithmetic = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-authority-discovery = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-runtime_primitives = { package = "sp-runtime", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+primitives = { package = "sp-core", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+application-crypto = { package = "sp-application-crypto", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-keystore = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", optional = true }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-version = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-std = { package = "sp-std", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-staking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-arithmetic = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-authority-discovery = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+runtime_primitives = { package = "sp-runtime", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
 polkadot-parachain = { path = "../parachain", default-features = false }
 polkadot-core-primitives = { path = "../core-primitives", default-features = false }
-trie = { package = "sp-trie", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+trie = { package = "sp-trie", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
 bitvec = { version = "0.17.4", default-features = false, features = ["alloc"] }
-frame-system = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
 
 [dev-dependencies]
-sp-serializer = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-serializer = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
 pretty_assertions = "0.6.1"
 
 [features]

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -7,24 +7,24 @@ edition = "2018"
 [dependencies]
 jsonrpc-core = "15.1.0"
 polkadot-primitives = { path = "../primitives" }
-sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "master"  }
-sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "master"  }
-sp-keystore = { git = "https://github.com/paritytech/substrate", branch = "master"  }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master"  }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "master"  }
-sp-consensus = { git = "https://github.com/paritytech/substrate", branch = "master"  }
-sp-consensus-babe = { git = "https://github.com/paritytech/substrate", branch = "master"  }
-sc-chain-spec = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sc-rpc = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sc-consensus-babe = { git = "https://github.com/paritytech/substrate", branch = "master"}
-sc-consensus-babe-rpc = { git = "https://github.com/paritytech/substrate", branch = "master"}
-sc-consensus-epochs = { git = "https://github.com/paritytech/substrate", branch = "master"}
-sc-finality-grandpa = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sc-finality-grandpa-rpc = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sc-keystore = { git = "https://github.com/paritytech/substrate", branch = "master"}
-sc-sync-state-rpc = { git = "https://github.com/paritytech/substrate", branch = "master"}
-txpool-api = { package = "sp-transaction-pool", git = "https://github.com/paritytech/substrate", branch = "master" }
-frame-rpc-system = { package = "substrate-frame-rpc-system", git = "https://github.com/paritytech/substrate", branch = "master"  }
-pallet-transaction-payment-rpc = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27"  }
+sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27"  }
+sp-keystore = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27"  }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27"  }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27"  }
+sp-consensus = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27"  }
+sp-consensus-babe = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27"  }
+sc-chain-spec = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sc-rpc = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sc-consensus-babe = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27"}
+sc-consensus-babe-rpc = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27"}
+sc-consensus-epochs = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27"}
+sc-finality-grandpa = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sc-finality-grandpa-rpc = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sc-keystore = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27"}
+sc-sync-state-rpc = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27"}
+txpool-api = { package = "sp-transaction-pool", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+frame-rpc-system = { package = "substrate-frame-rpc-system", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27"  }
+pallet-transaction-payment-rpc = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
 parity-scale-codec = { version = "1.3.5", default-features = false }
-sp-block-builder = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-block-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -13,27 +13,27 @@ serde = { version = "1.0.118", default-features = false }
 serde_derive = { version = "1.0.117", optional = true }
 static_assertions = "1.1.0"
 
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-std = { package = "sp-std", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-session = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-staking = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-std = { package = "sp-std", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-session = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-staking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
 
-pallet-authorship = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-session = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-staking = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-frame-system = {git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-vesting = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-offences = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-treasury = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false, optional = true }
+pallet-authorship = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-session = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-staking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+frame-system = {git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-vesting = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-offences = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-treasury = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false, optional = true }
 
 primitives = { package = "polkadot-primitives", path = "../../primitives", default-features = false }
 libsecp256k1 = { version = "0.3.5", default-features = false, optional = true }
@@ -41,13 +41,13 @@ runtime-parachains = { package = "polkadot-runtime-parachains", path = "../parac
 
 [dev-dependencies]
 hex-literal = "0.3.1"
-keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-trie = { git = "https://github.com/paritytech/substrate", branch = "master" }
-pallet-babe = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-application-crypto = { git = "https://github.com/paritytech/substrate", branch = "master" }
-pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate", branch = "master" }
-pallet-staking-reward-curve = { git = "https://github.com/paritytech/substrate", branch = "master" }
-pallet-treasury = { git = "https://github.com/paritytech/substrate", branch = "master" }
+keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sp-trie = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+pallet-babe = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sp-application-crypto = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+pallet-staking-reward-curve = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+pallet-treasury = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
 trie-db = "0.22.1"
 serde_json = "1.0.60"
 libsecp256k1 = "0.3.5"

--- a/runtime/kusama/Cargo.toml
+++ b/runtime/kusama/Cargo.toml
@@ -15,59 +15,59 @@ serde_derive = { version = "1.0.117", optional = true }
 static_assertions = "1.1.0"
 smallvec = "1.5.1"
 
-authority-discovery-primitives = { package = "sp-authority-discovery", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-offchain-primitives = { package = "sp-offchain", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-std = { package = "sp-std", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-staking = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-session = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-version = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-tx-pool-api = { package = "sp-transaction-pool", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-block-builder-api = { package = "sp-block-builder", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+authority-discovery-primitives = { package = "sp-authority-discovery", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+offchain-primitives = { package = "sp-offchain", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-std = { package = "sp-std", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-staking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-session = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-version = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+tx-pool-api = { package = "sp-transaction-pool", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+block-builder-api = { package = "sp-block-builder", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
 
-pallet-authority-discovery = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-authorship = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-babe = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-collective = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-democracy = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-elections-phragmen = { package = "pallet-elections-phragmen", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-frame-executive = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-grandpa = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-identity = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-im-online = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-indices = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-membership = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-multisig = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-nicks = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-offences = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-proxy = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-recovery = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-scheduler = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-session = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-society = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-staking = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-staking-reward-curve = { package = "pallet-staking-reward-curve", git = "https://github.com/paritytech/substrate", branch = "master" }
-frame-system = {git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-treasury = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-utility = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-vesting = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+pallet-authority-discovery = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-authorship = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-babe = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-collective = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-democracy = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-elections-phragmen = { package = "pallet-elections-phragmen", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+frame-executive = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-grandpa = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-identity = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-im-online = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-indices = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-membership = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-multisig = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-nicks = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-offences = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-proxy = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-recovery = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-scheduler = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-session = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-society = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-staking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-staking-reward-curve = { package = "pallet-staking-reward-curve", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+frame-system = {git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-treasury = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-utility = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-vesting = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
 
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false, optional = true }
-pallet-offences-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false, optional = true }
-pallet-session-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false, optional = true }
-frame-system-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false, optional = true }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false, optional = true }
+pallet-offences-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false, optional = true }
+pallet-session-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false, optional = true }
+frame-system-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false, optional = true }
 hex-literal = { version = "0.3.1", optional = true }
 
 runtime-common = { package = "polkadot-runtime-common", path = "../common", default-features = false }
@@ -77,8 +77,8 @@ primitives = { package = "polkadot-primitives", path = "../../primitives", defau
 hex-literal = "0.3.1"
 libsecp256k1 = "0.3.5"
 tiny-keccak = "2.0.2"
-keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-trie = { git = "https://github.com/paritytech/substrate", branch = "master" }
+keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sp-trie = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
 separator = "0.4.1"
 serde_json = "1.0.60"
 

--- a/runtime/parachains/Cargo.toml
+++ b/runtime/parachains/Cargo.toml
@@ -12,27 +12,27 @@ rustc-hex = { version = "2.1.0", default-features = false }
 serde = { version = "1.0.118", features = [ "derive" ], optional = true }
 derive_more = "0.99.11"
 
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-std = { package = "sp-std", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-session = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-staking = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-keystore = { git = "https://github.com/paritytech/substrate", branch = "master", optional = true }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-std = { package = "sp-std", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-session = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-staking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-keystore = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", optional = true }
 
-pallet-authority-discovery = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-authorship = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-session = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-staking = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-frame-system = {git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-vesting = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-offences = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false, optional = true }
+pallet-authority-discovery = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-authorship = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-session = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-staking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+frame-system = {git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-vesting = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-offences = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false, optional = true }
 
 xcm = { package = "xcm", path = "../../xcm", default-features = false }
 primitives = { package = "polkadot-primitives", path = "../../primitives", default-features = false }
@@ -44,17 +44,17 @@ rand_chacha = { version = "0.2.2", default-features = false }
 [dev-dependencies]
 futures = "0.3.8"
 hex-literal = "0.3.1"
-keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-trie = { git = "https://github.com/paritytech/substrate", branch = "master" }
-pallet-babe = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-application-crypto = { git = "https://github.com/paritytech/substrate", branch = "master" }
-pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate", branch = "master" }
-pallet-staking-reward-curve = { git = "https://github.com/paritytech/substrate", branch = "master" }
-pallet-treasury = { git = "https://github.com/paritytech/substrate", branch = "master" }
+keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sp-trie = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+pallet-babe = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sp-application-crypto = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+pallet-staking-reward-curve = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+pallet-treasury = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
 serde_json = "1.0.60"
 libsecp256k1 = "0.3.5"
-sp-version = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sc-keystore = { git = "https://github.com/paritytech/substrate", branch = "master"}
+sp-version = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sc-keystore = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27"}
 
 
 [features]

--- a/runtime/polkadot/Cargo.toml
+++ b/runtime/polkadot/Cargo.toml
@@ -15,57 +15,57 @@ serde_derive = { version = "1.0.117", optional = true }
 static_assertions = "1.1.0"
 smallvec = "1.5.1"
 
-authority-discovery-primitives = { package = "sp-authority-discovery", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-offchain-primitives = { package = "sp-offchain", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-staking = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-session = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-version = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-tx-pool-api = { package = "sp-transaction-pool", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-block-builder-api = { package = "sp-block-builder", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+authority-discovery-primitives = { package = "sp-authority-discovery", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+offchain-primitives = { package = "sp-offchain", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-staking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-session = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-version = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+tx-pool-api = { package = "sp-transaction-pool", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+block-builder-api = { package = "sp-block-builder", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
 
-pallet-authority-discovery = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-authorship = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-babe = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-collective = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-democracy = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-elections-phragmen = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-frame-executive = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-grandpa = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-identity = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-im-online = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-indices = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-membership = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-multisig = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-nicks = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-offences = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-proxy = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-scheduler = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-session = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-staking = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-staking-reward-curve = { git = "https://github.com/paritytech/substrate", branch = "master" }
-frame-system = {git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-treasury = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-vesting = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-utility = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+pallet-authority-discovery = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-authorship = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-babe = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-collective = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-democracy = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-elections-phragmen = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+frame-executive = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-grandpa = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-identity = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-im-online = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-indices = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-membership = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-multisig = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-nicks = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-offences = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-proxy = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-scheduler = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-session = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-staking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-staking-reward-curve = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+frame-system = {git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-treasury = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-vesting = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-utility = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
 
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false, optional = true }
-frame-system-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false, optional = true }
-pallet-offences-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false, optional = true }
-pallet-session-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false, optional = true }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false, optional = true }
+frame-system-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false, optional = true }
+pallet-offences-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false, optional = true }
+pallet-session-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false, optional = true }
 hex-literal = { version = "0.3.1", optional = true }
 
 runtime-common = { package = "polkadot-runtime-common", path = "../common", default-features = false }
@@ -75,8 +75,8 @@ primitives = { package = "polkadot-primitives", path = "../../primitives", defau
 hex-literal = "0.3.1"
 libsecp256k1 = "0.3.5"
 tiny-keccak = "2.0.2"
-keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-trie = { git = "https://github.com/paritytech/substrate", branch = "master" }
+keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sp-trie = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
 trie-db = "0.22.1"
 serde_json = "1.0.60"
 

--- a/runtime/rococo/Cargo.toml
+++ b/runtime/rococo/Cargo.toml
@@ -11,42 +11,42 @@ serde = { version = "1.0.118", default-features = false }
 serde_derive = { version = "1.0.117", optional = true }
 smallvec = "1.5.1"
 
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-std = { package = "sp-std", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-session = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-staking = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-version = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-std = { package = "sp-std", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-session = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-staking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-version = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
 
-tx-pool-api = { package = "sp-transaction-pool", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-block-builder-api = { package = "sp-block-builder", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-offchain-primitives = { package = "sp-offchain", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+tx-pool-api = { package = "sp-transaction-pool", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+block-builder-api = { package = "sp-block-builder", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+offchain-primitives = { package = "sp-offchain", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
 
-pallet-authority-discovery = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-authorship = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-babe = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-sudo = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-session = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-im-online = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-indices = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-staking = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-staking-reward-curve = { package = "pallet-staking-reward-curve", git = "https://github.com/paritytech/substrate", branch = "master" }
-frame-executive = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-grandpa = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-offences = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-authority-discovery-primitives = { package = "sp-authority-discovery", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+pallet-authority-discovery = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-authorship = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-babe = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-sudo = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-session = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-im-online = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-indices = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-staking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-staking-reward-curve = { package = "pallet-staking-reward-curve", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+frame-executive = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-grandpa = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-offences = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+authority-discovery-primitives = { package = "sp-authority-discovery", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
 
-frame-system = {git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+frame-system = {git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
 
 runtime-common = { package = "polkadot-runtime-common", path = "../common", default-features = false }
 primitives = { package = "polkadot-primitives", path = "../../primitives", default-features = false }

--- a/runtime/test-runtime/Cargo.toml
+++ b/runtime/test-runtime/Cargo.toml
@@ -14,42 +14,42 @@ serde = { version = "1.0.118", default-features = false }
 serde_derive = { version = "1.0.117", optional = true }
 smallvec = "1.5.1"
 
-authority-discovery-primitives = { package = "sp-authority-discovery", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-offchain-primitives = { package = "sp-offchain", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-staking = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-session = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-version = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-tx-pool-api = { package = "sp-transaction-pool", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-block-builder-api = { package = "sp-block-builder", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+authority-discovery-primitives = { package = "sp-authority-discovery", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+offchain-primitives = { package = "sp-offchain", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-staking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-session = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-version = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+tx-pool-api = { package = "sp-transaction-pool", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+block-builder-api = { package = "sp-block-builder", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
 
-pallet-authority-discovery = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-authorship = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-babe = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-frame-executive = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-grandpa = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-indices = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-nicks = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-offences = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-session = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-staking = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-staking-reward-curve = { git = "https://github.com/paritytech/substrate", branch = "master" }
-frame-system = {git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-sudo = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-vesting = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+pallet-authority-discovery = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-authorship = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-babe = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+frame-executive = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-grandpa = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-indices = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-nicks = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-offences = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-session = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-staking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-staking-reward-curve = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+frame-system = {git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-sudo = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-vesting = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
 
 runtime-common = { package = "polkadot-runtime-common", path = "../common", default-features = false }
 primitives = { package = "polkadot-primitives", path = "../../primitives", default-features = false }
@@ -60,8 +60,8 @@ polkadot-runtime-parachains = { path = "../parachains", default-features = false
 hex-literal = "0.3.1"
 libsecp256k1 = "0.3.5"
 tiny-keccak = "2.0.2"
-keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-trie = { git = "https://github.com/paritytech/substrate", branch = "master" }
+keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sp-trie = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
 serde_json = "1.0.60"
 
 [build-dependencies]

--- a/runtime/westend/Cargo.toml
+++ b/runtime/westend/Cargo.toml
@@ -15,60 +15,60 @@ serde_derive = { version = "1.0.117", optional = true }
 smallvec = "1.5.1"
 static_assertions = "1.1.0"
 
-authority-discovery-primitives = { package = "sp-authority-discovery", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-offchain-primitives = { package = "sp-offchain", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-std = { package = "sp-std", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-staking = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-session = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-version = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-tx-pool-api = { package = "sp-transaction-pool", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-block-builder-api = { package = "sp-block-builder", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+authority-discovery-primitives = { package = "sp-authority-discovery", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+offchain-primitives = { package = "sp-offchain", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-std = { package = "sp-std", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-staking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-session = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-version = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+tx-pool-api = { package = "sp-transaction-pool", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+block-builder-api = { package = "sp-block-builder", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
 
-pallet-authority-discovery = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-authorship = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-babe = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-collective = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-democracy = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-elections-phragmen = { package = "pallet-elections-phragmen", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-frame-executive = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-grandpa = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-identity = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-im-online = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-indices = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-membership = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-multisig = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-nicks = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-offences = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-proxy = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-recovery = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-scheduler = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-session = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-society = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-staking = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-staking-reward-curve = { package = "pallet-staking-reward-curve", git = "https://github.com/paritytech/substrate", branch = "master" }
-pallet-sudo = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-frame-system = {git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-treasury = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-utility = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-vesting = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+pallet-authority-discovery = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-authorship = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-babe = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-collective = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-democracy = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-elections-phragmen = { package = "pallet-elections-phragmen", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+frame-executive = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-grandpa = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-identity = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-im-online = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-indices = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-membership = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-multisig = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-nicks = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-offences = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-proxy = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-recovery = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-scheduler = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-session = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-society = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-staking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-staking-reward-curve = { package = "pallet-staking-reward-curve", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+pallet-sudo = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+frame-system = {git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-treasury = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-utility = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+pallet-vesting = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
 
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false, optional = true }
-frame-system-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false, optional = true }
-pallet-offences-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false, optional = true }
-pallet-session-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false, optional = true }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false, optional = true }
+frame-system-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false, optional = true }
+pallet-offences-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false, optional = true }
+pallet-session-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false, optional = true }
 hex-literal = { version = "0.3.1", optional = true }
 
 runtime-common = { package = "polkadot-runtime-common", path = "../common", default-features = false }
@@ -79,8 +79,8 @@ polkadot-parachain = { path = "../../parachain", default-features = false }
 hex-literal = "0.3.1"
 libsecp256k1 = "0.3.5"
 tiny-keccak = "2.0.2"
-keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-trie = { git = "https://github.com/paritytech/substrate", branch = "master" }
+keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sp-trie = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
 serde_json = "1.0.60"
 
 [build-dependencies]

--- a/statement-table/Cargo.toml
+++ b/statement-table/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2018"
 
 [dependencies]
 parity-scale-codec = { version = "1.3.5", default-features = false, features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
 primitives = { package = "polkadot-primitives", path = "../primitives" }

--- a/validation/Cargo.toml
+++ b/validation/Cargo.toml
@@ -7,25 +7,25 @@ edition = "2018"
 [dependencies]
 polkadot-primitives = { path = "../primitives" }
 parachain = { package = "polkadot-parachain", path = "../parachain" }
-sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-timestamp = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sc-basic-authorship = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "master" }
-consensus = { package = "sp-consensus", git = "https://github.com/paritytech/substrate", branch = "master" }
-runtime_primitives = { package = "sp-runtime", git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sp-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sc-basic-authorship = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+consensus = { package = "sp-consensus", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+runtime_primitives = { package = "sp-runtime", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
 futures = "0.3.8"
 log = "0.4.11"
 parity-scale-codec = { version = "1.3.5", default-features = false, features = ["derive"] }
-grandpa = { package = "sc-finality-grandpa", git = "https://github.com/paritytech/substrate", branch = "master" }
-inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "master" }
-primitives = { package = "sp-core", git = "https://github.com/paritytech/substrate", branch = "master" }
-txpool-api = { package = "sp-transaction-pool", git = "https://github.com/paritytech/substrate", branch = "master" }
-sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "master" }
-block-builder = { package = "sc-block-builder", git = "https://github.com/paritytech/substrate", branch = "master" }
-trie = { package = "sp-trie", git = "https://github.com/paritytech/substrate", branch = "master" }
-babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/paritytech/substrate", branch = "master" }
-prometheus-endpoint = { package = "substrate-prometheus-endpoint", git = "https://github.com/paritytech/substrate", branch = "master" }
+grandpa = { package = "sc-finality-grandpa", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+primitives = { package = "sp-core", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+txpool-api = { package = "sp-transaction-pool", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+block-builder = { package = "sc-block-builder", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+trie = { package = "sp-trie", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
+prometheus-endpoint = { package = "substrate-prometheus-endpoint", git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }
 thiserror = "1.0.22"
 
 [dev-dependencies]
-sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27" }

--- a/xcm/xcm-builder/Cargo.toml
+++ b/xcm/xcm-builder/Cargo.toml
@@ -9,11 +9,11 @@ version = "0.8.22"
 parity-scale-codec = { version = "1.3.5", default-features = false, features = ["derive"] }
 xcm = { path = "..", default-features = false }
 xcm-executor = { path = "../xcm-executor", default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-arithmetic = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-arithmetic = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
 
 # Polkadot dependencies
 polkadot-parachain = { path = "../../parachain", default-features = false }

--- a/xcm/xcm-executor/Cargo.toml
+++ b/xcm/xcm-executor/Cargo.toml
@@ -9,12 +9,12 @@ version = "0.8.22"
 impl-trait-for-tuples = "0.2.0"
 parity-scale-codec = { version = "1.3.5", default-features = false, features = ["derive"] }
 xcm = { path = "..", default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-arithmetic = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-arithmetic = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-release-v0.8.27", default-features = false }
 
 [features]
 default = ["std"]


### PR DESCRIPTION
This change switches substrate crates to use the `polkadot-release-v0.8.27` branch on Substrate, [here](https://github.com/paritytech/substrate/tree/polkadot-release-v0.8.27). This branch simply has a cherry-pick of [#7733](https://github.com/paritytech/substrate/pull/7733) applied to the commit of Substrate used when this release-branch was forked, to help fix node-stalling bugs some node runners were running into.

If we don't actually need to backport substrate/#7733 to v0.8.27, we can simply close this PR.