### PR TITLE
CI: remove squash and fix buildah push

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -244,19 +244,16 @@ publish-docker:
       ( echo "no docker credentials provided"; exit 1 )
     - cd ./artifacts
     - buildah bud
-      --squash
-      --format=docker
-      --build-arg VCS_REF="${CI_COMMIT_SHA}"
-      --build-arg BUILD_DATE="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
-      --tag "$IMAGE_NAME:$VERSION"
-      --tag "$IMAGE_NAME:$EXTRATAG" .
+        --format=docker
+        --build-arg VCS_REF="${CI_COMMIT_SHA}"
+        --build-arg BUILD_DATE="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+        --tag "$IMAGE_NAME:$VERSION"
+        --tag "$IMAGE_NAME:$EXTRATAG" .
     - echo "$Docker_Hub_Pass_Parity" |
       buildah login --username "$Docker_Hub_User_Parity" --password-stdin docker.io
     - buildah info
-    - buildah push
-      --format=v2s2
-      "$IMAGE_NAME:$VERSION"
-      "$IMAGE_NAME:$EXTRATAG"
+    - buildah push --format=v2s2 "$IMAGE_NAME:$VERSION"
+    - buildah push --format=v2s2 "$IMAGE_NAME:$EXTRATAG"
   after_script:
     - buildah logout "$IMAGE_NAME"
     # only VERSION information is needed for the deployment


### PR DESCRIPTION
- fixes buildah bush, apparently it couldn't push several tags within one command
- removes --squash, is wins in the final image size, but makes it one layer, hence unable to reuse the base image, looses in download time.

Substrate companion: https://github.com/paritytech/substrate/pull/7841