### PR TITLE
Better error handling in approval-voting

### DIFF
--- a/node/core/approval-voting/src/import.rs
+++ b/node/core/approval-voting/src/import.rs
@@ -190,12 +190,16 @@ async fn determine_new_blocks(
 	Ok(ancestry)
 }
 
+// Sessions unavailable in state to cache.
+#[derive(Debug)]
+struct SessionsUnavailable;
+
 async fn load_all_sessions(
 	ctx: &mut impl SubsystemContext,
 	block_hash: Hash,
 	start: SessionIndex,
 	end_inclusive: SessionIndex,
-) -> SubsystemResult<Option<Vec<SessionInfo>>> {
+) -> Result<Vec<SessionInfo>, SessionsUnavailable> {
 	let mut v = Vec::new();
 	for i in start..=end_inclusive {
 		let (tx, rx)= oneshot::channel();
@@ -214,21 +218,16 @@ async fn load_all_sessions(
 					block_hash,
 				);
 
-				return Ok(None);
+				return Err(SessionsUnavailable);
 			}
-			Ok(Err(e)) => return Err(SubsystemError::with_origin("approval-voting", e)),
-			Err(e) => return Err(SubsystemError::with_origin("approval-voting", e)),
+			Ok(Err(_)) | Err(_) => return Err(SessionsUnavailable),
 		};
 
 		v.push(session_info);
 	}
 
-	Ok(Some(v))
+	Ok(v)
 }
-
-// Sessions unavailable in state to cache.
-#[derive(Debug)]
-struct SessionsUnavailable;
 
 // When inspecting a new import notification, updates the session info cache to match
 // the session of the imported block.
@@ -242,7 +241,7 @@ async fn cache_session_info_for_head(
 	session_window: &mut RollingSessionWindow,
 	block_hash: Hash,
 	block_header: &Header,
-) -> SubsystemResult<Result<(), SessionsUnavailable>> {
+) -> Result<(), SessionsUnavailable> {
 	let session_index = {
 		let (s_tx, s_rx) = oneshot::channel();
 
@@ -254,9 +253,9 @@ async fn cache_session_info_for_head(
 			RuntimeApiRequest::SessionIndexForChild(s_tx),
 		).into()).await;
 
-		match s_rx.await? {
-			Ok(s) => s,
-			Err(e) => return Err(SubsystemError::with_origin("approval-voting", e)),
+		match s_rx.await {
+			Ok(Ok(s)) => s,
+			Ok(Err(_)) | Err(_) => return Err(SessionsUnavailable),
 		}
 	};
 
@@ -271,17 +270,17 @@ async fn cache_session_info_for_head(
 				window_start, session_index,
 			);
 
-			match load_all_sessions(ctx, block_hash, window_start, session_index).await? {
-				None => {
+			match load_all_sessions(ctx, block_hash, window_start, session_index).await {
+				Err(SessionsUnavailable) => {
 					tracing::warn!(
 						target: LOG_TARGET,
 						"Could not load sessions {}..={} from block {:?} in session {}",
 						window_start, session_index, block_hash, session_index,
 					);
 
-					return Ok(Err(SessionsUnavailable));
+					return Err(SessionsUnavailable);
 				},
-				Some(s) => {
+				Ok(s) => {
 					session_window.earliest_session = Some(window_start);
 					session_window.session_info = s;
 				}
@@ -291,7 +290,7 @@ async fn cache_session_info_for_head(
 			let latest = session_window.latest_session().expect("latest always exists if earliest does; qed");
 
 			// Either cached or ancient.
-			if session_index <= latest { return Ok(Ok(())) }
+			if session_index <= latest { return Ok(()) }
 
 			let old_window_end = latest;
 
@@ -311,17 +310,17 @@ async fn cache_session_info_for_head(
 				latest + 1
 			};
 
-			match load_all_sessions(ctx, block_hash, fresh_start, session_index).await? {
-				None => {
+			match load_all_sessions(ctx, block_hash, fresh_start, session_index).await {
+				Err(SessionsUnavailable) => {
 					tracing::warn!(
 						target: LOG_TARGET,
 						"Could not load sessions {}..={} from block {:?} in session {}",
 						latest + 1, session_index, block_hash, session_index,
 					);
 
-					return Ok(Err(SessionsUnavailable));
+					return Err(SessionsUnavailable);
 				}
-				Some(s) => {
+				Ok(s) => {
 					let outdated = std::cmp::min(overlap_start as usize, session_window.session_info.len());
 					session_window.session_info.drain(..outdated);
 					session_window.session_info.extend(s);
@@ -335,7 +334,7 @@ async fn cache_session_info_for_head(
 		}
 	}
 
-	Ok(Ok(()))
+	Ok(())
 }
 
 struct ImportedBlockInfo {
@@ -539,7 +538,13 @@ pub(crate) async fn handle_new_head(
 
 		match h_rx.await? {
 			Err(e) => {
-				return Err(SubsystemError::with_origin("approval-voting", e));
+				tracing::debug!(
+					target: LOG_TARGET,
+					"Chain API subsystem temporarily unreachable {}",
+					e,
+				);
+
+				return Ok(Vec::new());
 			}
 			Ok(None) => {
 				tracing::warn!(target: LOG_TARGET, "Missing header for new head {}", head);
@@ -555,7 +560,7 @@ pub(crate) async fn handle_new_head(
 			&mut state.session_window,
 			head,
 			&header,
-		).await?
+		).await
 	{
 		tracing::warn!(
 			target: LOG_TARGET,
@@ -1772,7 +1777,7 @@ mod tests {
 					&mut window,
 					hash,
 					&header,
-				).await.unwrap().unwrap();
+				).await.unwrap();
 
 				assert_eq!(window.earliest_session, Some(expected_start_session));
 				assert_eq!(
@@ -1953,7 +1958,7 @@ mod tests {
 					&mut window,
 					hash,
 					&header,
-				).await.unwrap();
+				).await;
 
 				assert_matches!(res, Err(SessionsUnavailable));
 			})
@@ -2020,7 +2025,7 @@ mod tests {
 					&mut window,
 					hash,
 					&header,
-				).await.unwrap().unwrap();
+				).await.unwrap();
 
 				assert_eq!(window.earliest_session, Some(session));
 				assert_eq!(


### PR DESCRIPTION
The subsystem would previously fail on spurious errors when the chain API or runtime API subsystems were unavailable. This changeset makes the subsystem more resilient to such errors by ignoring them. If we encounter such an error when importing a new section of the chain, we discard the entire section of the chain from the approval voting subsystem, with the expectation that upon the next block we'll surpass the spurious error.