### PR TITLE
Minor refactor + doc fixes/improvements

### DIFF
--- a/node/network/bridge/src/lib.rs
+++ b/node/network/bridge/src/lib.rs
@@ -39,7 +39,7 @@ use polkadot_subsystem::messages::{
 };
 use polkadot_primitives::v1::{AuthorityDiscoveryId, Block, Hash, BlockNumber};
 use polkadot_node_network_protocol::{
-	ObservedRole, ReputationChange, PeerId, PeerSet, View, NetworkBridgeEvent, v1 as protocol_v1
+	ObservedRole, ReputationChange, PeerId, peer_set::PeerSet, View, NetworkBridgeEvent, v1 as protocol_v1
 };
 
 use std::collections::{HashMap, hash_map};
@@ -55,10 +55,6 @@ mod validator_discovery;
 /// We use the same limit to compute the view sent to peers locally.
 const MAX_VIEW_HEADS: usize = 5;
 
-/// The protocol name for the validation peer-set.
-pub const VALIDATION_PROTOCOL_NAME: &'static str = "/polkadot/validation/1";
-/// The protocol name for the collation peer-set.
-pub const COLLATION_PROTOCOL_NAME: &'static str = "/polkadot/collation/1";
 
 const MALFORMED_MESSAGE_COST: ReputationChange
 	= ReputationChange::new(-500, "Malformed Network-bridge message");
@@ -81,30 +77,6 @@ pub enum WireMessage<M> {
 	ViewUpdate(View),
 }
 
-/// Information about the extra peers set. Should be used during network configuration
-/// to register the protocol with the network service.
-pub fn peers_sets_info() -> Vec<sc_network::config::NonDefaultSetConfig> {
-	vec![
-		sc_network::config::NonDefaultSetConfig {
-			notifications_protocol: VALIDATION_PROTOCOL_NAME.into(),
-			set_config: sc_network::config::SetConfig {
-				in_peers: 0,
-				out_peers: 0,
-				reserved_nodes: Vec::new(),
-				non_reserved_mode: sc_network::config::NonReservedPeerMode::Deny,
-			},
-		},
-		sc_network::config::NonDefaultSetConfig {
-			notifications_protocol: COLLATION_PROTOCOL_NAME.into(),
-			set_config: sc_network::config::SetConfig {
-				in_peers: 25,
-				out_peers: 0,
-				reserved_nodes: Vec::new(),
-				non_reserved_mode: sc_network::config::NonReservedPeerMode::Accept,
-			},
-		}
-	]
-}
 
 /// An action to be carried out by the network.
 #[derive(Debug, PartialEq)]
@@ -177,20 +149,8 @@ impl Network for Arc<sc_network::NetworkService<Block, Hash>> {
 							cost_benefit,
 						)
 					}
-					NetworkAction::WriteNotification(peer, peer_set, message) => {
-						match peer_set {
-							PeerSet::Validation => self.0.write_notification(
-								peer,
-								VALIDATION_PROTOCOL_NAME.into(),
-								message,
-							),
-							PeerSet::Collation => self.0.write_notification(
-								peer,
-								COLLATION_PROTOCOL_NAME.into(),
-								message,
-							),
-						}
-					}
+					NetworkAction::WriteNotification(peer, peer_set, message) =>
+						self.0.write_notification(peer, peer_set.into_protocol_name(), message)
 				}
 
 				Ok(())
@@ -327,26 +287,16 @@ fn action_from_network_message(event: Option<NetworkEvent>) -> Action {
 		Some(NetworkEvent::SyncDisconnected { .. }) => Action::Nop,
 		Some(NetworkEvent::NotificationStreamOpened { remote, protocol, role }) => {
 			let role = role.into();
-			match protocol {
-				x if x == VALIDATION_PROTOCOL_NAME
-					=> Action::PeerConnected(PeerSet::Validation, remote, role),
-				x if x == COLLATION_PROTOCOL_NAME
-					=> Action::PeerConnected(PeerSet::Collation, remote, role),
-				_ => Action::Nop,
-			}
+			PeerSet::try_from_protocol_name(&protocol)
+				.map_or(Action::Nop, |peer_set| Action::PeerConnected(peer_set, remote, role))
 		}
 		Some(NetworkEvent::NotificationStreamClosed { remote, protocol }) => {
-			match protocol {
-				x if x == VALIDATION_PROTOCOL_NAME
-					=> Action::PeerDisconnected(PeerSet::Validation, remote),
-				x if x == COLLATION_PROTOCOL_NAME
-					=> Action::PeerDisconnected(PeerSet::Collation, remote),
-				_ => Action::Nop,
-			}
+			PeerSet::try_from_protocol_name(&protocol)
+				.map_or(Action::Nop, |peer_set| Action::PeerDisconnected(peer_set, remote))
 		}
 		Some(NetworkEvent::NotificationsReceived { remote, messages }) => {
 			let v_messages: Result<Vec<_>, _> = messages.iter()
-				.filter(|(protocol, _)| protocol == &VALIDATION_PROTOCOL_NAME)
+				.filter(|(protocol, _)| protocol == &PeerSet::Validation.into_protocol_name())
 				.map(|(_, msg_bytes)| WireMessage::decode(&mut msg_bytes.as_ref()))
 				.collect();
 
@@ -356,7 +306,7 @@ fn action_from_network_message(event: Option<NetworkEvent>) -> Action {
 			};
 
 			let c_messages: Result<Vec<_>, _> = messages.iter()
-				.filter(|(protocol, _)| protocol == &COLLATION_PROTOCOL_NAME)
+				.filter(|(protocol, _)| protocol == &PeerSet::Collation.into_protocol_name())
 				.map(|(_, msg_bytes)| WireMessage::decode(&mut msg_bytes.as_ref()))
 				.collect();
 
@@ -835,13 +785,6 @@ mod tests {
 		)
 	}
 
-	fn peer_set_protocol(peer_set: PeerSet) -> std::borrow::Cow<'static, str> {
-		match peer_set {
-			PeerSet::Validation => VALIDATION_PROTOCOL_NAME.into(),
-			PeerSet::Collation => COLLATION_PROTOCOL_NAME.into(),
-		}
-	}
-
 	impl Network for TestNetwork {
 		fn event_stream(&mut self) -> BoxStream<'static, NetworkEvent> {
 			self.net_events.lock()
@@ -898,7 +841,7 @@ mod tests {
 		async fn connect_peer(&mut self, peer: PeerId, peer_set: PeerSet, role: ObservedRole) {
 			self.send_network_event(NetworkEvent::NotificationStreamOpened {
 				remote: peer,
-				protocol: peer_set_protocol(peer_set),
+				protocol: peer_set.into_protocol_name(),
 				role: role.into(),
 			}).await;
 		}
@@ -906,14 +849,14 @@ mod tests {
 		async fn disconnect_peer(&mut self, peer: PeerId, peer_set: PeerSet) {
 			self.send_network_event(NetworkEvent::NotificationStreamClosed {
 				remote: peer,
-				protocol: peer_set_protocol(peer_set),
+				protocol: peer_set.into_protocol_name(),
 			}).await;
 		}
 
 		async fn peer_message(&mut self, peer: PeerId, peer_set: PeerSet, message: Vec<u8>) {
 			self.send_network_event(NetworkEvent::NotificationsReceived {
 				remote: peer,
-				messages: vec![(peer_set_protocol(peer_set), message.into())],
+				messages: vec![(peer_set.into_protocol_name(), message.into())],
 			}).await;
 		}
 

--- a/node/network/bridge/src/lib.rs
+++ b/node/network/bridge/src/lib.rs
@@ -70,7 +70,7 @@ const MALFORMED_VIEW_COST: ReputationChange
 // network bridge log target
 const LOG_TARGET: &'static str = "network_bridge";
 
-/// Messages received on the network.
+/// Messages from and to the network.
 #[derive(Debug, Encode, Decode, Clone)]
 pub enum WireMessage<M> {
 	/// A message from a peer on a specific protocol.
@@ -259,6 +259,11 @@ struct PeerData {
 	view: View,
 }
 
+/// Internal type combining all actions a `NetworkBridge` might perform.
+///
+/// Both messages coming from the network (`NetworkEvent`) and messages coming from other
+/// subsystems (`FromOverseer`) will be converted to `Action` in `run_network` before being
+/// processed.
 #[derive(Debug)]
 enum Action {
 	SendValidationMessage(Vec<PeerId>, protocol_v1::ValidationProtocol),
@@ -589,6 +594,7 @@ async fn dispatch_collation_events_to_all<I>(
 	ctx.send_messages(events.into_iter().flat_map(messages_for)).await
 }
 
+/// Main driver, processing network events and messages from other subsystems.
 #[tracing::instrument(skip(network_service, authority_discovery_service, ctx), fields(subsystem = LOG_TARGET))]
 async fn run_network<N, AD>(
 	mut network_service: N,

--- a/node/network/bridge/src/validator_discovery.rs
+++ b/node/network/bridge/src/validator_discovery.rs
@@ -28,6 +28,7 @@ use sc_network::multiaddr::{Multiaddr, Protocol};
 use sc_authority_discovery::Service as AuthorityDiscoveryService;
 use polkadot_node_network_protocol::PeerId;
 use polkadot_primitives::v1::{AuthorityDiscoveryId, Block, Hash};
+use polkadot_node_network_protocol::peer_set::PeerSet;
 
 const LOG_TARGET: &str = "validator_discovery";
 
@@ -276,24 +277,24 @@ impl<N: Network, AD: AuthorityDiscovery> Service<N, AD> {
 		// ask the network to connect to these nodes and not disconnect
 		// from them until removed from the set
 		if let Err(e) = network_service.add_peers_set_reserved(
-			super::COLLATION_PROTOCOL_NAME.into(),
+			PeerSet::Collation.into_protocol_name(),
 			multiaddr_to_add.clone(),
 		).await {
 			tracing::warn!(target: LOG_TARGET, err = ?e, "AuthorityDiscoveryService returned an invalid multiaddress");
 		}
 		if let Err(e) = network_service.add_peers_set_reserved(
-			super::VALIDATION_PROTOCOL_NAME.into(),
+			PeerSet::Validation.into_protocol_name(),
 			multiaddr_to_add,
 		).await {
 			tracing::warn!(target: LOG_TARGET, err = ?e, "AuthorityDiscoveryService returned an invalid multiaddress");
 		}
 		// the addresses are known to be valid
 		let _ = network_service.remove_peers_set_reserved(
-			super::COLLATION_PROTOCOL_NAME.into(),
+			PeerSet::Collation.into_protocol_name(),
 			multiaddr_to_remove.clone()
 		).await;
 		let _ = network_service.remove_peers_set_reserved(
-			super::VALIDATION_PROTOCOL_NAME.into(),
+			PeerSet::Validation.into_protocol_name(),
 			multiaddr_to_remove
 		).await;
 

--- a/node/network/protocol/src/lib.rs
+++ b/node/network/protocol/src/lib.rs
@@ -26,6 +26,10 @@ use std::fmt;
 
 pub use sc_network::{ReputationChange, PeerId};
 
+
+/// Peer-sets and protocols used for parachains.
+pub mod peer_set;
+
 /// A unique identifier of a request.
 pub type RequestId = u64;
 
@@ -45,14 +49,6 @@ impl fmt::Display for WrongVariant {
 impl std::error::Error for WrongVariant {}
 
 
-/// The peer-sets that the network manages. Different subsystems will use different peer-sets.
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub enum PeerSet {
-	/// The validation peer-set is responsible for all messages related to candidate validation and communication among validators.
-	Validation,
-	/// The collation peer-set is used for validator<>collator communication.
-	Collation,
-}
 
 /// The advertised role of a node.
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/node/network/protocol/src/peer_set.rs
+++ b/node/network/protocol/src/peer_set.rs
@@ -1,0 +1,91 @@
+// Copyright 2021 Parity Technologies (UK) Ltd.
+// This file is part of Polkadot.
+
+// Polkadot is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Polkadot is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
+
+//! All peersets and protocols used for parachains.
+
+use sc_network::config::{NonDefaultSetConfig, SetConfig};
+use std::borrow::Cow;
+
+/// The peer-sets and thus the protocols which are used for the network.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum PeerSet {
+	/// The validation peer-set is responsible for all messages related to candidate validation and communication among validators.
+	Validation,
+	/// The collation peer-set is used for validator<>collator communication.
+	Collation,
+}
+
+/// Protocol name as understood in substrate.
+///
+/// Ideally this would be defined in substrate as a newtype.
+type ProtocolName = Cow<'static, str>;
+
+impl PeerSet {
+	/// Get `sc_network` peer set configurations for each peerset.
+	///
+	/// Those should be used in the network configuration to register the protocols with the
+	/// network service.
+	pub fn get_info(self) -> NonDefaultSetConfig {
+		let protocol = self.into_protocol_name();
+		match self {
+			PeerSet::Validation => NonDefaultSetConfig {
+				notifications_protocol: protocol,
+				set_config: sc_network::config::SetConfig {
+					in_peers: 0,
+					out_peers: 0,
+					reserved_nodes: Vec::new(),
+					non_reserved_mode: sc_network::config::NonReservedPeerMode::Deny,
+				},
+			},
+			PeerSet::Collation => NonDefaultSetConfig {
+				notifications_protocol: protocol,
+				set_config: SetConfig {
+					in_peers: 25,
+					out_peers: 0,
+					reserved_nodes: Vec::new(),
+					non_reserved_mode: sc_network::config::NonReservedPeerMode::Accept,
+				},
+			},
+		}
+	}
+
+	/// Get the protocol name associated with each peer set as static str.
+	pub const fn get_protocol_name_static(self) -> &'static str {
+		match self {
+			PeerSet::Validation => "/polkadot/validation/1",
+			PeerSet::Collation => "/polkadot/collation/1",
+		}
+	}
+
+	/// Convert a peer set into a protocol name as understood by Substrate.
+	///
+	/// With `ProtocolName` being a proper newtype we could use the `Into` trait here.
+	pub fn into_protocol_name(self) -> ProtocolName {
+		self.get_protocol_name_static().into()
+	}
+
+	/// Try parsing a protocol name into a peer set.
+	///
+	/// If ProtocolName was a newtype, this would actually be nice to implement in terms of the
+	/// standard `TryFrom` trait.
+	pub fn try_from_protocol_name(name: &ProtocolName) -> Option<PeerSet> {
+		match name {
+			n if n == &PeerSet::Validation.into_protocol_name() => Some(PeerSet::Validation),
+			n if n == &PeerSet::Collation.into_protocol_name() => Some(PeerSet::Collation),
+			_ => None,
+		}
+	}
+}

--- a/roadmap/implementers-guide/src/node/utility/network-bridge.md
+++ b/roadmap/implementers-guide/src/node/utility/network-bridge.md
@@ -32,7 +32,7 @@ Output:
 This network bridge sends messages of these types over the network.
 
 ```rust
-enum ProtocolMessage<M> {
+enum WireMessage<M> {
 	ProtocolMessage(M),
 	ViewUpdate(View),
 }
@@ -41,8 +41,8 @@ enum ProtocolMessage<M> {
 and instantiates this type twice, once using the [`ValidationProtocolV1`][VP1] message type, and once with the [`CollationProtocolV1`][CP1] message type.
 
 ```rust
-type ValidationV1Message = ProtocolMessage<ValidationProtocolV1>;
-type CollationV1Message = ProtocolMessage<CollationProtocolV1>;
+type ValidationV1Message = WireMessage<ValidationProtocolV1>;
+type CollationV1Message = WireMessage<CollationProtocolV1>;
 ```
 
 ### Startup


### PR DESCRIPTION
By having everything peer set related depend directly on the enum the
code becomes more clear and it is also straight forward to add more
peersets/protocols as the compiler will complain if you forget to
implement parts of it.