### PR TITLE
Make sure we generate a valid slot in tests

### DIFF
--- a/node/test/client/src/block_builder.rs
+++ b/node/test/client/src/block_builder.rs
@@ -62,7 +62,13 @@ impl InitPolkadotBlockBuilder for Client {
 		let minimum_period = BasicExternalities::new_empty()
 			.execute_with(|| polkadot_test_runtime::MinimumPeriod::get());
 
-		let timestamp = last_timestamp + minimum_period;
+		let timestamp = if last_timestamp == 0 {
+			std::time::SystemTime::now().duration_since(std::time::SystemTime::UNIX_EPOCH)
+				.expect("Time is always after UNIX_EPOCH; qed")
+				.as_millis() as u64
+		} else {
+			last_timestamp + minimum_period
+		};
 
 		// `SlotDuration` is a storage parameter type that requires externalities to access the value.
 		let slot_duration = BasicExternalities::new_empty()


### PR DESCRIPTION
Currently the first last timestamp is `0` and that leads to the first
slot being `0` which is reserved for genesis. There is some debug assert
in BABE that complains about this in Cumulus :D