### PR TITLE
Change a few fee/weight parameters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5713,6 +5713,7 @@ dependencies = [
  "polkadot-primitives",
  "polkadot-runtime-common",
  "rustc-hex",
+ "separator",
  "serde",
  "serde_derive",
  "serde_json",

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -54,9 +54,9 @@ pub type NegativeImbalance<T> = <pallet_balances::Module<T> as Currency<<T as fr
 /// valid wasm module.
 pub const WASM_MAGIC: &[u8] = &[0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00];
 
-/// We assume that an on-initialize consumes 2.5% of the weight on average, hence a single extrinsic
-/// will not be allowed to consume more than `AvailableBlockRatio - 2.5%`.
-pub const AVERAGE_ON_INITIALIZE_RATIO: Perbill = Perbill::from_perthousand(25);
+/// We assume that an on-initialize consumes 1% of the weight on average, hence a single extrinsic
+/// will not be allowed to consume more than `AvailableBlockRatio - 1%`.
+pub const AVERAGE_ON_INITIALIZE_RATIO: Perbill = Perbill::from_percent(1);
 /// We allow `Normal` extrinsics to fill up the block up to 75%, the rest can be used
 /// by  Operational  extrinsics.
 const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
@@ -77,7 +77,7 @@ parameter_types! {
 	/// Minimum amount of the multiplier. This value cannot be too low. A test case should ensure
 	/// that combined with `AdjustmentVariable`, we can recover from the minimum.
 	/// See `multiplier_can_grow_from_zero`.
-	pub MinimumMultiplier: Multiplier = Multiplier::saturating_from_rational(1, 1_000_000_000u128);
+	pub MinimumMultiplier: Multiplier = Multiplier::saturating_from_rational(1, 1_000u128);
 	/// Maximum length of block. Up to 5MB.
 	pub BlockLength: limits::BlockLength =
 		limits::BlockLength::max_with_normal_ratio(5 * 1024 * 1024, NORMAL_DISPATCH_RATIO);
@@ -243,7 +243,7 @@ mod multiplier_tests {
 		type SS58Prefix = ();
 	}
 
-	fn run_with_system_weight<F>(w: Weight, assertions: F) where F: Fn() -> () {
+	fn run_with_system_weight<F>(w: Weight, mut assertions: F) where F: FnMut() -> () {
 		let mut t: sp_io::TestExternalities =
 			frame_system::GenesisConfig::default().build_storage::<Runtime>().unwrap().into();
 		t.execute_with(|| {
@@ -258,10 +258,32 @@ mod multiplier_tests {
 		let target = TargetBlockFullness::get() *
 			BlockWeights::get().get(DispatchClass::Normal).max_total.unwrap();
 		// if the min is too small, then this will not change, and we are doomed forever.
-		// the weight is 1/10th bigger than target.
+		// the weight is 1/100th bigger than target.
 		run_with_system_weight(target * 101 / 100, || {
 			let next = SlowAdjustingFeeUpdate::<Runtime>::convert(minimum_multiplier);
 			assert!(next > minimum_multiplier, "{:?} !>= {:?}", next, minimum_multiplier);
 		})
+	}
+
+	#[test]
+	#[ignore]
+	fn multiplier_growth_simulator() {
+		// assume the multiplier is initially set to its minimum. We update it with values twice the
+		//target (target is 25%, thus 50%) and we see at which point it reaches 1.
+		let mut multiplier = MinimumMultiplier::get();
+		let block_weight = TargetBlockFullness::get()
+			* BlockWeights::get().get(DispatchClass::Normal).max_total.unwrap()
+			* 2;
+		let mut blocks = 0;
+		while multiplier <= Multiplier::one() {
+			run_with_system_weight(block_weight, || {
+				let next = SlowAdjustingFeeUpdate::<Runtime>::convert(multiplier);
+				// ensure that it is growing as well.
+				assert!(next > multiplier, "{:?} !>= {:?}", next, multiplier);
+				multiplier = next;
+			});
+			blocks += 1;
+			println!("block = {} multiplier {:?}", blocks, multiplier);
+		}
 	}
 }

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -77,7 +77,7 @@ parameter_types! {
 	/// Minimum amount of the multiplier. This value cannot be too low. A test case should ensure
 	/// that combined with `AdjustmentVariable`, we can recover from the minimum.
 	/// See `multiplier_can_grow_from_zero`.
-	pub MinimumMultiplier: Multiplier = Multiplier::saturating_from_rational(1, 1_000u128);
+	pub MinimumMultiplier: Multiplier = Multiplier::saturating_from_rational(1, 1_000_000u128);
 	/// Maximum length of block. Up to 5MB.
 	pub BlockLength: limits::BlockLength =
 		limits::BlockLength::max_with_normal_ratio(5 * 1024 * 1024, NORMAL_DISPATCH_RATIO);

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -1420,39 +1420,23 @@ mod test_fees {
 		let len = call.using_encoded(|e| e.len()) as u32;
 
 		let mut ext = sp_io::TestExternalities::new_empty();
-		ext.execute_with(|| {
-			pallet_transaction_payment::NextFeeMultiplier::put(min_multiplier);
-			let fee = TransactionPayment::compute_fee(len, &info, 0);
-			println!(
-				"weight = {:?} // multiplier = {:?} // full transfer fee = {:?}",
-				info.weight.separated_string(),
-				pallet_transaction_payment::NextFeeMultiplier::get(),
-				fee.separated_string(),
-			);
-		});
+		let mut test_with_multiplier = |m| {
+			ext.execute_with(|| {
+				pallet_transaction_payment::NextFeeMultiplier::put(m);
+				let fee = TransactionPayment::compute_fee(len, &info, 0);
+				println!(
+					"weight = {:?} // multiplier = {:?} // full transfer fee = {:?}",
+					info.weight.separated_string(),
+					pallet_transaction_payment::NextFeeMultiplier::get(),
+					fee.separated_string(),
+				);
+			});
+		};
 
-		ext.execute_with(|| {
-			let mul = Multiplier::saturating_from_rational(1, 1000_000_000u128);
-			pallet_transaction_payment::NextFeeMultiplier::put(mul);
-			let fee = TransactionPayment::compute_fee(len, &info, 0);
-			println!(
-				"weight = {:?} // multiplier = {:?} // full transfer fee = {:?}",
-				info.weight.separated_string(),
-				pallet_transaction_payment::NextFeeMultiplier::get(),
-				fee.separated_string(),
-			);
-		});
-
-		ext.execute_with(|| {
-			let mul = Multiplier::saturating_from_rational(1, 1u128);
-			pallet_transaction_payment::NextFeeMultiplier::put(mul);
-			let fee = TransactionPayment::compute_fee(len, &info, 0);
-			println!(
-				"weight = {:?} // multiplier = {:?} // full transfer fee = {:?}",
-				info.weight.separated_string(),
-				pallet_transaction_payment::NextFeeMultiplier::get(),
-				fee.separated_string(),
-			);
-		});
+		test_with_multiplier(min_multiplier);
+		test_with_multiplier(Multiplier::saturating_from_rational(1, 1u128));
+		test_with_multiplier(Multiplier::saturating_from_rational(1, 1_000u128));
+		test_with_multiplier(Multiplier::saturating_from_rational(1, 1_000_000u128));
+		test_with_multiplier(Multiplier::saturating_from_rational(1, 1_000_000_000u128));
 	}
 }

--- a/runtime/polkadot/Cargo.toml
+++ b/runtime/polkadot/Cargo.toml
@@ -81,6 +81,7 @@ keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substra
 sp-trie = { git = "https://github.com/paritytech/substrate", branch = "master" }
 trie-db = "0.22.3"
 serde_json = "1.0.61"
+separator = "0.4.1"
 
 [build-dependencies]
 substrate-wasm-builder = "3.0.0"

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -1378,3 +1378,60 @@ sp_api::impl_runtime_apis! {
 		}
 	}
 }
+
+#[cfg(test)]
+mod test_fees {
+	use super::*;
+	use frame_support::weights::WeightToFeePolynomial;
+	use frame_support::storage::StorageValue;
+	use sp_runtime::FixedPointNumber;
+	use frame_support::weights::GetDispatchInfo;
+	use parity_scale_codec::Encode;
+	use pallet_transaction_payment::Multiplier;
+	use separator::Separatable;
+
+
+	#[test]
+	#[ignore]
+	fn block_cost() {
+		let max_block_weight = BlockWeights::get().max_block;
+		let raw_fee = WeightToFee::calc(&max_block_weight);
+
+		println!(
+			"Full Block weight == {} // WeightToFee(full_block) == {} plank",
+			max_block_weight,
+			raw_fee.separated_string(),
+		);
+	}
+
+	#[test]
+	#[ignore]
+	fn transfer_cost_min_multiplier() {
+		let min_multiplier = runtime_common::MinimumMultiplier::get();
+		let call = <pallet_balances::Call<Runtime>>::transfer_keep_alive(Default::default(), Default::default());
+		let info = call.get_dispatch_info();
+		// convert to outer call.
+		let call = Call::Balances(call);
+		let len = call.using_encoded(|e| e.len()) as u32;
+
+		let mut ext = sp_io::TestExternalities::new_empty();
+		let mut test_with_multiplier = |m| {
+			ext.execute_with(|| {
+				pallet_transaction_payment::NextFeeMultiplier::put(m);
+				let fee = TransactionPayment::compute_fee(len, &info, 0);
+				println!(
+					"weight = {:?} // multiplier = {:?} // full transfer fee = {:?}",
+					info.weight.separated_string(),
+					pallet_transaction_payment::NextFeeMultiplier::get(),
+					fee.separated_string(),
+				);
+			});
+		};
+
+		test_with_multiplier(min_multiplier);
+		test_with_multiplier(Multiplier::saturating_from_rational(1, 1u128));
+		test_with_multiplier(Multiplier::saturating_from_rational(1, 1_000u128));
+		test_with_multiplier(Multiplier::saturating_from_rational(1, 1_000_000u128));
+		test_with_multiplier(Multiplier::saturating_from_rational(1, 1_000_000_000u128));
+	}
+}


### PR DESCRIPTION
Closes https://github.com/paritytech/polkadot/issues/2464

### Fee 

You can run the `test_fees` to get a sense of why this change is not a big deal as long as the chain is not congested. Nonetheless, this will make the chain react faster to an increase of weight, if it happens. To that end, I am also considering proposing increasing the `variability_factor` of `TargetedFeeAdjustment`. But I thik for that I should first propose it to the council for review. 

These logs are for the weight-fee of one `transfer_keep_alive` call:

```
// Polkadot 
weight = "189,060,000" // multiplier = FixedU128(0.001000000000000000) // full transfer fee = "46,015,124"
weight = "189,060,000" // multiplier = FixedU128(1.000000000000000000) // full transfer fee = "61,124,800"
weight = "189,060,000" // multiplier = FixedU128(0.001000000000000000) // full transfer fee = "46,015,124"
weight = "189,060,000" // multiplier = FixedU128(0.000001000000000000) // full transfer fee = "46,000,015"
weight = "189,060,000" // multiplier = FixedU128(0.000000001000000000) // full transfer fee = "46,000,000"

// Kusama
weight = "188,971,000" // multiplier = FixedU128(0.001000000000000000) // full transfer fee = "766,918,387"
weight = "188,971,000" // multiplier = FixedU128(1.000000000000000000) // full transfer fee = "1,018,627,759"
weight = "188,971,000" // multiplier = FixedU128(0.001000000000000000) // full transfer fee = "766,918,387"
weight = "188,971,000" // multiplier = FixedU128(0.000001000000000000) // full transfer fee = "766,666,677"
weight = "188,971,000" // multiplier = FixedU128(0.000000001000000000) // full transfer fee = "766,666,426"
```

### Weight

A new analysis of weights show that the average weight weight is still 6B and 8B for polkadot and kusama respectively: 

<img width="930" alt="Screenshot 2021-02-19 at 11 05 33" src="https://user-images.githubusercontent.com/5588131/108497324-30450f00-72a3-11eb-8c11-78a52f22d31e.png">


Which means the average `on_initialize` is 0.4% and 0.3% respectively, so we set it now to 1%. Note that this is again mostly to make the nominator community of polkadot temporarily bigger, while PRs to fix this fundamentally arrive. Afterwards, we can go back to numbers like 5% again. 



