### PR TITLE
approval-distribution: split peer knowledge into sent and received

### DIFF
--- a/node/network/approval-distribution/src/lib.rs
+++ b/node/network/approval-distribution/src/lib.rs
@@ -535,10 +535,10 @@ impl State {
 		if let Some(peer_id) = source.peer_id() {
 			// check if our knowledge of the peer already contains this assignment
 			match entry.known_by.entry(peer_id.clone()) {
-				hash_map::Entry::Occupied(peer_knowledge) => {
-					let knowledge = peer_knowledge.get();
-					if knowledge.contains(&fingerprint) {
-						if knowledge.received.contains(&fingerprint) {
+				hash_map::Entry::Occupied(mut peer_knowledge) => {
+					let peer_knowledge = peer_knowledge.get_mut();
+					if peer_knowledge.contains(&fingerprint) {
+						if peer_knowledge.received.contains(&fingerprint) {
 							tracing::debug!(
 								target: LOG_TARGET,
 								?peer_id,
@@ -547,6 +547,7 @@ impl State {
 							);
 							modify_reputation(ctx, peer_id, COST_DUPLICATE_MESSAGE).await;
 						}
+						peer_knowledge.received.insert(fingerprint);
 						return;
 					}
 				}
@@ -760,8 +761,8 @@ impl State {
 
 			// check if our knowledge of the peer already contains this approval
 			match entry.known_by.entry(peer_id.clone()) {
-				hash_map::Entry::Occupied(knowledge) => {
-					let peer_knowledge = knowledge.get();
+				hash_map::Entry::Occupied(mut knowledge) => {
+					let peer_knowledge = knowledge.get_mut();
 					if peer_knowledge.contains(&fingerprint) {
 						if peer_knowledge.received.contains(&fingerprint) {
 							tracing::debug!(
@@ -773,6 +774,7 @@ impl State {
 
 							modify_reputation(ctx, peer_id, COST_DUPLICATE_MESSAGE).await;
 						}
+						peer_knowledge.received.insert(fingerprint);
 						return;
 					}
 				}

--- a/node/network/approval-distribution/src/lib.rs
+++ b/node/network/approval-distribution/src/lib.rs
@@ -121,7 +121,8 @@ impl PeerKnowledge {
 
 /// Information about blocks in our current view as well as whether peers know of them.
 struct BlockEntry {
-	/// The candidates we shared with peers.
+	/// Peers who we know are aware of this block and thus, the candidates within it.
+	/// This maps to their knowledge of messages.
 	known_by: HashMap<PeerId, PeerKnowledge>,
 	/// The number of the block.
 	number: BlockNumber,

--- a/node/network/approval-distribution/src/lib.rs
+++ b/node/network/approval-distribution/src/lib.rs
@@ -95,11 +95,34 @@ struct Knowledge {
 	known_messages: HashSet<MessageFingerprint>,
 }
 
+impl Knowledge {
+	fn contains(&self, fingerprint: &MessageFingerprint) -> bool {
+		self.known_messages.contains(fingerprint)
+	}
+
+	fn insert(&mut self, fingerprint: MessageFingerprint) -> bool {
+		self.known_messages.insert(fingerprint)
+	}
+}
+
+#[derive(Debug, Clone, Default)]
+struct PeerKnowledge {
+	/// The knowledge we've sent to the peer.
+	sent: Knowledge,
+	/// The knowledge we've received from the peer.
+	received: Knowledge,
+}
+
+impl PeerKnowledge {
+	fn contains(&self, fingerprint: &MessageFingerprint) -> bool {
+		self.sent.contains(fingerprint) || self.received.contains(fingerprint)
+	}
+}
+
 /// Information about blocks in our current view as well as whether peers know of them.
 struct BlockEntry {
-	/// Peers who we know are aware of this block and thus, the candidates within it.
-	/// This maps to their knowledge of messages.
-	known_by: HashMap<PeerId, Knowledge>,
+	/// The candidates we shared with peers.
+	known_by: HashMap<PeerId, PeerKnowledge>,
 	/// The number of the block.
 	number: BlockNumber,
 	/// The parent hash of the block.
@@ -212,7 +235,6 @@ impl State {
 							"Cleaning up stale pending messages",
 						);
 					}
-
 					live
 				});
 			}
@@ -513,15 +535,18 @@ impl State {
 		if let Some(peer_id) = source.peer_id() {
 			// check if our knowledge of the peer already contains this assignment
 			match entry.known_by.entry(peer_id.clone()) {
-				hash_map::Entry::Occupied(knowledge) => {
-					if knowledge.get().known_messages.contains(&fingerprint) {
-						tracing::debug!(
-							target: LOG_TARGET,
-							?peer_id,
-							?fingerprint,
-							"Duplicate assignment",
-						);
-						modify_reputation(ctx, peer_id, COST_DUPLICATE_MESSAGE).await;
+				hash_map::Entry::Occupied(peer_knowledge) => {
+					let knowledge = peer_knowledge.get();
+					if knowledge.contains(&fingerprint) {
+						if knowledge.received.contains(&fingerprint) {
+							tracing::debug!(
+								target: LOG_TARGET,
+								?peer_id,
+								?fingerprint,
+								"Duplicate assignment",
+							);
+							modify_reputation(ctx, peer_id, COST_DUPLICATE_MESSAGE).await;
+						}
 						return;
 					}
 				}
@@ -546,7 +571,7 @@ impl State {
 						?fingerprint,
 						"Known assignment",
 					);
-					peer_knowledge.known_messages.insert(fingerprint.clone());
+					peer_knowledge.received.insert(fingerprint.clone());
 				}
 				return;
 			}
@@ -584,7 +609,7 @@ impl State {
 					modify_reputation(ctx, peer_id.clone(), BENEFIT_VALID_MESSAGE_FIRST).await;
 					entry.knowledge.known_messages.insert(fingerprint.clone());
 					if let Some(peer_knowledge) = entry.known_by.get_mut(&peer_id) {
-						peer_knowledge.known_messages.insert(fingerprint.clone());
+						peer_knowledge.received.insert(fingerprint.clone());
 					}
 				}
 				AssignmentCheckResult::AcceptedDuplicate => {
@@ -592,7 +617,7 @@ impl State {
 					// There is more than one way each validator can be assigned to each core.
 					// cf. https://github.com/paritytech/polkadot/pull/2160#discussion_r557628699
 					if let Some(peer_knowledge) = entry.known_by.get_mut(&peer_id) {
-						peer_knowledge.known_messages.insert(fingerprint);
+						peer_knowledge.received.insert(fingerprint);
 					}
 					return;
 				}
@@ -663,8 +688,8 @@ impl State {
 		// Add the fingerprint of the assignment to the knowledge of each peer.
 		for peer in peers.iter() {
 			// we already filtered peers above, so this should always be Some
-			if let Some(entry) = entry.known_by.get_mut(peer) {
-				entry.known_messages.insert(fingerprint.clone());
+			if let Some(peer_knowledge) = entry.known_by.get_mut(peer) {
+				peer_knowledge.sent.insert(fingerprint.clone());
 			}
 		}
 
@@ -736,15 +761,18 @@ impl State {
 			// check if our knowledge of the peer already contains this approval
 			match entry.known_by.entry(peer_id.clone()) {
 				hash_map::Entry::Occupied(knowledge) => {
-					if knowledge.get().known_messages.contains(&fingerprint) {
-						tracing::debug!(
-							target: LOG_TARGET,
-							?peer_id,
-							?fingerprint,
-							"Duplicate approval",
-						);
+					let peer_knowledge = knowledge.get();
+					if peer_knowledge.contains(&fingerprint) {
+						if peer_knowledge.received.contains(&fingerprint) {
+							tracing::debug!(
+								target: LOG_TARGET,
+								?peer_id,
+								?fingerprint,
+								"Duplicate approval",
+							);
 
-						modify_reputation(ctx, peer_id, COST_DUPLICATE_MESSAGE).await;
+							modify_reputation(ctx, peer_id, COST_DUPLICATE_MESSAGE).await;
+						}
 						return;
 					}
 				}
@@ -760,7 +788,7 @@ impl State {
 			}
 
 			// if the approval is known to be valid, reward the peer
-			if entry.knowledge.known_messages.contains(&fingerprint) {
+			if entry.knowledge.contains(&fingerprint) {
 				tracing::trace!(
 					target: LOG_TARGET,
 					?peer_id,
@@ -769,7 +797,7 @@ impl State {
 				);
 				modify_reputation(ctx, peer_id.clone(), BENEFIT_VALID_MESSAGE).await;
 				if let Some(peer_knowledge) = entry.known_by.get_mut(&peer_id) {
-					peer_knowledge.known_messages.insert(fingerprint.clone());
+					peer_knowledge.received.insert(fingerprint.clone());
 				}
 				return;
 			}
@@ -805,9 +833,9 @@ impl State {
 				ApprovalCheckResult::Accepted => {
 					modify_reputation(ctx, peer_id.clone(), BENEFIT_VALID_MESSAGE_FIRST).await;
 
-					entry.knowledge.known_messages.insert(fingerprint.clone());
+					entry.knowledge.insert(fingerprint.clone());
 					if let Some(peer_knowledge) = entry.known_by.get_mut(&peer_id) {
-						peer_knowledge.known_messages.insert(fingerprint.clone());
+						peer_knowledge.received.insert(fingerprint.clone());
 					}
 				}
 				ApprovalCheckResult::Bad => {
@@ -821,7 +849,7 @@ impl State {
 				}
 			}
 		} else {
-			if !entry.knowledge.known_messages.insert(fingerprint.clone()) {
+			if !entry.knowledge.insert(fingerprint.clone()) {
 				// if we already imported an approval, there is no need to distribute it again
 				tracing::warn!(
 					target: LOG_TARGET,
@@ -898,7 +926,7 @@ impl State {
 		for peer in peers.iter() {
 			// we already filtered peers above, so this should always be Some
 			if let Some(entry) = entry.known_by.get_mut(peer) {
-				entry.known_messages.insert(fingerprint.clone());
+				entry.sent.insert(fingerprint.clone());
 			}
 		}
 
@@ -947,7 +975,11 @@ impl State {
 					hash_map::Entry::Occupied(_) => return None,
 					// step 4.
 					hash_map::Entry::Vacant(vacant) => {
-						vacant.insert(entry.knowledge.clone());
+						let knowledge = PeerKnowledge {
+							sent: entry.knowledge.clone(),
+							received: Default::default(),
+						};
+						vacant.insert(knowledge);
 						block
 					}
 				};

--- a/roadmap/implementers-guide/src/node/approval/approval-distribution.md
+++ b/roadmap/implementers-guide/src/node/approval/approval-distribution.md
@@ -76,10 +76,17 @@ struct Knowledge {
   known_messages: HashSet<MessageFingerprint>,
 }
 
+struct PeerKnowledge {
+  /// The knowledge we've sent to the peer.
+  sent: Knowledge,
+  /// The knowledge we've received from the peer.
+  received: Knowledge,
+}
+
 /// Information about blocks in our current view as well as whether peers know of them.
 struct BlockEntry {
   // Peers who we know are aware of this block and thus, the candidates within it. This maps to their knowledge of messages.
-  known_by: HashMap<PeerId, Knowledge>,
+  known_by: HashMap<PeerId, PeerKnowledge>,
   // The number of the block.
   number: BlockNumber,
   // The parent hash of the block.
@@ -188,7 +195,7 @@ The algorithm is the following:
   * Load the BlockEntry using `assignment.block_hash`. If it does not exist, report the source if it is `MessageSource::Peer` and return.
   * Compute a fingerprint for the `assignment` using `claimed_candidate_index`.
   * If the source is `MessageSource::Peer(sender)`:
-    * check if `peer` appears under `known_by` and whether the fingerprint is in the `known_messages` of the peer. If the peer does not know the block, report for providing data out-of-view and proceed. If the peer does know the block and the knowledge contains the fingerprint, report for providing replicate data and return.
+    * check if `peer` appears under `known_by` and whether the fingerprint is in the knowledge of the peer. If the peer does not know the block, report for providing data out-of-view and proceed. If the peer does know the block and the `sent` knowledge contains the fingerprint, report for providing replicate data and return, otherwise, just return.
     * If the message fingerprint appears under the `BlockEntry`'s `Knowledge`, give the peer a small positive reputation boost,
     add the fingerprint to the peer's knowledge only if it knows about the block and return.
     Note that we must do this after checking for out-of-view and if the peers knows about the block to avoid being spammed.
@@ -215,7 +222,7 @@ Imports an approval signature referenced by block hash and candidate index:
   * Compute a fingerprint for the approval.
   * Compute a fingerprint for the corresponding assignment. If the `BlockEntry`'s knowledge does not contain that fingerprint, then report the source if it is `MessageSource::Peer` and return. All references to a fingerprint after this refer to the approval's, not the assignment's.
   * If the source is `MessageSource::Peer(sender)`:
-    * check if `peer` appears under `known_by` and whether the fingerprint is in the `known_messages` of the peer. If the peer does not know the block, report for providing data out-of-view and proceed. If the peer does know the block and the knowledge contains the fingerprint, report for providing replicate data and return.
+    * check if `peer` appears under `known_by` and whether the fingerprint is in the knowledge of the peer. If the peer does not know the block, report for providing data out-of-view and proceed. If the peer does know the block and the `sent` knowledge contains the fingerprint, report for providing replicate data and return, otherwise, just return.
     * If the message fingerprint appears under the `BlockEntry`'s `Knowledge`, give the peer a small positive reputation boost,
     add the fingerprint to the peer's knowledge only if it knows about the block and return.
     Note that we must do this after checking for out-of-view to avoid being spammed. If we did this check earlier, a peer could provide data out-of-view repeatedly and be rewarded for it.

--- a/roadmap/implementers-guide/src/node/approval/approval-distribution.md
+++ b/roadmap/implementers-guide/src/node/approval/approval-distribution.md
@@ -195,7 +195,7 @@ The algorithm is the following:
   * Load the BlockEntry using `assignment.block_hash`. If it does not exist, report the source if it is `MessageSource::Peer` and return.
   * Compute a fingerprint for the `assignment` using `claimed_candidate_index`.
   * If the source is `MessageSource::Peer(sender)`:
-    * check if `peer` appears under `known_by` and whether the fingerprint is in the knowledge of the peer. If the peer does not know the block, report for providing data out-of-view and proceed. If the peer does know the block and the `sent` knowledge contains the fingerprint, report for providing replicate data and return, otherwise, just return.
+    * check if `peer` appears under `known_by` and whether the fingerprint is in the knowledge of the peer. If the peer does not know the block, report for providing data out-of-view and proceed. If the peer does know the block and the `sent` knowledge contains the fingerprint, report for providing replicate data and return, otherwise, insert into the `received` knowledge and return.
     * If the message fingerprint appears under the `BlockEntry`'s `Knowledge`, give the peer a small positive reputation boost,
     add the fingerprint to the peer's knowledge only if it knows about the block and return.
     Note that we must do this after checking for out-of-view and if the peers knows about the block to avoid being spammed.
@@ -222,7 +222,7 @@ Imports an approval signature referenced by block hash and candidate index:
   * Compute a fingerprint for the approval.
   * Compute a fingerprint for the corresponding assignment. If the `BlockEntry`'s knowledge does not contain that fingerprint, then report the source if it is `MessageSource::Peer` and return. All references to a fingerprint after this refer to the approval's, not the assignment's.
   * If the source is `MessageSource::Peer(sender)`:
-    * check if `peer` appears under `known_by` and whether the fingerprint is in the knowledge of the peer. If the peer does not know the block, report for providing data out-of-view and proceed. If the peer does know the block and the `sent` knowledge contains the fingerprint, report for providing replicate data and return, otherwise, just return.
+    * check if `peer` appears under `known_by` and whether the fingerprint is in the knowledge of the peer. If the peer does not know the block, report for providing data out-of-view and proceed. If the peer does know the block and the `sent` knowledge contains the fingerprint, report for providing replicate data and return, otherwise, insert into the `received` knowledge and return.
     * If the message fingerprint appears under the `BlockEntry`'s `Knowledge`, give the peer a small positive reputation boost,
     add the fingerprint to the peer's knowledge only if it knows about the block and return.
     Note that we must do this after checking for out-of-view to avoid being spammed. If we did this check earlier, a peer could provide data out-of-view repeatedly and be rewarded for it.


### PR DESCRIPTION
Closes #2499.

By splitting the knowledge we'll not punish a peer on the first "duplicate" message, as mentioned in the issue, this can happen due to a race and is normal. However, if a peer continues sending the same message, we'll punish it.