### PR TITLE
Fix check-labels.yml for forked repos

### DIFF
--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -12,6 +12,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Check labels
         run: bash ${{ github.workspace }}/scripts/github/check_labels.sh
         env:

--- a/scripts/github/check_labels.sh
+++ b/scripts/github/check_labels.sh
@@ -31,10 +31,11 @@ priority_labels=(
 )
 
 audit_labels=(
-  'D1-trivial'
-  'D1-audited👍'
-  'D5-nicetohaveaudit⚠️ '
-  'D9-needsaudit👮'
+  'D1-audited 👍'
+  'D2-notlive 💤'
+  'D3-trivial 🧸'
+  'D5-nicetohaveaudit ⚠️'
+  'D9-needsaudit 👮'
 )
 
 echo "[+] Checking release notes (B) labels for $CI_COMMIT_BRANCH"


### PR DESCRIPTION
Need to include the name of the forked repository to check it out correctly. Same as https://github.com/paritytech/substrate/pull/8387