### PR TITLE
distribution: handle sqrt peer view updates

### DIFF
--- a/node/network/approval-distribution/src/lib.rs
+++ b/node/network/approval-distribution/src/lib.rs
@@ -450,7 +450,7 @@ impl State {
 			"Peer view change",
 		);
 		let finalized_number = view.finalized_number;
-		let old_view = self.peer_views.insert(peer_id.clone(), view);
+		let old_view = self.peer_views.insert(peer_id.clone(), view.clone());
 		let old_finalized_number = old_view.map(|v| v.finalized_number).unwrap_or(0);
 
 		// we want to prune every block known_by peer up to (including) view.finalized_number
@@ -460,7 +460,7 @@ impl State {
 		// but we need to make sure the range is not empty, otherwise it will panic
 		// it shouldn't be, we make sure of this in the network bridge
 		let range = old_finalized_number..=finalized_number;
-		if !range.is_empty() && !blocks.empty() {
+		if !range.is_empty() && !blocks.is_empty() {
 			self.blocks_by_number
 			.range(range)
 			.map(|(_number, hashes)| hashes)
@@ -481,7 +481,7 @@ impl State {
 			metrics,
 			&mut self.blocks,
 			peer_id.clone(),
-			view.clone(),
+			view,
 		).await;
 	}
 

--- a/node/network/approval-distribution/src/lib.rs
+++ b/node/network/approval-distribution/src/lib.rs
@@ -442,18 +442,13 @@ impl State {
 		peer_id: PeerId,
 		view: View,
 	) {
+		let lucky = util::gen_ratio_sqrt_subset(self.peer_views.len(), util::MIN_GOSSIP_PEERS);
 		tracing::trace!(
 			target: LOG_TARGET,
 			?view,
+			?lucky,
 			"Peer view change",
 		);
-		Self::unify_with_peer(
-			ctx,
-			metrics,
-			&mut self.blocks,
-			peer_id.clone(),
-			view.clone(),
-		).await;
 		let finalized_number = view.finalized_number;
 		let old_view = self.peer_views.insert(peer_id.clone(), view);
 		let old_finalized_number = old_view.map(|v| v.finalized_number).unwrap_or(0);
@@ -465,7 +460,7 @@ impl State {
 		// but we need to make sure the range is not empty, otherwise it will panic
 		// it shouldn't be, we make sure of this in the network bridge
 		let range = old_finalized_number..=finalized_number;
-		if !range.is_empty() {
+		if !range.is_empty() && !blocks.empty() {
 			self.blocks_by_number
 			.range(range)
 			.map(|(_number, hashes)| hashes)
@@ -476,6 +471,18 @@ impl State {
 				}
 			});
 		}
+
+		if !lucky {
+			return;
+		}
+
+		Self::unify_with_peer(
+			ctx,
+			metrics,
+			&mut self.blocks,
+			peer_id.clone(),
+			view.clone(),
+		).await;
 	}
 
 	fn handle_block_finalized(

--- a/node/network/bitfield-distribution/src/lib.rs
+++ b/node/network/bitfield-distribution/src/lib.rs
@@ -599,7 +599,16 @@ where
 	Context: SubsystemContext<Message = BitfieldDistributionMessage>,
 {
 	let added = state.peer_views.entry(origin.clone()).or_default().replace_difference(view).cloned().collect::<Vec<_>>();
-
+	let lucky = util::gen_ratio_sqrt_subset(state.peer_views.len(), util::MIN_GOSSIP_PEERS);
+	if !lucky {
+		tracing::trace!(
+			target: LOG_TARGET,
+			?peerid,
+			?view,
+			"Peer view change is ignored",
+		);
+		return;
+	}
 	// Send all messages we've seen before and the peer is now interested
 	// in to that peer.
 

--- a/node/network/bitfield-distribution/src/lib.rs
+++ b/node/network/bitfield-distribution/src/lib.rs
@@ -603,8 +603,7 @@ where
 	if !lucky {
 		tracing::trace!(
 			target: LOG_TARGET,
-			?peerid,
-			?view,
+			?origin,
 			"Peer view change is ignored",
 		);
 		return;

--- a/node/subsystem-util/src/lib.rs
+++ b/node/subsystem-util/src/lib.rs
@@ -224,7 +224,8 @@ pub fn choose_random_sqrt_subset<T>(mut v: Vec<T>, min: usize) -> Vec<T> {
 /// Returns bool with a probability of `max(len.sqrt(), min) / len`
 /// being true.
 pub fn gen_ratio_sqrt_subset(len: usize, min: usize) -> bool {
-	let mut rng = thread_rng();
+	use rand::Rng as _;
+	let mut rng = rand::thread_rng();
 	let threshold = max_of_min_and_sqrt_len(len, min);
 	let n = rng.gen_range(0..len);
 	n < threshold

--- a/node/subsystem-util/src/lib.rs
+++ b/node/subsystem-util/src/lib.rs
@@ -216,10 +216,23 @@ pub fn choose_random_sqrt_subset<T>(mut v: Vec<T>, min: usize) -> Vec<T> {
 	let mut rng = rand::thread_rng();
 	v.shuffle(&mut rng);
 
-	let len_sqrt = (v.len() as f64).sqrt() as usize;
-	let len = std::cmp::max(min, len_sqrt);
+	let len = max_of_min_and_sqrt_len(v.len(), min);
 	v.truncate(len);
 	v
+}
+
+/// Returns bool with a probability of `max(len.sqrt(), min) / len`
+/// being true.
+pub fn gen_ratio_sqrt_subset(len: usize, min: usize) -> bool {
+	let mut rng = thread_rng();
+	let threshold = max_of_min_and_sqrt_len(len, min);
+	let n = rng.gen_range(0..len);
+	n < threshold
+}
+
+fn max_of_min_and_sqrt_len(len: usize, min: usize) -> usize {
+	let len_sqrt = (len as f64).sqrt() as usize;
+	std::cmp::max(min, len_sqrt)
 }
 
 /// Local validator information

--- a/roadmap/implementers-guide/src/node/utility/gossip-support.md
+++ b/roadmap/implementers-guide/src/node/utility/gossip-support.md
@@ -9,3 +9,7 @@ from any validator in that set.
 Gossiping subsystems will be notified when a new peer connects or disconnects by network bridge.
 It is their responsibility to limit the amount of outgoing gossip messages.
 At the moment we enforce a cap of `max(sqrt(peers.len()), 25)` message recipients at a time in each gossiping subsystem.
+
+We also flip a coin with the same probability when handling peer view updates in the distribution subsystems.
+Over time the probability of not handling a peer view update converges to zero, so it shouldn't be cause much trouble.
+This should be considered as a temporary measure until we implement a more robust solution for gossiping.


### PR DESCRIPTION
We already restrict the number of sent messages, but not on peer view update.
I *think* this doesn't break any assumptions about the fact that the state should be updated on every peer view change.