### PR TITLE
Unused variable can be ignored

### DIFF
--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -349,7 +349,7 @@ fn real_overseer<Spawner, RuntimeClient>(
 	_: AvailabilityConfig,
 	_: Arc<sc_network::NetworkService<Block, Hash>>,
 	_: AuthorityDiscoveryService,
-	request_multiplexer: (),
+	_request_multiplexer: (),
 	registry: Option<&Registry>,
 	spawner: Spawner,
 	_: IsCollator,


### PR DESCRIPTION
The request_multiplexer at https://github.com/paritytech/polkadot/blob/4866f8e72029e719d7ce74e341bb1e94ebd724f7/node/service/src/lib.rs#L352 can be ignored at compile-time, as it's not used anywhere.