### PR TITLE
Refactored the build steps for building with cargo

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,12 +67,19 @@ dnf install polkadot
 
 ### Install via Cargo
 
+Before building, make sure you have the following installed on your system :
+
+- The `build-essential` package (install with ` apt install build-essential`)
+- Nightly Rust version (set it with `rustup override set nightly`)
+- The `wasm32-unknown-unknown` package (install it with `rustup target add wasm32-unknown-unknown`)
+
 If you want to install Polkadot in your PATH, you can do so with with:
 
 ```bash
 cargo install --git https://github.com/paritytech/polkadot --tag <version> polkadot --locked
 ```
 
+Replace the `<version>` with the [release version](https://github.com/paritytech/polkadot/releases).
 ### Build from Source
 
 If you'd like to build from source, first install Rust. You may need to add Cargo's bin directory


### PR DESCRIPTION
Hi, the steps for `Install via Cargo` at **https://github.com/paritytech/polkadot#install-via-cargo** are incomplete in the regard that they miss important pre-requisites for getting the project up and running with cargo.

This PR addresses this.