### PR TITLE
Override RuntimeApi::authorities() to include past sessions

### DIFF
--- a/runtime/parachains/src/runtime_api_impl/v1.rs
+++ b/runtime/parachains/src/runtime_api_impl/v1.rs
@@ -234,11 +234,11 @@ pub fn session_index_for_child<T: initializer::Config>() -> SessionIndex {
 
 /// Implementation for the `AuthorityDiscoveryApi::authorities()` function of the runtime API.
 /// It is a heavy call, but currently only used for authority discovery, so it is fine.
-/// Gets current and historical authority ids using session_info module.
-pub fn get_historical_and_current_authority_ids<T: initializer::Config + pallet_authority_discovery::Config>() -> Vec<AuthorityDiscoveryId> {
+/// Gets next, current and some historical authority ids using session_info module.
+pub fn relevant_authority_ids<T: initializer::Config + pallet_authority_discovery::Config>() -> Vec<AuthorityDiscoveryId> {
 	let current_session_index = session_index_for_child::<T>();
 	let earliest_stored_session = <session_info::Module<T>>::earliest_stored_session();
-	let mut authority_ids = vec![];
+	let mut authority_ids = <pallet_authority_discovery::Module<T>>::next_authorities();
 
 	for session_index in earliest_stored_session..=current_session_index {
 		let info = <session_info::Module<T>>::session_info(session_index);
@@ -246,9 +246,6 @@ pub fn get_historical_and_current_authority_ids<T: initializer::Config + pallet_
 			authority_ids.append(&mut info.discovery_keys);
 		}
 	}
-
-	let mut next_authorities = <pallet_authority_discovery::Module<T>>::next_authorities();
-	authority_ids.append(&mut next_authorities);
 
 	authority_ids.sort();
 	authority_ids.dedup();

--- a/runtime/parachains/src/runtime_api_impl/v1.rs
+++ b/runtime/parachains/src/runtime_api_impl/v1.rs
@@ -235,17 +235,23 @@ pub fn session_index_for_child<T: initializer::Config>() -> SessionIndex {
 /// Implementation for the `AuthorityDiscoveryApi::authorities()` function of the runtime API.
 /// It is a heavy call, but currently only used for authority discovery, so it is fine.
 /// Gets current and historical authority ids using session_info module.
-pub fn get_historical_authority_ids<T: initializer::Config>() -> Vec<AuthorityDiscoveryId> {
+pub fn get_historical_and_current_authority_ids<T: initializer::Config + pallet_authority_discovery::Config>() -> Vec<AuthorityDiscoveryId> {
 	let current_session_index = session_index_for_child::<T>();
 	let earliest_stored_session = <session_info::Module<T>>::earliest_stored_session();
 	let mut authority_ids = vec![];
 
-	for session_index in earliest_stored_session..current_session_index {
+	for session_index in earliest_stored_session..=current_session_index {
 		let info = <session_info::Module<T>>::session_info(session_index);
 		if let Some(mut info) = info {
 			authority_ids.append(&mut info.discovery_keys);
 		}
 	}
+
+	let mut next_authorities = <pallet_authority_discovery::Module<T>>::next_authorities();
+	authority_ids.append(&mut next_authorities);
+
+	authority_ids.sort();
+	authority_ids.dedup();
 
 	authority_ids
 }

--- a/runtime/parachains/src/runtime_api_impl/v1.rs
+++ b/runtime/parachains/src/runtime_api_impl/v1.rs
@@ -25,10 +25,11 @@ use primitives::v1::{
 	Id as ParaId, OccupiedCoreAssumption, SessionIndex, ValidationCode,
 	CommittedCandidateReceipt, ScheduledCore, OccupiedCore, CoreOccupied, CoreIndex,
 	GroupIndex, CandidateEvent, PersistedValidationData, SessionInfo,
-	InboundDownwardMessage, InboundHrmpMessage, Hash,
+	InboundDownwardMessage, InboundHrmpMessage, Hash, AuthorityDiscoveryId
 };
 use frame_support::debug;
 use crate::{initializer, inclusion, scheduler, configuration, paras, session_info, dmp, hrmp, shared};
+
 
 /// Implementation for the `validators` function of the runtime API.
 pub fn validators<T: initializer::Config>() -> Vec<ValidatorId> {
@@ -229,6 +230,21 @@ pub fn session_index_for_child<T: initializer::Config>() -> SessionIndex {
 	// Incidentally, this is also the rationale for why it is OK to query validators or
 	// occupied cores or etc. and expect the correct response "for child".
 	<shared::Module<T>>::session_index()
+}
+
+pub fn get_historical_authority_ids<T: initializer::Config>() -> Vec<AuthorityDiscoveryId> {
+	let current_session_index = session_index_for_child::<T>();
+	let earliest_stored_session = <session_info::Module<T>>::earliest_stored_session();
+	let mut authority_ids = vec![];
+
+	for session_index in earliest_stored_session..current_session_index {
+		let info = <session_info::Module<T>>::session_info(session_index);
+		if info.is_some() {
+			authority_ids.append(&mut info.unwrap().discovery_keys);
+		}
+	}
+
+	authority_ids
 }
 
 /// Implementation for the `validation_code` function of the runtime API.

--- a/runtime/parachains/src/runtime_api_impl/v1.rs
+++ b/runtime/parachains/src/runtime_api_impl/v1.rs
@@ -232,17 +232,25 @@ pub fn session_index_for_child<T: initializer::Config>() -> SessionIndex {
 	<shared::Module<T>>::session_index()
 }
 
-pub fn get_historical_authority_ids<T: initializer::Config>() -> Vec<AuthorityDiscoveryId> {
+/// Implementation for the `AuthorityDiscoveryApi::authorities()` function of the runtime API.
+/// Gets current and historical authority ids using session_info module.
+pub fn get_current_and_historical_authority_ids<T: initializer::Config>() -> Vec<AuthorityDiscoveryId> {
 	let current_session_index = session_index_for_child::<T>();
 	let earliest_stored_session = <session_info::Module<T>>::earliest_stored_session();
 	let mut authority_ids = vec![];
 
-	for session_index in earliest_stored_session..current_session_index {
+	// At session boundary, If there is a race condition between getting session indexes above and
+	// loop execution, we might miss latest session's authority ids, which can break the semantics.
+	// So, to cover widest possible range here we are querying session info for current+1.
+	for session_index in earliest_stored_session..=current_session_index+1 {
 		let info = <session_info::Module<T>>::session_info(session_index);
-		if info.is_some() {
-			authority_ids.append(&mut info.unwrap().discovery_keys);
+		if let Some(mut info) = info {
+			authority_ids.append(&mut info.discovery_keys);
 		}
 	}
+
+	authority_ids.sort();
+	authority_ids.dedup();
 
 	authority_ids
 }

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -849,12 +849,7 @@ sp_api::impl_runtime_apis! {
 
 	impl authority_discovery_primitives::AuthorityDiscoveryApi<Block> for Runtime {
 		fn authorities() -> Vec<AuthorityDiscoveryId> {
-			let mut authorities = AuthorityDiscovery::authorities();
-			let mut past_authorities = runtime_api_impl::get_historical_authority_ids::<Runtime>();
-			authorities.append(&mut past_authorities);
-			authorities.sort();
-			authorities.dedup();
-			authorities
+			runtime_api_impl::get_current_and_historical_authority_ids::<Runtime>()
 		}
 	}
 

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -849,7 +849,7 @@ sp_api::impl_runtime_apis! {
 
 	impl authority_discovery_primitives::AuthorityDiscoveryApi<Block> for Runtime {
 		fn authorities() -> Vec<AuthorityDiscoveryId> {
-			runtime_api_impl::get_historical_and_current_authority_ids::<Runtime>()
+			runtime_api_impl::relevant_authority_ids::<Runtime>()
 		}
 	}
 

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -849,7 +849,18 @@ sp_api::impl_runtime_apis! {
 
 	impl authority_discovery_primitives::AuthorityDiscoveryApi<Block> for Runtime {
 		fn authorities() -> Vec<AuthorityDiscoveryId> {
-			runtime_api_impl::get_current_and_historical_authority_ids::<Runtime>()
+			// Past session's authority ids
+			let mut past_authority_ids = runtime_api_impl::get_historical_authority_ids::<Runtime>();
+			// Current and next session's authority ids
+			let mut current_and_next_authority_ids = AuthorityDiscovery::authorities();
+
+			past_authority_ids.append(&mut current_and_next_authority_ids);
+			let mut authorities = past_authority_ids;
+
+			authorities.sort();
+			authorities.dedup();
+
+			authorities
 		}
 	}
 

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -849,18 +849,7 @@ sp_api::impl_runtime_apis! {
 
 	impl authority_discovery_primitives::AuthorityDiscoveryApi<Block> for Runtime {
 		fn authorities() -> Vec<AuthorityDiscoveryId> {
-			// Past session's authority ids
-			let mut past_authority_ids = runtime_api_impl::get_historical_authority_ids::<Runtime>();
-			// Current and next session's authority ids
-			let mut current_and_next_authority_ids = AuthorityDiscovery::authorities();
-
-			past_authority_ids.append(&mut current_and_next_authority_ids);
-			let mut authorities = past_authority_ids;
-
-			authorities.sort();
-			authorities.dedup();
-
-			authorities
+			runtime_api_impl::get_historical_and_current_authority_ids::<Runtime>()
 		}
 	}
 

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -849,7 +849,12 @@ sp_api::impl_runtime_apis! {
 
 	impl authority_discovery_primitives::AuthorityDiscoveryApi<Block> for Runtime {
 		fn authorities() -> Vec<AuthorityDiscoveryId> {
-			AuthorityDiscovery::authorities()
+			let mut authorities = AuthorityDiscovery::authorities();
+			let mut past_authorities = runtime_api_impl::get_historical_authority_ids::<Runtime>();
+			authorities.append(&mut past_authorities);
+			authorities.sort();
+			authorities.dedup();
+			authorities
 		}
 	}
 


### PR DESCRIPTION
Overrides RuntimeApi::Authorities() to include past sessions as well with the help of session_info module.

Fixes p.2 of #2460

cc: @ordian 