### PR TITLE
CI: add rococo build and conteinerization

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -215,6 +215,7 @@ build-linux-rococo:
     # build job so that publish-docker-rococo would "needs" this job. This leads either to blocked
     # or to forever running pipeline. It was decided to run these jobs from UI and on schedule.
     - if: $IMAGE_NAME == "rococo"
+  needs:                           []
   script:
     - mkdir -p ./artifacts
     - VERSION="${CI_COMMIT_REF_NAME}" # will be tag or branch name

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -243,65 +243,65 @@ generate-impl-guide:
 
 #### stage:                        publish
 
-.build-push-docker-image:          &build-push-docker-image
-  <<:                              *kubernetes-env
-  <<:                              *collect-artifacts
-  image:                           quay.io/buildah/stable
-  before_script:                   &unpack-artifacts
-    - test -s ./artifacts/VERSION || exit 1
-    - test -s ./artifacts/EXTRATAG || exit 1
-    - VERSION="$(cat ./artifacts/VERSION)"
-    - EXTRATAG="$(cat ./artifacts/EXTRATAG)"
-    - echo "Polkadot version = ${VERSION} (EXTRATAG ${EXTRATAG})"
-  script:
-    - test "$Docker_Hub_User_Parity" -a "$Docker_Hub_Pass_Parity" ||
-        ( echo "no docker credentials provided"; exit 1 )
-    - cd ./artifacts
-    - buildah bud
-        --format=docker
-        --build-arg VCS_REF="${CI_COMMIT_SHA}"
-        --build-arg BUILD_DATE="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
-        --tag "$IMAGE_NAME:$VERSION"
-        --tag "$IMAGE_NAME:$EXTRATAG" .
-    - echo "$Docker_Hub_Pass_Parity" |
-      buildah login --username "$Docker_Hub_User_Parity" --password-stdin docker.io
-    - buildah info
-    - buildah push --format=v2s2 "$IMAGE_NAME:$VERSION"
-    - buildah push --format=v2s2 "$IMAGE_NAME:$EXTRATAG"
-  after_script:
-    - buildah logout "$IMAGE_NAME"
-    # only VERSION information is needed for the deployment
-    - find ./artifacts/ -depth -not -name VERSION -not -name artifacts -delete
+# .build-push-docker-image:          &build-push-docker-image
+#   <<:                              *kubernetes-env
+#   <<:                              *collect-artifacts
+#   image:                           quay.io/buildah/stable
+#   before_script:                   &unpack-artifacts
+#     - test -s ./artifacts/VERSION || exit 1
+#     - test -s ./artifacts/EXTRATAG || exit 1
+#     - VERSION="$(cat ./artifacts/VERSION)"
+#     - EXTRATAG="$(cat ./artifacts/EXTRATAG)"
+#     - echo "Polkadot version = ${VERSION} (EXTRATAG ${EXTRATAG})"
+#   script:
+#     - test "$Docker_Hub_User_Parity" -a "$Docker_Hub_Pass_Parity" ||
+#         ( echo "no docker credentials provided"; exit 1 )
+#     - cd ./artifacts
+#     - buildah bud
+#         --format=docker
+#         --build-arg VCS_REF="${CI_COMMIT_SHA}"
+#         --build-arg BUILD_DATE="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+#         --tag "$IMAGE_NAME:$VERSION"
+#         --tag "$IMAGE_NAME:$EXTRATAG" .
+#     - echo "$Docker_Hub_Pass_Parity" |
+#       buildah login --username "$Docker_Hub_User_Parity" --password-stdin docker.io
+#     - buildah info
+#     - buildah push --format=v2s2 "$IMAGE_NAME:$VERSION"
+#     - buildah push --format=v2s2 "$IMAGE_NAME:$EXTRATAG"
+#   after_script:
+#     - buildah logout "$IMAGE_NAME"
+#     # only VERSION information is needed for the deployment
+#     - find ./artifacts/ -depth -not -name VERSION -not -name artifacts -delete
 
-publish-docker-polkadot:
-  stage:                           publish
-  <<:                              *build-push-docker-image
-  # Don't run on releases - this is handled by the Github Action here:
-  # .github/workflows/publish-docker-release.yml
-  rules:
-    - if: $CI_PIPELINE_SOURCE == "web"
-    - if: $CI_PIPELINE_SOURCE == "schedule"
-    - if: $CI_COMMIT_REF_NAME == "master"
-  needs:
-    - job:                         build-linux-release
-      artifacts:                   true
-  variables:
-    GIT_STRATEGY:                  none
-    # DOCKERFILE:                  scripts/docker/Dockerfile
-    IMAGE_NAME:                    docker.io/parity/polkadot
+# publish-docker-polkadot:
+#   stage:                           publish
+#   <<:                              *build-push-docker-image
+#   # Don't run on releases - this is handled by the Github Action here:
+#   # .github/workflows/publish-docker-release.yml
+#   rules:
+#     - if: $CI_PIPELINE_SOURCE == "web"
+#     - if: $CI_PIPELINE_SOURCE == "schedule"
+#     - if: $CI_COMMIT_REF_NAME == "master"
+#   needs:
+#     - job:                         build-linux-release
+#       artifacts:                   true
+#   variables:
+#     GIT_STRATEGY:                  none
+#     # DOCKERFILE:                  scripts/docker/Dockerfile
+#     IMAGE_NAME:                    docker.io/parity/polkadot
 
-publish-docker-rococo:
-  stage:                           build
-  <<:                              *build-push-docker-image
-  rules:
-    - if: $PIPELIN3 == "rococo"
-  # needs:
-  #   - job:                         build-linux-rococo
-  #     artifacts:                   true
-  variables:
-    GIT_STRATEGY:                  none
-    # DOCKERFILE:                  scripts/docker/Dockerfile
-    IMAGE_NAME:                    docker.io/parity/rococo
+# publish-docker-rococo:
+#   stage:                           build
+#   <<:                              *build-push-docker-image
+#   rules:
+#     - if: $PIPELIN3 == "rococo"
+#   # needs:
+#   #   - job:                         build-linux-rococo
+#   #     artifacts:                   true
+#   variables:
+#     GIT_STRATEGY:                  none
+#     # DOCKERFILE:                  scripts/docker/Dockerfile
+#     IMAGE_NAME:                    docker.io/parity/rococo
 
 publish-s3-release:
   stage:                           publish

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -123,84 +123,84 @@ build-linux-rococo:
     - time cargo build --release --verbose --features=real-overseer
     - sccache -s
 
-# check-runtime:
+check-runtime:
+  stage:                           test
+  image:                           paritytech/tools:latest
+  <<:                              *kubernetes-env
+  <<:                              *rules-pr-only
+  variables:
+    GITLAB_API:                    "https://gitlab.parity.io/api/v4"
+    GITHUB_API_PROJECT:            "parity%2Finfrastructure%2Fgithub-api"
+  script:
+    - ./scripts/gitlab/check_runtime.sh
+  allow_failure:                   true
+
+check-line-width:
+  stage:                           test
+  image:                           paritytech/tools:latest
+  <<:                              *kubernetes-env
+  <<:                              *rules-pr-only
+  script:
+    - ./scripts/gitlab/check_line_width.sh
+  allow_failure:                   true
+
+# test-deterministic-wasm:
 #   stage:                           test
-#   image:                           paritytech/tools:latest
-#   <<:                              *kubernetes-env
-#   <<:                              *rules-pr-only
+#   <<:                              *docker-env
+#   script:
+#     - ./scripts/gitlab/test_deterministic_wasm.sh
+
+# test-linux-stable:
+#   stage:                           test
+#   <<:                              *rules-test
+#   <<:                              *docker-env
+#   <<:                              *compiler-info
 #   variables:
-#     GITLAB_API:                    "https://gitlab.parity.io/api/v4"
-#     GITHUB_API_PROJECT:            "parity%2Finfrastructure%2Fgithub-api"
+#     RUST_TOOLCHAIN: stable
+#     # Enable debug assertions since we are running optimized builds for testing
+#     # but still want to have debug assertions.
+#     RUSTFLAGS: "-Cdebug-assertions=y -Dwarnings"
+#     TARGET: native
+#   artifacts:
+#     paths:
+#       - ./target/release/polkadot
 #   script:
-#     - ./scripts/gitlab/check_runtime.sh
-#   allow_failure:                   true
+#     - ./scripts/gitlab/test_linux_stable.sh
+#     - sccache -s
 
-# check-line-width:
+# check-web-wasm:
 #   stage:                           test
-#   image:                           paritytech/tools:latest
-#   <<:                              *kubernetes-env
-#   <<:                              *rules-pr-only
+#   <<:                              *rules-test
+#   <<:                              *docker-env
+#   <<:                              *compiler-info
 #   script:
-#     - ./scripts/gitlab/check_line_width.sh
-#   allow_failure:                   true
+#     # WASM support is in progress. As more and more crates support WASM, we
+#     # should add entries here. See https://github.com/paritytech/polkadot/issues/625
+#     - ./scripts/gitlab/check_web_wasm.sh
+#     - sccache -s
 
-# # test-deterministic-wasm:
-# #   stage:                           test
-# #   <<:                              *docker-env
-# #   script:
-# #     - ./scripts/gitlab/test_deterministic_wasm.sh
+# check-runtime-benchmarks:
+#   stage:                           test
+#   <<:                              *rules-test
+#   <<:                              *docker-env
+#   <<:                              *compiler-info
+#   script:
+#     # Check that the node will compile with `runtime-benchmarks` feature flag.
+#     - ./scripts/gitlab/check_runtime_benchmarks.sh
+#     - sccache -s
 
-# # test-linux-stable:
-# #   stage:                           test
-# #   <<:                              *rules-test
-# #   <<:                              *docker-env
-# #   <<:                              *compiler-info
-# #   variables:
-# #     RUST_TOOLCHAIN: stable
-# #     # Enable debug assertions since we are running optimized builds for testing
-# #     # but still want to have debug assertions.
-# #     RUSTFLAGS: "-Cdebug-assertions=y -Dwarnings"
-# #     TARGET: native
-# #   artifacts:
-# #     paths:
-# #       - ./target/release/polkadot
-# #   script:
-# #     - ./scripts/gitlab/test_linux_stable.sh
-# #     - sccache -s
+#### stage:                        build
 
-# # check-web-wasm:
-# #   stage:                           test
-# #   <<:                              *rules-test
-# #   <<:                              *docker-env
-# #   <<:                              *compiler-info
-# #   script:
-# #     # WASM support is in progress. As more and more crates support WASM, we
-# #     # should add entries here. See https://github.com/paritytech/polkadot/issues/625
-# #     - ./scripts/gitlab/check_web_wasm.sh
-# #     - sccache -s
-
-# # check-runtime-benchmarks:
-# #   stage:                           test
-# #   <<:                              *rules-test
-# #   <<:                              *docker-env
-# #   <<:                              *compiler-info
-# #   script:
-# #     # Check that the node will compile with `runtime-benchmarks` feature flag.
-# #     - ./scripts/gitlab/check_runtime_benchmarks.sh
-# #     - sccache -s
-
-# #### stage:                        build
-
-# # check-transaction-versions:
-# #   image:                           node:15
-# #   stage:                           build
-# #   needs:
-# #     - job:                         test-linux-stable
-# #       artifacts:                   false
-# #   before_script:
-# #     - npm install -g @polkadot/metadata-cmp
-# #     - git fetch origin release
-# #   script: "scripts/gitlab/check_extrinsics_ordering.sh"
+# check-transaction-versions:
+#   image:                           node:15
+#   stage:                           build
+#   needs:
+#     - job:                         test-linux-stable
+#       artifacts:                   false
+#   before_script:
+#     - npm install -g @polkadot/metadata-cmp
+#     - git fetch origin release
+#   script: "scripts/gitlab/check_extrinsics_ordering.sh"
 
 # build-wasm-release:
 #   stage:                           build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -114,9 +114,8 @@ default:
 build-linux-rococo:
   stage:                           test
   <<:                              *build-linux
-  only:
-    variables:
-      - $PIPELIN3 == "rococo"
+  rules:
+    - if: $PIPELIN3 == "rococo"
   script:
     - mkdir -p ./artifacts
     - VERSION="${CI_COMMIT_REF_NAME}" # will be tag or branch name

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -299,6 +299,7 @@ publish-docker-rococo:
       when: manual
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
       when: manual
+      allow_failure: true
   needs:
     - job:                         build-linux-rococo
       artifacts:                   true
@@ -306,7 +307,6 @@ publish-docker-rococo:
     GIT_STRATEGY:                  none
     # DOCKERFILE:                  scripts/docker/Dockerfile
     IMAGE_NAME:                    docker.io/parity/rococo
-  allow_failure:                   true
 
 publish-s3-release:
   <<:                              *publish-build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,12 +13,12 @@ stages:
 
 image:                             paritytech/ci-linux:production
 
-workflow:
-  rules:
-    - if: $CI_COMMIT_TAG
-    - if: $CI_COMMIT_BRANCH
-    - if: $CI_PIPELINE_SOURCE == "web"
-    - if: $CI_PIPELINE_SOURCE == "schedule"
+# workflow:
+#   rules:
+#     - if: $CI_COMMIT_TAG
+#     - if: $CI_COMMIT_BRANCH
+#     - if: $CI_PIPELINE_SOURCE == "web"
+#     - if: $CI_PIPELINE_SOURCE == "schedule"
 
 variables:
   GIT_STRATEGY:                    fetch

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -61,14 +61,14 @@ default:
 .build-refs:                       &build-refs
   rules:
     - if: $CI_PIPELINE_SOURCE == "web"
-    - if: $CI_PIPELINE_SOURCE == "schedule"
+    - if: $PIPELINE == "nightly" && $CI_PIPELINE_SOURCE == "schedule"
     - if: $CI_COMMIT_REF_NAME == "master"
     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
 
 .test-refs:                        &test-refs
   rules:
     - if: $CI_PIPELINE_SOURCE == "web"
-    - if: $CI_PIPELINE_SOURCE == "schedule"
+    - if: $PIPELINE == "nightly" && $CI_PIPELINE_SOURCE == "schedule"
     - if: $CI_COMMIT_REF_NAME == "master"
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
@@ -177,7 +177,7 @@ build-linux-release:               &build
   rules:
     # .test-refs with manual on PRs
     - if: $CI_PIPELINE_SOURCE == "web"
-    - if: $CI_PIPELINE_SOURCE == "schedule"
+    - if: $PIPELINE == "nightly" && $CI_PIPELINE_SOURCE == "schedule"
     - if: $CI_COMMIT_REF_NAME == "master"
     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
@@ -205,12 +205,12 @@ build-linux-release:               &build
 
 build-linux-rococo:
   <<:                              *build
-  stage:                           test
+  stage:                           build
   rules:
     # Due to https://gitlab.com/gitlab-org/gitlab/-/issues/31264 there's no way to setup a manual
     # build job so that publish-docker-rococo would "needs" this job. This leads either to blocked
     # or to forever running pipeline. It was decided to run these jobs from UI and on schedule.
-    - if: $IMAGE == "rococo"
+    - if: $PIPELINE == "rococo"
   script:
     - mkdir -p ./artifacts
     - VERSION="${CI_COMMIT_REF_NAME}" # will be tag or branch name
@@ -250,7 +250,7 @@ publish-docker-polkadot:           &build-push-docker-image
   # .github/workflows/publish-docker-release.yml
   rules:
     - if: $CI_PIPELINE_SOURCE == "web"
-    - if: $CI_PIPELINE_SOURCE == "schedule"
+    - if: $PIPELINE == "nightly" && $CI_PIPELINE_SOURCE == "schedule"
     - if: $CI_COMMIT_REF_NAME == "master"
   variables:
     GIT_STRATEGY:                  none
@@ -278,9 +278,9 @@ publish-docker-polkadot:           &build-push-docker-image
 
 publish-docker-rococo:
   <<:                              *build-push-docker-image
-  stage:                           build
-  # rules:
-  #   - if: $IMAGE == "rococo"
+  stage:                           publish
+  rules:
+    - if: $PIPELINE == "rococo"
   needs:
     - job:                         build-linux-rococo
       artifacts:                   true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -224,7 +224,7 @@ build-linux-rococo:
   stage:                           test
   <<:                              *build-linux
   rules:
-    - if: $PIPELINE =~ "rococo"
+    - if: '$PIPELINE =~ "rococo"'
   script:
     - mkdir -p ./artifacts
     - VERSION="${CI_COMMIT_REF_NAME}" # will be tag or branch name

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -90,37 +90,7 @@ default:
       when: never
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
 
-.build-linux:                      &build-linux
-  # <<:                              *collect-artifacts
-  <<:                              *docker-env
-  # <<:                              *compiler-info
-  after_script:
-    - mv ./target/release/polkadot ./artifacts/.
-    - sha256sum ./artifacts/polkadot | tee ./artifacts/polkadot.sha256
-    - if [ "${CI_COMMIT_TAG}" ]; then
-        EXTRATAG="latest";
-      else
-        EXTRATAG="$(./artifacts/polkadot --version |
-          sed -n -r 's/^polkadot ([0-9.]+.*-[0-9a-f]{7,13})-.*$/\1/p')";
-        EXTRATAG="${CI_COMMIT_REF_NAME}-${EXTRATAG}-$(cut -c 1-8 ./artifacts/polkadot.sha256)";
-      fi
-    - echo "Polkadot version = ${VERSION} (EXTRATAG ${EXTRATAG})"
-    - echo -n ${VERSION} > ./artifacts/VERSION
-    - echo -n ${EXTRATAG} > ./artifacts/EXTRATAG
-    - cp -r scripts/docker/* ./artifacts
-
 #### stage:                        test
-
-build-linux-rococo:
-  stage:                           test
-  <<:                              *build-linux
-  rules:
-    - if: $PIPELIN3 == "rococo"
-  script:
-    - mkdir -p ./artifacts
-    - VERSION="${CI_COMMIT_REF_NAME}" # will be tag or branch name
-    - time cargo build --release --verbose --features=real-overseer
-    - sccache -s
 
 check-runtime:
   stage:                           test
@@ -214,6 +184,25 @@ build-wasm-release:
     - for f in polkadot_cli*; do sha256sum "${f}" > "${f}.sha256"; done
     - mv ./polkadot_cli* ../../artifacts/wasm/.
 
+.build-linux:                      &build-linux
+  <<:                              *collect-artifacts
+  <<:                              *docker-env
+  <<:                              *compiler-info
+  after_script:
+    - mv ./target/release/polkadot ./artifacts/.
+    - sha256sum ./artifacts/polkadot | tee ./artifacts/polkadot.sha256
+    - if [ "${CI_COMMIT_TAG}" ]; then
+        EXTRATAG="latest";
+      else
+        EXTRATAG="$(./artifacts/polkadot --version |
+          sed -n -r 's/^polkadot ([0-9.]+.*-[0-9a-f]{7,13})-.*$/\1/p')";
+        EXTRATAG="${CI_COMMIT_REF_NAME}-${EXTRATAG}-$(cut -c 1-8 ./artifacts/polkadot.sha256)";
+      fi
+    - echo "Polkadot version = ${VERSION} (EXTRATAG ${EXTRATAG})"
+    - echo -n ${VERSION} > ./artifacts/VERSION
+    - echo -n ${EXTRATAG} > ./artifacts/EXTRATAG
+    - cp -r scripts/docker/* ./artifacts
+
 build-linux-release:
   stage:                           build
   <<:                              *build-linux
@@ -229,6 +218,17 @@ build-linux-release:
     - mkdir -p ./artifacts
     - VERSION="${CI_COMMIT_REF_NAME}" # will be tag or branch name
     - time cargo build --release --verbose
+    - sccache -s
+
+build-linux-rococo:
+  stage:                           build
+  <<:                              *build-linux
+  rules:
+    - if: $PIPELIN3 == "rococo"
+  script:
+    - mkdir -p ./artifacts
+    - VERSION="${CI_COMMIT_REF_NAME}" # will be tag or branch name
+    - time cargo build --release --verbose --features=real-overseer
     - sccache -s
 
 generate-impl-guide:
@@ -291,7 +291,7 @@ generate-impl-guide:
 #     IMAGE_NAME:                    docker.io/parity/polkadot
 
 publish-docker-rococo:
-  stage:                           build
+  stage:                           publish
   <<:                              *build-push-docker-image
   rules:
     - if: $PIPELIN3 == "rococo"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -214,7 +214,6 @@ build-linux-rococo:
     # build job so that publish-docker-rococo would "needs" this job. This leads either to blocked
     # or to forever running pipeline. It was decided to run these jobs from UI and on schedule.
     - if: $IMAGE == "rococo"
-  needs:                           []
   script:
     - mkdir -p ./artifacts
     - VERSION="${CI_COMMIT_REF_NAME}" # will be tag or branch name

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -65,9 +65,9 @@ default:
     # either to blocked or to forever running pipeline. It was decided to run these jobs from UI
     # and on schedule.
     #
-    # $PIPELINE should be passed in https://gitlab.parity.io/parity/polkadot/-/pipeline_schedules
+    # $PIPELIN3 should be passed in https://gitlab.parity.io/parity/polkadot/-/pipeline_schedules
     # or other trigger to avoid running these jobs.
-    - if: $PIPELINE == "rococo"
+    - if: $PIPELIN3 == "rococo"
       when: never
     - if: $CI_PIPELINE_SOURCE == "web"
     - if: $CI_PIPELINE_SOURCE == "schedule"
@@ -77,20 +77,51 @@ default:
 .rules-test:                       &rules-test
   # these jobs run always*
   rules:
-    - if: $PIPELINE == "rococo"
+    - if: $PIPELIN3 == "rococo"
       when: never
     - when: always
 
 .pr-only:                          &rules-pr-only
   # these jobs run only on PRs
   rules:
-    - if: $PIPELINE == "rococo"
+    - if: $PIPELIN3 == "rococo"
       when: never
     - if: $CI_PIPELINE_SOURCE == "schedule"
       when: never
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
 
+.build-linux:                      &build-linux
+  <<:                              *collect-artifacts
+  <<:                              *docker-env
+  <<:                              *compiler-info
+  after_script:
+    - mv ./target/release/polkadot ./artifacts/.
+    - sha256sum ./artifacts/polkadot | tee ./artifacts/polkadot.sha256
+    - if [ "${CI_COMMIT_TAG}" ]; then
+        EXTRATAG="latest";
+      else
+        EXTRATAG="$(./artifacts/polkadot --version |
+          sed -n -r 's/^polkadot ([0-9.]+.*-[0-9a-f]{7,13})-.*$/\1/p')";
+        EXTRATAG="${CI_COMMIT_REF_NAME}-${EXTRATAG}-$(cut -c 1-8 ./artifacts/polkadot.sha256)";
+      fi
+    - echo "Polkadot version = ${VERSION} (EXTRATAG ${EXTRATAG})"
+    - echo -n ${VERSION} > ./artifacts/VERSION
+    - echo -n ${EXTRATAG} > ./artifacts/EXTRATAG
+    - cp -r scripts/docker/* ./artifacts
+
 #### stage:                        test
+
+build-linux-rococo:
+  stage:                           test
+  <<:                              *build-linux
+  only:
+    variables:
+      - $PIPELIN3 == "rococo"
+  script:
+    - mkdir -p ./artifacts
+    - VERSION="${CI_COMMIT_REF_NAME}" # will be tag or branch name
+    - time cargo build --release --verbose --features=real-overseer
+    - sccache -s
 
 check-runtime:
   stage:                           test
@@ -184,31 +215,12 @@ build-wasm-release:
     - for f in polkadot_cli*; do sha256sum "${f}" > "${f}.sha256"; done
     - mv ./polkadot_cli* ../../artifacts/wasm/.
 
-.build-linux:                      &build-linux
-  <<:                              *collect-artifacts
-  <<:                              *docker-env
-  <<:                              *compiler-info
-  after_script:
-    - mv ./target/release/polkadot ./artifacts/.
-    - sha256sum ./artifacts/polkadot | tee ./artifacts/polkadot.sha256
-    - if [ "${CI_COMMIT_TAG}" ]; then
-        EXTRATAG="latest";
-      else
-        EXTRATAG="$(./artifacts/polkadot --version |
-          sed -n -r 's/^polkadot ([0-9.]+.*-[0-9a-f]{7,13})-.*$/\1/p')";
-        EXTRATAG="${CI_COMMIT_REF_NAME}-${EXTRATAG}-$(cut -c 1-8 ./artifacts/polkadot.sha256)";
-      fi
-    - echo "Polkadot version = ${VERSION} (EXTRATAG ${EXTRATAG})"
-    - echo -n ${VERSION} > ./artifacts/VERSION
-    - echo -n ${EXTRATAG} > ./artifacts/EXTRATAG
-    - cp -r scripts/docker/* ./artifacts
-
 build-linux-release:
   stage:                           build
   <<:                              *build-linux
   rules:
     # .rules-test with manual on PRs
-    - if: $PIPELINE == "rococo"
+    - if: $PIPELIN3 == "rococo"
       when: never
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
       when: manual
@@ -218,18 +230,6 @@ build-linux-release:
     - mkdir -p ./artifacts
     - VERSION="${CI_COMMIT_REF_NAME}" # will be tag or branch name
     - time cargo build --release --verbose
-    - sccache -s
-
-build-linux-rococo:
-  stage:                           test
-  <<:                              *build-linux
-  only:
-    variables:
-      - $PIPELINE == "rococo"
-  script:
-    - mkdir -p ./artifacts
-    - VERSION="${CI_COMMIT_REF_NAME}" # will be tag or branch name
-    - time cargo build --release --verbose --features=real-overseer
     - sccache -s
 
 generate-impl-guide:
@@ -298,7 +298,7 @@ publish-docker-polkadot:
 #   stage:                           build
 #   <<:                              *build-push-docker-image
 #   rules:
-#     - if: $PIPELINE == "rococo"
+#     - if: $PIPELIN3 == "rococo"
 #   # needs:
 #   #   - job:                         build-linux-rococo
 #   #     artifacts:                   true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -224,7 +224,7 @@ build-linux-rococo:
   stage:                           test
   <<:                              *build-linux
   rules:
-    - if: $PIPELINE == "rococo"
+    - if: $PIPELINE
   script:
     - mkdir -p ./artifacts
     - VERSION="${CI_COMMIT_REF_NAME}" # will be tag or branch name

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -86,6 +86,8 @@ default:
   rules:
     - if: $PIPELINE == "rococo"
       when: never
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+      when: never
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
 
 #### stage:                        test
@@ -228,7 +230,7 @@ build-linux-rococo:
 
 generate-impl-guide:
   stage:                           build
-  # <<:                              *rules-test
+  <<:                              *rules-test
   <<:                              *docker-env
   image:
     name: michaelfbryan/mdbook-docker-image:latest

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,7 +49,6 @@ default:
       - unknown_failure
       - api_failure
   interruptible:                   true
-  dependencies:                    []
   tags:
     - linux-docker
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -224,7 +224,7 @@ build-linux-rococo:
   stage:                           test
   <<:                              *build-linux
   rules:
-    - if: '$PIPELINE =~ "rococo"'
+    - if: $PIPELINE == rococo
   script:
     - mkdir -p ./artifacts
     - VERSION="${CI_COMMIT_REF_NAME}" # will be tag or branch name

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,7 +17,8 @@ workflow:
   rules:
     - if: $CI_COMMIT_TAG
     - if: $CI_COMMIT_BRANCH
-    - if: $IMAGE_NAME
+    - if: $CI_PIPELINE_SOURCE == "web"
+    - if: $CI_PIPELINE_SOURCE == "schedule"
 
 variables:
   GIT_STRATEGY:                    fetch

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -39,8 +39,6 @@ default:
 .kubernetes-env:                   &kubernetes-env
   tags:
     - kubernetes-parity-build
-  environment:
-    name: parity-build
   interruptible:                   true
 
 .docker-env:                       &docker-env
@@ -299,7 +297,7 @@ publish-docker-rococo:
       when: manual
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
       when: manual
-      allow_failure: true
+      allow_failure: false
   needs:
     - job:                         build-linux-rococo
       artifacts:                   true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -69,7 +69,7 @@ default:
     # and on schedule.
     #
     # $PIPELINE should be passed in https://gitlab.parity.io/parity/polkadot/-/pipeline_schedules
-    # or other trigger to avoid running these jobs and run just those allowing this variable
+    # or other trigger to avoid running these jobs and run just those allowing this variable.
     - if: $PIPELINE == "rococo"
       when: never
     - if: $CI_PIPELINE_SOURCE == "web"
@@ -148,8 +148,8 @@ check-web-wasm:
   <<:                              *docker-env
   <<:                              *compiler-info
   script:
-    # WASM support is in progress. As more and more crates support WASM, we
-    # should add entries here. See https://github.com/paritytech/polkadot/issues/625
+    # WASM support is in progress. As more and more crates support WASM, we should
+    # add entries here. See https://github.com/paritytech/polkadot/issues/625
     - ./scripts/gitlab/check_web_wasm.sh
     - sccache -s
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -99,63 +99,63 @@ check-line-width:
     - ./scripts/gitlab/check_line_width.sh
   allow_failure:                   true
 
-# test-deterministic-wasm:
-#   stage:                           test
-#   <<:                              *docker-env
-#   script:
-#     - ./scripts/gitlab/test_deterministic_wasm.sh
+test-deterministic-wasm:
+  stage:                           test
+  <<:                              *docker-env
+  script:
+    - ./scripts/gitlab/test_deterministic_wasm.sh
 
-# test-linux-stable:                 &test
-#   stage:                           test
-#   <<:                              *test-refs
-#   <<:                              *docker-env
-#   <<:                              *compiler_info
-#   variables:
-#     RUST_TOOLCHAIN: stable
-#     # Enable debug assertions since we are running optimized builds for testing
-#     # but still want to have debug assertions.
-#     RUSTFLAGS: "-Cdebug-assertions=y -Dwarnings"
-#     TARGET: native
-#   artifacts:
-#     paths:
-#       - ./target/release/polkadot
-#   script:
-#     - ./scripts/gitlab/test_linux_stable.sh
-#     - sccache -s
+test-linux-stable:                 &test
+  stage:                           test
+  <<:                              *test-refs
+  <<:                              *docker-env
+  <<:                              *compiler_info
+  variables:
+    RUST_TOOLCHAIN: stable
+    # Enable debug assertions since we are running optimized builds for testing
+    # but still want to have debug assertions.
+    RUSTFLAGS: "-Cdebug-assertions=y -Dwarnings"
+    TARGET: native
+  artifacts:
+    paths:
+      - ./target/release/polkadot
+  script:
+    - ./scripts/gitlab/test_linux_stable.sh
+    - sccache -s
 
-# check-web-wasm:                    &test
-#   stage:                           test
-#   <<:                              *test-refs
-#   <<:                              *docker-env
-#   <<:                              *compiler_info
-#   script:
-#     # WASM support is in progress. As more and more crates support WASM, we
-#     # should add entries here. See https://github.com/paritytech/polkadot/issues/625
-#     - ./scripts/gitlab/check_web_wasm.sh
-#     - sccache -s
+check-web-wasm:                    &test
+  stage:                           test
+  <<:                              *test-refs
+  <<:                              *docker-env
+  <<:                              *compiler_info
+  script:
+    # WASM support is in progress. As more and more crates support WASM, we
+    # should add entries here. See https://github.com/paritytech/polkadot/issues/625
+    - ./scripts/gitlab/check_web_wasm.sh
+    - sccache -s
 
-# check-runtime-benchmarks:          &test
-#   stage:                           test
-#   <<:                              *test-refs
-#   <<:                              *docker-env
-#   <<:                              *compiler_info
-#   script:
-#     # Check that the node will compile with `runtime-benchmarks` feature flag.
-#     - ./scripts/gitlab/check_runtime_benchmarks.sh
-#     - sccache -s
+check-runtime-benchmarks:          &test
+  stage:                           test
+  <<:                              *test-refs
+  <<:                              *docker-env
+  <<:                              *compiler_info
+  script:
+    # Check that the node will compile with `runtime-benchmarks` feature flag.
+    - ./scripts/gitlab/check_runtime_benchmarks.sh
+    - sccache -s
 
 #### stage:                        build
 
-# check-transaction-versions:
-#   image:                           node:15
-#   stage:                           build
-#   needs:
-#     - job:                         test-linux-stable
-#       artifacts:                   false
-#   before_script:
-#     - npm install -g @polkadot/metadata-cmp
-#     - git fetch origin release
-#   script: "scripts/gitlab/check_extrinsics_ordering.sh"
+check-transaction-versions:
+  image:                           node:15
+  stage:                           build
+  needs:
+    - job:                         test-linux-stable
+      artifacts:                   false
+  before_script:
+    - npm install -g @polkadot/metadata-cmp
+    - git fetch origin release
+  script: "scripts/gitlab/check_extrinsics_ordering.sh"
 
 build-wasm-release:
   stage:                           build
@@ -210,16 +210,13 @@ build-linux-release:               &build
 build-linux-rococo:
   <<:                              *build
   rules:
-    # .test-refs with manual on PRs, master and tags
+    # Due to https://gitlab.com/gitlab-org/gitlab/-/issues/31264 there's no way to setup a manual
+    # build job so that publish-docker-rococo would "needs" this job. This leads either to blocked
+    # or to forever running pipeline. It was decided to run these jobs from UI and on schedule.
     - if: $CI_PIPELINE_SOURCE == "web"
     - if: $CI_PIPELINE_SOURCE == "schedule"
-    - if: $CI_COMMIT_REF_NAME == "master"
-      when: manual
     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
-      when: manual
-    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
-      when: manual
-      allow_failure: false
+    - if: $IMAGE_NAME == "rococo"
   script:
     - time cargo build --release --verbose --features=real-overseer
     - sccache -s
@@ -287,19 +284,11 @@ publish-docker-polkadot:           &build-push-docker-image
 
 publish-docker-rococo:
   <<:                              *build-push-docker-image
-  # can't be executed on PRs since registry credentials are protected
-  # <<:                              *build-refs
   rules:
-    # .test-refs with manual on PRs, master and tags
     - if: $CI_PIPELINE_SOURCE == "web"
     - if: $CI_PIPELINE_SOURCE == "schedule"
-    - if: $CI_COMMIT_REF_NAME == "master"
-      when: manual
     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
-      when: manual
-    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
-      when: manual
-      allow_failure: false
+    - if: $IMAGE_NAME == "rococo"
   needs:
     - job:                         build-linux-rococo
       artifacts:                   true
@@ -357,12 +346,5 @@ check-labels:
   <<:                              *kubernetes-env
   rules:
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
-  # needs:
-    # due to https://gitlab.com/gitlab-org/gitlab/-/issues/31264
-    # here we should list the non-manual jobs from the previous stage
-    # - job:                         check-transaction-versions
-    #   artifacts:                   false
-    # - job:                         generate-impl-guide
-    #   artifacts:                   false
   script:
     - ./scripts/gitlab/check_labels.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -223,8 +223,9 @@ build-linux-release:
 build-linux-rococo:
   stage:                           test
   <<:                              *build-linux
-  rules:
-    - if: $CI_PIPELINE_SOURCE == "schedule" && $PIPELINE == "rococo"
+  only:
+    variables:
+      - $PIPELINE == "rococo"
   script:
     - mkdir -p ./artifacts
     - VERSION="${CI_COMMIT_REF_NAME}" # will be tag or branch name

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -82,7 +82,6 @@ check-runtime:
   <<:                              *kubernetes-env
   rules:
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
-    - if: $IMAGE == "rococo"
   variables:
     GITLAB_API:                    "https://gitlab.parity.io/api/v4"
     GITHUB_API_PROJECT:            "parity%2Finfrastructure%2Fgithub-api"
@@ -209,6 +208,7 @@ build-linux-release:               &build
 
 build-linux-rococo:
   <<:                              *build
+  stage:                           test
   rules:
     # Due to https://gitlab.com/gitlab-org/gitlab/-/issues/31264 there's no way to setup a manual
     # build job so that publish-docker-rococo would "needs" this job. This leads either to blocked
@@ -283,6 +283,7 @@ publish-docker-polkadot:           &build-push-docker-image
 
 publish-docker-rococo:
   <<:                              *build-push-docker-image
+  stage:                           build
   rules:
     - if: $IMAGE == "rococo"
   needs:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -243,13 +243,13 @@ generate-impl-guide:
 
 #### stage:                        publish
 
-# .publish-build:                    &publish-build
-#   before_script:
-#     - test -s ./artifacts/VERSION || exit 1
-#     - test -s ./artifacts/EXTRATAG || exit 1
-#     - VERSION="$(cat ./artifacts/VERSION)"
-#     - EXTRATAG="$(cat ./artifacts/EXTRATAG)"
-#     - echo "Polkadot version = ${VERSION} (EXTRATAG ${EXTRATAG})"
+.publish-build:                    &publish-build
+  before_script:
+    - test -s ./artifacts/VERSION || exit 1
+    - test -s ./artifacts/EXTRATAG || exit 1
+    - VERSION="$(cat ./artifacts/VERSION)"
+    - EXTRATAG="$(cat ./artifacts/EXTRATAG)"
+    - echo "Polkadot version = ${VERSION} (EXTRATAG ${EXTRATAG})"
 
 # .build-push-docker-image:          &build-push-docker-image
 #   <<:                              *kubernetes-env
@@ -306,43 +306,43 @@ generate-impl-guide:
 #     # DOCKERFILE:                  scripts/docker/Dockerfile
 #     IMAGE_NAME:                    docker.io/parity/rococo
 
-# publish-s3-release:
-#   stage:                           publish
-#   needs:
-#     - job:                         build-linux-release
-#       artifacts:                   true
-#     - job:                         build-wasm-release
-#       artifacts:                   true
-#   <<:                              *rules-build
-#   <<:                              *kubernetes-env
-#   <<:                              *publish-build
-#   image:                           paritytech/awscli:latest
-#   variables:
-#     GIT_STRATEGY:                  none
-#     BUCKET:                        "releases.parity.io"
-#     PREFIX:                        "polkadot/${ARCH}-${DOCKER_OS}"
-#   script:
-#     - echo "uploading objects to https://${BUCKET}/${PREFIX}/${VERSION}"
-#     - aws s3 sync ./artifacts/ s3://${BUCKET}/${PREFIX}/${VERSION}/
-#     - echo "update objects at https://${BUCKET}/${PREFIX}/${EXTRATAG}"
-#     - find ./artifacts -type f | while read file; do
-#       name="${file#./artifacts/}";
-#       aws s3api copy-object
-#         --copy-source ${BUCKET}/${PREFIX}/${VERSION}/${name}
-#         --bucket ${BUCKET} --key ${PREFIX}/${EXTRATAG}/${name};
-#       done
-#     - |
-#       cat <<-EOM
-#       |
-#       |  polkadot binary paths:
-#       |
-#       |  - https://${BUCKET}/${PREFIX}/${EXTRATAG}/polkadot
-#       |  - https://${BUCKET}/${PREFIX}/${VERSION}/polkadot
-#       |
-#       EOM
-#   after_script:
-#     - aws s3 ls s3://${BUCKET}/${PREFIX}/${EXTRATAG}/
-#         --recursive --human-readable --summarize
+publish-s3-release:
+  stage:                           publish
+  needs:
+    - job:                         build-linux-release
+      artifacts:                   true
+    - job:                         build-wasm-release
+      artifacts:                   true
+  <<:                              *rules-build
+  <<:                              *kubernetes-env
+  <<:                              *publish-build
+  image:                           paritytech/awscli:latest
+  variables:
+    GIT_STRATEGY:                  none
+    BUCKET:                        "releases.parity.io"
+    PREFIX:                        "polkadot/${ARCH}-${DOCKER_OS}"
+  script:
+    - echo "uploading objects to https://${BUCKET}/${PREFIX}/${VERSION}"
+    - aws s3 sync ./artifacts/ s3://${BUCKET}/${PREFIX}/${VERSION}/
+    - echo "update objects at https://${BUCKET}/${PREFIX}/${EXTRATAG}"
+    - find ./artifacts -type f | while read file; do
+      name="${file#./artifacts/}";
+      aws s3api copy-object
+        --copy-source ${BUCKET}/${PREFIX}/${VERSION}/${name}
+        --bucket ${BUCKET} --key ${PREFIX}/${EXTRATAG}/${name};
+      done
+    - |
+      cat <<-EOM
+      |
+      |  polkadot binary paths:
+      |
+      |  - https://${BUCKET}/${PREFIX}/${EXTRATAG}/polkadot
+      |  - https://${BUCKET}/${PREFIX}/${VERSION}/polkadot
+      |
+      EOM
+  after_script:
+    - aws s3 ls s3://${BUCKET}/${PREFIX}/${EXTRATAG}/
+        --recursive --human-readable --summarize
 
 #### stage:                        deploy
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -243,19 +243,16 @@ generate-impl-guide:
 
 #### stage:                        publish
 
-.unpack-artifacts:                 &unpack-artifacts
-  - test -s ./artifacts/VERSION || exit 1
-  - test -s ./artifacts/EXTRATAG || exit 1
-  - VERSION="$(cat ./artifacts/VERSION)"
-  - EXTRATAG="$(cat ./artifacts/EXTRATAG)"
-  - echo "Polkadot version = ${VERSION} (EXTRATAG ${EXTRATAG})"
-
 .build-push-docker-image:          &build-push-docker-image
   <<:                              *kubernetes-env
   <<:                              *collect-artifacts
   image:                           quay.io/buildah/stable
-  before_script:
-    - *unpack-artifacts
+  before_script:                   &unpack-artifacts
+    - test -s ./artifacts/VERSION || exit 1
+    - test -s ./artifacts/EXTRATAG || exit 1
+    - VERSION="$(cat ./artifacts/VERSION)"
+    - EXTRATAG="$(cat ./artifacts/EXTRATAG)"
+    - echo "Polkadot version = ${VERSION} (EXTRATAG ${EXTRATAG})"
   script:
     - test "$Docker_Hub_User_Parity" -a "$Docker_Hub_Pass_Parity" ||
         ( echo "no docker credentials provided"; exit 1 )

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,6 +17,7 @@ workflow:
   rules:
     - if: $CI_COMMIT_TAG
     - if: $CI_COMMIT_BRANCH
+    - if: $IMAGE_NAME
 
 variables:
   GIT_STRATEGY:                    fetch
@@ -53,7 +54,7 @@ default:
   tags:
     - linux-docker
 
-.compiler_info:                    &compiler_info
+.compiler-info:                    &compiler-info
   before_script:
     - rustup show
     - cargo --version
@@ -109,7 +110,7 @@ test-linux-stable:                 &test
   stage:                           test
   <<:                              *test-refs
   <<:                              *docker-env
-  <<:                              *compiler_info
+  <<:                              *compiler-info
   variables:
     RUST_TOOLCHAIN: stable
     # Enable debug assertions since we are running optimized builds for testing
@@ -127,7 +128,7 @@ check-web-wasm:                    &test
   stage:                           test
   <<:                              *test-refs
   <<:                              *docker-env
-  <<:                              *compiler_info
+  <<:                              *compiler-info
   script:
     # WASM support is in progress. As more and more crates support WASM, we
     # should add entries here. See https://github.com/paritytech/polkadot/issues/625
@@ -138,7 +139,7 @@ check-runtime-benchmarks:          &test
   stage:                           test
   <<:                              *test-refs
   <<:                              *docker-env
-  <<:                              *compiler_info
+  <<:                              *compiler-info
   script:
     # Check that the node will compile with `runtime-benchmarks` feature flag.
     - ./scripts/gitlab/check_runtime_benchmarks.sh
@@ -161,7 +162,7 @@ build-wasm-release:
   stage:                           build
   <<:                              *collect-artifacts
   <<:                              *docker-env
-  <<:                              *compiler_info
+  <<:                              *compiler-info
   # Note: We likely only want to do this for tagged releases, hence the 'rules:'
   rules:
     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
@@ -176,7 +177,7 @@ build-linux-release:               &build
   stage:                           build
   <<:                              *collect-artifacts
   <<:                              *docker-env
-  <<:                              *compiler_info
+  <<:                              *compiler-info
   rules:
     # .test-refs with manual on PRs
     - if: $CI_PIPELINE_SOURCE == "web"
@@ -186,10 +187,9 @@ build-linux-release:               &build
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
       when: manual
       allow_failure: true
-  before_script:
+  script:
     - mkdir -p ./artifacts
     - VERSION="${CI_COMMIT_REF_NAME}" # will be tag or branch name
-  script:
     - time cargo build --release --verbose
     - sccache -s
   after_script:
@@ -218,6 +218,8 @@ build-linux-rococo:
     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
     - if: $IMAGE_NAME == "rococo"
   script:
+    - mkdir -p ./artifacts
+    - VERSION="${CI_COMMIT_REF_NAME}" # will be tag or branch name
     - time cargo build --release --verbose --features=real-overseer
     - sccache -s
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,6 +4,9 @@
 #
 # pipelines can be triggered manually in the web
 # setting DEPLOY_TAG will only deploy the tagged image
+#
+# Please do not add new jobs without "rules:" there are &rules-test
+# for all, &rules-pr-only and &rules-build presets.
 
 stages:
   - test
@@ -13,10 +16,10 @@ stages:
 
 image:                             paritytech/ci-linux:production
 
-# workflow:
-#   rules:
-#     - if: $CI_COMMIT_TAG
-#     - if: $CI_COMMIT_BRANCH
+workflow:
+  rules:
+    - if: $CI_COMMIT_TAG
+    - if: $CI_COMMIT_BRANCH
 
 variables:
   GIT_STRATEGY:                    fetch
@@ -250,7 +253,7 @@ generate-impl-guide:
   <<:                              *kubernetes-env
   <<:                              *collect-artifacts
   image:                           quay.io/buildah/stable
-  before_script:
+  before_script:                   &unpack-artifacts
     - test -s ./artifacts/VERSION || exit 1
     - test -s ./artifacts/EXTRATAG || exit 1
     - VERSION="$(cat ./artifacts/VERSION)"
@@ -266,6 +269,7 @@ generate-impl-guide:
         --build-arg BUILD_DATE="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
         --tag "$IMAGE_NAME:$VERSION"
         --tag "$IMAGE_NAME:$EXTRATAG" .
+    # The job will succeed only on the protected branch
     - echo "$Docker_Hub_Pass_Parity" |
       buildah login --username "$Docker_Hub_User_Parity" --password-stdin docker.io
     - buildah info
@@ -322,11 +326,7 @@ publish-s3-release:
     BUCKET:                        "releases.parity.io"
     PREFIX:                        "polkadot/${ARCH}-${DOCKER_OS}"
   before_script:
-    - test -s ./artifacts/VERSION || exit 1
-    - test -s ./artifacts/EXTRATAG || exit 1
-    - VERSION="$(cat ./artifacts/VERSION)"
-    - EXTRATAG="$(cat ./artifacts/EXTRATAG)"
-    - echo "Polkadot version = ${VERSION} (EXTRATAG ${EXTRATAG})"
+    - *unpack-artifacts
   script:
     - echo "uploading objects to https://${BUCKET}/${PREFIX}/${VERSION}"
     - aws s3 sync ./artifacts/ s3://${BUCKET}/${PREFIX}/${VERSION}/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -243,35 +243,35 @@ generate-impl-guide:
 
 #### stage:                        publish
 
-# .build-push-docker-image:          &build-push-docker-image
-#   <<:                              *kubernetes-env
-#   <<:                              *collect-artifacts
-#   image:                           quay.io/buildah/stable
-#   before_script:
-#     - test -s ./artifacts/VERSION || exit 1
-#     - test -s ./artifacts/EXTRATAG || exit 1
-#     - VERSION="$(cat ./artifacts/VERSION)"
-#     - EXTRATAG="$(cat ./artifacts/EXTRATAG)"
-#     - echo "Polkadot version = ${VERSION} (EXTRATAG ${EXTRATAG})"
-#   script:
-#     - test "$Docker_Hub_User_Parity" -a "$Docker_Hub_Pass_Parity" ||
-#         ( echo "no docker credentials provided"; exit 1 )
-#     - cd ./artifacts
-#     - buildah bud
-#         --format=docker
-#         --build-arg VCS_REF="${CI_COMMIT_SHA}"
-#         --build-arg BUILD_DATE="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
-#         --tag "$IMAGE_NAME:$VERSION"
-#         --tag "$IMAGE_NAME:$EXTRATAG" .
-#     - echo "$Docker_Hub_Pass_Parity" |
-#       buildah login --username "$Docker_Hub_User_Parity" --password-stdin docker.io
-#     - buildah info
-#     - buildah push --format=v2s2 "$IMAGE_NAME:$VERSION"
-#     - buildah push --format=v2s2 "$IMAGE_NAME:$EXTRATAG"
-#   after_script:
-#     - buildah logout "$IMAGE_NAME"
-#     # only VERSION information is needed for the deployment
-#     - find ./artifacts/ -depth -not -name VERSION -not -name artifacts -delete
+.build-push-docker-image:          &build-push-docker-image
+  <<:                              *kubernetes-env
+  <<:                              *collect-artifacts
+  image:                           quay.io/buildah/stable
+  before_script:
+    - test -s ./artifacts/VERSION || exit 1
+    - test -s ./artifacts/EXTRATAG || exit 1
+    - VERSION="$(cat ./artifacts/VERSION)"
+    - EXTRATAG="$(cat ./artifacts/EXTRATAG)"
+    - echo "Polkadot version = ${VERSION} (EXTRATAG ${EXTRATAG})"
+  script:
+    - test "$Docker_Hub_User_Parity" -a "$Docker_Hub_Pass_Parity" ||
+        ( echo "no docker credentials provided"; exit 1 )
+    - cd ./artifacts
+    - buildah bud
+        --format=docker
+        --build-arg VCS_REF="${CI_COMMIT_SHA}"
+        --build-arg BUILD_DATE="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+        --tag "$IMAGE_NAME:$VERSION"
+        --tag "$IMAGE_NAME:$EXTRATAG" .
+    - echo "$Docker_Hub_Pass_Parity" |
+      buildah login --username "$Docker_Hub_User_Parity" --password-stdin docker.io
+    - buildah info
+    - buildah push --format=v2s2 "$IMAGE_NAME:$VERSION"
+    - buildah push --format=v2s2 "$IMAGE_NAME:$EXTRATAG"
+  after_script:
+    - buildah logout "$IMAGE_NAME"
+    # only VERSION information is needed for the deployment
+    - find ./artifacts/ -depth -not -name VERSION -not -name artifacts -delete
 
 # publish-docker-polkadot:
 #   stage:                           publish

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -243,19 +243,19 @@ generate-impl-guide:
 
 #### stage:                        publish
 
-.publish-build:                    &publish-build
-  before_script:
-    - test -s ./artifacts/VERSION || exit 1
-    - test -s ./artifacts/EXTRATAG || exit 1
-    - VERSION="$(cat ./artifacts/VERSION)"
-    - EXTRATAG="$(cat ./artifacts/EXTRATAG)"
-    - echo "Polkadot version = ${VERSION} (EXTRATAG ${EXTRATAG})"
+.unpack-artifacts:                 &unpack-artifacts
+  - test -s ./artifacts/VERSION || exit 1
+  - test -s ./artifacts/EXTRATAG || exit 1
+  - VERSION="$(cat ./artifacts/VERSION)"
+  - EXTRATAG="$(cat ./artifacts/EXTRATAG)"
+  - echo "Polkadot version = ${VERSION} (EXTRATAG ${EXTRATAG})"
 
 .build-push-docker-image:          &build-push-docker-image
   <<:                              *kubernetes-env
   <<:                              *collect-artifacts
-  <<:                              *publish-build
   image:                           quay.io/buildah/stable
+  before_script:
+    - *unpack-artifacts
   script:
     - test "$Docker_Hub_User_Parity" -a "$Docker_Hub_Pass_Parity" ||
         ( echo "no docker credentials provided"; exit 1 )
@@ -293,18 +293,18 @@ publish-docker-polkadot:
     # DOCKERFILE:                  scripts/docker/Dockerfile
     IMAGE_NAME:                    docker.io/parity/polkadot
 
-# publish-docker-rococo:
-#   stage:                           build
-#   <<:                              *build-push-docker-image
-#   rules:
-#     - if: $PIPELIN3 == "rococo"
-#   # needs:
-#   #   - job:                         build-linux-rococo
-#   #     artifacts:                   true
-#   variables:
-#     GIT_STRATEGY:                  none
-#     # DOCKERFILE:                  scripts/docker/Dockerfile
-#     IMAGE_NAME:                    docker.io/parity/rococo
+publish-docker-rococo:
+  stage:                           build
+  <<:                              *build-push-docker-image
+  rules:
+    - if: $PIPELIN3 == "rococo"
+  # needs:
+  #   - job:                         build-linux-rococo
+  #     artifacts:                   true
+  variables:
+    GIT_STRATEGY:                  none
+    # DOCKERFILE:                  scripts/docker/Dockerfile
+    IMAGE_NAME:                    docker.io/parity/rococo
 
 publish-s3-release:
   stage:                           publish
@@ -315,12 +315,13 @@ publish-s3-release:
       artifacts:                   true
   <<:                              *rules-build
   <<:                              *kubernetes-env
-  <<:                              *publish-build
   image:                           paritytech/awscli:latest
   variables:
     GIT_STRATEGY:                  none
     BUCKET:                        "releases.parity.io"
     PREFIX:                        "polkadot/${ARCH}-${DOCKER_OS}"
+  before_script:
+    - *unpack-artifacts
   script:
     - echo "uploading objects to https://${BUCKET}/${PREFIX}/${VERSION}"
     - aws s3 sync ./artifacts/ s3://${BUCKET}/${PREFIX}/${VERSION}/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -293,18 +293,18 @@ publish-docker-polkadot:
     # DOCKERFILE:                  scripts/docker/Dockerfile
     IMAGE_NAME:                    docker.io/parity/polkadot
 
-publish-docker-rococo:
-  stage:                           build
-  <<:                              *build-push-docker-image
-  rules:
-    - if: $PIPELINE == "rococo"
-  # needs:
-  #   - job:                         build-linux-rococo
-  #     artifacts:                   true
-  variables:
-    GIT_STRATEGY:                  none
-    # DOCKERFILE:                  scripts/docker/Dockerfile
-    IMAGE_NAME:                    docker.io/parity/rococo
+# publish-docker-rococo:
+#   stage:                           build
+#   <<:                              *build-push-docker-image
+#   rules:
+#     - if: $PIPELINE == "rococo"
+#   # needs:
+#   #   - job:                         build-linux-rococo
+#   #     artifacts:                   true
+#   variables:
+#     GIT_STRATEGY:                  none
+#     # DOCKERFILE:                  scripts/docker/Dockerfile
+#     IMAGE_NAME:                    docker.io/parity/rococo
 
 publish-s3-release:
   stage:                           publish

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -357,12 +357,12 @@ check-labels:
   <<:                              *kubernetes-env
   rules:
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
-  needs:
+  # needs:
     # due to https://gitlab.com/gitlab-org/gitlab/-/issues/31264
     # here we should list the non-manual jobs from the previous stage
     # - job:                         check-transaction-versions
     #   artifacts:                   false
-    - job:                         generate-impl-guide
-      artifacts:                   false
+    # - job:                         generate-impl-guide
+    #   artifacts:                   false
   script:
     - ./scripts/gitlab/check_labels.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -91,9 +91,9 @@ default:
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
 
 .build-linux:                      &build-linux
-  <<:                              *collect-artifacts
+  # <<:                              *collect-artifacts
   <<:                              *docker-env
-  <<:                              *compiler-info
+  # <<:                              *compiler-info
   after_script:
     - mv ./target/release/polkadot ./artifacts/.
     - sha256sum ./artifacts/polkadot | tee ./artifacts/polkadot.sha256
@@ -123,245 +123,245 @@ build-linux-rococo:
     - time cargo build --release --verbose --features=real-overseer
     - sccache -s
 
-check-runtime:
-  stage:                           test
-  image:                           paritytech/tools:latest
-  <<:                              *kubernetes-env
-  <<:                              *rules-pr-only
-  variables:
-    GITLAB_API:                    "https://gitlab.parity.io/api/v4"
-    GITHUB_API_PROJECT:            "parity%2Finfrastructure%2Fgithub-api"
-  script:
-    - ./scripts/gitlab/check_runtime.sh
-  allow_failure:                   true
-
-check-line-width:
-  stage:                           test
-  image:                           paritytech/tools:latest
-  <<:                              *kubernetes-env
-  <<:                              *rules-pr-only
-  script:
-    - ./scripts/gitlab/check_line_width.sh
-  allow_failure:                   true
-
-# test-deterministic-wasm:
+# check-runtime:
 #   stage:                           test
-#   <<:                              *docker-env
-#   script:
-#     - ./scripts/gitlab/test_deterministic_wasm.sh
-
-# test-linux-stable:
-#   stage:                           test
-#   <<:                              *rules-test
-#   <<:                              *docker-env
-#   <<:                              *compiler-info
+#   image:                           paritytech/tools:latest
+#   <<:                              *kubernetes-env
+#   <<:                              *rules-pr-only
 #   variables:
-#     RUST_TOOLCHAIN: stable
-#     # Enable debug assertions since we are running optimized builds for testing
-#     # but still want to have debug assertions.
-#     RUSTFLAGS: "-Cdebug-assertions=y -Dwarnings"
-#     TARGET: native
-#   artifacts:
-#     paths:
-#       - ./target/release/polkadot
+#     GITLAB_API:                    "https://gitlab.parity.io/api/v4"
+#     GITHUB_API_PROJECT:            "parity%2Finfrastructure%2Fgithub-api"
 #   script:
-#     - ./scripts/gitlab/test_linux_stable.sh
-#     - sccache -s
+#     - ./scripts/gitlab/check_runtime.sh
+#   allow_failure:                   true
 
-# check-web-wasm:
+# check-line-width:
 #   stage:                           test
-#   <<:                              *rules-test
+#   image:                           paritytech/tools:latest
+#   <<:                              *kubernetes-env
+#   <<:                              *rules-pr-only
+#   script:
+#     - ./scripts/gitlab/check_line_width.sh
+#   allow_failure:                   true
+
+# # test-deterministic-wasm:
+# #   stage:                           test
+# #   <<:                              *docker-env
+# #   script:
+# #     - ./scripts/gitlab/test_deterministic_wasm.sh
+
+# # test-linux-stable:
+# #   stage:                           test
+# #   <<:                              *rules-test
+# #   <<:                              *docker-env
+# #   <<:                              *compiler-info
+# #   variables:
+# #     RUST_TOOLCHAIN: stable
+# #     # Enable debug assertions since we are running optimized builds for testing
+# #     # but still want to have debug assertions.
+# #     RUSTFLAGS: "-Cdebug-assertions=y -Dwarnings"
+# #     TARGET: native
+# #   artifacts:
+# #     paths:
+# #       - ./target/release/polkadot
+# #   script:
+# #     - ./scripts/gitlab/test_linux_stable.sh
+# #     - sccache -s
+
+# # check-web-wasm:
+# #   stage:                           test
+# #   <<:                              *rules-test
+# #   <<:                              *docker-env
+# #   <<:                              *compiler-info
+# #   script:
+# #     # WASM support is in progress. As more and more crates support WASM, we
+# #     # should add entries here. See https://github.com/paritytech/polkadot/issues/625
+# #     - ./scripts/gitlab/check_web_wasm.sh
+# #     - sccache -s
+
+# # check-runtime-benchmarks:
+# #   stage:                           test
+# #   <<:                              *rules-test
+# #   <<:                              *docker-env
+# #   <<:                              *compiler-info
+# #   script:
+# #     # Check that the node will compile with `runtime-benchmarks` feature flag.
+# #     - ./scripts/gitlab/check_runtime_benchmarks.sh
+# #     - sccache -s
+
+# #### stage:                        build
+
+# # check-transaction-versions:
+# #   image:                           node:15
+# #   stage:                           build
+# #   needs:
+# #     - job:                         test-linux-stable
+# #       artifacts:                   false
+# #   before_script:
+# #     - npm install -g @polkadot/metadata-cmp
+# #     - git fetch origin release
+# #   script: "scripts/gitlab/check_extrinsics_ordering.sh"
+
+# build-wasm-release:
+#   stage:                           build
+#   <<:                              *collect-artifacts
 #   <<:                              *docker-env
+#   <<:                              *rules-build
 #   <<:                              *compiler-info
 #   script:
-#     # WASM support is in progress. As more and more crates support WASM, we
-#     # should add entries here. See https://github.com/paritytech/polkadot/issues/625
-#     - ./scripts/gitlab/check_web_wasm.sh
-#     - sccache -s
+#     - time wasm-pack build --target web --out-dir wasm --release cli -- --no-default-features --features browser
+#     - mkdir -p ./artifacts/wasm
+#     - cd ./cli/wasm/
+#     - for f in polkadot_cli*; do sha256sum "${f}" > "${f}.sha256"; done
+#     - mv ./polkadot_cli* ../../artifacts/wasm/.
 
-# check-runtime-benchmarks:
-#   stage:                           test
-#   <<:                              *rules-test
-#   <<:                              *docker-env
-#   <<:                              *compiler-info
-#   script:
-#     # Check that the node will compile with `runtime-benchmarks` feature flag.
-#     - ./scripts/gitlab/check_runtime_benchmarks.sh
-#     - sccache -s
-
-#### stage:                        build
-
-# check-transaction-versions:
-#   image:                           node:15
+# build-linux-release:
 #   stage:                           build
-#   needs:
-#     - job:                         test-linux-stable
-#       artifacts:                   false
-#   before_script:
-#     - npm install -g @polkadot/metadata-cmp
-#     - git fetch origin release
-#   script: "scripts/gitlab/check_extrinsics_ordering.sh"
-
-build-wasm-release:
-  stage:                           build
-  <<:                              *collect-artifacts
-  <<:                              *docker-env
-  <<:                              *rules-build
-  <<:                              *compiler-info
-  script:
-    - time wasm-pack build --target web --out-dir wasm --release cli -- --no-default-features --features browser
-    - mkdir -p ./artifacts/wasm
-    - cd ./cli/wasm/
-    - for f in polkadot_cli*; do sha256sum "${f}" > "${f}.sha256"; done
-    - mv ./polkadot_cli* ../../artifacts/wasm/.
-
-build-linux-release:
-  stage:                           build
-  <<:                              *build-linux
-  rules:
-    # .rules-test with manual on PRs
-    - if: $PIPELIN3 == "rococo"
-      when: never
-    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
-      when: manual
-      allow_failure: true
-    - when: always
-  script:
-    - mkdir -p ./artifacts
-    - VERSION="${CI_COMMIT_REF_NAME}" # will be tag or branch name
-    - time cargo build --release --verbose
-    - sccache -s
-
-generate-impl-guide:
-  stage:                           build
-  <<:                              *rules-test
-  <<:                              *docker-env
-  image:
-    name: michaelfbryan/mdbook-docker-image:latest
-    entrypoint: [""]
-  script:
-    - mdbook build roadmap/implementers-guide
-
-#### stage:                        publish
-
-.publish-build:                    &publish-build
-  before_script:
-    - test -s ./artifacts/VERSION || exit 1
-    - test -s ./artifacts/EXTRATAG || exit 1
-    - VERSION="$(cat ./artifacts/VERSION)"
-    - EXTRATAG="$(cat ./artifacts/EXTRATAG)"
-    - echo "Polkadot version = ${VERSION} (EXTRATAG ${EXTRATAG})"
-
-.build-push-docker-image:          &build-push-docker-image
-  <<:                              *kubernetes-env
-  <<:                              *collect-artifacts
-  <<:                              *publish-build
-  image:                           quay.io/buildah/stable
-  script:
-    - test "$Docker_Hub_User_Parity" -a "$Docker_Hub_Pass_Parity" ||
-        ( echo "no docker credentials provided"; exit 1 )
-    - cd ./artifacts
-    - buildah bud
-        --format=docker
-        --build-arg VCS_REF="${CI_COMMIT_SHA}"
-        --build-arg BUILD_DATE="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
-        --tag "$IMAGE_NAME:$VERSION"
-        --tag "$IMAGE_NAME:$EXTRATAG" .
-    - echo "$Docker_Hub_Pass_Parity" |
-      buildah login --username "$Docker_Hub_User_Parity" --password-stdin docker.io
-    - buildah info
-    - buildah push --format=v2s2 "$IMAGE_NAME:$VERSION"
-    - buildah push --format=v2s2 "$IMAGE_NAME:$EXTRATAG"
-  after_script:
-    - buildah logout "$IMAGE_NAME"
-    # only VERSION information is needed for the deployment
-    - find ./artifacts/ -depth -not -name VERSION -not -name artifacts -delete
-
-publish-docker-polkadot:
-  stage:                           publish
-  <<:                              *build-push-docker-image
-  # Don't run on releases - this is handled by the Github Action here:
-  # .github/workflows/publish-docker-release.yml
-  rules:
-    - if: $CI_PIPELINE_SOURCE == "web"
-    - if: $CI_PIPELINE_SOURCE == "schedule"
-    - if: $CI_COMMIT_REF_NAME == "master"
-  needs:
-    - job:                         build-linux-release
-      artifacts:                   true
-  variables:
-    GIT_STRATEGY:                  none
-    # DOCKERFILE:                  scripts/docker/Dockerfile
-    IMAGE_NAME:                    docker.io/parity/polkadot
-
-# publish-docker-rococo:
-#   stage:                           build
-#   <<:                              *build-push-docker-image
+#   <<:                              *build-linux
 #   rules:
+#     # .rules-test with manual on PRs
 #     - if: $PIPELIN3 == "rococo"
-#   # needs:
-#   #   - job:                         build-linux-rococo
-#   #     artifacts:                   true
+#       when: never
+#     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
+#       when: manual
+#       allow_failure: true
+#     - when: always
+#   script:
+#     - mkdir -p ./artifacts
+#     - VERSION="${CI_COMMIT_REF_NAME}" # will be tag or branch name
+#     - time cargo build --release --verbose
+#     - sccache -s
+
+# generate-impl-guide:
+#   stage:                           build
+#   <<:                              *rules-test
+#   <<:                              *docker-env
+#   image:
+#     name: michaelfbryan/mdbook-docker-image:latest
+#     entrypoint: [""]
+#   script:
+#     - mdbook build roadmap/implementers-guide
+
+# #### stage:                        publish
+
+# .publish-build:                    &publish-build
+#   before_script:
+#     - test -s ./artifacts/VERSION || exit 1
+#     - test -s ./artifacts/EXTRATAG || exit 1
+#     - VERSION="$(cat ./artifacts/VERSION)"
+#     - EXTRATAG="$(cat ./artifacts/EXTRATAG)"
+#     - echo "Polkadot version = ${VERSION} (EXTRATAG ${EXTRATAG})"
+
+# .build-push-docker-image:          &build-push-docker-image
+#   <<:                              *kubernetes-env
+#   <<:                              *collect-artifacts
+#   <<:                              *publish-build
+#   image:                           quay.io/buildah/stable
+#   script:
+#     - test "$Docker_Hub_User_Parity" -a "$Docker_Hub_Pass_Parity" ||
+#         ( echo "no docker credentials provided"; exit 1 )
+#     - cd ./artifacts
+#     - buildah bud
+#         --format=docker
+#         --build-arg VCS_REF="${CI_COMMIT_SHA}"
+#         --build-arg BUILD_DATE="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+#         --tag "$IMAGE_NAME:$VERSION"
+#         --tag "$IMAGE_NAME:$EXTRATAG" .
+#     - echo "$Docker_Hub_Pass_Parity" |
+#       buildah login --username "$Docker_Hub_User_Parity" --password-stdin docker.io
+#     - buildah info
+#     - buildah push --format=v2s2 "$IMAGE_NAME:$VERSION"
+#     - buildah push --format=v2s2 "$IMAGE_NAME:$EXTRATAG"
+#   after_script:
+#     - buildah logout "$IMAGE_NAME"
+#     # only VERSION information is needed for the deployment
+#     - find ./artifacts/ -depth -not -name VERSION -not -name artifacts -delete
+
+# publish-docker-polkadot:
+#   stage:                           publish
+#   <<:                              *build-push-docker-image
+#   # Don't run on releases - this is handled by the Github Action here:
+#   # .github/workflows/publish-docker-release.yml
+#   rules:
+#     - if: $CI_PIPELINE_SOURCE == "web"
+#     - if: $CI_PIPELINE_SOURCE == "schedule"
+#     - if: $CI_COMMIT_REF_NAME == "master"
+#   needs:
+#     - job:                         build-linux-release
+#       artifacts:                   true
 #   variables:
 #     GIT_STRATEGY:                  none
 #     # DOCKERFILE:                  scripts/docker/Dockerfile
-#     IMAGE_NAME:                    docker.io/parity/rococo
+#     IMAGE_NAME:                    docker.io/parity/polkadot
 
-publish-s3-release:
-  stage:                           publish
-  needs:
-    - job:                         build-linux-release
-      artifacts:                   true
-    - job:                         build-wasm-release
-      artifacts:                   true
-  <<:                              *rules-build
-  <<:                              *kubernetes-env
-  <<:                              *publish-build
-  image:                           paritytech/awscli:latest
-  variables:
-    GIT_STRATEGY:                  none
-    BUCKET:                        "releases.parity.io"
-    PREFIX:                        "polkadot/${ARCH}-${DOCKER_OS}"
-  script:
-    - echo "uploading objects to https://${BUCKET}/${PREFIX}/${VERSION}"
-    - aws s3 sync ./artifacts/ s3://${BUCKET}/${PREFIX}/${VERSION}/
-    - echo "update objects at https://${BUCKET}/${PREFIX}/${EXTRATAG}"
-    - find ./artifacts -type f | while read file; do
-      name="${file#./artifacts/}";
-      aws s3api copy-object
-        --copy-source ${BUCKET}/${PREFIX}/${VERSION}/${name}
-        --bucket ${BUCKET} --key ${PREFIX}/${EXTRATAG}/${name};
-      done
-    - |
-      cat <<-EOM
-      |
-      |  polkadot binary paths:
-      |
-      |  - https://${BUCKET}/${PREFIX}/${EXTRATAG}/polkadot
-      |  - https://${BUCKET}/${PREFIX}/${VERSION}/polkadot
-      |
-      EOM
-  after_script:
-    - aws s3 ls s3://${BUCKET}/${PREFIX}/${EXTRATAG}/
-        --recursive --human-readable --summarize
+# # publish-docker-rococo:
+# #   stage:                           build
+# #   <<:                              *build-push-docker-image
+# #   rules:
+# #     - if: $PIPELIN3 == "rococo"
+# #   # needs:
+# #   #   - job:                         build-linux-rococo
+# #   #     artifacts:                   true
+# #   variables:
+# #     GIT_STRATEGY:                  none
+# #     # DOCKERFILE:                  scripts/docker/Dockerfile
+# #     IMAGE_NAME:                    docker.io/parity/rococo
 
-#### stage:                        deploy
+# publish-s3-release:
+#   stage:                           publish
+#   needs:
+#     - job:                         build-linux-release
+#       artifacts:                   true
+#     - job:                         build-wasm-release
+#       artifacts:                   true
+#   <<:                              *rules-build
+#   <<:                              *kubernetes-env
+#   <<:                              *publish-build
+#   image:                           paritytech/awscli:latest
+#   variables:
+#     GIT_STRATEGY:                  none
+#     BUCKET:                        "releases.parity.io"
+#     PREFIX:                        "polkadot/${ARCH}-${DOCKER_OS}"
+#   script:
+#     - echo "uploading objects to https://${BUCKET}/${PREFIX}/${VERSION}"
+#     - aws s3 sync ./artifacts/ s3://${BUCKET}/${PREFIX}/${VERSION}/
+#     - echo "update objects at https://${BUCKET}/${PREFIX}/${EXTRATAG}"
+#     - find ./artifacts -type f | while read file; do
+#       name="${file#./artifacts/}";
+#       aws s3api copy-object
+#         --copy-source ${BUCKET}/${PREFIX}/${VERSION}/${name}
+#         --bucket ${BUCKET} --key ${PREFIX}/${EXTRATAG}/${name};
+#       done
+#     - |
+#       cat <<-EOM
+#       |
+#       |  polkadot binary paths:
+#       |
+#       |  - https://${BUCKET}/${PREFIX}/${EXTRATAG}/polkadot
+#       |  - https://${BUCKET}/${PREFIX}/${VERSION}/polkadot
+#       |
+#       EOM
+#   after_script:
+#     - aws s3 ls s3://${BUCKET}/${PREFIX}/${EXTRATAG}/
+#         --recursive --human-readable --summarize
 
-deploy-polkasync-kusama:
-  stage:                           deploy
-  <<:                              *rules-build
-  variables:
-    POLKADOT_CI_COMMIT_NAME:       "${CI_COMMIT_REF_NAME}"
-    POLKADOT_CI_COMMIT_REF:        "${CI_COMMIT_REF}"
-  allow_failure:                   true
-  trigger:                         "parity/infrastructure/parity-testnet"
+# #### stage:                        deploy
 
-#### stage:                        .post
+# deploy-polkasync-kusama:
+#   stage:                           deploy
+#   <<:                              *rules-build
+#   variables:
+#     POLKADOT_CI_COMMIT_NAME:       "${CI_COMMIT_REF_NAME}"
+#     POLKADOT_CI_COMMIT_REF:        "${CI_COMMIT_REF}"
+#   allow_failure:                   true
+#   trigger:                         "parity/infrastructure/parity-testnet"
 
-check-labels:
-  stage:                           .post
-  image:                           paritytech/tools:latest
-  <<:                              *kubernetes-env
-  <<:                              *rules-pr-only
-  script:
-    - ./scripts/gitlab/check_labels.sh
+# #### stage:                        .post
+
+# check-labels:
+#   stage:                           .post
+#   image:                           paritytech/tools:latest
+#   <<:                              *kubernetes-env
+#   <<:                              *rules-pr-only
+#   script:
+#     - ./scripts/gitlab/check_labels.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -281,9 +281,9 @@ publish-docker-rococo:
   stage:                           build
   # rules:
   #   - if: $IMAGE == "rococo"
-  # needs:
-  #   - job:                         build-linux-rococo
-  #     artifacts:                   true
+  needs:
+    - job:                         build-linux-rococo
+      artifacts:                   true
   variables:
     GIT_STRATEGY:                  none
     # DOCKERFILE:                  scripts/docker/Dockerfile

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -289,7 +289,16 @@ publish-docker-rococo:
   <<:                              *build-push-docker-image
   # can't be executed on PRs since registry credentials are protected
   # <<:                              *build-refs
-  <<:                              *test-refs
+  rules:
+    # .test-refs with manual on PRs, master and tags
+    - if: $CI_PIPELINE_SOURCE == "web"
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+    - if: $CI_COMMIT_REF_NAME == "master"
+      when: manual
+    - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
+      when: manual
+    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
+      when: manual
   needs:
     - job:                         build-linux-rococo
       artifacts:                   true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -84,6 +84,7 @@ check-runtime:
   <<:                              *kubernetes-env
   rules:
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
+    - if: $IMAGE == "rococo"
   variables:
     GITLAB_API:                    "https://gitlab.parity.io/api/v4"
     GITHUB_API_PROJECT:            "parity%2Finfrastructure%2Fgithub-api"
@@ -101,50 +102,50 @@ check-line-width:
     - ./scripts/gitlab/check_line_width.sh
   allow_failure:                   true
 
-test-deterministic-wasm:
-  stage:                           test
-  <<:                              *docker-env
-  script:
-    - ./scripts/gitlab/test_deterministic_wasm.sh
+# test-deterministic-wasm:
+#   stage:                           test
+#   <<:                              *docker-env
+#   script:
+#     - ./scripts/gitlab/test_deterministic_wasm.sh
 
-test-linux-stable:                 &test
-  stage:                           test
-  <<:                              *test-refs
-  <<:                              *docker-env
-  <<:                              *compiler-info
-  variables:
-    RUST_TOOLCHAIN: stable
-    # Enable debug assertions since we are running optimized builds for testing
-    # but still want to have debug assertions.
-    RUSTFLAGS: "-Cdebug-assertions=y -Dwarnings"
-    TARGET: native
-  artifacts:
-    paths:
-      - ./target/release/polkadot
-  script:
-    - ./scripts/gitlab/test_linux_stable.sh
-    - sccache -s
+# test-linux-stable:                 &test
+#   stage:                           test
+#   <<:                              *test-refs
+#   <<:                              *docker-env
+#   <<:                              *compiler-info
+#   variables:
+#     RUST_TOOLCHAIN: stable
+#     # Enable debug assertions since we are running optimized builds for testing
+#     # but still want to have debug assertions.
+#     RUSTFLAGS: "-Cdebug-assertions=y -Dwarnings"
+#     TARGET: native
+#   artifacts:
+#     paths:
+#       - ./target/release/polkadot
+#   script:
+#     - ./scripts/gitlab/test_linux_stable.sh
+#     - sccache -s
 
-check-web-wasm:                    &test
-  stage:                           test
-  <<:                              *test-refs
-  <<:                              *docker-env
-  <<:                              *compiler-info
-  script:
-    # WASM support is in progress. As more and more crates support WASM, we
-    # should add entries here. See https://github.com/paritytech/polkadot/issues/625
-    - ./scripts/gitlab/check_web_wasm.sh
-    - sccache -s
+# check-web-wasm:                    &test
+#   stage:                           test
+#   <<:                              *test-refs
+#   <<:                              *docker-env
+#   <<:                              *compiler-info
+#   script:
+#     # WASM support is in progress. As more and more crates support WASM, we
+#     # should add entries here. See https://github.com/paritytech/polkadot/issues/625
+#     - ./scripts/gitlab/check_web_wasm.sh
+#     - sccache -s
 
-check-runtime-benchmarks:          &test
-  stage:                           test
-  <<:                              *test-refs
-  <<:                              *docker-env
-  <<:                              *compiler-info
-  script:
-    # Check that the node will compile with `runtime-benchmarks` feature flag.
-    - ./scripts/gitlab/check_runtime_benchmarks.sh
-    - sccache -s
+# check-runtime-benchmarks:          &test
+#   stage:                           test
+#   <<:                              *test-refs
+#   <<:                              *docker-env
+#   <<:                              *compiler-info
+#   script:
+#     # Check that the node will compile with `runtime-benchmarks` feature flag.
+#     - ./scripts/gitlab/check_runtime_benchmarks.sh
+#     - sccache -s
 
 #### stage:                        build
 
@@ -214,7 +215,7 @@ build-linux-rococo:
     # Due to https://gitlab.com/gitlab-org/gitlab/-/issues/31264 there's no way to setup a manual
     # build job so that publish-docker-rococo would "needs" this job. This leads either to blocked
     # or to forever running pipeline. It was decided to run these jobs from UI and on schedule.
-    - if: $IMAGE_NAME == "rococo"
+    - if: $IMAGE == "rococo"
   needs:                           []
   script:
     - mkdir -p ./artifacts
@@ -286,7 +287,7 @@ publish-docker-polkadot:           &build-push-docker-image
 publish-docker-rococo:
   <<:                              *build-push-docker-image
   rules:
-    - if: $IMAGE_NAME == "rococo"
+    - if: $IMAGE == "rococo"
   needs:
     - job:                         build-linux-rococo
       artifacts:                   true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -251,47 +251,47 @@ generate-impl-guide:
     - EXTRATAG="$(cat ./artifacts/EXTRATAG)"
     - echo "Polkadot version = ${VERSION} (EXTRATAG ${EXTRATAG})"
 
-# .build-push-docker-image:          &build-push-docker-image
-#   <<:                              *kubernetes-env
-#   <<:                              *collect-artifacts
-#   <<:                              *publish-build
-#   image:                           quay.io/buildah/stable
-#   script:
-#     - test "$Docker_Hub_User_Parity" -a "$Docker_Hub_Pass_Parity" ||
-#         ( echo "no docker credentials provided"; exit 1 )
-#     - cd ./artifacts
-#     - buildah bud
-#         --format=docker
-#         --build-arg VCS_REF="${CI_COMMIT_SHA}"
-#         --build-arg BUILD_DATE="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
-#         --tag "$IMAGE_NAME:$VERSION"
-#         --tag "$IMAGE_NAME:$EXTRATAG" .
-#     - echo "$Docker_Hub_Pass_Parity" |
-#       buildah login --username "$Docker_Hub_User_Parity" --password-stdin docker.io
-#     - buildah info
-#     - buildah push --format=v2s2 "$IMAGE_NAME:$VERSION"
-#     - buildah push --format=v2s2 "$IMAGE_NAME:$EXTRATAG"
-#   after_script:
-#     - buildah logout "$IMAGE_NAME"
-#     # only VERSION information is needed for the deployment
-#     - find ./artifacts/ -depth -not -name VERSION -not -name artifacts -delete
+.build-push-docker-image:          &build-push-docker-image
+  <<:                              *kubernetes-env
+  <<:                              *collect-artifacts
+  <<:                              *publish-build
+  image:                           quay.io/buildah/stable
+  script:
+    - test "$Docker_Hub_User_Parity" -a "$Docker_Hub_Pass_Parity" ||
+        ( echo "no docker credentials provided"; exit 1 )
+    - cd ./artifacts
+    - buildah bud
+        --format=docker
+        --build-arg VCS_REF="${CI_COMMIT_SHA}"
+        --build-arg BUILD_DATE="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+        --tag "$IMAGE_NAME:$VERSION"
+        --tag "$IMAGE_NAME:$EXTRATAG" .
+    - echo "$Docker_Hub_Pass_Parity" |
+      buildah login --username "$Docker_Hub_User_Parity" --password-stdin docker.io
+    - buildah info
+    - buildah push --format=v2s2 "$IMAGE_NAME:$VERSION"
+    - buildah push --format=v2s2 "$IMAGE_NAME:$EXTRATAG"
+  after_script:
+    - buildah logout "$IMAGE_NAME"
+    # only VERSION information is needed for the deployment
+    - find ./artifacts/ -depth -not -name VERSION -not -name artifacts -delete
 
-# publish-docker-polkadot:
-#   stage:                           publish
-#   <<:                              *build-push-docker-image
-#   # Don't run on releases - this is handled by the Github Action here:
-#   # .github/workflows/publish-docker-release.yml
-#   rules:
-#     - if: $CI_PIPELINE_SOURCE == "web"
-#     - if: $CI_PIPELINE_SOURCE == "schedule"
-#     - if: $CI_COMMIT_REF_NAME == "master"
-#   needs:
-#     - job:                         build-linux-release
-#       artifacts:                   true
-#   variables:
-#     GIT_STRATEGY:                  none
-#     # DOCKERFILE:                  scripts/docker/Dockerfile
-#     IMAGE_NAME:                    docker.io/parity/polkadot
+publish-docker-polkadot:
+  stage:                           publish
+  <<:                              *build-push-docker-image
+  # Don't run on releases - this is handled by the Github Action here:
+  # .github/workflows/publish-docker-release.yml
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "web"
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+    - if: $CI_COMMIT_REF_NAME == "master"
+  needs:
+    - job:                         build-linux-release
+      artifacts:                   true
+  variables:
+    GIT_STRATEGY:                  none
+    # DOCKERFILE:                  scripts/docker/Dockerfile
+    IMAGE_NAME:                    docker.io/parity/polkadot
 
 # publish-docker-rococo:
 #   stage:                           build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,8 +5,9 @@
 # pipelines can be triggered manually in the web
 # setting DEPLOY_TAG will only deploy the tagged image
 #
-# please do not add new jobs without "rules:" there are
-# &rules-test for all, &rules-pr-only and &rules-build presets
+# please do not add new jobs without "rules:" and "*-env". There are &rules-test for everything,
+# &rules-pr-only and &rules-build presets. And "kubernetes-env" with "docker-env" to set a runner
+# which executes the job.
 
 stages:
   - test
@@ -169,6 +170,7 @@ check-transaction-versions:
   image:                           node:15
   stage:                           build
   <<:                              *rules-test
+  <<:                              *docker-env
   needs:
     - job:                         test-linux-stable
       artifacts:                   false
@@ -177,19 +179,6 @@ check-transaction-versions:
     - git fetch origin release
   script:
     - scripts/gitlab/check_extrinsics_ordering.sh
-
-build-wasm-release:
-  stage:                           build
-  <<:                              *collect-artifacts
-  <<:                              *docker-env
-  <<:                              *rules-build
-  <<:                              *compiler-info
-  script:
-    - time wasm-pack build --target web --out-dir wasm --release cli -- --no-default-features --features browser
-    - mkdir -p ./artifacts/wasm
-    - cd ./cli/wasm/
-    - for f in polkadot_cli*; do sha256sum "${f}" > "${f}.sha256"; done
-    - mv ./polkadot_cli* ../../artifacts/wasm/.
 
 .build-linux:                      &build-linux
   <<:                              *collect-artifacts
@@ -254,7 +243,7 @@ generate-impl-guide:
   <<:                              *kubernetes-env
   <<:                              *collect-artifacts
   image:                           quay.io/buildah/stable
-  before_script:
+  before_script:                   &check-versions
     - test -s ./artifacts/VERSION || exit 1
     - test -s ./artifacts/EXTRATAG || exit 1
     - VERSION="$(cat ./artifacts/VERSION)"
@@ -319,8 +308,6 @@ publish-s3-release:
   needs:
     - job:                         build-linux-release
       artifacts:                   true
-    - job:                         build-wasm-release
-      artifacts:                   true
   <<:                              *kubernetes-env
   image:                           paritytech/awscli:latest
   variables:
@@ -328,11 +315,7 @@ publish-s3-release:
     BUCKET:                        "releases.parity.io"
     PREFIX:                        "polkadot/${ARCH}-${DOCKER_OS}"
   before_script:
-    - test -s ./artifacts/VERSION || exit 1
-    - test -s ./artifacts/EXTRATAG || exit 1
-    - VERSION="$(cat ./artifacts/VERSION)"
-    - EXTRATAG="$(cat ./artifacts/EXTRATAG)"
-    - echo "Polkadot version = ${VERSION} (EXTRATAG ${EXTRATAG})"
+    - *check-versions
   script:
     - echo "uploading objects to https://${BUCKET}/${PREFIX}/${VERSION}"
     - aws s3 sync ./artifacts/ s3://${BUCKET}/${PREFIX}/${VERSION}/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -160,10 +160,8 @@ build-wasm-release:
   stage:                           build
   <<:                              *collect-artifacts
   <<:                              *docker-env
+  <<:                              *build-refs
   <<:                              *compiler-info
-  # Note: We likely only want to do this for tagged releases, hence the 'rules:'
-  rules:
-    - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
   script:
     - time wasm-pack build --target web --out-dir wasm --release cli -- --no-default-features --features browser
     - mkdir -p ./artifacts/wasm
@@ -231,14 +229,6 @@ generate-impl-guide:
 #### stage:                        publish
 
 .publish-build:                    &publish-build
-  stage:                           publish
-  needs:
-    - job:                         build-linux-release
-      artifacts:                   true
-    - job:                         build-wasm-release
-      artifacts:                   true
-  <<:                              *build-refs
-  <<:                              *kubernetes-env
   before_script:
     - test -s ./artifacts/VERSION || exit 1
     - test -s ./artifacts/EXTRATAG || exit 1
@@ -247,6 +237,12 @@ generate-impl-guide:
     - echo "Polkadot version = ${VERSION} (EXTRATAG ${EXTRATAG})"
 
 publish-docker-polkadot:           &build-push-docker-image
+  stage:                           publish
+  needs:
+    - job:                         build-linux-release
+      artifacts:                   true
+  <<:                              *build-refs
+  <<:                              *kubernetes-env
   <<:                              *publish-build
   image:                           quay.io/buildah/stable
   <<:                              *collect-artifacts
@@ -294,6 +290,14 @@ publish-docker-rococo:
     IMAGE_NAME:                    docker.io/parity/rococo
 
 publish-s3-release:
+  stage:                           publish
+  needs:
+    - job:                         build-linux-release
+      artifacts:                   true
+    - job:                         build-wasm-release
+      artifacts:                   true
+  <<:                              *build-refs
+  <<:                              *kubernetes-env
   <<:                              *publish-build
   image:                           paritytech/awscli:latest
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,10 +13,10 @@ stages:
 
 image:                             paritytech/ci-linux:production
 
-workflow:
-  rules:
-    - if: $CI_COMMIT_TAG
-    - if: $CI_COMMIT_BRANCH
+# workflow:
+#   rules:
+#     - if: $CI_COMMIT_TAG
+#     - if: $CI_COMMIT_BRANCH
 
 variables:
   GIT_STRATEGY:                    fetch

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -201,45 +201,45 @@ check-line-width:
 #     - git fetch origin release
 #   script: "scripts/gitlab/check_extrinsics_ordering.sh"
 
-# build-wasm-release:
-#   stage:                           build
-#   <<:                              *collect-artifacts
-#   <<:                              *docker-env
-#   <<:                              *rules-build
-#   <<:                              *compiler-info
-#   script:
-#     - time wasm-pack build --target web --out-dir wasm --release cli -- --no-default-features --features browser
-#     - mkdir -p ./artifacts/wasm
-#     - cd ./cli/wasm/
-#     - for f in polkadot_cli*; do sha256sum "${f}" > "${f}.sha256"; done
-#     - mv ./polkadot_cli* ../../artifacts/wasm/.
+build-wasm-release:
+  stage:                           build
+  <<:                              *collect-artifacts
+  <<:                              *docker-env
+  <<:                              *rules-build
+  <<:                              *compiler-info
+  script:
+    - time wasm-pack build --target web --out-dir wasm --release cli -- --no-default-features --features browser
+    - mkdir -p ./artifacts/wasm
+    - cd ./cli/wasm/
+    - for f in polkadot_cli*; do sha256sum "${f}" > "${f}.sha256"; done
+    - mv ./polkadot_cli* ../../artifacts/wasm/.
 
-# build-linux-release:
-#   stage:                           build
-#   <<:                              *build-linux
-#   rules:
-#     # .rules-test with manual on PRs
-#     - if: $PIPELIN3 == "rococo"
-#       when: never
-#     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
-#       when: manual
-#       allow_failure: true
-#     - when: always
-#   script:
-#     - mkdir -p ./artifacts
-#     - VERSION="${CI_COMMIT_REF_NAME}" # will be tag or branch name
-#     - time cargo build --release --verbose
-#     - sccache -s
+build-linux-release:
+  stage:                           build
+  <<:                              *build-linux
+  rules:
+    # .rules-test with manual on PRs
+    - if: $PIPELIN3 == "rococo"
+      when: never
+    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
+      when: manual
+      allow_failure: true
+    - when: always
+  script:
+    - mkdir -p ./artifacts
+    - VERSION="${CI_COMMIT_REF_NAME}" # will be tag or branch name
+    - time cargo build --release --verbose
+    - sccache -s
 
-# generate-impl-guide:
-#   stage:                           build
-#   <<:                              *rules-test
-#   <<:                              *docker-env
-#   image:
-#     name: michaelfbryan/mdbook-docker-image:latest
-#     entrypoint: [""]
-#   script:
-#     - mdbook build roadmap/implementers-guide
+generate-impl-guide:
+  stage:                           build
+  <<:                              *rules-test
+  <<:                              *docker-env
+  image:
+    name: michaelfbryan/mdbook-docker-image:latest
+    entrypoint: [""]
+  script:
+    - mdbook build roadmap/implementers-guide
 
 # #### stage:                        publish
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -219,12 +219,14 @@ build-linux-rococo:
       when: manual
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
       when: manual
+      allow_failure: false
   script:
     - time cargo build --release --verbose --features=real-overseer
     - sccache -s
 
 generate-impl-guide:
   stage:                           build
+  <<:                              *docker-env
   image:
     name: michaelfbryan/mdbook-docker-image:latest
     entrypoint: [""]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -290,18 +290,18 @@ generate-impl-guide:
 #     # DOCKERFILE:                  scripts/docker/Dockerfile
 #     IMAGE_NAME:                    docker.io/parity/polkadot
 
-# publish-docker-rococo:
-#   stage:                           build
-#   <<:                              *build-push-docker-image
-#   rules:
-#     - if: $PIPELIN3 == "rococo"
-#   # needs:
-#   #   - job:                         build-linux-rococo
-#   #     artifacts:                   true
-#   variables:
-#     GIT_STRATEGY:                  none
-#     # DOCKERFILE:                  scripts/docker/Dockerfile
-#     IMAGE_NAME:                    docker.io/parity/rococo
+publish-docker-rococo:
+  stage:                           build
+  <<:                              *build-push-docker-image
+  rules:
+    - if: $PIPELIN3 == "rococo"
+  # needs:
+  #   - job:                         build-linux-rococo
+  #     artifacts:                   true
+  variables:
+    GIT_STRATEGY:                  none
+    # DOCKERFILE:                  scripts/docker/Dockerfile
+    IMAGE_NAME:                    docker.io/parity/rococo
 
 publish-s3-release:
   stage:                           publish

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -344,23 +344,23 @@ publish-s3-release:
     - aws s3 ls s3://${BUCKET}/${PREFIX}/${EXTRATAG}/
         --recursive --human-readable --summarize
 
-#### stage:                        deploy
+# #### stage:                        deploy
 
-deploy-polkasync-kusama:
-  stage:                           deploy
-  <<:                              *rules-build
-  variables:
-    POLKADOT_CI_COMMIT_NAME:       "${CI_COMMIT_REF_NAME}"
-    POLKADOT_CI_COMMIT_REF:        "${CI_COMMIT_REF}"
-  allow_failure:                   true
-  trigger:                         "parity/infrastructure/parity-testnet"
+# deploy-polkasync-kusama:
+#   stage:                           deploy
+#   <<:                              *rules-build
+#   variables:
+#     POLKADOT_CI_COMMIT_NAME:       "${CI_COMMIT_REF_NAME}"
+#     POLKADOT_CI_COMMIT_REF:        "${CI_COMMIT_REF}"
+#   allow_failure:                   true
+#   trigger:                         "parity/infrastructure/parity-testnet"
 
-#### stage:                        .post
+# #### stage:                        .post
 
-check-labels:
-  stage:                           .post
-  image:                           paritytech/tools:latest
-  <<:                              *kubernetes-env
-  <<:                              *rules-pr-only
-  script:
-    - ./scripts/gitlab/check_labels.sh
+# check-labels:
+#   stage:                           .post
+#   image:                           paritytech/tools:latest
+#   <<:                              *kubernetes-env
+#   <<:                              *rules-pr-only
+#   script:
+#     - ./scripts/gitlab/check_labels.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -247,7 +247,7 @@ generate-impl-guide:
 #   <<:                              *kubernetes-env
 #   <<:                              *collect-artifacts
 #   image:                           quay.io/buildah/stable
-#   before_script:                   &unpack-artifacts
+#   before_script:
 #     - test -s ./artifacts/VERSION || exit 1
 #     - test -s ./artifacts/EXTRATAG || exit 1
 #     - VERSION="$(cat ./artifacts/VERSION)"
@@ -318,7 +318,11 @@ publish-s3-release:
     BUCKET:                        "releases.parity.io"
     PREFIX:                        "polkadot/${ARCH}-${DOCKER_OS}"
   before_script:
-    - *unpack-artifacts
+    - test -s ./artifacts/VERSION || exit 1
+    - test -s ./artifacts/EXTRATAG || exit 1
+    - VERSION="$(cat ./artifacts/VERSION)"
+    - EXTRATAG="$(cat ./artifacts/EXTRATAG)"
+    - echo "Polkadot version = ${VERSION} (EXTRATAG ${EXTRATAG})"
   script:
     - echo "uploading objects to https://${BUCKET}/${PREFIX}/${VERSION}"
     - aws s3 sync ./artifacts/ s3://${BUCKET}/${PREFIX}/${VERSION}/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -224,7 +224,7 @@ build-linux-rococo:
   stage:                           test
   <<:                              *build-linux
   rules:
-    - if: $PIPELINE == rococo
+    - if: $CI_PIPELINE_SOURCE == "schedule" && $PIPELINE == "rococo"
   script:
     - mkdir -p ./artifacts
     - VERSION="${CI_COMMIT_REF_NAME}" # will be tag or branch name

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -241,126 +241,126 @@ generate-impl-guide:
   script:
     - mdbook build roadmap/implementers-guide
 
-# #### stage:                        publish
+#### stage:                        publish
 
-# .publish-build:                    &publish-build
-#   before_script:
-#     - test -s ./artifacts/VERSION || exit 1
-#     - test -s ./artifacts/EXTRATAG || exit 1
-#     - VERSION="$(cat ./artifacts/VERSION)"
-#     - EXTRATAG="$(cat ./artifacts/EXTRATAG)"
-#     - echo "Polkadot version = ${VERSION} (EXTRATAG ${EXTRATAG})"
+.publish-build:                    &publish-build
+  before_script:
+    - test -s ./artifacts/VERSION || exit 1
+    - test -s ./artifacts/EXTRATAG || exit 1
+    - VERSION="$(cat ./artifacts/VERSION)"
+    - EXTRATAG="$(cat ./artifacts/EXTRATAG)"
+    - echo "Polkadot version = ${VERSION} (EXTRATAG ${EXTRATAG})"
 
-# .build-push-docker-image:          &build-push-docker-image
-#   <<:                              *kubernetes-env
-#   <<:                              *collect-artifacts
-#   <<:                              *publish-build
-#   image:                           quay.io/buildah/stable
-#   script:
-#     - test "$Docker_Hub_User_Parity" -a "$Docker_Hub_Pass_Parity" ||
-#         ( echo "no docker credentials provided"; exit 1 )
-#     - cd ./artifacts
-#     - buildah bud
-#         --format=docker
-#         --build-arg VCS_REF="${CI_COMMIT_SHA}"
-#         --build-arg BUILD_DATE="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
-#         --tag "$IMAGE_NAME:$VERSION"
-#         --tag "$IMAGE_NAME:$EXTRATAG" .
-#     - echo "$Docker_Hub_Pass_Parity" |
-#       buildah login --username "$Docker_Hub_User_Parity" --password-stdin docker.io
-#     - buildah info
-#     - buildah push --format=v2s2 "$IMAGE_NAME:$VERSION"
-#     - buildah push --format=v2s2 "$IMAGE_NAME:$EXTRATAG"
-#   after_script:
-#     - buildah logout "$IMAGE_NAME"
-#     # only VERSION information is needed for the deployment
-#     - find ./artifacts/ -depth -not -name VERSION -not -name artifacts -delete
+.build-push-docker-image:          &build-push-docker-image
+  <<:                              *kubernetes-env
+  <<:                              *collect-artifacts
+  <<:                              *publish-build
+  image:                           quay.io/buildah/stable
+  script:
+    - test "$Docker_Hub_User_Parity" -a "$Docker_Hub_Pass_Parity" ||
+        ( echo "no docker credentials provided"; exit 1 )
+    - cd ./artifacts
+    - buildah bud
+        --format=docker
+        --build-arg VCS_REF="${CI_COMMIT_SHA}"
+        --build-arg BUILD_DATE="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+        --tag "$IMAGE_NAME:$VERSION"
+        --tag "$IMAGE_NAME:$EXTRATAG" .
+    - echo "$Docker_Hub_Pass_Parity" |
+      buildah login --username "$Docker_Hub_User_Parity" --password-stdin docker.io
+    - buildah info
+    - buildah push --format=v2s2 "$IMAGE_NAME:$VERSION"
+    - buildah push --format=v2s2 "$IMAGE_NAME:$EXTRATAG"
+  after_script:
+    - buildah logout "$IMAGE_NAME"
+    # only VERSION information is needed for the deployment
+    - find ./artifacts/ -depth -not -name VERSION -not -name artifacts -delete
 
-# publish-docker-polkadot:
-#   stage:                           publish
+publish-docker-polkadot:
+  stage:                           publish
+  <<:                              *build-push-docker-image
+  # Don't run on releases - this is handled by the Github Action here:
+  # .github/workflows/publish-docker-release.yml
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "web"
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+    - if: $CI_COMMIT_REF_NAME == "master"
+  needs:
+    - job:                         build-linux-release
+      artifacts:                   true
+  variables:
+    GIT_STRATEGY:                  none
+    # DOCKERFILE:                  scripts/docker/Dockerfile
+    IMAGE_NAME:                    docker.io/parity/polkadot
+
+# publish-docker-rococo:
+#   stage:                           build
 #   <<:                              *build-push-docker-image
-#   # Don't run on releases - this is handled by the Github Action here:
-#   # .github/workflows/publish-docker-release.yml
 #   rules:
-#     - if: $CI_PIPELINE_SOURCE == "web"
-#     - if: $CI_PIPELINE_SOURCE == "schedule"
-#     - if: $CI_COMMIT_REF_NAME == "master"
-#   needs:
-#     - job:                         build-linux-release
-#       artifacts:                   true
+#     - if: $PIPELIN3 == "rococo"
+#   # needs:
+#   #   - job:                         build-linux-rococo
+#   #     artifacts:                   true
 #   variables:
 #     GIT_STRATEGY:                  none
 #     # DOCKERFILE:                  scripts/docker/Dockerfile
-#     IMAGE_NAME:                    docker.io/parity/polkadot
+#     IMAGE_NAME:                    docker.io/parity/rococo
 
-# # publish-docker-rococo:
-# #   stage:                           build
-# #   <<:                              *build-push-docker-image
-# #   rules:
-# #     - if: $PIPELIN3 == "rococo"
-# #   # needs:
-# #   #   - job:                         build-linux-rococo
-# #   #     artifacts:                   true
-# #   variables:
-# #     GIT_STRATEGY:                  none
-# #     # DOCKERFILE:                  scripts/docker/Dockerfile
-# #     IMAGE_NAME:                    docker.io/parity/rococo
+publish-s3-release:
+  stage:                           publish
+  needs:
+    - job:                         build-linux-release
+      artifacts:                   true
+    - job:                         build-wasm-release
+      artifacts:                   true
+  <<:                              *rules-build
+  <<:                              *kubernetes-env
+  <<:                              *publish-build
+  image:                           paritytech/awscli:latest
+  variables:
+    GIT_STRATEGY:                  none
+    BUCKET:                        "releases.parity.io"
+    PREFIX:                        "polkadot/${ARCH}-${DOCKER_OS}"
+  script:
+    - echo "uploading objects to https://${BUCKET}/${PREFIX}/${VERSION}"
+    - aws s3 sync ./artifacts/ s3://${BUCKET}/${PREFIX}/${VERSION}/
+    - echo "update objects at https://${BUCKET}/${PREFIX}/${EXTRATAG}"
+    - find ./artifacts -type f | while read file; do
+      name="${file#./artifacts/}";
+      aws s3api copy-object
+        --copy-source ${BUCKET}/${PREFIX}/${VERSION}/${name}
+        --bucket ${BUCKET} --key ${PREFIX}/${EXTRATAG}/${name};
+      done
+    - |
+      cat <<-EOM
+      |
+      |  polkadot binary paths:
+      |
+      |  - https://${BUCKET}/${PREFIX}/${EXTRATAG}/polkadot
+      |  - https://${BUCKET}/${PREFIX}/${VERSION}/polkadot
+      |
+      EOM
+  after_script:
+    - aws s3 ls s3://${BUCKET}/${PREFIX}/${EXTRATAG}/
+        --recursive --human-readable --summarize
 
-# publish-s3-release:
-#   stage:                           publish
-#   needs:
-#     - job:                         build-linux-release
-#       artifacts:                   true
-#     - job:                         build-wasm-release
-#       artifacts:                   true
-#   <<:                              *rules-build
-#   <<:                              *kubernetes-env
-#   <<:                              *publish-build
-#   image:                           paritytech/awscli:latest
-#   variables:
-#     GIT_STRATEGY:                  none
-#     BUCKET:                        "releases.parity.io"
-#     PREFIX:                        "polkadot/${ARCH}-${DOCKER_OS}"
-#   script:
-#     - echo "uploading objects to https://${BUCKET}/${PREFIX}/${VERSION}"
-#     - aws s3 sync ./artifacts/ s3://${BUCKET}/${PREFIX}/${VERSION}/
-#     - echo "update objects at https://${BUCKET}/${PREFIX}/${EXTRATAG}"
-#     - find ./artifacts -type f | while read file; do
-#       name="${file#./artifacts/}";
-#       aws s3api copy-object
-#         --copy-source ${BUCKET}/${PREFIX}/${VERSION}/${name}
-#         --bucket ${BUCKET} --key ${PREFIX}/${EXTRATAG}/${name};
-#       done
-#     - |
-#       cat <<-EOM
-#       |
-#       |  polkadot binary paths:
-#       |
-#       |  - https://${BUCKET}/${PREFIX}/${EXTRATAG}/polkadot
-#       |  - https://${BUCKET}/${PREFIX}/${VERSION}/polkadot
-#       |
-#       EOM
-#   after_script:
-#     - aws s3 ls s3://${BUCKET}/${PREFIX}/${EXTRATAG}/
-#         --recursive --human-readable --summarize
+#### stage:                        deploy
 
-# #### stage:                        deploy
+deploy-polkasync-kusama:
+  stage:                           deploy
+  <<:                              *rules-build
+  variables:
+    POLKADOT_CI_COMMIT_NAME:       "${CI_COMMIT_REF_NAME}"
+    POLKADOT_CI_COMMIT_REF:        "${CI_COMMIT_REF}"
+  allow_failure:                   true
+  trigger:                         "parity/infrastructure/parity-testnet"
 
-# deploy-polkasync-kusama:
-#   stage:                           deploy
-#   <<:                              *rules-build
-#   variables:
-#     POLKADOT_CI_COMMIT_NAME:       "${CI_COMMIT_REF_NAME}"
-#     POLKADOT_CI_COMMIT_REF:        "${CI_COMMIT_REF}"
-#   allow_failure:                   true
-#   trigger:                         "parity/infrastructure/parity-testnet"
+#### stage:                        .post
 
-# #### stage:                        .post
-
-# check-labels:
-#   stage:                           .post
-#   image:                           paritytech/tools:latest
-#   <<:                              *kubernetes-env
-#   <<:                              *rules-pr-only
-#   script:
-#     - ./scripts/gitlab/check_labels.sh
+check-labels:
+  stage:                           .post
+  image:                           paritytech/tools:latest
+  <<:                              *kubernetes-env
+  <<:                              *rules-pr-only
+  script:
+    - ./scripts/gitlab/check_labels.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -241,9 +241,11 @@ generate-impl-guide:
 
 .publish-build:                    &publish-build
   stage:                           publish
-  dependencies:
-    - build-linux-release
-    - build-wasm-release
+  needs:
+    - job:                         build-linux-release
+      artifacts:                   true
+    - job:                         build-wasm-release
+      artifacts:                   true
   <<:                              *build-refs
   <<:                              *kubernetes-env
   before_script:
@@ -292,12 +294,14 @@ publish-docker-rococo:
   # can't be executed on PRs since registry credentials are protected
   # <<:                              *build-refs
   <<:                              *test-refs
-  dependencies:
-    - build-linux-rococo
+  needs:
+    - job:                         build-linux-rococo
+      artifacts:                   true
   variables:
     GIT_STRATEGY:                  none
     # DOCKERFILE:                  scripts/docker/Dockerfile
     IMAGE_NAME:                    docker.io/parity/rococo
+  allow_failure:                   true
 
 publish-s3-release:
   <<:                              *publish-build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -273,31 +273,31 @@ generate-impl-guide:
     # only VERSION information is needed for the deployment
     - find ./artifacts/ -depth -not -name VERSION -not -name artifacts -delete
 
-# publish-docker-polkadot:
-#   stage:                           publish
-#   <<:                              *build-push-docker-image
-#   # Don't run on releases - this is handled by the Github Action here:
-#   # .github/workflows/publish-docker-release.yml
-#   rules:
-#     - if: $CI_PIPELINE_SOURCE == "web"
-#     - if: $CI_PIPELINE_SOURCE == "schedule"
-#     - if: $CI_COMMIT_REF_NAME == "master"
-#   needs:
-#     - job:                         build-linux-release
-#       artifacts:                   true
-#   variables:
-#     GIT_STRATEGY:                  none
-#     # DOCKERFILE:                  scripts/docker/Dockerfile
-#     IMAGE_NAME:                    docker.io/parity/polkadot
+publish-docker-polkadot:
+  stage:                           publish
+  <<:                              *build-push-docker-image
+  # Don't run on releases - this is handled by the Github Action here:
+  # .github/workflows/publish-docker-release.yml
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "web"
+    - if: $CI_PIPELINE_SOURCE == "schedule" && $PIPELIN3 != "rococo"
+    - if: $CI_COMMIT_REF_NAME == "master"
+  needs:
+    - job:                         build-linux-release
+      artifacts:                   true
+  variables:
+    GIT_STRATEGY:                  none
+    # DOCKERFILE:                  scripts/docker/Dockerfile
+    IMAGE_NAME:                    docker.io/parity/polkadot
 
 publish-docker-rococo:
   stage:                           publish
   <<:                              *build-push-docker-image
   rules:
     - if: $PIPELIN3 == "rococo"
-  # needs:
-  #   - job:                         build-linux-rococo
-  #     artifacts:                   true
+  needs:
+    - job:                         build-linux-rococo
+      artifacts:                   true
   variables:
     GIT_STRATEGY:                  none
     # DOCKERFILE:                  scripts/docker/Dockerfile

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -298,9 +298,9 @@ publish-docker-rococo:
   <<:                              *build-push-docker-image
   rules:
     - if: $PIPELINE == "rococo"
-  needs:
-    - job:                         build-linux-rococo
-      artifacts:                   true
+  # needs:
+  #   - job:                         build-linux-rococo
+  #     artifacts:                   true
   variables:
     GIT_STRATEGY:                  none
     # DOCKERFILE:                  scripts/docker/Dockerfile

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,8 +5,8 @@
 # pipelines can be triggered manually in the web
 # setting DEPLOY_TAG will only deploy the tagged image
 #
-# Please do not add new jobs without "rules:" there are &rules-test
-# for all, &rules-pr-only and &rules-build presets.
+# please do not add new jobs without "rules:" there are
+# &rules-test for all, &rules-pr-only and &rules-build presets
 
 stages:
   - test
@@ -69,7 +69,7 @@ default:
     # and on schedule.
     #
     # $PIPELINE should be passed in https://gitlab.parity.io/parity/polkadot/-/pipeline_schedules
-    # or other trigger to avoid running these jobs.
+    # or other trigger to avoid running these jobs and run just those allowing this variable
     - if: $PIPELINE == "rococo"
       when: never
     - if: $CI_PIPELINE_SOURCE == "web"
@@ -168,6 +168,7 @@ check-runtime-benchmarks:
 check-transaction-versions:
   image:                           node:15
   stage:                           build
+  <<:                              *rules-test
   needs:
     - job:                         test-linux-stable
       artifacts:                   false
@@ -269,7 +270,7 @@ generate-impl-guide:
         --build-arg BUILD_DATE="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
         --tag "$IMAGE_NAME:$VERSION"
         --tag "$IMAGE_NAME:$EXTRATAG" .
-    # The job will succeed only on the protected branch
+    # The job will success only on the protected branch
     - echo "$Docker_Hub_Pass_Parity" |
       buildah login --username "$Docker_Hub_User_Parity" --password-stdin docker.io
     - buildah info
@@ -286,9 +287,10 @@ publish-docker-polkadot:
   # Don't run on releases - this is handled by the Github Action here:
   # .github/workflows/publish-docker-release.yml
   rules:
+    - if: $PIPELINE == "rococo"
+      when: never
+    - if: $CI_PIPELINE_SOURCE == "schedule"
     - if: $CI_PIPELINE_SOURCE == "web"
-    # without this "&&" the pipeline scheduled with variable won't start 
-    - if: $CI_PIPELINE_SOURCE == "schedule" && $PIPELINE != "rococo"
     - if: $CI_COMMIT_REF_NAME == "master"
   needs:
     - job:                         build-linux-release
@@ -313,12 +315,12 @@ publish-docker-rococo:
 
 publish-s3-release:
   stage:                           publish
+  <<:                              *rules-build
   needs:
     - job:                         build-linux-release
       artifacts:                   true
     - job:                         build-wasm-release
       artifacts:                   true
-  <<:                              *rules-build
   <<:                              *kubernetes-env
   image:                           paritytech/awscli:latest
   variables:
@@ -370,7 +372,7 @@ deploy-polkasync-kusama:
 check-labels:
   stage:                           .post
   image:                           paritytech/tools:latest
-  <<:                              *kubernetes-env
   <<:                              *rules-pr-only
+  <<:                              *kubernetes-env
   script:
     - ./scripts/gitlab/check_labels.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -214,9 +214,6 @@ build-linux-rococo:
     # Due to https://gitlab.com/gitlab-org/gitlab/-/issues/31264 there's no way to setup a manual
     # build job so that publish-docker-rococo would "needs" this job. This leads either to blocked
     # or to forever running pipeline. It was decided to run these jobs from UI and on schedule.
-    - if: $CI_PIPELINE_SOURCE == "web"
-    - if: $CI_PIPELINE_SOURCE == "schedule"
-    - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
     - if: $IMAGE_NAME == "rococo"
   script:
     - mkdir -p ./artifacts
@@ -288,9 +285,6 @@ publish-docker-polkadot:           &build-push-docker-image
 publish-docker-rococo:
   <<:                              *build-push-docker-image
   rules:
-    - if: $CI_PIPELINE_SOURCE == "web"
-    - if: $CI_PIPELINE_SOURCE == "schedule"
-    - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
     - if: $IMAGE_NAME == "rococo"
   needs:
     - job:                         build-linux-rococo

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -283,8 +283,8 @@ publish-docker-polkadot:           &build-push-docker-image
 publish-docker-rococo:
   <<:                              *build-push-docker-image
   stage:                           build
-  rules:
-    - if: $IMAGE == "rococo"
+  # rules:
+  #   - if: $IMAGE == "rococo"
   needs:
     - job:                         build-linux-rococo
       artifacts:                   true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -219,7 +219,7 @@ build-linux-release:               &build-linux
 
 build-linux-rococo:
   <<:                              *build-linux
-  stage:                           build
+  stage:                           test
   rules:
     - if: $PIPELINE == "rococo"
   script:
@@ -290,7 +290,7 @@ publish-docker-polkadot:           &build-push-docker-image
 
 publish-docker-rococo:
   <<:                              *build-push-docker-image
-  stage:                           publish
+  stage:                           build
   rules:
     - if: $PIPELINE == "rococo"
   needs:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -102,63 +102,63 @@ check-line-width:
   interruptible:                   true
   allow_failure:                   true
 
-test-deterministic-wasm:
-  stage:                           test
-  <<:                              *docker-env
-  script:
-    - ./scripts/gitlab/test_deterministic_wasm.sh
+# test-deterministic-wasm:
+#   stage:                           test
+#   <<:                              *docker-env
+#   script:
+#     - ./scripts/gitlab/test_deterministic_wasm.sh
 
-test-linux-stable:                 &test
-  stage:                           test
-  <<:                              *test-refs
-  <<:                              *docker-env
-  <<:                              *compiler_info
-  variables:
-    RUST_TOOLCHAIN: stable
-    # Enable debug assertions since we are running optimized builds for testing
-    # but still want to have debug assertions.
-    RUSTFLAGS: "-Cdebug-assertions=y -Dwarnings"
-    TARGET: native
-  artifacts:
-    paths:
-      - ./target/release/polkadot
-  script:
-    - ./scripts/gitlab/test_linux_stable.sh
-    - sccache -s
+# test-linux-stable:                 &test
+#   stage:                           test
+#   <<:                              *test-refs
+#   <<:                              *docker-env
+#   <<:                              *compiler_info
+#   variables:
+#     RUST_TOOLCHAIN: stable
+#     # Enable debug assertions since we are running optimized builds for testing
+#     # but still want to have debug assertions.
+#     RUSTFLAGS: "-Cdebug-assertions=y -Dwarnings"
+#     TARGET: native
+#   artifacts:
+#     paths:
+#       - ./target/release/polkadot
+#   script:
+#     - ./scripts/gitlab/test_linux_stable.sh
+#     - sccache -s
 
-check-web-wasm:                    &test
-  stage:                           test
-  <<:                              *test-refs
-  <<:                              *docker-env
-  <<:                              *compiler_info
-  script:
-    # WASM support is in progress. As more and more crates support WASM, we
-    # should add entries here. See https://github.com/paritytech/polkadot/issues/625
-    - ./scripts/gitlab/check_web_wasm.sh
-    - sccache -s
+# check-web-wasm:                    &test
+#   stage:                           test
+#   <<:                              *test-refs
+#   <<:                              *docker-env
+#   <<:                              *compiler_info
+#   script:
+#     # WASM support is in progress. As more and more crates support WASM, we
+#     # should add entries here. See https://github.com/paritytech/polkadot/issues/625
+#     - ./scripts/gitlab/check_web_wasm.sh
+#     - sccache -s
 
-check-runtime-benchmarks:          &test
-  stage:                           test
-  <<:                              *test-refs
-  <<:                              *docker-env
-  <<:                              *compiler_info
-  script:
-    # Check that the node will compile with `runtime-benchmarks` feature flag.
-    - ./scripts/gitlab/check_runtime_benchmarks.sh
-    - sccache -s
+# check-runtime-benchmarks:          &test
+#   stage:                           test
+#   <<:                              *test-refs
+#   <<:                              *docker-env
+#   <<:                              *compiler_info
+#   script:
+#     # Check that the node will compile with `runtime-benchmarks` feature flag.
+#     - ./scripts/gitlab/check_runtime_benchmarks.sh
+#     - sccache -s
 
 #### stage:                        build
 
-check-transaction-versions:
-  image:                           node:15
-  stage:                           build
-  needs:
-    - job:                         test-linux-stable
-      artifacts:                   false
-  before_script:
-    - npm install -g @polkadot/metadata-cmp
-    - git fetch origin release
-  script: "scripts/gitlab/check_extrinsics_ordering.sh"
+# check-transaction-versions:
+#   image:                           node:15
+#   stage:                           build
+#   needs:
+#     - job:                         test-linux-stable
+#       artifacts:                   false
+#   before_script:
+#     - npm install -g @polkadot/metadata-cmp
+#     - git fetch origin release
+#   script: "scripts/gitlab/check_extrinsics_ordering.sh"
 
 build-wasm-release:
   stage:                           build
@@ -241,11 +241,9 @@ generate-impl-guide:
 
 .publish-build:                    &publish-build
   stage:                           publish
-  needs:
-    - job:                         build-linux-release
-      artifacts:                   true
-    - job:                         build-wasm-release
-      artifacts:                   true
+  dependencies:
+    - build-linux-release
+    - build-wasm-release
   <<:                              *build-refs
   <<:                              *kubernetes-env
   before_script:
@@ -292,10 +290,10 @@ publish-docker-polkadot:           &build-push-docker-image
 publish-docker-rococo:
   <<:                              *build-push-docker-image
   # can't be executed on PRs since registry credentials are protected
-  <<:                              *build-refs
-  needs:
-    - job:                         build-linux-rococo
-      artifacts:                   true
+  # <<:                              *build-refs
+  <<:                              *test-refs
+  dependencies:
+    - build-linux-rococo
   variables:
     GIT_STRATEGY:                  none
     # DOCKERFILE:                  scripts/docker/Dockerfile
@@ -350,12 +348,12 @@ check-labels:
   <<:                              *kubernetes-env
   rules:
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
-  needs:
-    # due to https://gitlab.com/gitlab-org/gitlab/-/issues/31264
-    # here we should list the non-manual jobs from the previous stage
-    - job:                         check-transaction-versions
-      artifacts:                   false
-    - job:                         generate-impl-guide
-      artifacts:                   false
+  # needs:
+  #   # due to https://gitlab.com/gitlab-org/gitlab/-/issues/31264
+  #   # here we should list the non-manual jobs from the previous stage
+  #   - job:                         check-transaction-versions
+  #     artifacts:                   false
+  #   - job:                         generate-impl-guide
+  #     artifacts:                   false
   script:
     - ./scripts/gitlab/check_labels.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -58,20 +58,35 @@ default:
     - cargo --version
     - sccache -s
 
-.build-refs:                       &build-refs
+.rules-build:                      &rules-build
   rules:
+    # Due to https://gitlab.com/gitlab-org/gitlab/-/issues/31264 there's no way to setup a manual
+    # build job so that publish-docker-rococo would "needs" build-linux-rococo job. This leads
+    # either to blocked or to forever running pipeline. It was decided to run these jobs from UI
+    # and on schedule.
+    #
+    # $PIPELINE should be passed in https://gitlab.parity.io/parity/polkadot/-/pipeline_schedules
+    # or other trigger to avoid running these jobs.
+    - if: $PIPELINE == "rococo"
+      when: never
     - if: $CI_PIPELINE_SOURCE == "web"
-    - if: $PIPELINE == "nightly" && $CI_PIPELINE_SOURCE == "schedule"
+    - if: $CI_PIPELINE_SOURCE == "schedule"
     - if: $CI_COMMIT_REF_NAME == "master"
     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
 
-.test-refs:                        &test-refs
+.rules-test:                       &rules-test
+  # these jobs run always*
   rules:
-    - if: $CI_PIPELINE_SOURCE == "web"
-    - if: $PIPELINE == "nightly" && $CI_PIPELINE_SOURCE == "schedule"
-    - if: $CI_COMMIT_REF_NAME == "master"
+    - if: $PIPELINE == "rococo"
+      when: never
+    - when: always
+
+.pr-only:                          &rules-pr-only
+  # these jobs run only on PRs
+  rules:
+    - if: $PIPELINE == "rococo"
+      when: never
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
-    - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
 
 #### stage:                        test
 
@@ -79,8 +94,7 @@ check-runtime:
   stage:                           test
   image:                           paritytech/tools:latest
   <<:                              *kubernetes-env
-  rules:
-    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
+  <<:                              *rules-pr-only
   variables:
     GITLAB_API:                    "https://gitlab.parity.io/api/v4"
     GITHUB_API_PROJECT:            "parity%2Finfrastructure%2Fgithub-api"
@@ -92,8 +106,7 @@ check-line-width:
   stage:                           test
   image:                           paritytech/tools:latest
   <<:                              *kubernetes-env
-  rules:
-    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
+  <<:                              *rules-pr-only
   script:
     - ./scripts/gitlab/check_line_width.sh
   allow_failure:                   true
@@ -104,9 +117,9 @@ check-line-width:
 #   script:
 #     - ./scripts/gitlab/test_deterministic_wasm.sh
 
-# test-linux-stable:                 &test
+# test-linux-stable:
 #   stage:                           test
-#   <<:                              *test-refs
+#   <<:                              *rules-test
 #   <<:                              *docker-env
 #   <<:                              *compiler-info
 #   variables:
@@ -122,9 +135,9 @@ check-line-width:
 #     - ./scripts/gitlab/test_linux_stable.sh
 #     - sccache -s
 
-# check-web-wasm:                    &test
+# check-web-wasm:
 #   stage:                           test
-#   <<:                              *test-refs
+#   <<:                              *rules-test
 #   <<:                              *docker-env
 #   <<:                              *compiler-info
 #   script:
@@ -133,9 +146,9 @@ check-line-width:
 #     - ./scripts/gitlab/check_web_wasm.sh
 #     - sccache -s
 
-# check-runtime-benchmarks:          &test
+# check-runtime-benchmarks:
 #   stage:                           test
-#   <<:                              *test-refs
+#   <<:                              *rules-test
 #   <<:                              *docker-env
 #   <<:                              *compiler-info
 #   script:
@@ -160,7 +173,7 @@ build-wasm-release:
   stage:                           build
   <<:                              *collect-artifacts
   <<:                              *docker-env
-  <<:                              *build-refs
+  <<:                              *rules-build
   <<:                              *compiler-info
   script:
     - time wasm-pack build --target web --out-dir wasm --release cli -- --no-default-features --features browser
@@ -169,20 +182,19 @@ build-wasm-release:
     - for f in polkadot_cli*; do sha256sum "${f}" > "${f}.sha256"; done
     - mv ./polkadot_cli* ../../artifacts/wasm/.
 
-build-linux-release:               &build
+build-linux-release:               &build-linux
   stage:                           build
   <<:                              *collect-artifacts
   <<:                              *docker-env
   <<:                              *compiler-info
   rules:
-    # .test-refs with manual on PRs
-    - if: $CI_PIPELINE_SOURCE == "web"
-    - if: $PIPELINE == "nightly" && $CI_PIPELINE_SOURCE == "schedule"
-    - if: $CI_COMMIT_REF_NAME == "master"
-    - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
+    # .rules-test with manual on PRs
+    - if: $PIPELINE == "rococo"
+      when: never
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
       when: manual
       allow_failure: true
+    - when: always
   script:
     - mkdir -p ./artifacts
     - VERSION="${CI_COMMIT_REF_NAME}" # will be tag or branch name
@@ -204,12 +216,9 @@ build-linux-release:               &build
     - cp -r scripts/docker/* ./artifacts
 
 build-linux-rococo:
-  <<:                              *build
+  <<:                              *build-linux
   stage:                           build
   rules:
-    # Due to https://gitlab.com/gitlab-org/gitlab/-/issues/31264 there's no way to setup a manual
-    # build job so that publish-docker-rococo would "needs" this job. This leads either to blocked
-    # or to forever running pipeline. It was decided to run these jobs from UI and on schedule.
     - if: $PIPELINE == "rococo"
   script:
     - mkdir -p ./artifacts
@@ -219,6 +228,7 @@ build-linux-rococo:
 
 generate-impl-guide:
   stage:                           build
+  # <<:                              *rules-test
   <<:                              *docker-env
   image:
     name: michaelfbryan/mdbook-docker-image:latest
@@ -241,7 +251,7 @@ publish-docker-polkadot:           &build-push-docker-image
   needs:
     - job:                         build-linux-release
       artifacts:                   true
-  <<:                              *build-refs
+  <<:                              *rules-build
   <<:                              *kubernetes-env
   <<:                              *publish-build
   image:                           quay.io/buildah/stable
@@ -250,7 +260,7 @@ publish-docker-polkadot:           &build-push-docker-image
   # .github/workflows/publish-docker-release.yml
   rules:
     - if: $CI_PIPELINE_SOURCE == "web"
-    - if: $PIPELINE == "nightly" && $CI_PIPELINE_SOURCE == "schedule"
+    - if: $CI_PIPELINE_SOURCE == "schedule"
     - if: $CI_COMMIT_REF_NAME == "master"
   variables:
     GIT_STRATEGY:                  none
@@ -296,7 +306,7 @@ publish-s3-release:
       artifacts:                   true
     - job:                         build-wasm-release
       artifacts:                   true
-  <<:                              *build-refs
+  <<:                              *rules-build
   <<:                              *kubernetes-env
   <<:                              *publish-build
   image:                           paritytech/awscli:latest
@@ -331,7 +341,7 @@ publish-s3-release:
 
 deploy-polkasync-kusama:
   stage:                           deploy
-  <<:                              *build-refs
+  <<:                              *rules-build
   variables:
     POLKADOT_CI_COMMIT_NAME:       "${CI_COMMIT_REF_NAME}"
     POLKADOT_CI_COMMIT_REF:        "${CI_COMMIT_REF}"
@@ -344,7 +354,6 @@ check-labels:
   stage:                           .post
   image:                           paritytech/tools:latest
   <<:                              *kubernetes-env
-  rules:
-    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
+  <<:                              *rules-pr-only
   script:
     - ./scripts/gitlab/check_labels.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -149,16 +149,16 @@ check-line-width:
 
 #### stage:                        build
 
-check-transaction-versions:
-  image:                           node:15
-  stage:                           build
-  needs:
-    - job:                         test-linux-stable
-      artifacts:                   false
-  before_script:
-    - npm install -g @polkadot/metadata-cmp
-    - git fetch origin release
-  script: "scripts/gitlab/check_extrinsics_ordering.sh"
+# check-transaction-versions:
+#   image:                           node:15
+#   stage:                           build
+#   needs:
+#     - job:                         test-linux-stable
+#       artifacts:                   false
+#   before_script:
+#     - npm install -g @polkadot/metadata-cmp
+#     - git fetch origin release
+#   script: "scripts/gitlab/check_extrinsics_ordering.sh"
 
 build-wasm-release:
   stage:                           build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,12 +13,10 @@ stages:
 
 image:                             paritytech/ci-linux:production
 
-# workflow:
-#   rules:
-#     - if: $CI_COMMIT_TAG
-#     - if: $CI_COMMIT_BRANCH
-#     - if: $CI_PIPELINE_SOURCE == "web"
-#     - if: $CI_PIPELINE_SOURCE == "schedule"
+workflow:
+  rules:
+    - if: $CI_COMMIT_TAG
+    - if: $CI_COMMIT_BRANCH
 
 variables:
   GIT_STRATEGY:                    fetch

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -65,9 +65,9 @@ default:
     # either to blocked or to forever running pipeline. It was decided to run these jobs from UI
     # and on schedule.
     #
-    # $PIPELIN3 should be passed in https://gitlab.parity.io/parity/polkadot/-/pipeline_schedules
+    # $PIPELINE should be passed in https://gitlab.parity.io/parity/polkadot/-/pipeline_schedules
     # or other trigger to avoid running these jobs.
-    - if: $PIPELIN3 == "rococo"
+    - if: $PIPELINE == "rococo"
       when: never
     - if: $CI_PIPELINE_SOURCE == "web"
     - if: $CI_PIPELINE_SOURCE == "schedule"
@@ -77,14 +77,14 @@ default:
 .rules-test:                       &rules-test
   # these jobs run always*
   rules:
-    - if: $PIPELIN3 == "rococo"
+    - if: $PIPELINE == "rococo"
       when: never
     - when: always
 
 .pr-only:                          &rules-pr-only
   # these jobs run only on PRs
   rules:
-    - if: $PIPELIN3 == "rococo"
+    - if: $PIPELINE == "rococo"
       when: never
     - if: $CI_PIPELINE_SOURCE == "schedule"
       when: never
@@ -113,63 +113,66 @@ check-line-width:
     - ./scripts/gitlab/check_line_width.sh
   allow_failure:                   true
 
-# test-deterministic-wasm:
-#   stage:                           test
-#   <<:                              *docker-env
-#   script:
-#     - ./scripts/gitlab/test_deterministic_wasm.sh
+test-deterministic-wasm:
+  stage:                           test
+  <<:                              *rules-test
+  <<:                              *docker-env
+  <<:                              *compiler-info
+  script:
+    - ./scripts/gitlab/test_deterministic_wasm.sh
 
-# test-linux-stable:
-#   stage:                           test
-#   <<:                              *rules-test
-#   <<:                              *docker-env
-#   <<:                              *compiler-info
-#   variables:
-#     RUST_TOOLCHAIN: stable
-#     # Enable debug assertions since we are running optimized builds for testing
-#     # but still want to have debug assertions.
-#     RUSTFLAGS: "-Cdebug-assertions=y -Dwarnings"
-#     TARGET: native
-#   artifacts:
-#     paths:
-#       - ./target/release/polkadot
-#   script:
-#     - ./scripts/gitlab/test_linux_stable.sh
-#     - sccache -s
+test-linux-stable:
+  stage:                           test
+  <<:                              *rules-test
+  <<:                              *docker-env
+  <<:                              *compiler-info
+  variables:
+    RUST_TOOLCHAIN: stable
+    # Enable debug assertions since we are running optimized builds for testing
+    # but still want to have debug assertions.
+    RUSTFLAGS: "-Cdebug-assertions=y -Dwarnings"
+    TARGET: native
+  artifacts:
+    paths:
+      - ./target/release/polkadot
+  script:
+    - ./scripts/gitlab/test_linux_stable.sh
+    - sccache -s
 
-# check-web-wasm:
-#   stage:                           test
-#   <<:                              *rules-test
-#   <<:                              *docker-env
-#   <<:                              *compiler-info
-#   script:
-#     # WASM support is in progress. As more and more crates support WASM, we
-#     # should add entries here. See https://github.com/paritytech/polkadot/issues/625
-#     - ./scripts/gitlab/check_web_wasm.sh
-#     - sccache -s
+check-web-wasm:
+  stage:                           test
+  <<:                              *rules-test
+  <<:                              *docker-env
+  <<:                              *compiler-info
+  script:
+    # WASM support is in progress. As more and more crates support WASM, we
+    # should add entries here. See https://github.com/paritytech/polkadot/issues/625
+    - ./scripts/gitlab/check_web_wasm.sh
+    - sccache -s
 
-# check-runtime-benchmarks:
-#   stage:                           test
-#   <<:                              *rules-test
-#   <<:                              *docker-env
-#   <<:                              *compiler-info
-#   script:
-#     # Check that the node will compile with `runtime-benchmarks` feature flag.
-#     - ./scripts/gitlab/check_runtime_benchmarks.sh
-#     - sccache -s
+check-runtime-benchmarks:
+  stage:                           test
+  <<:                              *rules-test
+  <<:                              *docker-env
+  <<:                              *compiler-info
+  script:
+    # Check that the node will compile with `runtime-benchmarks` feature flag.
+    - ./scripts/gitlab/check_runtime_benchmarks.sh
+    - sccache -s
 
 #### stage:                        build
 
-# check-transaction-versions:
-#   image:                           node:15
-#   stage:                           build
-#   needs:
-#     - job:                         test-linux-stable
-#       artifacts:                   false
-#   before_script:
-#     - npm install -g @polkadot/metadata-cmp
-#     - git fetch origin release
-#   script: "scripts/gitlab/check_extrinsics_ordering.sh"
+check-transaction-versions:
+  image:                           node:15
+  stage:                           build
+  needs:
+    - job:                         test-linux-stable
+      artifacts:                   false
+  before_script:
+    - npm install --ignore-scripts -g @polkadot/metadata-cmp
+    - git fetch origin release
+  script:
+    - scripts/gitlab/check_extrinsics_ordering.sh
 
 build-wasm-release:
   stage:                           build
@@ -208,7 +211,7 @@ build-linux-release:
   <<:                              *build-linux
   rules:
     # .rules-test with manual on PRs
-    - if: $PIPELIN3 == "rococo"
+    - if: $PIPELINE == "rococo"
       when: never
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
       when: manual
@@ -224,7 +227,7 @@ build-linux-rococo:
   stage:                           build
   <<:                              *build-linux
   rules:
-    - if: $PIPELIN3 == "rococo"
+    - if: $PIPELINE == "rococo"
   script:
     - mkdir -p ./artifacts
     - VERSION="${CI_COMMIT_REF_NAME}" # will be tag or branch name
@@ -280,7 +283,8 @@ publish-docker-polkadot:
   # .github/workflows/publish-docker-release.yml
   rules:
     - if: $CI_PIPELINE_SOURCE == "web"
-    - if: $CI_PIPELINE_SOURCE == "schedule" && $PIPELIN3 != "rococo"
+    # without this "&&" the pipeline scheduled with variable won't start 
+    - if: $CI_PIPELINE_SOURCE == "schedule" && $PIPELINE != "rococo"
     - if: $CI_COMMIT_REF_NAME == "master"
   needs:
     - job:                         build-linux-release
@@ -294,7 +298,7 @@ publish-docker-rococo:
   stage:                           publish
   <<:                              *build-push-docker-image
   rules:
-    - if: $PIPELIN3 == "rococo"
+    - if: $PIPELINE == "rococo"
   needs:
     - job:                         build-linux-rococo
       artifacts:                   true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -243,55 +243,55 @@ generate-impl-guide:
 
 #### stage:                        publish
 
-.publish-build:                    &publish-build
-  before_script:
-    - test -s ./artifacts/VERSION || exit 1
-    - test -s ./artifacts/EXTRATAG || exit 1
-    - VERSION="$(cat ./artifacts/VERSION)"
-    - EXTRATAG="$(cat ./artifacts/EXTRATAG)"
-    - echo "Polkadot version = ${VERSION} (EXTRATAG ${EXTRATAG})"
+# .publish-build:                    &publish-build
+#   before_script:
+#     - test -s ./artifacts/VERSION || exit 1
+#     - test -s ./artifacts/EXTRATAG || exit 1
+#     - VERSION="$(cat ./artifacts/VERSION)"
+#     - EXTRATAG="$(cat ./artifacts/EXTRATAG)"
+#     - echo "Polkadot version = ${VERSION} (EXTRATAG ${EXTRATAG})"
 
-.build-push-docker-image:          &build-push-docker-image
-  <<:                              *kubernetes-env
-  <<:                              *collect-artifacts
-  <<:                              *publish-build
-  image:                           quay.io/buildah/stable
-  script:
-    - test "$Docker_Hub_User_Parity" -a "$Docker_Hub_Pass_Parity" ||
-        ( echo "no docker credentials provided"; exit 1 )
-    - cd ./artifacts
-    - buildah bud
-        --format=docker
-        --build-arg VCS_REF="${CI_COMMIT_SHA}"
-        --build-arg BUILD_DATE="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
-        --tag "$IMAGE_NAME:$VERSION"
-        --tag "$IMAGE_NAME:$EXTRATAG" .
-    - echo "$Docker_Hub_Pass_Parity" |
-      buildah login --username "$Docker_Hub_User_Parity" --password-stdin docker.io
-    - buildah info
-    - buildah push --format=v2s2 "$IMAGE_NAME:$VERSION"
-    - buildah push --format=v2s2 "$IMAGE_NAME:$EXTRATAG"
-  after_script:
-    - buildah logout "$IMAGE_NAME"
-    # only VERSION information is needed for the deployment
-    - find ./artifacts/ -depth -not -name VERSION -not -name artifacts -delete
+# .build-push-docker-image:          &build-push-docker-image
+#   <<:                              *kubernetes-env
+#   <<:                              *collect-artifacts
+#   <<:                              *publish-build
+#   image:                           quay.io/buildah/stable
+#   script:
+#     - test "$Docker_Hub_User_Parity" -a "$Docker_Hub_Pass_Parity" ||
+#         ( echo "no docker credentials provided"; exit 1 )
+#     - cd ./artifacts
+#     - buildah bud
+#         --format=docker
+#         --build-arg VCS_REF="${CI_COMMIT_SHA}"
+#         --build-arg BUILD_DATE="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+#         --tag "$IMAGE_NAME:$VERSION"
+#         --tag "$IMAGE_NAME:$EXTRATAG" .
+#     - echo "$Docker_Hub_Pass_Parity" |
+#       buildah login --username "$Docker_Hub_User_Parity" --password-stdin docker.io
+#     - buildah info
+#     - buildah push --format=v2s2 "$IMAGE_NAME:$VERSION"
+#     - buildah push --format=v2s2 "$IMAGE_NAME:$EXTRATAG"
+#   after_script:
+#     - buildah logout "$IMAGE_NAME"
+#     # only VERSION information is needed for the deployment
+#     - find ./artifacts/ -depth -not -name VERSION -not -name artifacts -delete
 
-publish-docker-polkadot:
-  stage:                           publish
-  <<:                              *build-push-docker-image
-  # Don't run on releases - this is handled by the Github Action here:
-  # .github/workflows/publish-docker-release.yml
-  rules:
-    - if: $CI_PIPELINE_SOURCE == "web"
-    - if: $CI_PIPELINE_SOURCE == "schedule"
-    - if: $CI_COMMIT_REF_NAME == "master"
-  needs:
-    - job:                         build-linux-release
-      artifacts:                   true
-  variables:
-    GIT_STRATEGY:                  none
-    # DOCKERFILE:                  scripts/docker/Dockerfile
-    IMAGE_NAME:                    docker.io/parity/polkadot
+# publish-docker-polkadot:
+#   stage:                           publish
+#   <<:                              *build-push-docker-image
+#   # Don't run on releases - this is handled by the Github Action here:
+#   # .github/workflows/publish-docker-release.yml
+#   rules:
+#     - if: $CI_PIPELINE_SOURCE == "web"
+#     - if: $CI_PIPELINE_SOURCE == "schedule"
+#     - if: $CI_COMMIT_REF_NAME == "master"
+#   needs:
+#     - job:                         build-linux-release
+#       artifacts:                   true
+#   variables:
+#     GIT_STRATEGY:                  none
+#     # DOCKERFILE:                  scripts/docker/Dockerfile
+#     IMAGE_NAME:                    docker.io/parity/polkadot
 
 # publish-docker-rococo:
 #   stage:                           build
@@ -306,61 +306,61 @@ publish-docker-polkadot:
 #     # DOCKERFILE:                  scripts/docker/Dockerfile
 #     IMAGE_NAME:                    docker.io/parity/rococo
 
-publish-s3-release:
-  stage:                           publish
-  needs:
-    - job:                         build-linux-release
-      artifacts:                   true
-    - job:                         build-wasm-release
-      artifacts:                   true
-  <<:                              *rules-build
-  <<:                              *kubernetes-env
-  <<:                              *publish-build
-  image:                           paritytech/awscli:latest
-  variables:
-    GIT_STRATEGY:                  none
-    BUCKET:                        "releases.parity.io"
-    PREFIX:                        "polkadot/${ARCH}-${DOCKER_OS}"
-  script:
-    - echo "uploading objects to https://${BUCKET}/${PREFIX}/${VERSION}"
-    - aws s3 sync ./artifacts/ s3://${BUCKET}/${PREFIX}/${VERSION}/
-    - echo "update objects at https://${BUCKET}/${PREFIX}/${EXTRATAG}"
-    - find ./artifacts -type f | while read file; do
-      name="${file#./artifacts/}";
-      aws s3api copy-object
-        --copy-source ${BUCKET}/${PREFIX}/${VERSION}/${name}
-        --bucket ${BUCKET} --key ${PREFIX}/${EXTRATAG}/${name};
-      done
-    - |
-      cat <<-EOM
-      |
-      |  polkadot binary paths:
-      |
-      |  - https://${BUCKET}/${PREFIX}/${EXTRATAG}/polkadot
-      |  - https://${BUCKET}/${PREFIX}/${VERSION}/polkadot
-      |
-      EOM
-  after_script:
-    - aws s3 ls s3://${BUCKET}/${PREFIX}/${EXTRATAG}/
-        --recursive --human-readable --summarize
-
-# #### stage:                        deploy
-
-# deploy-polkasync-kusama:
-#   stage:                           deploy
+# publish-s3-release:
+#   stage:                           publish
+#   needs:
+#     - job:                         build-linux-release
+#       artifacts:                   true
+#     - job:                         build-wasm-release
+#       artifacts:                   true
 #   <<:                              *rules-build
-#   variables:
-#     POLKADOT_CI_COMMIT_NAME:       "${CI_COMMIT_REF_NAME}"
-#     POLKADOT_CI_COMMIT_REF:        "${CI_COMMIT_REF}"
-#   allow_failure:                   true
-#   trigger:                         "parity/infrastructure/parity-testnet"
-
-# #### stage:                        .post
-
-# check-labels:
-#   stage:                           .post
-#   image:                           paritytech/tools:latest
 #   <<:                              *kubernetes-env
-#   <<:                              *rules-pr-only
+#   <<:                              *publish-build
+#   image:                           paritytech/awscli:latest
+#   variables:
+#     GIT_STRATEGY:                  none
+#     BUCKET:                        "releases.parity.io"
+#     PREFIX:                        "polkadot/${ARCH}-${DOCKER_OS}"
 #   script:
-#     - ./scripts/gitlab/check_labels.sh
+#     - echo "uploading objects to https://${BUCKET}/${PREFIX}/${VERSION}"
+#     - aws s3 sync ./artifacts/ s3://${BUCKET}/${PREFIX}/${VERSION}/
+#     - echo "update objects at https://${BUCKET}/${PREFIX}/${EXTRATAG}"
+#     - find ./artifacts -type f | while read file; do
+#       name="${file#./artifacts/}";
+#       aws s3api copy-object
+#         --copy-source ${BUCKET}/${PREFIX}/${VERSION}/${name}
+#         --bucket ${BUCKET} --key ${PREFIX}/${EXTRATAG}/${name};
+#       done
+#     - |
+#       cat <<-EOM
+#       |
+#       |  polkadot binary paths:
+#       |
+#       |  - https://${BUCKET}/${PREFIX}/${EXTRATAG}/polkadot
+#       |  - https://${BUCKET}/${PREFIX}/${VERSION}/polkadot
+#       |
+#       EOM
+#   after_script:
+#     - aws s3 ls s3://${BUCKET}/${PREFIX}/${EXTRATAG}/
+#         --recursive --human-readable --summarize
+
+#### stage:                        deploy
+
+deploy-polkasync-kusama:
+  stage:                           deploy
+  <<:                              *rules-build
+  variables:
+    POLKADOT_CI_COMMIT_NAME:       "${CI_COMMIT_REF_NAME}"
+    POLKADOT_CI_COMMIT_REF:        "${CI_COMMIT_REF}"
+  allow_failure:                   true
+  trigger:                         "parity/infrastructure/parity-testnet"
+
+#### stage:                        .post
+
+check-labels:
+  stage:                           .post
+  image:                           paritytech/tools:latest
+  <<:                              *kubernetes-env
+  <<:                              *rules-pr-only
+  script:
+    - ./scripts/gitlab/check_labels.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -150,20 +150,21 @@ check-runtime-benchmarks:          &test
 #### stage:                        build
 
 check-transaction-versions:
-  image:                          node:15
-  stage:                          build
+  image:                           node:15
+  stage:                           build
   needs:
-    - job:                        test-linux-stable
+    - job:                         test-linux-stable
+      artifacts:                   false
   before_script:
     - npm install -g @polkadot/metadata-cmp
     - git fetch origin release
   script: "scripts/gitlab/check_extrinsics_ordering.sh"
 
 build-wasm-release:
-  stage:                          build
-  <<:                             *collect-artifacts
-  <<:                             *docker-env
-  <<:                             *compiler_info
+  stage:                           build
+  <<:                              *collect-artifacts
+  <<:                              *docker-env
+  <<:                              *compiler_info
   # Note: We likely only want to do this for tagged releases, hence the 'rules:'
   rules:
     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
@@ -291,7 +292,7 @@ publish-docker-polkadot:           &build-push-docker-image
 publish-docker-rococo:
   <<:                              *build-push-docker-image
   # can't be executed on PRs since registry credentials are protected
-  <<:                              *test-refs
+  <<:                              *build-refs
   needs:
     - job:                         build-linux-rococo
       artifacts:                   true
@@ -341,17 +342,19 @@ deploy-polkasync-kusama:
   allow_failure:                   true
   trigger:                         "parity/infrastructure/parity-testnet"
 
-#### stage:                       .post
+#### stage:                        .post
 
 check-labels:
-  stage:                          .post
-  image:                          paritytech/tools:latest
-  <<:                             *kubernetes-env
+  stage:                           .post
+  image:                           paritytech/tools:latest
+  <<:                              *kubernetes-env
   rules:
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
   needs:
     # due to https://gitlab.com/gitlab-org/gitlab/-/issues/31264
     # here we should list the non-manual jobs from the previous stage
+    - job:                         check-transaction-versions
+      artifacts:                   false
     - job:                         generate-impl-guide
       artifacts:                   false
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -253,7 +253,7 @@ generate-impl-guide:
   <<:                              *kubernetes-env
   <<:                              *collect-artifacts
   image:                           quay.io/buildah/stable
-  before_script:                   &unpack-artifacts
+  before_script:
     - test -s ./artifacts/VERSION || exit 1
     - test -s ./artifacts/EXTRATAG || exit 1
     - VERSION="$(cat ./artifacts/VERSION)"
@@ -326,7 +326,11 @@ publish-s3-release:
     BUCKET:                        "releases.parity.io"
     PREFIX:                        "polkadot/${ARCH}-${DOCKER_OS}"
   before_script:
-    - *unpack-artifacts
+    - test -s ./artifacts/VERSION || exit 1
+    - test -s ./artifacts/EXTRATAG || exit 1
+    - VERSION="$(cat ./artifacts/VERSION)"
+    - EXTRATAG="$(cat ./artifacts/EXTRATAG)"
+    - echo "Polkadot version = ${VERSION} (EXTRATAG ${EXTRATAG})"
   script:
     - echo "uploading objects to https://${BUCKET}/${PREFIX}/${VERSION}"
     - aws s3 sync ./artifacts/ s3://${BUCKET}/${PREFIX}/${VERSION}/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -351,8 +351,8 @@ check-labels:
   needs:
     # due to https://gitlab.com/gitlab-org/gitlab/-/issues/31264
     # here we should list the non-manual jobs from the previous stage
-    - job:                         check-transaction-versions
-      artifacts:                   false
+    # - job:                         check-transaction-versions
+    #   artifacts:                   false
     - job:                         generate-impl-guide
       artifacts:                   false
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -184,24 +184,10 @@ build-wasm-release:
     - for f in polkadot_cli*; do sha256sum "${f}" > "${f}.sha256"; done
     - mv ./polkadot_cli* ../../artifacts/wasm/.
 
-build-linux-release:               &build-linux
-  stage:                           build
+.build-linux:                      &build-linux
   <<:                              *collect-artifacts
   <<:                              *docker-env
   <<:                              *compiler-info
-  rules:
-    # .rules-test with manual on PRs
-    - if: $PIPELINE == "rococo"
-      when: never
-    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
-      when: manual
-      allow_failure: true
-    - when: always
-  script:
-    - mkdir -p ./artifacts
-    - VERSION="${CI_COMMIT_REF_NAME}" # will be tag or branch name
-    - time cargo build --release --verbose
-    - sccache -s
   after_script:
     - mv ./target/release/polkadot ./artifacts/.
     - sha256sum ./artifacts/polkadot | tee ./artifacts/polkadot.sha256
@@ -217,9 +203,26 @@ build-linux-release:               &build-linux
     - echo -n ${EXTRATAG} > ./artifacts/EXTRATAG
     - cp -r scripts/docker/* ./artifacts
 
-build-linux-rococo:
+build-linux-release:
+  stage:                           build
   <<:                              *build-linux
+  rules:
+    # .rules-test with manual on PRs
+    - if: $PIPELINE == "rococo"
+      when: never
+    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
+      when: manual
+      allow_failure: true
+    - when: always
+  script:
+    - mkdir -p ./artifacts
+    - VERSION="${CI_COMMIT_REF_NAME}" # will be tag or branch name
+    - time cargo build --release --verbose
+    - sccache -s
+
+build-linux-rococo:
   stage:                           test
+  <<:                              *build-linux
   rules:
     - if: $PIPELINE == "rococo"
   script:
@@ -248,26 +251,11 @@ generate-impl-guide:
     - EXTRATAG="$(cat ./artifacts/EXTRATAG)"
     - echo "Polkadot version = ${VERSION} (EXTRATAG ${EXTRATAG})"
 
-publish-docker-polkadot:           &build-push-docker-image
-  stage:                           publish
-  needs:
-    - job:                         build-linux-release
-      artifacts:                   true
-  <<:                              *rules-build
+.build-push-docker-image:          &build-push-docker-image
   <<:                              *kubernetes-env
+  <<:                              *collect-artifacts
   <<:                              *publish-build
   image:                           quay.io/buildah/stable
-  <<:                              *collect-artifacts
-  # Don't run on releases - this is handled by the Github Action here:
-  # .github/workflows/publish-docker-release.yml
-  rules:
-    - if: $CI_PIPELINE_SOURCE == "web"
-    - if: $CI_PIPELINE_SOURCE == "schedule"
-    - if: $CI_COMMIT_REF_NAME == "master"
-  variables:
-    GIT_STRATEGY:                  none
-    # DOCKERFILE:                  scripts/docker/Dockerfile
-    IMAGE_NAME:                    docker.io/parity/polkadot
   script:
     - test "$Docker_Hub_User_Parity" -a "$Docker_Hub_Pass_Parity" ||
         ( echo "no docker credentials provided"; exit 1 )
@@ -288,9 +276,26 @@ publish-docker-polkadot:           &build-push-docker-image
     # only VERSION information is needed for the deployment
     - find ./artifacts/ -depth -not -name VERSION -not -name artifacts -delete
 
-publish-docker-rococo:
+publish-docker-polkadot:
+  stage:                           publish
   <<:                              *build-push-docker-image
+  # Don't run on releases - this is handled by the Github Action here:
+  # .github/workflows/publish-docker-release.yml
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "web"
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+    - if: $CI_COMMIT_REF_NAME == "master"
+  needs:
+    - job:                         build-linux-release
+      artifacts:                   true
+  variables:
+    GIT_STRATEGY:                  none
+    # DOCKERFILE:                  scripts/docker/Dockerfile
+    IMAGE_NAME:                    docker.io/parity/polkadot
+
+publish-docker-rococo:
   stage:                           build
+  <<:                              *build-push-docker-image
   rules:
     - if: $PIPELINE == "rococo"
   needs:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -285,9 +285,9 @@ publish-docker-rococo:
   stage:                           build
   # rules:
   #   - if: $IMAGE == "rococo"
-  needs:
-    - job:                         build-linux-rococo
-      artifacts:                   true
+  # needs:
+  #   - job:                         build-linux-rococo
+  #     artifacts:                   true
   variables:
     GIT_STRATEGY:                  none
     # DOCKERFILE:                  scripts/docker/Dockerfile

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -224,7 +224,7 @@ build-linux-rococo:
   stage:                           test
   <<:                              *build-linux
   rules:
-    - if: $PIPELINE
+    - if: $PIPELINE =~ "rococo"
   script:
     - mkdir -p ./artifacts
     - VERSION="${CI_COMMIT_REF_NAME}" # will be tag or branch name

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -218,13 +218,10 @@ build-linux-rococo:
     - if: $CI_PIPELINE_SOURCE == "schedule"
     - if: $CI_COMMIT_REF_NAME == "master"
       when: manual
-      allow_failure: true
     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
       when: manual
-      allow_failure: true
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
       when: manual
-      allow_failure: true
   script:
     - time cargo build --release --verbose --features=real-overseer
     - sccache -s

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,6 +41,7 @@ default:
     - kubernetes-parity-build
   environment:
     name: parity-build
+  interruptible:                   true
 
 .docker-env:                       &docker-env
   retry:
@@ -88,7 +89,6 @@ check-runtime:
     GITHUB_API_PROJECT:            "parity%2Finfrastructure%2Fgithub-api"
   script:
     - ./scripts/gitlab/check_runtime.sh
-  interruptible:                   true
   allow_failure:                   true
 
 check-line-width:
@@ -99,7 +99,6 @@ check-line-width:
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
   script:
     - ./scripts/gitlab/check_line_width.sh
-  interruptible:                   true
   allow_failure:                   true
 
 # test-deterministic-wasm:
@@ -349,12 +348,12 @@ check-labels:
   <<:                              *kubernetes-env
   rules:
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
-  # needs:
-  #   # due to https://gitlab.com/gitlab-org/gitlab/-/issues/31264
-  #   # here we should list the non-manual jobs from the previous stage
-  #   - job:                         check-transaction-versions
-  #     artifacts:                   false
-  #   - job:                         generate-impl-guide
-  #     artifacts:                   false
+  needs:
+    # due to https://gitlab.com/gitlab-org/gitlab/-/issues/31264
+    # here we should list the non-manual jobs from the previous stage
+    - job:                         check-transaction-versions
+      artifacts:                   false
+    - job:                         generate-impl-guide
+      artifacts:                   false
   script:
     - ./scripts/gitlab/check_labels.sh


### PR DESCRIPTION
- build `rococo` binary, manually from https://gitlab.parity.io/parity/polkadot/-/pipeline_schedules
- publishes this image to `docker.io/parity/rococo` with `latest` and `$VERSION` tags
- full CI overhaul (sorry for doing it here, but otherwise it wasn't possible)
- add `--ignore-scripts` to `npm install` as required by https://github.com/paritytech/ci_cd/issues/82
- remove `web-wasm` publishing cc https://github.com/paritytech/devops/issues/401 as it's no longer needed

tests:
master - https://gitlab.parity.io/TriplEight/polkadot/-/pipelines/119714 (without deploy because it triggers the other project)
tag - https://gitlab.parity.io/TriplEight/polkadot/-/pipelines/119717
rococo release - https://gitlab.parity.io/TriplEight/polkadot/-/pipelines/119716
and PR - https://gitlab.parity.io/parity/polkadot/-/pipelines/119719