### PR TITLE
approval-distribution: moar logs

### DIFF
--- a/node/network/approval-distribution/src/lib.rs
+++ b/node/network/approval-distribution/src/lib.rs
@@ -526,7 +526,18 @@ impl State {
 		} else {
 			if !entry.knowledge.known_messages.insert(fingerprint.clone()) {
 				// if we already imported an assignment, there is no need to distribute it again
+				tracing::warn!(
+					target: LOG_TARGET,
+					?fingerprint,
+					"Importing locally an already known assignment",
+				);
 				return;
+			} else {
+				tracing::debug!(
+					target: LOG_TARGET,
+					?fingerprint,
+					"Importing locally a new assignment",
+				);
 			}
 		}
 
@@ -575,7 +586,7 @@ impl State {
 		if !peers.is_empty() {
 			tracing::trace!(
 				target: LOG_TARGET,
-				"Sending assignment (block={}, index={})to {} peers",
+				"Sending assignment (block={}, index={}) to {} peers",
 				block_hash,
 				claimed_candidate_index,
 				peers.len(),
@@ -724,7 +735,18 @@ impl State {
 		} else {
 			if !entry.knowledge.known_messages.insert(fingerprint.clone()) {
 				// if we already imported an approval, there is no need to distribute it again
+				tracing::warn!(
+					target: LOG_TARGET,
+					?fingerprint,
+					"Importing locally an already known approval",
+				);
 				return;
+			} else {
+				tracing::debug!(
+					target: LOG_TARGET,
+					?fingerprint,
+					"Importing locally a new approval",
+				);
 			}
 		}
 


### PR DESCRIPTION
I think a `warn!` is justified as the approval-voting shouldn't issue an import of the same assignment/approval.