### PR TITLE
use executor cache in polkadot-parachain executor

### DIFF
--- a/core-primitives/src/lib.rs
+++ b/core-primitives/src/lib.rs
@@ -20,8 +20,10 @@
 //!
 //! These core Polkadot types are used by the relay chain and the Parachains.
 
-use sp_runtime::{generic, MultiSignature, traits::{Verify, BlakeTwo256, IdentifyAccount}};
+use sp_runtime::{generic, MultiSignature, traits::{Verify, IdentifyAccount}};
 use parity_scale_codec::{Encode, Decode};
+
+pub use sp_runtime::traits::{BlakeTwo256, Hash as HashT};
 
 /// The block number type used by Polkadot.
 /// 32-bits will allow for 136 years of blocks assuming 1 block per second.

--- a/parachain/src/wasm_executor/mod.rs
+++ b/parachain/src/wasm_executor/mod.rs
@@ -181,7 +181,6 @@ impl Default for ExecutorCache {
 }
 
 /// Validate a candidate under the given validation code.
-/// The provided cache is only used if the isolation strategy is local.
 ///
 /// This will fail if the validation code is not a proper parachain validation module.
 pub fn validate_candidate(

--- a/parachain/src/wasm_executor/mod.rs
+++ b/parachain/src/wasm_executor/mod.rs
@@ -160,8 +160,28 @@ pub enum InternalError {
 	WasmWorker(String),
 }
 
+/// A cache of executors for different parachain Wasm instances.
+///
+/// This should be reused across candidate validation instances.
+pub struct ExecutorCache(sc_executor::WasmExecutor);
+
+impl Default for ExecutorCache {
+	fn default() -> Self {
+		ExecutorCache(sc_executor::WasmExecutor::new(
+			#[cfg(all(feature = "wasmtime", not(any(target_os = "android", target_os = "unknown"))))]
+			sc_executor::WasmExecutionMethod::Compiled,
+			#[cfg(any(not(feature = "wasmtime"), target_os = "android", target_os = "unknown"))]
+			sc_executor::WasmExecutionMethod::Interpreted,
+			// TODO: Make sure we don't use more than 1GB: https://github.com/paritytech/polkadot/issues/699
+			Some(1024),
+			HostFunctions::host_functions(),
+			8
+		))
+	}
+}
 
 /// Validate a candidate under the given validation code.
+/// The provided cache is only used if the isolation strategy is local.
 ///
 /// This will fail if the validation code is not a proper parachain validation module.
 pub fn validate_candidate(
@@ -172,7 +192,12 @@ pub fn validate_candidate(
 ) -> Result<ValidationResult, ValidationError> {
 	match isolation_strategy {
 		IsolationStrategy::InProcess => {
-			validate_candidate_internal(validation_code, &params.encode(), spawner)
+			validate_candidate_internal(
+				&ExecutorCache::default(),
+				validation_code,
+				&params.encode(),
+				spawner,
+			)
 		},
 		#[cfg(not(any(target_os = "android", target_os = "unknown")))]
 		IsolationStrategy::ExternalProcessSelfHost(pool) => {
@@ -193,20 +218,12 @@ type HostFunctions = sp_io::SubstrateHostFunctions;
 ///
 /// This will fail if the validation code is not a proper parachain validation module.
 pub fn validate_candidate_internal(
+	executor: &ExecutorCache,
 	validation_code: &[u8],
 	encoded_call_data: &[u8],
 	spawner: impl SpawnNamed + 'static,
 ) -> Result<ValidationResult, ValidationError> {
-	let executor = sc_executor::WasmExecutor::new(
-		#[cfg(all(feature = "wasmtime", not(any(target_os = "android", target_os = "unknown"))))]
-		sc_executor::WasmExecutionMethod::Compiled,
-		#[cfg(any(not(feature = "wasmtime"), target_os = "android", target_os = "unknown"))]
-		sc_executor::WasmExecutionMethod::Interpreted,
-		// TODO: Make sure we don't use more than 1GB: https://github.com/paritytech/polkadot/issues/699
-		Some(1024),
-		HostFunctions::host_functions(),
-		8
-	);
+	let executor = &executor.0;
 
 	let mut extensions = Extensions::new();
 	extensions.register(sp_core::traits::TaskExecutorExt::new(spawner));
@@ -214,9 +231,16 @@ pub fn validate_candidate_internal(
 
 	let mut ext = ValidationExternalities(extensions);
 
+	// Expensive, but not more-so than recompiling the wasm module.
+	// And we need this hash to access the `sc_executor` cache.
+	let code_hash = {
+		use polkadot_core_primitives::{BlakeTwo256, HashT};
+		BlakeTwo256::hash(validation_code)
+	};
+
 	let res = executor.call_in_wasm(
 		validation_code,
-		None,
+		Some(code_hash.as_bytes().to_vec()),
 		"validate_block",
 		encoded_call_data,
 		&mut ext,

--- a/parachain/src/wasm_executor/validation_host.rs
+++ b/parachain/src/wasm_executor/validation_host.rs
@@ -151,6 +151,8 @@ pub fn run_worker(mem_id: &str) -> Result<(), String> {
 	memory.set(Event::WorkerReady as usize, EventState::Signaled)
 		.map_err(|e| format!("{} Error setting shared event: {:?}", process::id(), e))?;
 
+	let executor = super::ExecutorCache::default();
+
 	loop {
 		if watch_exit.load(atomic::Ordering::Relaxed) {
 			break;
@@ -184,7 +186,7 @@ pub fn run_worker(mem_id: &str) -> Result<(), String> {
 				let (call_data, _) = rest.split_at_mut(MAX_RUNTIME_MEM);
 				let (call_data, _) = call_data.split_at_mut(header.params_size as usize);
 
-				let result = validate_candidate_internal(code, call_data, task_executor.clone());
+				let result = validate_candidate_internal(&executor, code, call_data, task_executor.clone());
 				debug!(target: LOG_TARGET, "{} Candidate validated: {:?}", process::id(), result);
 
 				match result {


### PR DESCRIPTION
The `sc_executor` cache isn't really built for this purpose, but we can reuse it.

I'm not super familiar with the lower-level executor code but my understanding is it'll allow reuse of the Wasmtime-compiled code across runs of the program. As things were implemented before, I think we'd be re-compiling the code every time we wanted to execute a parachain block.

The changes I made here only really help the child processes. It doesn't reuse any cache for in-main-process candidate validation.

This might be high in memory as we'll have a separate cache for every one of our child processes for executing the parachain code. It would be nice to find a way to share the cache among these child processes for two reasons:
  1. Less memory
  2. Pre-populate the cache based on our assignments in approval voting or our backing group rotation

