### PR TITLE
Max notification size -> 100k.

### DIFF
--- a/node/network/protocol/src/peer_set.rs
+++ b/node/network/protocol/src/peer_set.rs
@@ -48,9 +48,7 @@ impl PeerSet {
 	/// network service.
 	pub fn get_info(self, is_authority: IsAuthority) -> NonDefaultSetConfig {
 		let protocol = self.into_protocol_name();
-		// TODO: lower this limit after https://github.com/paritytech/polkadot/issues/2283 is
-		// done and collations use request-response protocols
-		let max_notification_size = 16 * 1024 * 1024;
+		let max_notification_size = 100 * 1024;
 
 		match self {
 			PeerSet::Validation => NonDefaultSetConfig {


### PR DESCRIPTION
Can be merged once we have PoV distribution on request response and also runtime fetching on request response.