### PR TITLE
Use ParaId instead of FundIndex in Crowdloan

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5067,7 +5067,7 @@ name = "polkadot-node-core-approval-voting"
 version = "0.1.0"
 dependencies = [
  "bitvec",
- "futures 0.3.8",
+ "futures 0.3.12",
  "parity-scale-codec",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",

--- a/runtime/common/src/auctions.rs
+++ b/runtime/common/src/auctions.rs
@@ -19,8 +19,11 @@
 //! happens elsewhere.
 
 use sp_std::{prelude::*, mem::swap, convert::TryInto};
-use sp_runtime::traits::{
-	CheckedSub, StaticLookup, Zero, One, CheckedConversion, Hash, AccountIdConversion,
+use sp_runtime::{
+	RuntimeDebug,
+	traits::{
+		CheckedSub, StaticLookup, Zero, One, CheckedConversion, Hash, AccountIdConversion,
+	},
 };
 use parity_scale_codec::{Encode, Decode, Codec};
 use frame_support::{
@@ -163,8 +166,8 @@ decl_event!(
 		WonDeploy(NewBidder<AccountId>, SlotRange, ParaId, Balance),
 		/// An existing parachain won the right to continue.
 		/// First balance is the extra amount reseved. Second is the total amount reserved.
-		/// [parachain_id, range, extra_reseved, total_amount]
-		WonRenewal(ParaId, SlotRange, Balance, Balance),
+		/// [parachain_id, begin, count, total_amount]
+		WonRenewal(ParaId, LeasePeriod, LeasePeriod, Balance),
 		/// Funds were reserved for a winning bid. First balance is the extra amount reserved.
 		/// Second is the total. [bidder, extra_reserved, total_amount]
 		Reserved(AccountId, Balance, Balance),
@@ -553,7 +556,8 @@ impl<T: Config> Module<T> {
 				.expect("none values are filtered out in previous logic; qed"));
 			let (slot_winner, bid) = final_winner;
 			match slot_winner {
-				Bidder::New(new_bidder) => (Some(new_bidder), new_id(), bid, r),
+				//Bidder::New(new_bidder) => (Some(new_bidder), new_id(), bid, r),
+				Bidder::New(new_bidder) => (Some(new_bidder), Default::default(), bid, r),
 				Bidder::Existing(para_id) => (None, para_id, bid, r),
 			}
 		}).collect::<Vec<_>>()

--- a/runtime/common/src/auctions.rs
+++ b/runtime/common/src/auctions.rs
@@ -412,7 +412,7 @@ impl<T: Config> Module<T> {
 			let period_begin = auction_lease_period_index + begin_offset;
 			let period_count = <LeasePeriodOf<T>>::from(range.len() as u32);
 
-			match T::Leaser::lease_out(para, leaser, amount, period_begin, period_count) {
+			match T::Leaser::lease_out(para, &leaser, amount, period_begin, period_count) {
 				Err(LeaseError::ReserveFailed) | Err(LeaseError::AlreadyEnded) => {
 					// Should never happen since we just unreserved this amount (and our offset is from the
 					// present period). But if it does, there's not much we can do.
@@ -577,8 +577,8 @@ impl<T: Config> Module<T> {
 			let (slot_winner, bid) = final_winner;
 			match slot_winner {
 				//Bidder::New(new_bidder) => (Some(new_bidder), new_id(), bid, r),
-				Bidder::New(new_bidder) => (Some(new_bidder), Default::default(), bid, r),
-				Bidder::Existing(para_id) => (None, para_id, bid, r),
+				Bidder::New(new_bidder) => (Default::default(), Default::default(), bid, r),
+				Bidder::Existing(para_id) => (Default::default(), para_id, bid, r),
 			}
 		}).collect::<Vec<_>>()
 	}

--- a/runtime/common/src/auctions.rs
+++ b/runtime/common/src/auctions.rs
@@ -348,11 +348,6 @@ impl<T: Config> Module<T> {
 		None
 	}
 
-	/// Returns the current lease period.
-	fn lease_period_index() -> LeasePeriodOf<T> {
-		(<frame_system::Module<T>>::block_number() / T::Leaser::lease_period()).into()
-	}
-
 	/// Some when the auction's end is known (with the end block number). None if it is unknown.
 	/// If `Some` then the block number must be at most the previous block and at least the
 	/// previous block minus `T::EndingPeriod::get()`.
@@ -389,7 +384,7 @@ impl<T: Config> Module<T> {
 	) {
 		// TODO: This should just use `Leaser`'s interface.
 		//   Much (most?) of this logic should move into the implementation of Leaser.
-		
+
 		// First, unreserve all amounts that were reserved for the bids. We will later deduct the
 		// amounts from the bidders that ended up being assigned the slot so there's no need to
 		// special-case them here.

--- a/runtime/common/src/crowdloan.rs
+++ b/runtime/common/src/crowdloan.rs
@@ -77,7 +77,7 @@ use frame_system::ensure_signed;
 use sp_runtime::{ModuleId, DispatchResult,
 	traits::{AccountIdConversion, Hash, Saturating, Zero, CheckedAdd, Bounded}
 };
-use crate::slots;
+use crate::{slots, auctions};
 use parity_scale_codec::{Encode, Decode};
 use sp_std::vec::Vec;
 use primitives::v1::{Id as ParaId, HeadData};
@@ -119,7 +119,7 @@ pub type FundIndex = u32;
 #[cfg_attr(feature = "std", derive(Debug))]
 pub enum LastContribution<BlockNumber> {
 	Never,
-	PreEnding(slots::AuctionIndex),
+	PreEnding(auctions::AuctionIndex),
 	Ending(BlockNumber),
 }
 
@@ -182,7 +182,7 @@ decl_storage! {
 		NewRaise get(fn new_raise): Vec<FundIndex>;
 
 		/// The number of auctions that have entered into their ending period so far.
-		EndingsCount get(fn endings_count): slots::AuctionIndex;
+		EndingsCount get(fn endings_count): auctions::AuctionIndex;
 	}
 }
 
@@ -512,7 +512,7 @@ decl_module! {
 					EndingsCount::mutate(|c| *c += 1);
 				}
 				for (fund, index) in NewRaise::take().into_iter().filter_map(|i| Self::funds(i).map(|f| (f, i))) {
-					let bidder = slots::Bidder::New(slots::NewBidder {
+					let bidder = auctions::Bidder::New(auctions::NewBidder {
 						who: Self::fund_account_id(index),
 						/// FundIndex and slots::SubId happen to be the same type (u32). If this
 						/// ever changes, then some sort of conversion will be needed here.

--- a/runtime/common/src/crowdloan.rs
+++ b/runtime/common/src/crowdloan.rs
@@ -273,6 +273,8 @@ decl_module! {
 		) {
 			let owner = ensure_signed(origin)?;
 
+			// TODO: ensure this is the parachain manager. Needs Registrar Update.
+
 			ensure!(first_slot < last_slot, Error::<T>::LastSlotBeforeFirstSlot);
 			ensure!(last_slot <= first_slot + 3u32.into(), Error::<T>::LastSlotTooFarInFuture);
 			ensure!(end > <frame_system::Module<T>>::block_number(), Error::<T>::CannotEndInPast);

--- a/runtime/common/src/crowdloan.rs
+++ b/runtime/common/src/crowdloan.rs
@@ -112,9 +112,6 @@ pub trait Config: slots::Config + auctions::Config {
 	type RemoveKeysLimit: Get<u32>;
 }
 
-/// Simple index for identifying a fund.
-pub type FundIndex = u32;
-
 #[derive(Encode, Decode, Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "std", derive(Debug))]
 pub enum LastContribution<BlockNumber> {
@@ -172,15 +169,12 @@ decl_storage! {
 	trait Store for Module<T: Config> as Crowdloan {
 		/// Info on all of the funds.
 		Funds get(fn funds):
-			map hasher(twox_64_concat) FundIndex
+			map hasher(twox_64_concat) ParaId
 			=> Option<FundInfo<T::AccountId, BalanceOf<T>, T::Hash, T::BlockNumber>>;
-
-		/// The total number of funds that have so far been allocated.
-		FundCount get(fn fund_count): FundIndex;
 
 		/// The funds that have had additional contributions during the last block. This is used
 		/// in order to determine which funds should submit new or updated bids.
-		NewRaise get(fn new_raise): Vec<FundIndex>;
+		NewRaise get(fn new_raise): Vec<ParaId>;
 
 		/// The number of auctions that have entered into their ending period so far.
 		EndingsCount get(fn endings_count): auctions::AuctionIndex;
@@ -193,24 +187,24 @@ decl_event! {
 		Balance = BalanceOf<T>,
 	{
 		/// Create a new crowdloaning campaign. [fund_index]
-		Created(FundIndex),
+		Created(ParaId),
 		/// Contributed to a crowd sale. [who, fund_index, amount]
-		Contributed(AccountId, FundIndex, Balance),
+		Contributed(AccountId, ParaId, Balance),
 		/// Withdrew full balance of a contributor. [who, fund_index, amount]
-		Withdrew(AccountId, FundIndex, Balance),
+		Withdrew(AccountId, ParaId, Balance),
 		/// Fund is placed into retirement. [fund_index]
-		Retiring(FundIndex),
+		Retiring(ParaId),
 		/// Fund is partially dissolved, i.e. there are some left over child
 		/// keys that still need to be killed. [fund_index]
-		PartiallyDissolved(FundIndex),
+		PartiallyDissolved(ParaId),
 		/// Fund is dissolved. [fund_index]
-		Dissolved(FundIndex),
+		Dissolved(ParaId),
 		/// The deploy data of the funded parachain is setted. [fund_index]
-		DeployDataFixed(FundIndex),
+		DeployDataFixed(ParaId),
 		/// Onboarding process for a winning parachain fund is completed. [find_index, parachain_id]
-		Onboarded(FundIndex, ParaId),
+		Onboarded(ParaId, ParaId),
 		/// The result of trying to submit a new bid to the Slots pallet.
-		HandleBidResult(FundIndex, DispatchResult),
+		HandleBidResult(ParaId, DispatchResult),
 	}
 }
 
@@ -227,7 +221,7 @@ decl_error! {
 		/// The contribution was below the minimum, `MinContribution`.
 		ContributionTooSmall,
 		/// Invalid fund index.
-		InvalidFundIndex,
+		InvalidParaId,
 		/// Contributions exceed maximum amount.
 		CapExceeded,
 		/// The contribution period has already ended.
@@ -271,6 +265,7 @@ decl_module! {
 		/// Create a new crowdloaning campaign for a parachain slot deposit for the current auction.
 		#[weight = 100_000_000]
 		fn create(origin,
+			index: ParaId,
 			#[compact] cap: BalanceOf<T>,
 			#[compact] first_slot: T::BlockNumber,
 			#[compact] last_slot: T::BlockNumber,
@@ -282,15 +277,12 @@ decl_module! {
 			ensure!(last_slot <= first_slot + 3u32.into(), Error::<T>::LastSlotTooFarInFuture);
 			ensure!(end > <frame_system::Module<T>>::block_number(), Error::<T>::CannotEndInPast);
 
-			let index = FundCount::get();
-			let next_index = index.checked_add(1).ok_or(Error::<T>::Overflow)?;
-
 			let deposit = T::SubmissionDeposit::get();
 			CurrencyOf::<T>::transfer(&owner, &Self::fund_account_id(index), deposit, AllowDeath)?;
-			FundCount::put(next_index);
 
 			Funds::<T>::insert(index, FundInfo {
-				parachain: None,
+				parachain: index,
+				is_leased: false,
 				owner,
 				deposit,
 				raised: Zero::zero(),
@@ -309,11 +301,11 @@ decl_module! {
 		/// slot. It will be withdrawable in two instances: the parachain becomes retired; or the
 		/// slot is unable to be purchased and the timeout expires.
 		#[weight = 0]
-		fn contribute(origin, #[compact] index: FundIndex, #[compact] value: BalanceOf<T>) {
+		fn contribute(origin, index: ParaId, #[compact] value: BalanceOf<T>) {
 			let who = ensure_signed(origin)?;
 
 			ensure!(value >= T::MinContribution::get(), Error::<T>::ContributionTooSmall);
-			let mut fund = Self::funds(index).ok_or(Error::<T>::InvalidFundIndex)?;
+			let mut fund = Self::funds(index).ok_or(Error::<T>::InvalidParaId)?;
 			fund.raised  = fund.raised.checked_add(&value).ok_or(Error::<T>::Overflow)?;
 			ensure!(fund.raised <= fund.cap, Error::<T>::CapExceeded);
 
@@ -362,10 +354,10 @@ decl_module! {
 
 		/// Note that a successful fund has lost its parachain slot, and place it into retirement.
 		#[weight = 0]
-		fn begin_retirement(origin, #[compact] index: FundIndex) {
+		fn begin_retirement(origin, #[compact] index: ParaId) {
 			ensure_signed(origin)?;
 
-			let mut fund = Self::funds(index).ok_or(Error::<T>::InvalidFundIndex)?;
+			let mut fund = Self::funds(index).ok_or(Error::<T>::InvalidParaId)?;
 			let parachain_id = fund.parachain;
 
 			// No deposit information implies the parachain was off-boarded
@@ -389,10 +381,10 @@ decl_module! {
 
 		/// Withdraw full balance of a contributor to an unsuccessful or off-boarded fund.
 		#[weight = 0]
-		fn withdraw(origin, who: T::AccountId, #[compact] index: FundIndex) {
+		fn withdraw(origin, who: T::AccountId, #[compact] index: ParaId) {
 			ensure_signed(origin)?;
 
-			let mut fund = Self::funds(index).ok_or(Error::<T>::InvalidFundIndex)?;
+			let mut fund = Self::funds(index).ok_or(Error::<T>::InvalidParaId)?;
 			ensure!(!fund.is_leased, Error::<T>::FundNotRetired);
 			let now = <frame_system::Module<T>>::block_number();
 
@@ -418,10 +410,10 @@ decl_module! {
 		/// but it has been retired from its parachain slot. This places any deposits that were not
 		/// withdrawn into the treasury.
 		#[weight = 0]
-		fn dissolve(origin, #[compact] index: FundIndex) {
+		fn dissolve(origin, #[compact] index: ParaId) {
 			ensure_signed(origin)?;
 
-			let fund = Self::funds(index).ok_or(Error::<T>::InvalidFundIndex)?;
+			let fund = Self::funds(index).ok_or(Error::<T>::InvalidParaId)?;
 			ensure!(!fund.is_leased, Error::<T>::HasActiveParachain);
 			let now = <frame_system::Module<T>>::block_number();
 			ensure!(
@@ -456,11 +448,11 @@ decl_module! {
 					// first block of ending period.
 					EndingsCount::mutate(|c| *c += 1);
 				}
-				for (fund, index) in NewRaise::take().into_iter().filter_map(|i| Self::funds(i).map(|f| (f, i))) {
+				for (fund, para_id) in NewRaise::take().into_iter().filter_map(|i| Self::funds(i).map(|f| (f, i))) {
 					// Care needs to be taken by the crowdloan creator that this function will succeed given
 					// the crowdloaning configuration. We do some checks ahead of time in crowdloan `create`.
 					let result = auctions::Module::<T>::handle_bid(
-						Self::fund_account_id(index),
+						Self::fund_account_id(para_id),
 						para_id,
 						auction_index,
 						fund.first_slot,
@@ -468,7 +460,7 @@ decl_module! {
 						fund.raised,
 					);
 
-					Self::deposit_event(RawEvent::HandleBidResult(index, result));
+					Self::deposit_event(RawEvent::HandleBidResult(para_id, result));
 				}
 			}
 
@@ -482,33 +474,33 @@ impl<T: Config> Module<T> {
 	///
 	/// This actually does computation. If you need to keep using it, then make sure you cache the
 	/// value and only call this once.
-	pub fn fund_account_id(index: FundIndex) -> T::AccountId {
+	pub fn fund_account_id(index: ParaId) -> T::AccountId {
 		T::ModuleId::get().into_sub_account(index)
 	}
 
-	pub fn id_from_index(index: FundIndex) -> child::ChildInfo {
+	pub fn id_from_index(index: ParaId) -> child::ChildInfo {
 		let mut buf = Vec::new();
 		buf.extend_from_slice(b"crowdloan");
-		buf.extend_from_slice(&index.to_le_bytes()[..]);
+		buf.extend_from_slice(&index.encode()[..]);
 		child::ChildInfo::new_default(T::Hashing::hash(&buf[..]).as_ref())
 	}
 
-	pub fn contribution_put(index: FundIndex, who: &T::AccountId, balance: &BalanceOf<T>) {
+	pub fn contribution_put(index: ParaId, who: &T::AccountId, balance: &BalanceOf<T>) {
 		who.using_encoded(|b| child::put(&Self::id_from_index(index), b, balance));
 	}
 
-	pub fn contribution_get(index: FundIndex, who: &T::AccountId) -> BalanceOf<T> {
+	pub fn contribution_get(index: ParaId, who: &T::AccountId) -> BalanceOf<T> {
 		who.using_encoded(|b| child::get_or_default::<BalanceOf<T>>(
 			&Self::id_from_index(index),
 			b,
 		))
 	}
 
-	pub fn contribution_kill(index: FundIndex, who: &T::AccountId) {
+	pub fn contribution_kill(index: ParaId, who: &T::AccountId) {
 		who.using_encoded(|b| child::kill(&Self::id_from_index(index), b));
 	}
 
-	pub fn crowdloan_kill(index: FundIndex) -> child::KillOutcome {
+	pub fn crowdloan_kill(index: ParaId) -> child::KillOutcome {
 		child::kill_storage(&Self::id_from_index(index), Some(T::RemoveKeysLimit::get()))
 	}
 }
@@ -745,7 +737,7 @@ mod tests {
 			assert_eq!(System::block_number(), 0);
 			assert_eq!(Crowdloan::fund_count(), 0);
 			assert_eq!(Crowdloan::funds(0), None);
-			let empty: Vec<FundIndex> = Vec::new();
+			let empty: Vec<ParaId> = Vec::new();
 			assert_eq!(Crowdloan::new_raise(), empty);
 			assert_eq!(Crowdloan::contribution_get(0, &1), 0);
 			assert_eq!(Crowdloan::endings_count(), 0);
@@ -778,7 +770,7 @@ mod tests {
 			// Deposit is placed in crowdloan free balance
 			assert_eq!(Balances::free_balance(Crowdloan::fund_account_id(0)), 1);
 			// No new raise until first contribution
-			let empty: Vec<FundIndex> = Vec::new();
+			let empty: Vec<ParaId> = Vec::new();
 			assert_eq!(Crowdloan::new_raise(), empty);
 		});
 	}
@@ -838,7 +830,7 @@ mod tests {
 	fn contribute_handles_basic_errors() {
 		new_test_ext().execute_with(|| {
 			// Cannot contribute to non-existing fund
-			assert_noop!(Crowdloan::contribute(Origin::signed(1), 0, 49), Error::<Test>::InvalidFundIndex);
+			assert_noop!(Crowdloan::contribute(Origin::signed(1), 0, 49), Error::<Test>::InvalidParaId);
 			// Cannot contribute below minimum contribution
 			assert_noop!(Crowdloan::contribute(Origin::signed(1), 0, 9), Error::<Test>::ContributionTooSmall);
 
@@ -911,7 +903,7 @@ mod tests {
 				<Test as frame_system::Config>::Hash::default(),
 				0,
 				vec![0].into()),
-				Error::<Test>::InvalidFundIndex
+				Error::<Test>::InvalidParaId
 			);
 
 			// Cannot set deploy data after it already has been set
@@ -984,7 +976,7 @@ mod tests {
 			run_to_block(10);
 
 			// Cannot onboard invalid fund index
-			assert_noop!(Crowdloan::onboard(Origin::signed(1), 1, 0.into()), Error::<Test>::InvalidFundIndex);
+			assert_noop!(Crowdloan::onboard(Origin::signed(1), 1, 0.into()), Error::<Test>::InvalidParaId);
 			// Cannot onboard crowdloan without deploy data
 			assert_noop!(Crowdloan::onboard(Origin::signed(1), 0, 0.into()), Error::<Test>::UnsetDeployData);
 
@@ -1088,7 +1080,7 @@ mod tests {
 			run_to_block(50);
 
 			// Cannot retire invalid fund index
-			assert_noop!(Crowdloan::begin_retirement(Origin::signed(1), 1), Error::<Test>::InvalidFundIndex);
+			assert_noop!(Crowdloan::begin_retirement(Origin::signed(1), 1), Error::<Test>::InvalidParaId);
 
 			// Cannot retire twice
 			assert_ok!(Crowdloan::begin_retirement(Origin::signed(1), 0));
@@ -1142,7 +1134,7 @@ mod tests {
 			// Cannot withdraw if they did not contribute
 			assert_noop!(Crowdloan::withdraw(Origin::signed(1337), 2, 0), Error::<Test>::NoContributions);
 			// Cannot withdraw from a non-existent fund
-			assert_noop!(Crowdloan::withdraw(Origin::signed(1337), 2, 1), Error::<Test>::InvalidFundIndex);
+			assert_noop!(Crowdloan::withdraw(Origin::signed(1337), 2, 1), Error::<Test>::InvalidParaId);
 		});
 	}
 
@@ -1260,7 +1252,7 @@ mod tests {
 			assert_ok!(Crowdloan::contribute(Origin::signed(3), 0, 300));
 
 			// Cannot dissolve an invalid fund index
-			assert_noop!(Crowdloan::dissolve(Origin::signed(1), 1), Error::<Test>::InvalidFundIndex);
+			assert_noop!(Crowdloan::dissolve(Origin::signed(1), 1), Error::<Test>::InvalidParaId);
 			// Cannot dissolve a fund in progress
 			assert_noop!(Crowdloan::dissolve(Origin::signed(1), 0), Error::<Test>::InRetirementPeriod);
 
@@ -1406,7 +1398,7 @@ mod benchmarking {
 		assert_eq!(event, &system_event);
 	}
 
-	fn create_fund<T: Config>(end: T::BlockNumber) -> FundIndex {
+	fn create_fund<T: Config>(end: T::BlockNumber) -> ParaId {
 		let cap = BalanceOf::<T>::max_value();
 		let lease_period_index = end / T::LeasePeriod::get();
 		let first_slot = lease_period_index;
@@ -1419,7 +1411,7 @@ mod benchmarking {
 		FundCount::get() - 1
 	}
 
-	fn contribute_fund<T: Config>(who: &T::AccountId, index: FundIndex) {
+	fn contribute_fund<T: Config>(who: &T::AccountId, index: ParaId) {
 		CurrencyOf::<T>::make_free_balance_be(&who, BalanceOf::<T>::max_value());
 		let value = T::MinContribution::get();
 		assert_ok!(Crowdloan::<T>::contribute(RawOrigin::Signed(who.clone()).into(), index, value));
@@ -1451,7 +1443,7 @@ mod benchmarking {
 	}
 
 	fn setup_onboarding<T: Config>(
-		fund_index: FundIndex,
+		fund_index: ParaId,
 		para_id: ParaId,
 		end_block: T::BlockNumber,
 	) -> DispatchResult {

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -21,6 +21,7 @@
 pub mod claims;
 pub mod slot_range;
 pub mod slots;
+pub mod auctions;
 pub mod crowdloan;
 pub mod purchase;
 pub mod impls;

--- a/runtime/common/src/slots.rs
+++ b/runtime/common/src/slots.rs
@@ -230,6 +230,8 @@ decl_error! {
 		HeadDataTooLarge,
 		/// The Id given is already in use.
 		InUse,
+		/// There was an error with the lease.
+		LeaseError,
 	}
 }
 
@@ -280,6 +282,8 @@ decl_module! {
 		) -> DispatchResult {
 			ensure_root(origin)?;
 			Self::lease_out(para, leaser, amount, period_begin, period_count)
+				.map_err(|_| Error::<T>::LeaseError)?;
+			Ok(())
 		}
 
 		/// Set the deploy information for a successful bid to deploy a new parachain.

--- a/runtime/common/src/slots.rs
+++ b/runtime/common/src/slots.rs
@@ -150,7 +150,7 @@ decl_storage! {
 		///
 		/// The given account ID is responsible for registering the code and initial head data, but may only do
 		/// so if it isn't yet registered. (After that, it's up to governance to do so.)
-		pub Paras: map hasher(twox_64_concat) ParaId => Option<(BalanceOf<T>, T::AccountId)>;
+		pub Paras: map hasher(twox_64_concat) ParaId => Option<(T::AccountId, BalanceOf<T>)>;
 
 		/// Amounts held on deposit for each (possibly future) leased parachain.
 		///
@@ -262,6 +262,7 @@ decl_module! {
 			// TODO...
 			//   (Should only be possible when called from the parachain itself or Root. Should free up
 			//   all associated deposits)
+			Ok(())
 		}
 
 		/// Just a hotwire into the `lease_out` call, in case Root wants to force some lease to happen
@@ -362,6 +363,7 @@ decl_module! {
 			// } else {
 			// 	Err(Error::<T>::UnsetDeployData)?
 			// }
+			Ok(())
 		}
 	}
 }


### PR DESCRIPTION
Now that ParaId registration happens ahead of time, we can use it instead of a Fund Index for Crowdloans.