### PR TITLE
Fix run_to_block functions

### DIFF
--- a/runtime/parachains/src/dmp.rs
+++ b/runtime/parachains/src/dmp.rs
@@ -236,14 +236,14 @@ mod tests {
 		while System::block_number() < to {
 			let b = System::block_number();
 			Dmp::initializer_finalize();
+			if new_session.as_ref().map_or(false, |v| v.contains(&(b + 1))) {
+				Dmp::initializer_on_new_session(&Default::default());
+			}
 			System::on_finalize(b);
 
 			System::on_initialize(b + 1);
 			System::set_block_number(b + 1);
 
-			if new_session.as_ref().map_or(false, |v| v.contains(&(b + 1))) {
-				Dmp::initializer_on_new_session(&Default::default());
-			}
 			Dmp::initializer_initialize(b + 1);
 		}
 	}

--- a/runtime/parachains/src/hrmp.rs
+++ b/runtime/parachains/src/hrmp.rs
@@ -280,7 +280,7 @@ decl_storage! {
 		// NOTE that this field is used by parachains via merkle storage proofs, therefore changing
 		// the format will require migration of parachains.
 		HrmpEgressChannelsIndex: map hasher(twox_64_concat) ParaId => Vec<ParaId>;
-	
+
 		/// Storage for the messages for each channel.
 		/// Invariant: cannot be non-empty if the corresponding channel in `HrmpChannels` is `None`.
 		HrmpChannelContents: map hasher(twox_64_concat) HrmpChannelId => Vec<InboundHrmpMessage<T::BlockNumber>>;
@@ -1101,16 +1101,16 @@ mod tests {
 			Hrmp::initializer_finalize();
 			Paras::initializer_finalize();
 
-			System::on_finalize(b);
-
-			System::on_initialize(b + 1);
-			System::set_block_number(b + 1);
-
 			if new_session.as_ref().map_or(false, |v| v.contains(&(b + 1))) {
 				// NOTE: this is in initialization order.
 				Paras::initializer_on_new_session(&Default::default());
 				Hrmp::initializer_on_new_session(&Default::default());
 			}
+
+			System::on_finalize(b);
+
+			System::on_initialize(b + 1);
+			System::set_block_number(b + 1);
 
 			// NOTE: this is in initialization order.
 			Paras::initializer_initialize(b + 1);

--- a/runtime/parachains/src/inclusion.rs
+++ b/runtime/parachains/src/inclusion.rs
@@ -1036,15 +1036,15 @@ mod tests {
 			Inclusion::initializer_finalize();
 			Paras::initializer_finalize();
 
-			System::on_finalize(b);
-
-			System::on_initialize(b + 1);
-			System::set_block_number(b + 1);
-
 			if let Some(notification) = new_session(b + 1) {
 				Paras::initializer_on_new_session(&notification);
 				Inclusion::initializer_on_new_session(&notification);
 			}
+
+			System::on_finalize(b);
+
+			System::on_initialize(b + 1);
+			System::set_block_number(b + 1);
 
 			Paras::initializer_initialize(b + 1);
 			Inclusion::initializer_initialize(b + 1);

--- a/runtime/parachains/src/paras.rs
+++ b/runtime/parachains/src/paras.rs
@@ -578,14 +578,14 @@ mod tests {
 		while System::block_number() < to {
 			let b = System::block_number();
 			Paras::initializer_finalize();
+			if new_session.as_ref().map_or(false, |v| v.contains(&(b + 1))) {
+				Paras::initializer_on_new_session(&Default::default());
+			}
 			System::on_finalize(b);
 
 			System::on_initialize(b + 1);
 			System::set_block_number(b + 1);
 
-			if new_session.as_ref().map_or(false, |v| v.contains(&(b + 1))) {
-				Paras::initializer_on_new_session(&Default::default());
-			}
 			Paras::initializer_initialize(b + 1);
 		}
 	}
@@ -1059,8 +1059,8 @@ mod tests {
 				assert_eq!(<Paras as Store>::Heads::get(&para_id), Some(Default::default()));
 			}
 
-			// run to block, with a session change at that block.
-			run_to_block(3, Some(vec![3]));
+			// run to block №4, with a session change at the end of the block 3.
+			run_to_block(4, Some(vec![4]));
 
 			// cleaning up the parachain should place the current parachain code
 			// into the past code buffer & schedule cleanup.

--- a/runtime/parachains/src/session_info.rs
+++ b/runtime/parachains/src/session_info.rs
@@ -183,15 +183,15 @@ mod tests {
 			SessionInfo::initializer_finalize();
 			Configuration::initializer_finalize();
 
-			System::on_finalize(b);
-
-			System::on_initialize(b + 1);
-			System::set_block_number(b + 1);
-
 			if let Some(notification) = new_session(b + 1) {
 				Configuration::initializer_on_new_session(&notification.validators, &notification.queued);
 				SessionInfo::initializer_on_new_session(&notification);
 			}
+
+			System::on_finalize(b);
+
+			System::on_initialize(b + 1);
+			System::set_block_number(b + 1);
 
 			Configuration::initializer_initialize(b + 1);
 			SessionInfo::initializer_initialize(b + 1);


### PR DESCRIPTION
Similar to https://github.com/paritytech/polkadot/pull/2257 fixes the fallout from #2123 