### PR TITLE
prefix parachain log targets with parachain::

### DIFF
--- a/node/collation-generation/src/lib.rs
+++ b/node/collation-generation/src/lib.rs
@@ -46,7 +46,7 @@ use std::sync::Arc;
 
 mod error;
 
-const LOG_TARGET: &'static str = "collation_generation";
+const LOG_TARGET: &'static str = "parachain::collation-generation";
 
 /// Collation Generation Subsystem
 pub struct CollationGenerationSubsystem {

--- a/node/core/approval-voting/src/lib.rs
+++ b/node/core/approval-voting/src/lib.rs
@@ -75,7 +75,7 @@ mod persisted_entries;
 mod tests;
 
 const APPROVAL_SESSIONS: SessionIndex = 6;
-const LOG_TARGET: &str = "approval_voting";
+const LOG_TARGET: &str = "parachain::approval-voting";
 
 /// Configuration for the approval voting subsystem
 pub struct Config {

--- a/node/core/av-store/src/lib.rs
+++ b/node/core/av-store/src/lib.rs
@@ -49,7 +49,7 @@ use bitvec::{vec::BitVec, order::Lsb0 as BitOrderLsb0};
 #[cfg(test)]
 mod tests;
 
-const LOG_TARGET: &str = "availability";
+const LOG_TARGET: &str = "parachain::availability";
 
 mod columns {
 	pub const DATA: u32 = 0;

--- a/node/core/backing/src/lib.rs
+++ b/node/core/backing/src/lib.rs
@@ -66,7 +66,7 @@ use statement_table::{
 };
 use thiserror::Error;
 
-const LOG_TARGET: &str = "candidate_backing";
+const LOG_TARGET: &str = "parachain::candidate-backing";
 
 #[derive(Debug, Error)]
 enum Error {

--- a/node/core/bitfield-signing/src/lib.rs
+++ b/node/core/bitfield-signing/src/lib.rs
@@ -39,7 +39,7 @@ use wasm_timer::{Delay, Instant};
 
 /// Delay between starting a bitfield signing job and its attempting to create a bitfield.
 const JOB_DELAY: Duration = Duration::from_millis(1500);
-const LOG_TARGET: &str = "bitfield_signing";
+const LOG_TARGET: &str = "parachain::bitfield-signing";
 
 /// Each `BitfieldSigningJob` prepares a signed bitfield for a single relay parent.
 pub struct BitfieldSigningJob;

--- a/node/core/candidate-selection/src/lib.rs
+++ b/node/core/candidate-selection/src/lib.rs
@@ -43,7 +43,7 @@ use polkadot_node_primitives::SignedFullStatement;
 use std::{pin::Pin, sync::Arc};
 use thiserror::Error;
 
-const LOG_TARGET: &'static str = "candidate_selection";
+const LOG_TARGET: &'static str = "parachain::candidate-selection";
 
 struct CandidateSelectionJob {
 	assignment: ParaId,

--- a/node/core/candidate-validation/src/lib.rs
+++ b/node/core/candidate-validation/src/lib.rs
@@ -51,7 +51,7 @@ use futures::prelude::*;
 
 use std::sync::Arc;
 
-const LOG_TARGET: &'static str = "candidate_validation";
+const LOG_TARGET: &'static str = "parachain::candidate-validation";
 
 /// The candidate validation subsystem.
 pub struct CandidateValidationSubsystem<S> {

--- a/node/core/chain-api/src/lib.rs
+++ b/node/core/chain-api/src/lib.rs
@@ -44,7 +44,7 @@ use std::sync::Arc;
 
 use futures::prelude::*;
 
-const LOG_TARGET: &str = "chain_api";
+const LOG_TARGET: &str = "parachain::chain-api";
 
 /// The Chain API Subsystem implementation.
 pub struct ChainApiSubsystem<Client> {

--- a/node/core/provisioner/src/lib.rs
+++ b/node/core/provisioner/src/lib.rs
@@ -46,7 +46,7 @@ use futures_timer::Delay;
 /// How long to wait before proposing.
 const PRE_PROPOSE_TIMEOUT: std::time::Duration = core::time::Duration::from_millis(2000);
 
-const LOG_TARGET: &str = "provisioner";
+const LOG_TARGET: &str = "parachain::provisioner";
 
 enum InherentAfter {
 	Ready,

--- a/node/core/runtime-api/src/lib.rs
+++ b/node/core/runtime-api/src/lib.rs
@@ -43,7 +43,7 @@ use cache::{RequestResult, RequestResultCache};
 
 mod cache;
 
-const LOG_TARGET: &str = "runtime_api";
+const LOG_TARGET: &str = "parachain::runtime-api";
 
 /// The number of maximum runtime api requests can be executed in parallel. Further requests will be buffered.
 const MAX_PARALLEL_REQUESTS: usize = 4;

--- a/node/network/approval-distribution/src/lib.rs
+++ b/node/network/approval-distribution/src/lib.rs
@@ -45,7 +45,7 @@ use polkadot_node_network_protocol::{
 
 };
 
-const LOG_TARGET: &str = "approval_distribution";
+const LOG_TARGET: &str = "parachain::approval-distribution";
 
 const COST_UNEXPECTED_MESSAGE: Rep = Rep::CostMinor("Peer sent an out-of-view assignment or approval");
 const COST_DUPLICATE_MESSAGE: Rep = Rep::CostMinorRepeated("Peer sent identical messages");

--- a/node/network/availability-distribution/src/lib.rs
+++ b/node/network/availability-distribution/src/lib.rs
@@ -46,7 +46,7 @@ pub use metrics::Metrics;
 #[cfg(test)]
 mod tests;
 
-const LOG_TARGET: &'static str = "availability_distribution";
+const LOG_TARGET: &'static str = "parachain::availability-distribution";
 
 /// The availability distribution subsystem.
 pub struct AvailabilityDistributionSubsystem {

--- a/node/network/availability-recovery/src/lib.rs
+++ b/node/network/availability-recovery/src/lib.rs
@@ -56,7 +56,7 @@ mod error;
 #[cfg(test)]
 mod tests;
 
-const LOG_TARGET: &str = "availability_recovery";
+const LOG_TARGET: &str = "parachain::availability-recovery";
 
 const COST_MERKLE_PROOF_INVALID: Rep = Rep::CostMinor("Merkle proof was invalid");
 const COST_UNEXPECTED_CHUNK: Rep = Rep::CostMinor("Peer has sent an unexpected chunk");

--- a/node/network/bitfield-distribution/src/lib.rs
+++ b/node/network/bitfield-distribution/src/lib.rs
@@ -136,7 +136,7 @@ impl PerRelayParentData {
 	}
 }
 
-const LOG_TARGET: &str = "bitfield_distribution";
+const LOG_TARGET: &str = "parachain::bitfield-distribution";
 
 /// The bitfield distribution subsystem.
 pub struct BitfieldDistribution {

--- a/node/network/bridge/src/lib.rs
+++ b/node/network/bridge/src/lib.rs
@@ -77,7 +77,7 @@ const MALFORMED_VIEW_COST: Rep = Rep::CostMajor("Malformed view");
 const EMPTY_VIEW_COST: Rep = Rep::CostMajor("Peer sent us an empty view");
 
 // network bridge log target
-const LOG_TARGET: &'static str = "network_bridge";
+const LOG_TARGET: &'static str = "parachain::network-bridge";
 
 /// Messages from and to the network.
 ///

--- a/node/network/bridge/src/validator_discovery.rs
+++ b/node/network/bridge/src/validator_discovery.rs
@@ -30,7 +30,7 @@ use polkadot_node_network_protocol::PeerId;
 use polkadot_primitives::v1::{AuthorityDiscoveryId, Block, Hash};
 use polkadot_node_network_protocol::peer_set::{PeerSet, PerPeerSet};
 
-const LOG_TARGET: &str = "validator_discovery";
+const LOG_TARGET: &str = "parachain::validator-discovery";
 
 /// An abstraction over networking for the purposes of validator discovery service.
 #[async_trait]

--- a/node/network/collator-protocol/src/lib.rs
+++ b/node/network/collator-protocol/src/lib.rs
@@ -43,7 +43,7 @@ use polkadot_node_subsystem_util::{
 mod collator_side;
 mod validator_side;
 
-const LOG_TARGET: &'static str = "collator_protocol";
+const LOG_TARGET: &'static str = "parachain::collator-protocol";
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(1);
 
 #[derive(Debug, Error)]

--- a/node/network/gossip-support/src/lib.rs
+++ b/node/network/gossip-support/src/lib.rs
@@ -36,7 +36,7 @@ use polkadot_primitives::v1::{
 };
 use polkadot_node_network_protocol::peer_set::PeerSet;
 
-const LOG_TARGET: &str = "gossip_support";
+const LOG_TARGET: &str = "parachain::gossip-support";
 
 /// The Gossip Support subsystem.
 pub struct GossipSupport {}

--- a/node/network/pov-distribution/src/lib.rs
+++ b/node/network/pov-distribution/src/lib.rs
@@ -64,7 +64,7 @@ const BENEFIT_FRESH_POV: Rep = Rep::BenefitMinorFirst("Peer supplied us with an 
 const BENEFIT_LATE_POV: Rep = Rep::BenefitMinor("Peer supplied us with an awaited PoV, \
 	but was not the first to do so");
 
-const LOG_TARGET: &str = "pov_distribution";
+const LOG_TARGET: &str = "parachain::pov-distribution";
 
 /// The PoV Distribution Subsystem.
 pub struct PoVDistribution {

--- a/node/network/statement-distribution/src/lib.rs
+++ b/node/network/statement-distribution/src/lib.rs
@@ -63,7 +63,7 @@ const BENEFIT_VALID_STATEMENT_FIRST: Rep = Rep::BenefitMajorFirst(
 /// Typically we will only keep 1, but when a validator equivocates we will need to track 2.
 const VC_THRESHOLD: usize = 2;
 
-const LOG_TARGET: &str = "statement_distribution";
+const LOG_TARGET: &str = "parachain::statement-distribution";
 
 /// The statement distribution subsystem.
 pub struct StatementDistribution {

--- a/node/overseer/src/lib.rs
+++ b/node/overseer/src/lib.rs
@@ -100,7 +100,7 @@ const CHANNEL_CAPACITY: usize = 1024;
 // A graceful `Overseer` teardown time delay.
 const STOP_DELAY: u64 = 1;
 // Target for logs.
-const LOG_TARGET: &'static str = "overseer";
+const LOG_TARGET: &'static str = "parachain::overseer";
 // Rate at which messages are timed.
 const MESSAGE_TIMER_METRIC_CAPTURE_RATE: f64 = 0.005;
 

--- a/node/service/src/grandpa_support.rs
+++ b/node/service/src/grandpa_support.rs
@@ -158,7 +158,7 @@ impl<B> grandpa::VotingRule<PolkadotBlock, B> for ApprovalCheckingDiagnostic
 			}
 
 			tracing::debug!(
-				target: "approval_voting",
+				target: "parachain::approval-voting",
 				"GRANDPA: voting on {:?}. Approval-checking lag behind best is {}",
 				actual_vote_target,
 				approval_checking_subsystem_lag,

--- a/node/subsystem-util/src/validator_discovery.rs
+++ b/node/subsystem-util/src/validator_discovery.rs
@@ -78,7 +78,7 @@ pub async fn connect_to_validators_in_session<Context: SubsystemContext>(
 	};
 
 	tracing::trace!(
-		target: "network_bridge",
+		target: "parachain::validator-discovery",
 		validators = ?validators,
 		discovery_keys = ?discovery_keys,
 		session_index,

--- a/parachain/src/wasm_executor/validation_host.rs
+++ b/parachain/src/wasm_executor/validation_host.rs
@@ -28,7 +28,7 @@ const WORKER_ARG: &'static str = "validation-worker";
 /// CLI Argument to start in validation worker mode.
 pub const WORKER_ARGS: &[&'static str] = &[WORKER_ARG];
 
-const LOG_TARGET: &'static str = "validation-worker";
+const LOG_TARGET: &'static str = "parachain::validation-worker";
 
 mod workspace;
 

--- a/runtime/parachains/src/inclusion_inherent.rs
+++ b/runtime/parachains/src/inclusion_inherent.rs
@@ -39,6 +39,7 @@ use crate::{
 };
 use inherents::{InherentIdentifier, InherentData, MakeFatalError, ProvideInherent};
 
+const LOG_TARGET: &str = "runtime::inclusion-inherent";
 // In the future, we should benchmark these consts; these are all untested assumptions for now.
 const BACKED_CANDIDATE_WEIGHT: Weight = 100_000;
 const INCLUSION_INHERENT_CLAIMED_WEIGHT: Weight = 1_000_000_000;
@@ -228,7 +229,7 @@ impl<T: Config> ProvideInherent for Module<T> {
 						Ok(_) => (signed_bitfields, backed_candidates),
 						Err(err) => {
 							log::warn!(
-								target: "runtime_inclusion_inherent",
+								target: LOG_TARGET,
 								"dropping signed_bitfields and backed_candidates because they produced \
 								an invalid inclusion inherent: {:?}",
 								err,

--- a/runtime/parachains/src/ump.rs
+++ b/runtime/parachains/src/ump.rs
@@ -23,6 +23,8 @@ use sp_std::collections::{btree_map::BTreeMap, vec_deque::VecDeque};
 use frame_support::{decl_module, decl_storage, StorageMap, StorageValue, weights::Weight, traits::Get};
 use primitives::v1::{Id as ParaId, UpwardMessage};
 
+const LOG_TARGET: &str = "runtime::ump-sink";
+
 /// All upward messages coming from parachains will be funneled into an implementation of this trait.
 ///
 /// The message is opaque from the perspective of UMP. The message size can range from 0 to
@@ -76,7 +78,7 @@ impl<Config: xcm_executor::Config> UmpSink for XcmSink<Config> {
 			}
 		} else {
 			log::error!(
-				target: "runtime::ump-sink",
+				target: LOG_TARGET,
 				"Failed to decode versioned XCM from upward message.",
 			);
 		}


### PR DESCRIPTION
To make it consistent with https://github.com/paritytech/polkadot/blob/e6b065f6a273da609a8de336617d5782da58796d/runtime/parachains/src/ump.rs#L79 and allow to easily enable logs for every parachain subsystem.