### PR TITLE
Replace AuxStore with custom RocksDB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5202,6 +5202,7 @@ dependencies = [
  "futures 0.3.12",
  "futures-timer 3.0.2",
  "kvdb",
+ "kvdb-memorydb",
  "maplit",
  "merlin",
  "parity-scale-codec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5203,6 +5203,7 @@ dependencies = [
  "futures-timer 3.0.2",
  "kvdb",
  "kvdb-memorydb",
+ "kvdb-rocksdb",
  "maplit",
  "merlin",
  "parity-scale-codec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5198,8 +5198,10 @@ version = "0.1.0"
 dependencies = [
  "assert_matches",
  "bitvec",
+ "derive_more",
  "futures 0.3.12",
  "futures-timer 3.0.2",
+ "kvdb",
  "maplit",
  "merlin",
  "parity-scale-codec",

--- a/node/core/approval-voting/Cargo.toml
+++ b/node/core/approval-voting/Cargo.toml
@@ -13,6 +13,8 @@ tracing-futures = "0.2.4"
 bitvec = { version = "0.20.1", default-features = false, features = ["alloc"] }
 merlin = "2.0"
 schnorrkel = "0.9.1"
+kvdb = "0.9.0"
+derive_more = "0.99.1"
 
 polkadot-subsystem = { package = "polkadot-node-subsystem", path = "../../subsystem" }
 polkadot-overseer = { path = "../../overseer" }

--- a/node/core/approval-voting/Cargo.toml
+++ b/node/core/approval-voting/Cargo.toml
@@ -14,6 +14,7 @@ bitvec = { version = "0.20.1", default-features = false, features = ["alloc"] }
 merlin = "2.0"
 schnorrkel = "0.9.1"
 kvdb = "0.9.0"
+kvdb-rocksdb = "0.11.0"
 derive_more = "0.99.1"
 
 polkadot-subsystem = { package = "polkadot-node-subsystem", path = "../../subsystem" }

--- a/node/core/approval-voting/Cargo.toml
+++ b/node/core/approval-voting/Cargo.toml
@@ -38,3 +38,4 @@ sp-consensus-babe = { git = "https://github.com/paritytech/substrate", branch = 
 maplit = "1.0.2"
 polkadot-node-subsystem-test-helpers = { path = "../../subsystem-test-helpers" }
 assert_matches = "1.4.0"
+kvdb-memorydb = "0.9.0"

--- a/node/core/approval-voting/src/approval_db/v1/mod.rs
+++ b/node/core/approval-voting/src/approval_db/v1/mod.rs
@@ -16,7 +16,7 @@
 
 //! Version 1 of the DB schema.
 
-use sc_client_api::backend::AuxStore;
+use kvdb::{DBTransaction, KeyValueDB};
 use polkadot_node_primitives::approval::{DelayTranche, AssignmentCert};
 use polkadot_primitives::v1::{
 	ValidatorIndex, GroupIndex, CandidateReceipt, SessionIndex, CoreIndex,
@@ -28,6 +28,8 @@ use parity_scale_codec::{Encode, Decode};
 use std::collections::{BTreeMap, HashMap};
 use std::collections::hash_map::Entry;
 use bitvec::{vec::BitVec, order::Lsb0 as BitOrderLsb0};
+
+const DATA_COL: u32 = 0;
 
 #[cfg(test)]
 pub mod tests;
@@ -119,14 +121,26 @@ impl From<Tick> for crate::Tick {
 	}
 }
 
+/// Errors while accessing things from the DB.
+#[derive(Debug, derive_more::From, derive_more::Display)]
+pub enum Error {
+	Io(std::io::Error),
+	InvalidDecoding(parity_scale_codec::Error),
+}
+
+impl std::error::Error for Error {}
+
+/// Result alias for DB errors.
+pub type Result<T> = std::result::Result<T, Error>;
+
 /// Canonicalize some particular block, pruning everything before it and
 /// pruning any competing branches at the same height.
 pub(crate) fn canonicalize(
-	store: &impl AuxStore,
+	store: &dyn KeyValueDB,
 	canon_number: BlockNumber,
 	canon_hash: Hash,
 )
-	-> sp_blockchain::Result<()>
+	-> Result<()>
 {
 	let range = match load_stored_blocks(store)? {
 		None => return Ok(()),
@@ -137,8 +151,7 @@ pub(crate) fn canonicalize(
 		},
 	};
 
-	let mut deleted_height_keys = Vec::new();
-	let mut deleted_block_keys = Vec::new();
+	let mut transaction = DBTransaction::new();
 
 	// Storing all candidates in memory is potentially heavy, but should be fine
 	// as long as finality doesn't stall for a long while. We could optimize this
@@ -150,15 +163,15 @@ pub(crate) fn canonicalize(
 
 	let visit_and_remove_block_entry = |
 		block_hash: Hash,
-		deleted_block_keys: &mut Vec<_>,
+		transaction: &mut DBTransaction,
 		visited_candidates: &mut HashMap<CandidateHash, CandidateEntry>,
-	| -> sp_blockchain::Result<Vec<Hash>> {
+	| -> Result<Vec<Hash>> {
 		let block_entry = match load_block_entry(store, &block_hash)? {
 			None => return Ok(Vec::new()),
 			Some(b) => b,
 		};
 
-		deleted_block_keys.push(block_entry_key(&block_hash));
+		transaction.delete(DATA_COL, &block_entry_key(&block_hash)[..]);
 		for &(_, ref candidate_hash) in &block_entry.candidates {
 			let candidate = match visited_candidates.entry(*candidate_hash) {
 				Entry::Occupied(e) => e.into_mut(),
@@ -179,12 +192,12 @@ pub(crate) fn canonicalize(
 	// First visit everything before the height.
 	for i in range.0..canon_number {
 		let at_height = load_blocks_at_height(store, i)?;
-		deleted_height_keys.push(blocks_at_height_key(i));
+		transaction.delete(DATA_COL, &blocks_at_height_key(i)[..]);
 
 		for b in at_height {
 			let _ = visit_and_remove_block_entry(
 				b,
-				&mut deleted_block_keys,
+				&mut transaction,
 				&mut visited_candidates,
 			)?;
 		}
@@ -193,7 +206,7 @@ pub(crate) fn canonicalize(
 	// Then visit everything at the height.
 	let pruned_branches = {
 		let at_height = load_blocks_at_height(store, canon_number)?;
-		deleted_height_keys.push(blocks_at_height_key(canon_number));
+		transaction.delete(DATA_COL, &blocks_at_height_key(canon_number));
 
 		// Note that while there may be branches descending from blocks at earlier heights,
 		// we have already covered them by removing everything at earlier heights.
@@ -202,7 +215,7 @@ pub(crate) fn canonicalize(
 		for b in at_height {
 			let children = visit_and_remove_block_entry(
 				b,
-				&mut deleted_block_keys,
+				&mut transaction,
 				&mut visited_candidates,
 			)?;
 
@@ -220,7 +233,7 @@ pub(crate) fn canonicalize(
 		while let Some((height, next_child)) = frontier.pop() {
 			let children = visit_and_remove_block_entry(
 				next_child,
-				&mut deleted_block_keys,
+				&mut transaction,
 				&mut visited_candidates,
 			)?;
 
@@ -240,32 +253,26 @@ pub(crate) fn canonicalize(
 	}
 
 	// Update all `CandidateEntry`s, deleting all those which now have empty `block_assignments`.
-	let (written_candidates, deleted_candidates) = {
-		let mut written = Vec::new();
-		let mut deleted = Vec::new();
-
-		for (candidate_hash, candidate) in visited_candidates {
-			if candidate.block_assignments.is_empty() {
-				deleted.push(candidate_entry_key(&candidate_hash));
-			} else {
-				written.push((candidate_entry_key(&candidate_hash), candidate.encode()));
-			}
+	for (candidate_hash, candidate) in visited_candidates {
+		if candidate.block_assignments.is_empty() {
+			transaction.delete(DATA_COL, &candidate_entry_key(&candidate_hash)[..]);
+		} else {
+			transaction.put_vec(
+				DATA_COL,
+				&candidate_entry_key(&candidate_hash)[..],
+				candidate.encode(),
+			);
 		}
-
-		(written, deleted)
-	};
+	}
 
 	// Update all blocks-at-height keys, deleting all those which now have empty `block_assignments`.
-	let written_at_height = {
-		visited_heights.into_iter().filter_map(|(h, at)| {
-			if at.is_empty() {
-				deleted_height_keys.push(blocks_at_height_key(h));
-				None
-			} else {
-				Some((blocks_at_height_key(h), at.encode()))
-			}
-		}).collect::<Vec<_>>()
-	};
+	for (h, at) in visited_heights {
+		if at.is_empty() {
+			transaction.delete(DATA_COL, &blocks_at_height_key(h)[..]);
+		} else {
+			transaction.put_vec(DATA_COL, &blocks_at_height_key(h), at.encode());
+		}
+	}
 
 	// due to the fork pruning, this range actually might go too far above where our actual highest block is,
 	// if a relatively short fork is canonicalized.
@@ -274,81 +281,20 @@ pub(crate) fn canonicalize(
 		std::cmp::max(range.1, canon_number + 2),
 	).encode();
 
-	// Because aux-store requires &&[u8], we have to collect.
-
-	let inserted_keys: Vec<_> = std::iter::once((&STORED_BLOCKS_KEY[..], &new_range[..]))
-		.chain(written_candidates.iter().map(|&(ref k, ref v)| (&k[..], &v[..])))
-		.chain(written_at_height.iter().map(|&(ref k, ref v)| (&k[..], &v[..])))
-		.collect();
-
-	let deleted_keys: Vec<_> = deleted_block_keys.iter().map(|k| &k[..])
-		.chain(deleted_height_keys.iter().map(|k| &k[..]))
-		.chain(deleted_candidates.iter().map(|k| &k[..]))
-		.collect();
+	transaction.put_vec(DATA_COL, &STORED_BLOCKS_KEY[..], new_range);
 
 	// Update the values on-disk.
-	store.insert_aux(
-		inserted_keys.iter(),
-		deleted_keys.iter(),
-	)?;
-
-	Ok(())
+	store.write(transaction).map_err(Into::into)
 }
 
-/// Clear the aux store of everything.
-pub(crate) fn clear(store: &impl AuxStore)
-	-> sp_blockchain::Result<()>
+fn load_decode<D: Decode>(store: &dyn KeyValueDB, key: &[u8])
+	-> Result<Option<D>>
 {
-	let range = match load_stored_blocks(store)? {
-		None => return Ok(()),
-		Some(range) => range,
-	};
-
-	let mut visited_height_keys = Vec::new();
-	let mut visited_block_keys = Vec::new();
-	let mut visited_candidate_keys = Vec::new();
-
-	for i in range.0..range.1 {
-		let at_height = load_blocks_at_height(store, i)?;
-
-		visited_height_keys.push(blocks_at_height_key(i));
-
-		for block_hash in at_height {
-			let block_entry = match load_block_entry(store, &block_hash)? {
-				None => continue,
-				Some(e) => e,
-			};
-
-			visited_block_keys.push(block_entry_key(&block_hash));
-
-			for &(_, candidate_hash) in &block_entry.candidates {
-				visited_candidate_keys.push(candidate_entry_key(&candidate_hash));
-			}
-		}
-	}
-
-	// unfortunately demands a `collect` because aux store wants `&&[u8]` for some reason.
-	let visited_keys_borrowed = visited_height_keys.iter().map(|x| &x[..])
-		.chain(visited_block_keys.iter().map(|x| &x[..]))
-		.chain(visited_candidate_keys.iter().map(|x| &x[..]))
-		.chain(std::iter::once(&STORED_BLOCKS_KEY[..]))
-		.collect::<Vec<_>>();
-
-	store.insert_aux(&[], &visited_keys_borrowed)?;
-
-	Ok(())
-}
-
-fn load_decode<D: Decode>(store: &impl AuxStore, key: &[u8])
-	-> sp_blockchain::Result<Option<D>>
-{
-	match store.get_aux(key)? {
+	match store.get(DATA_COL, key)? {
 		None => Ok(None),
 		Some(raw) => D::decode(&mut &raw[..])
 			.map(Some)
-			.map_err(|e| sp_blockchain::Error::Storage(
-				format!("Failed to decode item in approvals DB: {:?}", e)
-			)),
+			.map_err(Into::into),
 	}
 }
 
@@ -372,16 +318,18 @@ pub(crate) struct NewCandidateInfo {
 /// `None` for any of the candidates referenced by the block entry. In these cases,
 /// no information about new candidates will be referred to by this function.
 pub(crate) fn add_block_entry(
-	store: &impl AuxStore,
+	store: &dyn KeyValueDB,
 	parent_hash: Hash,
 	number: BlockNumber,
 	entry: BlockEntry,
 	n_validators: usize,
 	candidate_info: impl Fn(&CandidateHash) -> Option<NewCandidateInfo>,
-) -> sp_blockchain::Result<Vec<(CandidateHash, CandidateEntry)>> {
+) -> Result<Vec<(CandidateHash, CandidateEntry)>> {
+	let mut transaction = DBTransaction::new();
 	let session = entry.session;
 
-	let new_block_range = {
+	// Update the stored block range.
+	{
 		let new_range = match load_stored_blocks(store)? {
 			None => Some(StoredBlockRange(number, number + 1)),
 			Some(range) => if range.1 <= number {
@@ -391,10 +339,11 @@ pub(crate) fn add_block_entry(
 			}
 		};
 
-		new_range.map(|n| (STORED_BLOCKS_KEY, n.encode()))
+		new_range.map(|n| transaction.put_vec(DATA_COL, &STORED_BLOCKS_KEY[..], n.encode()))
 	};
 
-	let updated_blocks_at = {
+	// Update the blocks at height meta key.
+	{
 		let mut blocks_at_height = load_blocks_at_height(store, number)?;
 		if blocks_at_height.contains(&entry.block_hash) {
 			// seems we already have a block entry for this block. nothing to do here.
@@ -402,13 +351,13 @@ pub(crate) fn add_block_entry(
 		}
 
 		blocks_at_height.push(entry.block_hash);
-		(blocks_at_height_key(number), blocks_at_height.encode())
+		transaction.put_vec(DATA_COL, &blocks_at_height_key(number)[..], blocks_at_height.encode())
 	};
 
 	let mut candidate_entries = Vec::with_capacity(entry.candidates.len());
 
-	let candidate_entry_updates = {
-		let mut updated_entries = Vec::with_capacity(entry.candidates.len());
+	// read and write all updated entries.
+	{
 		for &(_, ref candidate_hash) in &entry.candidates {
 			let NewCandidateInfo {
 				candidate,
@@ -438,43 +387,26 @@ pub(crate) fn add_block_entry(
 				}
 			);
 
-			updated_entries.push(
-				(candidate_entry_key(&candidate_hash), candidate_entry.encode())
+			transaction.put_vec(
+				DATA_COL,
+				&candidate_entry_key(&candidate_hash)[..],
+				candidate_entry.encode(),
 			);
 
 			candidate_entries.push((*candidate_hash, candidate_entry));
 		}
-
-		updated_entries
 	};
 
-	let updated_parent = {
-		load_block_entry(store, &parent_hash)?.map(|mut e| {
-			e.children.push(entry.block_hash);
-			(block_entry_key(&parent_hash), e.encode())
-		})
-	};
+	// Update the child index for the parent.
+	load_block_entry(store, &parent_hash)?.map(|mut e| {
+		e.children.push(entry.block_hash);
+		transaction.put_vec(DATA_COL, &block_entry_key(&parent_hash)[..], e.encode())
+	});
 
-	let write_block_entry = (block_entry_key(&entry.block_hash), entry.encode());
+	// Put the new block entry in.
+	transaction.put_vec(DATA_COL, &block_entry_key(&entry.block_hash)[..], entry.encode());
 
-	// write:
-	//   - new block range
-	//   - updated blocks-at item
-	//   - fresh and updated candidate entries
-	//   - the parent block entry.
-	//   - the block entry itself
-
-	// Unfortunately have to collect because aux-store demands &(&[u8], &[u8]).
-	let all_keys_and_values: Vec<_> = new_block_range.as_ref().into_iter()
-		.map(|&(ref k, ref v)| (&k[..], &v[..]))
-		.chain(std::iter::once((&updated_blocks_at.0[..], &updated_blocks_at.1[..])))
-		.chain(candidate_entry_updates.iter().map(|&(ref k, ref v)| (&k[..], &v[..])))
-		.chain(std::iter::once((&write_block_entry.0[..], &write_block_entry.1[..])))
-		.chain(updated_parent.as_ref().into_iter().map(|&(ref k, ref v)| (&k[..], &v[..])))
-		.collect();
-
-	store.insert_aux(&all_keys_and_values, &[])?;
-
+	store.write(transaction)?;
 	Ok(candidate_entries)
 }
 
@@ -501,57 +433,55 @@ impl Transaction {
 	}
 
 	/// Write the contents of the transaction, atomically, to the DB.
-	pub(crate) fn write(self, db: &impl AuxStore) -> sp_blockchain::Result<()> {
+	pub(crate) fn write(self, db: &dyn KeyValueDB) -> Result<()> {
 		if self.block_entries.is_empty() && self.candidate_entries.is_empty() {
 			return Ok(())
 		}
 
-		let blocks: Vec<_> = self.block_entries.into_iter().map(|(hash, entry)| {
+		let mut db_transaction = DBTransaction::new();
+
+		for (hash, entry) in self.block_entries {
 			let k = block_entry_key(&hash);
 			let v = entry.encode();
 
-			(k, v)
-		}).collect();
+			db_transaction.put_vec(DATA_COL, &k, v);
+		}
 
-		let candidates: Vec<_> = self.candidate_entries.into_iter().map(|(hash, entry)| {
+		for (hash, entry) in self.candidate_entries {
 			let k = candidate_entry_key(&hash);
 			let v = entry.encode();
 
-			(k, v)
-		}).collect();
+			db_transaction.put_vec(DATA_COL, &k, v);
+		}
 
-		let kv = blocks.iter().map(|(k, v)| (&k[..], &v[..]))
-			.chain(candidates.iter().map(|(k, v)| (&k[..], &v[..])))
-			.collect::<Vec<_>>();
-
-		db.insert_aux(&kv, &[])
+		db.write(db_transaction).map_err(Into::into)
 	}
 }
 
 /// Load the stored-blocks key from the state.
-fn load_stored_blocks(store: &impl AuxStore)
-	-> sp_blockchain::Result<Option<StoredBlockRange>>
+fn load_stored_blocks(store: &dyn KeyValueDB)
+	-> Result<Option<StoredBlockRange>>
 {
 	load_decode(store, STORED_BLOCKS_KEY)
 }
 
 /// Load a blocks-at-height entry for a given block number.
-pub(crate) fn load_blocks_at_height(store: &impl AuxStore, block_number: BlockNumber)
-	-> sp_blockchain::Result<Vec<Hash>> {
+pub(crate) fn load_blocks_at_height(store: &dyn KeyValueDB, block_number: BlockNumber)
+	-> Result<Vec<Hash>> {
 	load_decode(store, &blocks_at_height_key(block_number))
 		.map(|x| x.unwrap_or_default())
 }
 
 /// Load a block entry from the aux store.
-pub(crate) fn load_block_entry(store: &impl AuxStore, block_hash: &Hash)
-	-> sp_blockchain::Result<Option<BlockEntry>>
+pub(crate) fn load_block_entry(store: &dyn KeyValueDB, block_hash: &Hash)
+	-> Result<Option<BlockEntry>>
 {
 	load_decode(store, &block_entry_key(block_hash))
 }
 
 /// Load a candidate entry from the aux store.
-pub(crate) fn load_candidate_entry(store: &impl AuxStore, candidate_hash: &CandidateHash)
-	-> sp_blockchain::Result<Option<CandidateEntry>>
+pub(crate) fn load_candidate_entry(store: &dyn KeyValueDB, candidate_hash: &CandidateHash)
+	-> Result<Option<CandidateEntry>>
 {
 	load_decode(store, &candidate_entry_key(candidate_hash))
 }

--- a/node/core/approval-voting/src/approval_db/v1/mod.rs
+++ b/node/core/approval-voting/src/approval_db/v1/mod.rs
@@ -114,7 +114,12 @@ pub fn clear_and_recreate(path: &std::path::Path, cache_size: usize)
 	use kvdb_rocksdb::{DatabaseConfig, Database as RocksDB};
 
 	tracing::info!("Recreating approval-checking DB at {:?}", path);
-	std::fs::remove_dir_all(path)?;
+
+	if let Err(e) = std::fs::remove_dir_all(path) {
+		if e.kind() != std::io::ErrorKind::NotFound {
+			return Err(e);
+		}
+	}
 	std::fs::create_dir_all(path)?;
 
 	let mut db_config = DatabaseConfig::with_columns(NUM_COLUMNS);

--- a/node/core/approval-voting/src/approval_db/v1/tests.rs
+++ b/node/core/approval-voting/src/approval_db/v1/tests.rs
@@ -18,64 +18,37 @@
 
 use super::*;
 use polkadot_primitives::v1::Id as ParaId;
-use std::cell::RefCell;
 
-#[derive(Default)]
-pub struct TestStore {
-	inner: RefCell<HashMap<Vec<u8>, Vec<u8>>>,
+pub(crate) fn write_stored_blocks(tx: &mut DBTransaction, range: StoredBlockRange) {
+	tx.put_vec(
+		DATA_COL,
+		&STORED_BLOCKS_KEY[..],
+		range.encode(),
+	);
 }
 
-impl AuxStore for TestStore {
-	fn insert_aux<'a, 'b: 'a, 'c: 'a, I, D>(&self, insertions: I, deletions: D) -> sp_blockchain::Result<()>
-		where I: IntoIterator<Item = &'a (&'c [u8], &'c [u8])>, D: IntoIterator<Item = &'a &'b [u8]>
-	{
-		let mut store = self.inner.borrow_mut();
-
-		// insertions before deletions.
-		for (k, v) in insertions {
-			store.insert(k.to_vec(), v.to_vec());
-		}
-
-		for k in deletions {
-			store.remove(&k[..]);
-		}
-
-		Ok(())
-	}
-
-	fn get_aux(&self, key: &[u8]) -> sp_blockchain::Result<Option<Vec<u8>>> {
-		Ok(self.inner.borrow().get(key).map(|v| v.clone()))
-	}
+pub(crate) fn write_blocks_at_height(tx: &mut DBTransaction, height: BlockNumber, blocks: &[Hash]) {
+	tx.put_vec(
+		DATA_COL,
+		&blocks_at_height_key(height)[..],
+		blocks.encode(),
+	);
 }
 
-impl TestStore {
-	pub(crate) fn write_stored_blocks(&self, range: StoredBlockRange) {
-		self.inner.borrow_mut().insert(
-			STORED_BLOCKS_KEY.to_vec(),
-			range.encode(),
-		);
-	}
+pub(crate) fn write_block_entry(tx: &mut DBTransaction, block_hash: &Hash, entry: &BlockEntry) {
+	tx.put_vec(
+		DATA_COL,
+		&block_entry_key(block_hash)[..],
+		entry.encode(),
+	);
+}
 
-	pub(crate) fn write_blocks_at_height(&self, height: BlockNumber, blocks: &[Hash]) {
-		self.inner.borrow_mut().insert(
-			blocks_at_height_key(height).to_vec(),
-			blocks.encode(),
-		);
-	}
-
-	pub(crate) fn write_block_entry(&self, block_hash: &Hash, entry: &BlockEntry) {
-		self.inner.borrow_mut().insert(
-			block_entry_key(block_hash).to_vec(),
-			entry.encode(),
-		);
-	}
-
-	pub(crate) fn write_candidate_entry(&self, candidate_hash: &CandidateHash, entry: &CandidateEntry) {
-		self.inner.borrow_mut().insert(
-			candidate_entry_key(candidate_hash).to_vec(),
-			entry.encode(),
-		);
-	}
+pub(crate) fn write_candidate_entry(tx: &mut DBTransaction, candidate_hash: &CandidateHash, entry: &CandidateEntry) {
+	tx.put_vec(
+		DATA_COL,
+		&candidate_entry_key(candidate_hash)[..],
+		entry.encode(),
+	);
 }
 
 fn make_bitvec(len: usize) -> BitVec<BitOrderLsb0, u8> {
@@ -108,7 +81,7 @@ fn make_candidate(para_id: ParaId, relay_parent: Hash) -> CandidateReceipt {
 
 #[test]
 fn read_write() {
-	let store = TestStore::default();
+	let store = kvdb_memorydb::create(1);
 
 	let hash_a = Hash::repeat_byte(1);
 	let hash_b = Hash::repeat_byte(2);
@@ -137,10 +110,14 @@ fn read_write() {
 		approvals: Default::default(),
 	};
 
-	store.write_stored_blocks(range.clone());
-	store.write_blocks_at_height(1, &at_height);
-	store.write_block_entry(&hash_a, &block_entry);
-	store.write_candidate_entry(&candidate_hash, &candidate_entry);
+	let mut tx = DBTransaction::new();
+
+	write_stored_blocks(&mut tx, range.clone());
+	write_blocks_at_height(&mut tx, 1, &at_height);
+	write_block_entry(&mut tx, &hash_a, &block_entry);
+	write_candidate_entry(&mut tx, &candidate_hash, &candidate_entry);
+
+	store.write(tx).unwrap();
 
 	assert_eq!(load_stored_blocks(&store).unwrap(), Some(range));
 	assert_eq!(load_blocks_at_height(&store, 1).unwrap(), at_height);
@@ -154,8 +131,12 @@ fn read_write() {
 		candidate_entry_key(&candidate_hash).to_vec(),
 	];
 
-	let delete_keys: Vec<_> = delete_keys.iter().map(|k| &k[..]).collect();
-	store.insert_aux(&[], &delete_keys).unwrap();
+	let mut tx = DBTransaction::new();
+	for key in delete_keys {
+		tx.delete(DATA_COL, &key[..]);
+	}
+
+	store.write(tx).unwrap();
 
 	assert!(load_stored_blocks(&store).unwrap().is_none());
 	assert!(load_blocks_at_height(&store, 1).unwrap().is_empty());
@@ -165,7 +146,7 @@ fn read_write() {
 
 #[test]
 fn add_block_entry_works() {
-	let store = TestStore::default();
+	let store = kvdb_memorydb::create(1);
 
 	let parent_hash = Hash::repeat_byte(1);
 	let block_hash_a = Hash::repeat_byte(2);
@@ -230,7 +211,7 @@ fn add_block_entry_works() {
 
 #[test]
 fn add_block_entry_adds_child() {
-	let store = TestStore::default();
+	let store = kvdb_memorydb::create(1);
 
 	let parent_hash = Hash::repeat_byte(1);
 	let block_hash_a = Hash::repeat_byte(2);
@@ -274,7 +255,7 @@ fn add_block_entry_adds_child() {
 
 #[test]
 fn canonicalize_works() {
-	let store = TestStore::default();
+	let store = kvdb_memorydb::create(1);
 
 	//   -> B1 -> C1 -> D1
 	// A -> B2 -> C2 -> D2
@@ -291,7 +272,9 @@ fn canonicalize_works() {
 
 	let n_validators = 10;
 
-	store.write_stored_blocks(StoredBlockRange(1, 5));
+	let mut tx = DBTransaction::new();
+	write_stored_blocks(&mut tx, StoredBlockRange(1, 5));
+	store.write(tx).unwrap();
 
 	let genesis = Hash::repeat_byte(0);
 

--- a/node/core/approval-voting/src/approval_db/v1/tests.rs
+++ b/node/core/approval-voting/src/approval_db/v1/tests.rs
@@ -273,56 +273,6 @@ fn add_block_entry_adds_child() {
 }
 
 #[test]
-fn clear_works() {
-	let store = TestStore::default();
-
-	let hash_a = Hash::repeat_byte(1);
-	let hash_b = Hash::repeat_byte(2);
-	let candidate_hash = CandidateHash(Hash::repeat_byte(3));
-
-	let range = StoredBlockRange(0, 5);
-	let at_height = vec![hash_a, hash_b];
-
-	let block_entry = make_block_entry(
-		hash_a,
-		vec![(CoreIndex(0), candidate_hash)],
-	);
-
-	let candidate_entry = CandidateEntry {
-		candidate: Default::default(),
-		session: 5,
-		block_assignments: vec![
-			(hash_a, ApprovalEntry {
-				tranches: Vec::new(),
-				backing_group: GroupIndex(1),
-				our_assignment: None,
-				assignments: Default::default(),
-				approved: false,
-			})
-		].into_iter().collect(),
-		approvals: Default::default(),
-	};
-
-	store.write_stored_blocks(range.clone());
-	store.write_blocks_at_height(1, &at_height);
-	store.write_block_entry(&hash_a, &block_entry);
-	store.write_candidate_entry(&candidate_hash, &candidate_entry);
-
-	assert_eq!(load_stored_blocks(&store).unwrap(), Some(range));
-	assert_eq!(load_blocks_at_height(&store, 1).unwrap(), at_height);
-	assert_eq!(load_block_entry(&store, &hash_a).unwrap(), Some(block_entry));
-	assert_eq!(load_candidate_entry(&store, &candidate_hash).unwrap(), Some(candidate_entry));
-
-	clear(&store).unwrap();
-
-	assert!(load_stored_blocks(&store).unwrap().is_none());
-	assert!(load_blocks_at_height(&store, 1).unwrap().is_empty());
-	assert!(load_block_entry(&store, &hash_a).unwrap().is_none());
-	assert!(load_candidate_entry(&store, &candidate_hash).unwrap().is_none());
-}
-
-
-#[test]
 fn canonicalize_works() {
 	let store = TestStore::default();
 

--- a/node/core/approval-voting/src/import.rs
+++ b/node/core/approval-voting/src/import.rs
@@ -42,8 +42,8 @@ use polkadot_node_primitives::approval::{
 	self as approval_types, BlockApprovalMeta, RelayVRFStory,
 };
 use sc_keystore::LocalKeystore;
-use sc_client_api::backend::AuxStore;
 use sp_consensus_slots::Slot;
+use kvdb::KeyValueDB;
 
 use futures::prelude::*;
 use futures::channel::oneshot;
@@ -317,7 +317,7 @@ async fn cache_session_info_for_head(
 					session_window.session_info.drain(..outdated);
 					session_window.session_info.extend(s);
 					// we need to account for this case:
-					// window_start ................................... session_index 
+					// window_start ................................... session_index
 					//              old_window_start ........... latest
 					let new_earliest = std::cmp::max(window_start, old_window_start);
 					session_window.earliest_session = Some(new_earliest);
@@ -516,7 +516,7 @@ pub struct BlockImportedCandidates {
 pub(crate) async fn handle_new_head(
 	ctx: &mut impl SubsystemContext,
 	state: &mut State<impl DBReader>,
-	db_writer: &impl AuxStore,
+	db_writer: &dyn KeyValueDB,
 	head: Hash,
 	finalized_number: &Option<BlockNumber>,
 ) -> SubsystemResult<Vec<BlockImportedCandidates>> {
@@ -1543,7 +1543,7 @@ mod tests {
 		let session = 5;
 		let irrelevant = 666;
 		let session_info = SessionInfo {
-			validators: vec![Sr25519Keyring::Alice.public().into(); 6], 
+			validators: vec![Sr25519Keyring::Alice.public().into(); 6],
 			discovery_keys: Vec::new(),
 			assignment_keys: Vec::new(),
 			validator_groups: vec![vec![0; 5], vec![0; 2]],

--- a/node/core/approval-voting/src/import.rs
+++ b/node/core/approval-voting/src/import.rs
@@ -1610,7 +1610,7 @@ mod tests {
 			}.into(),
 		);
 
-		let db_writer = crate::approval_db::v1::tests::TestStore::default();
+		let db_writer = kvdb_memorydb::create(1);
 
 		let test_fut = {
 			Box::pin(async move {

--- a/node/core/approval-voting/src/lib.rs
+++ b/node/core/approval-voting/src/lib.rs
@@ -44,9 +44,9 @@ use polkadot_node_primitives::approval::{
 use parity_scale_codec::Encode;
 use sc_keystore::LocalKeystore;
 use sp_consensus_slots::Slot;
-use sc_client_api::backend::AuxStore;
 use sp_runtime::traits::AppVerify;
 use sp_application_crypto::Pair;
+use kvdb::KeyValueDB;
 
 use futures::prelude::*;
 use futures::channel::{mpsc, oneshot};
@@ -75,16 +75,20 @@ const APPROVAL_SESSIONS: SessionIndex = 6;
 const LOG_TARGET: &str = "approval_voting";
 
 /// The approval voting subsystem.
-pub struct ApprovalVotingSubsystem<T> {
+pub struct ApprovalVotingSubsystem {
 	keystore: Arc<LocalKeystore>,
 	slot_duration_millis: u64,
-	db: Arc<T>,
+	db: Arc<dyn KeyValueDB>,
 }
 
-impl<T> ApprovalVotingSubsystem<T> {
+impl ApprovalVotingSubsystem {
 	/// Create a new approval voting subsystem with the given keystore, slot duration,
-	/// and underlying DB.
-	pub fn new(keystore: Arc<LocalKeystore>, slot_duration_millis: u64, db: Arc<T>) -> Self {
+	/// and underlying DB. The DB should be fresh, with nothing in it.
+	pub fn new(
+		keystore: Arc<LocalKeystore>,
+		slot_duration_millis: u64,
+		db: Arc<dyn KeyValueDB>,
+	) -> Self {
 		ApprovalVotingSubsystem {
 			keystore,
 			slot_duration_millis,
@@ -93,10 +97,11 @@ impl<T> ApprovalVotingSubsystem<T> {
 	}
 }
 
-impl<T, C> Subsystem<C> for ApprovalVotingSubsystem<T>
-	where T: AuxStore + Send + Sync + 'static, C: SubsystemContext<Message = ApprovalVotingMessage> {
+impl<C> Subsystem<C> for ApprovalVotingSubsystem
+	where C: SubsystemContext<Message = ApprovalVotingMessage>
+{
 	fn start(self, ctx: C) -> SpawnedSubsystem {
-		let future = run::<T, C>(
+		let future = run::<C>(
 			ctx,
 			self,
 			Box::new(SystemClock),
@@ -204,20 +209,20 @@ trait DBReader {
 // This is a submodule to enforce opacity of the inner DB type.
 mod approval_db_v1_reader {
 	use super::{
-		DBReader, AuxStore, Hash, CandidateHash, BlockEntry, CandidateEntry,
+		DBReader, KeyValueDB, Hash, CandidateHash, BlockEntry, CandidateEntry,
 		Arc, SubsystemResult, SubsystemError, approval_db,
 	};
 
 	/// A DB reader that uses the approval-db V1 under the hood.
-	pub(super) struct ApprovalDBV1Reader<T>(Arc<T>);
+	pub(super) struct ApprovalDBV1Reader<T: ?Sized>(Arc<T>);
 
-	impl<T> From<Arc<T>> for ApprovalDBV1Reader<T> {
+	impl<T: ?Sized> From<Arc<T>> for ApprovalDBV1Reader<T> {
 		fn from(a: Arc<T>) -> Self {
 			ApprovalDBV1Reader(a)
 		}
 	}
 
-	impl<T: AuxStore> DBReader for ApprovalDBV1Reader<T> {
+	impl DBReader for ApprovalDBV1Reader<dyn KeyValueDB> {
 		fn load_block_entry(
 			&self,
 			block_hash: &Hash,
@@ -273,13 +278,13 @@ enum Action {
 	Conclude,
 }
 
-async fn run<T, C>(
+async fn run<C>(
 	mut ctx: C,
-	subsystem: ApprovalVotingSubsystem<T>,
+	subsystem: ApprovalVotingSubsystem,
 	clock: Box<dyn Clock + Send + Sync>,
 	assignment_criteria: Box<dyn AssignmentCriteria + Send + Sync>,
 ) -> SubsystemResult<()>
-	where T: AuxStore + Send + Sync + 'static, C: SubsystemContext<Message = ApprovalVotingMessage>
+	where C: SubsystemContext<Message = ApprovalVotingMessage>
 {
 	let (background_tx, background_rx) = mpsc::channel::<BackgroundRequest>(64);
 	let mut state = State {
@@ -297,11 +302,6 @@ async fn run<T, C>(
 	let mut background_rx = background_rx.fuse();
 
 	let db_writer = &*subsystem.db;
-
-	if let Err(e) = approval_db::v1::clear(db_writer) {
-		tracing::warn!(target: LOG_TARGET, "Failed to clear DB: {:?}", e);
-		return Err(SubsystemError::with_origin("db", e));
-	}
 
 	loop {
 		let wait_til_next_tick = match wakeups.first() {
@@ -367,7 +367,7 @@ async fn run<T, C>(
 async fn handle_actions(
 	ctx: &mut impl SubsystemContext,
 	wakeups: &mut Wakeups,
-	db: &impl AuxStore,
+	db: &dyn KeyValueDB,
 	background_tx: &mpsc::Sender<BackgroundRequest>,
 	actions: impl IntoIterator<Item = Action>,
 ) -> SubsystemResult<bool> {
@@ -427,7 +427,7 @@ async fn handle_actions(
 async fn handle_from_overseer(
 	ctx: &mut impl SubsystemContext,
 	state: &mut State<impl DBReader>,
-	db_writer: &impl AuxStore,
+	db_writer: &dyn KeyValueDB,
 	x: FromOverseer<ApprovalVotingMessage>,
 	last_finalized_height: &mut Option<BlockNumber>,
 ) -> SubsystemResult<Vec<Action>> {

--- a/node/service/Cargo.toml
+++ b/node/service/Cargo.toml
@@ -107,6 +107,7 @@ default = ["db", "full-node"]
 db = ["service/db"]
 full-node = [
 	"polkadot-node-core-av-store",
+	"polkadot-node-core-approval-voting",
 	"sc-finality-grandpa-warp-sync"
 ]
 
@@ -134,5 +135,4 @@ real-overseer = [
 	"polkadot-pov-distribution",
 	"polkadot-statement-distribution",
 	"polkadot-approval-distribution",
-	"polkadot-node-core-approval-voting",
 ]

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -422,7 +422,7 @@ where
 	use polkadot_node_core_approval_voting::ApprovalVotingSubsystem;
 
 	#[cfg(not(feature = "approval-checking"))]
-	let _ = slot_duration; // silence.
+	let _ = approval_voting_config; // silence.
 
 	let all_subsystems = AllSubsystems {
 		availability_distribution: AvailabilityDistributionSubsystem::new(


### PR DESCRIPTION
This gets cleared on every run of the program.

I do this for 3 reasons:
1. `AuxStore` is a terrible interface
2. We can remove the `clear()` function and replace it with a filesystem delete. This makes it easier to upgrade the schema as the `clear` function was schema dependent. Now we can just change the workings however we like.
3. We found that import & propagation times for blocks grew substantially when approval checking was enabled. I suspect this is due to `AuxStore` interfering with the critical path of Substrate's block import. Moving to a separate DB should unblock that, I hope.

After #2470 , and then I'll merge this on top of that.