### PR TITLE
Diagnostics quality of life improvements

### DIFF
--- a/core-primitives/src/lib.rs
+++ b/core-primitives/src/lib.rs
@@ -60,7 +60,7 @@ pub type Hash = sp_core::H256;
 /// This type is produced by [`CandidateReceipt::hash`].
 ///
 /// This type makes it easy to enforce that a hash is a candidate hash on the type level.
-#[derive(Clone, Copy, Encode, Decode, Hash, Eq, PartialEq, Debug, Default)]
+#[derive(Clone, Copy, Encode, Decode, Hash, Eq, PartialEq, Default)]
 #[cfg_attr(feature = "std", derive(MallocSizeOf))]
 pub struct CandidateHash(pub Hash);
 
@@ -69,6 +69,12 @@ impl std::fmt::Display for CandidateHash {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		self.0.fmt(f)
 	}
+}
+
+impl sp_std::fmt::Debug for CandidateHash {
+    fn fmt(&self, f: &mut sp_std::fmt::Formatter<'_>) -> sp_std::fmt::Result {
+        write!(f, "{:?}", self.0)
+    }
 }
 
 /// Index of a transaction in the relay chain. 32-bit should be plenty.

--- a/node/collation-generation/src/lib.rs
+++ b/node/collation-generation/src/lib.rs
@@ -337,6 +337,14 @@ async fn handle_new_activations<Context: SubsystemContext>(
 					},
 				};
 
+				tracing::debug!(
+					target: LOG_TARGET,
+					candidate_hash = %ccr.hash(),
+					?pov_hash,
+					?relay_parent,
+					para_id = %scheduled_core.para_id,
+					"candidate is generated",
+				);
 				metrics.on_collation_generated();
 
 				if let Err(err) = task_sender.send(AllMessages::CollatorProtocol(

--- a/node/network/collator-protocol/src/validator_side.rs
+++ b/node/network/collator-protocol/src/validator_side.rs
@@ -386,6 +386,9 @@ where
 					tracing::debug!(
 						target: LOG_TARGET,
 						%request_id,
+						?para_id,
+						?relay_parent,
+						candidate_hash = ?receipt.hash(),
 						"Received collation",
 					);
 

--- a/node/network/protocol/src/lib.rs
+++ b/node/network/protocol/src/lib.rs
@@ -366,7 +366,7 @@ pub mod v1 {
 	}
 
 	/// SCALE and Zstd encoded [`PoV`].
-	#[derive(Debug, Clone, Encode, Decode, PartialEq, Eq)]
+	#[derive(Clone, Encode, Decode, PartialEq, Eq)]
 	pub struct CompressedPoV(Vec<u8>);
 
 	impl CompressedPoV {
@@ -410,6 +410,12 @@ pub mod v1 {
 		#[cfg(target_os = "unknown")]
 		pub fn decompress(&self) -> Result<PoV, CompressedPoVError> {
 			Err(CompressedPoVError::NotSupported)
+		}
+	}
+
+	impl std::fmt::Debug for CompressedPoV {
+    	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+			write!(f, "CompressedPoV({} bytes)", self.0.len())
 		}
 	}
 


### PR DESCRIPTION
This PR addresses a few points:

- It's important to have an ability to track a collation starting from the collator. However, the when collator generates a collation it prints everything but the candidate hash. With this PR we print the candidate hash just after it was produced.
- Recently a struct `CandidateHash` was added to make candidate hash manipulations type safe. However that also introduced some inconsistencies how we print it. Namely, there are places where we use a naked hash and there are places where we print using the derived `Debug` implementation. This PR changes the way we debug format `CandidateHash` to just the inner hash.
- Do not print `CompressedPoV`s guts. If you reached the level of debugging where you use look at the trace-level and look at all messages, you will definitely appreciate `CompressedPoV` not printing its contents in the decimal format. This PR does just that.

