### PR TITLE
Narrow the set of available host functions for PVF

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1864,7 +1864,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -1882,7 +1882,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "3.1.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1901,7 +1901,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "Inflector",
  "chrono",
@@ -1924,7 +1924,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1937,7 +1937,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1952,7 +1952,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -1963,7 +1963,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "bitflags",
  "frame-metadata",
@@ -1989,7 +1989,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "Inflector",
  "frame-support-procedural-tools",
@@ -2001,7 +2001,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 1.0.0",
@@ -2013,7 +2013,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2023,7 +2023,7 @@ dependencies = [
 [[package]]
 name = "frame-support-test"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "frame-metadata",
  "frame-support",
@@ -2043,7 +2043,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -2060,7 +2060,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2074,7 +2074,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -2083,7 +2083,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -4469,7 +4469,7 @@ checksum = "13370dae44474229701bb69b90b4f4dca6404cb0357a2d50d635f1171dc3aa7b"
 [[package]]
 name = "pallet-authority-discovery"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4484,7 +4484,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4498,7 +4498,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4521,7 +4521,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4550,7 +4550,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4564,7 +4564,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4580,7 +4580,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4595,7 +4595,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -4615,7 +4615,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4632,7 +4632,7 @@ dependencies = [
 [[package]]
 name = "pallet-gilt"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4646,7 +4646,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4667,7 +4667,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -4682,7 +4682,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4701,7 +4701,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4717,7 +4717,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4732,7 +4732,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "ckb-merkle-mountain-range",
  "frame-benchmarking",
@@ -4749,7 +4749,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr-primitives"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4765,7 +4765,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr-rpc"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -4783,7 +4783,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4798,7 +4798,7 @@ dependencies = [
 [[package]]
 name = "pallet-nicks"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4811,7 +4811,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4827,7 +4827,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -4849,7 +4849,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4864,7 +4864,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4877,7 +4877,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "enumflags2",
  "frame-support",
@@ -4891,7 +4891,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4906,7 +4906,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4925,7 +4925,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4941,7 +4941,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4954,7 +4954,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -4978,7 +4978,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "proc-macro-crate 1.0.0",
  "proc-macro2",
@@ -4989,7 +4989,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -4998,7 +4998,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5011,7 +5011,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5029,7 +5029,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5044,7 +5044,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5060,7 +5060,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -5077,7 +5077,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -5088,7 +5088,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5104,7 +5104,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5119,7 +5119,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -7339,7 +7339,7 @@ dependencies = [
 [[package]]
 name = "remote-externalities"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "env_logger 0.8.2",
  "hex-literal",
@@ -7624,7 +7624,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -7653,7 +7653,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "futures 0.3.14",
  "futures-timer 3.0.2",
@@ -7676,7 +7676,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -7692,7 +7692,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -7713,7 +7713,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "proc-macro-crate 1.0.0",
  "proc-macro2",
@@ -7724,7 +7724,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "chrono",
  "fdlimit",
@@ -7762,7 +7762,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "derive_more",
  "fnv",
@@ -7796,7 +7796,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "blake2-rfc",
  "hash-db",
@@ -7826,7 +7826,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "parking_lot 0.11.1",
  "sc-client-api",
@@ -7838,7 +7838,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -7884,7 +7884,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "derive_more",
  "futures 0.3.14",
@@ -7908,7 +7908,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -7921,7 +7921,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "async-trait",
  "futures 0.3.14",
@@ -7949,7 +7949,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-uncles"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "sc-client-api",
  "sp-authorship",
@@ -7960,7 +7960,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "derive_more",
  "lazy_static",
@@ -7990,7 +7990,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "derive_more",
  "parity-scale-codec",
@@ -8007,7 +8007,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -8022,7 +8022,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -8040,7 +8040,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -8080,7 +8080,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa-rpc"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "derive_more",
  "finality-grandpa",
@@ -8104,7 +8104,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa-warp-sync"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "derive_more",
  "futures 0.3.14",
@@ -8125,7 +8125,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "ansi_term 0.12.1",
  "futures 0.3.14",
@@ -8143,7 +8143,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -8163,7 +8163,7 @@ dependencies = [
 [[package]]
 name = "sc-light"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "hash-db",
  "lazy_static",
@@ -8182,7 +8182,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "async-std",
  "async-trait",
@@ -8235,7 +8235,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "futures 0.3.14",
  "futures-timer 3.0.2",
@@ -8252,7 +8252,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "bytes 0.5.6",
  "fnv",
@@ -8280,7 +8280,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "futures 0.3.14",
  "libp2p",
@@ -8293,7 +8293,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -8302,7 +8302,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "futures 0.3.14",
  "hash-db",
@@ -8337,7 +8337,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "derive_more",
  "futures 0.3.14",
@@ -8362,7 +8362,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "futures 0.1.29",
  "jsonrpc-core",
@@ -8380,7 +8380,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "async-trait",
  "directories",
@@ -8444,7 +8444,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -8459,7 +8459,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -8479,7 +8479,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "chrono",
  "futures 0.3.14",
@@ -8499,7 +8499,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
@@ -8536,7 +8536,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "proc-macro-crate 1.0.0",
  "proc-macro2",
@@ -8547,7 +8547,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-graph"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "derive_more",
  "futures 0.3.14",
@@ -8569,7 +8569,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "futures 0.3.14",
  "futures-diagnose",
@@ -9000,7 +9000,7 @@ dependencies = [
 [[package]]
 name = "sp-allocator"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "log",
  "sp-core",
@@ -9012,7 +9012,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "hash-db",
  "log",
@@ -9029,7 +9029,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate 1.0.0",
@@ -9041,7 +9041,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -9053,7 +9053,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -9067,7 +9067,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -9079,7 +9079,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -9091,7 +9091,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -9103,7 +9103,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "futures 0.3.14",
  "log",
@@ -9121,7 +9121,7 @@ dependencies = [
 [[package]]
 name = "sp-chain-spec"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "serde",
  "serde_json",
@@ -9130,7 +9130,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "async-trait",
  "futures 0.3.14",
@@ -9157,7 +9157,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "async-trait",
  "merlin",
@@ -9179,7 +9179,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "parity-scale-codec",
  "sp-arithmetic",
@@ -9189,7 +9189,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "parity-scale-codec",
  "schnorrkel",
@@ -9201,7 +9201,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "base58",
  "blake2-rfc",
@@ -9245,7 +9245,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "kvdb",
  "parking_lot 0.11.1",
@@ -9254,7 +9254,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9264,7 +9264,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -9275,7 +9275,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -9292,7 +9292,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -9306,7 +9306,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "futures 0.3.14",
  "hash-db",
@@ -9330,7 +9330,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -9341,7 +9341,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -9358,7 +9358,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "ruzstd",
  "zstd",
@@ -9367,7 +9367,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -9380,7 +9380,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections-compact"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "proc-macro-crate 1.0.0",
  "proc-macro2",
@@ -9391,7 +9391,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -9401,7 +9401,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "backtrace",
 ]
@@ -9409,7 +9409,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -9420,7 +9420,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -9441,7 +9441,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -9458,7 +9458,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "Inflector",
  "proc-macro-crate 1.0.0",
@@ -9470,7 +9470,7 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "serde",
  "serde_json",
@@ -9479,7 +9479,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -9492,7 +9492,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -9502,7 +9502,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "hash-db",
  "log",
@@ -9525,12 +9525,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 
 [[package]]
 name = "sp-storage"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -9543,7 +9543,7 @@ dependencies = [
 [[package]]
 name = "sp-tasks"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "log",
  "sp-core",
@@ -9556,7 +9556,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "async-trait",
  "futures-timer 3.0.2",
@@ -9573,7 +9573,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "erased-serde",
  "log",
@@ -9591,7 +9591,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "derive_more",
  "futures 0.3.14",
@@ -9607,7 +9607,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -9621,7 +9621,7 @@ dependencies = [
 [[package]]
 name = "sp-utils"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "futures 0.3.14",
  "futures-core",
@@ -9633,7 +9633,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -9645,7 +9645,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -9802,7 +9802,7 @@ dependencies = [
 [[package]]
 name = "substrate-browser-utils"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "chrono",
  "console_error_panic_hook",
@@ -9828,7 +9828,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "platforms",
 ]
@@ -9836,7 +9836,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.14",
@@ -9859,7 +9859,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "async-std",
  "derive_more",
@@ -9873,7 +9873,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "async-trait",
  "futures 0.1.29",
@@ -9902,7 +9902,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-utils"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "futures 0.3.14",
  "substrate-test-utils-derive",
@@ -9912,7 +9912,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-utils-derive"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "proc-macro-crate 1.0.0",
  "quote",
@@ -10654,7 +10654,7 @@ checksum = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
 [[package]]
 name = "try-runtime-cli"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
+source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
 dependencies = [
  "frame-try-runtime",
  "log",

--- a/node/core/pvf/src/executor_intf.rs
+++ b/node/core/pvf/src/executor_intf.rs
@@ -79,7 +79,14 @@ pub fn execute(
 	})?
 }
 
-type HostFunctions = sp_io::SubstrateHostFunctions;
+type HostFunctions = (
+	sp_io::misc::HostFunctions,
+	sp_io::crypto::HostFunctions,
+	sp_io::hashing::HostFunctions,
+	sp_io::allocator::HostFunctions,
+	sp_io::logging::HostFunctions,
+	sp_io::trie::HostFunctions,
+);
 
 /// The validation externalities that will panic on any storage related access.
 struct ValidationExternalities(sp_externalities::Extensions);


### PR DESCRIPTION
The original definition is

```rust
pub type SubstrateHostFunctions = (
	storage::HostFunctions,
	default_child_storage::HostFunctions,
	misc::HostFunctions,
	wasm_tracing::HostFunctions,
	offchain::HostFunctions,
	crypto::HostFunctions,
	hashing::HostFunctions,
	allocator::HostFunctions,
	logging::HostFunctions,
	sandbox::HostFunctions,
	crate::trie::HostFunctions,
	offchain_index::HostFunctions,
	runtime_tasks::HostFunctions,
);
```

we leave out:

- storage related stuff (PVF doesn't have a notion of a persistent storage/trie),
- tracing
- off chain workers (PVFs do not have such a notion)
- runtime tasks (it is experimental)
- sandbox (still is being worked on)
