### PR TITLE
Approval voting guide changes

### DIFF
--- a/roadmap/implementers-guide/src/node/approval/approval-voting.md
+++ b/roadmap/implementers-guide/src/node/approval/approval-voting.md
@@ -113,6 +113,15 @@ struct ApprovalVoteRequest {
   candidate_index: CandidateIndex,
 }
 
+// Requests that background work (approval voting tasks) may need to make of the main subsystem
+// task.
+enum BackgroundRequest {
+  ApprovalVote(ApprovalVoteRequest),
+  // .. others, unspecified as per implementation.
+}
+
+// This is the general state of the subsystem. The actual implementation may split this
+// into further pieces.
 struct State {
     earliest_session: SessionIndex,
     session_info: Vec<SessionInfo>,
@@ -121,10 +130,12 @@ struct State {
     wakeups: BTreeMap<Tick, Vec<(Hash, Hash)>>, // Tick -> [(Relay Block, Candidate Hash)]
 
     // These are connected to each other.
-    approval_vote_tx: mpsc::Sender<ApprovalVoteRequest>,
-    approval_vote_rx: mpsc::Receiver<ApprovalVoteRequest>,
+    background_tx: mpsc::Sender<BackgroundRequest>,
+    background_rx: mpsc::Receiver<BackgroundRequest>,
 }
 ```
+
+This guide section makes no explicit references to writes to or reads from disk. Instead, it handles them implicitly, with the understanding that updates to block, candidate, and approval entries are persisted to disk.
 
 [`SessionInfo`](../../runtime/session_info.md)
 
@@ -134,7 +145,8 @@ Main loop:
   * Each iteration, select over all of
     * The next `Tick` in `wakeups`: trigger `wakeup_process` for each `(Hash, Hash)` pair scheduled under the `Tick` and then remove all entries under the `Tick`.
     * The next message from the overseer: handle the message as described in the [Incoming Messages section](#incoming-messages)
-    * The next request from `approval_vote_rx`: handle with `issue_approval`
+    * The next approval vote request from `background_rx`
+      * If this is an `ApprovalVoteRequest`, [Issue an approval vote](#issue-approval-vote).
 
 ### Incoming Messages
 
@@ -160,7 +172,7 @@ On receiving an `OverseerSignal::ActiveLeavesUpdate(update)`:
   * If a validator in this session, compute and assign `our_assignment` for the `block_assignments`
     * Only if not a member of the backing group.
     * Run `RelayVRFModulo` and `RelayVRFDelay` according to the [the approvals protocol section](../../protocol-approval.md#assignment-criteria). Ensure that the assigned core derived from the output is covered by the auxiliary signature aggregated in the `VRFPRoof`.
-  * invoke `process_wakeup(relay_block, candidate)` for each new candidate in each new block - this will automatically broadcast a 0-tranche assignment, kick off approval work, and schedule the next delay.
+  * [Handle Wakeup](#handle-wakeup) for each new candidate in each new block - this will automatically broadcast a 0-tranche assignment, kick off approval work, and schedule the next delay.
   * Dispatch an `ApprovalDistributionMessage::NewBlocks` with the meta information filled out for each new block.
 
 #### `ApprovalVotingMessage::CheckAndImportAssignment`
@@ -182,8 +194,8 @@ On receiving a `ApprovalVotingMessage::CheckAndImportAssignment` message, we che
     * Ensure the validator index is not present in the approval entry already.
     * Create a tranche entry for the delay tranche in the approval entry and note the assignment within it.
     * Note the candidate index within the approval entry.
-  * `check_full_approvals(candidate_entry, filter by this specific approval entry)`
-  * Schedule a wakeup with `next_wakeup`.
+  * [Check for full approval of the candidate entry](#check-full-approval) of the candidate_entry, filtering by this specific approval entry.
+  * [Schedule a wakeup](#schedule-wakeup) of the candidate.
   * return the appropriate `AssignmentCheckResult` on the response channel.
 
 #### `ApprovalVotingMessage::CheckAndImportApproval`
@@ -193,7 +205,7 @@ On receiving a `CheckAndImportApproval(indirect_approval_vote, response_channel)
   * Fetch the `CandidateEntry` from the indirect approval vote's `candidate_index`. If the block did not trigger inclusion of enough candidates, return `ApprovalCheckResult::Bad`.
   * Construct a `SignedApprovalVote` using the candidate hash and check against the validator's approval key, based on the session info of the block. If invalid or no such validator, return `ApprovalCheckResult::Bad`.
   * Send `ApprovalCheckResult::Accepted`
-  * `import_checked_approval(BlockEntry, CandidateEntry, ValidatorIndex)`
+  * [Import the checked approval vote](#import-checked-approval)
 
 #### `ApprovalVotingMessage::ApprovedAncestor`
 
@@ -205,24 +217,71 @@ On receiving an `ApprovedAncestor(Hash, BlockNumber, response_channel)`:
   * If the block entry's `approval_bitfield` has any 0 bits, set `all_approved_max = None`.
   * After iterating all ancestry, return `all_approved_max`.
 
-### Utility
+### Updates and Auxiliary Logic
 
-#### `tranche_now(slot_number, time) -> DelayTranche`
-  * Convert `time.saturating_sub(slot_number.to_time())` to a delay tranches value
-
-
-#### `import_checked_approval(BlockEntry, CandidateEntry, ValidatorIndex)`
+#### Import Checked Approval
+  * Import an approval vote which we can assume to have passed signature checks.
+  * Requires `(BlockEntry, CandidateEntry, ValidatorIndex)`
   * Set the corresponding bit of the `approvals` bitfield in the `CandidateEntry` to `1`. If already `1`, return.
-  * `check_full_approvals(candidate_entry, filter by validators assigned to)`
+  * [Check full approval of the candidate](#check-full-approval)
 
-#### `check_full_approvals(CandidateEntry, filter)`:
+#### Check Full Approval
+  * Checks the approval state of the candidate under every block it is included by, and updates the block entries accordingly.
+  * Requires `(CandidateEntry, filter)`, where filter is used to limit which approval entries are inspected.
   * Checks every `ApprovalEntry` that is not yet `approved` for whether it is now approved.
     * For each `ApprovalEntry` in the `CandidateEntry` that is not `approved` and passes the `filter`
     * Load the block entry for the `ApprovalEntry`.
-    * If so, set `n_tranches = tranches_to_approve(approval_entry, tranche_now(block.slot, now()))`.
-    * If `check_approval(block_entry, candidate_entry, approval_entry, n_tranches)` is true, set the corresponding bit in the `block_entry.approved_bitfield`.
+    * If so, [determine the tranches to inspect](#determine-required-tranches) of the candidate, 
+    * If [the candidate is approved under the block](#check-approval), set the corresponding bit in the `block_entry.approved_bitfield`.
 
-#### `tranches_to_approve(approval_entry, approvals, tranche_now, block_tick, no_show_duration, needed_approvals) -> RequiredTranches`
+#### Handling Wakeup
+  * Handle a previously-scheduled wakeup of a candidate under a specific block.
+  * Requires `(relay_block, candidate_hash)`
+  * Load the `BlockEntry` and `CandidateEntry` from disk. If either is not present, this may have lost a race with finality and can be ignored. Also load the `ApprovalEntry` for the block and candidate.
+  * [determine the `RequiredTranches` of the candidate](#determine-required-tranches).
+  * Determine if we should trigger our assignment.
+    * If we've already triggered or `OurAssignment` is `None`, we do not trigger.
+    * If we have  `RequiredTranches::All`, then we trigger if the candidate is [not approved](#check-approval).
+    * If we have `RequiredTranches::Pending(max)`, then we trigger if our assignment's tranche is less than or equal to `max`.
+    * If we have `RequiredTranches::Exact(tranche)` then we do not trigger, because this value indicates that no new assignments are needed at the moment.
+  * If we should trigger our assignment
+    * Import the assignment to the `ApprovalEntry`
+    * Broadcast on network with an `ApprovalDistributionMessage::DistributeAssignment`.
+    * [Launch approval work](#launch-approval-work) for the candidate. 
+  * [Schedule a new wakeup](#schedule-wakeup) of the candidate.
+
+#### Schedule Wakeup
+  * Requires `(approval_entry, candidate_entry)` which effectively denotes a `(Block Hash, Candidate Hash)` pair - the candidate, along with the block it appears in.
+  * If the `approval_entry` is approved, this doesn't need to be woken up again.
+  * Return the earlier of our next no-show timeout or the tranche of our assignment, if not yet triggered
+  * Our next no-show timeout is computed by finding the earliest-received assignment within `n_tranches` for which we have not received an approval and adding `to_ticks(session_info.no_show_slots)` to it.
+  * If the approval entry is already approved, or we have triggered our assignment and there are no pending no-shows, we do not need to schedule a wakeup. Note that the latter case is only possible when we have not seen enough assignments in order to approve. When we receive an incoming assignment, we will schedule a new wakeup, and the `(Block, Candidate)` pair will continue to be processed appropriately.
+
+#### Launch Approval Work
+  * Requires `(SessionIndex, SessionInfo, CandidateReceipt, ValidatorIndex, block_hash, candidate_index)`
+  * Extract the public key of the `ValidatorIndex` from the `SessionInfo` for the session.
+  * Issue an `AvailabilityRecoveryMessage::RecoverAvailableData(candidate, session_index, response_sender)`
+  * Load the historical validation code of the parachain by dispatching a `RuntimeApiRequest::HistoricalValidationCode(`descriptor.para_id`, `descriptor.relay_parent`)` against the state of `block_hash`.
+  * Spawn a background task with a clone of `background_tx`
+    * Wait for the available data
+    * Issue a `CandidateValidationMessage::ValidateFromExhaustive` message
+    * Wait for the result of validation
+    * If valid, issue a message on `background_tx` detailing the request.
+
+#### Issue Approval Vote
+  * Fetch the block entry and candidate entry. Ignore if `None` - we've probably just lost a race with finality.
+  * Construct a `SignedApprovalVote` with the validator index for the session.
+  * [Import the checked approval vote](#import-checked-approval). It is "checked" as we've just issued the signature.
+  * Construct a `IndirectSignedApprovalVote` using the information about the vote.
+  * Dispatch `ApprovalDistributionMessage::DistributeApproval`.
+
+### Determining Approval of Candidate
+
+#### Determine Required Tranches
+
+This is pure logic is for inspecting an approval entry, containing the assignments received, the current time, requirements for approval, and the approval votes already received to determine how many of the delay tranches of the approval entry are relevant, as well as contextual information about what may be remaining to check on the candidate.
+
+Requires `(approval_entry, approvals_received, tranche_now, block_tick, no_show_duration, needed_approvals)`
 
 ```rust
 enum RequiredTranches {
@@ -243,45 +302,17 @@ enum RequiredTranches {
       * We run out of tranches to take, having not received any assignments past a certain point. In this case we set `n_tranches` to a special value `RequiredTranches::Pending(last_taken_tranche + uncovered_no_shows)` which indicates that new assignments are needed. `uncovered_no_shows` is the number of no-shows we have not yet covered with `last_taken_tranche`.
       * All no-shows are covered by at least one non-empty tranche. Set `n_tranches` to the number of tranches taken and return `RequiredTranches::Exact(n_tranches)`.
       * The amount of assignments in non-empty & taken tranches plus the amount of needed extras equals or exceeds the total number of validators for the approval entry, which can be obtained by measuring the bitfield. In this case we return a special value `RequiredTranches::All` indicating that all validators have effectively been assigned to check.
-    * return `n_tranches`
+    * return `RequiredTranches::Exact(n_tranches, total_no_shows)`
 
-#### `check_approval(block_entry, candidate_entry, approval_entry, n_tranches) -> bool`
+#### Check Approval
+  * Check whether a candidate is approved under a particular block.
+  * Requires `(block_entry, candidate_entry, approval_entry, n_tranches)`
   * If `n_tranches` is `RequiredTranches::Pending`, return false
   * If `n_tranches` is `RequiredTranches::All`,  then we return `3 * n_approvals > 2 * n_validators`.
   * If `n_tranches` is `RequiredTranches::Exact(tranche, no_shows)`, then we return whether all assigned validators up to `tranche` less `no_shows` have approved. e.g. if we had 5 tranches and 1 no-show, we would accept all validators in tranches 0..=5 except for 1 approving. In that example, we also accept all validators in tranches 0..=5 approving, but that would indicate that the `RequiredTranches` value was incorrectly constructed, so it is not realistic. If there are more missing approvals than there are no-shows, that indicates that there are some assignments which are not yet no-shows, but may become no-shows.
 
-#### `process_wakeup(relay_block, candidate_hash)`
-  * Load the `BlockEntry` and `CandidateEntry` from disk. If either is not present, this may have lost a race with finality and can be ignored. Also load the `ApprovalEntry` for the block and candidate.
-  * Set `required = tranches_to_approve(approval_entry, tranche_now(block.slot, now()))`
-  * Determine if we should trigger our assignment.
-    * If we've already triggered or `OurAssignment` is `None`, we do not trigger.
-    * If `required` is `RequiredTranches::All`, then we trigger if `check_approval(block_entry, approval_entry, All)` is false.
-    * If `required` is `RequiredTranches::Pending(max)`, then we trigger if our assignment's tranche is less than or equal to `max`.
-    * If `required` is `RequiredTranches::Exact(tranche)` then we do not trigger, because this value indicates that no new assignments are needed at the moment.
-  * If we should trigger our assignment
-    * Import the assignment to the `ApprovalEntry`
-    * Broadcast on network with an `ApprovalDistributionMessage::DistributeAssignment`.
-    * Kick off approval work with `launch_approval`
-  * Schedule another wakeup based on `next_wakeup`
+### Time
 
-#### `next_wakeup(approval_entry, candidate_entry)`:
-  * If the `approval_entry` is approved, this doesn't need to be woken up again.
-  * Return the earlier of our next no-show timeout or the tranche of our assignment, if not yet triggered
-  * Our next no-show timeout is computed by finding the earliest-received assignment within `n_tranches` for which we have not received an approval and adding `to_ticks(session_info.no_show_slots)` to it.
-
-#### `launch_approval(SessionIndex, SessionInfo, CandidateReceipt, ValidatorIndex, block_hash, candidate_index)`:
-  * Extract the public key of the `ValidatorIndex` from the `SessionInfo` for the session.
-  * Issue an `AvailabilityRecoveryMessage::RecoverAvailableData(candidate, session_index, response_sender)`
-  * Load the historical validation code of the parachain by dispatching a `RuntimeApiRequest::HistoricalValidationCode(`descriptor.para_id`, `descriptor.relay_parent`)` against the state of `block_hash`.
-  * Spawn a background task with a clone of `approval_vote_tx`
-    * Wait for the available data
-    * Issue a `CandidateValidationMessage::ValidateFromExhaustive` message
-    * Wait for the result of validation
-    * If valid, issue a message on `approval_vote_tx` detailing the request.
-
-#### `issue_approval(request)`:
-  * Fetch the block entry and candidate entry. Ignore if `None` - we've probably just lost a race with finality.
-  * Construct a `SignedApprovalVote` with the validator index for the session.
-  * `import_checked_approval(block_entry, candidate_entry, validator_index)`
-  * Construct a `IndirectSignedApprovalVote` using the information about the vote.
-  * Dispatch `ApprovalDistributionMessage::DistributeApproval`.
+#### Current Tranche
+  * Given the slot number of a block, and the current time, this informs about the current tranche.
+  * Convert `time.saturating_sub(slot_number.to_time())` to a delay tranches value

--- a/roadmap/implementers-guide/src/runtime-api/candidate-events.md
+++ b/roadmap/implementers-guide/src/runtime-api/candidate-events.md
@@ -5,11 +5,11 @@ Yields a vector of events concerning candidates that occurred within the given b
 ```rust
 enum CandidateEvent {
 	/// This candidate receipt was backed in the most recent block.
-	CandidateBacked(CandidateReceipt, HeadData),
+	CandidateBacked(CandidateReceipt, HeadData, CoreIndex, GroupIndex),
 	/// This candidate receipt was included and became a parablock at the most recent block.
-	CandidateIncluded(CandidateReceipt, HeadData),
+	CandidateIncluded(CandidateReceipt, HeadData, CoreIndex, GroupIndex),
 	/// This candidate receipt was not made available in time and timed out.
-	CandidateTimedOut(CandidateReceipt, HeadData),
+	CandidateTimedOut(CandidateReceipt, HeadData, CoreIndex),
 }
 
 fn candidate_events(at: Block) -> Vec<CandidateEvent>;

--- a/roadmap/implementers-guide/src/runtime/inclusion.md
+++ b/roadmap/implementers-guide/src/runtime/inclusion.md
@@ -20,6 +20,7 @@ struct CandidatePendingAvailability {
   relay_parent_number: BlockNumber, // number of the relay-parent.
   backers: Bitfield, // one bit per validator, set for those who backed the candidate.
   backed_in_number: BlockNumber,
+  backing_group: GroupIndex,
 }
 ```
 

--- a/roadmap/implementers-guide/src/types/overseer-protocol.md
+++ b/roadmap/implementers-guide/src/types/overseer-protocol.md
@@ -59,28 +59,29 @@ enum ApprovalCheckResult {
 }
 
 enum ApprovalVotingMessage {
-    /// Check if the assignment is valid and can be accepted by our view of the protocol.
-    /// Should not be sent unless the block hash is known.
-    CheckAndImportAssignment(
-        IndirectAssignmentCert,
-        ResponseChannel<AssignmentCheckResult>,
-    ),
-    /// Check if the approval vote is valid and can be accepted by our view of the
-    /// protocol.
-    ///
-    /// Should not be sent unless the block hash within the indirect vote is known.
-    CheckAndImportApproval(
-        IndirectSignedApprovalVote,
-        ResponseChannel<ApprovalCheckResult>,
-    ),
-    /// Returns the highest possible ancestor hash of the provided block hash which is
-    /// acceptable to vote on finality for.
-    /// The `BlockNumber` provided is the number of the block's ancestor which is the
-    /// earliest possible vote.
-    ///
-    /// It can also return the same block hash, if that is acceptable to vote upon.
-    /// Return `None` if the input hash is unrecognized.
-    ApprovedAncestor(Hash, BlockNumber, ResponseChannel<Option<Hash>>),
+	/// Check if the assignment is valid and can be accepted by our view of the protocol.
+	/// Should not be sent unless the block hash is known.
+	CheckAndImportAssignment(
+		IndirectAssignmentCert,
+		CandidateIndex, // The index of the candidate included in the block.
+		ResponseChannel<AssignmentCheckResult>,
+	),
+	/// Check if the approval vote is valid and can be accepted by our view of the
+	/// protocol.
+	///
+	/// Should not be sent unless the block hash within the indirect vote is known.
+	CheckAndImportApproval(
+		IndirectSignedApprovalVote,
+		ResponseChannel<ApprovalCheckResult>,
+	),
+	/// Returns the highest possible ancestor hash of the provided block hash which is
+	/// acceptable to vote on finality for.
+	/// The `BlockNumber` provided is the number of the block's ancestor which is the
+	/// earliest possible vote.
+	///
+	/// It can also return the same block hash, if that is acceptable to vote upon.
+	/// Return `None` if the input hash is unrecognized.
+	ApprovedAncestor(Hash, BlockNumber, ResponseChannel<Option<Hash>>),
 }
 ```
 
@@ -472,43 +473,45 @@ This is fueled by an auxiliary type encapsulating all request types defined in t
 
 ```rust
 enum RuntimeApiRequest {
-    /// Get the current validator set.
-    Validators(ResponseChannel<Vec<ValidatorId>>),
-    /// Get the validator groups and rotation info.
-    ValidatorGroups(ResponseChannel<(Vec<Vec<ValidatorIndex>>, GroupRotationInfo)>),
-    /// Get information about all availability cores.
-    AvailabilityCores(ResponseChannel<Vec<CoreState>>),
-    /// with the given occupied core assumption.
-    PersistedValidationData(
-        ParaId,
-        OccupiedCoreAssumption,
-        ResponseChannel<Option<PersistedValidationData>>,
-    ),
-    /// Sends back `true` if the commitments pass all acceptance criteria checks.
-    CheckValidationOutputs(
-        ParaId,
-        CandidateCommitments,
-        RuntimeApiSender<bool>,
-    ),
-    /// Get the session index for children of the block. This can be used to construct a signing
-    /// context.
-    SessionIndexForChild(ResponseChannel<SessionIndex>),
-    /// Get the validation code for a specific para, using the given occupied core assumption.
-    ValidationCode(ParaId, OccupiedCoreAssumption, ResponseChannel<Option<ValidationCode>>),
-    /// Fetch the historical validation code used by a para for candidates executed in
-    /// the context of a given block height in the current chain.
-    HistoricalValidationCode(ParaId, BlockNumber, ResponseChannel<Option<ValidationCode>>),
-    /// Get a committed candidate receipt for all candidates pending availability.
-    CandidatePendingAvailability(ParaId, ResponseChannel<Option<CommittedCandidateReceipt>>),
-    /// Get all events concerning candidates in the last block.
-    CandidateEvents(ResponseChannel<Vec<CandidateEvent>>),
-    /// Get the session info for the given session, if stored.
-    SessionInfo(SessionIndex, ResponseChannel<Option<SessionInfo>>),
-    /// Get all the pending inbound messages in the downward message queue for a para.
-    DmqContents(ParaId, ResponseChannel<Vec<InboundDownwardMessage<BlockNumber>>>),
-    /// Get the contents of all channels addressed to the given recipient. Channels that have no
-    /// messages in them are also included.
-    InboundHrmpChannelsContents(ParaId, ResponseChannel<BTreeMap<ParaId, Vec<InboundHrmpMessage<BlockNumber>>>>),
+	/// Get the current validator set.
+	Validators(ResponseChannel<Vec<ValidatorId>>),
+	/// Get the validator groups and rotation info.
+	ValidatorGroups(ResponseChannel<(Vec<Vec<ValidatorIndex>>, GroupRotationInfo)>),
+	/// Get information about all availability cores.
+	AvailabilityCores(ResponseChannel<Vec<CoreState>>),
+	/// with the given occupied core assumption.
+	PersistedValidationData(
+		ParaId,
+		OccupiedCoreAssumption,
+		ResponseChannel<Option<PersistedValidationData>>,
+	),
+	/// Sends back `true` if the commitments pass all acceptance criteria checks.
+	CheckValidationOutputs(
+		ParaId,
+		CandidateCommitments,
+		RuntimeApiSender<bool>,
+	),
+	/// Get the session index for children of the block. This can be used to construct a signing
+	/// context.
+	SessionIndexForChild(ResponseChannel<SessionIndex>),
+	/// Get the validation code for a specific para, using the given occupied core assumption.
+	ValidationCode(ParaId, OccupiedCoreAssumption, ResponseChannel<Option<ValidationCode>>),
+	/// Fetch the historical validation code used by a para for candidates executed in
+	/// the context of a given block height in the current chain.
+	HistoricalValidationCode(ParaId, BlockNumber, ResponseChannel<Option<ValidationCode>>),
+	/// Get a committed candidate receipt for all candidates pending availability.
+	CandidatePendingAvailability(ParaId, ResponseChannel<Option<CommittedCandidateReceipt>>),
+	/// Get all events concerning candidates in the last block.
+	CandidateEvents(ResponseChannel<Vec<CandidateEvent>>),
+	/// Get the session info for the given session, if stored.
+	SessionInfo(SessionIndex, ResponseChannel<Option<SessionInfo>>),
+	/// Get all the pending inbound messages in the downward message queue for a para.
+	DmqContents(ParaId, ResponseChannel<Vec<InboundDownwardMessage<BlockNumber>>>),
+	/// Get the contents of all channels addressed to the given recipient. Channels that have no
+	/// messages in them are also included.
+	InboundHrmpChannelsContents(ParaId, ResponseChannel<BTreeMap<ParaId, Vec<InboundHrmpMessage<BlockNumber>>>>),
+	/// Get information about the BABE epoch this block was produced in.
+	BabeEpoch(ResponseChannel<BabeEpoch>),
 }
 
 enum RuntimeApiMessage {

--- a/roadmap/implementers-guide/src/types/overseer-protocol.md
+++ b/roadmap/implementers-guide/src/types/overseer-protocol.md
@@ -59,29 +59,29 @@ enum ApprovalCheckResult {
 }
 
 enum ApprovalVotingMessage {
-	/// Check if the assignment is valid and can be accepted by our view of the protocol.
-	/// Should not be sent unless the block hash is known.
-	CheckAndImportAssignment(
-		IndirectAssignmentCert,
-		CandidateIndex, // The index of the candidate included in the block.
-		ResponseChannel<AssignmentCheckResult>,
-	),
-	/// Check if the approval vote is valid and can be accepted by our view of the
-	/// protocol.
-	///
-	/// Should not be sent unless the block hash within the indirect vote is known.
-	CheckAndImportApproval(
-		IndirectSignedApprovalVote,
-		ResponseChannel<ApprovalCheckResult>,
-	),
-	/// Returns the highest possible ancestor hash of the provided block hash which is
-	/// acceptable to vote on finality for.
-	/// The `BlockNumber` provided is the number of the block's ancestor which is the
-	/// earliest possible vote.
-	///
-	/// It can also return the same block hash, if that is acceptable to vote upon.
-	/// Return `None` if the input hash is unrecognized.
-	ApprovedAncestor(Hash, BlockNumber, ResponseChannel<Option<Hash>>),
+    /// Check if the assignment is valid and can be accepted by our view of the protocol.
+    /// Should not be sent unless the block hash is known.
+    CheckAndImportAssignment(
+        IndirectAssignmentCert,
+        CandidateIndex, // The index of the candidate included in the block.
+        ResponseChannel<AssignmentCheckResult>,
+    ),
+    /// Check if the approval vote is valid and can be accepted by our view of the
+    /// protocol.
+    ///
+    /// Should not be sent unless the block hash within the indirect vote is known.
+    CheckAndImportApproval(
+        IndirectSignedApprovalVote,
+        ResponseChannel<ApprovalCheckResult>,
+    ),
+    /// Returns the highest possible ancestor hash of the provided block hash which is
+    /// acceptable to vote on finality for.
+    /// The `BlockNumber` provided is the number of the block's ancestor which is the
+    /// earliest possible vote.
+    ///
+    /// It can also return the same block hash, if that is acceptable to vote upon.
+    /// Return `None` if the input hash is unrecognized.
+    ApprovedAncestor(Hash, BlockNumber, ResponseChannel<Option<Hash>>),
 }
 ```
 
@@ -473,45 +473,45 @@ This is fueled by an auxiliary type encapsulating all request types defined in t
 
 ```rust
 enum RuntimeApiRequest {
-	/// Get the current validator set.
-	Validators(ResponseChannel<Vec<ValidatorId>>),
-	/// Get the validator groups and rotation info.
-	ValidatorGroups(ResponseChannel<(Vec<Vec<ValidatorIndex>>, GroupRotationInfo)>),
-	/// Get information about all availability cores.
-	AvailabilityCores(ResponseChannel<Vec<CoreState>>),
-	/// with the given occupied core assumption.
-	PersistedValidationData(
-		ParaId,
-		OccupiedCoreAssumption,
-		ResponseChannel<Option<PersistedValidationData>>,
-	),
-	/// Sends back `true` if the commitments pass all acceptance criteria checks.
-	CheckValidationOutputs(
-		ParaId,
-		CandidateCommitments,
-		RuntimeApiSender<bool>,
-	),
-	/// Get the session index for children of the block. This can be used to construct a signing
-	/// context.
-	SessionIndexForChild(ResponseChannel<SessionIndex>),
-	/// Get the validation code for a specific para, using the given occupied core assumption.
-	ValidationCode(ParaId, OccupiedCoreAssumption, ResponseChannel<Option<ValidationCode>>),
-	/// Fetch the historical validation code used by a para for candidates executed in
-	/// the context of a given block height in the current chain.
-	HistoricalValidationCode(ParaId, BlockNumber, ResponseChannel<Option<ValidationCode>>),
-	/// Get a committed candidate receipt for all candidates pending availability.
-	CandidatePendingAvailability(ParaId, ResponseChannel<Option<CommittedCandidateReceipt>>),
-	/// Get all events concerning candidates in the last block.
-	CandidateEvents(ResponseChannel<Vec<CandidateEvent>>),
-	/// Get the session info for the given session, if stored.
-	SessionInfo(SessionIndex, ResponseChannel<Option<SessionInfo>>),
-	/// Get all the pending inbound messages in the downward message queue for a para.
-	DmqContents(ParaId, ResponseChannel<Vec<InboundDownwardMessage<BlockNumber>>>),
-	/// Get the contents of all channels addressed to the given recipient. Channels that have no
-	/// messages in them are also included.
-	InboundHrmpChannelsContents(ParaId, ResponseChannel<BTreeMap<ParaId, Vec<InboundHrmpMessage<BlockNumber>>>>),
-	/// Get information about the BABE epoch this block was produced in.
-	BabeEpoch(ResponseChannel<BabeEpoch>),
+    /// Get the current validator set.
+    Validators(ResponseChannel<Vec<ValidatorId>>),
+    /// Get the validator groups and rotation info.
+    ValidatorGroups(ResponseChannel<(Vec<Vec<ValidatorIndex>>, GroupRotationInfo)>),
+    /// Get information about all availability cores.
+    AvailabilityCores(ResponseChannel<Vec<CoreState>>),
+    /// with the given occupied core assumption.
+    PersistedValidationData(
+        ParaId,
+        OccupiedCoreAssumption,
+        ResponseChannel<Option<PersistedValidationData>>,
+    ),
+    /// Sends back `true` if the commitments pass all acceptance criteria checks.
+    CheckValidationOutputs(
+        ParaId,
+        CandidateCommitments,
+        RuntimeApiSender<bool>,
+    ),
+    /// Get the session index for children of the block. This can be used to construct a signing
+    /// context.
+    SessionIndexForChild(ResponseChannel<SessionIndex>),
+    /// Get the validation code for a specific para, using the given occupied core assumption.
+    ValidationCode(ParaId, OccupiedCoreAssumption, ResponseChannel<Option<ValidationCode>>),
+    /// Fetch the historical validation code used by a para for candidates executed in
+    /// the context of a given block height in the current chain.
+    HistoricalValidationCode(ParaId, BlockNumber, ResponseChannel<Option<ValidationCode>>),
+    /// Get a committed candidate receipt for all candidates pending availability.
+    CandidatePendingAvailability(ParaId, ResponseChannel<Option<CommittedCandidateReceipt>>),
+    /// Get all events concerning candidates in the last block.
+    CandidateEvents(ResponseChannel<Vec<CandidateEvent>>),
+    /// Get the session info for the given session, if stored.
+    SessionInfo(SessionIndex, ResponseChannel<Option<SessionInfo>>),
+    /// Get all the pending inbound messages in the downward message queue for a para.
+    DmqContents(ParaId, ResponseChannel<Vec<InboundDownwardMessage<BlockNumber>>>),
+    /// Get the contents of all channels addressed to the given recipient. Channels that have no
+    /// messages in them are also included.
+    InboundHrmpChannelsContents(ParaId, ResponseChannel<BTreeMap<ParaId, Vec<InboundHrmpMessage<BlockNumber>>>>),
+    /// Get information about the BABE epoch this block was produced in.
+    BabeEpoch(ResponseChannel<BabeEpoch>),
 }
 
 enum RuntimeApiMessage {


### PR DESCRIPTION
I've created a separate PR for guide updates to approval voting. I have initially taken these from #2112, but I will be modifying the guide to make it more understandable.

I also wrote this section of the guide initially with lots of implementation details. That was good for initially thinking out the design, but it didn't map cleanly onto good Rust code. It wasn't clear whether diverging from the guide in terms of these details would require a guide update.

I'm amending the guide to try and omit lower-level details and focus instead on higher level information and invariants that are to be preserved. I'll follow this up with some refactoring of the approval-voting code to improve it and make it more testable in the main approval-voting PR.