### PR TITLE
Use construct_runtime in tests, remove default PalletInfo impl

### DIFF
--- a/runtime/common/src/claims.rs
+++ b/runtime/common/src/claims.rs
@@ -627,7 +627,7 @@ mod tests {
 			System: frame_system::{Module, Call, Config, Storage, Event<T>},
 			Balances: pallet_balances::{Module, Call, Storage, Config<T>, Event<T>},
 			Vesting: pallet_vesting::{Module, Call, Storage, Config<T>, Event<T>},
-			Claims: claims::{Module, Call, Storage, Config<T>, Event<T>},
+			Claims: claims::{Module, Call, Storage, Config<T>, Event<T>, ValidateUnsigned},
 		}
 	);
 

--- a/runtime/common/src/claims.rs
+++ b/runtime/common/src/claims.rs
@@ -607,27 +607,30 @@ mod tests {
 	// or public keys. `u64` is used as the `AccountId` and no `Signature`s are required.
 	use sp_runtime::{traits::{BlakeTwo256, IdentityLookup, Identity}, testing::Header};
 	use frame_support::{
-		impl_outer_origin, impl_outer_dispatch, assert_ok, assert_err, assert_noop, parameter_types,
+		assert_ok, assert_err, assert_noop, parameter_types,
 		ord_parameter_types, weights::{Pays, GetDispatchInfo}, traits::ExistenceRequirement,
 		dispatch::DispatchError::BadOrigin,
 	};
 	use pallet_balances;
-	use super::Call as ClaimsCall;
+	use crate::claims;
+	use claims::Call as ClaimsCall;
 
-	impl_outer_origin! {
-		pub enum Origin for Test {}
-	}
+	type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+	type Block = frame_system::mocking::MockBlock<Test>;
 
-	impl_outer_dispatch! {
-		pub enum Call for Test where origin: Origin {
-			claims::Claims,
+	frame_support::construct_runtime!(
+		pub enum Test where
+			Block = Block,
+			NodeBlock = Block,
+			UncheckedExtrinsic = UncheckedExtrinsic,
+		{
+			System: frame_system::{Module, Call, Config, Storage, Event<T>},
+			Balances: pallet_balances::{Module, Call, Storage, Config<T>, Event<T>},
+			Vesting: pallet_vesting::{Module, Call, Storage, Config<T>, Event<T>},
+			Claims: claims::{Module, Call, Storage, Config<T>, Event<T>},
 		}
-	}
-	// For testing the module, we construct most of a mock runtime. This means
-	// first constructing a configuration type (`Test`) which `impl`s each of the
-	// configuration traits of modules we want to use.
-	#[derive(Clone, Eq, PartialEq)]
-	pub struct Test;
+	);
+
 	parameter_types! {
 		pub const BlockHashCount: u32 = 250;
 	}
@@ -645,10 +648,10 @@ mod tests {
 		type AccountId = u64;
 		type Lookup = IdentityLookup<u64>;
 		type Header = Header;
-		type Event = ();
+		type Event = Event;
 		type BlockHashCount = BlockHashCount;
 		type Version = ();
-		type PalletInfo = ();
+		type PalletInfo = PalletInfo;
 		type AccountData = pallet_balances::AccountData<u64>;
 		type OnNewAccount = ();
 		type OnKilledAccount = ();
@@ -662,7 +665,7 @@ mod tests {
 
 	impl pallet_balances::Config for Test {
 		type Balance = u64;
-		type Event = ();
+		type Event = Event;
 		type DustRemoval = ();
 		type ExistentialDeposit = ExistentialDeposit;
 		type AccountStore = System;
@@ -675,7 +678,7 @@ mod tests {
 	}
 
 	impl pallet_vesting::Config for Test {
-		type Event = ();
+		type Event = Event;
 		type Currency = Balances;
 		type BlockNumberToBalance = Identity;
 		type MinVestedTransfer = MinVestedTransfer;
@@ -690,16 +693,12 @@ mod tests {
 	}
 
 	impl Config for Test {
-		type Event = ();
+		type Event = Event;
 		type VestingSchedule = Vesting;
 		type Prefix = Prefix;
 		type MoveClaimOrigin = frame_system::EnsureSignedBy<Six, u64>;
 		type WeightInfo = TestWeightInfo;
 	}
-	type System = frame_system::Module<Test>;
-	type Balances = pallet_balances::Module<Test>;
-	type Vesting = pallet_vesting::Module<Test>;
-	type Claims = Module<Test>;
 
 	fn alice() -> secp256k1::SecretKey {
 		secp256k1::SecretKey::parse(&keccak_256(b"Alice")).unwrap()
@@ -723,7 +722,7 @@ mod tests {
 		let mut t = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();
 		// We use default for brevity, but you can configure as desired if needed.
 		pallet_balances::GenesisConfig::<Test>::default().assimilate_storage(&mut t).unwrap();
-		GenesisConfig::<Test>{
+		claims::GenesisConfig::<Test>{
 			claims: vec![
 				(eth(&alice()), 100, None, None),
 				(eth(&dave()), 200, None, Some(StatementKind::Regular)),

--- a/runtime/common/src/impls.rs
+++ b/runtime/common/src/impls.rs
@@ -73,7 +73,7 @@ where
 mod tests {
 	use super::*;
 	use frame_system::limits;
-	use frame_support::{impl_outer_origin, parameter_types, weights::DispatchClass};
+	use frame_support::{parameter_types, weights::DispatchClass};
 	use frame_support::traits::FindAuthor;
 	use sp_core::H256;
 	use sp_runtime::{
@@ -83,12 +83,20 @@ mod tests {
 	};
 	use primitives::v1::AccountId;
 
-	#[derive(Clone, PartialEq, Eq, Debug)]
-	pub struct Test;
+	type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+	type Block = frame_system::mocking::MockBlock<Test>;
 
-	impl_outer_origin!{
-		pub enum Origin for Test {}
-	}
+	frame_support::construct_runtime!(
+		pub enum Test where
+			Block = Block,
+			NodeBlock = Block,
+			UncheckedExtrinsic = UncheckedExtrinsic,
+		{
+			System: frame_system::{Module, Call, Config, Storage, Event<T>},
+			Balances: pallet_balances::{Module, Call, Storage, Config<T>, Event<T>},
+			Treasury: pallet_treasury::{Module, Call, Storage, Config, Event<T>},
+		}
+	);
 
 	parameter_types! {
 		pub const BlockHashCount: u64 = 250;
@@ -109,19 +117,19 @@ mod tests {
 		type Origin = Origin;
 		type Index = u64;
 		type BlockNumber = u64;
-		type Call = ();
+		type Call = Call;
 		type Hash = H256;
 		type Hashing = BlakeTwo256;
 		type AccountId = AccountId;
 		type Lookup = IdentityLookup<Self::AccountId>;
 		type Header = Header;
-		type Event = ();
+		type Event = Event;
 		type BlockHashCount = BlockHashCount;
 		type BlockLength = BlockLength;
 		type BlockWeights = BlockWeights;
 		type DbWeight = ();
 		type Version = ();
-		type PalletInfo = ();
+		type PalletInfo = PalletInfo;
 		type AccountData = pallet_balances::AccountData<u64>;
 		type OnNewAccount = ();
 		type OnKilledAccount = ();
@@ -131,7 +139,7 @@ mod tests {
 
 	impl pallet_balances::Config for Test {
 		type Balance = u64;
-		type Event = ();
+		type Event = Event;
 		type DustRemoval = ();
 		type ExistentialDeposit = ();
 		type AccountStore = System;
@@ -147,7 +155,7 @@ mod tests {
 		type Currency = pallet_balances::Module<Test>;
 		type ApproveOrigin = frame_system::EnsureRoot<AccountId>;
 		type RejectOrigin = frame_system::EnsureRoot<AccountId>;
-		type Event = ();
+		type Event = Event;
 		type OnSlash = ();
 		type ProposalBond = ();
 		type ProposalBondMinimum = ();
@@ -173,10 +181,6 @@ mod tests {
 		type FilterUncle = ();
 		type EventHandler = ();
 	}
-
-	type Treasury = pallet_treasury::Module<Test>;
-	type Balances = pallet_balances::Module<Test>;
-	type System = frame_system::Module<Test>;
 
 	pub fn new_test_ext() -> sp_io::TestExternalities {
 		let mut t = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -188,7 +188,7 @@ impl<T: pallet_session::Config> OneSessionHandler<T::AccountId> for AssignmentSe
 #[cfg(test)]
 mod multiplier_tests {
 	use super::*;
-	use frame_support::{impl_outer_origin, parameter_types, weights::Weight};
+	use frame_support::{parameter_types, weights::Weight};
 	use sp_core::H256;
 	use sp_runtime::{
 		testing::Header,
@@ -196,12 +196,18 @@ mod multiplier_tests {
 		Perbill,
 	};
 
-	#[derive(Clone, PartialEq, Eq, Debug)]
-	pub struct Runtime;
+	type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;
+	type Block = frame_system::mocking::MockBlock<Runtime>;
 
-	impl_outer_origin!{
-		pub enum Origin for Runtime {}
-	}
+	frame_support::construct_runtime!(
+		pub enum Runtime where
+			Block = Block,
+			NodeBlock = Block,
+			UncheckedExtrinsic = UncheckedExtrinsic,
+		{
+			System: frame_system::{Module, Call, Config, Storage, Event<T>}
+		}
+	);
 
 	parameter_types! {
 		pub const BlockHashCount: u64 = 250;
@@ -220,24 +226,22 @@ mod multiplier_tests {
 		type Origin = Origin;
 		type Index = u64;
 		type BlockNumber = u64;
-		type Call = ();
+		type Call = Call;
 		type Hash = H256;
 		type Hashing = BlakeTwo256;
 		type AccountId = u64;
 		type Lookup = IdentityLookup<Self::AccountId>;
 		type Header = Header;
-		type Event = ();
+		type Event = Event;
 		type BlockHashCount = BlockHashCount;
 		type Version = ();
-		type PalletInfo = ();
+		type PalletInfo = PalletInfo;
 		type AccountData = ();
 		type OnNewAccount = ();
 		type OnKilledAccount = ();
 		type SystemWeightInfo = ();
 		type SS58Prefix = ();
 	}
-
-	type System = frame_system::Module<Runtime>;
 
 	fn run_with_system_weight<F>(w: Weight, assertions: F) where F: Fn() -> () {
 		let mut t: sp_io::TestExternalities =

--- a/runtime/common/src/purchase.rs
+++ b/runtime/common/src/purchase.rs
@@ -398,30 +398,31 @@ mod tests {
 		testing::Header
 	};
 	use frame_support::{
-		impl_outer_origin, impl_outer_dispatch, assert_ok, assert_noop, parameter_types,
+		assert_ok, assert_noop, parameter_types,
 		ord_parameter_types, dispatch::DispatchError::BadOrigin,
 	};
 	use frame_support::traits::Currency;
 	use pallet_balances::Error as BalancesError;
+	use crate::purchase;
 
-	impl_outer_origin! {
-		pub enum Origin for Test {}
-	}
+	type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+	type Block = frame_system::mocking::MockBlock<Test>;
 
-	impl_outer_dispatch! {
-		pub enum Call for Test where origin: Origin {
-			purchase::Purchase,
-			vesting::Vesting,
+	frame_support::construct_runtime!(
+		pub enum Test where
+			Block = Block,
+			NodeBlock = Block,
+			UncheckedExtrinsic = UncheckedExtrinsic,
+		{
+			System: frame_system::{Module, Call, Config, Storage, Event<T>},
+			Balances: pallet_balances::{Module, Call, Storage, Config<T>, Event<T>},
+			Vesting: pallet_vesting::{Module, Call, Storage, Config<T>, Event<T>},
+			Purchase: purchase::{Module, Call, Storage, Event<T>},
 		}
-	}
+	);
 
 	type AccountId = AccountId32;
 
-	// For testing the module, we construct most of a mock runtime. This means
-	// first constructing a configuration type (`Test`) which `impl`s each of the
-	// configuration traits of modules we want to use.
-	#[derive(Clone, Eq, PartialEq)]
-	pub struct Test;
 	parameter_types! {
 		pub const BlockHashCount: u32 = 250;
 	}
@@ -439,10 +440,10 @@ mod tests {
 		type AccountId = AccountId;
 		type Lookup = IdentityLookup<AccountId>;
 		type Header = Header;
-		type Event = ();
+		type Event = Event;
 		type BlockHashCount = BlockHashCount;
 		type Version = ();
-		type PalletInfo = ();
+		type PalletInfo = PalletInfo;
 		type AccountData = pallet_balances::AccountData<u64>;
 		type OnNewAccount = ();
 		type OnKilledAccount = ();
@@ -456,7 +457,7 @@ mod tests {
 
 	impl pallet_balances::Config for Test {
 		type Balance = u64;
-		type Event = ();
+		type Event = Event;
 		type DustRemoval = ();
 		type ExistentialDeposit = ExistentialDeposit;
 		type AccountStore = System;
@@ -469,7 +470,7 @@ mod tests {
 	}
 
 	impl pallet_vesting::Config for Test {
-		type Event = ();
+		type Event = Event;
 		type Currency = Balances;
 		type BlockNumberToBalance = Identity;
 		type MinVestedTransfer = MinVestedTransfer;
@@ -489,7 +490,7 @@ mod tests {
 	}
 
 	impl Config for Test {
-		type Event = ();
+		type Event = Event;
 		type Currency = Balances;
 		type VestingSchedule = Vesting;
 		type ValidityOrigin = frame_system::EnsureSignedBy<ValidityOrigin, AccountId>;
@@ -498,11 +499,6 @@ mod tests {
 		type UnlockedProportion = UnlockedProportion;
 		type MaxUnlocked = MaxUnlocked;
 	}
-
-	type System = frame_system::Module<Test>;
-	type Balances = pallet_balances::Module<Test>;
-	type Vesting = pallet_vesting::Module<Test>;
-	type Purchase = Module<Test>;
 
 	// This function basically just builds a genesis storage key/value store according to
 	// our desired mockup. It also executes our `setup` function which sets up this pallet for use.

--- a/runtime/common/src/slots.rs
+++ b/runtime/common/src/slots.rs
@@ -944,21 +944,29 @@ mod tests {
 	use sp_core::H256;
 	use sp_runtime::traits::{BlakeTwo256, Hash, IdentityLookup};
 	use frame_support::{
-		impl_outer_origin, parameter_types, assert_ok, assert_noop,
+		parameter_types, assert_ok, assert_noop,
 		traits::{OnInitialize, OnFinalize}
 	};
 	use pallet_balances;
 	use primitives::v1::{BlockNumber, Header, Id as ParaId};
+	use crate::slots;
 
-	impl_outer_origin! {
-		pub enum Origin for Test {}
-	}
+	type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+	type Block = frame_system::mocking::MockBlock<Test>;
 
-	// For testing the module, we construct most of a mock runtime. This means
-	// first constructing a configuration type (`Test`) which `impl`s each of the
-	// configuration traits of modules we want to use.
-	#[derive(Clone, Eq, PartialEq)]
-	pub struct Test;
+	frame_support::construct_runtime!(
+		pub enum Test where
+			Block = Block,
+			NodeBlock = Block,
+			UncheckedExtrinsic = UncheckedExtrinsic,
+		{
+			System: frame_system::{Module, Call, Config, Storage, Event<T>},
+			Balances: pallet_balances::{Module, Call, Storage, Config<T>, Event<T>},
+			Slots: slots::{Module, Call, Storage, Event<T>},
+	 		RandomnessCollectiveFlip: pallet_randomness_collective_flip::{Module, Call, Storage},
+		}
+	);
+
 	parameter_types! {
 		pub const BlockHashCount: u32 = 250;
 	}
@@ -968,7 +976,7 @@ mod tests {
 		type BlockLength = ();
 		type DbWeight = ();
 		type Origin = Origin;
-		type Call = ();
+		type Call = Call;
 		type Index = u64;
 		type BlockNumber = BlockNumber;
 		type Hash = H256;
@@ -976,10 +984,10 @@ mod tests {
 		type AccountId = u64;
 		type Lookup = IdentityLookup<Self::AccountId>;
 		type Header = Header;
-		type Event = ();
+		type Event = Event;
 		type BlockHashCount = BlockHashCount;
 		type Version = ();
-		type PalletInfo = ();
+		type PalletInfo = PalletInfo;
 		type AccountData = pallet_balances::AccountData<u64>;
 		type OnNewAccount = ();
 		type OnKilledAccount = ();
@@ -993,7 +1001,7 @@ mod tests {
 
 	impl pallet_balances::Config for Test {
 		type Balance = u64;
-		type Event = ();
+		type Event = Event;
 		type DustRemoval = ();
 		type ExistentialDeposit = ExistentialDeposit;
 		type AccountStore = System;
@@ -1066,18 +1074,13 @@ mod tests {
 	}
 
 	impl Config for Test {
-		type Event = ();
+		type Event = Event;
 		type Currency = Balances;
 		type Parachains = TestParachains;
 		type LeasePeriod = LeasePeriod;
 		type EndingPeriod = EndingPeriod;
 		type Randomness = RandomnessCollectiveFlip;
 	}
-
-	type System = frame_system::Module<Test>;
-	type Balances = pallet_balances::Module<Test>;
-	type Slots = Module<Test>;
-	type RandomnessCollectiveFlip = pallet_randomness_collective_flip::Module<Test>;
 
 	// This function basically just builds a genesis storage key/value store according to
 	// our desired mock up.

--- a/runtime/parachains/src/dmp.rs
+++ b/runtime/parachains/src/dmp.rs
@@ -232,7 +232,7 @@ mod tests {
 	use frame_support::StorageValue;
 	use frame_support::traits::{OnFinalize, OnInitialize};
 	use parity_scale_codec::Encode;
-	use crate::mock::{Configuration, new_test_ext, System, Dmp, GenesisConfig as MockGenesisConfig};
+	use crate::mock::{Configuration, new_test_ext, System, Dmp, MockGenesisConfig};
 
 	pub(crate) fn run_to_block(to: BlockNumber, new_session: Option<Vec<BlockNumber>>) {
 		while System::block_number() < to {

--- a/runtime/parachains/src/hrmp.rs
+++ b/runtime/parachains/src/hrmp.rs
@@ -1124,7 +1124,7 @@ impl<T: Config> Module<T> {
 mod tests {
 	use super::*;
 	use crate::mock::{
-		new_test_ext, Test, Configuration, Paras, Hrmp, System, GenesisConfig as MockGenesisConfig,
+		new_test_ext, Test, Configuration, Paras, Hrmp, System, MockGenesisConfig,
 	};
 	use frame_support::{assert_err, traits::Currency as _};
 	use primitives::v1::BlockNumber;
@@ -1198,7 +1198,7 @@ mod tests {
 	}
 
 	impl GenesisConfigBuilder {
-		fn build(self) -> crate::mock::GenesisConfig {
+		fn build(self) -> crate::mock::MockGenesisConfig {
 			let mut genesis = default_genesis_config();
 			let config = &mut genesis.configuration.config;
 			config.hrmp_channel_max_capacity = self.hrmp_channel_max_capacity;

--- a/runtime/parachains/src/inclusion.rs
+++ b/runtime/parachains/src/inclusion.rs
@@ -907,7 +907,7 @@ mod tests {
 	use sc_keystore::LocalKeystore;
 	use crate::mock::{
 		new_test_ext, Configuration, Paras, System, Inclusion,
-		GenesisConfig as MockGenesisConfig, Test,
+		MockGenesisConfig, Test,
 	};
 	use crate::initializer::SessionChangeNotification;
 	use crate::configuration::HostConfiguration;

--- a/runtime/parachains/src/inclusion_inherent.rs
+++ b/runtime/parachains/src/inclusion_inherent.rs
@@ -225,7 +225,7 @@ mod tests {
 	use super::*;
 
 	use crate::mock::{
-		new_test_ext, System, GenesisConfig as MockGenesisConfig, Test
+		new_test_ext, System, MockGenesisConfig, Test
 	};
 
 	mod limit_backed_candidates {
@@ -278,7 +278,7 @@ mod tests {
 		use super::*;
 
 		use crate::mock::{
-			new_test_ext, System, GenesisConfig as MockGenesisConfig, Test
+			new_test_ext, System, MockGenesisConfig, Test
 		};
 
 		use frame_support::traits::UnfilteredDispatchable;

--- a/runtime/parachains/src/mock.rs
+++ b/runtime/parachains/src/mock.rs
@@ -22,38 +22,36 @@ use sp_runtime::traits::{
 	BlakeTwo256, IdentityLookup,
 };
 use primitives::v1::{AuthorityDiscoveryId, Balance, BlockNumber, Header, ValidatorIndex};
-use frame_support::{
-	impl_outer_origin, impl_outer_dispatch, impl_outer_event, parameter_types,
-	traits::Randomness as RandomnessT,
-};
+use frame_support::{parameter_types, traits::Randomness as RandomnessT};
 use std::cell::RefCell;
 use std::collections::HashMap;
-use crate::inclusion;
-use crate as parachains;
+use crate::{
+	inclusion, scheduler, dmp, ump, hrmp, session_info, paras, configuration,
+	initializer,
+};
 
-/// A test runtime struct.
-#[derive(Clone, Eq, PartialEq)]
-pub struct Test;
+type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type Block = frame_system::mocking::MockBlock<Test>;
 
-impl_outer_origin! {
-	pub enum Origin for Test {
-		parachains
+frame_support::construct_runtime!(
+	pub enum Test where
+		Block = Block,
+		NodeBlock = Block,
+		UncheckedExtrinsic = UncheckedExtrinsic,
+	{
+		System: frame_system::{Module, Call, Config, Storage, Event<T>},
+		Balances: pallet_balances::{Module, Call, Storage, Config<T>, Event<T>},
+		Paras: paras::{Module, Origin, Call, Storage, Config<T>},
+		Configuration: configuration::{Module, Call, Storage, Config<T>},
+		Inclusion: inclusion::{Module, Call, Storage, Event<T>},
+		Scheduler: scheduler::{Module, Call, Storage},
+		Initializer: initializer::{Module, Call, Storage},
+		Dmp: dmp::{Module, Call, Storage},
+		Ump: ump::{Module, Call, Storage},
+		Hrmp: hrmp::{Module, Call, Storage},
+		SessionInfo: session_info::{Module, Call, Storage},
 	}
-}
-
-impl_outer_dispatch! {
-	pub enum Call for Test where origin: Origin {
-		initializer::Initializer,
-	}
-}
-
-impl_outer_event! {
-	pub enum TestEvent for Test {
-		frame_system<T>,
-		pallet_balances<T>,
-		inclusion<T>,
-	}
-}
+);
 
 pub struct TestRandomness;
 
@@ -83,10 +81,10 @@ impl frame_system::Config for Test {
 	type AccountId = u64;
 	type Lookup = IdentityLookup<u64>;
 	type Header = Header;
-	type Event = TestEvent;
+	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type Version = ();
-	type PalletInfo = ();
+	type PalletInfo = PalletInfo;
 	type AccountData = pallet_balances::AccountData<u128>;
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
@@ -101,7 +99,7 @@ parameter_types! {
 impl pallet_balances::Config for Test {
 	type MaxLocks = ();
 	type Balance = Balance;
-	type Event = TestEvent;
+	type Event = Event;
 	type DustRemoval = ();
 	type ExistentialDeposit = ExistentialDeposit;
 	type AccountStore = System;
@@ -132,7 +130,7 @@ impl crate::hrmp::Config for Test {
 impl crate::scheduler::Config for Test { }
 
 impl crate::inclusion::Config for Test {
-	type Event = TestEvent;
+	type Event = Event;
 	type RewardValidators = TestRewardValidators;
 }
 
@@ -182,35 +180,6 @@ impl inclusion::RewardValidators for TestRewardValidators {
 		})
 	}
 }
-
-pub type System = frame_system::Module<Test>;
-
-/// Mocked initializer.
-pub type Initializer = crate::initializer::Module<Test>;
-
-/// Mocked configuration.
-pub type Configuration = crate::configuration::Module<Test>;
-
-/// Mocked paras.
-pub type Paras = crate::paras::Module<Test>;
-
-/// Mocked DMP
-pub type Dmp = crate::dmp::Module<Test>;
-
-/// Mocked UMP
-pub type Ump = crate::ump::Module<Test>;
-
-/// Mocked HRMP
-pub type Hrmp = crate::hrmp::Module<Test>;
-
-/// Mocked scheduler.
-pub type Scheduler = crate::scheduler::Module<Test>;
-
-/// Mocked inclusion module.
-pub type Inclusion = crate::inclusion::Module<Test>;
-
-/// Mocked session info module.
-pub type SessionInfo = crate::session_info::Module<Test>;
 
 /// Create a new set of test externalities.
 pub fn new_test_ext(state: GenesisConfig) -> TestExternalities {

--- a/runtime/parachains/src/mock.rs
+++ b/runtime/parachains/src/mock.rs
@@ -182,7 +182,7 @@ impl inclusion::RewardValidators for TestRewardValidators {
 }
 
 /// Create a new set of test externalities.
-pub fn new_test_ext(state: GenesisConfig) -> TestExternalities {
+pub fn new_test_ext(state: MockGenesisConfig) -> TestExternalities {
 	BACKING_REWARDS.with(|r| r.borrow_mut().clear());
 	AVAILABILITY_REWARDS.with(|r| r.borrow_mut().clear());
 
@@ -194,7 +194,7 @@ pub fn new_test_ext(state: GenesisConfig) -> TestExternalities {
 }
 
 #[derive(Default)]
-pub struct GenesisConfig {
+pub struct MockGenesisConfig {
 	pub system: frame_system::GenesisConfig,
 	pub configuration: crate::configuration::GenesisConfig<Test>,
 	pub paras: crate::paras::GenesisConfig<Test>,

--- a/runtime/parachains/src/paras.rs
+++ b/runtime/parachains/src/paras.rs
@@ -837,7 +837,7 @@ mod tests {
 	use primitives::v1::BlockNumber;
 	use frame_support::traits::{OnFinalize, OnInitialize};
 
-	use crate::mock::{new_test_ext, Paras, System, GenesisConfig as MockGenesisConfig};
+	use crate::mock::{new_test_ext, Paras, System, MockGenesisConfig};
 	use crate::configuration::HostConfiguration;
 
 	fn run_to_block(to: BlockNumber, new_session: Option<Vec<BlockNumber>>) {

--- a/runtime/parachains/src/scheduler.rs
+++ b/runtime/parachains/src/scheduler.rs
@@ -739,7 +739,7 @@ mod tests {
 	use frame_support::traits::{OnFinalize, OnInitialize};
 	use keyring::Sr25519Keyring;
 
-	use crate::mock::{new_test_ext, Configuration, Paras, System, Scheduler, GenesisConfig as MockGenesisConfig};
+	use crate::mock::{new_test_ext, Configuration, Paras, System, Scheduler, MockGenesisConfig};
 	use crate::initializer::SessionChangeNotification;
 	use crate::configuration::HostConfiguration;
 	use crate::paras::ParaGenesisArgs;

--- a/runtime/parachains/src/session_info.rs
+++ b/runtime/parachains/src/session_info.rs
@@ -165,7 +165,7 @@ impl<T: pallet_session::Config + Config> OneSessionHandler<T::AccountId> for Mod
 mod tests {
 	use super::*;
 	use crate::mock::{
-		new_test_ext, Configuration, SessionInfo, System, GenesisConfig as MockGenesisConfig,
+		new_test_ext, Configuration, SessionInfo, System, MockGenesisConfig,
 		Origin,
 	};
 	use crate::initializer::SessionChangeNotification;

--- a/runtime/parachains/src/ump.rs
+++ b/runtime/parachains/src/ump.rs
@@ -661,7 +661,7 @@ pub(crate) mod mock_sink {
 mod tests {
 	use super::*;
 	use super::mock_sink::Probe;
-	use crate::mock::{Configuration, Ump, new_test_ext, GenesisConfig as MockGenesisConfig};
+	use crate::mock::{Configuration, Ump, new_test_ext, MockGenesisConfig};
 	use frame_support::IterableStorageMap;
 	use std::collections::HashSet;
 
@@ -686,7 +686,7 @@ mod tests {
 	}
 
 	impl GenesisConfigBuilder {
-		fn build(self) -> crate::mock::GenesisConfig {
+		fn build(self) -> crate::mock::MockGenesisConfig {
 			let mut genesis = default_genesis_config();
 			let config = &mut genesis.configuration.config;
 


### PR DESCRIPTION
See https://github.com/paritytech/substrate/issues/7949