### PR TITLE
Enable Para Registration on Kusama

### DIFF
--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -144,13 +144,12 @@ pub fn native_version() -> NativeVersion {
 	}
 }
 
-/// Avoid processing transactions from slots and parachain registrar except by root.
+/// Don't allow swaps until parathread story is more mature.
 pub struct BaseFilter;
 impl Filter<Call> for BaseFilter {
 	fn filter(c: &Call) -> bool {
 		!matches!(c,
-			Call::Registrar(..) |
-			Call::Slots(..)
+			Call::Registrar(paras_registrar::Call::swap(..))
 		)
 	}
 }

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -146,7 +146,7 @@ pub fn native_version() -> NativeVersion {
 /// Allow everything.
 pub struct BaseFilter;
 impl Filter<Call> for BaseFilter {
-	fn filter(c: &Call) -> bool {
+	fn filter(_: &Call) -> bool {
 		true
 	}
 }

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -143,14 +143,11 @@ pub fn native_version() -> NativeVersion {
 	}
 }
 
-/// Avoid processing transactions from slots and parachain registrar except by root.
+/// Allow everything.
 pub struct BaseFilter;
 impl Filter<Call> for BaseFilter {
 	fn filter(c: &Call) -> bool {
-		!matches!(c,
-			Call::Registrar(..) |
-			Call::Slots(..)
-		)
+		true
 	}
 }
 


### PR DESCRIPTION
Removes the call filters which would prevent external users from calling the Registrar Pallet.

We still disable swaps, since the parathread story is not complete yet.