### PR TITLE
Print an error if a collator connects to a node without real-overseer

### DIFF
--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -610,6 +610,20 @@ pub fn new_full<RuntimeApi, Executor>(
 	#[cfg(feature = "real-overseer")]
 	config.network.extra_sets.extend(polkadot_network_bridge::peer_sets_info());
 
+	// Add a dummy collation set with the intent of printing an error if one tries to connect a
+	// collator to a node that isn't compiled with `--features real-overseer`.
+	#[cfg(not(feature = "real-overseer"))]
+	config.network.extra_sets.push(sc_network::config::NonDefaultSetConfig {
+		notifications_protocol: "/polkadot/collation/1".into(),
+		max_notification_size: 16,
+		set_config: sc_network::config::SetConfig {
+			in_peers: 25,
+			out_peers: 0,
+			reserved_nodes: Vec::new(),
+			non_reserved_mode: sc_network::config::NonReservedPeerMode::Accept,
+		},
+	});
+
 	// TODO: At the moment, the collator protocol uses notifications protocols to download
 	// collations. Because of DoS-protection measures, notifications protocols have a very limited
 	// bandwidth capacity, resulting in the collation download taking a long time.
@@ -648,6 +662,28 @@ pub fn new_full<RuntimeApi, Executor>(
 			on_demand: None,
 			block_announce_validator_builder: None,
 		})?;
+
+	// See above. We have added a dummy collation set with the intent of printing an error if one
+	// tries to connect a collator to a node that isn't compiled with `--features real-overseer`.
+	#[cfg(not(feature = "real-overseer"))]
+	task_manager.spawn_handle().spawn("dummy-collation-handler", {
+		let mut network_events = network.event_stream("dummy-collation-handler");
+		async move {
+			use futures::prelude::*;
+			while let Some(ev) = network_events.next().await {
+				if let sc_network::Event::NotificationStreamOpened { protocol, .. } = ev {
+					if protocol == "/polkadot/collation/1" {
+						tracing::warn!(
+							"Incoming collator on a node with parachains disabled. This warning \
+							is harmless and is here to warn developers that they might have
+							accidentally compiled their node without the parachains features
+							enabled."
+						);
+					}
+				}
+			}
+		}
+	});
 
 	if config.offchain_worker.enabled {
 		let _ = service::build_offchain_workers(

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -676,7 +676,7 @@ pub fn new_full<RuntimeApi, Executor>(
 						tracing::warn!(
 							"Incoming collator on a node with parachains disabled. This warning \
 							is harmless and is here to warn developers that they might have
-							accidentally compiled their node without the parachains features
+							accidentally compiled their node without the `real-overseer` feature
 							enabled."
 						);
 					}


### PR DESCRIPTION
It's not a lot of code, and it can prevent stupid accidental mistakes.

Note that I haven't tested if this works, but it seems pretty straight-forward.