### PR TITLE
CancelProxy uses `reject_announcement` instead of `remove_announcement`

### DIFF
--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -918,7 +918,7 @@ impl InstanceFilter<Call> for ProxyType {
 				Call::Utility(..)
 			),
 			ProxyType::CancelProxy => matches!(c,
-				Call::Proxy(pallet_proxy::Call::remove_announcement(..))
+				Call::Proxy(pallet_proxy::Call::reject_announcement(..))
 			)
 		}
 	}

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -918,8 +918,7 @@ impl InstanceFilter<Call> for ProxyType {
 				Call::Utility(..)
 			),
 			ProxyType::CancelProxy => matches!(c,
-				Call::Proxy(pallet_proxy::Call::reject_announcement(..)) |
-				Call::Proxy(pallet_proxy::Call::remove_announcement(..))
+				Call::Proxy(pallet_proxy::Call::reject_announcement(..))
 			)
 		}
 	}

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -918,7 +918,8 @@ impl InstanceFilter<Call> for ProxyType {
 				Call::Utility(..)
 			),
 			ProxyType::CancelProxy => matches!(c,
-				Call::Proxy(pallet_proxy::Call::reject_announcement(..))
+				Call::Proxy(pallet_proxy::Call::reject_announcement(..)) |
+				Call::Proxy(pallet_proxy::Call::remove_announcement(..))
 			)
 		}
 	}

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -922,7 +922,7 @@ impl InstanceFilter<Call> for ProxyType {
 				Call::Utility(..)
 			),
 			ProxyType::CancelProxy => matches!(c,
-				Call::Proxy(pallet_proxy::Call::remove_announcement(..))
+				Call::Proxy(pallet_proxy::Call::reject_announcement(..))
 			)
 		}
 	}

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -922,8 +922,7 @@ impl InstanceFilter<Call> for ProxyType {
 				Call::Utility(..)
 			),
 			ProxyType::CancelProxy => matches!(c,
-				Call::Proxy(pallet_proxy::Call::reject_announcement(..)) |
-				Call::Proxy(pallet_proxy::Call::remove_announcement(..))
+				Call::Proxy(pallet_proxy::Call::reject_announcement(..))
 			)
 		}
 	}

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -922,7 +922,8 @@ impl InstanceFilter<Call> for ProxyType {
 				Call::Utility(..)
 			),
 			ProxyType::CancelProxy => matches!(c,
-				Call::Proxy(pallet_proxy::Call::reject_announcement(..))
+				Call::Proxy(pallet_proxy::Call::reject_announcement(..)) |
+				Call::Proxy(pallet_proxy::Call::remove_announcement(..))
 			)
 		}
 	}

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -649,7 +649,7 @@ impl InstanceFilter<Call> for ProxyType {
 				Call::Utility(..)
 			),
 			ProxyType::CancelProxy => matches!(c,
-				Call::Proxy(pallet_proxy::Call::remove_announcement(..))
+				Call::Proxy(pallet_proxy::Call::reject_announcement(..))
 			)
 		}
 	}

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -649,8 +649,7 @@ impl InstanceFilter<Call> for ProxyType {
 				Call::Utility(..)
 			),
 			ProxyType::CancelProxy => matches!(c,
-				Call::Proxy(pallet_proxy::Call::reject_announcement(..)) |
-				Call::Proxy(pallet_proxy::Call::remove_announcement(..))
+				Call::Proxy(pallet_proxy::Call::reject_announcement(..))
 			)
 		}
 	}

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -649,7 +649,8 @@ impl InstanceFilter<Call> for ProxyType {
 				Call::Utility(..)
 			),
 			ProxyType::CancelProxy => matches!(c,
-				Call::Proxy(pallet_proxy::Call::reject_announcement(..))
+				Call::Proxy(pallet_proxy::Call::reject_announcement(..)) |
+				Call::Proxy(pallet_proxy::Call::remove_announcement(..))
 			)
 		}
 	}


### PR DESCRIPTION
Cancel proxies were designed for a situation where we have 3 accounts:
1. `Alice`, a cold storage account which is meant to be controlled via its proxies
2. `Bob`, a time-delay proxy with `Any` permissions. This account must _announce_ its intentions ahead of time.
3. `Charlie`, a `CancelProxy`, which can observe and cancel `Bob`'s announcements.

In practice, we may have multiple proxies in the place of `Bob`, but this minimal example suffices to explain. Also in practice, `Bob` and `Charlie` may be multi-sigs, but that's irrelevant to the example, again. And also in practice, `Alice` might be an anonymous proxy, and this also doesn't matter.

If the `Bob` account is compromised, we'd like `Charlie` to be able to issue a transaction to cancel `Bob`'s announcements.

Thus we have the following desired control flow to detect, mitigate, and deter future attacks:

1. `Bob` issues `proxy::Announce(Alice, bad_call_hash)`.
2. `Charlie` does not recognize the `bad_call_hash`, and does ????, canceling the call by `Bob`.
3. `Bob` is replaced as a proxy by `Alice`.

The purpose of this PR is to address what ???? stands for.

In the status quo, `Charlie` has access to issue `proxy::RemoveAnnouncement` calls on behalf of `Alice`.  However, `proxy::RemoveAnnouncement` is meant to be called by a _proxy_ in order to retract a previously announced call. As `Alice` is not a proxy, it isn't useful for `Charlie` to issue `proxy::Proxy(Alice, proxy::RemoveAnnouncement(Alice, bad_call_hash))`. This is a no-op. 

In fact, unless `Charlie` is equal to `Bob`, `Charlie` has no way of retracting calls by `Bob`. If `Charlie` is equal to `Bob`, `Charlie` can issue a `proxy::RemoveAnnouncement(Alice, bad_call_hash)` - note, this is not a proxy call on behalf of Alice - and successfully remove `Bob`'s announcement. The reason I bring up this `Bob == Charlie` case is because I suspect it was used during testing.

This PR gives `CancelProxy` access to `proxy::RejectAnnouncement` which is intended to be called _by_ a delegate account to reject the announcements by its proxies. With this change, `Charlie` can issue `proxy::Proxy(Alice, proxy::RejectAnnouncement(Bob, bad_call_hash))` to cause the `Alice` account to reject Bob's bad call hash. I believe this is the desired behavior.

It's also possible that I'm completely missing the point; I haven't found anyone able to explain this feature adequately to me yet and I wasn't part of the initial design discussions.