### PR TITLE
use validators.len(), not shuffling

### DIFF
--- a/node/network/availability-recovery/src/lib.rs
+++ b/node/network/availability-recovery/src/lib.rs
@@ -444,7 +444,7 @@ impl RequestChunksPhase {
 			if is_unavailable(
 				self.received_chunks.len(),
 				self.requesting_chunks.len(),
-				self.shuffling.len(),
+				params.validators.len(),
 				params.threshold,
 			) {
 				tracing::debug!(
@@ -453,7 +453,7 @@ impl RequestChunksPhase {
 					erasure_root = ?params.erasure_root,
 					received = %self.received_chunks.len(),
 					requesting = %self.requesting_chunks.len(),
-					n_validators = %self.shuffling.len(),
+					n_validators = %params.validators.len(),
 					"Data recovery is not possible",
 				);
 				to_state.send(FromInteraction::Concluded(


### PR DESCRIPTION
`self.shuffling` is reduced in size over time