### PR TITLE
Emit an Event for Random Block Selected in Auction

### DIFF
--- a/runtime/common/src/auctions.rs
+++ b/runtime/common/src/auctions.rs
@@ -121,6 +121,7 @@ decl_event!(
 		LeasePeriod = LeasePeriodOf<T>,
 		ParaId = ParaId,
 		Balance = BalanceOf<T>,
+		WinningData = WinningData<T>,
 	{
 		/// An auction started. Provides its index and the block number where it will begin to
 		/// close and the first lease period of the quadruplet that is auctioned.
@@ -147,6 +148,9 @@ decl_event!(
 		/// A new bid has been accepted as the current winner.
 		/// \[who, para_id, amount, first_slot, last_slot\]
 		BidAccepted(AccountId, ParaId, Balance, LeasePeriod, LeasePeriod),
+		/// The winning offset was chosen for an auction. This will map into the `Winning` storage map.
+		/// \[auction_index, block_number\]
+		WinningOffset(AuctionIndex, BlockNumber),
 	}
 );
 
@@ -496,6 +500,8 @@ impl<T: Config> Module<T> {
 						.expect("secure hashes should always be bigger than the block number; qed");
 					let offset = (raw_offset_block_number % ending_period) / T::SampleLength::get();
 
+					let auction_counter = AuctionCounter::get();
+					Self::deposit_event(RawEvent::WinningOffset(auction_counter, offset));
 					let res = Winning::<T>::get(offset).unwrap_or_default();
 					let mut i = T::BlockNumber::zero();
 					while i < ending_period {

--- a/runtime/common/src/auctions.rs
+++ b/runtime/common/src/auctions.rs
@@ -121,7 +121,6 @@ decl_event!(
 		LeasePeriod = LeasePeriodOf<T>,
 		ParaId = ParaId,
 		Balance = BalanceOf<T>,
-		WinningData = WinningData<T>,
 	{
 		/// An auction started. Provides its index and the block number where it will begin to
 		/// close and the first lease period of the quadruplet that is auctioned.


### PR DESCRIPTION
This PR adds an event which shows which block (as an offset) was selected for winning the candle auction for Parachains.