### PR TITLE
primitives: export the current slot number storage key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6237,6 +6237,7 @@ dependencies = [
  "sp-application-crypto",
  "sp-arithmetic",
  "sp-authority-discovery",
+ "sp-consensus-slots",
  "sp-core",
  "sp-inherents",
  "sp-io",

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -10,6 +10,7 @@ parity-scale-codec = { version = "2.0.0", default-features = false, features = [
 primitives = { package = "sp-core", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 application-crypto = { package = "sp-application-crypto", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+sp-consensus-slots = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 sp-keystore = { git = "https://github.com/paritytech/substrate", branch = "master", optional = true }
 sp-api = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 sp-version = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
@@ -42,6 +43,7 @@ std = [
 	"trie/std",
 	"sp-api/std",
 	"sp-authority-discovery/std",
+	"sp-consensus-slots/std",
 	"sp-keystore",
 	"sp-std/std",
 	"sp-io/std",

--- a/primitives/src/v1/mod.rs
+++ b/primitives/src/v1/mod.rs
@@ -57,6 +57,7 @@ pub use crate::v0::{ValidatorPair, CollatorPair};
 
 pub use sp_staking::SessionIndex;
 pub use sp_authority_discovery::AuthorityId as AuthorityDiscoveryId;
+pub use sp_consensus_slots::Slot;
 
 /// Signed data.
 mod signed;
@@ -81,6 +82,12 @@ pub mod well_known_keys {
 	//
 	//     <Hrmp as Store>::HrmpEgressChannelsIndex::prefix_hash();
 	//
+
+	/// The current slot number.
+	///
+	/// The storage entry should be accessed as a `Slot` encoded value.
+	pub const CURRENT_SLOT: &[u8] =
+		&hex!["1cb6f36e027abb2091cfb5110ab5087f06155b3cd9a8c9e5e9a23fd5dc13a5ed"];
 
 	/// The currently active host configuration.
 	///


### PR DESCRIPTION
Required for https://github.com/paritytech/cumulus/pull/437.