### PR TITLE
Fixed a grammatical error

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Westend's WND tokens, see the faucet
 
 ## Hacking on Polkadot
 
-If you'd actually like hack on Polkadot, you can grab the source code and build it. Ensure you have
+If you'd actually like to hack on Polkadot, you can grab the source code and build it. Ensure you have
 Rust and the support software installed. This script will install or update Rust and install the
 required dependencies (this may take up to 30 minutes on Mac machines):
 


### PR DESCRIPTION
The following line in the README.md file under the paragraph _Hacking on Polkadot_ can be better readable and grammatically correct after adding the word `to` :

> If you'd actually like hack on Polkadot, you can grab the source code and build it. Ensure you have Rust and the support software installed. This script will install or update Rust and install the required dependencies (this may take up to 30 minutes on Mac machines):

This PR fixes this little thing.

