### PR TITLE
Paras Module Directly Cleans Up Outgoing Parachain Data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5712,6 +5712,7 @@ dependencies = [
  "frame-system",
  "futures 0.3.12",
  "hex-literal",
+ "impl-trait-for-tuples 0.2.0",
  "libsecp256k1",
  "log",
  "pallet-authority-discovery",

--- a/roadmap/implementers-guide/src/runtime/dmp.md
+++ b/roadmap/implementers-guide/src/runtime/dmp.md
@@ -4,14 +4,6 @@ A module responsible for Downward Message Processing (DMP). See [Messaging Overv
 
 ## Storage
 
-General storage entries
-
-```rust
-/// Paras that are to be cleaned up at the end of the session.
-/// The entries are sorted ascending by the para id.
-OutgoingParas: Vec<ParaId>;
-```
-
 Storage layout required for implementation of DMP.
 
 ```rust

--- a/roadmap/implementers-guide/src/runtime/hrmp.md
+++ b/roadmap/implementers-guide/src/runtime/hrmp.md
@@ -4,14 +4,6 @@ A module responsible for Horizontally Relay-routed Message Passing (HRMP). See [
 
 ## Storage
 
-General storage entries
-
-```rust
-/// Paras that are to be cleaned up at the end of the session.
-/// The entries are sorted ascending by the para id.
-OutgoingParas: Vec<ParaId>;
-```
-
 HRMP related structs:
 
 ```rust

--- a/roadmap/implementers-guide/src/runtime/ump.md
+++ b/roadmap/implementers-guide/src/runtime/ump.md
@@ -4,14 +4,6 @@ A module responsible for Upward Message Passing (UMP). See [Messaging Overview](
 
 ## Storage
 
-General storage entries
-
-```rust
-/// Paras that are to be cleaned up at the end of the session.
-/// The entries are sorted ascending by the para id.
-OutgoingParas: Vec<ParaId>;
-```
-
 Storage related to UMP
 
 ```rust

--- a/runtime/common/src/paras_registrar.rs
+++ b/runtime/common/src/paras_registrar.rs
@@ -470,6 +470,7 @@ mod tests {
 
 	impl paras::Config for Test {
 		type Origin = Origin;
+		type ParachainCleanup = ();
 	}
 
 	impl configuration::Config for Test { }

--- a/runtime/parachains/Cargo.toml
+++ b/runtime/parachains/Cargo.toml
@@ -41,6 +41,7 @@ libsecp256k1 = { version = "0.3.5", default-features = false, optional = true }
 
 rand = { version = "0.8.3", default-features = false }
 rand_chacha = { version = "0.3.0", default-features = false }
+impl-trait-for-tuples = "0.2.0"
 
 [dev-dependencies]
 futures = "0.3.12"

--- a/runtime/parachains/src/dmp.rs
+++ b/runtime/parachains/src/dmp.rs
@@ -66,10 +66,6 @@ pub trait Config: frame_system::Config + configuration::Config {}
 
 decl_storage! {
 	trait Store for Module<T: Config> as Dmp {
-		/// Paras that are to be cleaned up at the end of the session.
-		/// The entries are sorted ascending by the para id.
-		OutgoingParas: Vec<ParaId>;
-
 		/// The downward messages addressed for a certain para.
 		DownwardMessageQueues: map hasher(twox_64_concat) ParaId => Vec<InboundDownwardMessage<T::BlockNumber>>;
 		/// A mapping that stores the downward message queue MQC head for each para.
@@ -216,7 +212,6 @@ mod tests {
 	use super::*;
 	use hex_literal::hex;
 	use primitives::v1::BlockNumber;
-	use frame_support::StorageValue;
 	use frame_support::traits::{OnFinalize, OnInitialize};
 	use parity_scale_codec::Encode;
 	use crate::mock::{Configuration, new_test_ext, System, Dmp, GenesisConfig as MockGenesisConfig};

--- a/runtime/parachains/src/lib.rs
+++ b/runtime/parachains/src/lib.rs
@@ -57,13 +57,8 @@ pub fn schedule_para_initialize<T: paras::Config>(
 pub fn schedule_para_cleanup<T>(id: primitives::v1::Id)
 where
 	T: paras::Config
-	+ dmp::Config
-	+ ump::Config
-	+ hrmp::Config,
 {
 	<paras::Module<T>>::schedule_para_cleanup(id);
-	<ump::Module<T>>::schedule_para_cleanup(id);
-	<hrmp::Module<T>>::schedule_para_cleanup(id);
 }
 
 /// Trait to trigger the removal of any data about a parachain when the parachain will be removed.

--- a/runtime/parachains/src/lib.rs
+++ b/runtime/parachains/src/lib.rs
@@ -43,6 +43,7 @@ mod util;
 mod mock;
 
 pub use origin::{Origin, ensure_parachain};
+use primitives::v1::Id as ParaId;
 
 /// Schedule a para to be initialized at the start of the next session with the given genesis data.
 pub fn schedule_para_initialize<T: paras::Config>(
@@ -61,7 +62,12 @@ where
 	+ hrmp::Config,
 {
 	<paras::Module<T>>::schedule_para_cleanup(id);
-	<dmp::Module<T>>::schedule_para_cleanup(id);
 	<ump::Module<T>>::schedule_para_cleanup(id);
 	<hrmp::Module<T>>::schedule_para_cleanup(id);
+}
+
+/// Trait to trigger the removal of any data about a parachain when the parachain will be removed.
+#[impl_trait_for_tuples::impl_for_tuples(30)]
+pub trait ParachainCleanup {
+	fn parachain_cleanup(id: ParaId);
 }

--- a/runtime/parachains/src/mock.rs
+++ b/runtime/parachains/src/mock.rs
@@ -116,7 +116,7 @@ impl crate::configuration::Config for Test { }
 
 impl crate::paras::Config for Test {
 	type Origin = Origin;
-	type ParachainCleanup = Dmp;
+	type ParachainCleanup = (Dmp, Hrmp, Ump);
 }
 
 impl crate::dmp::Config for Test { }

--- a/runtime/parachains/src/mock.rs
+++ b/runtime/parachains/src/mock.rs
@@ -116,6 +116,7 @@ impl crate::configuration::Config for Test { }
 
 impl crate::paras::Config for Test {
 	type Origin = Origin;
+	type ParachainCleanup = Dmp;
 }
 
 impl crate::dmp::Config for Test { }

--- a/runtime/parachains/src/ump.rs
+++ b/runtime/parachains/src/ump.rs
@@ -148,10 +148,6 @@ pub trait Config: frame_system::Config + configuration::Config {
 
 decl_storage! {
 	trait Store for Module<T: Config> as Ump {
-		/// Paras that are to be cleaned up at the end of the session.
-		/// The entries are sorted ascending by the para id.
-		OutgoingParas: Vec<ParaId>;
-
 		/// The messages waiting to be handled by the relay-chain originating from a certain parachain.
 		///
 		/// Note that some upward messages might have been already processed by the inclusion logic. E.g.
@@ -207,27 +203,7 @@ impl<T: Config> Module<T> {
 	/// Called by the initializer to note that a new session has started.
 	pub(crate) fn initializer_on_new_session(
 		_notification: &initializer::SessionChangeNotification<T::BlockNumber>,
-	) {
-		Self::perform_outgoing_para_cleanup();
-	}
-
-	/// Iterate over all paras that were registered for offboarding and remove all the data
-	/// associated with them.
-	fn perform_outgoing_para_cleanup() {
-		let outgoing = OutgoingParas::take();
-		for outgoing_para in outgoing {
-			Self::clean_ump_after_outgoing(outgoing_para);
-		}
-	}
-
-	/// Schedule a para to be cleaned up at the start of the next session.
-	pub(crate) fn schedule_para_cleanup(id: ParaId) {
-		OutgoingParas::mutate(|v| {
-			if let Err(i) = v.binary_search(&id) {
-				v.insert(i, id);
-			}
-		});
-	}
+	) {}
 
 	fn clean_ump_after_outgoing(outgoing_para: ParaId) {
 		<Self as Store>::RelayDispatchQueueSize::remove(&outgoing_para);
@@ -654,6 +630,14 @@ pub(crate) mod mock_sink {
 			});
 			// an `Err` here signals here that the thread local was already destroyed.
 		}
+	}
+}
+
+impl<T: Config> crate::ParachainCleanup for Module<T> {
+	// Remove all data about a parachain from this pallet when the parachain is
+	// being removed from the system.
+	fn parachain_cleanup(id: ParaId) {
+		Self::clean_ump_after_outgoing(id);
 	}
 }
 

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -511,6 +511,7 @@ impl parachains_inclusion::Config for Runtime {
 
 impl parachains_paras::Config for Runtime {
 	type Origin = Origin;
+	type ParachainCleanup = (Dmp, Hrmp, Ump);
 }
 
 parameter_types! {

--- a/runtime/test-runtime/src/lib.rs
+++ b/runtime/test-runtime/src/lib.rs
@@ -463,6 +463,7 @@ impl parachains_session_info::Config for Runtime {}
 
 impl parachains_paras::Config for Runtime {
 	type Origin = Origin;
+	type ParachainCleanup = (Dmp, Hrmp, Ump);
 }
 
 impl parachains_dmp::Config for Runtime {}
@@ -522,6 +523,9 @@ construct_runtime! {
 		Scheduler: parachains_scheduler::{Module, Call, Storage},
 		ParasSudoWrapper: paras_sudo_wrapper::{Module, Call},
 		SessionInfo: parachains_session_info::{Module, Call, Storage},
+		Dmp: parachains_dmp::{Module, Call, Storage},
+		Ump: parachains_ump::{Module, Call, Storage},
+		Hrmp: parachains_hrmp::{Module, Call, Storage},
 
 		Sudo: pallet_sudo::{Module, Call, Storage, Config<T>, Event<T>},
 	}


### PR DESCRIPTION
I noticed while reviewing all the code around parachain offboarding that each of the messaging pallets had their own offboarding queue which would would trigger a parachain cleanup on the next session.

This was really strange to me since we need to basically maintain a copy of the same queue logic in each pallet... especially if there was ever a situation where a parachain was placed in offboarding, but then later would be removed from the offboarding queue, it would be a lot more work to make sure there isn't any state issue.

This PR introduces the `ParachainCleanup` trait which can be used by any pallet to clean up some data about a Parachain when it is being offboarded by the paras module.

As a result of this change, the Paras module is the definitive source of the outgoing parachains queue, and the trigger to remove data for the parachain will happen exactly when the paras module actually cleans up the data about the parachain.

Thus, there is only one source of the queue and there is no chance to be some kind of synchronization issue among all the pallets.