### PR TITLE
tweaks to relevant_authority_ids

### DIFF
--- a/runtime/parachains/src/runtime_api_impl/v1.rs
+++ b/runtime/parachains/src/runtime_api_impl/v1.rs
@@ -240,9 +240,16 @@ pub fn session_index_for_child<T: initializer::Config>() -> SessionIndex {
 pub fn relevant_authority_ids<T: initializer::Config + pallet_authority_discovery::Config>() -> Vec<AuthorityDiscoveryId> {
 	let current_session_index = session_index_for_child::<T>();
 	let earliest_stored_session = <session_info::Module<T>>::earliest_stored_session();
-	let mut authority_ids = <pallet_authority_discovery::Module<T>>::next_authorities();
 
-	for session_index in earliest_stored_session..=current_session_index {
+	// Due to `max_validators`, the `SessionInfo` stores only the validators who are actively
+	// selected to participate in parachain consensus. We'd like all authorities for the current
+	// and next sessions to be used in authority-discovery. The two sets likely have large overlap.
+	let mut authority_ids = <pallet_authority_discovery::Module<T>>::current_authorities();
+	authority_ids.extend(<pallet_authority_discovery::Module<T>>::next_authorities());
+
+	// Due to disputes, we'd like to remain connected to authorities of the previous few sessions.
+	// For this, we don't need anyone other than the validators actively participating in consensus.
+	for session_index in earliest_stored_session..current_session_index {
 		let info = <session_info::Module<T>>::session_info(session_index);
 		if let Some(mut info) = info {
 			authority_ids.append(&mut info.discovery_keys);


### PR DESCRIPTION
We were including the next authorities but not the current. These sets are mostly the same, but, best to have all the nodes in.