### PR TITLE
Evict inactive peers from the collator protocol peer-set

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5365,6 +5365,7 @@ dependencies = [
  "assert_matches",
  "env_logger 0.8.2",
  "futures 0.3.12",
+ "futures-timer 3.0.2",
  "log",
  "polkadot-node-network-protocol",
  "polkadot-node-primitives",

--- a/node/network/bridge/src/action.rs
+++ b/node/network/bridge/src/action.rs
@@ -57,6 +57,9 @@ pub(crate) enum Action {
 	/// Report a peer to the network implementation (decreasing/increasing its reputation).
 	ReportPeer(PeerId, UnifiedReputationChange),
 
+	/// Disconnect a peer from the given peer-set without affecting their reputation.
+	DisconnectPeer(PeerId, PeerSet),
+
 	/// A subsystem updates us on the relay chain leaves we consider active.
 	///
 	/// Implementation will send `WireMessage::ViewUpdate` message to peers as appropriate to the
@@ -119,6 +122,9 @@ impl From<polkadot_subsystem::SubsystemResult<FromOverseer<NetworkBridgeMessage>
 			}
 			Ok(FromOverseer::Communication { msg }) => match msg {
 				NetworkBridgeMessage::ReportPeer(peer, rep) => Action::ReportPeer(peer, rep),
+				NetworkBridgeMessage::DisconnectPeer(peer, peer_set) => {
+					Action::DisconnectPeer(peer, peer_set)
+				}
 				NetworkBridgeMessage::SendValidationMessage(peers, msg) => {
 					Action::SendValidationMessages(vec![(peers, msg)])
 				}

--- a/node/network/bridge/src/lib.rs
+++ b/node/network/bridge/src/lib.rs
@@ -297,6 +297,16 @@ where
 				bridge.network_service.report_peer(peer, rep).await?
 			}
 
+			Action::DisconnectPeer(peer, peer_set) => {
+				tracing::debug!(
+					target: LOG_TARGET,
+					action = "DisconnectPeer",
+					?peer,
+					peer_set = ?peer_set,
+				);
+				bridge.network_service.disconnect_peer(peer, peer_set);
+			}
+
 			Action::ActiveLeaves(ActiveLeavesUpdate { activated, deactivated }) => {
 				tracing::debug!(
 					target: LOG_TARGET,

--- a/node/network/collator-protocol/Cargo.toml
+++ b/node/network/collator-protocol/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 futures = "0.3.12"
 tracing = "0.1.25"
 thiserror = "1.0.23"
+futures-timer = "3"
 
 polkadot-primitives = { path = "../../../primitives" }
 polkadot-node-network-protocol = { path = "../../network/protocol" }

--- a/node/network/collator-protocol/src/validator_side.rs
+++ b/node/network/collator-protocol/src/validator_side.rs
@@ -673,7 +673,7 @@ pub(crate) async fn run<Context>(
 	let next_inactivity_stream = futures::stream::unfold(
 		Instant::now() + ACTIVITY_POLL,
 		|next_check| async move { Some(((), wait_until_next_check(next_check).await)) }
-	);
+	).fuse();
 
 	futures::pin_mut!(next_inactivity_stream);
 

--- a/node/network/collator-protocol/src/validator_side.rs
+++ b/node/network/collator-protocol/src/validator_side.rs
@@ -654,7 +654,6 @@ async fn wait_until_next_check(last_poll: Instant) -> Instant {
 	let next_poll = last_poll + ACTIVITY_POLL;
 
 	if next_poll > now {
-		println!("waiting {:?}", next_poll - now);
 		Delay::new(next_poll - now).await
 	}
 
@@ -712,7 +711,6 @@ pub(crate) async fn run<Context>(
 				continue
 			}
 			Some(Either::Right(())) => {
-				println!("disconnecting inactive of {}", state.peer_data.len());
 				disconnect_inactive_peers(&mut ctx, &state.peer_data).await;
 				continue
 			}
@@ -749,7 +747,6 @@ async fn disconnect_inactive_peers(
 	};
 
 	for (peer, peer_data) in peers {
-		println!("peer {:?} active at {:?} cutoff {:?}", peer, peer_data.last_active, cutoff);
 		if !peer_data.active_since(cutoff) {
 			ctx.send_message(
 				NetworkBridgeMessage::DisconnectPeer(peer.clone(), PeerSet::Collation).into()

--- a/node/network/collator-protocol/src/validator_side.rs
+++ b/node/network/collator-protocol/src/validator_side.rs
@@ -47,12 +47,11 @@ const COST_CORRUPTED_MESSAGE: Rep = Rep::CostMinor("Message was corrupt");
 /// Network errors that originated at the remote host should have same cost as timeout.
 const COST_NETWORK_ERROR: Rep = Rep::CostMinor("Some network error");
 const COST_REQUEST_TIMED_OUT: Rep = Rep::CostMinor("A collation request has timed out");
-const COST_REPORT_BAD: Rep = Rep::CostMajor("A collator was reported by another subsystem");
+const COST_REPORT_BAD: Rep = Rep::Malicious("A collator was reported by another subsystem");
 const BENEFIT_NOTIFY_GOOD: Rep = Rep::BenefitMinor("A collator was noted good by another subsystem");
 
 #[derive(Clone, Default)]
 pub struct Metrics(Option<MetricsInner>);
-
 
 impl Metrics {
 	fn on_request(&self, succeeded: std::result::Result<(), ()>) {

--- a/node/network/protocol/src/reputation.rs
+++ b/node/network/protocol/src/reputation.rs
@@ -32,7 +32,7 @@ impl UnifiedReputationChange {
 			Self::CostMajor(_) => -300_000,
 			Self::CostMinorRepeated(_) => -200_000,
 			Self::CostMajorRepeated(_) => -600_000,
-			Self::Malicious(_) => -1_000_000,
+			Self::Malicious(_) => i32::min_value(),
 			Self::BenefitMajorFirst(_) => 300_000,
 			Self::BenefitMajor(_) => 200_000,
 			Self::BenefitMinorFirst(_) => 15_000,

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -503,7 +503,7 @@ where
 		collator_protocol: {
 			let side = match is_collator {
 				IsCollator::Yes(id) => ProtocolSide::Collator(id, Metrics::register(registry)?),
-				IsCollator::No => ProtocolSide::Validator(Metrics::register(registry)?),
+				IsCollator::No => ProtocolSide::Validator(Default::default(),Metrics::register(registry)?),
 			};
 			CollatorProtocolSubsystem::new(
 				side,

--- a/node/subsystem/src/messages.rs
+++ b/node/subsystem/src/messages.rs
@@ -211,6 +211,9 @@ pub enum NetworkBridgeMessage {
 	/// Report a peer for their actions.
 	ReportPeer(PeerId, UnifiedReputationChange),
 
+	/// Disconnect a peer from the given peer-set without affecting their reputation.
+	DisconnectPeer(PeerSet, PeerId),
+
 	/// Send a message to one or more peers on the validation peer-set.
 	SendValidationMessage(Vec<PeerId>, protocol_v1::ValidationProtocol),
 

--- a/node/subsystem/src/messages.rs
+++ b/node/subsystem/src/messages.rs
@@ -252,6 +252,7 @@ impl NetworkBridgeMessage {
 	pub fn relay_parent(&self) -> Option<Hash> {
 		match self {
 			Self::ReportPeer(_, _) => None,
+			Self::DisconnectPeer(_, _) => None,
 			Self::SendValidationMessage(_, _) => None,
 			Self::SendCollationMessage(_, _) => None,
 			Self::SendValidationMessages(_) => None,

--- a/node/subsystem/src/messages.rs
+++ b/node/subsystem/src/messages.rs
@@ -212,7 +212,7 @@ pub enum NetworkBridgeMessage {
 	ReportPeer(PeerId, UnifiedReputationChange),
 
 	/// Disconnect a peer from the given peer-set without affecting their reputation.
-	DisconnectPeer(PeerSet, PeerId),
+	DisconnectPeer(PeerId, PeerSet),
 
 	/// Send a message to one or more peers on the validation peer-set.
 	SendValidationMessage(Vec<PeerId>, protocol_v1::ValidationProtocol),

--- a/roadmap/implementers-guide/src/node/utility/network-bridge.md
+++ b/roadmap/implementers-guide/src/node/utility/network-bridge.md
@@ -86,6 +86,10 @@ Map the message onto the corresponding [Event Handler](#event-handlers) based on
 
 - Adjust peer reputation according to cost or benefit provided
 
+### DisconnectPeer
+
+- Disconnect the peer from the peer-set requested, if connected.
+
 ### SendValidationMessage / SendValidationMessages
 
 - Issue a corresponding `ProtocolMessage` to each listed peer on the validation peer-set.

--- a/roadmap/implementers-guide/src/types/overseer-protocol.md
+++ b/roadmap/implementers-guide/src/types/overseer-protocol.md
@@ -329,6 +329,8 @@ enum PeerSet {
 enum NetworkBridgeMessage {
     /// Report a cost or benefit of a peer. Negative values are costs, positive are benefits.
     ReportPeer(PeerSet, PeerId, cost_benefit: i32),
+    /// Disconnect a peer from the given peer-set without affecting their reputation.
+    DisconnectPeer(PeerSet, PeerId),
     /// Send a message to one or more peers on the validation peerset.
     SendValidationMessage([PeerId], ValidationProtocolV1),
     /// Send a message to one or more peers on the collation peerset.

--- a/roadmap/implementers-guide/src/types/overseer-protocol.md
+++ b/roadmap/implementers-guide/src/types/overseer-protocol.md
@@ -328,9 +328,9 @@ enum PeerSet {
 
 enum NetworkBridgeMessage {
     /// Report a cost or benefit of a peer. Negative values are costs, positive are benefits.
-    ReportPeer(PeerSet, PeerId, cost_benefit: i32),
+    ReportPeer(PeerId, cost_benefit: i32),
     /// Disconnect a peer from the given peer-set without affecting their reputation.
-    DisconnectPeer(PeerSet, PeerId),
+    DisconnectPeer(PeerId, PeerSet),
     /// Send a message to one or more peers on the validation peerset.
     SendValidationMessage([PeerId], ValidationProtocolV1),
     /// Send a message to one or more peers on the collation peerset.


### PR DESCRIPTION
Closes #2679 , #2678 

...and ensure that cheap tricks to extend activity are punished with negative reputation.

This also exposes a wrapper around `NetworkBridge::disconnect_peer` for use by subsystems.