### PR TITLE
rococo-v1: increase in validation slots

### DIFF
--- a/node/network/protocol/src/peer_set.rs
+++ b/node/network/protocol/src/peer_set.rs
@@ -57,7 +57,7 @@ impl PeerSet {
 				notifications_protocol: protocol,
 				max_notification_size,
 				set_config: sc_network::config::SetConfig {
-					in_peers: 4,
+					in_peers: 10,
 					out_peers: 0,
 					reserved_nodes: Vec::new(),
 					non_reserved_mode: sc_network::config::NonReservedPeerMode::Accept,


### PR DESCRIPTION
the slots might be occupied by non-active validators which might cause some trouble to us and might explain high inclusion times