### PR TITLE
Fix ArtifactId::path

### DIFF
--- a/node/core/pvf/src/artifacts.rs
+++ b/node/core/pvf/src/artifacts.rs
@@ -276,7 +276,10 @@ async fn scan_for_known_artifacts(
 
 #[cfg(test)]
 mod tests {
+	use async_std::path::Path;
 	use super::ArtifactId;
+	use sp_core::H256;
+	use std::str::FromStr;
 
 	#[test]
 	fn ensure_wasmtime_version() {
@@ -307,5 +310,13 @@ mod tests {
 				.into()
 			)),
 		);
+	}
+
+	#[test]
+	fn path() {
+		let path = Path::new("/test");
+		let hash = H256::from_str("1234567890123456789012345678901234567890123456789012345678901234").unwrap();
+
+		assert_eq!(ArtifactId::new(hash).path(path).to_str(), Some("/test/1234567890123456789012345678901234567890123456789012345678901234"));
 	}
 }

--- a/node/core/pvf/src/artifacts.rs
+++ b/node/core/pvf/src/artifacts.rs
@@ -82,7 +82,7 @@ impl ArtifactId {
 
 	/// Returns the expected path to this artifact given the root of the cache.
 	pub fn path(&self, cache_path: &Path) -> PathBuf {
-		let file_name = format!("{}{}", Self::PREFIX, self.code_hash.to_string());
+		let file_name = format!("{}{:#x}", Self::PREFIX, self.code_hash);
 		cache_path.join(file_name)
 	}
 }
@@ -317,6 +317,6 @@ mod tests {
 		let path = Path::new("/test");
 		let hash = H256::from_str("1234567890123456789012345678901234567890123456789012345678901234").unwrap();
 
-		assert_eq!(ArtifactId::new(hash).path(path).to_str(), Some("/test/1234567890123456789012345678901234567890123456789012345678901234"));
+		assert_eq!(ArtifactId::new(hash).path(path).to_str(), Some("/test/wasmtime_1_0x1234567890123456789012345678901234567890123456789012345678901234"));
 	}
 }

--- a/node/core/pvf/src/artifacts.rs
+++ b/node/core/pvf/src/artifacts.rs
@@ -317,6 +317,9 @@ mod tests {
 		let path = Path::new("/test");
 		let hash = H256::from_str("1234567890123456789012345678901234567890123456789012345678901234").unwrap();
 
-		assert_eq!(ArtifactId::new(hash).path(path).to_str(), Some("/test/wasmtime_1_0x1234567890123456789012345678901234567890123456789012345678901234"));
+		assert_eq!(
+			ArtifactId::new(hash).path(path).to_str(),
+			Some("/test/wasmtime_1_0x1234567890123456789012345678901234567890123456789012345678901234"),
+		);
 	}
 }


### PR DESCRIPTION
This is the default behavior of display, which I don't think is what we want
https://github.com/paritytech/parity-common/blob/0867e488f6567e0d7fe13e78a14797ff019033f7/fixed-hash/src/hash.rs#L219-L227

cc @bkchr @pepyakin 