### PR TITLE
Reduce network bridge logging verbosity

### DIFF
--- a/node/network/bridge/src/lib.rs
+++ b/node/network/bridge/src/lib.rs
@@ -290,7 +290,7 @@ where
 			},
 
 			Action::ReportPeer(peer, rep) => {
-				tracing::trace!(
+				tracing::debug!(
 					target: LOG_TARGET,
 					action = "ReportPeer"
 				);

--- a/node/network/bridge/src/lib.rs
+++ b/node/network/bridge/src/lib.rs
@@ -218,7 +218,7 @@ where
 			}
 
 			Action::SendValidationMessages(msgs) => {
-				tracing::debug!(
+				tracing::trace!(
 					target: LOG_TARGET,
 					action = "SendValidationMessages",
 					num_messages = %msgs.len(),
@@ -235,7 +235,7 @@ where
 			}
 
 			Action::SendCollationMessages(msgs) => {
-				tracing::debug!(
+				tracing::trace!(
 					target: LOG_TARGET,
 					action = "SendCollationMessages",
 					num_messages = %msgs.len(),
@@ -252,7 +252,7 @@ where
 			}
 
 			Action::SendRequests(reqs, if_disconnected) => {
-				tracing::debug!(
+				tracing::trace!(
 					target: LOG_TARGET,
 					action = "SendRequests",
 					num_requests = %reqs.len(),
@@ -271,7 +271,7 @@ where
 				peer_set,
 				connected,
 			} => {
-				tracing::debug!(
+				tracing::trace!(
 					target: LOG_TARGET,
 					action = "ConnectToValidators",
 					peer_set = ?peer_set,
@@ -290,7 +290,7 @@ where
 			},
 
 			Action::ReportPeer(peer, rep) => {
-				tracing::debug!(
+				tracing::trace!(
 					target: LOG_TARGET,
 					action = "ReportPeer"
 				);
@@ -298,7 +298,7 @@ where
 			}
 
 			Action::DisconnectPeer(peer, peer_set) => {
-				tracing::debug!(
+				tracing::trace!(
 					target: LOG_TARGET,
 					action = "DisconnectPeer",
 					?peer,
@@ -308,7 +308,7 @@ where
 			}
 
 			Action::ActiveLeaves(ActiveLeavesUpdate { activated, deactivated }) => {
-				tracing::debug!(
+				tracing::trace!(
 					target: LOG_TARGET,
 					action = "ActiveLeaves",
 					num_activated = %activated.len(),
@@ -330,7 +330,7 @@ where
 			}
 
 			Action::BlockFinalized(number) => {
-				tracing::debug!(
+				tracing::trace!(
 					target: LOG_TARGET,
 					action = "BlockFinalized"
 				);
@@ -345,7 +345,7 @@ where
 			},
 
 			Action::PeerConnected(peer_set, peer, role) => {
-				tracing::debug!(
+				tracing::trace!(
 					target: LOG_TARGET,
 					action = "PeerConnected",
 					peer_set = ?peer_set,
@@ -419,7 +419,7 @@ where
 				}
 			}
 			Action::PeerDisconnected(peer_set, peer) => {
-				tracing::debug!(
+				tracing::trace!(
 					target: LOG_TARGET,
 					action = "PeerDisconnected",
 					peer_set = ?peer_set,
@@ -447,7 +447,7 @@ where
 				}
 			},
 			Action::PeerMessages(peer, v_messages, c_messages) => {
-				tracing::debug!(
+				tracing::trace!(
 					target: LOG_TARGET,
 					action = "PeerMessages",
 					peer = ?peer,
@@ -480,7 +480,7 @@ where
 			Action::SendMessage(msg) => ctx.send_message(msg).await,
 		}
 
-		tracing::debug!(
+		tracing::trace!(
 			target: LOG_TARGET,
 			elapsed = ?before_action_process.elapsed(),
 			"Processed action",


### PR DESCRIPTION
- Very spammy
- And they in fact trace the execution
- Should not be enabled lightly - will slow network bridge down.