### PR TITLE
CI: bot allows simnet failure

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -388,3 +388,4 @@ trigger-simnet:
   script:
     # API trigger for a simnet job
     - ./scripts/gitlab/trigger_pipeline.sh
+  allow_failure:                   true


### PR DESCRIPTION
See https://github.com/paritytech/polkadot/pull/2958#issuecomment-833841942 for context.
This is a workaround until simnet job is proven to be stable.