### PR TITLE
parity-scale-codec 1.3.5 -> 1.3.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4498,9 +4498,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "1.3.5"
+version = "1.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c740e5fbcb6847058b40ac7e5574766c6388f585e184d769910fe0d3a2ca861"
+checksum = "79602888a81ace83e3d1d4b2873286c1f5f906c84db667594e8db8da3506c383"
 dependencies = [
  "arrayvec 0.5.2",
  "bitvec",

--- a/core-primitives/Cargo.toml
+++ b/core-primitives/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 sp-std = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-parity-scale-codec = { version = "1.3.5", default-features = false, features = [ "derive" ] }
+parity-scale-codec = { version = "1.3.6", default-features = false, features = [ "derive" ] }
 
 [features]
 default = [ "std" ]

--- a/erasure-coding/Cargo.toml
+++ b/erasure-coding/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 primitives = { package = "polkadot-primitives", path = "../primitives" }
 reed_solomon = { package = "reed-solomon-erasure", version = "4.0.2" }
-parity-scale-codec = { version = "1.3.5", default-features = false, features = ["derive"] }
+parity-scale-codec = { version = "1.3.6", default-features = false, features = ["derive"] }
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
 trie = { package = "sp-trie", git = "https://github.com/paritytech/substrate", branch = "master" }
 thiserror = "1.0.23"

--- a/node/core/av-store/Cargo.toml
+++ b/node/core/av-store/Cargo.toml
@@ -13,7 +13,7 @@ thiserror = "1.0.23"
 tracing = "0.1.22"
 tracing-futures = "0.2.4"
 
-parity-scale-codec = { version = "1.3.5", features = ["derive"] }
+parity-scale-codec = { version = "1.3.6", features = ["derive"] }
 erasure = { package = "polkadot-erasure-coding", path = "../../../erasure-coding" }
 polkadot-subsystem = { package = "polkadot-node-subsystem", path = "../../subsystem" }
 polkadot-node-subsystem-util = { path = "../../subsystem-util" }

--- a/node/core/candidate-validation/Cargo.toml
+++ b/node/core/candidate-validation/Cargo.toml
@@ -10,7 +10,7 @@ tracing = "0.1.22"
 tracing-futures = "0.2.4"
 
 sp-core = { package = "sp-core", git = "https://github.com/paritytech/substrate", branch = "master" }
-parity-scale-codec = { version = "1.3.5", default-features = false, features = ["bit-vec", "derive"] }
+parity-scale-codec = { version = "1.3.6", default-features = false, features = ["bit-vec", "derive"] }
 
 polkadot-primitives = { path = "../../../primitives" }
 polkadot-parachain = { path = "../../../parachain" }

--- a/node/network/availability-distribution/Cargo.toml
+++ b/node/network/availability-distribution/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 futures = "0.3.8"
 tracing = "0.1.22"
 tracing-futures = "0.2.4"
-parity-scale-codec = { version = "1.3.5", features = ["std"]  }
+parity-scale-codec = { version = "1.3.6", features = ["std"]  }
 polkadot-primitives = { path = "../../../primitives" }
 polkadot-erasure-coding = { path = "../../../erasure-coding" }
 polkadot-subsystem = { package = "polkadot-node-subsystem", path = "../../subsystem" }

--- a/node/network/bitfield-distribution/Cargo.toml
+++ b/node/network/bitfield-distribution/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 futures = "0.3.8"
 tracing = "0.1.22"
 tracing-futures = "0.2.4"
-parity-scale-codec = { version = "1.3.5", default-features = false, features = ["derive"] }
+parity-scale-codec = { version = "1.3.6", default-features = false, features = ["derive"] }
 polkadot-primitives = { path = "../../../primitives" }
 polkadot-subsystem = { package = "polkadot-node-subsystem", path = "../../subsystem" }
 polkadot-node-subsystem-util = { path = "../../subsystem-util" }

--- a/node/network/bridge/Cargo.toml
+++ b/node/network/bridge/Cargo.toml
@@ -10,7 +10,7 @@ futures = "0.3.8"
 tracing = "0.1.22"
 tracing-futures = "0.2.4"
 polkadot-primitives = { path = "../../../primitives" }
-parity-scale-codec = { version = "1.3.5", default-features = false, features = ["derive"] }
+parity-scale-codec = { version = "1.3.6", default-features = false, features = ["derive"] }
 sc-authority-discovery = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sc-network = { git = "https://github.com/paritytech/substrate", branch = "master" }
 polkadot-subsystem = { package = "polkadot-node-subsystem", path = "../../subsystem" }

--- a/node/network/protocol/Cargo.toml
+++ b/node/network/protocol/Cargo.toml
@@ -9,5 +9,5 @@ description = "Primitives types for the Node-side"
 polkadot-primitives = { path = "../../../primitives" }
 polkadot-node-primitives = { path = "../../primitives" }
 polkadot-node-jaeger = { path = "../../jaeger" }
-parity-scale-codec = { version = "1.3.5", default-features = false, features = ["derive"] }
+parity-scale-codec = { version = "1.3.6", default-features = false, features = ["derive"] }
 sc-network = { git = "https://github.com/paritytech/substrate", branch = "master" }

--- a/node/primitives/Cargo.toml
+++ b/node/primitives/Cargo.toml
@@ -9,7 +9,7 @@ description = "Primitives types for the Node-side"
 futures = "0.3.8"
 polkadot-primitives = { path = "../../primitives" }
 polkadot-statement-table = { path = "../../statement-table" }
-parity-scale-codec = { version = "1.3.5", default-features = false, features = ["derive"] }
+parity-scale-codec = { version = "1.3.6", default-features = false, features = ["derive"] }
 runtime_primitives = { package = "sp-runtime", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sp-consensus-vrf = { git = "https://github.com/paritytech/substrate", branch = "master" }

--- a/node/subsystem-test-helpers/Cargo.toml
+++ b/node/subsystem-test-helpers/Cargo.toml
@@ -11,7 +11,7 @@ futures = "0.3.8"
 futures-timer = "3.0.2"
 tracing = "0.1.22"
 tracing-futures = "0.2.4"
-parity-scale-codec = { version = "1.3.5", default-features = false, features = ["derive"] }
+parity-scale-codec = { version = "1.3.6", default-features = false, features = ["derive"] }
 parking_lot = "0.11.1"
 pin-project = "1.0.3"
 polkadot-node-primitives = { path = "../primitives" }

--- a/node/subsystem-util/Cargo.toml
+++ b/node/subsystem-util/Cargo.toml
@@ -9,7 +9,7 @@ description = "Subsystem traits and message definitions"
 async-trait = "0.1.42"
 futures = "0.3.8"
 futures-timer = "3.0.2"
-parity-scale-codec = { version = "1.3.5", default-features = false, features = ["derive"] }
+parity-scale-codec = { version = "1.3.6", default-features = false, features = ["derive"] }
 parking_lot = { version = "0.11.1", optional = true }
 pin-project = "1.0.3"
 streamunordered = "0.5.1"

--- a/node/subsystem/Cargo.toml
+++ b/node/subsystem/Cargo.toml
@@ -15,7 +15,7 @@ mick-jaeger = "0.1.2"
 lazy_static = "1.4"
 tracing = "0.1.22"
 tracing-futures = "0.2.4"
-parity-scale-codec = { version = "1.3.5", default-features = false, features = ["derive"] }
+parity-scale-codec = { version = "1.3.6", default-features = false, features = ["derive"] }
 parking_lot = "0.11.1"
 pin-project = "1.0.3"
 polkadot-node-primitives = { path = "../primitives" }

--- a/node/test/client/Cargo.toml
+++ b/node/test/client/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 
 [dependencies]
-parity-scale-codec = { version = "1.3.5", default-features = false, features = ["derive"] }
+parity-scale-codec = { version = "1.3.6", default-features = false, features = ["derive"] }
 
 # Polkadot dependencies
 polkadot-test-runtime = { path = "../../../runtime/test-runtime" }

--- a/parachain/Cargo.toml
+++ b/parachain/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 # note: special care is taken to avoid inclusion of `sp-io` externals when compiling
 # this crate for WASM. This is critical to avoid forcing all parachain WASM into implementing
 # various unnecessary Substrate-specific endpoints.
-parity-scale-codec = { version = "1.3.5", default-features = false, features = [ "derive" ] }
+parity-scale-codec = { version = "1.3.6", default-features = false, features = [ "derive" ] }
 sp-std = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }

--- a/parachain/test-parachains/Cargo.toml
+++ b/parachain/test-parachains/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 tiny-keccak = "2.0.2"
-parity-scale-codec = { version = "1.3.5", default-features = false, features = ["derive"] }
+parity-scale-codec = { version = "1.3.6", default-features = false, features = ["derive"] }
 
 parachain = { package = "polkadot-parachain", path = ".." }
 adder = { package = "test-parachain-adder", path = "adder" }

--- a/parachain/test-parachains/adder/Cargo.toml
+++ b/parachain/test-parachains/adder/Cargo.toml
@@ -8,7 +8,7 @@ build = "build.rs"
 
 [dependencies]
 parachain = { package = "polkadot-parachain", path = "../../", default-features = false, features = [ "wasm-api" ] }
-parity-scale-codec = { version = "1.3.5", default-features = false, features = ["derive"] }
+parity-scale-codec = { version = "1.3.6", default-features = false, features = ["derive"] }
 sp-std = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 tiny-keccak = { version = "2.0.2", features = ["keccak"] }
 dlmalloc = { version = "0.2.1", features = [ "global" ] }

--- a/parachain/test-parachains/adder/collator/Cargo.toml
+++ b/parachain/test-parachains/adder/collator/Cargo.toml
@@ -10,7 +10,7 @@ name = "adder-collator"
 path = "src/main.rs"
 
 [dependencies]
-parity-scale-codec = { version = "1.3.5", default-features = false, features = ["derive"] }
+parity-scale-codec = { version = "1.3.6", default-features = false, features = ["derive"] }
 futures = "0.3.8"
 futures-timer = "3.0.2"
 log = "0.4.11"

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 serde = { version = "1.0.118", optional = true, features = ["derive"] }
-parity-scale-codec = { version = "1.3.5", default-features = false, features = ["bit-vec", "derive"] }
+parity-scale-codec = { version = "1.3.6", default-features = false, features = ["bit-vec", "derive"] }
 primitives = { package = "sp-core", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 application-crypto = { package = "sp-application-crypto", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -26,5 +26,5 @@ sc-sync-state-rpc = { git = "https://github.com/paritytech/substrate", branch = 
 txpool-api = { package = "sp-transaction-pool", git = "https://github.com/paritytech/substrate", branch = "master" }
 frame-rpc-system = { package = "substrate-frame-rpc-system", git = "https://github.com/paritytech/substrate", branch = "master"  }
 pallet-transaction-payment-rpc = { git = "https://github.com/paritytech/substrate", branch = "master" }
-parity-scale-codec = { version = "1.3.5", default-features = false }
+parity-scale-codec = { version = "1.3.6", default-features = false }
 sp-block-builder = { git = "https://github.com/paritytech/substrate", branch = "master" }

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 bitvec = { version = "0.17.4", default-features = false, features = ["alloc"] }
-parity-scale-codec = { version = "1.3.5", default-features = false, features = ["derive"] }
+parity-scale-codec = { version = "1.3.6", default-features = false, features = ["derive"] }
 log = { version = "0.4.11", optional = true }
 rustc-hex = { version = "2.1.0", default-features = false }
 serde = { version = "1.0.118", default-features = false }

--- a/runtime/kusama/Cargo.toml
+++ b/runtime/kusama/Cargo.toml
@@ -7,7 +7,7 @@ build = "build.rs"
 
 [dependencies]
 bitvec = { version = "0.17.4", default-features = false, features = ["alloc"] }
-parity-scale-codec = { version = "1.3.5", default-features = false, features = ["derive"] }
+parity-scale-codec = { version = "1.3.6", default-features = false, features = ["derive"] }
 log = { version = "0.4.11", optional = true }
 rustc-hex = { version = "2.1.0", default-features = false }
 serde = { version = "1.0.118", default-features = false }

--- a/runtime/parachains/Cargo.toml
+++ b/runtime/parachains/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 bitvec = { version = "0.17.4", default-features = false, features = ["alloc"] }
-parity-scale-codec = { version = "1.3.5", default-features = false, features = ["derive"] }
+parity-scale-codec = { version = "1.3.6", default-features = false, features = ["derive"] }
 log = "0.4.11"
 rustc-hex = { version = "2.1.0", default-features = false }
 serde = { version = "1.0.118", features = [ "derive" ], optional = true }

--- a/runtime/polkadot/Cargo.toml
+++ b/runtime/polkadot/Cargo.toml
@@ -7,7 +7,7 @@ build = "build.rs"
 
 [dependencies]
 bitvec = { version = "0.17.4", default-features = false, features = ["alloc"] }
-parity-scale-codec = { version = "1.3.5", default-features = false, features = ["derive"] }
+parity-scale-codec = { version = "1.3.6", default-features = false, features = ["derive"] }
 log = { version = "0.4.11", optional = true }
 rustc-hex = { version = "2.1.0", default-features = false }
 serde = { version = "1.0.118", default-features = false }

--- a/runtime/rococo/Cargo.toml
+++ b/runtime/rococo/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 build = "build.rs"
 
 [dependencies]
-parity-scale-codec = { version = "1.3.5", default-features = false, features = ["derive"] }
+parity-scale-codec = { version = "1.3.6", default-features = false, features = ["derive"] }
 serde = { version = "1.0.118", default-features = false }
 serde_derive = { version = "1.0.117", optional = true }
 smallvec = "1.6.0"

--- a/runtime/test-runtime/Cargo.toml
+++ b/runtime/test-runtime/Cargo.toml
@@ -7,7 +7,7 @@ build = "build.rs"
 
 [dependencies]
 bitvec = { version = "0.17.4", default-features = false, features = ["alloc"] }
-parity-scale-codec = { version = "1.3.5", default-features = false, features = ["derive"] }
+parity-scale-codec = { version = "1.3.6", default-features = false, features = ["derive"] }
 log = { version = "0.4.11", optional = true }
 rustc-hex = { version = "2.1.0", default-features = false }
 serde = { version = "1.0.118", default-features = false }

--- a/runtime/westend/Cargo.toml
+++ b/runtime/westend/Cargo.toml
@@ -7,7 +7,7 @@ build = "build.rs"
 
 [dependencies]
 bitvec = { version = "0.17.4", default-features = false, features = ["alloc"] }
-parity-scale-codec = { version = "1.3.5", default-features = false, features = ["derive"] }
+parity-scale-codec = { version = "1.3.6", default-features = false, features = ["derive"] }
 log = { version = "0.4.11", optional = true }
 rustc-hex = { version = "2.1.0", default-features = false }
 serde = { version = "1.0.118", default-features = false }

--- a/statement-table/Cargo.toml
+++ b/statement-table/Cargo.toml
@@ -5,6 +5,6 @@ authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 
 [dependencies]
-parity-scale-codec = { version = "1.3.5", default-features = false, features = ["derive"] }
+parity-scale-codec = { version = "1.3.6", default-features = false, features = ["derive"] }
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
 primitives = { package = "polkadot-primitives", path = "../primitives" }

--- a/validation/Cargo.toml
+++ b/validation/Cargo.toml
@@ -15,7 +15,7 @@ consensus = { package = "sp-consensus", git = "https://github.com/paritytech/sub
 runtime_primitives = { package = "sp-runtime", git = "https://github.com/paritytech/substrate", branch = "master" }
 futures = "0.3.8"
 log = "0.4.11"
-parity-scale-codec = { version = "1.3.5", default-features = false, features = ["derive"] }
+parity-scale-codec = { version = "1.3.6", default-features = false, features = ["derive"] }
 grandpa = { package = "sc-finality-grandpa", git = "https://github.com/paritytech/substrate", branch = "master" }
 inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "master" }
 primitives = { package = "sp-core", git = "https://github.com/paritytech/substrate", branch = "master" }

--- a/xcm/Cargo.toml
+++ b/xcm/Cargo.toml
@@ -6,7 +6,7 @@ description = "The basic XCM datastructures."
 edition = "2018"
 
 [dependencies]
-parity-scale-codec = { version = "1.3.5", default-features = false, features = [ "derive" ] }
+parity-scale-codec = { version = "1.3.6", default-features = false, features = [ "derive" ] }
 
 [features]
 default = ["std"]

--- a/xcm/xcm-builder/Cargo.toml
+++ b/xcm/xcm-builder/Cargo.toml
@@ -6,7 +6,7 @@ description = "Tools & types for building with XCM and its executor."
 version = "0.8.22"
 
 [dependencies]
-parity-scale-codec = { version = "1.3.5", default-features = false, features = ["derive"] }
+parity-scale-codec = { version = "1.3.6", default-features = false, features = ["derive"] }
 xcm = { path = "..", default-features = false }
 xcm-executor = { path = "../xcm-executor", default-features = false }
 sp-std = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }

--- a/xcm/xcm-executor/Cargo.toml
+++ b/xcm/xcm-executor/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.8.22"
 
 [dependencies]
 impl-trait-for-tuples = "0.2.0"
-parity-scale-codec = { version = "1.3.5", default-features = false, features = ["derive"] }
+parity-scale-codec = { version = "1.3.6", default-features = false, features = ["derive"] }
 xcm = { path = "..", default-features = false }
 sp-std = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 sp-io = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }


### PR DESCRIPTION
1.3.6 include some minor bug fix.

If prefered I can also just update the Cargo.lock and not the Cargo.toml