### PR TITLE
[CI] Matrix release-notifications redux

### DIFF
--- a/.github/workflows/release-bot.yml
+++ b/.github/workflows/release-bot.yml
@@ -1,4 +1,4 @@
-name: Push release notes to internal release notes channel
+name: Send new release notification to matrix channels
 on:
   release:
     types:
@@ -8,13 +8,11 @@ jobs:
     strategy:
       matrix:
         channel:
-          # TODO: Test channels, remove before merging
-          - '!BtOFjyjPaOPcxxIzll:matrix.parity.io'
-          - '!wvmkoSfnHAQEOZKJcg:matrix.parity.io'
-#         - '!LhjZccBOqFNYKLdmbb:polkadot.builders' # #KusamaValidatorLounge:polkadot.builders
-#         - '!FMwxpQnYhRCNDRsYGI:matrix.parity.io' # #kusama-announcements:matrix.parity.io
-#         - '!NZrbtteFeqYKCUGQtr:matrix.parity.io' # #polkadotvalidatorlounge:web3.foundation
-#         - '!UqHPWiCBGZWxrmYBkF:matrix.parity.io' # #polkadot-announcements:matrix.parity.io
+        - '!LhjZccBOqFNYKLdmbb:polkadot.builders' # #KusamaValidatorLounge:polkadot.builders
+        - '!FMwxpQnYhRCNDRsYGI:matrix.parity.io' # #kusama-announcements:matrix.parity.io
+        - '!NZrbtteFeqYKCUGQtr:matrix.parity.io' # #polkadotvalidatorlounge:web3.foundation
+        - '!UqHPWiCBGZWxrmYBkF:matrix.parity.io' # #polkadot-announcements:matrix.parity.io
+        - '!NTogofoetwjbTwOoPi:matrix.parity.io' # Internal release-notes channel
     runs-on: ubuntu-latest
     steps:
       - uses: s3krit/matrix-message-action@v0.0.3

--- a/.github/workflows/release-bot.yml
+++ b/.github/workflows/release-bot.yml
@@ -4,17 +4,17 @@ on:
     types:
       - published
 jobs:
-  strategy:
-    matrix:
-      channel:
-        # TODO: Test channels, remove before merging
-        - '!BtOFjyjPaOPcxxIzll:matrix.parity.io'
-        - '!wvmkoSfnHAQEOZKJcg:matrix.parity.io'
+  ping_matrix:
+    strategy:
+      matrix:
+        channel:
+          # TODO: Test channels, remove before merging
+          - '!BtOFjyjPaOPcxxIzll:matrix.parity.io'
+          - '!wvmkoSfnHAQEOZKJcg:matrix.parity.io'
 #         - '!LhjZccBOqFNYKLdmbb:polkadot.builders' # #KusamaValidatorLounge:polkadot.builders
 #         - '!FMwxpQnYhRCNDRsYGI:matrix.parity.io' # #kusama-announcements:matrix.parity.io
 #         - '!NZrbtteFeqYKCUGQtr:matrix.parity.io' # #polkadotvalidatorlounge:web3.foundation
 #         - '!UqHPWiCBGZWxrmYBkF:matrix.parity.io' # #polkadot-announcements:matrix.parity.io
-  ping_matrix:
     runs-on: ubuntu-latest
     steps:
       - uses: s3krit/matrix-message-action@v0.0.3

--- a/.github/workflows/release-bot.yml
+++ b/.github/workflows/release-bot.yml
@@ -4,29 +4,22 @@ on:
     types:
       - published
 jobs:
+  strategy:
+    matrix:
+      channel:
+        # TODO: Test channels, remove before merging
+        - '!BtOFjyjPaOPcxxIzll:matrix.parity.io'
+        - '!wvmkoSfnHAQEOZKJcg:matrix.parity.io'
+#         - '!LhjZccBOqFNYKLdmbb:polkadot.builders' # #KusamaValidatorLounge:polkadot.builders
+#         - '!FMwxpQnYhRCNDRsYGI:matrix.parity.io' # #kusama-announcements:matrix.parity.io
+#         - '!NZrbtteFeqYKCUGQtr:matrix.parity.io' # #polkadotvalidatorlounge:web3.foundation
+#         - '!UqHPWiCBGZWxrmYBkF:matrix.parity.io' # #polkadot-announcements:matrix.parity.io
   ping_matrix:
     runs-on: ubuntu-latest
     steps:
-      - name: Internal Release Notes Channel
-        uses: s3krit/matrix-message-action@v0.0.3
+      - uses: s3krit/matrix-message-action@v0.0.3
         with:
-          room_id: ${{ secrets.MATRIX_ROOM_ID }}
+          room_id: ${{ matrix.channel }} # heh
           access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
-          message: "**${{github.event.repository.full_name}}:** A release has been ${{github.event.action}}<br/>Release version [${{github.event.release.tag_name}}](${{github.event.release.html_url}})<br/><br/>***Description:***<br/>${{github.event.release.body}}<br/>"
-          server: "matrix.parity.io"
-
-      - name: Validator Lounge
-        uses: s3krit/matrix-message-action@v0.0.3
-        with:
-          room_id: ${{ secrets.VALIDATOR_LOUNGE_MATRIX_ROOM_ID }}
-          access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
-          message: "***Polkadot ${{github.event.release.tag_name}} has been released!***<br/>Please update at your earliest convenience.<br/>${{github.event.release.html_url}}<br/><br/>${{github.event.release.body}}<br/>"
-          server: "matrix.parity.io"
-
-      - name: Polkadot Announcements
-        uses: s3krit/matrix-message-action@v0.0.3
-        with:
-          room_id: ${{ secrets.KUSAMA_ANNOUNCEMENTS_MATRIX_ROOM_ID }}
-          access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
-          message: "***Polkadot ${{github.event.release.tag_name}} has been released!***<br/>Please update at your earliest convenience.<br/>${{github.event.release.html_url}}<br/><br/>${{github.event.release.body}}<br/>"
+          message: "***Polkadot ${{github.event.release.tag_name}} has been released!***<br/>${{github.event.release.html_url}}<br/><br/>${{github.event.release.body}}<br/>"
           server: "matrix.parity.io"


### PR DESCRIPTION
This changes the matrix notification CI job to take a list of channels and iterate over them, rather than having 1 step per channel. This also means we can remove the channel 'internal IDs' from secrets (I verified on #matrix-dev:matrix.org that internal IDs are not considered secrets, and cannot be used to gain any more information than 'a channel with this ID once existed on this server, maybe'). Any additional channels we wish to send release notifications for can now easily be appended to the strategy.

@wpank if you think there are any other channels we should add to this list, let me know. It also means you can stop manually notifying the polkadot channels every release ;)