### PR TITLE
Expose paras config in rococo runtime

### DIFF
--- a/node/service/src/chain_spec.rs
+++ b/node/service/src/chain_spec.rs
@@ -890,6 +890,10 @@ fn rococo_staging_testnet_config_genesis(wasm_binary: &[u8]) -> rococo_runtime::
 		pallet_sudo: rococo_runtime::SudoConfig {
 			key: endowed_accounts[0].clone(),
 		},
+		parachains_paras: rococo_runtime::ParasConfig {
+			paras: vec![],
+		    _phdata: Default::default(),
+		},
 		parachains_configuration: rococo_runtime::ParachainsConfigurationConfig {
 			config: polkadot_runtime_parachains::configuration::HostConfiguration {
 				validation_upgrade_frequency: 1u32,
@@ -1482,6 +1486,10 @@ pub fn rococo_testnet_genesis(
 				zeroth_delay_tranche_width: 0,
 				..Default::default()
 			},
+		},
+		parachains_paras: rococo_runtime::ParasConfig {
+			paras: vec![],
+		    _phdata: Default::default(),
 		},
 	}
 }

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -214,7 +214,7 @@ construct_runtime! {
 		Inclusion: parachains_inclusion::{Pallet, Call, Storage, Event<T>},
 		ParasInherent: parachains_paras_inherent::{Pallet, Call, Storage, Inherent},
 		Scheduler: parachains_scheduler::{Pallet, Call, Storage},
-		Paras: parachains_paras::{Pallet, Call, Storage, Event},
+		Paras: parachains_paras::{Pallet, Call, Storage, Event, Config<T>},
 		Initializer: parachains_initializer::{Pallet, Call, Storage},
 		Dmp: parachains_dmp::{Pallet, Call, Storage},
 		Ump: parachains_ump::{Pallet, Call, Storage},

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -110,7 +110,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("rococo"),
 	impl_name: create_runtime_str!("parity-rococo-v1.5"),
 	authoring_version: 0,
-	spec_version: 231,
+	spec_version: 232,
 	impl_version: 0,
 	#[cfg(not(feature = "disable-runtime-api"))]
 	apis: RUNTIME_API_VERSIONS,

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -110,7 +110,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("rococo"),
 	impl_name: create_runtime_str!("parity-rococo-v1.5"),
 	authoring_version: 0,
-	spec_version: 232,
+	spec_version: 231,
 	impl_version: 0,
 	#[cfg(not(feature = "disable-runtime-api"))]
 	apis: RUNTIME_API_VERSIONS,


### PR DESCRIPTION
The `paras` pallet has a genesis configuration that allows having parachains pre-registered at the time of relay chain genesis. 

Before this PR, this configuration was missed from the rococo runtime which means the genesis config couldn't be used in practice. This PR adds the necessary line to the runtime, and updates the `chain_spec.rs` file accordingly.

This change will be useful for parachain teams looking to test their parchains without waiting two sessions. This improvement can also be reflected in Polkadot Launch as described in https://github.com/paritytech/polkadot-launch/issues/66

cc @4meta5 @joelamouche