### PR TITLE
Add dispute types and change InclusionInherent to ParasInherent

### DIFF
--- a/node/collation-generation/src/lib.rs
+++ b/node/collation-generation/src/lib.rs
@@ -731,7 +731,7 @@ mod tests {
 			// correct descriptor
 			let expect_pov_hash = test_collation().proof_of_validity.hash();
 			let expect_validation_data_hash
-				= PersistedValidationData::<BlockNumber>::default().hash();
+				= PersistedValidationData::<Hash, BlockNumber>::default().hash();
 			let expect_relay_parent = Hash::repeat_byte(4);
 			let expect_payload = collator_signature_payload(
 				&expect_relay_parent,

--- a/node/core/provisioner/src/lib.rs
+++ b/node/core/provisioner/src/lib.rs
@@ -296,12 +296,16 @@ async fn send_inherent_data(
 		candidates,
 		relay_parent,
 		from_job,
-	)
-	.await?;
+	).await?;
 
-	let res = (bitfields, candidates);
+	let inherent_data = ProvisionerInherentData {
+		bitfields,
+		backed_candidates: candidates,
+		disputes: Vec::new(), // until disputes are implemented.
+	};
+
 	for return_sender in return_senders {
-		return_sender.send(res.clone()).map_err(|_data| Error::InherentDataReturnChannel)?;
+		return_sender.send(inherent_data.clone()).map_err(|_data| Error::InherentDataReturnChannel)?;
 	}
 
 	Ok(())

--- a/node/core/provisioner/src/tests.rs
+++ b/node/core/provisioner/src/tests.rs
@@ -342,7 +342,7 @@ mod select_candidates {
 		let mock_cores = mock_availability_cores();
 		let n_cores = mock_cores.len();
 
-		let empty_hash = PersistedValidationData::<BlockNumber>::default().hash();
+		let empty_hash = PersistedValidationData::<Hash, BlockNumber>::default().hash();
 
 		let candidate_template = CandidateReceipt {
 			descriptor: CandidateDescriptor {
@@ -415,7 +415,7 @@ mod select_candidates {
 		let mock_cores = mock_availability_cores();
 		let n_cores = mock_cores.len();
 
-		let empty_hash = PersistedValidationData::<BlockNumber>::default().hash();
+		let empty_hash = PersistedValidationData::<Hash, BlockNumber>::default().hash();
 
 		// why those particular indices? see the comments on mock_availability_cores()
 		// the first candidate with code is included out of [1, 4, 7, 8, 10].

--- a/node/subsystem/src/messages.rs
+++ b/node/subsystem/src/messages.rs
@@ -44,7 +44,7 @@ use polkadot_primitives::v1::{
 	PersistedValidationData, SessionIndex, SignedAvailabilityBitfield,
 	ValidationCode, ValidatorId, CandidateHash,
 	ValidatorIndex, ValidatorSignature, InboundDownwardMessage, InboundHrmpMessage,
-	CandidateIndex, GroupIndex,
+	CandidateIndex, GroupIndex, MultiDisputeStatementSet, SignedAvailabilityBitfields,
 };
 use polkadot_statement_table::v1::Misbehavior;
 use polkadot_procmacro_subsystem_dispatch_gen::subsystem_dispatch_gen;
@@ -549,10 +549,16 @@ pub enum ProvisionableData {
 	Dispute(Hash, ValidatorSignature),
 }
 
-/// This data needs to make its way from the provisioner into the InherentData.
-///
-/// There, it is used to construct the ParaInherent.
-pub type ProvisionerInherentData = (Vec<SignedAvailabilityBitfield>, Vec<BackedCandidate>);
+/// Inherent data returned by the provisioner
+#[derive(Debug, Clone)]
+pub struct ProvisionerInherentData {
+	/// Signed bitfields.
+	pub bitfields: SignedAvailabilityBitfields,
+	/// Backed candidates.
+	pub backed_candidates: Vec<BackedCandidate>,
+	/// Dispute statement sets.
+	pub disputes: MultiDisputeStatementSet,
+}
 
 /// Message to the Provisioner.
 ///

--- a/node/test/client/src/block_builder.rs
+++ b/node/test/client/src/block_builder.rs
@@ -100,12 +100,12 @@ impl InitPolkadotBlockBuilder for Client {
 		let parent_header = self.header(at)
 			.expect("Get the parent block header")
 			.expect("The target block header must exist");
-		let provisioner_data = polkadot_node_subsystem::messages::ProvisionerInherentData::default();
+
 		let parachains_inherent_data = ParachainsInherentData {
-			bitfields: provisioner_data.bitfields,
-			backed_candidates: provisioner_data.backed_candidates,
-			disputes: provisioner_data.disputes,
-			parent_header: self.parent_header,
+			bitfields: Vec::new(),
+			backed_candidates: Vec::new(),
+			disputes: Vec::new(),
+			parent_header: parent_header,
 		};
 
 		inherent_data

--- a/node/test/client/src/block_builder.rs
+++ b/node/test/client/src/block_builder.rs
@@ -113,7 +113,7 @@ impl InitPolkadotBlockBuilder for Client {
 				polkadot_primitives::v1::PARACHAINS_INHERENT_IDENTIFIER,
 				&parachains_inherent_data,
 			)
-			.expect("Put inclusion inherent data");
+			.expect("Put parachains inherent data");
 
 		let inherents = block_builder.create_inherents(inherent_data).expect("Creates inherents");
 

--- a/node/test/client/src/block_builder.rs
+++ b/node/test/client/src/block_builder.rs
@@ -16,7 +16,7 @@
 
 use crate::{Client, FullBackend};
 use polkadot_test_runtime::{GetLastTimestamp, UncheckedExtrinsic};
-use polkadot_primitives::v1::Block;
+use polkadot_primitives::v1::{Block, InherentData as ParachainsInherentData};
 use sp_runtime::{generic::BlockId, Digest, DigestItem};
 use sp_api::ProvideRuntimeApi;
 use sp_consensus_babe::{BABE_ENGINE_ID, digests::{PreDigest, SecondaryPlainPreDigest}};
@@ -101,15 +101,17 @@ impl InitPolkadotBlockBuilder for Client {
 			.expect("Get the parent block header")
 			.expect("The target block header must exist");
 		let provisioner_data = polkadot_node_subsystem::messages::ProvisionerInherentData::default();
-		let inclusion_inherent_data = (
-			provisioner_data.0,
-			provisioner_data.1,
-			parent_header,
-		);
+		let parachains_inherent_data = ParachainsInherentData {
+			bitfields: provisioner_data.bitfields,
+			backed_candidates: provisioner_data.backed_candidates,
+			disputes: provisioner_data.disputes,
+			parent_header: self.parent_header,
+		};
+
 		inherent_data
 			.put_data(
-				polkadot_primitives::v1::INCLUSION_INHERENT_IDENTIFIER,
-				&inclusion_inherent_data,
+				polkadot_primitives::v1::PARACHAINS_INHERENT_IDENTIFIER,
+				&parachains_inherent_data,
 			)
 			.expect("Put inclusion inherent data");
 

--- a/primitives/src/v1.rs
+++ b/primitives/src/v1.rs
@@ -991,6 +991,84 @@ impl<H> From<ConsensusLog> for runtime_primitives::DigestItem<H> {
 	}
 }
 
+/// TODO [now]: codec indices
+
+/// A statement about a candidate, to be used within the dispute resolution process.
+///
+/// Statements are either in favor of the candidate's validity or against it.
+#[derive(Encode, Decode, Clone)]
+pub enum DisputeStatement {
+	/// A valid statement, of the given kind.
+	#[codec(index = 0)]
+	Valid(ValidDisputeStatementKind),
+	/// An invalid statement, of the given kind.
+	#[codec(index = 1)]
+	Invalid(InvalidDisputeStatementKind),
+}
+
+/// Different kinds of statements of validity on  a candidate.
+#[derive(Encode, Decode, Clone)]
+pub enum ValidDisputeStatementKind {
+	/// An explicit statement issued as part of a dispute.
+	#[codec(index = 0)]
+	Explicit,
+	/// A seconded statement on a candidate from the backing phase.
+	#[codec(index = 1)]
+	BackingSeconded,
+	/// A valid statement on a candidate from the backing phase.
+	#[codec(index = 2)]
+	BackingValid,
+	/// An approval vote from the approval checking phase.
+	#[codec(index = 3)]
+	ApprovalChecking,
+}
+
+/// Different kinds of statements of invalidity on a candidate.
+#[derive(Encode, Decode, Clone)]
+pub enum InvalidDisputeStatementKind {
+	/// An explicit statement issued as part of a dispute.
+	#[codec(index = 0)]
+	Explicit,
+}
+
+/// An explicit statement on a candidate issued as part of a dispute.
+#[derive(Encode, Decode, Clone)]
+pub struct ExplicitDisputeStatement {
+	/// Whether the candidate is valid
+	pub valid: bool,
+	/// The candidate hash.
+	pub candidate_hash: CandidateHash,
+	/// The session index of the candidate.
+	pub session: SessionIndex,
+}
+
+/// A set of statements about a specific candidate.
+#[derive(Encode, Decode, Clone)]
+pub struct DisputeStatementSet {
+	/// The candidate referenced by this set.
+    pub candidate_hash: CandidateHash,
+	/// The session index of the candidate.
+    pub session: SessionIndex,
+	/// Statements about the candidate.
+    pub statements: Vec<(DisputeStatement, ValidatorIndex, ValidatorSignature)>,
+}
+
+/// A set of dispute statements.
+pub type MultiDisputeStatementSet = Vec<DisputeStatementSet>;
+
+/// The entire state of a dispute.
+#[derive(Encode, Decode, Clone)]
+pub struct DisputeState {
+	/// A bitfield indicating all validators for the candidate.
+	pub validators_for: BitVec<bitvec::order::Lsb0, u8>, // one bit per validator.
+	/// A bitfield indicating all validators against the candidate.
+	pub validators_against: BitVec<bitvec::order::Lsb0, u8>, // one bit per validator.
+	/// The block number at which the dispute started on-chain.
+	pub start: BlockNumber,
+	/// The block number at which the dispute concluded on-chain.
+	pub concluded_at: Option<BlockNumber>,
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;

--- a/primitives/src/v1.rs
+++ b/primitives/src/v1.rs
@@ -994,8 +994,7 @@ impl<H> From<ConsensusLog> for runtime_primitives::DigestItem<H> {
 /// A statement about a candidate, to be used within the dispute resolution process.
 ///
 /// Statements are either in favor of the candidate's validity or against it.
-#[derive(Encode, Decode, Clone, PartialEq)]
-#[cfg_attr(feature = "std", derive(Debug))]
+#[derive(Encode, Decode, Clone, PartialEq, RuntimeDebug)]
 pub enum DisputeStatement {
 	/// A valid statement, of the given kind.
 	#[codec(index = 0)]
@@ -1006,8 +1005,7 @@ pub enum DisputeStatement {
 }
 
 /// Different kinds of statements of validity on  a candidate.
-#[derive(Encode, Decode, Clone, PartialEq)]
-#[cfg_attr(feature = "std", derive(Debug))]
+#[derive(Encode, Decode, Clone, PartialEq, RuntimeDebug)]
 pub enum ValidDisputeStatementKind {
 	/// An explicit statement issued as part of a dispute.
 	#[codec(index = 0)]
@@ -1024,8 +1022,7 @@ pub enum ValidDisputeStatementKind {
 }
 
 /// Different kinds of statements of invalidity on a candidate.
-#[derive(Encode, Decode, Clone, PartialEq)]
-#[cfg_attr(feature = "std", derive(Debug))]
+#[derive(Encode, Decode, Clone, PartialEq, RuntimeDebug)]
 pub enum InvalidDisputeStatementKind {
 	/// An explicit statement issued as part of a dispute.
 	#[codec(index = 0)]
@@ -1033,8 +1030,7 @@ pub enum InvalidDisputeStatementKind {
 }
 
 /// An explicit statement on a candidate issued as part of a dispute.
-#[derive(Encode, Decode, Clone, PartialEq)]
-#[cfg_attr(feature = "std", derive(Debug))]
+#[derive(Encode, Decode, Clone, PartialEq, RuntimeDebug)]
 pub struct ExplicitDisputeStatement {
 	/// Whether the candidate is valid
 	pub valid: bool,
@@ -1045,8 +1041,7 @@ pub struct ExplicitDisputeStatement {
 }
 
 /// A set of statements about a specific candidate.
-#[derive(Encode, Decode, Clone, PartialEq)]
-#[cfg_attr(feature = "std", derive(Debug))]
+#[derive(Encode, Decode, Clone, PartialEq, RuntimeDebug)]
 pub struct DisputeStatementSet {
 	/// The candidate referenced by this set.
     pub candidate_hash: CandidateHash,
@@ -1060,8 +1055,7 @@ pub struct DisputeStatementSet {
 pub type MultiDisputeStatementSet = Vec<DisputeStatementSet>;
 
 /// The entire state of a dispute.
-#[derive(Encode, Decode, Clone)]
-#[cfg_attr(feature = "std", derive(Debug))]
+#[derive(Encode, Decode, Clone, RuntimeDebug)]
 pub struct DisputeState<N = BlockNumber> {
 	/// A bitfield indicating all validators for the candidate.
 	pub validators_for: BitVec<bitvec::order::Lsb0, u8>, // one bit per validator.
@@ -1074,8 +1068,7 @@ pub struct DisputeState<N = BlockNumber> {
 }
 
 /// Parachains inherent-data passed into the runtime by a block author
-#[derive(Encode, Decode, Clone, PartialEq)]
-#[cfg_attr(feature = "std", derive(Debug))]
+#[derive(Encode, Decode, Clone, PartialEq, RuntimeDebug)]
 pub struct InherentData<HDR: HeaderT = Header> {
 	/// Signed bitfields by validators about availability.
 	pub bitfields: SignedAvailabilityBitfields,

--- a/primitives/src/v1.rs
+++ b/primitives/src/v1.rs
@@ -169,8 +169,8 @@ pub mod well_known_keys {
 	}
 }
 
-/// Unique identifier for the Inclusion Inherent
-pub const INCLUSION_INHERENT_IDENTIFIER: InherentIdentifier = *b"inclusn0";
+/// Unique identifier for the Parachains Inherent
+pub const PARACHAINS_INHERENT_IDENTIFIER: InherentIdentifier = *b"parachn0";
 
 /// The key type ID for parachain assignment key.
 pub const ASSIGNMENT_KEY_TYPE_ID: KeyTypeId = KeyTypeId(*b"asgn");

--- a/primitives/src/v1.rs
+++ b/primitives/src/v1.rs
@@ -820,7 +820,7 @@ sp_api::decl_runtime_apis! {
 		/// and the para already occupies a core.
 		#[skip_initialize_block]
 		fn persisted_validation_data(para_id: Id, assumption: OccupiedCoreAssumption)
-			-> Option<PersistedValidationData<N>>;
+			-> Option<PersistedValidationData<H, N>>;
 
 		/// Checks if the given validation outputs pass the acceptance criteria.
 		#[skip_initialize_block]

--- a/primitives/src/v1.rs
+++ b/primitives/src/v1.rs
@@ -991,12 +991,11 @@ impl<H> From<ConsensusLog> for runtime_primitives::DigestItem<H> {
 	}
 }
 
-/// TODO [now]: codec indices
-
 /// A statement about a candidate, to be used within the dispute resolution process.
 ///
 /// Statements are either in favor of the candidate's validity or against it.
 #[derive(Encode, Decode, Clone)]
+#[cfg_attr(feature = "std", derive(Debug))]
 pub enum DisputeStatement {
 	/// A valid statement, of the given kind.
 	#[codec(index = 0)]
@@ -1008,6 +1007,7 @@ pub enum DisputeStatement {
 
 /// Different kinds of statements of validity on  a candidate.
 #[derive(Encode, Decode, Clone)]
+#[cfg_attr(feature = "std", derive(Debug))]
 pub enum ValidDisputeStatementKind {
 	/// An explicit statement issued as part of a dispute.
 	#[codec(index = 0)]
@@ -1025,6 +1025,7 @@ pub enum ValidDisputeStatementKind {
 
 /// Different kinds of statements of invalidity on a candidate.
 #[derive(Encode, Decode, Clone)]
+#[cfg_attr(feature = "std", derive(Debug))]
 pub enum InvalidDisputeStatementKind {
 	/// An explicit statement issued as part of a dispute.
 	#[codec(index = 0)]
@@ -1033,6 +1034,7 @@ pub enum InvalidDisputeStatementKind {
 
 /// An explicit statement on a candidate issued as part of a dispute.
 #[derive(Encode, Decode, Clone)]
+#[cfg_attr(feature = "std", derive(Debug))]
 pub struct ExplicitDisputeStatement {
 	/// Whether the candidate is valid
 	pub valid: bool,
@@ -1044,6 +1046,7 @@ pub struct ExplicitDisputeStatement {
 
 /// A set of statements about a specific candidate.
 #[derive(Encode, Decode, Clone)]
+#[cfg_attr(feature = "std", derive(Debug))]
 pub struct DisputeStatementSet {
 	/// The candidate referenced by this set.
     pub candidate_hash: CandidateHash,
@@ -1058,6 +1061,7 @@ pub type MultiDisputeStatementSet = Vec<DisputeStatementSet>;
 
 /// The entire state of a dispute.
 #[derive(Encode, Decode, Clone)]
+#[cfg_attr(feature = "std", derive(Debug))]
 pub struct DisputeState {
 	/// A bitfield indicating all validators for the candidate.
 	pub validators_for: BitVec<bitvec::order::Lsb0, u8>, // one bit per validator.
@@ -1067,6 +1071,20 @@ pub struct DisputeState {
 	pub start: BlockNumber,
 	/// The block number at which the dispute concluded on-chain.
 	pub concluded_at: Option<BlockNumber>,
+}
+
+/// Parachains inherent-data passed into the runtime by a block author
+#[derive(Encode, Decode, Clone)]
+#[cfg_attr(feature = "std", derive(Debug))]
+pub struct InherentData {
+	/// Signed bitfields by validators about availability.
+	pub bitfields: SignedAvailabilityBitfields,
+	/// Backed candidates for inclusion in the block.
+	pub backed_candidates: Vec<BackedCandidate>,
+	/// Sets of dispute votes for inclusion,
+	pub disputes: MultiDisputeStatementSet,
+	/// The parent block header. Used for checking state proofs.
+	pub parent_header: Header,
 }
 
 #[cfg(test)]

--- a/primitives/src/v1.rs
+++ b/primitives/src/v1.rs
@@ -1044,11 +1044,11 @@ pub struct ExplicitDisputeStatement {
 #[derive(Encode, Decode, Clone, PartialEq, RuntimeDebug)]
 pub struct DisputeStatementSet {
 	/// The candidate referenced by this set.
-    pub candidate_hash: CandidateHash,
+	pub candidate_hash: CandidateHash,
 	/// The session index of the candidate.
-    pub session: SessionIndex,
+	pub session: SessionIndex,
 	/// Statements about the candidate.
-    pub statements: Vec<(DisputeStatement, ValidatorIndex, ValidatorSignature)>,
+	pub statements: Vec<(DisputeStatement, ValidatorIndex, ValidatorSignature)>,
 }
 
 /// A set of dispute statements.

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -1170,7 +1170,7 @@ sp_api::impl_runtime_apis! {
 		}
 
 		fn persisted_validation_data(_: Id, _: OccupiedCoreAssumption)
-			-> Option<PersistedValidationData<BlockNumber>> {
+			-> Option<PersistedValidationData<Hash, BlockNumber>> {
 			None
 		}
 		fn check_validation_outputs(

--- a/runtime/parachains/src/inclusion.rs
+++ b/runtime/parachains/src/inclusion.rs
@@ -25,7 +25,7 @@ use primitives::v1::{
 	CandidateCommitments, CandidateDescriptor, ValidatorIndex, Id as ParaId,
 	AvailabilityBitfield as AvailabilityBitfield, SignedAvailabilityBitfields, SigningContext,
 	BackedCandidate, CoreIndex, GroupIndex, CommittedCandidateReceipt,
-	CandidateReceipt, HeadData, CandidateHash, Hash,
+	CandidateReceipt, HeadData, CandidateHash,
 };
 use frame_support::{
 	decl_storage, decl_module, decl_error, decl_event, ensure, dispatch::DispatchResult, IterableStorageMap,
@@ -378,7 +378,7 @@ impl<T: Config> Module<T> {
 	/// Both should be sorted ascending by core index, and the candidates should be a subset of
 	/// scheduled cores. If these conditions are not met, the execution of the function fails.
 	pub(crate) fn process_candidates(
-		parent_storage_root: Hash,
+		parent_storage_root: T::Hash,
 		candidates: Vec<BackedCandidate<T::Hash>>,
 		scheduled: Vec<CoreAssignment>,
 		group_validators: impl Fn(GroupIndex) -> Option<Vec<ValidatorIndex>>,

--- a/runtime/parachains/src/lib.rs
+++ b/runtime/parachains/src/lib.rs
@@ -25,9 +25,9 @@
 pub mod configuration;
 pub mod shared;
 pub mod inclusion;
-pub mod inclusion_inherent;
 pub mod initializer;
 pub mod paras;
+pub mod paras_inherent;
 pub mod scheduler;
 pub mod session_info;
 pub mod origin;

--- a/runtime/parachains/src/mock.rs
+++ b/runtime/parachains/src/mock.rs
@@ -133,7 +133,7 @@ impl crate::inclusion::Config for Test {
 	type RewardValidators = TestRewardValidators;
 }
 
-impl crate::inclusion_inherent::Config for Test { }
+impl crate::paras_inherent::Config for Test { }
 
 impl crate::session_info::Config for Test { }
 

--- a/runtime/parachains/src/paras_inherent.rs
+++ b/runtime/parachains/src/paras_inherent.rs
@@ -323,7 +323,7 @@ mod tests {
 		}
 	}
 
-	mod inclusion_inherent_weight {
+	mod paras_inherent_weight {
 		use super::*;
 
 		use crate::mock::{
@@ -343,7 +343,7 @@ mod tests {
 			}
 		}
 
-		/// We expect the weight of the inclusion inherent not to change when no truncation occurs:
+		/// We expect the weight of the paras inherent not to change when no truncation occurs:
 		/// its weight is dynamically computed from the size of the backed candidates list, and is
 		/// already incorporated into the current block weight when it is selected by the provisioner.
 		#[test]

--- a/runtime/parachains/src/paras_inherent.rs
+++ b/runtime/parachains/src/paras_inherent.rs
@@ -44,14 +44,14 @@ const LOG_TARGET: &str = "runtime::inclusion-inherent";
 // In the future, we should benchmark these consts; these are all untested assumptions for now.
 const BACKED_CANDIDATE_WEIGHT: Weight = 100_000;
 const INCLUSION_INHERENT_CLAIMED_WEIGHT: Weight = 1_000_000_000;
-// we assume that 75% of an inclusion inherent's weight is used processing backed candidates
+// we assume that 75% of an paras inherent's weight is used processing backed candidates
 const MINIMAL_INCLUSION_INHERENT_WEIGHT: Weight = INCLUSION_INHERENT_CLAIMED_WEIGHT / 4;
 
 pub trait Config: inclusion::Config + scheduler::Config {}
 
 decl_storage! {
 	trait Store for Module<T: Config> as ParaInherent {
-		/// Whether the inclusion inherent was included within this block.
+		/// Whether the paras inherent was included within this block.
 		///
 		/// The `Option<()>` is effectively a bool, but it never hits storage in the `None` variant
 		/// due to the guarantees of FRAME's storage APIs.
@@ -72,7 +72,7 @@ decl_error! {
 }
 
 decl_module! {
-	/// The inclusion inherent module.
+	/// The paras inherent module.
 	pub struct Module<T: Config> for enum Call where origin: <T as frame_system::Config>::Origin {
 		type Error = Error<T>;
 
@@ -201,7 +201,7 @@ fn limit_backed_candidates<T: Config>(
 		});
 	}
 
-	// the weight of the inclusion inherent is already included in the current block weight,
+	// the weight of the paras inherent is already included in the current block weight,
 	// so our operation is simple: if the block is currently overloaded, make this intrinsic smaller
 	if frame_system::Pallet::<T>::block_weight().total() > <T as frame_system::Config>::BlockWeights::get().max_block {
 		Vec::new()
@@ -242,7 +242,7 @@ impl<T: Config> ProvideInherent for Module<T> {
 				log::warn!(
 					target: LOG_TARGET,
 					"dropping signed_bitfields and backed_candidates because they produced \
-					an invalid inclusion inherent: {:?}",
+					an invalid paras inherent: {:?}",
 					err,
 				);
 
@@ -353,7 +353,7 @@ mod tests {
 				System::set_block_number(1);
 				System::set_parent_hash(header.hash());
 
-				// number of bitfields doesn't affect the inclusion inherent weight, so we can mock it with an empty one
+				// number of bitfields doesn't affect the paras inherent weight, so we can mock it with an empty one
 				let signed_bitfields = Vec::new();
 				// backed candidates must not be empty, so we can demonstrate that the weight has not changed
 				let backed_candidates = vec![BackedCandidate::default(); 10];
@@ -367,7 +367,7 @@ mod tests {
 				let used_block_weight = max_block_weight / 2;
 				System::set_block_consumed_resources(used_block_weight, 0);
 
-				// execute the inclusion inherent
+				// execute the paras inherent
 				let post_info = Call::<Test>::enter(ParachainsInherentData {
 					bitfields: signed_bitfields,
 					backed_candidates,
@@ -389,7 +389,7 @@ mod tests {
 			});
 		}
 
-		/// We expect the weight of the inclusion inherent to change when truncation occurs: its
+		/// We expect the weight of the paras inherent to change when truncation occurs: its
 		/// weight was initially dynamically computed from the size of the backed candidates list,
 		/// but was reduced by truncation.
 		#[test]
@@ -399,7 +399,7 @@ mod tests {
 				System::set_block_number(1);
 				System::set_parent_hash(header.hash());
 
-				// number of bitfields doesn't affect the inclusion inherent weight, so we can mock it with an empty one
+				// number of bitfields doesn't affect the paras inherent weight, so we can mock it with an empty one
 				let signed_bitfields = Vec::new();
 				// backed candidates must not be empty, so we can demonstrate that the weight has not changed
 				let backed_candidates = vec![BackedCandidate::default(); 10];
@@ -412,7 +412,7 @@ mod tests {
 				let used_block_weight = max_block_weight + 1;
 				System::set_block_consumed_resources(used_block_weight, 0);
 
-				// execute the inclusion inherent
+				// execute the paras inherent
 				let post_info = Call::<Test>::enter(ParachainsInherentData {
 					bitfields: signed_bitfields,
 					backed_candidates,

--- a/runtime/parachains/src/runtime_api_impl/v1.rs
+++ b/runtime/parachains/src/runtime_api_impl/v1.rs
@@ -25,7 +25,7 @@ use primitives::v1::{
 	Id as ParaId, OccupiedCoreAssumption, SessionIndex, ValidationCode,
 	CommittedCandidateReceipt, ScheduledCore, OccupiedCore, CoreOccupied, CoreIndex,
 	GroupIndex, CandidateEvent, PersistedValidationData, SessionInfo,
-	InboundDownwardMessage, InboundHrmpMessage, Hash, AuthorityDiscoveryId
+	InboundDownwardMessage, InboundHrmpMessage, AuthorityDiscoveryId
 };
 use crate::{initializer, inclusion, scheduler, configuration, paras, session_info, dmp, hrmp, shared};
 
@@ -200,10 +200,10 @@ fn with_assumption<Config, T, F>(
 pub fn persisted_validation_data<T: initializer::Config>(
 	para_id: ParaId,
 	assumption: OccupiedCoreAssumption,
-) -> Option<PersistedValidationData<T::BlockNumber>> {
+) -> Option<PersistedValidationData<T::Hash, T::BlockNumber>> {
 	use parity_scale_codec::Decode as _;
 	let relay_parent_number = <frame_system::Pallet<T>>::block_number();
-	let relay_parent_storage_root = Hash::decode(&mut &sp_io::storage::root()[..])
+	let relay_parent_storage_root = T::Hash::decode(&mut &sp_io::storage::root()[..])
 		.expect("storage root must decode to the Hash type; qed");
 	with_assumption::<T, _, _>(para_id, assumption, || {
 		crate::util::make_persisted_validation_data::<T>(

--- a/runtime/parachains/src/util.rs
+++ b/runtime/parachains/src/util.rs
@@ -17,7 +17,7 @@
 //! Utilities that don't belong to any particular module but may draw
 //! on all modules.
 
-use primitives::v1::{Id as ParaId, PersistedValidationData, Hash, ValidatorIndex};
+use primitives::v1::{Id as ParaId, PersistedValidationData, ValidatorIndex};
 use sp_std::vec::Vec;
 
 use crate::{configuration, paras, hrmp};
@@ -29,8 +29,8 @@ use crate::{configuration, paras, hrmp};
 pub fn make_persisted_validation_data<T: paras::Config + hrmp::Config>(
 	para_id: ParaId,
 	relay_parent_number: T::BlockNumber,
-	relay_parent_storage_root: Hash,
-) -> Option<PersistedValidationData<T::BlockNumber>> {
+	relay_parent_storage_root: T::Hash,
+) -> Option<PersistedValidationData<T::Hash, T::BlockNumber>> {
 	let config = <configuration::Module<T>>::config();
 
 	Some(PersistedValidationData {

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -1197,7 +1197,7 @@ sp_api::impl_runtime_apis! {
 		}
 
 		fn persisted_validation_data(_: Id, _: OccupiedCoreAssumption)
-			-> Option<PersistedValidationData<BlockNumber>> {
+			-> Option<PersistedValidationData<Hash, BlockNumber>> {
 			None
 		}
 

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -65,7 +65,7 @@ use runtime_parachains::origin as parachains_origin;
 use runtime_parachains::configuration as parachains_configuration;
 use runtime_parachains::shared as parachains_shared;
 use runtime_parachains::inclusion as parachains_inclusion;
-use runtime_parachains::inclusion_inherent as parachains_inclusion_inherent;
+use runtime_parachains::paras_inherent as parachains_paras_inherent;
 use runtime_parachains::initializer as parachains_initializer;
 use runtime_parachains::session_info as parachains_session_info;
 use runtime_parachains::paras as parachains_paras;
@@ -196,7 +196,7 @@ construct_runtime! {
 		ParachainsConfiguration: parachains_configuration::{Pallet, Call, Storage, Config<T>},
 		Shared: parachains_shared::{Pallet, Call, Storage},
 		Inclusion: parachains_inclusion::{Pallet, Call, Storage, Event<T>},
-		InclusionInherent: parachains_inclusion_inherent::{Pallet, Call, Storage, Inherent},
+		ParasInherent: parachains_paras_inherent::{Pallet, Call, Storage, Inherent},
 		Scheduler: parachains_scheduler::{Pallet, Call, Storage},
 		Paras: parachains_paras::{Pallet, Call, Storage, Event},
 		Initializer: parachains_initializer::{Pallet, Call, Storage},
@@ -584,7 +584,7 @@ impl parachains_hrmp::Config for Runtime {
 	type Currency = Balances;
 }
 
-impl parachains_inclusion_inherent::Config for Runtime {}
+impl parachains_paras_inherent::Config for Runtime {}
 
 impl parachains_scheduler::Config for Runtime {}
 

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -822,7 +822,7 @@ sp_api::impl_runtime_apis! {
 		}
 
 		fn persisted_validation_data(para_id: Id, assumption: OccupiedCoreAssumption)
-			-> Option<PersistedValidationData<BlockNumber>> {
+			-> Option<PersistedValidationData<Hash, BlockNumber>> {
 			runtime_api_impl::persisted_validation_data::<Runtime>(para_id, assumption)
 		}
 

--- a/runtime/test-runtime/src/lib.rs
+++ b/runtime/test-runtime/src/lib.rs
@@ -646,7 +646,7 @@ sp_api::impl_runtime_apis! {
 		}
 
 		fn persisted_validation_data(para_id: ParaId, assumption: OccupiedCoreAssumption)
-			-> Option<PersistedValidationData<BlockNumber>>
+			-> Option<PersistedValidationData<Hash, BlockNumber>>
 		{
 			runtime_impl::persisted_validation_data::<Runtime>(para_id, assumption)
 		}

--- a/runtime/test-runtime/src/lib.rs
+++ b/runtime/test-runtime/src/lib.rs
@@ -28,7 +28,7 @@ use parity_scale_codec::Encode;
 use polkadot_runtime_parachains::configuration as parachains_configuration;
 use polkadot_runtime_parachains::shared as parachains_shared;
 use polkadot_runtime_parachains::inclusion as parachains_inclusion;
-use polkadot_runtime_parachains::inclusion_inherent as parachains_inclusion_inherent;
+use polkadot_runtime_parachains::paras_inherent as parachains_paras_inherent;
 use polkadot_runtime_parachains::initializer as parachains_initializer;
 use polkadot_runtime_parachains::session_info as parachains_session_info;
 use polkadot_runtime_parachains::paras as parachains_paras;
@@ -455,7 +455,7 @@ impl parachains_inclusion::Config for Runtime {
 	type RewardValidators = RewardValidatorsWithEraPoints<Runtime>;
 }
 
-impl parachains_inclusion_inherent::Config for Runtime {}
+impl parachains_paras_inherent::Config for Runtime {}
 
 impl parachains_initializer::Config for Runtime {
 	type Randomness = pallet_babe::RandomnessFromOneEpochAgo<Runtime>;
@@ -521,7 +521,7 @@ construct_runtime! {
 		// Parachains runtime modules
 		ParachainsConfiguration: parachains_configuration::{Pallet, Call, Storage, Config<T>},
 		Inclusion: parachains_inclusion::{Pallet, Call, Storage, Event<T>},
-		InclusionInherent: parachains_inclusion_inherent::{Pallet, Call, Storage, Inherent},
+		ParasInherent: parachains_paras_inherent::{Pallet, Call, Storage, Inherent},
 		Initializer: parachains_initializer::{Pallet, Call, Storage},
 		Paras: parachains_paras::{Pallet, Call, Storage, Origin, Event},
 		Scheduler: parachains_scheduler::{Pallet, Call, Storage},

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -869,7 +869,7 @@ sp_api::impl_runtime_apis! {
 		}
 
 		fn persisted_validation_data(_: Id, _: OccupiedCoreAssumption)
-			-> Option<PersistedValidationData<BlockNumber>> {
+			-> Option<PersistedValidationData<Hash, BlockNumber>> {
 			None
 		}
 


### PR DESCRIPTION
I did the guide update for this ages ago. This makes the chain forwards-compatible for when we add disputes, so we don't have to change the inherent data type later.