### PR TITLE
Add an optional verifier to crowdloan

### DIFF
--- a/runtime/common/src/crowdloan.rs
+++ b/runtime/common/src/crowdloan.rs
@@ -1616,7 +1616,7 @@ mod benchmarking {
 			let caller: T::AccountId = whitelisted_caller();
 
 			T::Currency::make_free_balance_be(&caller, BalanceOf::<T>::max_value());
-		}: _(RawOrigin::Signed(caller), cap, first_slot, last_slot, end)
+		}: _(RawOrigin::Signed(caller), cap, first_slot, last_slot, end, None)
 		verify {
 			assert_last_event::<T>(RawEvent::Created(FundCount::get() - 1).into())
 		}
@@ -1627,7 +1627,7 @@ mod benchmarking {
 			let caller: T::AccountId = whitelisted_caller();
 			let contribution = T::MinContribution::get();
 			T::Currency::make_free_balance_be(&caller, BalanceOf::<T>::max_value());
-		}: _(RawOrigin::Signed(caller.clone()), fund_index, contribution, caller.clone())
+		}: _(RawOrigin::Signed(caller.clone()), fund_index, contribution, caller.clone(), None)
 		verify {
 			// NewRaise is appended to, so we don't need to fill it up for worst case scenario.
 			assert!(!NewRaise::get().is_empty());

--- a/runtime/common/src/crowdloan.rs
+++ b/runtime/common/src/crowdloan.rs
@@ -1538,14 +1538,14 @@ mod benchmarking {
 		let caller = account("fund_creator", 0, 0);
 		T::Currency::make_free_balance_be(&caller, BalanceOf::<T>::max_value());
 
-		assert_ok!(Crowdloan::<T>::create(RawOrigin::Signed(caller).into(), cap, first_slot, last_slot, end));
+		assert_ok!(Crowdloan::<T>::create(RawOrigin::Signed(caller).into(), cap, first_slot, last_slot, end, None));
 		FundCount::get() - 1
 	}
 
 	fn contribute_fund<T: Config>(who: &T::AccountId, index: FundIndex) {
 		T::Currency::make_free_balance_be(&who, BalanceOf::<T>::max_value());
 		let value = T::MinContribution::get();
-		assert_ok!(Crowdloan::<T>::contribute(RawOrigin::Signed(who.clone()).into(), index, value, who.clone()));
+		assert_ok!(Crowdloan::<T>::contribute(RawOrigin::Signed(who.clone()).into(), index, value, who.clone(), None));
 	}
 
 	fn worst_validation_code<T: Config>() -> Vec<u8> {
@@ -1716,7 +1716,7 @@ mod benchmarking {
 				let contributor: T::AccountId = account("contributor", i, 0);
 				let contribution = T::MinContribution::get() * (i + 1).into();
 				T::Currency::make_free_balance_be(&contributor, BalanceOf::<T>::max_value());
-				Crowdloan::<T>::contribute(RawOrigin::Signed(contributor).into(), fund_index, contribution, Default::default())?;
+				Crowdloan::<T>::contribute(RawOrigin::Signed(contributor).into(), fund_index, contribution, Default::default(), None)?;
 			}
 
 			let lease_period_index = end_block / T::LeasePeriod::get();

--- a/runtime/common/src/crowdloan.rs
+++ b/runtime/common/src/crowdloan.rs
@@ -111,8 +111,11 @@ pub trait Config: slots::Config {
 	/// Max number of storage keys to remove per extrinsic call.
 	type RemoveKeysLimit: Get<u32>;
 
+	/// The Signer type for contribution validation.
 	type ContributionSigner: IdentifyAccount<AccountId = Self::AccountId>;
-	type ContributionVerifier: Verify<Signer = Self::ContributionSigner> + Parameter;
+
+	/// The Signature type for contribution validation.
+	type ContributionSignature: Verify<Signer = Self::ContributionSigner> + Parameter;
 }
 
 /// Simple index for identifying a fund.
@@ -321,8 +324,15 @@ decl_module! {
 		/// Contribute to a crowd sale. This will transfer some balance over to fund a parachain
 		/// slot. It will be withdrawable in two instances: the parachain becomes retired; or the
 		/// slot is unable to be purchased and the timeout expires.
+		/// A valid signature maybe required in order to accept the contribution.
 		#[weight = 0]
-		fn contribute(origin, #[compact] index: FundIndex, #[compact] value: BalanceOf<T>, return_to: T::AccountId, signature: Option<T::ContributionVerifier>) {
+		fn contribute(
+			origin,
+			#[compact] index: FundIndex,
+			#[compact] value: BalanceOf<T>,
+			return_to: T::AccountId,
+			signature: Option<T::ContributionSignature>
+		) {
 			let who = ensure_signed(origin)?;
 
 			ensure!(value >= T::MinContribution::get(), Error::<T>::ContributionTooSmall);

--- a/runtime/common/src/crowdloan.rs
+++ b/runtime/common/src/crowdloan.rs
@@ -1513,7 +1513,7 @@ mod benchmarking {
 	fn contribute_fund<T: Config>(who: &T::AccountId, index: FundIndex) {
 		T::Currency::make_free_balance_be(&who, BalanceOf::<T>::max_value());
 		let value = T::MinContribution::get();
-		assert_ok!(Crowdloan::<T>::contribute(RawOrigin::Signed(who.clone()).into(), index, value));
+		assert_ok!(Crowdloan::<T>::contribute(RawOrigin::Signed(who.clone()).into(), index, value, None));
 	}
 
 	fn worst_validation_code<T: Config>() -> Vec<u8> {


### PR DESCRIPTION
This will allow crowd loan owner to enforce any custom policy offchain for contributors by requiring a valid signature before accept a contribution.

TODOs:
- [x] docs
- [ ] test
- [x] think about replay attack

Based on #2166