### PR TITLE
add disputes members to `HostConfiguration`

### DIFF
--- a/node/service/src/chain_spec.rs
+++ b/node/service/src/chain_spec.rs
@@ -387,7 +387,7 @@ fn westend_staging_testnet_config_genesis(wasm_binary: &[u8]) -> westend::Genesi
 			//5Fnu4YYBx9V71ihCBkJyFGsKw9Q2jjNzRQL9kRNpKTPNSAhc
 			hex!["03e9393ee30ae95fc2b7864230f53e45409a807949390140ce2bc77756cdb4bb83"].unchecked_into(),
 		),
-			
+
 	];
 
 	const ENDOWMENT: u128 = 1_000_000 * WND;
@@ -839,7 +839,7 @@ fn rococo_staging_testnet_config_genesis(wasm_binary: &[u8]) -> rococo_runtime::
 			hex!["4e262811acdfe94528bfc3c65036080426a0e1301b9ada8d687a70ffcae99c26"].unchecked_into(),
 			//5E41Znrr2YtZu8bZp3nvRuLVHg3jFksfQ3tXuviLku4wsao7
 			hex!["025e84e95ed043e387ddb8668176b42f8e2773ddd84f7f58a6d9bf436a4b527986"].unchecked_into(),
-		),				
+		),
 	];
 
 	const ENDOWMENT: u128 = 1_000_000 * ROC;
@@ -891,7 +891,7 @@ fn rococo_staging_testnet_config_genesis(wasm_binary: &[u8]) -> rococo_runtime::
 			config: polkadot_runtime_parachains::configuration::HostConfiguration {
 				validation_upgrade_frequency: 600u32,
 				validation_upgrade_delay: 300,
-				acceptance_period: 1200,
+				code_retention_period: 1200,
 				max_code_size: 5 * 1024 * 1024,
 				max_pov_size: MAX_POV_SIZE,
 				max_head_data_size: 32 * 1024,
@@ -1440,7 +1440,7 @@ pub fn rococo_testnet_genesis(
 			config: polkadot_runtime_parachains::configuration::HostConfiguration {
 				validation_upgrade_frequency: 600u32,
 				validation_upgrade_delay: 300,
-				acceptance_period: 1200,
+				code_retention_period: 1200,
 				max_code_size: 5 * 1024 * 1024,
 				max_pov_size: 50 * 1024 * 1024,
 				max_head_data_size: 32 * 1024,

--- a/node/test/service/src/chain_spec.rs
+++ b/node/test/service/src/chain_spec.rs
@@ -178,7 +178,7 @@ fn polkadot_testnet_genesis(
 			config: polkadot_runtime_parachains::configuration::HostConfiguration {
 				validation_upgrade_frequency: 10u32,
 				validation_upgrade_delay: 5,
-				acceptance_period: 1200,
+				code_retention_period: 1200,
 				max_code_size: 5 * 1024 * 1024,
 				max_pov_size: 50 * 1024 * 1024,
 				max_head_data_size: 32 * 1024,

--- a/roadmap/implementers-guide/src/runtime/disputes.md
+++ b/roadmap/implementers-guide/src/runtime/disputes.md
@@ -65,7 +65,7 @@ Frozen: bool,
 ## Routines
 
 * `provide_multi_dispute_data(MultiDisputeStatementSet) -> Vec<(SessionIndex, Hash)>`:
-  1. Fail if any disputes in the set are duplicate or concluded before the `config.dispute_post_conclusion_code_retention_period` window relative to now.
+  1. Fail if any disputes in the set are duplicate or concluded before the `config.dispute_post_conclusion_acceptance_period` window relative to now.
   1. Pass on each dispute statement set to `provide_dispute_data`, propagating failure.
   1. Return a list of all candidates who just had disputes initiated.
 
@@ -73,7 +73,7 @@ Frozen: bool,
   1. All statements must be issued under the correct session for the correct candidate. 
   1. `SessionInfo` is used to check statement signatures and this function should fail if any signatures are invalid.
   1. If there is no dispute under `Disputes`, create a new `DisputeState` with blank bitfields.
-  1. If `concluded_at` is `Some`, and is `concluded_at + config.post_conclusion_code_retention_period < now`, return false.
+  1. If `concluded_at` is `Some`, and is `concluded_at + config.post_conclusion_acceptance_period < now`, return false.
   1. If the overlap of the validators in the `DisputeStatementSet` and those already present in the `DisputeState` is fewer in number than `byzantine_threshold + 1` and the candidate is not present in the `Included` map
     1. increment `SpamSlots` for each validator in the `DisputeStatementSet` which is not already in the `DisputeState`. Initialize the `SpamSlots` to a zeroed vector first, if necessary.
     1. If the value for any spam slot exceeds `config.dispute_max_spam_slots`, return false.

--- a/roadmap/implementers-guide/src/runtime/disputes.md
+++ b/roadmap/implementers-guide/src/runtime/disputes.md
@@ -65,7 +65,7 @@ Frozen: bool,
 ## Routines
 
 * `provide_multi_dispute_data(MultiDisputeStatementSet) -> Vec<(SessionIndex, Hash)>`:
-  1. Fail if any disputes in the set are duplicate or concluded before the `config.dispute_post_conclusion_acceptance_period` window relative to now.
+  1. Fail if any disputes in the set are duplicate or concluded before the `config.dispute_post_conclusion_code_retention_period` window relative to now.
   1. Pass on each dispute statement set to `provide_dispute_data`, propagating failure.
   1. Return a list of all candidates who just had disputes initiated.
 
@@ -73,7 +73,7 @@ Frozen: bool,
   1. All statements must be issued under the correct session for the correct candidate. 
   1. `SessionInfo` is used to check statement signatures and this function should fail if any signatures are invalid.
   1. If there is no dispute under `Disputes`, create a new `DisputeState` with blank bitfields.
-  1. If `concluded_at` is `Some`, and is `concluded_at + config.post_conclusion_acceptance_period < now`, return false.
+  1. If `concluded_at` is `Some`, and is `concluded_at + config.post_conclusion_code_retention_period < now`, return false.
   1. If the overlap of the validators in the `DisputeStatementSet` and those already present in the `DisputeState` is fewer in number than `byzantine_threshold + 1` and the candidate is not present in the `Included` map
     1. increment `SpamSlots` for each validator in the `DisputeStatementSet` which is not already in the `DisputeState`. Initialize the `SpamSlots` to a zeroed vector first, if necessary.
     1. If the value for any spam slot exceeds `config.dispute_max_spam_slots`, return false.

--- a/roadmap/implementers-guide/src/types/runtime.md
+++ b/roadmap/implementers-guide/src/types/runtime.md
@@ -12,9 +12,9 @@ struct HostConfiguration {
 	pub validation_upgrade_frequency: BlockNumber,
 	/// The delay, in blocks, before a validation upgrade is applied.
 	pub validation_upgrade_delay: BlockNumber,
-	/// The acceptance period, in blocks. This is the amount of blocks after availability that validators
-	/// and fishermen have to perform secondary checks or issue reports.
-	pub acceptance_period: BlockNumber,
+	/// How long to keep code on-chain, in blocks. This should be sufficiently long that disputes
+	/// have concluded.
+	pub code_retention_period: BlockNumber,
 	/// The maximum validation code size, in bytes.
 	pub max_code_size: u32,
 	/// The maximum head-data size, in bytes.
@@ -41,7 +41,7 @@ struct HostConfiguration {
 	/// The amount of sessions to keep for disputes.
 	pub dispute_period: SessionIndex,
 	/// How long after dispute conclusion to accept statements.
-	pub dispute_post_conclusion_acceptance_period: BlockNumber,
+	pub dispute_post_conclusion_code_retention_period: BlockNumber,
 	/// The maximum number of dispute spam slots 
 	pub dispute_max_spam_slots: u32,
 	/// How long it takes for a dispute to conclude by time-out, if no supermajority is reached.

--- a/roadmap/implementers-guide/src/types/runtime.md
+++ b/roadmap/implementers-guide/src/types/runtime.md
@@ -41,7 +41,7 @@ struct HostConfiguration {
 	/// The amount of sessions to keep for disputes.
 	pub dispute_period: SessionIndex,
 	/// How long after dispute conclusion to accept statements.
-	pub dispute_post_conclusion_code_retention_period: BlockNumber,
+	pub dispute_post_conclusion_acceptance_period: BlockNumber,
 	/// The maximum number of dispute spam slots 
 	pub dispute_max_spam_slots: u32,
 	/// How long it takes for a dispute to conclude by time-out, if no supermajority is reached.


### PR DESCRIPTION
And rename `acceptance_period` to `code_retention_period`. It's a little bit of a wart that we don't match that up with `dispute_period` directly, but this'll all be updated when we move validation code off-chain completely.