### PR TITLE
Add /data symlink to Docker containers

### DIFF
--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -29,8 +29,7 @@ RUN apt-get update && \
 	find /var/lib/apt/lists/ -type f -not -name lock -delete; \
 # add user and link ~/.local/share/polkadot to /data
 	useradd -m -u 1000 -U -s /bin/sh -d /polkadot polkadot && \
-	mkdir -p /polkadot/.local/share && \
-	mkdir /data && \
+	mkdir -p /data /polkadot/.local/share && \
 	chown -R polkadot:polkadot /data && \
 	ln -s /data /polkadot/.local/share/polkadot
 

--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -27,8 +27,12 @@ RUN apt-get update && \
 	apt-get autoremove -y && \
 	apt-get clean && \
 	find /var/lib/apt/lists/ -type f -not -name lock -delete; \
-# add user
-	useradd -m -u 1000 -U -s /bin/sh -d /polkadot polkadot
+# add user and link ~/.local/share/polkadot to /data
+	useradd -m -u 1000 -U -s /bin/sh -d /polkadot polkadot && \
+	mkdir -p /polkadot/.local/share && \
+	mkdir /data && \
+	chown -R polkadot:polkadot /data && \
+	ln -s /data /polkadot/.local/share/polkadot
 
 # add polkadot binary to docker image
 COPY ./polkadot /usr/local/bin

--- a/scripts/docker/release.Dockerfile
+++ b/scripts/docker/release.Dockerfile
@@ -33,7 +33,11 @@ RUN apt-get update && \
 # apt cleanup
 		apt-get autoremove -y && \
 		apt-get clean && \
-		rm -rf /var/lib/apt/lists/*
+		rm -rf /var/lib/apt/lists/* ; \
+		mkdir -p /polkadot/.local/share && \
+		mkdir /data && \
+		chown -R polkadot:polkadot /data && \
+		ln -s /data /polkadot/.local/share/polkadot
 
 USER polkadot
 

--- a/scripts/docker/release.Dockerfile
+++ b/scripts/docker/release.Dockerfile
@@ -34,8 +34,7 @@ RUN apt-get update && \
 		apt-get autoremove -y && \
 		apt-get clean && \
 		rm -rf /var/lib/apt/lists/* ; \
-		mkdir -p /polkadot/.local/share && \
-		mkdir /data && \
+		mkdir -p /data /polkadot/.local/share && \
 		chown -R polkadot:polkadot /data && \
 		ln -s /data /polkadot/.local/share/polkadot
 


### PR DESCRIPTION
This PR adds a symlink from the chains directory to /data in the root directory in both our CI and release docker images. Brings them in line with https://github.com/paritytech/polkadot/blob/master/docker/Dockerfile and is also just a useful shortcut to have.

Fixes #2482