### PR TITLE
Explicit Para Lifecycle w/ Upgrades and Downgrades

### DIFF
--- a/roadmap/implementers-guide/src/runtime/paras.md
+++ b/roadmap/implementers-guide/src/runtime/paras.md
@@ -200,7 +200,8 @@ UpcomingDowngrades: Vec<ParaId>;
 * `lifecycle(ParaId) -> Option<ParaLifecycle>`: Return the `ParaLifecycle` of a para.
 * `is_parachain(ParaId) -> bool`: Returns true if the para ID references any live parachain, including
   those which may be transitioning to a parathread in the future.
-* `is_parathread(ParaId) -> bool`: Returns true if the para ID references any live parathread, including those which may be transitioning to a parachain in the future.
+* `is_parathread(ParaId) -> bool`: Returns true if the para ID references any live parathread,
+  including those which may be transitioning to a parachain in the future.
 * `is_valid_para(ParaId) -> bool`: Returns true if the para ID references either a live parathread
   or live parachain.
 * `last_code_upgrade(id: ParaId, include_future: bool) -> Option<BlockNumber>`: The block number of

--- a/roadmap/implementers-guide/src/runtime/paras.md
+++ b/roadmap/implementers-guide/src/runtime/paras.md
@@ -182,9 +182,9 @@ UpcomingDowngrades: Vec<ParaId>;
   session. Noop if para is already registered in the system with some `ParaLifecycle`.
 * `schedule_para_cleanup(ParaId)`: Schedule a para to be cleaned up at the next session.
 * `schedule_parathread_upgrade(ParaId)`: Schedule a parathread to be upgraded to a parachain. Noop
-  if `ParaLifecycle` is not `Parachain`.
+  if `ParaLifecycle` is not `Parathread`.
 * `schedule_parachain_downgrade(ParaId)`: Schedule a parachain to be downgraded to a parathread.
-  Noop if `ParaLifecycle` is not `Parachain`. `ParaLifecycle` is not `Parathread`.
+  Noop if `ParaLifecycle` is not `Parachain`.
 * `schedule_code_upgrade(ParaId, ValidationCode, expected_at: BlockNumber)`: Schedule a future code
   upgrade of the given parachain, to be applied after inclusion of a block of the same parachain
   executed in the context of a relay-chain block with number >= `expected_at`.

--- a/roadmap/implementers-guide/src/runtime/paras.md
+++ b/roadmap/implementers-guide/src/runtime/paras.md
@@ -56,10 +56,8 @@ struct ParaGenesisArgs {
 
 /// The possible states of a para, to take into account delayed lifecycle changes.
 pub enum ParaLifecycle {
-  /// Para is new and is onboarding as a Parathread.
-  OnboardingAsParathread,
-  /// Para is new and is onboarding as a Parachain.
-  OnboardingAsParachain,
+  /// A Para is new and is onboarding.
+  Onboarding,
   /// Para is a Parathread.
   Parathread,
   /// Para is a Parachain.
@@ -87,10 +85,10 @@ None                 Parathread                  Parachain
  |    (Session Delay)     |                          |
  |                        |                          |
  +----------------------->+                          |
- | OnboardingAsParathread |                          |
+ |       Onboarding       |                          |
  |                        |                          |
  +-------------------------------------------------->+
- | OnboardingAsParachain  |                          |
+ |       Onboarding       |                          |
  |                        |                          |
  |                        +------------------------->+
  |                        |  UpgradingToParachain    |

--- a/roadmap/implementers-guide/src/runtime/paras.md
+++ b/roadmap/implementers-guide/src/runtime/paras.md
@@ -1,8 +1,12 @@
 # Paras Module
 
-The Paras module is responsible for storing information on parachains and parathreads. Registered parachains and parathreads cannot change except at session boundaries. This is primarily to ensure that the number of bits required for the availability bitfields does not change except at session boundaries.
+The Paras module is responsible for storing information on parachains and parathreads. Registered
+parachains and parathreads cannot change except at session boundaries. This is primarily to ensure
+that the number of bits required for the availability bitfields does not change except at session
+boundaries.
 
-It's also responsible for managing parachain validation code upgrades as well as maintaining availability of old parachain code and its pruning.
+It's also responsible for managing parachain validation code upgrades as well as maintaining
+availability of old parachain code and its pruning.
 
 ## Storage
 
@@ -94,27 +98,49 @@ OutgoingParas: Vec<ParaId>;
 ## Session Change
 
 1. Clean up outgoing paras.
-	1. This means removing the entries under `Heads`, `ValidationCode`, `FutureCodeUpgrades`, and `FutureCode`. An according entry should be added to `PastCode`, `PastCodeMeta`, and `PastCodePruning` using the outgoing `ParaId` and removed `ValidationCode` value. This is because any outdated validation code must remain available on-chain for a determined amount of blocks, and validation code outdated by de-registering the para is still subject to that invariant.
-1. Apply all incoming paras by initializing the `Heads` and `ValidationCode` using the genesis parameters.
+  1. This means removing the entries under `Heads`, `ValidationCode`, `FutureCodeUpgrades`, and
+     `FutureCode`. An according entry should be added to `PastCode`, `PastCodeMeta`, and
+     `PastCodePruning` using the outgoing `ParaId` and removed `ValidationCode` value. This is
+     because any outdated validation code must remain available on-chain for a determined amount of
+     blocks, and validation code outdated by de-registering the para is still subject to that
+     invariant.
+1. Apply all incoming paras by initializing the `Heads` and `ValidationCode` using the genesis
+   parameters.
 1. Amend the `Parachains` list to reflect changes in registered parachains.
 1. Amend the `Parathreads` set to reflect changes in registered parathreads.
 
 ## Initialization
 
-1. Do pruning based on all entries in `PastCodePruning` with `BlockNumber <= now`. Update the corresponding `PastCodeMeta` and `PastCode` accordingly.
+1. Do pruning based on all entries in `PastCodePruning` with `BlockNumber <= now`. Update the
+   corresponding `PastCodeMeta` and `PastCode` accordingly.
 
 ## Routines
 
-* `schedule_para_initialize(ParaId, ParaGenesisArgs)`: schedule a para to be initialized at the next session.
+* `schedule_para_initialize(ParaId, ParaGenesisArgs)`: schedule a para to be initialized at the next
+  session.
 * `schedule_para_cleanup(ParaId)`: schedule a para to be cleaned up at the next session.
-* `schedule_code_upgrade(ParaId, ValidationCode, expected_at: BlockNumber)`: Schedule a future code upgrade of the given parachain, to be applied after inclusion of a block of the same parachain executed in the context of a relay-chain block with number >= `expected_at`.
-* `note_new_head(ParaId, HeadData, BlockNumber)`: note that a para has progressed to a new head, where the new head was executed in the context of a relay-chain block with given number. This will apply pending code upgrades based on the block number provided.
-* `validation_code_at(ParaId, at: BlockNumber, assume_intermediate: Option<BlockNumber>)`: Fetches the validation code to be used when validating a block in the context of the given relay-chain height. A second block number parameter may be used to tell the lookup to proceed as if an intermediate parablock has been included at the given relay-chain height. This may return past, current, or (with certain choices of `assume_intermediate`) future code. `assume_intermediate`, if provided, must be before `at`. If the validation code has been pruned, this will return `None`.
+* `schedule_code_upgrade(ParaId, ValidationCode, expected_at: BlockNumber)`: Schedule a future code
+  upgrade of the given parachain, to be applied after inclusion of a block of the same parachain
+  executed in the context of a relay-chain block with number >= `expected_at`.
+* `note_new_head(ParaId, HeadData, BlockNumber)`: note that a para has progressed to a new head,
+  where the new head was executed in the context of a relay-chain block with given number. This will
+  apply pending code upgrades based on the block number provided.
+* `validation_code_at(ParaId, at: BlockNumber, assume_intermediate: Option<BlockNumber>)`: Fetches
+  the validation code to be used when validating a block in the context of the given relay-chain
+  height. A second block number parameter may be used to tell the lookup to proceed as if an
+  intermediate parablock has been included at the given relay-chain height. This may return past,
+  current, or (with certain choices of `assume_intermediate`) future code. `assume_intermediate`, if
+  provided, must be before `at`. If the validation code has been pruned, this will return `None`.
 * `is_parathread(ParaId) -> bool`: Returns true if the para ID references any live parathread.
-* `is_valid_para(ParaId) -> bool`: Returns true if the para ID references either a live parathread or live parachain.
+* `is_valid_para(ParaId) -> bool`: Returns true if the para ID references either a live parathread
+  or live parachain.
 
-* `last_code_upgrade(id: ParaId, include_future: bool) -> Option<BlockNumber>`: The block number of the last scheduled upgrade of the requested para. Includes future upgrades if the flag is set. This is the `expected_at` number, not the `activated_at` number.
-* `persisted_validation_data(id: ParaId) -> Option<PersistedValidationData>`: Get the PersistedValidationData of the given para, assuming the context is the parent block. Returns `None` if the para is not known.
+* `last_code_upgrade(id: ParaId, include_future: bool) -> Option<BlockNumber>`: The block number of
+  the last scheduled upgrade of the requested para. Includes future upgrades if the flag is set.
+  This is the `expected_at` number, not the `activated_at` number.
+* `persisted_validation_data(id: ParaId) -> Option<PersistedValidationData>`: Get the
+  PersistedValidationData of the given para, assuming the context is the parent block. Returns
+  `None` if the para is not known.
 
 ## Finalization
 

--- a/roadmap/implementers-guide/src/runtime/paras.md
+++ b/roadmap/implementers-guide/src/runtime/paras.md
@@ -10,7 +10,7 @@ availability of old parachain code and its pruning.
 
 ## Storage
 
-Utility structs:
+### Utility Structs
 
 ```rust
 // the two key times necessary to track for every code replacement.
@@ -53,15 +53,69 @@ struct ParaGenesisArgs {
   /// True if parachain, false if parathread.
   parachain: bool,
 }
+
+/// The possible states of a para, to take into account delayed lifecycle changes.
+pub enum ParaLifecycle {
+  /// Para is new and is onboarding as a Parathread.
+  OnboardingAsParathread,
+  /// Para is new and is onboarding as a Parachain.
+  OnboardingAsParachain,
+  /// Para is a Parathread.
+  Parathread,
+  /// Para is a Parachain.
+  Parachain,
+  /// Para is a Parathread which is upgrading to a Parachain.
+  UpgradingToParachain,
+  /// Para is a Parachain which is downgrading to a Parathread.
+  DowngradingToParathread,
+  /// Parachain is being offboarded.
+  OutgoingParathread,
+  /// Parathread is being offboarded.
+  OutgoingParachain,
+}
 ```
 
-Storage layout:
+#### Para Lifecycle
+
+Because the state of parachains and parathreads are delayed by a session, we track the specific
+state of the para using the `ParaLifecycle` enum.
+
+```
+None                 Parathread                  Parachain
+ +                        +                          +
+ |                        |                          |
+ |    (Session Delay)     |                          |
+ |                        |                          |
+ +----------------------->+                          |
+ | OnboardingAsParathread |                          |
+ |                        |                          |
+ +-------------------------------------------------->+
+ | OnboardingAsParachain  |                          |
+ |                        |                          |
+ |                        +------------------------->+
+ |                        |  UpgradingToParachain    |
+ |                        |                          |
+ |                        +<-------------------------+
+ |                        |  DowngradingToParathread |
+ |                        |                          |
+ |<-----------------------+                          |
+ |        Outgoing        |                          |
+ |                        |                          |
+ +<--------------------------------------------------+
+ |                        |         Outgoing         |
+ |                        |                          |
+ +                        +                          +
+```
+
+During the transition period, the para object is still considered in its existing state.
+
+### Storage Layout
 
 ```rust
 /// All parachains. Ordered ascending by ParaId. Parathreads are not included.
 Parachains: Vec<ParaId>,
-/// All parathreads.
-Parathreads: map ParaId => Option<()>,
+/// The current lifecycle state of all known Para Ids.
+ParaLifecycle: map ParaId => Option<ParaLifecycle>,
 /// The head-data of every registered para.
 Heads: map ParaId => Option<HeadData>;
 /// The validation code of every live para.
@@ -87,12 +141,16 @@ FutureCodeUpgrades: map ParaId => Option<BlockNumber>;
 FutureCode: map ParaId => Option<ValidationCode>;
 
 /// Upcoming paras (chains and threads). These are only updated on session change. Corresponds to an
-/// entry in the upcoming-genesis map.
+/// entry in the upcoming-genesis map. Ordered ascending by ParaId.
 UpcomingParas: Vec<ParaId>;
 /// Upcoming paras instantiation arguments.
 UpcomingParasGenesis: map ParaId => Option<ParaGenesisArgs>;
-/// Paras that are to be cleaned up at the end of the session.
+/// Paras that are to be cleaned up at the end of the session. Ordered ascending by ParaId.
 OutgoingParas: Vec<ParaId>;
+/// Existing Parathreads that should upgrade to be a Parachain. Ordered ascending by ParaId.
+UpcomingUpgrades: Vec<ParaId>;
+/// Existing Parachains that should downgrade to be a Parathread. Ordered ascending by ParaId.
+UpcomingDowngrades: Vec<ParaId>;
 ```
 
 ## Session Change
@@ -106,8 +164,12 @@ OutgoingParas: Vec<ParaId>;
      invariant.
 1. Apply all incoming paras by initializing the `Heads` and `ValidationCode` using the genesis
    parameters.
-1. Amend the `Parachains` list to reflect changes in registered parachains.
-1. Amend the `Parathreads` set to reflect changes in registered parathreads.
+1. Amend the `Parachains` list and `ParaLifecycle` to reflect changes in registered parachains.
+1. Amend the `ParaLifecycle` set to reflect changes in registered parathreads.
+1. Upgrade all parathreads that should become parachains, updating the `Parachains` list and
+   `ParaLifecycle`.
+1. Downgrade all parachains that should become parathreads, updating the `Parachains` list and
+   `ParaLifecycle`.
 
 ## Initialization
 
@@ -116,9 +178,13 @@ OutgoingParas: Vec<ParaId>;
 
 ## Routines
 
-* `schedule_para_initialize(ParaId, ParaGenesisArgs)`: schedule a para to be initialized at the next
-  session.
-* `schedule_para_cleanup(ParaId)`: schedule a para to be cleaned up at the next session.
+* `schedule_para_initialize(ParaId, ParaGenesisArgs)`: Schedule a para to be initialized at the next
+  session. Noop if para is already registered in the system with some `ParaLifecycle`.
+* `schedule_para_cleanup(ParaId)`: Schedule a para to be cleaned up at the next session.
+* `schedule_parathread_upgrade(ParaId)`: Schedule a parathread to be upgraded to a parachain. Noop
+  if `ParaLifecycle` is not `Parachain`.
+* `schedule_parachain_downgrade(ParaId)`: Schedule a parachain to be downgraded to a parathread.
+  Noop if `ParaLifecycle` is not `Parachain`. `ParaLifecycle` is not `Parathread`.
 * `schedule_code_upgrade(ParaId, ValidationCode, expected_at: BlockNumber)`: Schedule a future code
   upgrade of the given parachain, to be applied after inclusion of a block of the same parachain
   executed in the context of a relay-chain block with number >= `expected_at`.
@@ -131,10 +197,11 @@ OutgoingParas: Vec<ParaId>;
   intermediate parablock has been included at the given relay-chain height. This may return past,
   current, or (with certain choices of `assume_intermediate`) future code. `assume_intermediate`, if
   provided, must be before `at`. If the validation code has been pruned, this will return `None`.
-* `is_parathread(ParaId) -> bool`: Returns true if the para ID references any live parathread.
+* `lifecycle(ParaId) -> Option<ParaLifecycle>`: Return the `ParaLifecycle` of a para.
+* `is_parachain(ParaId) -> bool`: Returns true if the para ID references any live parachain, including those which may be transitioning to a parathread in the future.
+* `is_parathread(ParaId) -> bool`: Returns true if the para ID references any live parathread, including those which may be transitioning to a parachain in the future.
 * `is_valid_para(ParaId) -> bool`: Returns true if the para ID references either a live parathread
   or live parachain.
-
 * `last_code_upgrade(id: ParaId, include_future: bool) -> Option<BlockNumber>`: The block number of
   the last scheduled upgrade of the requested para. Includes future upgrades if the flag is set.
   This is the `expected_at` number, not the `activated_at` number.

--- a/roadmap/implementers-guide/src/runtime/paras.md
+++ b/roadmap/implementers-guide/src/runtime/paras.md
@@ -198,7 +198,8 @@ UpcomingDowngrades: Vec<ParaId>;
   current, or (with certain choices of `assume_intermediate`) future code. `assume_intermediate`, if
   provided, must be before `at`. If the validation code has been pruned, this will return `None`.
 * `lifecycle(ParaId) -> Option<ParaLifecycle>`: Return the `ParaLifecycle` of a para.
-* `is_parachain(ParaId) -> bool`: Returns true if the para ID references any live parachain, including those which may be transitioning to a parathread in the future.
+* `is_parachain(ParaId) -> bool`: Returns true if the para ID references any live parachain, including
+  those which may be transitioning to a parathread in the future.
 * `is_parathread(ParaId) -> bool`: Returns true if the para ID references any live parathread, including those which may be transitioning to a parachain in the future.
 * `is_valid_para(ParaId) -> bool`: Returns true if the para ID references either a live parathread
   or live parachain.

--- a/roadmap/implementers-guide/src/runtime/paras.md
+++ b/roadmap/implementers-guide/src/runtime/paras.md
@@ -68,9 +68,9 @@ pub enum ParaLifecycle {
   UpgradingToParachain,
   /// Para is a Parachain which is downgrading to a Parathread.
   DowngradingToParathread,
-  /// Parachain is being offboarded.
-  OutgoingParathread,
   /// Parathread is being offboarded.
+  OutgoingParathread,
+  /// Parachain is being offboarded.
   OutgoingParachain,
 }
 ```

--- a/roadmap/implementers-guide/src/runtime/paras.md
+++ b/roadmap/implementers-guide/src/runtime/paras.md
@@ -99,10 +99,10 @@ None                 Parathread                  Parachain
  |                        |  DowngradingToParathread |
  |                        |                          |
  |<-----------------------+                          |
- |        Outgoing        |                          |
+ |   OutgoingParathread   |                          |
  |                        |                          |
  +<--------------------------------------------------+
- |                        |         Outgoing         |
+ |                        |    OutgoingParachain     |
  |                        |                          |
  +                        +                          +
 ```

--- a/roadmap/implementers-guide/src/runtime/paras.md
+++ b/roadmap/implementers-guide/src/runtime/paras.md
@@ -2,7 +2,7 @@
 
 The Paras module is responsible for storing information on parachains and parathreads. Registered
 parachains and parathreads cannot change except at session boundaries. This is primarily to ensure
-that the number of bits required for the availability bitfields does not change except at session
+that the number and meaning of bits required for the availability bitfields does not change except at session
 boundaries.
 
 It's also responsible for managing parachain validation code upgrades as well as maintaining

--- a/runtime/parachains/src/lib.rs
+++ b/runtime/parachains/src/lib.rs
@@ -42,6 +42,9 @@ mod util;
 #[cfg(test)]
 mod mock;
 
+use parity_scale_codec::{Encode, Decode};
+use sp_core::RuntimeDebug;
+
 pub use origin::{Origin, ensure_parachain};
 
 /// Schedule a para to be initialized at the start of the next session with the given genesis data.
@@ -64,4 +67,23 @@ where
 	<dmp::Module<T>>::schedule_para_cleanup(id);
 	<ump::Module<T>>::schedule_para_cleanup(id);
 	<hrmp::Module<T>>::schedule_para_cleanup(id);
+}
+
+/// The possible states of a para, to take into account delayed lifecycle changes.
+#[derive(PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug)]
+pub enum ParaLifecycle {
+	/// Para ID is new and is onboarding as a Parathread.
+	OnboardingAsParathread,
+	/// Para ID is new and is onboarding as a Parachain.
+	OnboardingAsParachain,
+	/// Para ID is a Parathread.
+	Parathread,
+	/// Para ID is a Parachain.
+	Parachain,
+	/// Para ID is a Parathread which is upgrading to a Parachain.
+	UpgradingToParachain,
+	/// Para ID is a Parachain which is downgrading to a Parathread.
+	DowngradingToParathread,
+	/// Para ID is being offboarded.
+	Outgoing,
 }

--- a/runtime/parachains/src/lib.rs
+++ b/runtime/parachains/src/lib.rs
@@ -42,10 +42,8 @@ mod util;
 #[cfg(test)]
 mod mock;
 
-use parity_scale_codec::{Encode, Decode};
-use sp_core::RuntimeDebug;
-
 pub use origin::{Origin, ensure_parachain};
+pub use paras::ParaLifecycle;
 
 /// Schedule a para to be initialized at the start of the next session with the given genesis data.
 pub fn schedule_para_initialize<T: paras::Config>(
@@ -67,23 +65,4 @@ where
 	<dmp::Module<T>>::schedule_para_cleanup(id);
 	<ump::Module<T>>::schedule_para_cleanup(id);
 	<hrmp::Module<T>>::schedule_para_cleanup(id);
-}
-
-/// The possible states of a para, to take into account delayed lifecycle changes.
-#[derive(PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug)]
-pub enum ParaLifecycle {
-	/// Para is new and is onboarding as a Parathread.
-	OnboardingAsParathread,
-	/// Para is new and is onboarding as a Parachain.
-	OnboardingAsParachain,
-	/// Para is a Parathread.
-	Parathread,
-	/// Para is a Parachain.
-	Parachain,
-	/// Para is a Parathread which is upgrading to a Parachain.
-	UpgradingToParachain,
-	/// Para is a Parachain which is downgrading to a Parathread.
-	DowngradingToParathread,
-	/// Para is being offboarded.
-	Outgoing,
 }

--- a/runtime/parachains/src/lib.rs
+++ b/runtime/parachains/src/lib.rs
@@ -72,18 +72,18 @@ where
 /// The possible states of a para, to take into account delayed lifecycle changes.
 #[derive(PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug)]
 pub enum ParaLifecycle {
-	/// Para ID is new and is onboarding as a Parathread.
+	/// Para is new and is onboarding as a Parathread.
 	OnboardingAsParathread,
-	/// Para ID is new and is onboarding as a Parachain.
+	/// Para is new and is onboarding as a Parachain.
 	OnboardingAsParachain,
-	/// Para ID is a Parathread.
+	/// Para is a Parathread.
 	Parathread,
-	/// Para ID is a Parachain.
+	/// Para is a Parachain.
 	Parachain,
-	/// Para ID is a Parathread which is upgrading to a Parachain.
+	/// Para is a Parathread which is upgrading to a Parachain.
 	UpgradingToParachain,
-	/// Para ID is a Parachain which is downgrading to a Parathread.
+	/// Para is a Parachain which is downgrading to a Parathread.
 	DowngradingToParathread,
-	/// Para ID is being offboarded.
+	/// Para is being offboarded.
 	Outgoing,
 }

--- a/runtime/parachains/src/paras.rs
+++ b/runtime/parachains/src/paras.rs
@@ -671,6 +671,11 @@ impl<T: Config> Module<T> {
 		}
 	}
 
+	/// Returns the current lifecycle state of the para.
+	pub fn lifecycle(id: ParaId) -> Option<ParaLifecycle> {
+		ParaLifecycles::get(&id)
+	}
+
 	/// Returns whether the given ID refers to a valid para.
 	pub fn is_valid_para(id: ParaId) -> bool {
 		match ParaLifecycles::get(&id) {
@@ -684,17 +689,25 @@ impl<T: Config> Module<T> {
 	}
 
 	/// Whether a para ID corresponds to any live parachain.
+	///
+	/// Includes parachains which will downgrade to a parathread in the future.
 	pub fn is_parachain(id: ParaId) -> bool {
 		match ParaLifecycles::get(&id) {
-			Some(ParaLifecycle::Parachain) => true,
+			Some(ParaLifecycle::Parachain) |
+			Some(ParaLifecycle::DowngradingToParathread)
+				=> true,
 			_ => false,
 		}
 	}
 
 	/// Whether a para ID corresponds to any live parathread.
+	///
+	/// Includes parathreads which will upgrade to parachains in the future.
 	pub fn is_parathread(id: ParaId) -> bool {
 		match ParaLifecycles::get(&id) {
-			Some(ParaLifecycle::Parathread) => true,
+			Some(ParaLifecycle::Parathread) |
+			Some(ParaLifecycle::UpgradingToParachain)
+				=> true,
 			_ => false,
 		}
 	}

--- a/runtime/parachains/src/paras.rs
+++ b/runtime/parachains/src/paras.rs
@@ -115,43 +115,23 @@ pub enum ParaLifecycle {
 
 impl ParaLifecycle {
 	pub fn is_onboarding(&self) -> bool {
-		match self {
-			ParaLifecycle::OnboardingAsParathread |
-			ParaLifecycle::OnboardingAsParachain
-				=> true,
-			_ => false,
-		}
+		matches!(self, ParaLifecycle::OnboardingAsParathread | ParaLifecycle::OnboardingAsParachain)
 	}
 
 	pub fn is_stable(&self) -> bool {
-		match self {
-			ParaLifecycle::Parathread |
-			ParaLifecycle::Parachain
-				=> true,
-			_ => false,
-		}
+		matches!(self, ParaLifecycle::Parathread | ParaLifecycle::Parachain)
 	}
 
 	pub fn is_parachain(&self) -> bool {
-		match self {
-			ParaLifecycle::Parachain => true,
-			_ => false,
-		}
+		matches!(self, ParaLifecycle::Parachain)
 	}
 
 	pub fn is_parathread(&self) -> bool {
-		match self {
-			ParaLifecycle::Parathread => true,
-			_ => false,
-		}
+		matches!(self, ParaLifecycle::Parathread)
 	}
 
 	pub fn is_outgoing(&self) -> bool {
-		match self {
-			ParaLifecycle::OutgoingParathread |
-			ParaLifecycle::OutgoingParachain => true,
-			_ => false,
-		}
+		matches!(self, ParaLifecycle::OutgoingParathread | ParaLifecycle::OutgoingParachain)
 	}
 
 	pub fn is_transitioning(&self) -> bool {

--- a/runtime/parachains/src/paras.rs
+++ b/runtime/parachains/src/paras.rs
@@ -650,7 +650,7 @@ impl<T: Config> Module<T> {
 		}
 	}
 
-	/// Whether a para ID corresponds to any live parathread.
+	/// Whether a para ID corresponds to any live parachain.
 	pub fn is_parachain(id: ParaId) -> bool {
 		match ParaLifecycles::get(&id) {
 			Some(ParaLifecycle::Parachain) => true,

--- a/runtime/parachains/src/paras.rs
+++ b/runtime/parachains/src/paras.rs
@@ -134,18 +134,14 @@ impl ParaLifecycle {
 
 	pub fn is_parachain(&self) -> bool {
 		match self {
-			ParaLifecycle::Parachain |
-			ParaLifecycle::DowngradingToParathread
-				=> true,
+			ParaLifecycle::Parachain => true,
 			_ => false,
 		}
 	}
 
 	pub fn is_parathread(&self) -> bool {
 		match self {
-			ParaLifecycle::Parathread |
-			ParaLifecycle::UpgradingToParachain
-				=> true,
+			ParaLifecycle::Parathread => true,
 			_ => false,
 		}
 	}

--- a/runtime/parachains/src/paras.rs
+++ b/runtime/parachains/src/paras.rs
@@ -107,9 +107,9 @@ pub enum ParaLifecycle {
 	UpgradingToParachain,
 	/// Para is a Parachain which is downgrading to a Parathread.
 	DowngradingToParathread,
-	/// Parachain is being offboarded.
-	OutgoingParathread,
 	/// Parathread is being offboarded.
+	OutgoingParathread,
+	/// Parachain is being offboarded.
 	OutgoingParachain,
 }
 

--- a/runtime/parachains/src/paras.rs
+++ b/runtime/parachains/src/paras.rs
@@ -28,7 +28,7 @@ use sp_std::result;
 #[cfg(feature = "std")]
 use sp_std::marker::PhantomData;
 use primitives::v1::{
-	Id as ParaId, ValidationCode, HeadData, SessionIndex,
+	Id as ParaId, ValidationCode, HeadData,
 };
 use sp_runtime::traits::One;
 use frame_support::{
@@ -51,9 +51,6 @@ pub trait Config: frame_system::Config + configuration::Config {
 		+ From<<Self as frame_system::Config>::Origin>
 		+ Into<result::Result<Origin, <Self as Config>::Origin>>;
 }
-
-// Wait until the session index is 2 larger then the current index to apply any changes.
-const SESSION_DELAY: SessionIndex = 2;
 
 // the two key times necessary to track for every code replacement.
 #[derive(Default, Encode, Decode)]
@@ -99,7 +96,9 @@ enum UseCodeAt<N> {
 #[derive(PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug)]
 pub enum ParaLifecycle {
 	/// Para is new and is onboarding as a Parathread.
-	Onboarding,
+	OnboardingAsParathread,
+	/// Para is new and is onboarding as a Parachain.
+	OnboardingAsParachain,
 	/// Para is a Parathread.
 	Parathread,
 	/// Para is a Parachain.
@@ -109,12 +108,14 @@ pub enum ParaLifecycle {
 	/// Para is a Parachain which is downgrading to a Parathread.
 	DowngradingToParathread,
 	/// Parathread is being offboarded.
-	Offboarding,
+	OutgoingParathread,
+	/// Parachain is being offboarded.
+	OutgoingParachain,
 }
 
 impl ParaLifecycle {
 	pub fn is_onboarding(&self) -> bool {
-		matches!(self, ParaLifecycle::Onboarding)
+		matches!(self, ParaLifecycle::OnboardingAsParathread | ParaLifecycle::OnboardingAsParachain)
 	}
 
 	pub fn is_stable(&self) -> bool {
@@ -130,25 +131,12 @@ impl ParaLifecycle {
 	}
 
 	pub fn is_outgoing(&self) -> bool {
-		matches!(self, ParaLifecycle::Offboarding)
+		matches!(self, ParaLifecycle::OutgoingParathread | ParaLifecycle::OutgoingParachain)
 	}
 
 	pub fn is_transitioning(&self) -> bool {
 		!Self::is_stable(self)
 	}
-}
-
-/// The possible actions that can be applied to a para.
-#[derive(PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug)]
-pub enum ParaAction {
-	/// New parathread needs to be onboarded.
-	Onboard,
-	/// Parathread needs to be upgraded to parachain.
-	Upgrade,
-	/// Parachain needs to be downgraded to parathread.
-	Downgrade,
-	/// Parathread needs to be offboarded.
-	Offboard,
 }
 
 impl<N: Ord + Copy> ParaPastCodeMeta<N> {
@@ -277,12 +265,6 @@ decl_storage! {
 		UpcomingUpgrades: Vec<ParaId>;
 		/// Existing Parachains that should downgrade to be a Parathread. Ordered ascending by ParaId.
 		UpcomingDowngrades: Vec<ParaId>;
-
-		/// The queue of actions to execute on a particular session index.
-		ActionsQueue: map hasher(twox_64_concat) SessionIndex => Vec<(ParaId, ParaAction)>;
-
-		/// The current session index.
-		CurrentSessionIndex get(fn session_index): SessionIndex;
 	}
 	add_extra_genesis {
 		config(paras): Vec<(ParaId, ParaGenesisArgs)>;
@@ -337,9 +319,8 @@ impl<T: Config> Module<T> {
 	pub(crate) fn initializer_finalize() { }
 
 	/// Called by the initializer to note that a new session has started.
-	pub(crate) fn initializer_on_new_session(notification: &SessionChangeNotification<T::BlockNumber>) {
+	pub(crate) fn initializer_on_new_session(_notification: &SessionChangeNotification<T::BlockNumber>) {
 		let now = <frame_system::Module<T>>::block_number();
-		CurrentSessionIndex::set(notification.session_index);
 		let mut parachains = Self::clean_up_outgoing(now);
 		Self::apply_incoming(&mut parachains);
 		Self::apply_upgrades(&mut parachains);
@@ -381,91 +362,14 @@ impl<T: Config> Module<T> {
 		parachains
 	}
 
-	// Apply all actions queued for the given session index.
-	//
-	// This function checks that the lifecycle of each parachain matches the expected state transition.
-	// If the lifecycle is incorrect, this will apply no changes to that para, except for outgoing
-	// paras, where we will be defensive and offboard them no matter their state.
-	fn apply_actions_queue(session: SessionIndex) {
-		let actions = ActionsQueue::take(session);
-		let mut parachains = <Self as Store>::Parachains::get();
-		let now = <frame_system::Module<T>>::block_number();
-
-		for (para, action) in actions {
-			match action {
-				// Onboard a new parathread
-				ParaAction::Onboard => {
-					ParaLifecycles::mutate(&para, |state| {
-						if *state == Some(ParaLifecycle::Onboarding) {
-							if let Some(genesis_data) = <Self as Store>::UpcomingParasGenesis::take(&para) {
-								*state = Some(ParaLifecycle::Parathread);
-								<Self as Store>::Heads::insert(&para, genesis_data.genesis_head);
-								<Self as Store>::CurrentCode::insert(&para, genesis_data.validation_code);
-							}
-						}
-					});
-				},
-				// Upgrade a parathread to a parachain
-				ParaAction::Upgrade => {
-					ParaLifecycles::mutate(&para, |state| {
-						if *state == Some(ParaLifecycle::UpgradingToParachain) {
-							if let Err(i) = parachains.binary_search(&para) {
-								parachains.insert(i, para);
-							}
-							*state = Some(ParaLifecycle::Parachain);
-						}
-					});
-				},
-				// Downgrade a parachain to a parathread
-				ParaAction::Downgrade => {
-					ParaLifecycles::mutate(&para, |state| {
-						if *state == Some(ParaLifecycle::DowngradingToParathread) {
-							if let Ok(i) = parachains.binary_search(&para) {
-								parachains.remove(i);
-							}
-							*state = Some(ParaLifecycle::Parathread);
-						}
-					});
-				},
-				// Offboard a parathread from the system
-				ParaAction::Offboard => {
-					// Warn if there is a state error... but still perform the offboarding to be defensive.
-					if let Some(state) = ParaLifecycles::get(&para) {
-						if !state.is_outgoing() {
-							frame_support::debug::error!(
-								target: "parachains",
-								"Outgoing parachain has wrong lifecycle state."
-							)
-						}
-					};
-
-					if let Ok(i) = parachains.binary_search(&para) {
-						parachains.remove(i);
-					}
-
-					<Self as Store>::Heads::remove(&para);
-					<Self as Store>::FutureCodeUpgrades::remove(&para);
-					<Self as Store>::FutureCode::remove(&para);
-					ParaLifecycles::remove(&para);
-
-					let removed_code = <Self as Store>::CurrentCode::take(&para);
-					if let Some(removed_code) = removed_code {
-						Self::note_past_code(para, now, now, removed_code);
-					}
-				},
-			}
-		}
-
-		// Place the new parachains set in storage.
-		<Self as Store>::Parachains::put(parachains);
-	}
-
 	/// Applies all incoming paras, updating the parachains list for those that are parachains.
 	fn apply_incoming(parachains: &mut Vec<ParaId>) {
 		let upcoming = <Self as Store>::UpcomingParas::take();
 		for upcoming_para in upcoming {
-			if ParaLifecycles::get(&upcoming_para) != Some(ParaLifecycle::Onboarding) {
-				continue;
+			let state = match ParaLifecycles::get(&upcoming_para) {
+				Some(ParaLifecycle::OnboardingAsParachain) => ParaLifecycle::OnboardingAsParachain,
+				Some(ParaLifecycle::OnboardingAsParathread) => ParaLifecycle::OnboardingAsParathread,
+				_ => continue,
 			};
 
 			let genesis_data = match <Self as Store>::UpcomingParasGenesis::take(&upcoming_para) {
@@ -473,10 +377,27 @@ impl<T: Config> Module<T> {
 				Some(g) => g,
 			};
 
-			ParaLifecycles::insert(&upcoming_para, ParaLifecycle::Parathread);
+			let mut onboarded = false;
 
-			<Self as Store>::Heads::insert(&upcoming_para, genesis_data.genesis_head);
-			<Self as Store>::CurrentCode::insert(&upcoming_para, genesis_data.validation_code);
+			if genesis_data.parachain {
+				if let Err(i) = parachains.binary_search(&upcoming_para) {
+					if state == ParaLifecycle::OnboardingAsParachain {
+						parachains.insert(i, upcoming_para);
+						ParaLifecycles::insert(&upcoming_para, ParaLifecycle::Parachain);
+						onboarded = true;
+					}
+				}
+			} else {
+				if state == ParaLifecycle::OnboardingAsParathread {
+					ParaLifecycles::insert(&upcoming_para, ParaLifecycle::Parathread);
+					onboarded = true
+				}
+			}
+
+			if onboarded {
+				<Self as Store>::Heads::insert(&upcoming_para, genesis_data.genesis_head);
+				<Self as Store>::CurrentCode::insert(&upcoming_para, genesis_data.validation_code);
+			}
 		}
 	}
 
@@ -615,8 +536,11 @@ impl<T: Config> Module<T> {
 		}
 		weight = weight.saturating_add(T::DbWeight::get().reads_writes(1, 1));
 
-
-		ParaLifecycles::insert(&id, ParaLifecycle::Onboarding);
+		if genesis.parachain {
+			ParaLifecycles::insert(&id, ParaLifecycle::OnboardingAsParachain);
+		} else {
+			ParaLifecycles::insert(&id, ParaLifecycle::OnboardingAsParathread);
+		}
 		UpcomingParasGenesis::insert(&id, &genesis);
 		weight = weight.saturating_add(T::DbWeight::get().writes(2));
 
@@ -628,7 +552,8 @@ impl<T: Config> Module<T> {
 	/// Noop if para is already outgoing or not known.
 	pub(crate) fn schedule_para_cleanup(id: ParaId) -> Weight {
 		match ParaLifecycles::get(&id) {
-			Some(ParaLifecycle::Onboarding) => {
+			Some(ParaLifecycle::OnboardingAsParathread) |
+			Some(ParaLifecycle::OnboardingAsParachain) => {
 				UpcomingParas::mutate(|v| {
 					match v.binary_search(&id) {
 						Ok(i) => {
@@ -642,9 +567,8 @@ impl<T: Config> Module<T> {
 					}
 				})
 			},
-			Some(ParaLifecycle::Parathread) |
-			Some(ParaLifecycle::Parachain) => {
-				ParaLifecycles::insert(&id, ParaLifecycle::Offboarding);
+			Some(ParaLifecycle::Parathread) => {
+				ParaLifecycles::insert(&id, ParaLifecycle::OutgoingParathread);
 				OutgoingParas::mutate(|v| {
 					match v.binary_search(&id) {
 						Ok(_) => T::DbWeight::get().reads_writes(1, 1),
@@ -655,6 +579,18 @@ impl<T: Config> Module<T> {
 					}
 				})
 
+			},
+			Some(ParaLifecycle::Parachain) => {
+				OutgoingParas::mutate(|v| {
+					match v.binary_search(&id) {
+						Ok(_) => T::DbWeight::get().reads_writes(1, 0),
+						Err(i) => {
+							v.insert(i, id);
+							ParaLifecycles::insert(&id, ParaLifecycle::OutgoingParachain);
+							T::DbWeight::get().reads_writes(1, 2)
+						}
+					}
+				})
 			},
 			Some(ParaLifecycle::UpgradingToParachain) => {
 				let upgrade_weight = UpcomingUpgrades::mutate(|v| {
@@ -671,7 +607,7 @@ impl<T: Config> Module<T> {
 						Ok(_) => T::DbWeight::get().reads_writes(1, 0),
 						Err(i) => {
 							v.insert(i, id);
-							ParaLifecycles::insert(&id, ParaLifecycle::Offboarding);
+							ParaLifecycles::insert(&id, ParaLifecycle::OutgoingParathread);
 							T::DbWeight::get().reads_writes(1, 2)
 						}
 					}
@@ -693,14 +629,17 @@ impl<T: Config> Module<T> {
 						Ok(_) => T::DbWeight::get().reads_writes(1, 0),
 						Err(i) => {
 							v.insert(i, id);
-							ParaLifecycles::insert(&id, ParaLifecycle::Offboarding);
+							ParaLifecycles::insert(&id, ParaLifecycle::OutgoingParathread);
 							T::DbWeight::get().reads_writes(1, 2)
 						}
 					}
 				});
 				downgrade_weight.saturating_add(outgoing_weight)
 			},
-			None | Some(ParaLifecycle::Offboarding) => { T::DbWeight::get().reads(1) },
+			None |
+			Some(ParaLifecycle::OutgoingParathread) |
+			Some(ParaLifecycle::OutgoingParachain)
+				=> { T::DbWeight::get().reads(1) },
 		}
 	}
 
@@ -1469,9 +1408,9 @@ mod tests {
 			assert_eq!(<Paras as Store>::UpcomingParas::get(), vec![c, b, a]);
 
 			// Lifecycle is tracked correctly
-			assert_eq!(ParaLifecycles::get(&a), Some(ParaLifecycle::Onboarding));
-			assert_eq!(ParaLifecycles::get(&b), Some(ParaLifecycle::Onboarding));
-			assert_eq!(ParaLifecycles::get(&c), Some(ParaLifecycle::Onboarding));
+			assert_eq!(ParaLifecycles::get(&a), Some(ParaLifecycle::OnboardingAsParathread));
+			assert_eq!(ParaLifecycles::get(&b), Some(ParaLifecycle::OnboardingAsParachain));
+			assert_eq!(ParaLifecycles::get(&c), Some(ParaLifecycle::OnboardingAsParachain));
 
 			// run to block without session change.
 			run_to_block(2, None);
@@ -1480,9 +1419,9 @@ mod tests {
 			assert_eq!(<Paras as Store>::UpcomingParas::get(), vec![c, b, a]);
 
 			// Lifecycle is tracked correctly
-			assert_eq!(ParaLifecycles::get(&a), Some(ParaLifecycle::Onboarding));
-			assert_eq!(ParaLifecycles::get(&b), Some(ParaLifecycle::Onboarding));
-			assert_eq!(ParaLifecycles::get(&c), Some(ParaLifecycle::Onboarding));
+			assert_eq!(ParaLifecycles::get(&a), Some(ParaLifecycle::OnboardingAsParathread));
+			assert_eq!(ParaLifecycles::get(&b), Some(ParaLifecycle::OnboardingAsParachain));
+			assert_eq!(ParaLifecycles::get(&c), Some(ParaLifecycle::OnboardingAsParachain));
 
 
 			run_to_block(3, Some(vec![3]));
@@ -1492,8 +1431,8 @@ mod tests {
 
 			// Lifecycle is tracked correctly
 			assert_eq!(ParaLifecycles::get(&a), Some(ParaLifecycle::Parathread));
-			assert_eq!(ParaLifecycles::get(&b), Some(ParaLifecycle::Parathread));
-			assert_eq!(ParaLifecycles::get(&c), Some(ParaLifecycle::Parathread));
+			assert_eq!(ParaLifecycles::get(&b), Some(ParaLifecycle::Parachain));
+			assert_eq!(ParaLifecycles::get(&c), Some(ParaLifecycle::Parachain));
 
 			assert_eq!(Paras::current_code(&a), Some(vec![2].into()));
 			assert_eq!(Paras::current_code(&b), Some(vec![1].into()));
@@ -1540,9 +1479,9 @@ mod tests {
 			assert_eq!(<Paras as Store>::UpcomingParas::get(), vec![c, b, a]);
 
 			// Lifecycle is tracked correctly
-			assert_eq!(ParaLifecycles::get(&a), Some(ParaLifecycle::Onboarding));
-			assert_eq!(ParaLifecycles::get(&b), Some(ParaLifecycle::Onboarding));
-			assert_eq!(ParaLifecycles::get(&c), Some(ParaLifecycle::Onboarding));
+			assert_eq!(ParaLifecycles::get(&a), Some(ParaLifecycle::OnboardingAsParathread));
+			assert_eq!(ParaLifecycles::get(&b), Some(ParaLifecycle::OnboardingAsParachain));
+			assert_eq!(ParaLifecycles::get(&c), Some(ParaLifecycle::OnboardingAsParachain));
 
 
 			// run to block without session change.
@@ -1552,9 +1491,9 @@ mod tests {
 			assert_eq!(<Paras as Store>::UpcomingParas::get(), vec![c, b, a]);
 
 			// Lifecycle is tracked correctly
-			assert_eq!(ParaLifecycles::get(&a), Some(ParaLifecycle::Onboarding));
-			assert_eq!(ParaLifecycles::get(&b), Some(ParaLifecycle::Onboarding));
-			assert_eq!(ParaLifecycles::get(&c), Some(ParaLifecycle::Onboarding));
+			assert_eq!(ParaLifecycles::get(&a), Some(ParaLifecycle::OnboardingAsParathread));
+			assert_eq!(ParaLifecycles::get(&b), Some(ParaLifecycle::OnboardingAsParachain));
+			assert_eq!(ParaLifecycles::get(&c), Some(ParaLifecycle::OnboardingAsParachain));
 
 			Paras::schedule_para_cleanup(c);
 
@@ -1567,7 +1506,7 @@ mod tests {
 
 			// Lifecycle is tracked correctly
 			assert_eq!(ParaLifecycles::get(&a), Some(ParaLifecycle::Parathread));
-			assert_eq!(ParaLifecycles::get(&b), Some(ParaLifecycle::Parathread));
+			assert_eq!(ParaLifecycles::get(&b), Some(ParaLifecycle::Parachain));
 			assert_eq!(ParaLifecycles::get(&c), None);
 
 			assert_eq!(Paras::current_code(&a), Some(vec![2].into()));


### PR DESCRIPTION
This PR introduces an explicit lifecycle tracking for paras within the `runtime_parachains::paras` module.

Changes to parachains are delayed by a session, and as such, tracking exactly what is happening to a Para ID was not very easy.

This introduces a new storage item `ParaLifecycles` which tracks the current lifecycle of any known Para Id. This replaces the `Parathreads` storage item since that data is now redundant.

The possible lifecycle states are as follows:

```
/// The possible states of a para, to take into account delayed lifecycle changes.
pub enum ParaLifecycle {
	/// Para is new and is onboarding as a Parathread.
	OnboardingAsParathread,
	/// Para is new and is onboarding as a Parachain.
	OnboardingAsParachain,
	/// Para is a Parathread.
	Parathread,
	/// Para is a Parachain.
	Parachain,
	/// Para is a Parathread which is upgrading to a Parachain.
	UpgradingToParachain,
	/// Para is a Parachain which is downgrading to a Parathread.
	DowngradingToParathread,
	/// Parachain is being offboarded.
	OutgoingParathread,
	/// Parachain is being offboarded.
	OutgoingParachain,
}
```

Additionally, this PR introduces the workflow for upgrading a parathread into a parachain, and downgrading a parachain into a parathread.

This will be used for both the Slots/Auction module (which will perform upgrades/downgrades based on parachain auctions and offboarding slots), and also for swaps between parachains and parathreads.