### PR TITLE
Add validation_code_by_hash request in RuntimeApiRequest

### DIFF
--- a/node/core/runtime-api/src/cache.rs
+++ b/node/core/runtime-api/src/cache.rs
@@ -18,8 +18,8 @@ use polkadot_primitives::v1::{
 	BlockNumber, CandidateCommitments, CommittedCandidateReceipt, CandidateEvent,
 	CoreState, GroupRotationInfo, InboundDownwardMessage, InboundHrmpMessage, Hash,
 	PersistedValidationData, Id as ParaId, OccupiedCoreAssumption,
-	SessionIndex, SessionInfo, ValidationCodeAndHash, ValidatorId, ValidatorIndex,
-	AuthorityDiscoveryId,
+	SessionIndex, SessionInfo, ValidationCode, ValidatorId, ValidatorIndex,
+	AuthorityDiscoveryId, ValidationCodeAndHash,
 };
 use sp_consensus_babe::Epoch;
 use parity_util_mem::{MallocSizeOf, MallocSizeOfExt};
@@ -39,6 +39,7 @@ const SESSION_INDEX_FOR_CHILD_CACHE_SIZE: usize = 64 * 1024;
 const VALIDATION_CODE_CACHE_SIZE: usize = 10 * 1024 * 1024;
 const VALIDATION_CODE_HASH_CACHE_SIZE: usize = 64 * 1024;
 const HISTORICAL_VALIDATION_CODE_CACHE_SIZE: usize = 10 * 1024 * 1024;
+const VALIDATION_CODE_BY_HASH_CACHE_SIZE: usize = 10 * 1024 * 1024;
 const CANDIDATE_PENDING_AVAILABILITY_CACHE_SIZE: usize = 64 * 1024;
 const CANDIDATE_EVENTS_CACHE_SIZE: usize = 64 * 1024;
 const SESSION_INFO_CACHE_SIZE: usize = 64 * 1024;
@@ -83,6 +84,7 @@ pub(crate) struct RequestResultCache {
 	validation_code: MemoryLruCache<(Hash, ParaId, OccupiedCoreAssumption), ResidentSizeOf<Option<ValidationCodeAndHash>>>,
 	validation_code_hash: MemoryLruCache<(Hash, ParaId, OccupiedCoreAssumption), ResidentSizeOf<Option<Hash>>>,
 	historical_validation_code: MemoryLruCache<(Hash, ParaId, BlockNumber), ResidentSizeOf<Option<ValidationCodeAndHash>>>,
+	validation_code_by_hash: MemoryLruCache<(Hash, Hash), ResidentSizeOf<Option<ValidationCode>>>,
 	candidate_pending_availability: MemoryLruCache<(Hash, ParaId), ResidentSizeOf<Option<CommittedCandidateReceipt>>>,
 	candidate_events: MemoryLruCache<Hash, ResidentSizeOf<Vec<CandidateEvent>>>,
 	session_info: MemoryLruCache<(Hash, SessionIndex), ResidentSizeOf<Option<SessionInfo>>>,
@@ -104,6 +106,7 @@ impl Default for RequestResultCache {
 			validation_code: MemoryLruCache::new(VALIDATION_CODE_CACHE_SIZE),
 			validation_code_hash: MemoryLruCache::new(VALIDATION_CODE_HASH_CACHE_SIZE),
 			historical_validation_code: MemoryLruCache::new(HISTORICAL_VALIDATION_CODE_CACHE_SIZE),
+			validation_code_by_hash: MemoryLruCache::new(VALIDATION_CODE_BY_HASH_CACHE_SIZE),
 			candidate_pending_availability: MemoryLruCache::new(CANDIDATE_PENDING_AVAILABILITY_CACHE_SIZE),
 			candidate_events: MemoryLruCache::new(CANDIDATE_EVENTS_CACHE_SIZE),
 			session_info: MemoryLruCache::new(SESSION_INFO_CACHE_SIZE),
@@ -195,6 +198,14 @@ impl RequestResultCache {
 		self.historical_validation_code.insert(key, ResidentSizeOf(value));
 	}
 
+	pub(crate) fn validation_code_by_hash(&mut self, key: (Hash, Hash)) -> Option<&Option<ValidationCode>> {
+		self.validation_code_by_hash.get(&key).map(|v| &v.0)
+	}
+
+	pub(crate) fn cache_validation_code_by_hash(&mut self, key: (Hash, Hash), value: Option<ValidationCode>) {
+		self.validation_code_by_hash.insert(key, ResidentSizeOf(value));
+	}
+
 	pub(crate) fn candidate_pending_availability(&mut self, key: (Hash, ParaId)) -> Option<&Option<CommittedCandidateReceipt>> {
 		self.candidate_pending_availability.get(&key).map(|v| &v.0)
 	}
@@ -255,6 +266,7 @@ pub(crate) enum RequestResult {
 	ValidationCode(Hash, ParaId, OccupiedCoreAssumption, Option<ValidationCodeAndHash>),
 	ValidationCodeHash(Hash, ParaId, OccupiedCoreAssumption, Option<Hash>),
 	HistoricalValidationCode(Hash, ParaId, BlockNumber, Option<ValidationCodeAndHash>),
+	ValidationCodeByHash(Hash, Hash, Option<ValidationCode>),
 	CandidatePendingAvailability(Hash, ParaId, Option<CommittedCandidateReceipt>),
 	CandidateEvents(Hash, Vec<CandidateEvent>),
 	SessionInfo(Hash, SessionIndex, Option<SessionInfo>),

--- a/node/subsystem-util/src/lib.rs
+++ b/node/subsystem-util/src/lib.rs
@@ -38,7 +38,7 @@ use pin_project::pin_project;
 use polkadot_primitives::v1::{
 	CandidateEvent, CommittedCandidateReceipt, CoreState, EncodeAs, PersistedValidationData,
 	GroupRotationInfo, Hash, Id as ParaId, OccupiedCoreAssumption,
-	SessionIndex, Signed, SigningContext, ValidatorId, ValidatorIndex, SessionInfo,
+	SessionIndex, Signed, SigningContext, ValidationCode, ValidatorId, ValidatorIndex, SessionInfo,
 	AuthorityDiscoveryId, GroupIndex, ValidationCodeAndHash,
 };
 use sp_core::{traits::SpawnNamed, Public};
@@ -178,6 +178,7 @@ specialize_requests! {
 	fn request_session_index_for_child() -> SessionIndex; SessionIndexForChild;
 	fn request_validation_code(para_id: ParaId, assumption: OccupiedCoreAssumption) -> Option<ValidationCodeAndHash>; ValidationCode;
 	fn request_validation_code_hash(para_id: ParaId, assumption: OccupiedCoreAssumption) -> Option<Hash>; ValidationCodeHash;
+	fn request_validation_code_by_hash(hash: Hash) -> Option<ValidationCode>; ValidationCodeByHash;
 	fn request_candidate_pending_availability(para_id: ParaId) -> Option<CommittedCandidateReceipt>; CandidatePendingAvailability;
 	fn request_candidate_events() -> Vec<CandidateEvent>; CandidateEvents;
 	fn request_session_info(index: SessionIndex) -> Option<SessionInfo>; SessionInfo;

--- a/node/subsystem/src/messages.rs
+++ b/node/subsystem/src/messages.rs
@@ -45,7 +45,7 @@ use polkadot_primitives::v1::{
 	CollatorId, CommittedCandidateReceipt, CoreState,
 	GroupRotationInfo, Hash, Id as ParaId, OccupiedCoreAssumption,
 	PersistedValidationData, SessionIndex, SignedAvailabilityBitfield,
-	ValidationCodeAndHash, ValidatorId, CandidateHash,
+	ValidationCode, ValidationCodeAndHash, ValidatorId, CandidateHash,
 	ValidatorIndex, ValidatorSignature, InboundDownwardMessage, InboundHrmpMessage,
 	CandidateIndex, GroupIndex, MultiDisputeStatementSet, SignedAvailabilityBitfields,
 };
@@ -489,6 +489,11 @@ pub enum RuntimeApiRequest {
 		ParaId,
 		BlockNumber,
 		RuntimeApiSender<Option<ValidationCodeAndHash>>,
+	),
+	/// Get the validation code of a para from its hash.
+	ValidationCodeByHash(
+		Hash,
+		RuntimeApiSender<Option<ValidationCode>>,
 	),
 	/// Get a the candidate pending availability for a particular parachain by parachain / core index
 	CandidatePendingAvailability(ParaId, RuntimeApiSender<Option<CommittedCandidateReceipt>>),

--- a/primitives/src/v1.rs
+++ b/primitives/src/v1.rs
@@ -911,6 +911,13 @@ sp_api::decl_runtime_apis! {
 		fn historical_validation_code(para_id: Id, context_height: N)
 			-> Option<ValidationCodeAndHash>;
 
+		/// Get the validation code from its hash.
+		///
+		/// The current code and future code of registered para is available. Past code of para is
+		/// available for a limited number of block.
+		#[skip_initialize_block]
+		fn validation_code_by_hash(hash: Hash) -> Option<ValidationCode>;
+
 		/// Get the receipt of a candidate pending availability. This returns `Some` for any paras
 		/// assigned to occupied cores in `availability_cores` and `None` otherwise.
 		#[skip_initialize_block]
@@ -930,10 +937,6 @@ sp_api::decl_runtime_apis! {
 		/// messages in them are also included.
 		#[skip_initialize_block]
 		fn inbound_hrmp_channels_contents(recipient: Id) -> BTreeMap<Id, Vec<InboundHrmpMessage<N>>>;
-
-		/// Get the validation code from its hash.
-		#[skip_initialize_block]
-		fn validation_code_by_hash(hash: Hash) -> Option<ValidationCode>;
 	}
 }
 

--- a/roadmap/implementers-guide/src/SUMMARY.md
+++ b/roadmap/implementers-guide/src/SUMMARY.md
@@ -30,6 +30,7 @@
   - [Session Index](runtime-api/session-index.md)
   - [Validation Code](runtime-api/validation-code.md)
   - [Validation Code Hash](runtime-api/validation-code-hash.md)
+  - [Validation Code By Hash](runtime-api/validation-code-by-hash.md)
   - [Candidate Pending Availability](runtime-api/candidate-pending-availability.md)
   - [Candidate Events](runtime-api/candidate-events.md)
   - [Disputes Info](runtime-api/disputes-info.md)

--- a/roadmap/implementers-guide/src/runtime-api/validation-code-by-hash.md
+++ b/roadmap/implementers-guide/src/runtime-api/validation-code-by-hash.md
@@ -1,0 +1,9 @@
+# Validation Code By Hash
+
+Fetch the current validation code, future validation code or past validation code (if not pruned) used by a para from the hash of the validation code.
+
+Past validation code of para are pruned as configured in runtime configuration module.
+
+```rust
+fn validation_code_by_hash(at: Block, Hash) -> Option<ValidationCode>;
+```

--- a/roadmap/implementers-guide/src/runtime-api/validation-code-hash.md
+++ b/roadmap/implementers-guide/src/runtime-api/validation-code-hash.md
@@ -5,3 +5,5 @@ Fetch the hash of the validation code used by a para, making the given `Occupied
 ```rust
 fn validation_code_hash(at: Block, ParaId, OccupiedCoreAssumption) -> Option<Hash>;
 ```
+
+The code can be fetched from the hash using `validation_code_by_hash` function.


### PR DESCRIPTION
Based on https://github.com/paritytech/polkadot/pull/2907

There is currently no usage of this runtime API in the client, but for consistency and future usage we can add it.

PR should be in reviewable state, but better to open it once https://github.com/paritytech/polkadot/pull/2907 is merged (or if people request it I can rebase it on master)