### PR TITLE
Compress the PoV block before sending it over the network

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5270,7 +5270,6 @@ dependencies = [
 name = "polkadot-node-network-protocol"
 version = "0.1.0"
 dependencies = [
- "flate2",
  "parity-scale-codec",
  "polkadot-node-jaeger",
  "polkadot-node-primitives",
@@ -5278,6 +5277,7 @@ dependencies = [
  "sc-network",
  "strum 0.20.0",
  "thiserror",
+ "zstd",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1463,11 +1463,11 @@ checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
 name = "flate2"
-version = "1.0.16"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68c90b0fc46cf89d227cc78b40e494ff81287a92dd07631e5af0d06fe3cf885e"
+checksum = "7411863d55df97a419aa64cb4d2f167103ea9d767e2c54a1868b7ac3f6b47129"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "crc32fast",
  "libc",
  "libz-sys",
@@ -3272,12 +3272,11 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.0.25"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb5e43362e38e2bca2fd5f5134c4d4564a23a5c28e9b95411652021a8675ebe"
+checksum = "602113192b08db8f38796c4e85c39e960c145965140e918018bcde1952429655"
 dependencies = [
  "cc",
- "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -5067,7 +5066,7 @@ name = "polkadot-node-core-approval-voting"
 version = "0.1.0"
 dependencies = [
  "bitvec",
- "futures 0.3.8",
+ "futures 0.3.12",
  "parity-scale-codec",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
@@ -5270,12 +5269,14 @@ dependencies = [
 name = "polkadot-node-network-protocol"
 version = "0.1.0"
 dependencies = [
+ "flate2",
  "parity-scale-codec",
  "polkadot-node-jaeger",
  "polkadot-node-primitives",
  "polkadot-primitives",
  "sc-network",
  "strum 0.20.0",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1463,11 +1463,11 @@ checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
 name = "flate2"
-version = "1.0.19"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7411863d55df97a419aa64cb4d2f167103ea9d767e2c54a1868b7ac3f6b47129"
+checksum = "68c90b0fc46cf89d227cc78b40e494ff81287a92dd07631e5af0d06fe3cf885e"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "crc32fast",
  "libc",
  "libz-sys",
@@ -3272,11 +3272,12 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.2"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "602113192b08db8f38796c4e85c39e960c145965140e918018bcde1952429655"
+checksum = "2eb5e43362e38e2bca2fd5f5134c4d4564a23a5c28e9b95411652021a8675ebe"
 dependencies = [
  "cc",
+ "libc",
  "pkg-config",
  "vcpkg",
 ]

--- a/node/network/collator-protocol/src/collator_side.rs
+++ b/node/network/collator-protocol/src/collator_side.rs
@@ -501,7 +501,7 @@ async fn send_collation(
 	receipt: CandidateReceipt,
 	pov: PoV,
 ) {
-	let pov = match protocol_v1::CompressedPoV::from_pov(&pov) {
+	let pov = match protocol_v1::CompressedPoV::compress(&pov) {
 		Ok(pov) => pov,
 		Err(error) => {
 			tracing::debug!(
@@ -1288,7 +1288,7 @@ mod tests {
 						protocol_v1::CollatorProtocolMessage::Collation(req_id, receipt, pov) => {
 							assert_eq!(req_id, request_id);
 							assert_eq!(receipt, candidate);
-							assert_eq!(pov.as_pov().unwrap(), pov_block);
+							assert_eq!(pov.decompress().unwrap(), pov_block);
 						}
 					);
 				}

--- a/node/network/collator-protocol/src/collator_side.rs
+++ b/node/network/collator-protocol/src/collator_side.rs
@@ -501,11 +501,19 @@ async fn send_collation(
 	receipt: CandidateReceipt,
 	pov: PoV,
 ) {
-	let wire_message = protocol_v1::CollatorProtocolMessage::Collation(
-		request_id,
-		receipt,
-		pov,
-	);
+	let pov = match protocol_v1::CompressedPoV::from_pov(&pov) {
+		Ok(pov) => pov,
+		Err(error) => {
+			tracing::debug!(
+				target: LOG_TARGET,
+				error = ?error,
+				"Failed to create `CompressedPov`",
+			);
+			return
+		}
+	};
+
+	let wire_message = protocol_v1::CollatorProtocolMessage::Collation(request_id, receipt, pov);
 
 	ctx.send_message(AllMessages::NetworkBridge(
 		NetworkBridgeMessage::SendCollationMessage(
@@ -1280,7 +1288,7 @@ mod tests {
 						protocol_v1::CollatorProtocolMessage::Collation(req_id, receipt, pov) => {
 							assert_eq!(req_id, request_id);
 							assert_eq!(receipt, candidate);
-							assert_eq!(pov, pov_block);
+							assert_eq!(pov.as_pov().unwrap(), pov_block);
 						}
 					);
 				}

--- a/node/network/collator-protocol/src/validator_side.rs
+++ b/node/network/collator-protocol/src/validator_side.rs
@@ -353,7 +353,7 @@ async fn received_collation<Context>(
 	origin: PeerId,
 	request_id: RequestId,
 	receipt: CandidateReceipt,
-	pov: PoV,
+	pov: protocol_v1::CompressedPoV,
 )
 where
 	Context: SubsystemContext<Message = CollatorProtocolMessage>
@@ -368,6 +368,21 @@ where
 			if let Some(per_request) = state.requests_info.remove(&id) {
 				let _ = per_request.received.send(());
 				if let Some(collator_id) = state.known_collators.get(&origin) {
+					let pov = match pov.as_pov() {
+						Ok(pov) => pov,
+						Err(error) => {
+							tracing::debug!(
+								target: LOG_TARGET,
+								%request_id,
+								?error,
+								"Failed to extract PoV",
+							);
+							return;
+						}
+					};
+
+					let _span = jaeger::pov_span(&pov, "received-collation");
+
 					tracing::debug!(
 						target: LOG_TARGET,
 						%request_id,
@@ -529,9 +544,8 @@ where
 			modify_reputation(ctx, origin, COST_UNEXPECTED_MESSAGE).await;
 		}
 		Collation(request_id, receipt, pov) => {
-			let _span1 = state.span_per_relay_parent.get(&receipt.descriptor.relay_parent)
+			let _span = state.span_per_relay_parent.get(&receipt.descriptor.relay_parent)
 				.map(|s| s.child("received-collation"));
-			let _span2 = jaeger::pov_span(&pov, "received-collation");
 			received_collation(ctx, state, origin, request_id, receipt, pov).await;
 		}
 	}
@@ -1295,9 +1309,9 @@ mod tests {
 						protocol_v1::CollatorProtocolMessage::Collation(
 							request_id,
 							candidate_a.clone(),
-							PoV {
+							protocol_v1::CompressedPoV::from_pov(&PoV {
 								block_data: BlockData(vec![]),
-							},
+							}).unwrap(),
 						)
 					)
 				)
@@ -1333,9 +1347,9 @@ mod tests {
 						protocol_v1::CollatorProtocolMessage::Collation(
 							request_id,
 							candidate_b.clone(),
-							PoV {
+							protocol_v1::CompressedPoV::from_pov(&PoV {
 								block_data: BlockData(vec![1, 2, 3]),
-							},
+							}).unwrap(),
 						)
 					)
 				)

--- a/node/network/collator-protocol/src/validator_side.rs
+++ b/node/network/collator-protocol/src/validator_side.rs
@@ -368,7 +368,7 @@ where
 			if let Some(per_request) = state.requests_info.remove(&id) {
 				let _ = per_request.received.send(());
 				if let Some(collator_id) = state.known_collators.get(&origin) {
-					let pov = match pov.as_pov() {
+					let pov = match pov.decompress() {
 						Ok(pov) => pov,
 						Err(error) => {
 							tracing::debug!(
@@ -1309,7 +1309,7 @@ mod tests {
 						protocol_v1::CollatorProtocolMessage::Collation(
 							request_id,
 							candidate_a.clone(),
-							protocol_v1::CompressedPoV::from_pov(&PoV {
+							protocol_v1::CompressedPoV::compress(&PoV {
 								block_data: BlockData(vec![]),
 							}).unwrap(),
 						)
@@ -1347,7 +1347,7 @@ mod tests {
 						protocol_v1::CollatorProtocolMessage::Collation(
 							request_id,
 							candidate_b.clone(),
-							protocol_v1::CompressedPoV::from_pov(&PoV {
+							protocol_v1::CompressedPoV::compress(&PoV {
 								block_data: BlockData(vec![1, 2, 3]),
 							}).unwrap(),
 						)

--- a/node/network/pov-distribution/src/lib.rs
+++ b/node/network/pov-distribution/src/lib.rs
@@ -106,7 +106,7 @@ struct State {
 }
 
 struct BlockBasedState {
-	known: HashMap<Hash, Arc<PoV>>,
+	known: HashMap<Hash, (Arc<PoV>, protocol_v1::CompressedPoV)>,
 
 	/// All the PoVs we are or were fetching, coupled with channels expecting the data.
 	///
@@ -131,11 +131,13 @@ fn awaiting_message(relay_parent: Hash, awaiting: Vec<Hash>)
 	)
 }
 
-fn send_pov_message(relay_parent: Hash, pov_hash: Hash, pov: PoV)
-	-> protocol_v1::ValidationProtocol
-{
+fn send_pov_message(
+	relay_parent: Hash,
+	pov_hash: Hash,
+	pov: &protocol_v1::CompressedPoV,
+) -> protocol_v1::ValidationProtocol {
 	protocol_v1::ValidationProtocol::PoVDistribution(
-		protocol_v1::PoVDistributionMessage::SendPoV(relay_parent, pov_hash, pov)
+		protocol_v1::PoVDistributionMessage::SendPoV(relay_parent, pov_hash, pov.clone())
 	)
 }
 
@@ -267,7 +269,7 @@ async fn distribute_to_awaiting(
 	metrics: &Metrics,
 	relay_parent: Hash,
 	pov_hash: Hash,
-	pov: &PoV,
+	pov: &protocol_v1::CompressedPoV,
 ) {
 	// Send to all peers who are awaiting the PoV and have that relay-parent in their view.
 	//
@@ -284,7 +286,7 @@ async fn distribute_to_awaiting(
 
 	if peers_to_send.is_empty() { return; }
 
-	let payload = send_pov_message(relay_parent, pov_hash, pov.clone());
+	let payload = send_pov_message(relay_parent, pov_hash, pov);
 
 	ctx.send_message(AllMessages::NetworkBridge(NetworkBridgeMessage::SendValidationMessage(
 		peers_to_send,
@@ -379,7 +381,7 @@ async fn handle_fetch(
 		None => return,
 	};
 
-	if let Some(pov) = relay_parent_state.known.get(&descriptor.pov_hash) {
+	if let Some((pov, _)) = relay_parent_state.known.get(&descriptor.pov_hash) {
 		let _  = response_sender.send(pov.clone());
 		return;
 	}
@@ -468,7 +470,17 @@ async fn handle_distribute(
 		}
 	}
 
-	relay_parent_state.known.insert(descriptor.pov_hash, pov.clone());
+	let encoded_pov = match protocol_v1::CompressedPoV::from_pov(&*pov) {
+		Ok(pov) => pov,
+		Err(error) => {
+			tracing::debug!(
+				target: LOG_TARGET,
+				error = ?error,
+				"Failed to create `CompressedPov`."
+			);
+			return
+		}
+	};
 
 	distribute_to_awaiting(
 		&mut state.peer_state,
@@ -476,8 +488,10 @@ async fn handle_distribute(
 		&state.metrics,
 		relay_parent,
 		descriptor.pov_hash,
-		&*pov,
-	).await
+		&encoded_pov,
+	).await;
+
+	relay_parent_state.known.insert(descriptor.pov_hash, (pov, encoded_pov));
 }
 
 /// Report a reputation change for a peer.
@@ -527,8 +541,9 @@ async fn handle_awaiting(
 		for pov_hash in pov_hashes {
 			// For all requested PoV hashes, if we have it, we complete the request immediately.
 			// Otherwise, we note that the peer is awaiting the PoV.
-			if let Some(pov) = relay_parent_state.known.get(&pov_hash) {
-				let payload = send_pov_message(relay_parent, pov_hash, (&**pov).clone());
+			if let Some((_, ref pov)) = relay_parent_state.known.get(&pov_hash) {
+				let payload = send_pov_message(relay_parent, pov_hash, pov);
+
 				ctx.send_message(AllMessages::NetworkBridge(
 					NetworkBridgeMessage::SendValidationMessage(vec![peer.clone()], payload)
 				)).await;
@@ -544,21 +559,33 @@ async fn handle_awaiting(
 /// Handle an incoming PoV from our peer. Reports them if unexpected, rewards them if not.
 ///
 /// Completes any requests awaiting that PoV.
-#[tracing::instrument(level = "trace", skip(ctx, state, pov), fields(subsystem = LOG_TARGET))]
+#[tracing::instrument(level = "trace", skip(ctx, state, encoded_pov), fields(subsystem = LOG_TARGET))]
 async fn handle_incoming_pov(
 	state: &mut State,
 	ctx: &mut impl SubsystemContext<Message = PoVDistributionMessage>,
 	peer: PeerId,
 	relay_parent: Hash,
 	pov_hash: Hash,
-	pov: PoV,
+	encoded_pov: protocol_v1::CompressedPoV,
 ) {
 	let relay_parent_state = match state.relay_parent_state.get_mut(&relay_parent) {
-		None =>	{
+		None => {
 			report_peer(ctx, peer, COST_UNEXPECTED_POV).await;
 			return;
 		},
 		Some(r) => r,
+	};
+
+	let pov = match encoded_pov.as_pov() {
+		Ok(pov) => pov,
+		Err(error) => {
+			tracing::debug!(
+				target: LOG_TARGET,
+				error = ?error,
+				"Could not extract PoV",
+			);
+			return;
+		}
 	};
 
 	let pov = {
@@ -607,8 +634,10 @@ async fn handle_incoming_pov(
 		&state.metrics,
 		relay_parent,
 		pov_hash,
-		&*pov,
-	).await
+		&encoded_pov,
+	).await;
+
+	relay_parent_state.known.insert(pov_hash, (pov, encoded_pov));
 }
 
 /// Handles a newly connected validator in the context of some relay leaf.

--- a/node/network/pov-distribution/src/lib.rs
+++ b/node/network/pov-distribution/src/lib.rs
@@ -470,7 +470,7 @@ async fn handle_distribute(
 		}
 	}
 
-	let encoded_pov = match protocol_v1::CompressedPoV::from_pov(&*pov) {
+	let encoded_pov = match protocol_v1::CompressedPoV::compress(&*pov) {
 		Ok(pov) => pov,
 		Err(error) => {
 			tracing::debug!(
@@ -576,7 +576,7 @@ async fn handle_incoming_pov(
 		Some(r) => r,
 	};
 
-	let pov = match encoded_pov.as_pov() {
+	let pov = match encoded_pov.decompress() {
 		Ok(pov) => pov,
 		Err(error) => {
 			tracing::debug!(

--- a/node/network/pov-distribution/src/tests.rs
+++ b/node/network/pov-distribution/src/tests.rs
@@ -396,7 +396,11 @@ fn ask_validators_for_povs() {
 			PoVDistributionMessage::NetworkBridgeUpdateV1(
 				NetworkBridgeEvent::PeerMessage(
 					test_state.validator_peer_id[2].clone(),
-					protocol_v1::PoVDistributionMessage::SendPoV(current, pov_hash, pov_block.clone()),
+					protocol_v1::PoVDistributionMessage::SendPoV(
+						current,
+						pov_hash,
+						protocol_v1::CompressedPoV::from_pov(&pov_block).unwrap(),
+					),
 				)
 			)
 		).await;
@@ -631,7 +635,7 @@ fn distributes_to_those_awaiting_and_completes_local() {
 				assert_eq!(peers, vec![peer_a.clone()]);
 				assert_eq!(
 					message,
-					send_pov_message(hash_a, pov_hash, pov.clone()),
+					send_pov_message(hash_a, pov_hash, &protocol_v1::CompressedPoV::from_pov(&pov).unwrap()),
 				);
 			}
 		)
@@ -943,7 +947,7 @@ fn peer_complete_fetch_and_is_rewarded() {
 			&mut ctx,
 			NetworkBridgeEvent::PeerMessage(
 				peer_a.clone(),
-				send_pov_message(hash_a, pov_hash, pov.clone()),
+				send_pov_message(hash_a, pov_hash, &protocol_v1::CompressedPoV::from_pov(&pov).unwrap()),
 			).focus().unwrap(),
 		).await;
 
@@ -952,7 +956,7 @@ fn peer_complete_fetch_and_is_rewarded() {
 			&mut ctx,
 			NetworkBridgeEvent::PeerMessage(
 				peer_b.clone(),
-				send_pov_message(hash_a, pov_hash, pov.clone()),
+				send_pov_message(hash_a, pov_hash, &protocol_v1::CompressedPoV::from_pov(&pov).unwrap()),
 			).focus().unwrap(),
 		).await;
 
@@ -1033,7 +1037,7 @@ fn peer_punished_for_sending_bad_pov() {
 			&mut ctx,
 			NetworkBridgeEvent::PeerMessage(
 				peer_a.clone(),
-				send_pov_message(hash_a, pov_hash, bad_pov.clone()),
+				send_pov_message(hash_a, pov_hash, &protocol_v1::CompressedPoV::from_pov(&bad_pov).unwrap()),
 			).focus().unwrap(),
 		).await;
 
@@ -1098,7 +1102,7 @@ fn peer_punished_for_sending_unexpected_pov() {
 			&mut ctx,
 			NetworkBridgeEvent::PeerMessage(
 				peer_a.clone(),
-				send_pov_message(hash_a, pov_hash, pov.clone()),
+				send_pov_message(hash_a, pov_hash, &protocol_v1::CompressedPoV::from_pov(&pov).unwrap()),
 			).focus().unwrap(),
 		).await;
 
@@ -1161,7 +1165,7 @@ fn peer_punished_for_sending_pov_out_of_our_view() {
 			&mut ctx,
 			NetworkBridgeEvent::PeerMessage(
 				peer_a.clone(),
-				send_pov_message(hash_b, pov_hash, pov.clone()),
+				send_pov_message(hash_b, pov_hash, &protocol_v1::CompressedPoV::from_pov(&pov).unwrap()),
 			).focus().unwrap(),
 		).await;
 
@@ -1450,7 +1454,7 @@ fn peer_complete_fetch_leads_to_us_completing_others() {
 			&mut ctx,
 			NetworkBridgeEvent::PeerMessage(
 				peer_a.clone(),
-				send_pov_message(hash_a, pov_hash, pov.clone()),
+				send_pov_message(hash_a, pov_hash, &protocol_v1::CompressedPoV::from_pov(&pov).unwrap()),
 			).focus().unwrap(),
 		).await;
 
@@ -1474,7 +1478,7 @@ fn peer_complete_fetch_leads_to_us_completing_others() {
 				assert_eq!(peers, vec![peer_b.clone()]);
 				assert_eq!(
 					message,
-					send_pov_message(hash_a, pov_hash, pov.clone()),
+					send_pov_message(hash_a, pov_hash, &protocol_v1::CompressedPoV::from_pov(&pov).unwrap()),
 				);
 			}
 		);
@@ -1534,7 +1538,7 @@ fn peer_completing_request_no_longer_awaiting() {
 			&mut ctx,
 			NetworkBridgeEvent::PeerMessage(
 				peer_a.clone(),
-				send_pov_message(hash_a, pov_hash, pov.clone()),
+				send_pov_message(hash_a, pov_hash, &protocol_v1::CompressedPoV::from_pov(&pov).unwrap()),
 			).focus().unwrap(),
 		).await;
 

--- a/node/network/pov-distribution/src/tests.rs
+++ b/node/network/pov-distribution/src/tests.rs
@@ -399,7 +399,7 @@ fn ask_validators_for_povs() {
 					protocol_v1::PoVDistributionMessage::SendPoV(
 						current,
 						pov_hash,
-						protocol_v1::CompressedPoV::from_pov(&pov_block).unwrap(),
+						protocol_v1::CompressedPoV::compress(&pov_block).unwrap(),
 					),
 				)
 			)
@@ -635,7 +635,7 @@ fn distributes_to_those_awaiting_and_completes_local() {
 				assert_eq!(peers, vec![peer_a.clone()]);
 				assert_eq!(
 					message,
-					send_pov_message(hash_a, pov_hash, &protocol_v1::CompressedPoV::from_pov(&pov).unwrap()),
+					send_pov_message(hash_a, pov_hash, &protocol_v1::CompressedPoV::compress(&pov).unwrap()),
 				);
 			}
 		)
@@ -947,7 +947,7 @@ fn peer_complete_fetch_and_is_rewarded() {
 			&mut ctx,
 			NetworkBridgeEvent::PeerMessage(
 				peer_a.clone(),
-				send_pov_message(hash_a, pov_hash, &protocol_v1::CompressedPoV::from_pov(&pov).unwrap()),
+				send_pov_message(hash_a, pov_hash, &protocol_v1::CompressedPoV::compress(&pov).unwrap()),
 			).focus().unwrap(),
 		).await;
 
@@ -956,7 +956,7 @@ fn peer_complete_fetch_and_is_rewarded() {
 			&mut ctx,
 			NetworkBridgeEvent::PeerMessage(
 				peer_b.clone(),
-				send_pov_message(hash_a, pov_hash, &protocol_v1::CompressedPoV::from_pov(&pov).unwrap()),
+				send_pov_message(hash_a, pov_hash, &protocol_v1::CompressedPoV::compress(&pov).unwrap()),
 			).focus().unwrap(),
 		).await;
 
@@ -1037,7 +1037,7 @@ fn peer_punished_for_sending_bad_pov() {
 			&mut ctx,
 			NetworkBridgeEvent::PeerMessage(
 				peer_a.clone(),
-				send_pov_message(hash_a, pov_hash, &protocol_v1::CompressedPoV::from_pov(&bad_pov).unwrap()),
+				send_pov_message(hash_a, pov_hash, &protocol_v1::CompressedPoV::compress(&bad_pov).unwrap()),
 			).focus().unwrap(),
 		).await;
 
@@ -1102,7 +1102,7 @@ fn peer_punished_for_sending_unexpected_pov() {
 			&mut ctx,
 			NetworkBridgeEvent::PeerMessage(
 				peer_a.clone(),
-				send_pov_message(hash_a, pov_hash, &protocol_v1::CompressedPoV::from_pov(&pov).unwrap()),
+				send_pov_message(hash_a, pov_hash, &protocol_v1::CompressedPoV::compress(&pov).unwrap()),
 			).focus().unwrap(),
 		).await;
 
@@ -1165,7 +1165,7 @@ fn peer_punished_for_sending_pov_out_of_our_view() {
 			&mut ctx,
 			NetworkBridgeEvent::PeerMessage(
 				peer_a.clone(),
-				send_pov_message(hash_b, pov_hash, &protocol_v1::CompressedPoV::from_pov(&pov).unwrap()),
+				send_pov_message(hash_b, pov_hash, &protocol_v1::CompressedPoV::compress(&pov).unwrap()),
 			).focus().unwrap(),
 		).await;
 
@@ -1454,7 +1454,7 @@ fn peer_complete_fetch_leads_to_us_completing_others() {
 			&mut ctx,
 			NetworkBridgeEvent::PeerMessage(
 				peer_a.clone(),
-				send_pov_message(hash_a, pov_hash, &protocol_v1::CompressedPoV::from_pov(&pov).unwrap()),
+				send_pov_message(hash_a, pov_hash, &protocol_v1::CompressedPoV::compress(&pov).unwrap()),
 			).focus().unwrap(),
 		).await;
 
@@ -1478,7 +1478,7 @@ fn peer_complete_fetch_leads_to_us_completing_others() {
 				assert_eq!(peers, vec![peer_b.clone()]);
 				assert_eq!(
 					message,
-					send_pov_message(hash_a, pov_hash, &protocol_v1::CompressedPoV::from_pov(&pov).unwrap()),
+					send_pov_message(hash_a, pov_hash, &protocol_v1::CompressedPoV::compress(&pov).unwrap()),
 				);
 			}
 		);
@@ -1538,7 +1538,7 @@ fn peer_completing_request_no_longer_awaiting() {
 			&mut ctx,
 			NetworkBridgeEvent::PeerMessage(
 				peer_a.clone(),
-				send_pov_message(hash_a, pov_hash, &protocol_v1::CompressedPoV::from_pov(&pov).unwrap()),
+				send_pov_message(hash_a, pov_hash, &protocol_v1::CompressedPoV::compress(&pov).unwrap()),
 			).focus().unwrap(),
 		).await;
 

--- a/node/network/protocol/Cargo.toml
+++ b/node/network/protocol/Cargo.toml
@@ -12,3 +12,5 @@ polkadot-node-jaeger = { path = "../../jaeger" }
 parity-scale-codec = { version = "1.3.6", default-features = false, features = ["derive"] }
 sc-network = { git = "https://github.com/paritytech/substrate", branch = "master" }
 strum = { version = "0.20", features = ["derive"] }
+thiserror = "1.0.23"
+flate2 = "1.0.19"

--- a/node/network/protocol/Cargo.toml
+++ b/node/network/protocol/Cargo.toml
@@ -13,4 +13,6 @@ parity-scale-codec = { version = "1.3.6", default-features = false, features = [
 sc-network = { git = "https://github.com/paritytech/substrate", branch = "master" }
 strum = { version = "0.20", features = ["derive"] }
 thiserror = "1.0.23"
+
+[target.'cfg(not(target_os = "unknown"))'.dependencies]
 zstd = "0.5.0"

--- a/node/network/protocol/Cargo.toml
+++ b/node/network/protocol/Cargo.toml
@@ -13,4 +13,4 @@ parity-scale-codec = { version = "1.3.6", default-features = false, features = [
 sc-network = { git = "https://github.com/paritytech/substrate", branch = "master" }
 strum = { version = "0.20", features = ["derive"] }
 thiserror = "1.0.23"
-flate2 = "1.0.19"
+flate2 = "1.0.16"

--- a/node/network/protocol/Cargo.toml
+++ b/node/network/protocol/Cargo.toml
@@ -13,4 +13,4 @@ parity-scale-codec = { version = "1.3.6", default-features = false, features = [
 sc-network = { git = "https://github.com/paritytech/substrate", branch = "master" }
 strum = { version = "0.20", features = ["derive"] }
 thiserror = "1.0.23"
-flate2 = "1.0.16"
+zstd = "0.5.0"

--- a/node/network/protocol/src/lib.rs
+++ b/node/network/protocol/src/lib.rs
@@ -355,14 +355,14 @@ pub mod v1 {
 	impl CompressedPoV {
 		/// Create from the given [`PoV`].
 		pub fn from_pov(pov: &PoV) -> Result<Self, CompressedPoVError> {
-			let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+			let mut encoder = GzEncoder::new(Vec::with_capacity(1024), Compression::default());
 			pov.encode_to(&mut encoder);
 			encoder.finish().map(Self).map_err(|_| CompressedPoVError::Compress)
 		}
 
 		/// Uncompress, decode and return the [`PoV`].
 		pub fn as_pov(&self) -> Result<PoV, CompressedPoVError> {
-			let mut writer = Vec::new();
+			let mut writer = Vec::with_capacity(1024);
 			let mut decoder = GzDecoder::new(&mut writer);
 			decoder.write_all(&self.0).map_err(|_| CompressedPoVError::Uncompress)?;
 			decoder.finish().map_err(|_| CompressedPoVError::Uncompress)?;

--- a/roadmap/implementers-guide/src/types/network.md
+++ b/roadmap/implementers-guide/src/types/network.md
@@ -19,6 +19,9 @@ enum ObservedRole {
 	Full,
 	Light,
 }
+
+/// SCALE and GZip encoded `PoV`.
+struct CompressedPoV(Vec<u8>);
 ```
 
 ## V1 Network Subsystem Message Types
@@ -75,8 +78,8 @@ enum PoVDistributionV1Message {
 	/// specific relay-parent hash.
 	Awaiting(Hash, Vec<Hash>),
 	/// Notification of an awaited PoV, in a given relay-parent context.
-	/// (relay_parent, pov_hash, pov)
-	SendPoV(Hash, Hash, PoV),
+	/// (relay_parent, pov_hash, compressed_pov)
+	SendPoV(Hash, Hash, CompressedPoV),
 }
 ```
 
@@ -101,7 +104,7 @@ enum CollatorProtocolV1Message {
 	/// Request the advertised collation at that relay-parent.
 	RequestCollation(RequestId, Hash, ParaId),
 	/// A requested collation.
-	Collation(RequestId, CandidateReceipt, PoV),
+	Collation(RequestId, CandidateReceipt, CompressedPoV),
 }
 ```
 

--- a/roadmap/implementers-guide/src/types/network.md
+++ b/roadmap/implementers-guide/src/types/network.md
@@ -20,7 +20,7 @@ enum ObservedRole {
 	Light,
 }
 
-/// SCALE and GZip encoded `PoV`.
+/// SCALE and zstd encoded `PoV`.
 struct CompressedPoV(Vec<u8>);
 ```
 

--- a/scripts/gitlab/check_web_wasm.sh
+++ b/scripts/gitlab/check_web_wasm.sh
@@ -1,13 +1,8 @@
 #!/usr/bin/env bash
 
+set -e
+
 #shellcheck source=lib.sh
 source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/lib.sh"
 
-time cargo build --locked --target=wasm32-unknown-unknown --manifest-path runtime/polkadot/Cargo.toml
-time cargo build --locked --target=wasm32-unknown-unknown --manifest-path runtime/kusama/Cargo.toml
-time cargo build --locked --target=wasm32-unknown-unknown --manifest-path erasure-coding/Cargo.toml
-time cargo build --locked --target=wasm32-unknown-unknown --manifest-path parachain/Cargo.toml
-time cargo build --locked --target=wasm32-unknown-unknown --manifest-path primitives/Cargo.toml
-time cargo build --locked --target=wasm32-unknown-unknown --manifest-path rpc/Cargo.toml
-time cargo build --locked --target=wasm32-unknown-unknown --manifest-path statement-table/Cargo.toml
 time cargo build --locked --target=wasm32-unknown-unknown --manifest-path cli/Cargo.toml --no-default-features --features browser


### PR DESCRIPTION
This pr changes the way we send PoV blocks over the network. We now
compress the PoV block before it is send over the network. This should
reduce the size significant for PoVs which contain the runtime WASM for
example.