### PR TITLE
proper executor/block type for benchmarks and try-runtime

### DIFF
--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -276,25 +276,25 @@ pub fn run() -> Result<()> {
 			let runner = cli.create_runner(cmd)?;
 			let chain_spec = &runner.config().chain_spec;
 			set_default_ss58_version(chain_spec);
-			let spec_name = runner.config().impl_name.to_lowercase();
 
-			if spec_name.contains("polkadot") {
+			ensure_dev(chain_spec).map_err(Error::Other)?;
+			if chain_spec.is_polkadot() {
 				Ok(runner.sync_run(|config| {
 					cmd.run::<service::polkadot_runtime::Block, service::PolkadotExecutor>(config)
 						.map_err(|e| Error::SubstrateCli(e))
 				})?)
-			} else if spec_name.contains("kusama") {
+			} else if chain_spec.is_kusama() {
 				Ok(runner.sync_run(|config| {
 					cmd.run::<service::kusama_runtime::Block, service::KusamaExecutor>(config)
 						.map_err(|e| Error::SubstrateCli(e))
 				})?)
-			} else if spec_name.contains("westend") {
+			} else if chain_spec.is_westend() {
 				Ok(runner.sync_run(|config| {
 					cmd.run::<service::westend_runtime::Block, service::WestendExecutor>(config)
 						.map_err(|e| Error::SubstrateCli(e))
 				})?)
 			} else {
-				panic!("can only use benchmarks with --chain value of [polkadot, kusama, westend], got {}", spec_name);
+				Err(format!("{}{}", DEV_ONLY_ERROR_PATTERN, chain_spec.id()).into())
 			}
 		},
 		Some(Subcommand::Key(cmd)) => Ok(cmd.run(&cli)?),

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -182,7 +182,6 @@ impl IdentifyVariant for Box<dyn ChainSpec> {
 		self.id().starts_with("polkadot") || self.id().starts_with("dot")
 	}
 	fn is_dev(&self) -> bool {
-		dbg!(self.id());
 		self.id().ends_with("dev")
 	}
 }

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -160,6 +160,12 @@ pub trait IdentifyVariant {
 
 	/// Returns if this is a configuration for the `Rococo` network.
 	fn is_rococo(&self) -> bool;
+
+	/// Returns if this is a configuration for the `Polkadot` network.
+	fn is_polkadot(&self) -> bool;
+
+	/// Returns true if this configuration is for a development network.
+	fn is_dev(&self) -> bool;
 }
 
 impl IdentifyVariant for Box<dyn ChainSpec> {
@@ -171,6 +177,13 @@ impl IdentifyVariant for Box<dyn ChainSpec> {
 	}
 	fn is_rococo(&self) -> bool {
 		self.id().starts_with("rococo") || self.id().starts_with("rco")
+	}
+	fn is_polkadot(&self) -> bool {
+		self.id().starts_with("polkadot") || self.id().starts_with("dot")
+	}
+	fn is_dev(&self) -> bool {
+		dbg!(self.id());
+		self.id().ends_with("dev")
 	}
 }
 


### PR DESCRIPTION
closes https://github.com/paritytech/polkadot/issues/2516


What I don't get is that when I run these two commands with `--chain=polkadot` and inspect the executor logs, I get `polkadot-0` as the spec-version, but when I do `--chain=polkadot-dev` I get `polkadot-30`. Is this why we also run benchmarks always with `-dev` variants? And why is this? 

Either way, that coded needed refactoring. 