### PR TITLE
Handle Onboarding in Current Lease Period

### DIFF
--- a/runtime/common/src/mock.rs
+++ b/runtime/common/src/mock.rs
@@ -19,7 +19,7 @@
 use std::{cell::RefCell, collections::HashMap};
 use parity_scale_codec::{Encode, Decode};
 use sp_runtime::traits::SaturatedConversion;
-use frame_support::dispatch::DispatchResult;
+use frame_support::dispatch::{DispatchError, DispatchResult};
 use primitives::v1::{HeadData, ValidationCode, Id as ParaId};
 use crate::traits::Registrar;
 
@@ -57,18 +57,21 @@ impl<T: frame_system::Config> Registrar for TestRegistrar<T> {
 		PARACHAINS.with(|x| {
 			let parachains = x.borrow_mut();
 			match parachains.binary_search(&id) {
-				Ok(_) => panic!("Already Parachain"),
-				Err(_) => {},
+				Ok(_) => Err(DispatchError::Other("Already Parachain")),
+				Err(_) => Ok(()),
 			}
-		});
+		})?;
 		// Should not be parathread, then make it.
 		PARATHREADS.with(|x| {
 			let mut parathreads = x.borrow_mut();
 			match parathreads.binary_search(&id) {
-				Ok(_) => panic!("Already Parathread"),
-				Err(i) => parathreads.insert(i, id),
+				Ok(_) => Err(DispatchError::Other("Already Parathread")),
+				Err(i) => {
+					parathreads.insert(i, id);
+					Ok(())
+				},
 			}
-		});
+		})?;
 		MANAGERS.with(|x| x.borrow_mut().insert(id, manager.encode()));
 		Ok(())
 	}
@@ -76,66 +79,77 @@ impl<T: frame_system::Config> Registrar for TestRegistrar<T> {
 	fn deregister(id: ParaId) -> DispatchResult {
 		// Should not be parachain.
 		PARACHAINS.with(|x| {
-			let mut parachains = x.borrow_mut();
+			let parachains = x.borrow_mut();
 			match parachains.binary_search(&id) {
-				Ok(i) => {
-					parachains.remove(i);
-				},
-				Err(_) => {},
+				Ok(_) => Err(DispatchError::Other("cannot deregister parachain")),
+				Err(_) => Ok(()),
 			}
-		});
+		})?;
 		// Remove from parathread.
 		PARATHREADS.with(|x| {
 			let mut parathreads = x.borrow_mut();
 			match parathreads.binary_search(&id) {
 				Ok(i) => {
 					parathreads.remove(i);
+					Ok(())
 				},
-				Err(_) => {},
+				Err(_) => Err(DispatchError::Other("not parathread, so cannot `deregister`")),
 			}
-		});
+		})?;
 		MANAGERS.with(|x| x.borrow_mut().remove(&id));
 		Ok(())
 	}
 
 	fn make_parachain(id: ParaId) -> DispatchResult {
-		OPERATIONS.with(|x| x.borrow_mut().push((id, frame_system::Pallet::<T>::block_number().saturated_into(), true)));
 		PARATHREADS.with(|x| {
 			let mut parathreads = x.borrow_mut();
 			match parathreads.binary_search(&id) {
 				Ok(i) => {
 					parathreads.remove(i);
+					Ok(())
 				},
-				Err(_) => panic!("not parathread, so cannot `make_parachain`"),
+				Err(_) => Err(DispatchError::Other("not parathread, so cannot `make_parachain`")),
 			}
-		});
+		})?;
 		PARACHAINS.with(|x| {
 			let mut parachains = x.borrow_mut();
 			match parachains.binary_search(&id) {
-				Ok(_) => {},
-				Err(i) => parachains.insert(i, id),
+				Ok(_) => Err(DispatchError::Other("already parachain, so cannot `make_parachain`")),
+				Err(i) => {
+					parachains.insert(i, id);
+					Ok(())
+				},
 			}
-		});
+		})?;
+		OPERATIONS.with(|x| x.borrow_mut().push(
+			(id, frame_system::Pallet::<T>::block_number().saturated_into(), true)
+		));
 		Ok(())
 	}
 	fn make_parathread(id: ParaId) -> DispatchResult {
-		OPERATIONS.with(|x| x.borrow_mut().push((id, frame_system::Pallet::<T>::block_number().saturated_into(), false)));
 		PARACHAINS.with(|x| {
 			let mut parachains = x.borrow_mut();
 			match parachains.binary_search(&id) {
 				Ok(i) => {
 					parachains.remove(i);
+					Ok(())
 				},
-				Err(_) => panic!("not parachain, so cannot `make_parathread`"),
+				Err(_) => Err(DispatchError::Other("not parachain, so cannot `make_parathread`")),
 			}
-		});
+		})?;
 		PARATHREADS.with(|x| {
 			let mut parathreads = x.borrow_mut();
 			match parathreads.binary_search(&id) {
-				Ok(_) => {},
-				Err(i) => parathreads.insert(i, id),
+				Ok(_) => Err(DispatchError::Other("already parathread, so cannot `make_parathread`")),
+				Err(i) => {
+					parathreads.insert(i, id);
+					Ok(())
+				},
 			}
-		});
+		})?;
+		OPERATIONS.with(|x| x.borrow_mut().push(
+			(id, frame_system::Pallet::<T>::block_number().saturated_into(), false)
+		));
 		Ok(())
 	}
 

--- a/runtime/common/src/slots.rs
+++ b/runtime/common/src/slots.rs
@@ -200,7 +200,7 @@ decl_module! {
 		///
 		/// Origin must be signed, but can be called by anyone.
 		#[weight = T::WeightInfo::trigger_onboard()]
-		fn trigger_onboard(origin, para: ParaId) {
+		fn trigger_onboard(origin, para: ParaId) -> DispatchResult {
 			let _ = ensure_signed(origin)?;
 			let leases = Leases::<T>::get(para);
 			match leases.first() {
@@ -213,7 +213,8 @@ decl_module! {
 				Some(None) | None => {
 					return Err(Error::<T>::ParaNotOnboarding.into());
 				}
-			}
+			};
+			Ok(())
 		}
 	}
 }
@@ -407,8 +408,8 @@ impl<T: Config> Leaser for Module<T> {
 			// Check if current lease period is same as period begin, and onboard them directly.
 			// This will allow us to support onboarding new parachains in the middle of a lease period.
 			if current_lease_period == period_begin {
-				let res = T::Registrar::make_parachain(para);
-				debug_assert!(res.is_ok());
+				// Best effort. Not much we can do if this fails.
+				let _ = T::Registrar::make_parachain(para);
 			}
 
 			Self::deposit_event(

--- a/runtime/common/src/slots.rs
+++ b/runtime/common/src/slots.rs
@@ -817,6 +817,9 @@ mod tests {
 			// Para 3 should fail cause their lease is in the future
 			assert_noop!(Slots::trigger_onboard(Origin::signed(1), 3.into()), Error::<Test>::ParaNotOnboarding);
 
+			// Trying Para 2 again should fail cause they are not currently a parathread
+			assert!(Slots::trigger_onboard(Origin::signed(1), 2.into()).is_err());
+
 			assert_eq!(TestRegistrar::<Test>::operations(), vec![
 				(2.into(), 1, true),
 			]);

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -627,7 +627,7 @@ impl Randomness<Hash, BlockNumber> for ParentHashRandomness {
 }
 
 parameter_types! {
-	pub const EndingPeriod: BlockNumber = 15 * MINUTES;
+	pub const EndingPeriod: BlockNumber = 1 * HOURS;
 	pub const SampleLength: BlockNumber = 1;
 }
 


### PR DESCRIPTION
This PR introduces two features which can help us handle parachains that should onboard in the current lease period:

* When we call `lease_out`, if the current lease period index is the same as the first slot they won, try to onboard them automatically.
* If there are any issues onboarding a parachain with an active lease during the current lease period, anyone can call `trigger_onboard` to resolve that and trigger an onboarding.