### PR TITLE
Cargo.lock: Update to libp2p-swarm v0.27.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3263,9 +3263,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.27.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ea8c69839a0e593c8c6a24282cb234d48ac37be4153183f4914e00f5303e75"
+checksum = "7955b973e1fd2bd61ffd43ce261c1223f61f4aacd5bae362a924993f9a25fd98"
 dependencies = [
  "either",
  "futures 0.3.12",


### PR DESCRIPTION
`libp2p-swarm` `CHANGELOG.md`:

> - Have `ToggleProtoHandler` ignore listen upgrade errors when disabled.
  [PR 1945](https://github.com/libp2p/rust-libp2p/pull/1945/files).

Fixes https://github.com/paritytech/polkadot/issues/2373

As far as I can tell no Polkadot version has been released since https://github.com/paritytech/substrate/pull/7963 merged, thus this does not require a changelog entry.