### PR TITLE
bump spec versions in kusama, polkadot and westend again II

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -254,31 +254,31 @@ generate-impl-guide:
       # https://docs.gitlab.com/ee/ci/multi_project_pipelines.html#with-variable-inheritance
       dotenv: ./artifacts/build.env
 
-# publish-polkadot-image:
-#   stage:                           build
-#   <<:                              *build-push-image
-#   variables:
-#     <<:                            *image-variables
-#     # scripts/docker/Dockerfile
-#     DOCKERFILE:                    Dockerfile
-#     IMAGE_NAME:                    docker.io/paritypr/synth-wave
-#   rules:
-#   # Don't run on releases - this is handled by the Github Action here:
-#   # .github/workflows/publish-docker-release.yml
-#     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
-#       when: never
-#     - if: $CI_PIPELINE_SOURCE == "schedule"
-#     - if: $CI_COMMIT_REF_NAME == "master"
-#     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
-#     - if: $CI_COMMIT_REF_NAME == "rococo-v1"
-#       variables:
-#         <<:                        *image-variables
-#         IMAGE_NAME:                docker.io/parity/rococo
-#         DOCKER_USER:               ${Docker_Hub_User_Parity}
-#         DOCKER_PASS:               ${Docker_Hub_Pass_Parity}
-#   needs:
-#     - job:                         test-build-linux-stable
-#       artifacts:                   true
+publish-polkadot-image:
+  stage:                           build
+  <<:                              *build-push-image
+#  variables:
+#    <<:                            *image-variables
+#    # scripts/docker/Dockerfile
+#    DOCKERFILE:                    Dockerfile
+#    IMAGE_NAME:                    docker.io/paritypr/synth-wave
+  rules:
+  # Don't run on releases - this is handled by the Github Action here:
+  # .github/workflows/publish-docker-release.yml
+#    - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
+#      when: never
+#  - if: $CI_PIPELINE_SOURCE == "schedule"
+#  - if: $CI_COMMIT_REF_NAME == "master"
+#  - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
+    - if: $CI_COMMIT_REF_NAME == "rococo-v1"
+      variables:
+        <<:                        *image-variables
+        IMAGE_NAME:                docker.io/parity/rococo
+        DOCKER_USER:               ${Docker_Hub_User_Parity}
+        DOCKER_PASS:               ${Docker_Hub_Pass_Parity}
+  needs:
+    - job:                         test-build-linux-stable
+      artifacts:                   true
 
 # publish-adder-collator-image:
 #   # service image for Simnet

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -254,58 +254,58 @@ generate-impl-guide:
       # https://docs.gitlab.com/ee/ci/multi_project_pipelines.html#with-variable-inheritance
       dotenv: ./artifacts/build.env
 
-publish-polkadot-image:
-  stage:                           build
-  <<:                              *build-push-image
-  variables:
-    <<:                            *image-variables
-    # scripts/docker/Dockerfile
-    DOCKERFILE:                    Dockerfile
-    IMAGE_NAME:                    docker.io/paritypr/synth-wave
-  rules:
-  # Don't run on releases - this is handled by the Github Action here:
-  # .github/workflows/publish-docker-release.yml
-    - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
-      when: never
-    - if: $CI_PIPELINE_SOURCE == "schedule"
-    - if: $CI_COMMIT_REF_NAME == "master"
-    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
-    - if: $CI_COMMIT_REF_NAME == "rococo-v1"
-      variables:
-        <<:                        *image-variables
-        IMAGE_NAME:                docker.io/parity/rococo
-        DOCKER_USER:               ${Docker_Hub_User_Parity}
-        DOCKER_PASS:               ${Docker_Hub_Pass_Parity}
-  needs:
-    - job:                         test-build-linux-stable
-      artifacts:                   true
+# publish-polkadot-image:
+#   stage:                           build
+#   <<:                              *build-push-image
+#   variables:
+#     <<:                            *image-variables
+#     # scripts/docker/Dockerfile
+#     DOCKERFILE:                    Dockerfile
+#     IMAGE_NAME:                    docker.io/paritypr/synth-wave
+#   rules:
+#   # Don't run on releases - this is handled by the Github Action here:
+#   # .github/workflows/publish-docker-release.yml
+#     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
+#       when: never
+#     - if: $CI_PIPELINE_SOURCE == "schedule"
+#     - if: $CI_COMMIT_REF_NAME == "master"
+#     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
+#     - if: $CI_COMMIT_REF_NAME == "rococo-v1"
+#       variables:
+#         <<:                        *image-variables
+#         IMAGE_NAME:                docker.io/parity/rococo
+#         DOCKER_USER:               ${Docker_Hub_User_Parity}
+#         DOCKER_PASS:               ${Docker_Hub_Pass_Parity}
+#   needs:
+#     - job:                         test-build-linux-stable
+#       artifacts:                   true
 
-publish-adder-collator-image:
-  # service image for Simnet
-  stage:                           build
-  <<:                              *build-push-image
-  variables:
-    <<:                            *image-variables
-    # scripts/docker/collator.Dockerfile
-    DOCKERFILE:                    collator.Dockerfile
-    IMAGE_NAME:                    docker.io/paritypr/colander
-  rules:
-    - if: $CI_PIPELINE_SOURCE == "schedule"
-    - if: $CI_COMMIT_REF_NAME == "master"
-    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
-    - if: $CI_COMMIT_REF_NAME == "rococo-v1"
-  needs:
-    - job:                         build-adder-collator
-      artifacts:                   true
-  after_script:
-    - buildah logout "$IMAGE_NAME"
-    # pass artifacts to the trigger-simnet job
-    - echo "COLLATOR_IMAGE=$IMAGE_NAME" > ./artifacts/collator.env
-    - echo "COLLATOR_IMAGE_TAG=$(cat ./artifacts/EXTRATAG)" >> ./artifacts/collator.env
-  artifacts:
-    reports:
-      # this artifact is used in trigger-simnet job
-      dotenv: ./artifacts/collator.env
+# publish-adder-collator-image:
+#   # service image for Simnet
+#   stage:                           build
+#   <<:                              *build-push-image
+#   variables:
+#     <<:                            *image-variables
+#     # scripts/docker/collator.Dockerfile
+#     DOCKERFILE:                    collator.Dockerfile
+#     IMAGE_NAME:                    docker.io/paritypr/colander
+#   rules:
+#     - if: $CI_PIPELINE_SOURCE == "schedule"
+#     - if: $CI_COMMIT_REF_NAME == "master"
+#     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
+#     - if: $CI_COMMIT_REF_NAME == "rococo-v1"
+#   needs:
+#     - job:                         build-adder-collator
+#       artifacts:                   true
+#   after_script:
+#     - buildah logout "$IMAGE_NAME"
+#     # pass artifacts to the trigger-simnet job
+#     - echo "COLLATOR_IMAGE=$IMAGE_NAME" > ./artifacts/collator.env
+#     - echo "COLLATOR_IMAGE_TAG=$(cat ./artifacts/EXTRATAG)" >> ./artifacts/collator.env
+#   artifacts:
+#     reports:
+#       # this artifact is used in trigger-simnet job
+#       dotenv: ./artifacts/collator.env
 
 #### stage:                        publish
 

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -119,7 +119,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("kusama"),
 	impl_name: create_runtime_str!("parity-kusama"),
 	authoring_version: 2,
-	spec_version: 9010,
+	spec_version: 9011,
 	impl_version: 0,
 	#[cfg(not(feature = "disable-runtime-api"))]
 	apis: RUNTIME_API_VERSIONS,

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -95,7 +95,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("polkadot"),
 	impl_name: create_runtime_str!("parity-polkadot"),
 	authoring_version: 0,
-	spec_version: 9010,
+	spec_version: 9011,
 	impl_version: 0,
 	#[cfg(not(feature = "disable-runtime-api"))]
 	apis: RUNTIME_API_VERSIONS,

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -118,7 +118,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("westend"),
 	impl_name: create_runtime_str!("parity-westend"),
 	authoring_version: 2,
-	spec_version: 9010,
+	spec_version: 9011,
 	impl_version: 0,
 	#[cfg(not(feature = "disable-runtime-api"))]
 	apis: RUNTIME_API_VERSIONS,


### PR DESCRIPTION
To unbreak CI again: https://gitlab.parity.io/parity/polkadot/-/jobs/925416

@s3krit I thought the idea would be that we only bump these versions in release branches? Anyway, is there a way to automate this after release is done?