### PR TITLE
Make Substrate deps uniform

### DIFF
--- a/bridges/bin/millau/node/Cargo.toml
+++ b/bridges/bin/millau/node/Cargo.toml
@@ -24,31 +24,31 @@ pallet-message-lane-rpc = { path = "../../../modules/message-lane/rpc" }
 
 # Substrate Dependencies
 
-frame-benchmarking = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-frame-benchmarking-cli = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sc-basic-authorship = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sc-cli = { git = "https://github.com/paritytech/substrate.git", branch = "master", features = ["wasmtime"] }
-sc-client-api = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sc-consensus = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sc-consensus-aura = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sc-executor = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sc-finality-grandpa = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sc-finality-grandpa-rpc = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sc-keystore = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sc-service = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sc-rpc = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sc-transaction-pool = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sp-consensus = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sp-consensus-aura = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sp-core = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sp-inherents = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sp-finality-grandpa = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-substrate-frame-rpc-system = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "master" }
+frame-benchmarking-cli = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-basic-authorship = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-cli = { git = "https://github.com/paritytech/substrate", branch = "master", features = ["wasmtime"] }
+sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-consensus = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-consensus-aura = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-executor = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-finality-grandpa = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-finality-grandpa-rpc = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-keystore = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-service = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-rpc = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-consensus = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-consensus-aura = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-inherents = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-finality-grandpa = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master" }
+substrate-frame-rpc-system = { git = "https://github.com/paritytech/substrate", branch = "master" }
 
 [build-dependencies]
 build-script-utils = { package = "substrate-build-script-utils", version = "2.0" }
-frame-benchmarking-cli = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
+frame-benchmarking-cli = { git = "https://github.com/paritytech/substrate", branch = "master" }
 vergen = "3.1.0"
 
 [features]

--- a/bridges/bin/millau/runtime/Cargo.toml
+++ b/bridges/bin/millau/runtime/Cargo.toml
@@ -28,31 +28,31 @@ pallet-substrate-bridge = { path = "../../../modules/substrate", default-feature
 
 # Substrate Dependencies
 
-frame-executive = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-frame-support = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-frame-system = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-pallet-aura = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-pallet-balances = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-pallet-grandpa = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-pallet-session = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-pallet-sudo = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-pallet-transaction-payment = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-api = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-block-builder = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-consensus-aura = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-inherents = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-finality-grandpa = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-offchain = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-session = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-transaction-pool = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-trie = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-version = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
+frame-executive = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+frame-system = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+pallet-aura = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+pallet-grandpa = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+pallet-session = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+pallet-sudo = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-block-builder = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-consensus-aura = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-inherents = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-finality-grandpa = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-offchain = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-session = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-trie = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-version = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
 
 [build-dependencies]
 wasm-builder-runner = { package = "substrate-wasm-builder-runner", version = "2.0.0" }

--- a/bridges/bin/rialto/node/Cargo.toml
+++ b/bridges/bin/rialto/node/Cargo.toml
@@ -24,32 +24,32 @@ rialto-runtime = { path = "../runtime" }
 
 # Substrate Dependencies
 
-frame-benchmarking = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-frame-benchmarking-cli = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sc-basic-authorship = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sc-cli = { git = "https://github.com/paritytech/substrate.git", branch = "master", features = ["wasmtime"] }
-sc-client-api = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sc-consensus = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sc-consensus-aura = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sc-executor = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sc-finality-grandpa = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sc-finality-grandpa-rpc = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sc-keystore = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sc-service = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sc-rpc = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sc-transaction-pool = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sc-telemetry = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sp-consensus = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sp-consensus-aura = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sp-core = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sp-inherents = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sp-finality-grandpa = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-substrate-frame-rpc-system = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "master" }
+frame-benchmarking-cli = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-basic-authorship = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-cli = { git = "https://github.com/paritytech/substrate", branch = "master", features = ["wasmtime"] }
+sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-consensus = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-consensus-aura = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-executor = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-finality-grandpa = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-finality-grandpa-rpc = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-keystore = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-service = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-rpc = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-telemetry = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-consensus = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-consensus-aura = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-inherents = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-finality-grandpa = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master" }
+substrate-frame-rpc-system = { git = "https://github.com/paritytech/substrate", branch = "master" }
 
 [build-dependencies]
 build-script-utils = { package = "substrate-build-script-utils", version = "2.0" }
-frame-benchmarking-cli = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
+frame-benchmarking-cli = { git = "https://github.com/paritytech/substrate", branch = "master" }
 vergen = "3.1.0"
 
 [features]

--- a/bridges/bin/rialto/runtime/Cargo.toml
+++ b/bridges/bin/rialto/runtime/Cargo.toml
@@ -34,33 +34,33 @@ pallet-shift-session-manager = { path = "../../../modules/shift-session-manager"
 
 # Substrate Dependencies
 
-frame-benchmarking = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false, optional = true }
-frame-executive = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-frame-support = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-frame-system = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-pallet-aura = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-pallet-balances = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-pallet-grandpa = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-pallet-session = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-pallet-sudo = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-pallet-transaction-payment = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-api = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-block-builder = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-consensus-aura = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-finality-grandpa = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-inherents = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-io = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-offchain = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-session = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-transaction-pool = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-trie = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-version = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false, optional = true }
+frame-executive = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+frame-system = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+pallet-aura = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+pallet-grandpa = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+pallet-session = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+pallet-sudo = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-block-builder = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-consensus-aura = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-finality-grandpa = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-inherents = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-offchain = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-session = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-trie = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-version = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
 
 [dev-dependencies]
 libsecp256k1 = { version = "0.3.4", features = ["hmac"] }

--- a/bridges/bin/runtime-common/Cargo.toml
+++ b/bridges/bin/runtime-common/Cargo.toml
@@ -23,12 +23,12 @@ pallet-substrate-bridge = { path = "../../modules/substrate", default-features =
 
 # Substrate dependencies
 
-frame-support = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-state-machine = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false, optional = true }
-sp-std = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-trie = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-state-machine = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false, optional = true }
+sp-std = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-trie = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
 
 [features]
 default = ["std"]

--- a/bridges/modules/call-dispatch/Cargo.toml
+++ b/bridges/modules/call-dispatch/Cargo.toml
@@ -16,14 +16,14 @@ bp-runtime = { path = "../../primitives/runtime", default-features = false }
 
 # Substrate Dependencies
 
-frame-support = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-frame-system = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+frame-system = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
 
 [dev-dependencies]
-sp-io = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "master" }
 serde = "1.0"
 
 [features]

--- a/bridges/modules/currency-exchange/Cargo.toml
+++ b/bridges/modules/currency-exchange/Cargo.toml
@@ -17,15 +17,15 @@ bp-header-chain = { path = "../../primitives/header-chain", default-features = f
 
 # Substrate Dependencies
 
-frame-benchmarking = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false, optional = true }
-frame-support = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-frame-system = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false, optional = true }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false, optional = true }
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+frame-system = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false, optional = true }
 
 [dev-dependencies]
-sp-core = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sp-io = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "master" }
 
 [features]
 default = ["std"]

--- a/bridges/modules/ethereum-contract/builtin/Cargo.toml
+++ b/bridges/modules/ethereum-contract/builtin/Cargo.toml
@@ -19,10 +19,10 @@ rialto-runtime = { path = "../../../bin/rialto/runtime" }
 
 # Substrate Dependencies
 
-sc-finality-grandpa = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sp-blockchain = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sp-finality-grandpa = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
+sc-finality-grandpa = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-finality-grandpa = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master" }
 
 [dev-dependencies]
-sp-core = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }

--- a/bridges/modules/ethereum/Cargo.toml
+++ b/bridges/modules/ethereum/Cargo.toml
@@ -17,12 +17,12 @@ bp-eth-poa = { path = "../../primitives/ethereum-poa", default-features = false 
 
 # Substrate Dependencies
 
-frame-benchmarking = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false, optional = true }
-frame-support = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-frame-system = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-io = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false, optional = true }
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+frame-system = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
 
 [dev-dependencies]
 libsecp256k1 = { version = "0.3.4", features = ["hmac"] }

--- a/bridges/modules/finality-verifier/Cargo.toml
+++ b/bridges/modules/finality-verifier/Cargo.toml
@@ -19,15 +19,15 @@ bp-header-chain = { path = "../../primitives/header-chain", default-features = f
 
 # Substrate Dependencies
 
-frame-support = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-frame-system = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+frame-system = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
 
 [dev-dependencies]
 bp-test-utils = {path = "../../primitives/test-utils" }
 pallet-substrate-bridge = { path = "../../modules/substrate" }
-sp-io = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "master" }
 
 
 [features]

--- a/bridges/modules/message-lane/Cargo.toml
+++ b/bridges/modules/message-lane/Cargo.toml
@@ -19,17 +19,17 @@ bp-runtime = { path = "../../primitives/runtime", default-features = false }
 
 # Substrate Dependencies
 
-frame-benchmarking = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false, optional = true }
-frame-support = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-frame-system = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false, optional = true }
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+frame-system = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.3"
-sp-io = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-pallet-balances = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "master" }
+pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "master" }
 
 [features]
 default = ["std"]

--- a/bridges/modules/message-lane/rpc/Cargo.toml
+++ b/bridges/modules/message-lane/rpc/Cargo.toml
@@ -21,9 +21,9 @@ bp-message-lane = { path = "../../../primitives/message-lane" }
 
 # Substrate Dependencies
 
-sc-client-api = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sp-blockchain = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sp-core = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sp-state-machine = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sp-trie = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
+sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-state-machine = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-trie = { git = "https://github.com/paritytech/substrate", branch = "master" }

--- a/bridges/modules/shift-session-manager/Cargo.toml
+++ b/bridges/modules/shift-session-manager/Cargo.toml
@@ -11,15 +11,15 @@ codec = { package = "parity-scale-codec", version = "2.0.0", default-features = 
 
 # Substrate Dependencies
 
-frame-support = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-frame-system = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-pallet-session = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-staking = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+frame-system = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+pallet-session = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-staking = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
 
 [dev-dependencies]
-sp-core = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master" }
 serde = "1.0"
 
 [features]

--- a/bridges/modules/substrate/Cargo.toml
+++ b/bridges/modules/substrate/Cargo.toml
@@ -20,18 +20,18 @@ bp-runtime = { path = "../../primitives/runtime", default-features = false }
 
 # Substrate Dependencies
 
-frame-support = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-frame-system = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-finality-grandpa = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-trie = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+frame-system = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-finality-grandpa = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-trie = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
 
 [dev-dependencies]
 bp-test-utils = {path = "../../primitives/test-utils" }
-sp-core = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sp-io = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sp-state-machine = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-state-machine = { git = "https://github.com/paritytech/substrate", branch = "master" }
 
 [features]
 default = ["std"]

--- a/bridges/primitives/currency-exchange/Cargo.toml
+++ b/bridges/primitives/currency-exchange/Cargo.toml
@@ -11,9 +11,9 @@ codec = { package = "parity-scale-codec", version = "2.0.0", default-features = 
 
 # Substrate Dependencies
 
-frame-support = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-api = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
 
 [features]
 default = ["std"]

--- a/bridges/primitives/ethereum-poa/Cargo.toml
+++ b/bridges/primitives/ethereum-poa/Cargo.toml
@@ -24,10 +24,10 @@ triehash = { version = "0.8.2", default-features = false }
 
 # Substrate Dependencies
 
-sp-api = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-io = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.2"

--- a/bridges/primitives/header-chain/Cargo.toml
+++ b/bridges/primitives/header-chain/Cargo.toml
@@ -13,11 +13,11 @@ serde = { version = "1.0", optional = true }
 
 # Substrate Dependencies
 
-frame-support = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-finality-grandpa = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-finality-grandpa = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
 
 [dev-dependencies]
 bp-test-utils = { path = "../test-utils" }

--- a/bridges/primitives/kusama/Cargo.toml
+++ b/bridges/primitives/kusama/Cargo.toml
@@ -15,12 +15,12 @@ bp-runtime = { path = "../runtime", default-features = false }
 
 # Substrate Based Dependencies
 
-frame-support = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-frame-system = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-api = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate.git", branch = "master", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "master", default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate.git", branch = "master", default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+frame-system = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 
 [features]
 default = ["std"]

--- a/bridges/primitives/message-lane/Cargo.toml
+++ b/bridges/primitives/message-lane/Cargo.toml
@@ -15,9 +15,9 @@ bp-runtime = { path = "../runtime", default-features = false }
 
 # Substrate Dependencies
 
-frame-support = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-frame-system = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+frame-system = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
 
 [features]
 default = ["std"]

--- a/bridges/primitives/millau/Cargo.toml
+++ b/bridges/primitives/millau/Cargo.toml
@@ -21,14 +21,14 @@ serde = { version = "1.0.101", optional = true, features = ["derive"] }
 
 # Substrate Based Dependencies
 
-frame-support = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-frame-system = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-api = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-io = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-trie = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+frame-system = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-trie = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
 
 [features]
 default = ["std"]

--- a/bridges/primitives/polkadot/Cargo.toml
+++ b/bridges/primitives/polkadot/Cargo.toml
@@ -15,12 +15,12 @@ bp-runtime = { path = "../runtime", default-features = false }
 
 # Substrate Based Dependencies
 
-frame-support = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-frame-system = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-api = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate.git", branch = "master", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "master", default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate.git", branch = "master", default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+frame-system = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 
 [features]
 default = ["std"]

--- a/bridges/primitives/rialto/Cargo.toml
+++ b/bridges/primitives/rialto/Cargo.toml
@@ -15,12 +15,12 @@ bp-runtime = { path = "../runtime", default-features = false }
 
 # Substrate Based Dependencies
 
-frame-support = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-frame-system = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-api = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+frame-system = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
 
 [features]
 default = ["std"]

--- a/bridges/primitives/runtime/Cargo.toml
+++ b/bridges/primitives/runtime/Cargo.toml
@@ -12,11 +12,11 @@ num-traits = { version = "0.2", default-features = false }
 
 # Substrate Dependencies
 
-frame-support = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-io = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate", branch = "master" , default-features = false }
 
 [features]
 default = ["std"]

--- a/bridges/primitives/test-utils/Cargo.toml
+++ b/bridges/primitives/test-utils/Cargo.toml
@@ -8,6 +8,6 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 [dependencies]
 finality-grandpa = { version = "0.14.0" }
 bp-header-chain = { path = "../header-chain" }
-sp-finality-grandpa = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sp-keyring = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
+sp-finality-grandpa = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master" }

--- a/bridges/relays/ethereum/Cargo.toml
+++ b/bridges/relays/ethereum/Cargo.toml
@@ -40,9 +40,9 @@ rialto-runtime = { path = "../../bin/rialto/runtime" }
 
 # Substrate Dependencies
 
-frame-system = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-pallet-transaction-payment = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sp-core = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sp-keyring = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-substrate-prometheus-endpoint = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
+frame-system = { git = "https://github.com/paritytech/substrate", branch = "master" }
+pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master" }
+substrate-prometheus-endpoint = { git = "https://github.com/paritytech/substrate", branch = "master" }

--- a/bridges/relays/kusama-client/Cargo.toml
+++ b/bridges/relays/kusama-client/Cargo.toml
@@ -17,9 +17,9 @@ bp-kusama = { path = "../../primitives/kusama" }
 
 # Substrate Dependencies
 
-frame-system = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-frame-support = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-pallet-transaction-payment = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sp-core = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sp-keyring = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
+frame-system = { git = "https://github.com/paritytech/substrate", branch = "master" }
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "master" }
+pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master" }

--- a/bridges/relays/millau-client/Cargo.toml
+++ b/bridges/relays/millau-client/Cargo.toml
@@ -17,9 +17,9 @@ millau-runtime = { path = "../../bin/millau/runtime" }
 
 # Substrate Dependencies
 
-frame-support = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-frame-system = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-pallet-transaction-payment = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sp-core = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sp-keyring = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "master" }
+frame-system = { git = "https://github.com/paritytech/substrate", branch = "master" }
+pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master" }

--- a/bridges/relays/polkadot-client/Cargo.toml
+++ b/bridges/relays/polkadot-client/Cargo.toml
@@ -17,9 +17,9 @@ bp-polkadot = { path = "../../primitives/polkadot" }
 
 # Substrate Dependencies
 
-frame-system = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-frame-support = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-pallet-transaction-payment = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sp-core = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sp-keyring = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
+frame-system = { git = "https://github.com/paritytech/substrate", branch = "master" }
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "master" }
+pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master" }

--- a/bridges/relays/rialto-client/Cargo.toml
+++ b/bridges/relays/rialto-client/Cargo.toml
@@ -17,9 +17,9 @@ rialto-runtime = { path = "../../bin/rialto/runtime" }
 
 # Substrate Dependencies
 
-frame-system = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-frame-support = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-pallet-transaction-payment = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sp-core = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sp-keyring = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
+frame-system = { git = "https://github.com/paritytech/substrate", branch = "master" }
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "master" }
+pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master" }

--- a/bridges/relays/substrate-client/Cargo.toml
+++ b/bridges/relays/substrate-client/Cargo.toml
@@ -23,15 +23,15 @@ relay-utils = { path = "../utils" }
 
 # Substrate Dependencies
 
-frame-support = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-frame-system = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-pallet-balances = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sc-rpc-api = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sp-core = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sp-std = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sp-trie = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sp-version = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "master" }
+frame-system = { git = "https://github.com/paritytech/substrate", branch = "master" }
+pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-rpc-api = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-std = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-trie = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-version = { git = "https://github.com/paritytech/substrate", branch = "master" }
 
 #[dev-dependencies]
 futures = "0.3.7"

--- a/bridges/relays/substrate/Cargo.toml
+++ b/bridges/relays/substrate/Cargo.toml
@@ -42,8 +42,8 @@ rialto-runtime = { path = "../../bin/rialto/runtime" }
 
 # Substrate Dependencies
 
-frame-support = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sp-core = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sp-finality-grandpa = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sp-trie = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-finality-grandpa = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-trie = { git = "https://github.com/paritytech/substrate", branch = "master" }

--- a/bridges/relays/utils/Cargo.toml
+++ b/bridges/relays/utils/Cargo.toml
@@ -19,4 +19,4 @@ time = "0.2"
 
 # Substrate dependencies
 
-substrate-prometheus-endpoint = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
+substrate-prometheus-endpoint = { git = "https://github.com/paritytech/substrate", branch = "master" }


### PR DESCRIPTION
People like me do a lot of search & replace in Cargo.tomls, which makes it annoying when the format isn't uniform across the Polkadot repo.
This PR just removes the `.git` at the end of the Substrate dependencies URLs.
