### PR TITLE
Bigger is better.

### DIFF
--- a/node/network/protocol/src/request_response/mod.rs
+++ b/node/network/protocol/src/request_response/mod.rs
@@ -100,9 +100,9 @@ impl Protocol {
 				name: p_name,
 				max_request_size: 10_000,
 				/// Collations are expected to be around 10Meg, probably much smaller with
-				/// compression. So 20Meg should be well sufficient, we might be able to reduce
+				/// compression. So 30Meg should be well sufficient, we might be able to reduce
 				/// this further, if needed.
-				max_response_size: 20_000_000,
+				max_response_size: 30_000_000,
 				// Taken from initial implementation in collator protocol:
 				request_timeout: DEFAULT_REQUEST_TIMEOUT_CONNECTED,
 				inbound_queue: Some(tx),

--- a/node/network/protocol/src/request_response/mod.rs
+++ b/node/network/protocol/src/request_response/mod.rs
@@ -91,18 +91,18 @@ impl Protocol {
 		let cfg = match self {
 			Protocol::AvailabilityFetching => RequestResponseConfig {
 				name: p_name,
-				max_request_size: 1_000,
-				max_response_size: 100_000,
+				max_request_size: 10_000,
+				max_response_size: 10_000_000,
 				request_timeout: DEFAULT_REQUEST_TIMEOUT,
 				inbound_queue: Some(tx),
 			},
 			Protocol::CollationFetching => RequestResponseConfig {
 				name: p_name,
-				max_request_size: 1_000,
+				max_request_size: 10_000,
 				/// Collations are expected to be around 10Meg, probably much smaller with
 				/// compression. So 10Meg should be sufficient, we might be able to reduce this
 				/// further.
-				max_response_size: 10_000_000,
+				max_response_size: 100_000_000,
 				// Taken from initial implementation in collator protocol:
 				request_timeout: DEFAULT_REQUEST_TIMEOUT_CONNECTED,
 				inbound_queue: Some(tx),

--- a/node/network/protocol/src/request_response/mod.rs
+++ b/node/network/protocol/src/request_response/mod.rs
@@ -100,8 +100,8 @@ impl Protocol {
 				name: p_name,
 				max_request_size: 10_000,
 				/// Collations are expected to be around 10Meg, probably much smaller with
-				/// compression. So 10Meg should be sufficient, we might be able to reduce this
-				/// further.
+				/// compression. So 20Meg should be well sufficient, we might be able to reduce
+				/// this further, if needed.
 				max_response_size: 20_000_000,
 				// Taken from initial implementation in collator protocol:
 				request_timeout: DEFAULT_REQUEST_TIMEOUT_CONNECTED,

--- a/node/network/protocol/src/request_response/mod.rs
+++ b/node/network/protocol/src/request_response/mod.rs
@@ -102,7 +102,7 @@ impl Protocol {
 				/// Collations are expected to be around 10Meg, probably much smaller with
 				/// compression. So 10Meg should be sufficient, we might be able to reduce this
 				/// further.
-				max_response_size: 100_000_000,
+				max_response_size: 20_000_000,
 				// Taken from initial implementation in collator protocol:
 				request_timeout: DEFAULT_REQUEST_TIMEOUT_CONNECTED,
 				inbound_queue: Some(tx),


### PR DESCRIPTION
Made all request response sizes 10 times bigger, so we much less likely hit the limit for legitimate purposes.