### PR TITLE
runtime: remove BabePalletPrefix impls for old migration

### DIFF
--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -1238,12 +1238,6 @@ construct_runtime! {
 	}
 }
 
-impl pallet_babe::migrations::BabePalletPrefix for Runtime {
-	fn pallet_prefix() -> &'static str {
-		"Babe"
-	}
-}
-
 pub struct ParachainHostConfigurationMigration;
 impl frame_support::traits::OnRuntimeUpgrade for ParachainHostConfigurationMigration {
 	fn on_runtime_upgrade() -> frame_support::weights::Weight {

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -1027,12 +1027,6 @@ construct_runtime! {
 	}
 }
 
-impl pallet_babe::migrations::BabePalletPrefix for Runtime {
-	fn pallet_prefix() -> &'static str {
-		"Babe"
-	}
-}
-
 /// The address format for describing accounts.
 pub type Address = sp_runtime::MultiAddress<AccountId, ()>;
 /// Block header type as expected by this runtime.

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -959,12 +959,6 @@ construct_runtime! {
 	}
 }
 
-impl pallet_babe::migrations::BabePalletPrefix for Runtime {
-	fn pallet_prefix() -> &'static str {
-		"Babe"
-	}
-}
-
 pub struct ParachainHostConfigurationMigration;
 impl frame_support::traits::OnRuntimeUpgrade for ParachainHostConfigurationMigration {
 	fn on_runtime_upgrade() -> frame_support::weights::Weight {


### PR DESCRIPTION
These should have been removed in #2764.