### PR TITLE
[CI] Fix check-tx-version Gitlab job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -157,7 +157,7 @@ check-transaction-versions:
   <<:                              *docker-env
   needs:
     - job:                         test-linux-stable
-      artifacts:                   false
+      artifacts:                   true
   before_script:
     - npm install --ignore-scripts -g @polkadot/metadata-cmp
     - git fetch origin release

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -159,6 +159,7 @@ check-transaction-versions:
     - job:                         test-linux-stable
       artifacts:                   true
   before_script:
+    - apt-get -y update; apt-get -y install jq
     - npm install --ignore-scripts -g @polkadot/metadata-cmp
     - git fetch origin release
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -159,7 +159,7 @@ check-transaction-versions:
     - job:                         test-linux-stable
       artifacts:                   true
   before_script:
-    - apt-get -y update; apt-get -y install jq
+    - apt-get -y update; apt-get -y install jq lsof
     - npm install --ignore-scripts -g @polkadot/metadata-cmp
     - git fetch origin release
   script:

--- a/scripts/common/lib.sh
+++ b/scripts/common/lib.sh
@@ -117,3 +117,10 @@ skip_if_companion_pr() {
     echo "[+] PR is not a companion PR. Proceeding test"
   fi
 }
+
+# Fetches the tag name of the latest release from a repository
+# repo: 'organisation/repo'
+# Usage: latest_release 'paritytech/polkadot'
+latest_release() {
+  curl -s "$api_base/$1/releases/latest" | jq -r '.tag_name'
+}

--- a/scripts/gitlab/check_extrinsics_ordering.sh
+++ b/scripts/gitlab/check_extrinsics_ordering.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 BIN=./target/release/polkadot
 LIVE_WS=wss://rpc.polkadot.io
 LOCAL_WS=ws://localhost:9944

--- a/scripts/gitlab/check_extrinsics_ordering.sh
+++ b/scripts/gitlab/check_extrinsics_ordering.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -e
 BIN=./target/release/polkadot
 LIVE_WS=wss://rpc.polkadot.io
 LOCAL_WS=ws://localhost:9944

--- a/scripts/gitlab/check_extrinsics_ordering.sh
+++ b/scripts/gitlab/check_extrinsics_ordering.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 # Include the common functions library
@@ -52,6 +52,18 @@ for RUNTIME in "${runtimes[@]}"; do
   jobs
 
   # Sleep a little to allow the nodes to spin up and start listening
+  TIMEOUT=5
+  for i in $(seq $TIMEOUT); do
+    sleep 1
+      if [ "$(lsof -nP -iTCP -sTCP:LISTEN | grep -c '994[45]')" == 2 ]; then
+        echo "[+] Both nodes listening"
+        break
+      fi
+      if [ "$i" == $TIMEOUT ]; then
+        echo "[!] Both nodes not listening after $i seconds. Exiting"
+        exit 1
+      fi
+  done
   sleep 5
 
   changed_extrinsics=$(

--- a/scripts/gitlab/check_extrinsics_ordering.sh
+++ b/scripts/gitlab/check_extrinsics_ordering.sh
@@ -9,9 +9,6 @@ HEAD_BIN=./target/release/polkadot
 HEAD_WS=ws://localhost:9944
 RELEASE_WS=ws://localhost:9945
 
-# Kill the polkadot client before exiting
-trap 'jobs -p | xargs kill' EXIT
-
 runtimes=(
   "westend"
   "kusama"

--- a/scripts/gitlab/check_extrinsics_ordering.sh
+++ b/scripts/gitlab/check_extrinsics_ordering.sh
@@ -1,16 +1,30 @@
 #!/bin/bash
-BIN=./target/release/polkadot
-LIVE_WS=wss://rpc.polkadot.io
-LOCAL_WS=ws://localhost:9944
+set -e
+
+# Include the common functions library
+#shellcheck source=../common/lib.sh
+. "$(dirname "${0}")/../common/lib.sh"
+
+HEAD_BIN=./target/release/polkadot
+HEAD_WS=ws://localhost:9944
+RELEASE_WS=ws://localhost:9945
 
 # Kill the polkadot client before exiting
-trap 'kill "$(jobs -p)"' EXIT
+trap 'jobs -p | xargs kill' EXIT
 
 runtimes=(
   "westend"
   "kusama"
   "polkadot"
 )
+
+# First we fetch the latest released binary
+latest_release=$(latest_release 'paritytech/polkadot')
+RELEASE_BIN="./polkadot-$latest_release"
+echo "[+] Fetching binary for Polkadot version $latest_release"
+curl -L "https://github.com/paritytech/polkadot/releases/download/$latest_release/polkadot" > "$RELEASE_BIN" || exit 1
+chmod +x "$RELEASE_BIN"
+
 
 for RUNTIME in "${runtimes[@]}"; do
   echo "[+] Checking runtime: ${RUNTIME}"
@@ -32,19 +46,17 @@ for RUNTIME in "${runtimes[@]}"; do
     exit 0
   fi
 
-  if [ "$RUNTIME" = 'polkadot' ]; then
-    LIVE_WS="wss://rpc.polkadot.io"
-  else
-    LIVE_WS="wss://${RUNTIME}-rpc.polkadot.io"
-  fi
-
-  # Start running the local polkadot node in the background
-  $BIN --chain="$RUNTIME-local"  &
+  # Start running the nodes in the background
+  $HEAD_BIN --chain="$RUNTIME-local" --tmp &
+  $RELEASE_BIN --chain="$RUNTIME-local" --ws-port 9945 --tmp &
   jobs
 
+  # Sleep a little to allow the nodes to spin up and start listening
+  sleep 5
+
   changed_extrinsics=$(
-    polkadot-js-metadata-cmp "$LIVE_WS" "$LOCAL_WS" \
-      | sed 's/^ \+//g' | grep -e 'idx: [0-9]\+ -> [0-9]\+'
+    polkadot-js-metadata-cmp "$RELEASE_WS" "$HEAD_WS" \
+      | sed 's/^ \+//g' | grep -e 'idx: [0-9]\+ -> [0-9]\+' || true
   )
 
   if [ -n "$changed_extrinsics" ]; then
@@ -54,6 +66,8 @@ for RUNTIME in "${runtimes[@]}"; do
   fi
 
   echo "[+] No change in extrinsics ordering for the ${RUNTIME} runtime"
-  kill "$(jobs -p)"; sleep 5
+  jobs -p | xargs kill; sleep 5
 done
 
+# Sleep a little to let the jobs die properly
+sleep 5


### PR DESCRIPTION
Makes the artifacts available to the check-transactions-version job which was causing an issue reported by @andresilva . In addition, we now also fetch the latest released version of Polkadot and compare the metadata with *that*.

Prior to this PR, we compare the metadata with whatever is live *on-chain*, which means if we have released a new version of polkadot but the runtime on Westend, Kusama or Polkadot has not been upgraded yet (as is currently the case on Polkadot), it could potentially complain about changed extrinsics. 

I'll make a followup PR at some point that checks more than just the *ordering* of the extrinsics (like new/removed modules, what have you) but that's dependent on me getting a more machine-readable summary of metadata..