### PR TITLE
Backing and collator protocol traces including para-id

### DIFF
--- a/node/core/backing/src/lib.rs
+++ b/node/core/backing/src/lib.rs
@@ -1081,8 +1081,7 @@ impl util::JobTrait for CandidateBackingJob {
 			};
 
 			drop(_span);
-			let _span = span.child("calc-validator-groups");
-
+			let mut assignments_span = span.child("compute-assignments");
 
 			let mut groups = HashMap::new();
 
@@ -1111,11 +1110,18 @@ impl util::JobTrait for CandidateBackingJob {
 			};
 
 			let (assignment, required_collator) = match assignment {
-				None => (None, None),
-				Some((assignment, required_collator)) => (Some(assignment), required_collator),
+				None => {
+					assignments_span.add_string_tag("assigned", "false");
+					(None, None)
+				}
+				Some((assignment, required_collator)) => {
+					assignments_span.add_string_tag("assigned", "true");
+					assignments_span.add_para_id(assignment);
+					(Some(assignment), required_collator)
+				}
 			};
 
-			drop(_span);
+			drop(assignments_span);
 			let _span = span.child("wait-for-job");
 
 			let (background_tx, background_rx) = mpsc::channel(16);

--- a/node/core/backing/src/lib.rs
+++ b/node/core/backing/src/lib.rs
@@ -624,7 +624,11 @@ impl CandidateBackingJob {
 		}
 
 		let candidate_hash = candidate.hash();
-		let span = self.get_unbacked_validation_child(parent_span, candidate_hash);
+		let span = self.get_unbacked_validation_child(
+			parent_span,
+			candidate_hash,
+			candidate.descriptor().para_id,
+		);
 
 		tracing::debug!(
 			target: LOG_TARGET,
@@ -871,7 +875,11 @@ impl CandidateBackingJob {
 		if let Some(summary) = self.import_statement(&statement, parent_span).await? {
 			if let Statement::Seconded(_) = statement.payload() {
 				if Some(summary.group_id) == self.assignment {
-					let span = self.get_unbacked_validation_child(parent_span, summary.candidate);
+					let span = self.get_unbacked_validation_child(
+						parent_span,
+						summary.candidate,
+						summary.group_id,
+					);
 
 					self.kick_off_validation_work(summary, span).await?;
 				}
@@ -911,11 +919,23 @@ impl CandidateBackingJob {
 	}
 
 	/// Insert or get the unbacked-span for the given candidate hash.
-	fn insert_or_get_unbacked_span(&mut self, parent_span: &jaeger::Span, hash: CandidateHash) -> Option<&jaeger::Span> {
+	fn insert_or_get_unbacked_span(
+		&mut self,
+		parent_span: &jaeger::Span,
+		hash: CandidateHash,
+		para_id: Option<ParaId>
+	) -> Option<&jaeger::Span> {
 		if !self.backed.contains(&hash) {
 			// only add if we don't consider this backed.
 			let span = self.unbacked_candidates.entry(hash).or_insert_with(|| {
-				parent_span.child_with_candidate("unbacked-candidate", &hash)
+				let s = parent_span.child_builder("unbacked-candidate").with_candidate(&hash);
+				let s = if let Some(para_id) = para_id {
+					s.with_para_id(para_id)
+				} else {
+					s
+				};
+
+				s.build()
 			});
 			Some(span)
 		} else {
@@ -923,8 +943,13 @@ impl CandidateBackingJob {
 		}
 	}
 
-	fn get_unbacked_validation_child(&mut self, parent_span: &jaeger::Span, hash: CandidateHash) -> Option<jaeger::Span> {
-		self.insert_or_get_unbacked_span(parent_span, hash)
+	fn get_unbacked_validation_child(
+		&mut self,
+		parent_span: &jaeger::Span,
+		hash: CandidateHash,
+		para_id: ParaId,
+	) -> Option<jaeger::Span> {
+		self.insert_or_get_unbacked_span(parent_span, hash, Some(para_id))
 			.map(|span| {
 				span.child_builder("validation")
 					.with_candidate(&hash)
@@ -939,7 +964,7 @@ impl CandidateBackingJob {
 		hash: CandidateHash,
 		validator: ValidatorIndex,
 	) -> Option<jaeger::Span> {
-		self.insert_or_get_unbacked_span(parent_span, hash).map(|span| {
+		self.insert_or_get_unbacked_span(parent_span, hash, None).map(|span| {
 			span.child_builder("import-statement")
 				.with_candidate(&hash)
 				.with_validator_index(validator)

--- a/node/core/backing/src/lib.rs
+++ b/node/core/backing/src/lib.rs
@@ -417,8 +417,9 @@ async fn validate_and_make_available(
 	let v = {
 		let _span = span.as_ref().map(|s| {
 			s.child_builder("request-validation")
-			.with_pov(&pov)
-			.build()
+				.with_pov(&pov)
+				.with_para_id(candidate.descriptor().para_id)
+				.build()
 		});
 		request_candidate_validation(&mut tx_from, candidate.descriptor.clone(), pov.clone()).await?
 	};

--- a/node/core/candidate-selection/src/lib.rs
+++ b/node/core/candidate-selection/src/lib.rs
@@ -134,7 +134,7 @@ impl JobTrait for CandidateSelectionJob {
 				Err(err) => return Err(Error::Util(err)),
 			};
 
-			let _span = span.child_builder("find-assignment")
+			let mut assignment_span = span.child_builder("find-assignment")
 				.with_relay_parent(&relay_parent)
 				.with_stage(jaeger::Stage::CandidateSelection)
 				.build();
@@ -156,11 +156,19 @@ impl JobTrait for CandidateSelectionJob {
 			}
 
 			let assignment = match assignment {
-				Some(assignment) => assignment,
-				None => return Ok(()),
+				Some(assignment) => {
+					assignment_span.add_string_tag("assigned", "true");
+					assignment_span.add_para_id(assignment);
+
+					assignment
+				}
+				None => {
+					assignment_span.add_string_tag("assigned", "false");
+					return Ok(())
+				}
 			};
 
-			drop(_span);
+			drop(assignment_span);
 
 			CandidateSelectionJob::new(assignment, metrics, sender, receiver).run_loop(&span).await
 		}.boxed()

--- a/node/core/candidate-selection/src/lib.rs
+++ b/node/core/candidate-selection/src/lib.rs
@@ -121,7 +121,7 @@ impl JobTrait for CandidateSelectionJob {
 			let cores = try_runtime_api!(cores);
 
 			drop(_span);
-			let _span = span.child_builder("find-assignment")
+			let _span = span.child_builder("validator-construction")
 				.with_relay_parent(&relay_parent)
 				.with_stage(jaeger::Stage::CandidateSelection)
 				.build();
@@ -133,6 +133,11 @@ impl JobTrait for CandidateSelectionJob {
 				Err(util::Error::NotAValidator) => return Ok(()),
 				Err(err) => return Err(Error::Util(err)),
 			};
+
+			let _span = span.child_builder("find-assignment")
+				.with_relay_parent(&relay_parent)
+				.with_stage(jaeger::Stage::CandidateSelection)
+				.build();
 
 			let mut assignment = None;
 

--- a/node/core/provisioner/src/lib.rs
+++ b/node/core/provisioner/src/lib.rs
@@ -198,10 +198,10 @@ impl ProvisioningJob {
 						}
 					}
 					Some(ProvisionableData(_, data)) => {
-						let _span = span.child("provisionable-data");
+						let span = span.child("provisionable-data");
 						let _timer = self.metrics.time_provisionable_data();
 
-						self.note_provisionable_data(data);
+						self.note_provisionable_data(&span, data);
 					}
 					None => break,
 				},
@@ -239,12 +239,14 @@ impl ProvisioningJob {
 	}
 
 	#[tracing::instrument(level = "trace", skip(self), fields(subsystem = LOG_TARGET))]
-	fn note_provisionable_data(&mut self, provisionable_data: ProvisionableData) {
+	fn note_provisionable_data(&mut self, span: &jaeger::Span, provisionable_data: ProvisionableData) {
 		match provisionable_data {
 			ProvisionableData::Bitfield(_, signed_bitfield) => {
 				self.signed_bitfields.push(signed_bitfield)
 			}
 			ProvisionableData::BackedCandidate(backed_candidate) => {
+				let mut span = span.child("provisionable_backed");
+				span.add_para_id(backed_candidate.descriptor().para_id);
 				self.backed_candidates.push(backed_candidate)
 			}
 			_ => {}

--- a/node/core/provisioner/src/lib.rs
+++ b/node/core/provisioner/src/lib.rs
@@ -245,7 +245,7 @@ impl ProvisioningJob {
 				self.signed_bitfields.push(signed_bitfield)
 			}
 			ProvisionableData::BackedCandidate(backed_candidate) => {
-				let mut span = span.child("provisionable_backed");
+				let mut span = span.child("provisionable-backed");
 				span.add_para_id(backed_candidate.descriptor().para_id);
 				self.backed_candidates.push(backed_candidate)
 			}

--- a/node/jaeger/src/lib.rs
+++ b/node/jaeger/src/lib.rs
@@ -315,7 +315,7 @@ impl Span {
 
 	/// Add the para-id to the span.
 	pub fn add_para_id(&mut self, para_id: ParaId) {
-		self.add_string_tag("para-id", &format!("{}", u32::from(para_id)));
+		self.add_int_tag("para-id", u32::from(para_id) as i64);
 	}
 
 	/// Add an additional tag to the span.

--- a/node/jaeger/src/lib.rs
+++ b/node/jaeger/src/lib.rs
@@ -45,7 +45,7 @@
 //! ```
 
 use sp_core::traits::SpawnNamed;
-use polkadot_primitives::v1::{CandidateHash, Hash, PoV, ValidatorIndex, BlakeTwo256, HashT};
+use polkadot_primitives::v1::{CandidateHash, Hash, PoV, ValidatorIndex, BlakeTwo256, HashT, Id as ParaId};
 use parity_scale_codec::Encode;
 use sc_network::PeerId;
 
@@ -204,6 +204,14 @@ impl SpanBuilder {
 		self.span.add_string_tag("candidate-hash", &format!("{:?}", candidate_hash.0));
 		self
 	}
+
+	/// Attach a para-id to the span.
+	#[inline(always)]
+	pub fn with_para_id(mut self, para_id: ParaId) -> Self {
+		self.span.add_para_id(para_id);
+		self
+	}
+
 	/// Attach a candidate stage.
 	/// Should always come with a `CandidateHash`.
 	#[inline(always)]
@@ -303,6 +311,11 @@ impl Span {
 			// avoid computing the pov hash if jaeger is not enabled
 			self.add_string_tag("pov", &format!("{:?}", pov.hash()));
 		}
+	}
+
+	/// Add the para-id to the span.
+	pub fn add_para_id(&mut self, para_id: ParaId) {
+		self.add_string_tag("para-id", &format!("{}", u32::from(para_id)));
 	}
 
 	/// Add an additional tag to the span.


### PR DESCRIPTION
This is meant to help narrow down at what point in the code the 2-minute backing stalls are occurring. With this, we'll at least be able to see whether validators request collations, validate, and back candidates. It could be a scheduler issue, an issue with networking (discovery), or a runtime (inclusion) issue.