### PR TITLE
fix expect catching

### DIFF
--- a/node/metered-channel/src/unbounded.rs
+++ b/node/metered-channel/src/unbounded.rs
@@ -140,7 +140,7 @@ impl<T> UnboundedMeteredSender<T> {
 
     /// Attempt to send message or fail immediately.
     pub fn unbounded_send(&mut self, msg: T) -> result::Result<(), mpsc::TrySendError<T>> {
-        self.inner.unbounded_send(msg).expect("Unbounded send never fails. qed");
+        self.inner.unbounded_send(msg)?;
         self.meter.fill.fetch_add(1, Ordering::SeqCst);
         Ok(())
     }


### PR DESCRIPTION
```
 I just tried to update or Validator to parity/rococo:rococo-v1-0.8.28-05832c3c-9192446d, but it's crashing a lot. Thread 'tokio-runtime-worker' panicked at 'Unbounded send never fails. qed: TrySendError { kind: Disconnected }', /builds/parity/polkadot/node/metered-channel/src/unbounded.rs:143 Does someone had a similar issue? I'm not sure what the cause could be? Looks like an unstable connection which seems unlikely?
```