### PR TITLE
Support opening HRMP channels in genesis

### DIFF
--- a/node/service/src/chain_spec.rs
+++ b/node/service/src/chain_spec.rs
@@ -879,6 +879,7 @@ fn rococo_staging_testnet_config_genesis(wasm_binary: &[u8]) -> rococo_runtime::
 			paras: vec![],
 		    _phdata: Default::default(),
 		},
+		parachains_hrmp: Default::default(),
 		parachains_configuration: rococo_runtime::ParachainsConfigurationConfig {
 			config: polkadot_runtime_parachains::configuration::HostConfiguration {
 				validation_upgrade_frequency: 1u32,
@@ -1471,6 +1472,7 @@ pub fn rococo_testnet_genesis(
 				..Default::default()
 			},
 		},
+		parachains_hrmp: Default::default(),
 		parachains_paras: rococo_runtime::ParasConfig {
 			paras: vec![],
 		    _phdata: Default::default(),

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -218,7 +218,7 @@ construct_runtime! {
 		Initializer: parachains_initializer::{Pallet, Call, Storage},
 		Dmp: parachains_dmp::{Pallet, Call, Storage},
 		Ump: parachains_ump::{Pallet, Call, Storage},
-		Hrmp: parachains_hrmp::{Pallet, Call, Storage, Event},
+		Hrmp: parachains_hrmp::{Pallet, Call, Storage, Event, Config},
 		SessionInfo: parachains_session_info::{Pallet, Call, Storage},
 
 		// Parachain Onboarding Pallets


### PR DESCRIPTION
This change allows to list channels that should be opened at the genesis. This should be useful for integration testing.