### PR TITLE
Make sure the adder collator fails when something is wrong

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9215,7 +9215,6 @@ dependencies = [
 name = "test-parachain-adder-collator"
 version = "0.7.26"
 dependencies = [
- "assert_matches",
  "futures 0.3.12",
  "futures-timer 3.0.2",
  "log",

--- a/parachain/test-parachains/adder/collator/Cargo.toml
+++ b/parachain/test-parachains/adder/collator/Cargo.toml
@@ -15,7 +15,6 @@ futures = "0.3.12"
 futures-timer = "3.0.2"
 log = "0.4.13"
 structopt = "0.3.21"
-assert_matches = "1.4.0"
 
 test-parachain-adder = { path = ".." }
 polkadot-primitives = { path = "../../../../primitives" }

--- a/parachain/test-parachains/adder/collator/src/lib.rs
+++ b/parachain/test-parachains/adder/collator/src/lib.rs
@@ -28,7 +28,6 @@ use std::{
 };
 use test_parachain_adder::{execute, hash_state, BlockData, HeadData};
 use futures::channel::oneshot;
-use assert_matches::assert_matches;
 
 /// The amount we add when producing a new block.
 ///
@@ -180,11 +179,13 @@ impl Collator {
 			let seconded_collations = seconded_collations.clone();
 			spawner.spawn("adder-collator-seconded", async move {
 				if let Ok(res) = recv.await {
-					assert_matches!(
+					if !matches!(
 						res.payload(),
 						Statement::Seconded(s) if s.descriptor.pov_hash == pov.hash(),
-						"Seconded statement should match our collation!",
-					);
+					) {
+						log::error!("Seconded statement should match our collation: {:?}", res.payload());
+						std::process::exit(-1);
+					}
 
 					seconded_collations.fetch_add(1, Ordering::Relaxed);
 				}


### PR DESCRIPTION
As futures most of the time are catching panics and we don't check this,
it could happen that we have some statement that isn't correct but the
test succeeds successfully.