### PR TITLE
silence some parachain warnings

### DIFF
--- a/node/core/approval-voting/src/import.rs
+++ b/node/core/approval-voting/src/import.rs
@@ -212,7 +212,7 @@ async fn load_all_sessions(
 		let session_info = match rx.await {
 			Ok(Ok(Some(s))) => s,
 			Ok(Ok(None)) => {
-				tracing::warn!(
+				tracing::debug!(
 					target: LOG_TARGET,
 					"Session {} is missing from session-info state of block {}",
 					i,
@@ -266,14 +266,14 @@ async fn cache_session_info_for_head(
 
 			let window_start = session_index.saturating_sub(APPROVAL_SESSIONS - 1);
 
-			tracing::info!(
+			tracing::debug!(
 				target: LOG_TARGET, "Loading approval window from session {}..={}",
 				window_start, session_index,
 			);
 
 			match load_all_sessions(ctx, block_hash, window_start, session_index).await {
 				Err(SessionsUnavailable) => {
-					tracing::warn!(
+					tracing::debug!(
 						target: LOG_TARGET,
 						"Could not load sessions {}..={} from block {:?} in session {}",
 						window_start, session_index, block_hash, session_index,
@@ -599,7 +599,7 @@ pub(crate) async fn handle_new_head(
 			&header,
 		).await
 	{
-		tracing::warn!(
+		tracing::debug!(
 			target: LOG_TARGET,
 			"Could not cache session info when processing head {:?}",
 			head,

--- a/node/core/provisioner/src/lib.rs
+++ b/node/core/provisioner/src/lib.rs
@@ -235,7 +235,11 @@ impl ProvisioningJob {
 		)
 		.await
 		{
-			tracing::warn!(target: LOG_TARGET, err = ?err, "failed to assemble or send inherent data");
+			// THIS IS A HACK: to silence warnings on live chains without the parachains runtime
+			// FIXME: remove this workaround once the parachains runtime is live
+			if !matches!(err, Error::CanceledBackedCandidates(oneshot::Canceled)) {
+				tracing::warn!(target: LOG_TARGET, err = ?err, "failed to assemble or send inherent data");
+			}
 			self.metrics.on_inherent_data_request(Err(()));
 		} else {
 			self.metrics.on_inherent_data_request(Ok(()));

--- a/node/core/provisioner/src/lib.rs
+++ b/node/core/provisioner/src/lib.rs
@@ -235,11 +235,7 @@ impl ProvisioningJob {
 		)
 		.await
 		{
-			// THIS IS A HACK: to silence warnings on live chains without the parachains runtime
-			// FIXME: remove this workaround once the parachains runtime is live
-			if !matches!(err, Error::CanceledBackedCandidates(oneshot::Canceled)) {
-				tracing::warn!(target: LOG_TARGET, err = ?err, "failed to assemble or send inherent data");
-			}
+			tracing::warn!(target: LOG_TARGET, err = ?err, "failed to assemble or send inherent data");
 			self.metrics.on_inherent_data_request(Err(()));
 		} else {
 			self.metrics.on_inherent_data_request(Ok(()));

--- a/node/network/availability-distribution/src/lib.rs
+++ b/node/network/availability-distribution/src/lib.rs
@@ -120,10 +120,18 @@ impl AvailabilityDistributionSubsystem {
 			};
 			match message {
 				FromOverseer::Signal(OverseerSignal::ActiveLeaves(update)) => {
-					log_error(
-						pov_requester.update_connected_validators(&mut ctx, &mut self.runtime, &update).await,
-						"PoVRequester::update_connected_validators"
-					);
+					let result = pov_requester.update_connected_validators(
+						&mut ctx,
+						&mut self.runtime,
+						&update,
+					).await;
+					if let Err(error) = result {
+						tracing::debug!(
+							target: LOG_TARGET,
+							?error,
+							"PoVRequester::update_connected_validators",
+						);
+					}
 					log_error(
 						requester.get_mut().update_fetching_heads(&mut ctx, update).await,
 						"Error in Requester::update_fetching_heads"


### PR DESCRIPTION
Burnin on westend revealed that we might show quite a few warnings with the dummy parachain host runtime api impl.
As a workaround we silence these warnings until the parachains runtime is live.
```
WARN tokio-runtime-worker parachain::availability-distribution: error=NoSuchSession(0) ctx="PoVRequester::update_connected_validators"
WARN tokio-runtime-worker parachain::approval-voting: Could not cache session info when processing head 0x50055721584deacfcdd37cc750775dc9775a7409a3d7863c5d861cb8e5e9a784
WARN tokio-runtime-worker parachain::approval-voting: Could not load sessions 0..=0 from block 0x50055721584deacfcdd37cc750775dc9775a7409a3d7863c5d861cb8e5e9a784 in session 0
WARN tokio-runtime-worker parachain::approval-voting: Session 0 is missing from session-info state of block 0x5005…a784
INFO tokio-runtime-worker parachain::approval-voting: Loading approval window from session 0..=0
```