### PR TITLE
Infrastructure improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6096,6 +6096,7 @@ dependencies = [
  "futures 0.3.13",
  "futures-timer 3.0.2",
  "log",
+ "lru",
  "metered-channel",
  "parity-scale-codec",
  "parking_lot 0.11.1",

--- a/node/core/candidate-validation/src/lib.rs
+++ b/node/core/candidate-validation/src/lib.rs
@@ -592,7 +592,7 @@ impl metrics::Metrics for Metrics {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+	use super::*;
 	use polkadot_node_subsystem_test_helpers as test_helpers;
 	use polkadot_primitives::v1::{HeadData, UpwardMessage};
 	use sp_core::testing::TaskExecutor;

--- a/node/network/approval-distribution/src/lib.rs
+++ b/node/network/approval-distribution/src/lib.rs
@@ -191,7 +191,7 @@ impl State {
 		event: NetworkBridgeEvent<protocol_v1::ApprovalDistributionMessage>,
 	) {
 		match event {
-			NetworkBridgeEvent::PeerConnected(peer_id, role) => {
+			NetworkBridgeEvent::PeerConnected(peer_id, role, _) => {
 				// insert a blank view if none already present
 				tracing::trace!(
 					target: LOG_TARGET,

--- a/node/network/approval-distribution/src/tests.rs
+++ b/node/network/approval-distribution/src/tests.rs
@@ -117,7 +117,7 @@ async fn setup_peer_with_view(
 	overseer_send(
 		virtual_overseer,
 		ApprovalDistributionMessage::NetworkBridgeUpdateV1(
-			NetworkBridgeEvent::PeerConnected(peer_id.clone(), ObservedRole::Full)
+			NetworkBridgeEvent::PeerConnected(peer_id.clone(), ObservedRole::Full, None)
 		)
 	).await;
 	overseer_send(

--- a/node/network/availability-distribution/src/lib.rs
+++ b/node/network/availability-distribution/src/lib.rs
@@ -28,9 +28,7 @@ mod error;
 pub use error::Error;
 use error::{Result, log_error};
 
-/// Runtime requests.
-mod runtime;
-use runtime::Runtime;
+use polkadot_node_subsystem_util::runtime::Runtime;
 
 /// `Requester` taking care of requesting chunks for candidates pending availability.
 mod requester;

--- a/node/network/availability-distribution/src/pov_requester/mod.rs
+++ b/node/network/availability-distribution/src/pov_requester/mod.rs
@@ -275,7 +275,7 @@ mod tests {
 		let (mut context, mut virtual_overseer) =
 			test_helpers::make_subsystem_context::<AvailabilityDistributionMessage, TaskExecutor>(pool.clone());
 		let keystore = make_ferdie_keystore();
-		let mut runtime = crate::runtime::Runtime::new(keystore);
+		let mut runtime = polkadot_node_subsystem_util::runtime::Runtime::new(keystore);
 
 		let (tx, rx) = oneshot::channel();
 		let testee = async {

--- a/node/network/availability-distribution/src/pov_requester/mod.rs
+++ b/node/network/availability-distribution/src/pov_requester/mod.rs
@@ -33,8 +33,9 @@ use polkadot_subsystem::{
 	ActiveLeavesUpdate, SubsystemContext, ActivatedLeaf,
 	messages::{AllMessages, NetworkBridgeMessage, IfDisconnected}
 };
+use polkadot_node_subsystem_util::runtime::{Runtime, ValidatorInfo};
 
-use crate::{error::{Error, log_error}, runtime::{Runtime, ValidatorInfo}};
+use crate::error::{Error, log_error};
 
 /// Number of sessions we want to keep in the LRU.
 const NUM_SESSIONS: usize = 2;

--- a/node/network/bitfield-distribution/src/lib.rs
+++ b/node/network/bitfield-distribution/src/lib.rs
@@ -508,7 +508,7 @@ where
 	let _timer = metrics.time_handle_network_msg();
 
 	match bridge_message {
-		NetworkBridgeEvent::PeerConnected(peerid, role) => {
+		NetworkBridgeEvent::PeerConnected(peerid, role, _) => {
 			tracing::trace!(
 				target: LOG_TARGET,
 				?peerid,
@@ -1335,7 +1335,7 @@ mod test {
 				&mut ctx,
 				&mut state,
 				&Default::default(),
-				NetworkBridgeEvent::PeerConnected(peer_b.clone(), ObservedRole::Full),
+				NetworkBridgeEvent::PeerConnected(peer_b.clone(), ObservedRole::Full, None),
 			));
 
 			// make peer b interested

--- a/node/network/collator-protocol/src/collator_side.rs
+++ b/node/network/collator-protocol/src/collator_side.rs
@@ -791,7 +791,7 @@ async fn handle_network_msg(
 	use NetworkBridgeEvent::*;
 
 	match bridge_message {
-		PeerConnected(peer_id, observed_role) => {
+		PeerConnected(peer_id, observed_role, _) => {
 			// If it is possible that a disconnected validator would attempt a reconnect
 			// it should be handled here.
 			tracing::trace!(
@@ -1343,6 +1343,7 @@ mod tests {
 				NetworkBridgeEvent::PeerConnected(
 					peer.clone(),
 					polkadot_node_network_protocol::ObservedRole::Authority,
+					None,
 				),
 			),
 		).await;

--- a/node/network/collator-protocol/src/validator_side.rs
+++ b/node/network/collator-protocol/src/validator_side.rs
@@ -873,7 +873,7 @@ where
 	use NetworkBridgeEvent::*;
 
 	match bridge_message {
-		PeerConnected(peer_id, _role) => {
+		PeerConnected(peer_id, _role, _) => {
 			state.peer_data.entry(peer_id).or_default();
 			state.metrics.note_collator_peer_count(state.peer_data.len());
 		},
@@ -1469,6 +1469,7 @@ mod tests {
 					NetworkBridgeEvent::PeerConnected(
 						peer_b,
 						ObservedRole::Full,
+						None,
 					),
 				)
 			).await;
@@ -1543,6 +1544,7 @@ mod tests {
 					NetworkBridgeEvent::PeerConnected(
 						peer_b,
 						ObservedRole::Full,
+						None,
 					),
 				)
 			).await;
@@ -1553,6 +1555,7 @@ mod tests {
 					NetworkBridgeEvent::PeerConnected(
 						peer_c,
 						ObservedRole::Full,
+						None,
 					),
 				)
 			).await;
@@ -1636,6 +1639,7 @@ mod tests {
 					NetworkBridgeEvent::PeerConnected(
 						peer_b,
 						ObservedRole::Full,
+						None,
 					),
 				)
 			).await;
@@ -1704,6 +1708,7 @@ mod tests {
 					NetworkBridgeEvent::PeerConnected(
 						peer_b,
 						ObservedRole::Full,
+						None,
 					),
 				)
 			).await;
@@ -1714,6 +1719,7 @@ mod tests {
 					NetworkBridgeEvent::PeerConnected(
 						peer_c,
 						ObservedRole::Full,
+						None,
 					),
 				)
 			).await;
@@ -1918,6 +1924,7 @@ mod tests {
 					NetworkBridgeEvent::PeerConnected(
 						peer_b.clone(),
 						ObservedRole::Full,
+						None,
 					)
 				)
 			).await;
@@ -2012,6 +2019,7 @@ mod tests {
 					NetworkBridgeEvent::PeerConnected(
 						peer_b.clone(),
 						ObservedRole::Full,
+						None,
 					)
 				)
 			).await;
@@ -2153,6 +2161,7 @@ mod tests {
 					NetworkBridgeEvent::PeerConnected(
 						peer_b.clone(),
 						ObservedRole::Full,
+						None,
 					)
 				)
 			).await;
@@ -2199,6 +2208,7 @@ mod tests {
 					NetworkBridgeEvent::PeerConnected(
 						peer_b.clone(),
 						ObservedRole::Full,
+						None,
 					)
 				)
 			).await;
@@ -2270,6 +2280,7 @@ mod tests {
 					NetworkBridgeEvent::PeerConnected(
 						peer_b.clone(),
 						ObservedRole::Full,
+						None,
 					)
 				)
 			).await;

--- a/node/network/protocol/src/request_response/mod.rs
+++ b/node/network/protocol/src/request_response/mod.rs
@@ -154,7 +154,7 @@ impl Protocol {
 				name: p_name,
 				max_request_size: 1_000,
 				// Available data size is dominated code size.
-                // + 1000 to account for protocol overhead (should be way less).
+				// + 1000 to account for protocol overhead (should be way less).
 				max_response_size: MAX_CODE_SIZE as u64 + 1000,
 				// We need statement fetching to be fast and will try our best at the responding
 				// side to answer requests within that timeout, assuming a bandwidth of 500Mbit/s
@@ -199,7 +199,7 @@ impl Protocol {
 				// waisting precious time.
 				let available_bandwidth = 7 * MIN_BANDWIDTH_BYTES / 10;
 				let size = u64::saturating_sub(
-                    STATEMENTS_TIMEOUT.as_millis() as u64 * available_bandwidth / (1000 * MAX_CODE_SIZE as u64),
+					STATEMENTS_TIMEOUT.as_millis() as u64 * available_bandwidth / (1000 * MAX_CODE_SIZE as u64),
 					MAX_PARALLEL_STATEMENT_REQUESTS as u64
 				);
 				debug_assert!(

--- a/node/network/statement-distribution/src/lib.rs
+++ b/node/network/statement-distribution/src/lib.rs
@@ -1437,7 +1437,7 @@ async fn handle_network_update(
 	metrics: &Metrics,
 ) {
 	match update {
-		NetworkBridgeEvent::PeerConnected(peer, role) => {
+		NetworkBridgeEvent::PeerConnected(peer, role, _) => {
 			tracing::trace!(
 				target: LOG_TARGET,
 				?peer,
@@ -2667,13 +2667,13 @@ mod tests {
 			// notify of peers and view
 			handle.send(FromOverseer::Communication {
 				msg: StatementDistributionMessage::NetworkBridgeUpdateV1(
-					NetworkBridgeEvent::PeerConnected(peer_a.clone(), ObservedRole::Full)
+					NetworkBridgeEvent::PeerConnected(peer_a.clone(), ObservedRole::Full, None)
 				)
 			}).await;
 
 			handle.send(FromOverseer::Communication {
 				msg: StatementDistributionMessage::NetworkBridgeUpdateV1(
-					NetworkBridgeEvent::PeerConnected(peer_b.clone(), ObservedRole::Full)
+					NetworkBridgeEvent::PeerConnected(peer_b.clone(), ObservedRole::Full, None)
 				)
 			}).await;
 
@@ -2835,23 +2835,23 @@ mod tests {
 			// notify of peers and view
 			handle.send(FromOverseer::Communication {
 				msg: StatementDistributionMessage::NetworkBridgeUpdateV1(
-					NetworkBridgeEvent::PeerConnected(peer_a.clone(), ObservedRole::Full)
+					NetworkBridgeEvent::PeerConnected(peer_a.clone(), ObservedRole::Full, None)
 				)
 			}).await;
 
 			handle.send(FromOverseer::Communication {
 				msg: StatementDistributionMessage::NetworkBridgeUpdateV1(
-					NetworkBridgeEvent::PeerConnected(peer_b.clone(), ObservedRole::Full)
+					NetworkBridgeEvent::PeerConnected(peer_b.clone(), ObservedRole::Full, None)
 				)
 			}).await;
 			handle.send(FromOverseer::Communication {
 				msg: StatementDistributionMessage::NetworkBridgeUpdateV1(
-					NetworkBridgeEvent::PeerConnected(peer_c.clone(), ObservedRole::Full)
+					NetworkBridgeEvent::PeerConnected(peer_c.clone(), ObservedRole::Full, None)
 				)
 			}).await;
 			handle.send(FromOverseer::Communication {
 				msg: StatementDistributionMessage::NetworkBridgeUpdateV1(
-					NetworkBridgeEvent::PeerConnected(peer_bad.clone(), ObservedRole::Full)
+					NetworkBridgeEvent::PeerConnected(peer_bad.clone(), ObservedRole::Full, None)
 				)
 			}).await;
 

--- a/node/subsystem-util/Cargo.toml
+++ b/node/subsystem-util/Cargo.toml
@@ -16,6 +16,7 @@ rand = "0.8.3"
 streamunordered = "0.5.1"
 thiserror = "1.0.23"
 tracing = "0.1.25"
+lru = "0.6.5"
 
 polkadot-node-primitives = { path = "../primitives" }
 polkadot-node-subsystem = { path = "../subsystem" }

--- a/node/subsystem-util/src/lib.rs
+++ b/node/subsystem-util/src/lib.rs
@@ -65,6 +65,9 @@ pub mod reexports {
 	};
 }
 
+/// Convenient and efficient runtime info access.
+pub mod runtime;
+
 /// Duration a job will wait after sending a stop signal before hard-aborting.
 pub const JOB_GRACEFUL_STOP_DURATION: Duration = Duration::from_secs(1);
 /// Capacity of channels to and from individual jobs

--- a/node/subsystem-util/src/runtime/error.rs
+++ b/node/subsystem-util/src/runtime/error.rs
@@ -1,0 +1,52 @@
+// Copyright 2021 Parity Technologies (UK) Ltd.
+// This file is part of Polkadot.
+
+// Polkadot is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Polkadot is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+//! Error handling related code and Error/Result definitions.
+
+use thiserror::Error;
+use futures::channel::oneshot;
+
+use polkadot_node_subsystem::errors::RuntimeApiError;
+use polkadot_primitives::v1::SessionIndex;
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Errors for fetching of runtime information.
+#[derive(Debug, Error)]
+pub enum Error {
+	/// Runtime API subsystem is down, which means we're shutting down.
+	#[error("Runtime request canceled")]
+	RuntimeRequestCanceled(oneshot::Canceled),
+
+	/// Some request to the runtime failed.
+	/// For example if we prune a block we're requesting info about.
+	#[error("Runtime API error")]
+	RuntimeRequest(RuntimeApiError),
+
+	/// We tried fetching a session info which was not available.
+	#[error("There was no session with the given index")]
+	NoSuchSession(SessionIndex),
+}
+
+/// Receive a response from a runtime request and convert errors.
+pub(crate) async fn recv_runtime<V>(
+	r: oneshot::Receiver<std::result::Result<V, RuntimeApiError>>,
+) -> std::result::Result<V, Error> {
+	r.await
+		.map_err(Error::RuntimeRequestCanceled)?
+		.map_err(Error::RuntimeRequest)
+}

--- a/node/subsystem/src/messages/network_bridge_event.rs
+++ b/node/subsystem/src/messages/network_bridge_event.rs
@@ -17,13 +17,15 @@
 use std::convert::TryFrom;
 
 pub use sc_network::{ReputationChange, PeerId};
+
 use polkadot_node_network_protocol::{WrongVariant, ObservedRole, OurView, View};
+use polkadot_primitives::v1::AuthorityDiscoveryId;
 
 /// Events from network.
 #[derive(Debug, Clone, PartialEq)]
 pub enum NetworkBridgeEvent<M> {
 	/// A peer has connected.
-	PeerConnected(PeerId, ObservedRole),
+	PeerConnected(PeerId, ObservedRole, Option<AuthorityDiscoveryId>),
 
 	/// A peer has disconnected.
 	PeerDisconnected(PeerId),
@@ -58,8 +60,8 @@ impl<M> NetworkBridgeEvent<M> {
 		where T: 'a + Clone, &'a T: TryFrom<&'a M, Error = WrongVariant>
 	{
 		Ok(match *self {
-			NetworkBridgeEvent::PeerConnected(ref peer, ref role)
-				=> NetworkBridgeEvent::PeerConnected(peer.clone(), role.clone()),
+			NetworkBridgeEvent::PeerConnected(ref peer, ref role, ref authority_id)
+				=> NetworkBridgeEvent::PeerConnected(peer.clone(), role.clone(), authority_id.clone()),
 			NetworkBridgeEvent::PeerDisconnected(ref peer)
 				=> NetworkBridgeEvent::PeerDisconnected(peer.clone()),
 			NetworkBridgeEvent::PeerMessage(ref peer, ref msg)


### PR DESCRIPTION
This PR does mostly two things (which I need right now and will be generally useful):

1. I moved the runtime module from availability-distribution  to subsystem-util, so it can be used by other subsystems as well.
2. We now expose on `PeerConnected` events if a peer is a validator node. We have been already gathering this information for all peers that connect, we might as well make it easily accessible.

The latter makes it easy for subsystems to treat validator nodes differently than normal peers, e.g. give them better priority and similar things. Now that we just connect to all validators by means of `gossip-support`, this is also needed for easily sending a message to a particular validator via `SendValidationMessage` (which works with `PeerId`s).