### PR TITLE
Less connected graph for rococo

### DIFF
--- a/node/network/gossip-support/src/lib.rs
+++ b/node/network/gossip-support/src/lib.rs
@@ -109,7 +109,7 @@ fn choose_random_subset<T>(mut v: Vec<T>) -> Vec<T> {
 	v.shuffle(&mut rng);
 
 	let sqrt = (v.len() as f64).sqrt() as usize;
-	let len = std::cmp::max(25, sqrt);
+	let len = std::cmp::max(4, sqrt);
 	v.truncate(len);
 	v
 }

--- a/node/network/protocol/src/peer_set.rs
+++ b/node/network/protocol/src/peer_set.rs
@@ -57,7 +57,7 @@ impl PeerSet {
 				notifications_protocol: protocol,
 				max_notification_size,
 				set_config: sc_network::config::SetConfig {
-					in_peers: 25,
+					in_peers: 4,
 					out_peers: 0,
 					reserved_nodes: Vec::new(),
 					non_reserved_mode: sc_network::config::NonReservedPeerMode::Accept,


### PR DESCRIPTION
Right now we accept 25 incoming connections and also issue that much in gossip-support. This essentially means that the network is fully connected right now. We would not be able to see any issues with request response for example not being able to open up connections (because they are already open) or whether or not gossip actually works.

I suggest trying out rococo with these changes, before doing any scaling up.