### PR TITLE
Mostly, let guide reflect #2579

### DIFF
--- a/node/core/backing/src/lib.rs
+++ b/node/core/backing/src/lib.rs
@@ -773,10 +773,10 @@ impl CandidateBackingJob {
 				if self.seconded.is_none() {
 					// This job has not seconded a candidate yet.
 					let candidate_hash = candidate.hash();
-					let pov = Arc::new(pov);
 
 					if !self.issued_statements.contains(&candidate_hash) {
-						self.validate_and_second(&span, &candidate, pov.clone()).await?;
+						let pov = Arc::new(pov);
+						self.validate_and_second(&span, &candidate, pov).await?;
 					}
 				}
 			}

--- a/roadmap/implementers-guide/src/node/backing/statement-distribution.md
+++ b/roadmap/implementers-guide/src/node/backing/statement-distribution.md
@@ -19,8 +19,6 @@ Output:
 
 Implemented as a gossip protocol. Handle updates to our view and peers' views. Neighbor packets are used to inform peers which chain heads we are interested in data for.
 
-Statement Distribution is the only backing subsystem which has any notion of peer nodes, who are any full nodes on the network. Validators will also act as peer nodes.
-
 It is responsible for distributing signed statements that we have generated and forwarding them, and for detecting a variety of Validator misbehaviors for reporting to [Misbehavior Arbitration](../utility/misbehavior-arbitration.md). During the Backing stage of the inclusion pipeline, it's the main point of contact with peer nodes. On receiving a signed statement from a peer, assuming the peer receipt state machine is in an appropriate state, it sends the Candidate Receipt to the [Candidate Backing subsystem](candidate-backing.md) to handle the validator's statement.
 
 Track equivocating validators and stop accepting information from them. Establish a data-dependency order:


### PR DESCRIPTION
Collators are now notified about their own collations being seconded, therefore statement distribution no longer needs to gossip to non validator nodes. See #2579

Also moved Arc creation into `if`, not that it should matter in practice.