### PR TITLE
Reduce Epoch Duration to 10 Min for Rococo

### DIFF
--- a/runtime/rococo/src/constants.rs
+++ b/runtime/rococo/src/constants.rs
@@ -34,7 +34,7 @@ pub mod time {
 	pub const MILLISECS_PER_BLOCK: Moment = 6000;
 	pub const SLOT_DURATION: Moment = MILLISECS_PER_BLOCK;
 	frame_support::parameter_types! {
-		pub storage EpochDurationInBlocks: BlockNumber = 30 * MINUTES;
+		pub storage EpochDurationInBlocks: BlockNumber = 10 * MINUTES;
 	}
 
 	// These time units are defined in number of blocks.


### PR DESCRIPTION
To make testing on Rococo faster, we will decrease the Epoch Duration to 10 min.

🐎 