### PR TITLE
send assignments even when we have an approval

### DIFF
--- a/node/network/approval-distribution/src/lib.rs
+++ b/node/network/approval-distribution/src/lib.rs
@@ -944,13 +944,24 @@ impl State {
 					}
 					match approval_state {
 						ApprovalState::Assigned(cert) => {
-							assignments.push((IndirectAssignmentCert {
-								block_hash: block.clone(),
-								validator: validator_index.clone(),
-								cert: cert.clone(),
-							}, candidate_index.clone()));
+							assignments.push((
+								IndirectAssignmentCert {
+									block_hash: block.clone(),
+									validator: validator_index.clone(),
+									cert: cert.clone(),
+								},
+								candidate_index.clone(),
+							));
 						}
-						ApprovalState::Approved(_, signature) => {
+						ApprovalState::Approved(assignment_cert, signature) => {
+							assignments.push((
+								IndirectAssignmentCert {
+									block_hash: block.clone(),
+									validator: validator_index.clone(),
+									cert: assignment_cert.clone(),
+								},
+								candidate_index.clone(),
+							));
 							approvals.push(IndirectSignedApprovalVote {
 								block_hash: block.clone(),
 								validator: validator_index.clone(),


### PR DESCRIPTION
Previously if we were unifying with a peer and we had an approval for a given validator, we'd only send the approval and not the assignment. We need to send the assignment as well, and this PR fixes that and adds a test.