### PR TITLE
Optimizations of av-store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3354,9 +3354,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be716eb6878ca2263eb5d00a781aa13264a794f519fe6af4fbb2668b2d5441c0"
+checksum = "3aae342b73d57ad0b8b364bd12584819f2c1fe9114285dfcf8b0722607671635"
 dependencies = [
  "hashbrown",
 ]
@@ -5051,6 +5051,7 @@ dependencies = [
  "kvdb-memorydb",
  "kvdb-rocksdb",
  "log",
+ "lru",
  "parity-scale-codec",
  "polkadot-erasure-coding",
  "polkadot-node-subsystem",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5051,7 +5051,6 @@ dependencies = [
  "kvdb-memorydb",
  "kvdb-rocksdb",
  "log",
- "lru",
  "parity-scale-codec",
  "polkadot-erasure-coding",
  "polkadot-node-subsystem",

--- a/node/core/av-store/Cargo.toml
+++ b/node/core/av-store/Cargo.toml
@@ -21,6 +21,7 @@ polkadot-overseer = { path = "../../overseer" }
 polkadot-primitives = { path = "../../../primitives" }
 
 sc-service = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+lru = "0.6.3"
 
 [dev-dependencies]
 log = "0.4.11"

--- a/node/core/av-store/Cargo.toml
+++ b/node/core/av-store/Cargo.toml
@@ -21,7 +21,6 @@ polkadot-overseer = { path = "../../overseer" }
 polkadot-primitives = { path = "../../../primitives" }
 
 sc-service = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-lru = "0.6.3"
 
 [dev-dependencies]
 log = "0.4.11"

--- a/node/core/av-store/src/tests.rs
+++ b/node/core/av-store/src/tests.rs
@@ -235,7 +235,6 @@ fn store_chunk_works() {
 		let chunk_msg = AvailabilityStoreMessage::StoreChunk {
 			candidate_hash,
 			relay_parent,
-			validator_index,
 			chunk: chunk.clone(),
 			tx,
 		};
@@ -385,7 +384,6 @@ fn stored_but_not_included_chunk_is_pruned() {
 		let chunk_msg = AvailabilityStoreMessage::StoreChunk {
 			candidate_hash,
 			relay_parent,
-			validator_index,
 			chunk: chunk.clone(),
 			tx,
 		};
@@ -589,7 +587,6 @@ fn stored_chunk_kept_until_finalized() {
 		let chunk_msg = AvailabilityStoreMessage::StoreChunk {
 			candidate_hash,
 			relay_parent,
-			validator_index,
 			chunk: chunk.clone(),
 			tx,
 		};

--- a/node/network/availability-distribution/src/lib.rs
+++ b/node/network/availability-distribution/src/lib.rs
@@ -1024,7 +1024,6 @@ where
 		AvailabilityStoreMessage::StoreChunk {
 			candidate_hash,
 			relay_parent,
-			validator_index,
 			chunk: erasure_chunk,
 			tx,
 		}

--- a/node/subsystem/src/messages.rs
+++ b/node/subsystem/src/messages.rs
@@ -309,8 +309,6 @@ pub enum AvailabilityStoreMessage {
 		candidate_hash: CandidateHash,
 		/// A relevant relay parent.
 		relay_parent: Hash,
-		/// The index of the validator this chunk belongs to.
-		validator_index: ValidatorIndex,
 		/// The chunk itself.
 		chunk: ErasureChunk,
 		/// Sending side of the channel to send result to.

--- a/roadmap/implementers-guide/src/types/overseer-protocol.md
+++ b/roadmap/implementers-guide/src/types/overseer-protocol.md
@@ -174,9 +174,9 @@ enum AvailabilityStoreMessage {
 	/// Query a specific availability chunk of the candidate's erasure-coding by validator index.
 	/// Returns the chunk and its inclusion proof against the candidate's erasure-root.
 	QueryChunk(CandidateHash, ValidatorIndex, ResponseChannel<Option<AvailabilityChunkAndProof>>),
-	/// Store a specific chunk of the candidate's erasure-coding by validator index, with an
+	/// Store a specific chunk of the candidate's erasure-coding, with an
 	/// accompanying proof.
-	StoreChunk(CandidateHash, ValidatorIndex, AvailabilityChunkAndProof, ResponseChannel<Result<()>>),
+	StoreChunk(CandidateHash, AvailabilityChunkAndProof, ResponseChannel<Result<()>>),
 	/// Store `AvailableData`. If `ValidatorIndex` is provided, also store this validator's
 	/// `AvailabilityChunkAndProof`.
 	StoreAvailableData(CandidateHash, Option<ValidatorIndex>, u32, AvailableData, ResponseChannel<Result<()>>),


### PR DESCRIPTION
Fixes #2211 

1. Compute and store all chunks at once.
2. Use LruCache for chunks
3. Also add two metrics for the sizes of pruning records.