### PR TITLE
Introduce plurality XCM locations

### DIFF
--- a/xcm/src/v0/junction.rs
+++ b/xcm/src/v0/junction.rs
@@ -32,6 +32,41 @@ pub enum NetworkId {
 	Kusama,
 }
 
+/// An identifier of a pluralistic body.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, Debug)]
+pub enum BodyId {
+	/// The only body in its context.
+	Unit,
+	/// A named body.
+	Named(Vec<u8>),
+	/// An indexed body.
+	// TODO: parity-scale-codec#262: Change to be a tuple.
+	Index { #[codec(compact)] id: u32 },
+	/// The unambiguous executive body (for Polkadot, this would be the Polkadot council).
+	Executive,
+	/// The unambiguous technical body (for Polkadot, this would be the Technical Committee).
+	Technical,
+	/// The unambiguous legislative body (for Polkadot, this could be considered the opinion of a majority of
+	/// lock-voters).
+	Legislative,
+	/// The unambiguous judicial body (this doesn't exist on Polkadot, but if it were to get a "grand oracle", it
+	/// may be considered as that).
+	Judicial,
+}
+
+/// A part of a pluralistic body.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, Debug)]
+pub enum BodyPart {
+	/// The body's declaration, under whatever means it decides.
+	Voice,
+	/// A given number of members of the body.
+	Members { #[codec(compact)] count: u32 },
+	/// No less than the given proportion of members of the body.
+	AtLeastProportion { #[codec(compact)] nom: u32, #[codec(compact)] denom: u32 },
+	/// More than than the given proportion of members of the body.
+	MoreThanProportion { #[codec(compact)] nom: u32, #[codec(compact)] denom: u32 },
+}
+
 /// A single item in a path to describe the relative location of a consensus system.
 ///
 /// Each item assumes a pre-existing location as its context and is defined in terms of it.
@@ -85,6 +120,11 @@ pub enum Junction {
 	///
 	/// Not currently used except as a fallback when deriving ancestry.
 	OnlyChild,
+	/// A pluralistic body existing within consensus.
+	///
+	/// Typical to be used to represent a governance origin of a chain, but could in principle be used to represent
+	/// things such as multisigs also.
+	Plurality { id: BodyId, part: BodyPart },
 }
 
 impl Junction {
@@ -92,14 +132,16 @@ impl Junction {
 		match self {
 			Junction::Parent => false,
 
-			Junction::Parachain { .. } |
-			Junction::AccountId32 { .. } |
-			Junction::AccountIndex64 { .. } |
-			Junction::AccountKey20 { .. } |
-			Junction::PalletInstance { .. } |
-			Junction::GeneralIndex { .. } |
-			Junction::GeneralKey(..) |
-			Junction::OnlyChild => true,
+			Junction::Parachain { .. }
+			| Junction::AccountId32 { .. }
+			| Junction::AccountIndex64 { .. }
+			| Junction::AccountKey20 { .. }
+			| Junction::PalletInstance { .. }
+			| Junction::GeneralIndex { .. }
+			| Junction::GeneralKey(..)
+			| Junction::OnlyChild
+			| Junction::Plurality { .. }
+			=> true,
 		}
 	}
 }

--- a/xcm/src/v0/junction.rs
+++ b/xcm/src/v0/junction.rs
@@ -128,7 +128,9 @@ pub enum Junction {
 }
 
 impl Junction {
-	pub fn is_sub_consensus(&self) -> bool {
+	/// Returns true if this junction can be considered an interior part of its context. This is generally `true`,
+	/// except for the `Parent` item.
+	pub fn is_interior(&self) -> bool {
 		match self {
 			Junction::Parent => false,
 

--- a/xcm/src/v0/mod.rs
+++ b/xcm/src/v0/mod.rs
@@ -227,6 +227,20 @@ pub enum Xcm<Call> {
 		#[codec(compact)] sender: u32,
 		#[codec(compact)] recipient: u32,
 	},
+
+	/// A message to indicate that the embedded XCM is actually arriving on behalf of some consensus
+	/// location within the origin.
+	///
+	/// Safety: No concerns.
+	///
+	/// Kind: *Instruction*
+	///
+	/// Errors:
+	#[codec(index = 10)]
+	RelayedFrom {
+		who: MultiLocation,
+		message: alloc::boxed::Box<Xcm<Call>>,
+	},
 }
 
 impl<Call> From<Xcm<Call>> for VersionedXcm<Call> {
@@ -268,7 +282,9 @@ impl<Call> Xcm<Call> {
 			HrmpChannelClosing { initiator, sender, recipient}
 			=> HrmpChannelClosing { initiator, sender, recipient},
 			Transact { origin_type, require_weight_at_most, call}
-			=> Transact { origin_type, require_weight_at_most, call: call.into() }
+			=> Transact { origin_type, require_weight_at_most, call: call.into() },
+			RelayedFrom { who, message }
+			=> RelayedFrom { who, message: alloc::boxed::Box::new((*message).into()) },
 		}
 	}
 }

--- a/xcm/src/v0/multi_location.rs
+++ b/xcm/src/v0/multi_location.rs
@@ -539,6 +539,23 @@ impl MultiLocation {
 		}
 	}
 
+	/// Mutate `self` so that it is suffixed with `prefix`. The correct normalised form is returned, removing any
+	/// internal `Parent`s.
+	///
+	/// Does not modify `self` and returns `Err` with `prefix` in case of overflow.
+	pub fn append_with(&mut self, suffix: MultiLocation) -> Result<(), MultiLocation> {
+		let mut prefix = suffix;
+		core::mem::swap(self, &mut prefix);
+		match self.prepend_with(prefix) {
+			Ok(()) => Ok(()),
+			Err(prefix) => {
+				let mut suffix = prefix;
+				core::mem::swap(self, &mut suffix);
+				Err(suffix)
+			}
+		}
+	}
+
 	/// Mutate `self` so that it is prefixed with `prefix`. The correct normalised form is returned, removing any
 	/// internal `Parent`s.
 	///
@@ -565,6 +582,12 @@ impl MultiLocation {
 			self.push_front(j).expect("len + prefix minus 2*skipped is less than 4; qed");
 		}
 		Ok(())
+	}
+
+	/// Returns true iff `self` is an interior location. For this it may not contain any `Junction`s for which
+	/// `Junction::is_interior` returns `false`. This
+	pub fn is_interior(&self) -> bool {
+		self.iter().all(Junction::is_interior)
 	}
 }
 


### PR DESCRIPTION
An additional `Junction` type for integrating origins such as the council into XCM without having to reduce them to `AccountId`s.