### PR TITLE
Initialize telemetry earlier

### DIFF
--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -572,6 +572,9 @@ pub fn new_full<RuntimeApi, Executor>(
 		RuntimeApiCollection<StateBackend = sc_client_api::StateBackendFor<FullBackend, Block>>,
 		Executor: NativeExecutionDispatch + 'static,
 {
+	let telemetry_span = TelemetrySpan::new();
+	let _telemetry_span_entered = telemetry_span.enter();
+
 	let role = config.role.clone();
 	let force_authoring = config.force_authoring;
 	let backoff_authoring_blocks =
@@ -661,9 +664,6 @@ pub fn new_full<RuntimeApi, Executor>(
 		slot_duration_millis: slot_duration,
 		cache_size: None, // default is fine.
 	};
-
-	let telemetry_span = TelemetrySpan::new();
-	let _telemetry_span_entered = telemetry_span.enter();
 
 	let (rpc_handlers, telemetry_connection_notifier) = service::spawn_tasks(service::SpawnTasksParams {
 		config,


### PR DESCRIPTION
This fixes a bug in block import not reporting to the telemetry.