### PR TITLE
XCM: Location Conversion for AccountKey20

### DIFF
--- a/xcm/xcm-builder/src/lib.rs
+++ b/xcm/xcm-builder/src/lib.rs
@@ -18,13 +18,13 @@
 
 mod location_conversion;
 pub use location_conversion::{
-	Account32Hash, ParentIsDefault, ChildParachainConvertsVia, SiblingParachainConvertsVia, AccountId32Aliases
+	Account32Hash, ParentIsDefault, ChildParachainConvertsVia, SiblingParachainConvertsVia, AccountId32Aliases, AccountKey20Aliases,
 };
 
 mod origin_conversion;
 pub use origin_conversion::{
 	SovereignSignedViaLocation, ParentAsSuperuser, ChildSystemParachainAsSuperuser, SiblingSystemParachainAsSuperuser,
-	ChildParachainAsNative, SiblingParachainAsNative, RelayChainAsNative, SignedAccountId32AsNative
+	ChildParachainAsNative, SiblingParachainAsNative, RelayChainAsNative, SignedAccountId32AsNative, SignedAccountKey20AsNative,
 };
 
 mod currency_adapter;

--- a/xcm/xcm-builder/src/location_conversion.rs
+++ b/xcm/xcm-builder/src/location_conversion.rs
@@ -124,3 +124,27 @@ impl<
 		Ok(Junction::AccountId32 { id: who.into(), network: Network::get() }.into())
 	}
 }
+
+pub struct AccountKey20Aliases<Network, AccountId>(PhantomData<(Network, AccountId)>);
+
+impl<
+	Network: Get<NetworkId>,
+	AccountId: From<[u8; 20]> + Into<[u8; 20]>
+> LocationConversion<AccountId> for AccountKey20Aliases<Network, AccountId> {
+	fn from_location(location: &MultiLocation) -> Option<AccountId> {
+		if let MultiLocation::X1(Junction::AccountKey20 { key, network }) = location {
+			if matches!(network, NetworkId::Any) || network == &Network::get() {
+				return Some((*key).into());
+			}
+		}
+		None
+	}
+
+	fn try_into_location(who: AccountId) -> Result<MultiLocation, AccountId> {
+		Ok(Junction::AccountKey20 {
+			key: who.into(),
+			network: Network::get(),
+		}
+		.into())
+	}
+}

--- a/xcm/xcm-builder/src/origin_conversion.rs
+++ b/xcm/xcm-builder/src/origin_conversion.rs
@@ -148,3 +148,24 @@ impl<
 		}
 	}
 }
+
+pub struct SignedAccountKey20AsNative<Network, Origin>(
+	PhantomData<(Network, Origin)>
+);
+impl<
+	Network: Get<NetworkId>,
+	Origin: OriginTrait
+> ConvertOrigin<Origin> for SignedAccountKey20AsNative<Network, Origin> where
+	Origin::AccountId: From<[u8; 20]>,
+{
+	fn convert_origin(origin: MultiLocation, kind: OriginKind) -> Result<Origin, MultiLocation> {
+		match (kind, origin) {
+			(OriginKind::Native, MultiLocation::X1(Junction::AccountKey20 { key, network }))
+				if matches!(network, NetworkId::Any) || network == Network::get() =>
+			{
+				Ok(Origin::signed(key.into()))
+			}
+			(_, origin) => Err(origin),
+		}
+	}
+}


### PR DESCRIPTION
Most substrate chains use `Junction::AccountId32` when referring to their native account id type as a MultiLocation so `AccountId32Aliases` and `SignedAccount32AsNative` are the relevant types to construct the `LocationConverter` (object that implements `trait LocationConversion<AccountId>`).

Moonbeam (and any other chains that set `system::AccountId: H160`) use `Junction::AccountKey20` when referring to their native account id type as a MultiLocation. This requires a different implementation for `AccountIdAliases` and `SignedAccountAsNative`, but the only difference is that the `AccountId` trait bounds use `[u8; 20]` instead of `[u8; 32]`.

Let me know if there are any other types that Moonbeam must add to ensure messages sent to the chain form the local account id as `[u8; 20]`. These types are already included in [this PR](https://github.com/PureStake/moonbeam/pull/263) with Moonbeam's XCMP pallets.