### PR TITLE
Introduce `add_memo` for Crowdloans

### DIFF
--- a/runtime/common/src/crowdloan.rs
+++ b/runtime/common/src/crowdloan.rs
@@ -247,6 +247,8 @@ decl_event! {
 		HandleBidResult(ParaId, DispatchResult),
 		/// The configuration to a crowdloan has been edited. [fund_index]
 		Edited(ParaId),
+		/// A memo has been updated. [who, fund_index, memo]
+		MemoUpdated(AccountId, ParaId, Vec<u8>),
 	}
 }
 
@@ -552,6 +554,7 @@ decl_module! {
 			ensure!(balance > Zero::zero(), Error::<T>::NoContributions);
 
 			Self::contribution_put(fund.trie_index, &who, &balance, &memo);
+			Self::deposit_event(RawEvent::MemoUpdated(who, index, memo));
 		}
 
 		fn on_initialize(n: T::BlockNumber) -> frame_support::weights::Weight {

--- a/runtime/common/src/crowdloan.rs
+++ b/runtime/common/src/crowdloan.rs
@@ -1339,18 +1339,25 @@ mod tests {
 			let para_1 = new_para();
 
 			assert_ok!(Crowdloan::create(Origin::signed(1), para_1, 1000, 1, 1, 9, None));
+			// Cant add a memo before you have contributed.
 			assert_noop!(
 				Crowdloan::add_memo(Origin::signed(1), para_1, b"hello, world".to_vec()),
 				Error::<Test>::NoContributions,
 			);
+			// Make a contribution. Initially no memo.
+			assert_ok!(Crowdloan::contribute(Origin::signed(1), para_1, 100, None));
+			assert_eq!(Crowdloan::contribution_get(0u32, &1), (100, vec![]));
+			// Can't place a memo that is too large.
 			assert_noop!(
 				Crowdloan::add_memo(Origin::signed(1), para_1, vec![123; 123]),
 				Error::<Test>::MemoTooLarge,
 			);
-			assert_ok!(Crowdloan::contribute(Origin::signed(1), para_1, 100, None));
-			assert_eq!(Crowdloan::contribution_get(0u32, &1), (100, vec![]));
+			// Adding a memo to an existing contribution works
 			assert_ok!(Crowdloan::add_memo(Origin::signed(1), para_1, b"hello, world".to_vec()));
 			assert_eq!(Crowdloan::contribution_get(0u32, &1), (100, b"hello, world".to_vec()));
+			// Can contribute again and data persists
+			assert_ok!(Crowdloan::contribute(Origin::signed(1), para_1, 100, None));
+			assert_eq!(Crowdloan::contribution_get(0u32, &1), (200, b"hello, world".to_vec()));
 		});
 	}
 }

--- a/runtime/common/src/crowdloan.rs
+++ b/runtime/common/src/crowdloan.rs
@@ -101,6 +101,7 @@ pub trait WeightInfo {
 	fn withdraw() -> Weight;
 	fn dissolve(k: u32, ) -> Weight;
 	fn edit() -> Weight;
+	fn add_memo() -> Weight;
 	fn on_initialize(n: u32, ) -> Weight;
 }
 
@@ -111,6 +112,7 @@ impl WeightInfo for TestWeightInfo {
 	fn withdraw() -> Weight { 0 }
 	fn dissolve(_k: u32, ) -> Weight { 0 }
 	fn edit() -> Weight { 0 }
+	fn add_memo() -> Weight { 0 }
 	fn on_initialize(_n: u32, ) -> Weight { 0 }
 }
 
@@ -546,7 +548,7 @@ decl_module! {
 		/// Add an optional memo to an existing crowdloan contribution.
 		///
 		/// Origin must be Signed, and the user must have contributed to the crowdloan.
-		#[weight = 0]
+		#[weight = T::WeightInfo::add_memo()]
 		pub fn add_memo(origin, index: ParaId, memo: Vec<u8>) {
 			let who = ensure_signed(origin)?;
 

--- a/runtime/common/src/integration_tests.rs
+++ b/runtime/common/src/integration_tests.rs
@@ -216,7 +216,7 @@ parameter_types! {
 	pub const MinContribution: Balance = 1;
 	pub const RetirementPeriod: BlockNumber = 10;
 	pub const RemoveKeysLimit: u32 = 100;
-
+	pub const MaxMemoLength: u8 = 32;
 }
 
 impl crowdloan::Config for Test {
@@ -229,6 +229,7 @@ impl crowdloan::Config for Test {
 	type RemoveKeysLimit = RemoveKeysLimit;
 	type Registrar = Registrar;
 	type Auctioneer = Auctions;
+	type MaxMemoLength = MaxMemoLength;
 	type WeightInfo = crate::crowdloan::TestWeightInfo;
 }
 

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -660,6 +660,8 @@ parameter_types! {
 	pub const MinContribution: Balance = 1 * DOLLARS;
 	pub const RetirementPeriod: BlockNumber = 6 * HOURS;
 	pub const RemoveKeysLimit: u32 = 500;
+	// Allow 32 bytes for an additional memo to a crowdloan.
+	pub const MaxMemoLength: u8 = 32;
 }
 
 impl crowdloan::Config for Runtime {
@@ -672,6 +674,7 @@ impl crowdloan::Config for Runtime {
 	type RemoveKeysLimit = RemoveKeysLimit;
 	type Registrar = Registrar;
 	type Auctioneer = Auctions;
+	type MaxMemoLength = MaxMemoLength;
 	type WeightInfo = crowdloan::TestWeightInfo;
 }
 


### PR DESCRIPTION
This PR introduces an additional extrinsic where a user can place some additional "memo" to a crowdloan contribution they have made.

The main reason to use this is to specify some other account that should receive the token distribution for a crowdloan you participated in.

cc @joshorndorff @xlc @jacogr 