### PR TITLE
check for lost race before warning

### DIFF
--- a/node/core/approval-voting/src/import.rs
+++ b/node/core/approval-voting/src/import.rs
@@ -636,13 +636,26 @@ pub(crate) async fn handle_new_head(
 			match imported_block_info(ctx, env, block_hash, &block_header).await? {
 				Some(i) => imported_blocks_and_info.push((block_hash, block_header, i)),
 				None => {
-					// Such errors are likely spurious, but this prevents us from getting gaps
-					// in the approval-db.
-					tracing::warn!(
-						target: LOG_TARGET,
-						"Unable to gather info about imported block {:?}. Skipping chain.",
-						(block_hash, block_header.number),
-					);
+					// It's possible that we've lost a race with finality.
+					let (tx, rx) = oneshot::channel();
+					ctx.send_message(
+						ChainApiMessage::FinalizedBlockHash(block_header.number.clone(), tx).into()
+					).await;
+
+					let lost_to_finality = match rx.await {
+						Ok(Ok(Some(h))) if h != block_hash => true,
+						_ => false,
+					};
+
+					if !lost_to_finality {
+						// Such errors are likely spurious, but this prevents us from getting gaps
+						// in the approval-db.
+						tracing::warn!(
+							target: LOG_TARGET,
+							"Unable to gather info about imported block {:?}. Skipping chain.",
+							(block_hash, block_header.number),
+						);
+					}
 
 					return Ok(Vec::new());
 				},


### PR DESCRIPTION
These warnings often fire when we've lost a race with finality and the runtime API no longer can return the data we need. This PR ensures the warning does not fire unless the block is either unfinalized or is in the finalized chain.

