### PR TITLE
CI: build an image and trigger simnet

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -253,7 +253,7 @@ generate-impl-guide:
     reports:
       # this artifact is used in trigger-simnet job
       # https://docs.gitlab.com/ee/ci/multi_project_pipelines.html#with-variable-inheritance
-      dotenv: artifacts/build.env
+      dotenv: build.env
 
 
 publish-dockerhub:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -244,11 +244,11 @@ generate-impl-guide:
     - buildah info
     - buildah push --format=v2s2 "$IMAGE_NAME:$VERSION"
     - buildah push --format=v2s2 "$IMAGE_NAME:$EXTRATAG"
+    # pass artifacts to the trigget-simnet job
+    - echo "VERSION=${VERSION}" > build.env
+    - echo "TRIGGERER=${CI_PROJECT_NAME}" >> build.env
   after_script:
     - buildah logout "$IMAGE_NAME"
-    # only VERSION information is needed for the deployment
-    - echo "VERSION=${VERSION}" >> build.env
-    - echo "TRIGGERER=${CI_PROJECT_NAME}" >> build.env
   artifacts:
     reports:
       # this artifact is used in trigger-simnet job

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -148,23 +148,6 @@ check-runtime-benchmarks:
     - ./scripts/gitlab/check_runtime_benchmarks.sh
     - sccache -s
 
-#### stage:                        build
-
-check-transaction-versions:
-  image:                           node:15
-  stage:                           build
-  <<:                              *rules-test
-  <<:                              *docker-env
-  needs:
-    - job:                         test-linux-stable
-      artifacts:                   true
-  before_script:
-    - apt-get -y update; apt-get -y install jq lsof
-    - npm install --ignore-scripts -g @polkadot/metadata-cmp
-    - git fetch origin release
-  script:
-    - scripts/gitlab/check_extrinsics_ordering.sh
-
 .pack-artifacts:                   &pack-artifacts
   - mkdir -p ./artifacts
   - VERSION="${CI_COMMIT_REF_NAME}" # will be tag or branch name
@@ -183,7 +166,7 @@ check-transaction-versions:
   - cp -r scripts/docker/* ./artifacts
 
 build-linux-release:
-  stage:                           build
+  stage:                           test
   <<:                              *collect-artifacts
   <<:                              *docker-env
   <<:                              *compiler-info
@@ -195,13 +178,30 @@ build-linux-release:
       variables:
         EXTRA_FLAGS:               "--features=real-overseer"
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
-      when:                        manual
-      allow_failure:               true
+      variables:
+        EXTRA_FLAGS:               "--features=real-overseer"
     - when:                        always
   script:
     - time cargo build --release --verbose ${EXTRA_FLAGS}
     - sccache -s
     - *pack-artifacts
+
+#### stage:                        build
+
+check-transaction-versions:
+  image:                           node:15
+  stage:                           build
+  <<:                              *rules-test
+  <<:                              *docker-env
+  needs:
+    - job:                         test-linux-stable
+      artifacts:                   true
+  before_script:
+    - apt-get -y update; apt-get -y install jq lsof
+    - npm install --ignore-scripts -g @polkadot/metadata-cmp
+    - git fetch origin release
+  script:
+    - scripts/gitlab/check_extrinsics_ordering.sh
 
 generate-impl-guide:
   stage:                           build
@@ -213,12 +213,15 @@ generate-impl-guide:
   script:
     - mdbook build roadmap/implementers-guide
 
-#### stage:                        publish
-
 .build-push-docker-image:          &build-push-docker-image
   <<:                              *kubernetes-env
-  <<:                              *collect-artifacts
   image:                           quay.io/buildah/stable
+  variables:
+    GIT_STRATEGY:                  none
+    # DOCKERFILE:                  scripts/docker/Dockerfile
+    IMAGE_NAME:                    docker.io/parity/polkadot
+    DOCKER_USER:                   ${Docker_Hub_User_Parity}
+    DOCKER_PASS:                   ${Docker_Hub_Pass_Parity}
   before_script:                   &check-versions
     - test -s ./artifacts/VERSION || exit 1
     - test -s ./artifacts/EXTRATAG || exit 1
@@ -226,7 +229,7 @@ generate-impl-guide:
     - EXTRATAG="$(cat ./artifacts/EXTRATAG)"
     - echo "Polkadot version = ${VERSION} (EXTRATAG ${EXTRATAG})"
   script:
-    - test "$Docker_Hub_User_Parity" -a "$Docker_Hub_Pass_Parity" ||
+    - test "$DOCKER_USER" -a "$DOCKER_PASS" ||
         ( echo "no docker credentials provided"; exit 1 )
     - cd ./artifacts
     - buildah bud
@@ -236,23 +239,26 @@ generate-impl-guide:
         --tag "$IMAGE_NAME:$VERSION"
         --tag "$IMAGE_NAME:$EXTRATAG" .
     # The job will success only on the protected branch
-    - echo "$Docker_Hub_Pass_Parity" |
-        buildah login --username "$Docker_Hub_User_Parity" --password-stdin docker.io
+    - echo "$DOCKER_PASS" |
+        buildah login --username "$DOCKER_USER" --password-stdin docker.io
     - buildah info
     - buildah push --format=v2s2 "$IMAGE_NAME:$VERSION"
     - buildah push --format=v2s2 "$IMAGE_NAME:$EXTRATAG"
   after_script:
     - buildah logout "$IMAGE_NAME"
     # only VERSION information is needed for the deployment
-    - find ./artifacts/ -depth -not -name VERSION -not -name artifacts -delete
+    - echo "VERSION=${VERSION}" >> build.env
+    - echo "TRIGGERER=${CI_PROJECT_NAME}" >> build.env
+  artifacts:
+    reports:
+      # this artifact is used in trigger-simnet job
+      # https://docs.gitlab.com/ee/ci/multi_project_pipelines.html#with-variable-inheritance
+      dotenv: artifacts/build.env
+
 
 publish-dockerhub:
-  stage:                           publish
+  stage:                           build
   <<:                              *build-push-docker-image
-  variables:
-    GIT_STRATEGY:                  none
-    # DOCKERFILE:                  scripts/docker/Dockerfile
-    IMAGE_NAME:                    docker.io/parity/polkadot
   rules:
   # Don't run on releases - this is handled by the Github Action here:
   # .github/workflows/publish-docker-release.yml
@@ -261,12 +267,20 @@ publish-dockerhub:
     - if: $CI_COMMIT_REF_NAME == "rococo-v1"
       variables:
         IMAGE_NAME:                docker.io/parity/rococo
+    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
+      variables:
+        # image to be tested with Simnet
+        IMAGE_NAME:                docker.io/paritypr/rococo
+        DOCKER_USER:               ${PARITYPR_USER}
+        DOCKER_PASS:               ${PARITYPR_PASS}
     - if: $CI_PIPELINE_SOURCE == "schedule"
     - if: $CI_PIPELINE_SOURCE == "web"
     - if: $CI_COMMIT_REF_NAME == "master"
   needs:
     - job:                         build-linux-release
       artifacts:                   true
+
+#### stage:                        publish
 
 publish-s3-release:
   stage:                           publish
@@ -329,3 +343,13 @@ deploy-polkasync-kusama:
     POLKADOT_CI_COMMIT_REF:        "${CI_COMMIT_REF}"
   allow_failure:                   true
   trigger:                         "parity/infrastructure/parity-testnet"
+
+trigger-simnet:
+  stage:                           deploy
+  <<:                              *rules-test
+  needs:
+    - job:                         publish-dockerhub
+  trigger:
+    project:                       parity/simnet
+    branch:                        master
+    strategy:                      depend

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -270,7 +270,7 @@ publish-dockerhub:
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
       variables:
         # image to be tested with Simnet
-        IMAGE_NAME:                docker.io/paritypr/rococo
+        IMAGE_NAME:                docker.io/paritypr/synth-wave
         DOCKER_USER:               ${PARITYPR_USER}
         DOCKER_PASS:               ${PARITYPR_PASS}
     - if: $CI_PIPELINE_SOURCE == "schedule"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -245,7 +245,8 @@ generate-impl-guide:
     - buildah push --format=v2s2 "$IMAGE_NAME:$VERSION"
     - buildah push --format=v2s2 "$IMAGE_NAME:$EXTRATAG"
     # pass artifacts to the trigget-simnet job
-    - echo "VERSION=${VERSION}" > build.env
+    # this twist is to match the similar logic in substrate
+    - echo "VERSION=${EXTRATAG}" > build.env
     - echo "TRIGGERER=${CI_PROJECT_NAME}" >> build.env
   after_script:
     - buildah logout "$IMAGE_NAME"
@@ -349,6 +350,9 @@ trigger-simnet:
   <<:                              *rules-test
   needs:
     - job:                         publish-dockerhub
+  # build.env is passed with an exact VERSION (EXTRATAG here, i.e. 2643-0.8.29-5f689e0a-6b24dc54)
+  # Simnet uses an image published on PRs with this exact version for triggered runs on commits.
+  # And parity/rococo:rococo-v1 for runs not launched by this job.
   trigger:
     project:                       parity/simnet
     branch:                        master


### PR DESCRIPTION
- builds the binary with `--features=real-overseer` for every PR commit
- `docker.io/paritypr/synth-wave:$VERSION` for every PR commit
- triggers `trigger-simnet:` with the exact `$VERSION` as an image tag on every PR commit
optimization:
- moves `build-linux-release:` to the `build` phase 
- and `publish-dockerhub:` to `build` phase
  this could've been not good for releasing, but we do the serious releases the other way.
