### PR TITLE
Add some magic to signed statements and approval votes

### DIFF
--- a/node/core/approval-voting/src/lib.rs
+++ b/node/core/approval-voting/src/lib.rs
@@ -697,7 +697,9 @@ fn approval_signing_payload(
 	approval_vote: ApprovalVote,
 	session_index: SessionIndex,
 ) -> Vec<u8> {
-	(approval_vote, session_index).encode()
+	const MAGIC: [u8; 4] = *b"APPR";
+
+	(MAGIC, approval_vote, session_index).encode()
 }
 
 // `Option::cmp` treats `None` as less than `Some`.

--- a/node/core/backing/src/lib.rs
+++ b/node/core/backing/src/lib.rs
@@ -195,7 +195,7 @@ struct InvalidErasureRoot;
 // the code. So this does the necessary conversion.
 fn primitive_statement_to_table(s: &SignedFullStatement) -> TableSignedStatement {
 	let statement = match s.payload() {
-		Statement::Seconded(c) => TableStatement::Candidate(c.clone()),
+		Statement::Seconded(c) => TableStatement::Seconded(c.clone()),
 		Statement::Valid(h) => TableStatement::Valid(h.clone()),
 		Statement::Invalid(h) => TableStatement::Invalid(h.clone()),
 	};
@@ -1239,7 +1239,7 @@ mod tests {
 		statement: TableStatement,
 	) -> Statement {
 		match statement {
-			TableStatement::Candidate(committed_candidate_receipt) => Statement::Seconded(committed_candidate_receipt),
+			TableStatement::Seconded(committed_candidate_receipt) => Statement::Seconded(committed_candidate_receipt),
 			TableStatement::Valid(candidate_hash) => Statement::Valid(candidate_hash),
 			TableStatement::Invalid(candidate_hash) => Statement::Invalid(candidate_hash),
 		}

--- a/node/network/statement-distribution/src/lib.rs
+++ b/node/network/statement-distribution/src/lib.rs
@@ -172,7 +172,7 @@ impl PeerRelayParentKnowledge {
 		}
 
 		let new_known = match fingerprint.0 {
-			CompactStatement::Candidate(ref h) => {
+			CompactStatement::Seconded(ref h) => {
 				self.seconded_counts.entry(fingerprint.1)
 					.or_default()
 					.note_local(h.clone());
@@ -224,7 +224,7 @@ impl PeerRelayParentKnowledge {
 		}
 
 		let candidate_hash = match fingerprint.0 {
-			CompactStatement::Candidate(ref h) => {
+			CompactStatement::Seconded(ref h) => {
 				let allowed_remote = self.seconded_counts.entry(fingerprint.1)
 					.or_insert_with(Default::default)
 					.note_remote(h.clone());
@@ -437,7 +437,7 @@ impl ActiveHeadData {
 		};
 
 		match comparator.compact {
-			CompactStatement::Candidate(h) => {
+			CompactStatement::Seconded(h) => {
 				let seconded_so_far = self.seconded_counts.entry(validator_index).or_insert(0);
 				if *seconded_so_far >= VC_THRESHOLD {
 					return NotedStatement::NotUseful;
@@ -1241,8 +1241,8 @@ mod tests {
 		assert!(knowledge.received_message_count.is_empty());
 
 		// Make the peer aware of the candidate.
-		assert_eq!(knowledge.send(&(CompactStatement::Candidate(hash_a), ValidatorIndex(0))), Some(true));
-		assert_eq!(knowledge.send(&(CompactStatement::Candidate(hash_a), ValidatorIndex(1))), Some(false));
+		assert_eq!(knowledge.send(&(CompactStatement::Seconded(hash_a), ValidatorIndex(0))), Some(true));
+		assert_eq!(knowledge.send(&(CompactStatement::Seconded(hash_a), ValidatorIndex(1))), Some(false));
 		assert!(knowledge.known_candidates.contains(&hash_a));
 		assert_eq!(knowledge.sent_statements.len(), 2);
 		assert!(knowledge.received_statements.is_empty());
@@ -1263,8 +1263,8 @@ mod tests {
 		let mut knowledge = PeerRelayParentKnowledge::default();
 
 		let hash_a = CandidateHash([1; 32].into());
-		assert!(knowledge.receive(&(CompactStatement::Candidate(hash_a), ValidatorIndex(0)), 3).unwrap());
-		assert!(knowledge.send(&(CompactStatement::Candidate(hash_a), ValidatorIndex(0))).is_none());
+		assert!(knowledge.receive(&(CompactStatement::Seconded(hash_a), ValidatorIndex(0)), 3).unwrap());
+		assert!(knowledge.send(&(CompactStatement::Seconded(hash_a), ValidatorIndex(0))).is_none());
 	}
 
 	#[test]
@@ -1279,7 +1279,7 @@ mod tests {
 		);
 
 		assert_eq!(
-			knowledge.receive(&(CompactStatement::Candidate(hash_a), ValidatorIndex(0)), 3),
+			knowledge.receive(&(CompactStatement::Seconded(hash_a), ValidatorIndex(0)), 3),
 			Ok(true),
 		);
 
@@ -1312,12 +1312,12 @@ mod tests {
 		let hash_c = CandidateHash([3; 32].into());
 
 		assert_eq!(
-			knowledge.receive(&(CompactStatement::Candidate(hash_b), ValidatorIndex(0)), 3),
+			knowledge.receive(&(CompactStatement::Seconded(hash_b), ValidatorIndex(0)), 3),
 			Ok(true),
 		);
 
 		assert_eq!(
-			knowledge.receive(&(CompactStatement::Candidate(hash_c), ValidatorIndex(0)), 3),
+			knowledge.receive(&(CompactStatement::Seconded(hash_c), ValidatorIndex(0)), 3),
 			Err(COST_UNEXPECTED_STATEMENT),
 		);
 
@@ -1328,7 +1328,7 @@ mod tests {
 		);
 
 		assert_eq!(
-			knowledge.receive(&(CompactStatement::Candidate(hash_b), ValidatorIndex(0)), 3),
+			knowledge.receive(&(CompactStatement::Seconded(hash_b), ValidatorIndex(0)), 3),
 			Err(COST_DUPLICATE_STATEMENT),
 		);
 	}
@@ -1451,7 +1451,7 @@ mod tests {
 
 			assert!(c_knowledge.known_candidates.contains(&candidate_hash));
 			assert!(c_knowledge.sent_statements.contains(
-				&(CompactStatement::Candidate(candidate_hash), ValidatorIndex(0))
+				&(CompactStatement::Seconded(candidate_hash), ValidatorIndex(0))
 			));
 			assert!(c_knowledge.sent_statements.contains(
 				&(CompactStatement::Valid(candidate_hash), ValidatorIndex(1))

--- a/node/primitives/src/lib.rs
+++ b/node/primitives/src/lib.rs
@@ -71,7 +71,7 @@ impl Statement {
 	/// of the candidate.
 	pub fn to_compact(&self) -> CompactStatement {
 		match *self {
-			Statement::Seconded(ref c) => CompactStatement::Candidate(c.hash()),
+			Statement::Seconded(ref c) => CompactStatement::Seconded(c.hash()),
 			Statement::Valid(hash) => CompactStatement::Valid(hash),
 			Statement::Invalid(hash) => CompactStatement::Invalid(hash),
 		}

--- a/primitives/src/v0.rs
+++ b/primitives/src/v0.rs
@@ -715,7 +715,8 @@ impl From<CompactStatement> for CompactStatementInner {
 
 impl parity_scale_codec::Encode for CompactStatement {
 	fn size_hint(&self) -> usize {
-		CompactStatementInner::from(self.clone()).size_hint() + 4
+		// magic + discriminant + payload
+		4 + 1 + 32
 	}
 
 	fn encode_to<T: parity_scale_codec::Output + ?Sized>(&self, dest: &mut T) {

--- a/primitives/src/v0.rs
+++ b/primitives/src/v0.rs
@@ -677,27 +677,73 @@ pub struct ErasureChunk {
 	pub proof: Vec<Vec<u8>>,
 }
 
+const BACKING_STATEMENT_MAGIC: [u8; 4] = *b"BKNG";
+
 /// Statements that can be made about parachain candidates. These are the
 /// actual values that are signed.
-#[derive(Clone, PartialEq, Eq, Encode, Decode)]
+#[derive(Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "std", derive(Debug, Hash))]
 pub enum CompactStatement {
 	/// Proposal of a parachain candidate.
-	#[codec(index = 1)]
-	Candidate(CandidateHash),
+	Seconded(CandidateHash),
 	/// State that a parachain candidate is valid.
-	#[codec(index = 2)]
 	Valid(CandidateHash),
 	/// State that a parachain candidate is invalid.
+	Invalid(CandidateHash),
+}
+
+// Inner helper for codec on `CompactStatement`.
+#[derive(Encode, Decode)]
+enum CompactStatementInner {
+	#[codec(index = 1)]
+	Seconded(CandidateHash),
+	#[codec(index = 2)]
+	Valid(CandidateHash),
 	#[codec(index = 3)]
 	Invalid(CandidateHash),
+}
+
+impl From<CompactStatement> for CompactStatementInner {
+	fn from(s: CompactStatement) -> Self {
+		match s {
+			CompactStatement::Seconded(h) => CompactStatementInner::Seconded(h),
+			CompactStatement::Valid(h) => CompactStatementInner::Valid(h),
+			CompactStatement::Invalid(h) => CompactStatementInner::Invalid(h),
+		}
+	}
+}
+
+impl parity_scale_codec::Encode for CompactStatement {
+	fn size_hint(&self) -> usize {
+		CompactStatementInner::from(self.clone()).size_hint() + 4
+	}
+
+	fn encode_to<T: parity_scale_codec::Output + ?Sized>(&self, dest: &mut T) {
+		dest.write(&BACKING_STATEMENT_MAGIC);
+		CompactStatementInner::from(self.clone()).encode_to(dest)
+	}
+}
+
+impl parity_scale_codec::Decode for CompactStatement {
+	fn decode<I: parity_scale_codec::Input>(input: &mut I) -> Result<Self, parity_scale_codec::Error> {
+		let maybe_magic = <[u8; 4]>::decode(input)?;
+		if maybe_magic != BACKING_STATEMENT_MAGIC {
+			return Err(parity_scale_codec::Error::from("invalid magic string"));
+		}
+
+		Ok(match CompactStatementInner::decode(input)? {
+			CompactStatementInner::Seconded(h) => CompactStatement::Seconded(h),
+			CompactStatementInner::Valid(h) => CompactStatement::Valid(h),
+			CompactStatementInner::Invalid(h) => CompactStatement::Invalid(h),
+		})
+	}
 }
 
 impl CompactStatement {
 	/// Get the underlying candidate hash this references.
 	pub fn candidate_hash(&self) -> &CandidateHash {
 		match *self {
-			CompactStatement::Candidate(ref h)
+			CompactStatement::Seconded(ref h)
 				| CompactStatement::Valid(ref h)
 				| CompactStatement::Invalid(ref h)
 				=> h
@@ -740,7 +786,7 @@ impl ValidityAttestation {
 	) -> Vec<u8> {
 		match *self {
 			ValidityAttestation::Implicit(_) => (
-				CompactStatement::Candidate(candidate_hash),
+				CompactStatement::Seconded(candidate_hash),
 				signing_context,
 			).encode(),
 			ValidityAttestation::Explicit(_) => (

--- a/statement-table/src/lib.rs
+++ b/statement-table/src/lib.rs
@@ -53,7 +53,7 @@ pub mod v1 {
 			match *s {
 				generic::Statement::Valid(s) => PrimitiveStatement::Valid(s),
 				generic::Statement::Invalid(s) => PrimitiveStatement::Invalid(s),
-				generic::Statement::Candidate(ref s) => PrimitiveStatement::Candidate(s.hash()),
+				generic::Statement::Seconded(ref s) => PrimitiveStatement::Seconded(s.hash()),
 			}
 		}
 	}


### PR DESCRIPTION
Different signed statements by validators weren't previously separable by magic. This change adds magic to the payloads so an upcoming dispute vote kind will not be used in place of backing statements.

I also changed the naming of `Candidate` statements in the table to match the `Seconded` we use elsewhere.