### PR TITLE
Check Intersecting Range on Para, not Bidder

### DIFF
--- a/runtime/common/src/auctions.rs
+++ b/runtime/common/src/auctions.rs
@@ -1029,7 +1029,7 @@ mod tests {
 				((23.into(), 2), LeaseData { leaser: 23, amount: 4 }),
 				((23.into(), 3), LeaseData { leaser: 23, amount: 4 }),
 			]);
-			// 5 didnt win
+			// 5 didn't win
 			assert_eq!(TestLeaser::deposit_held(5.into(), &5), 0);
 			// 1, 23, and 4 did.
 			assert_eq!(TestLeaser::deposit_held(1.into(), &1), 1);

--- a/runtime/common/src/auctions.rs
+++ b/runtime/common/src/auctions.rs
@@ -789,12 +789,12 @@ mod tests {
 	pub fn new_test_ext() -> sp_io::TestExternalities {
 		let mut t = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();
 		pallet_balances::GenesisConfig::<Test>{
-			balances: vec![(1, 10), (2, 20), (3, 30), (4, 40), (5, 50), (6, 60), (23, 230)],
+			balances: vec![(1, 10), (2, 20), (3, 30), (4, 40), (5, 50), (6, 60)],
 		}.assimilate_storage(&mut t).unwrap();
 		let mut ext: sp_io::TestExternalities = t.into();
 		ext.execute_with(|| {
 			// Register paras for tests
-			for i in vec![0u32, 1, 2, 3, 4, 5, 23] {
+			for i in vec![0u32, 1, 2, 3, 4, 5] {
 				assert_ok!(TestRegistrar::<Test>::register(1, i.into(), Default::default(), Default::default()));
 			}
 		});
@@ -1018,22 +1018,22 @@ mod tests {
 			run_to_block(1);
 			assert_ok!(Auctions::new_auction(Origin::signed(6), 5, 1));
 			assert_ok!(Auctions::bid(Origin::signed(1), 1.into(), 1, 1, 1, 1));
-			assert_ok!(Auctions::bid(Origin::signed(23), 23.into(), 1, 2, 3, 4));
+			assert_ok!(Auctions::bid(Origin::signed(2), 2.into(), 1, 2, 3, 4));
 			assert_ok!(Auctions::bid(Origin::signed(4), 4.into(), 1, 4, 4, 2));
 			assert_ok!(Auctions::bid(Origin::signed(5), 5.into(), 1, 1, 4, 2));
 			run_to_block(9);
 
 			assert_eq!(leases(), vec![
 				((1.into(), 1), LeaseData { leaser: 1, amount: 1 }),
+				((2.into(), 2), LeaseData { leaser: 2, amount: 4 }),
+				((2.into(), 3), LeaseData { leaser: 2, amount: 4 }),
 				((4.into(), 4), LeaseData { leaser: 4, amount: 2 }),
-				((23.into(), 2), LeaseData { leaser: 23, amount: 4 }),
-				((23.into(), 3), LeaseData { leaser: 23, amount: 4 }),
 			]);
 			// 5 didn't win
 			assert_eq!(TestLeaser::deposit_held(5.into(), &5), 0);
 			// 1, 23, and 4 did.
 			assert_eq!(TestLeaser::deposit_held(1.into(), &1), 1);
-			assert_eq!(TestLeaser::deposit_held(23.into(), &23), 4);
+			assert_eq!(TestLeaser::deposit_held(2.into(), &2), 4);
 			assert_eq!(TestLeaser::deposit_held(4.into(), &4), 2);
 		});
 	}


### PR DESCRIPTION
To optimize winning calculation, we do not allow non-intersecting bids for parachain slots.

However, the code was checking the bidder, not the parachain. A bidder should not have this requirement.