### PR TITLE
Add Root Functions to HRMP

### DIFF
--- a/runtime/parachains/src/hrmp.rs
+++ b/runtime/parachains/src/hrmp.rs
@@ -409,6 +409,14 @@ decl_module! {
 			Self::deposit_event(Event::ChannelClosed(origin, channel_id));
 			Ok(())
 		}
+
+		/// Force process hrmp open and close requests.
+
+		/// This extrinsic triggers the cleanup of all the HRMP storage items that
+		/// a para may have. Normally this happens once per session, but this allows
+		/// you to trigger the cleanup immediately for a specific parachain.
+		#[weight = 0]
+		pub fn force_clean_hrmp()
 	}
 }
 

--- a/runtime/parachains/src/hrmp.rs
+++ b/runtime/parachains/src/hrmp.rs
@@ -24,6 +24,7 @@ use frame_support::{
 	decl_storage, decl_module, decl_error, decl_event, ensure, traits::{Get, ReservableCurrency},
 	weights::Weight, StorageMap, StorageValue, dispatch::DispatchResult,
 };
+use frame_system::ensure_root;
 use primitives::v1::{
 	Balance, Hash, HrmpChannelId, Id as ParaId, InboundHrmpMessage, OutboundHrmpMessage,
 	SessionIndex,
@@ -410,13 +411,40 @@ decl_module! {
 			Ok(())
 		}
 
-		/// Force process hrmp open and close requests.
-
 		/// This extrinsic triggers the cleanup of all the HRMP storage items that
 		/// a para may have. Normally this happens once per session, but this allows
 		/// you to trigger the cleanup immediately for a specific parachain.
+		///
+		/// Origin must be Root.
 		#[weight = 0]
-		pub fn force_clean_hrmp()
+		pub fn force_clean_hrmp(origin, para: ParaId) -> DispatchResult {
+			ensure_root(origin)?;
+			Self::clean_hrmp_after_outgoing(&para);
+			Ok(())
+		}
+
+		/// Force process hrmp open channel requests.
+		///
+		/// If there are pending HRMP open channel requests, you can use this
+		/// function process all of those requests immediately.
+		#[weight = 0]
+		pub fn force_process_hrmp_open(origin) -> DispatchResult {
+			ensure_root(origin)?;
+			let host_config = configuration::Module::<T>::config();
+			Self::process_hrmp_open_channel_requests(&host_config);
+			Ok(())
+		}
+
+		/// Force process hrmp close channel requests.
+		///
+		/// If there are pending HRMP close channel requests, you can use this
+		/// function process all of those requests immediately.
+		#[weight = 0]
+		pub fn force_process_hrmp_close(origin) -> DispatchResult {
+			ensure_root(origin)?;
+			Self::process_hrmp_close_channel_requests();
+			Ok(())
+		}
 	}
 }
 


### PR DESCRIPTION
To help test HRMP more quickly, these utility functions for Root can be used to speed up the processing or cleanup of HRMP channels.