### PR TITLE
Fix link to polkadot runtime spec in implementers guide

### DIFF
--- a/roadmap/implementers-guide/src/further-reading.md
+++ b/roadmap/implementers-guide/src/further-reading.md
@@ -1,4 +1,4 @@
 # Further Reading
 
 - Polkadot Wiki on Consensus: <https://wiki.polkadot.network/docs/en/learn-consensus>
-- Polkadot Runtime Spec: <https://github.com/w3f/polkadot-spec/tree/spec-rt-anv-vrf-gen-and-announcement/runtime-spec>
+- Polkadot Spec: <https://github.com/w3f/polkadot-spec>


### PR DESCRIPTION
the previous link links to a branch which doesn't exist (anymore).

Also instead of linking only to the runtime spec I think we can link to the whole polkadot spec which itself links to both runtime and host spec.