### PR TITLE
WIP: CI: simnet to run pinned versions

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -164,27 +164,26 @@ check-runtime-benchmarks:
     - ./scripts/gitlab/check_runtime_benchmarks.sh
     - sccache -s
 
-# FIXME: uncomment this when simnet is ready
-# build-adder-collator:
-#   stage:                           test
-#   <<:                              *collect-artifacts
-#   <<:                              *docker-env
-#   <<:                              *compiler-info
-#   rules:
-#     - if: $CI_PIPELINE_SOURCE == "schedule"
-#     - if: $CI_COMMIT_REF_NAME == "master"
-#     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
-#     - if: $CI_COMMIT_REF_NAME == "rococo-v1"
-#   script:
-#     - time cargo build --release --verbose -p test-parachain-adder-collator
-#     - sccache -s
-#     # pack artifacts
-#     - mkdir -p ./artifacts
-#     - mv ./target/release/adder-collator ./artifacts/.
-#     - echo -n "${CI_COMMIT_REF_NAME}" > ./artifacts/VERSION
-#     - echo -n "${CI_COMMIT_REF_NAME}-${CI_COMMIT_SHORT_SHA}" > ./artifacts/EXTRATAG
-#     - echo "adder-collator version = $(cat ./artifacts/VERSION) (EXTRATAG = $(cat ./artifacts/EXTRATAG))"
-#     - cp -r scripts/docker/* ./artifacts
+build-adder-collator:
+  stage:                           test
+  <<:                              *collect-artifacts
+  <<:                              *docker-env
+  <<:                              *compiler-info
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+    - if: $CI_COMMIT_REF_NAME == "master"
+    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
+    - if: $CI_COMMIT_REF_NAME == "rococo-v1"
+  script:
+    - time cargo build --release --verbose -p test-parachain-adder-collator
+    - sccache -s
+    # pack artifacts
+    - mkdir -p ./artifacts
+    - mv ./target/release/adder-collator ./artifacts/.
+    - echo -n "${CI_COMMIT_REF_NAME}" > ./artifacts/VERSION
+    - echo -n "${CI_COMMIT_REF_NAME}-${CI_COMMIT_SHORT_SHA}" > ./artifacts/EXTRATAG
+    - echo "adder-collator version = $(cat ./artifacts/VERSION) (EXTRATAG = $(cat ./artifacts/EXTRATAG))"
+    - cp -r scripts/docker/* ./artifacts
 
 #### stage:                        build
 
@@ -258,21 +257,19 @@ generate-impl-guide:
 publish-polkadot-image:
   stage:                           build
   <<:                              *build-push-image
-# FIXME: uncomment this when simnet is ready
-#  variables:
-#    <<:                            *image-variables
-#    # scripts/docker/Dockerfile
-#    DOCKERFILE:                    Dockerfile
-#    IMAGE_NAME:                    docker.io/paritypr/synth-wave
+  variables:
+    <<:                            *image-variables
+    # scripts/docker/Dockerfile
+    DOCKERFILE:                    Dockerfile
+    IMAGE_NAME:                    docker.io/paritypr/synth-wave
   rules:
-  # Don't run on releases - this is handled by the Github Action here:
-  # .github/workflows/publish-docker-release.yml
+    # Don't run on releases - this is handled by the Github Action here:
+    # .github/workflows/publish-docker-release.yml
     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
       when: never
-# FIXME: uncomment this when simnet is ready
-#  - if: $CI_PIPELINE_SOURCE == "schedule"
-#  - if: $CI_COMMIT_REF_NAME == "master"
-#  - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+    - if: $CI_COMMIT_REF_NAME == "master"
+    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
     - if: $CI_COMMIT_REF_NAME == "rococo-v1"
       variables:
         <<:                        *image-variables
@@ -283,33 +280,32 @@ publish-polkadot-image:
     - job:                         test-build-linux-stable
       artifacts:                   true
 
-# FIXME: uncomment this when simnet is ready
-# publish-adder-collator-image:
-#   # service image for Simnet
-#   stage:                           build
-#   <<:                              *build-push-image
-#   variables:
-#     <<:                            *image-variables
-#     # scripts/docker/collator.Dockerfile
-#     DOCKERFILE:                    collator.Dockerfile
-#     IMAGE_NAME:                    docker.io/paritypr/colander
-#   rules:
-#     - if: $CI_PIPELINE_SOURCE == "schedule"
-#     - if: $CI_COMMIT_REF_NAME == "master"
-#     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
-#     - if: $CI_COMMIT_REF_NAME == "rococo-v1"
-#   needs:
-#     - job:                         build-adder-collator
-#       artifacts:                   true
-#   after_script:
-#     - buildah logout "$IMAGE_NAME"
-#     # pass artifacts to the trigger-simnet job
-#     - echo "COLLATOR_IMAGE=$IMAGE_NAME" > ./artifacts/collator.env
-#     - echo "COLLATOR_IMAGE_TAG=$(cat ./artifacts/EXTRATAG)" >> ./artifacts/collator.env
-#   artifacts:
-#     reports:
-#       # this artifact is used in trigger-simnet job
-#       dotenv: ./artifacts/collator.env
+publish-adder-collator-image:
+  # service image for Simnet
+  stage:                           build
+  <<:                              *build-push-image
+  variables:
+    <<:                            *image-variables
+    # scripts/docker/collator.Dockerfile
+    DOCKERFILE:                    collator.Dockerfile
+    IMAGE_NAME:                    docker.io/paritypr/colander
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+    - if: $CI_COMMIT_REF_NAME == "master"
+    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
+    - if: $CI_COMMIT_REF_NAME == "rococo-v1"
+  needs:
+    - job:                         build-adder-collator
+      artifacts:                   true
+  after_script:
+    - buildah logout "$IMAGE_NAME"
+    # pass artifacts to the trigger-simnet job
+    - echo "COLLATOR_IMAGE=$IMAGE_NAME" > ./artifacts/collator.env
+    - echo "COLLATOR_IMAGE_TAG=$(cat ./artifacts/EXTRATAG)" >> ./artifacts/collator.env
+  artifacts:
+    reports:
+      # this artifact is used in trigger-simnet job
+      dotenv: ./artifacts/collator.env
 
 #### stage:                        publish
 
@@ -367,30 +363,29 @@ deploy-polkasync-kusama:
   allow_failure:                   true
   trigger:                         "parity/infrastructure/parity-testnet"
 
-# FIXME: uncomment this when simnet is ready
-# trigger-simnet:
-#   stage:                           deploy
-#   image:                           paritytech/tools:latest
-#   rules:
-#     - if: $CI_PIPELINE_SOURCE == "schedule"
-#     - if: $CI_COMMIT_REF_NAME == "master"
-#     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
-#     - if: $CI_COMMIT_REF_NAME == "rococo-v1"
-#   needs:
-#     - job:                         publish-polkadot-image
-#     - job:                         publish-adder-collator-image
-#   # `build.env` brings here `$IMAGE_NAME` and `$IMAGE_TAG` (`$EXTRATAG` here,
-#   # i.e. `2643-0.8.29-5f689e0a-6b24dc54`).
-#   # `collator.env` bears adder-collator unique build tag. In non-triggered builds it
-#   # can be called by `master` tag.
-#   # Simnet uses an image published on PRs with this exact version for triggered runs
-#   # on commits. And parity/rococo:rococo-v1 for the runs not launched by this job.
-#   variables:
-#     TRGR_PROJECT:                  ${CI_PROJECT_NAME}
-#     TRGR_REF:                      ${CI_COMMIT_REF_NAME}
-#     # simnet project ID
-#     DWNSTRM_ID:                    332
-#   script:
-#     # API trigger for a simnet job
-#     - ./scripts/gitlab/trigger_pipeline.sh
-#   allow_failure:                   true
+trigger-simnet:
+  stage:                           deploy
+  image:                           paritytech/tools:latest
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+    - if: $CI_COMMIT_REF_NAME == "master"
+    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
+    - if: $CI_COMMIT_REF_NAME == "rococo-v1"
+  needs:
+    - job:                         publish-polkadot-image
+    - job:                         publish-adder-collator-image
+  # `build.env` brings here `$IMAGE_NAME` and `$IMAGE_TAG` (`$EXTRATAG` here,
+  # i.e. `2643-0.8.29-5f689e0a-6b24dc54`).
+  # `collator.env` bears adder-collator unique build tag. In non-triggered builds it
+  # can be called by `master` tag.
+  # Simnet uses an image published on PRs with this exact version for triggered runs
+  # on commits. And parity/rococo:rococo-v1 for the runs not launched by this job.
+  variables:
+    TRGR_PROJECT:                  ${CI_PROJECT_NAME}
+    TRGR_REF:                      ${CI_COMMIT_REF_NAME}
+    # simnet project ID
+    DWNSTRM_ID:                    332
+  script:
+    # API trigger for a simnet job
+    - ./scripts/gitlab/trigger_pipeline.sh
+  allow_failure:                   true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -366,6 +366,7 @@ deploy-polkasync-kusama:
 trigger-simnet:
   stage:                           deploy
   image:                           paritytech/tools:latest
+  <<:                              *kubernetes-env
   rules:
     - if: $CI_PIPELINE_SOURCE == "schedule"
     - if: $CI_COMMIT_REF_NAME == "master"

--- a/scripts/gitlab/trigger_pipeline.sh
+++ b/scripts/gitlab/trigger_pipeline.sh
@@ -8,7 +8,7 @@ echo "Triggering Simnet pipeline."
 curl --silent \
     -X POST \
     -F "token=${CI_JOB_TOKEN}" \
-    -F "ref=v2" `# trigger the pinned version of simnet CI config` \
+    -F "ref=v3" `# trigger the pinned version of simnet CI config` \
     -F "variables[TRGR_PROJECT]=${TRGR_PROJECT}" \
     -F "variables[TRGR_REF]=${TRGR_REF}" \
     -F "variables[IMAGE_NAME]=${IMAGE_NAME}" \

--- a/scripts/gitlab/trigger_pipeline.sh
+++ b/scripts/gitlab/trigger_pipeline.sh
@@ -8,7 +8,7 @@ echo "Triggering Simnet pipeline."
 curl --silent \
     -X POST \
     -F "token=${CI_JOB_TOKEN}" \
-    -F "ref=master" \
+    -F "ref=v1" \
     -F "variables[TRGR_PROJECT]=${TRGR_PROJECT}" \
     -F "variables[TRGR_REF]=${TRGR_REF}" \
     -F "variables[IMAGE_NAME]=${IMAGE_NAME}" \

--- a/scripts/gitlab/trigger_pipeline.sh
+++ b/scripts/gitlab/trigger_pipeline.sh
@@ -8,7 +8,7 @@ echo "Triggering Simnet pipeline."
 curl --silent \
     -X POST \
     -F "token=${CI_JOB_TOKEN}" \
-    -F "ref=v1" \
+    -F "ref=v1" `# trigger the pinned version of simnet CI config` \
     -F "variables[TRGR_PROJECT]=${TRGR_PROJECT}" \
     -F "variables[TRGR_REF]=${TRGR_REF}" \
     -F "variables[IMAGE_NAME]=${IMAGE_NAME}" \

--- a/scripts/gitlab/trigger_pipeline.sh
+++ b/scripts/gitlab/trigger_pipeline.sh
@@ -50,3 +50,4 @@ for i in $(seq 1 360); do
     fi
 sleep 8;
 done
+# dummy: delete me 

--- a/scripts/gitlab/trigger_pipeline.sh
+++ b/scripts/gitlab/trigger_pipeline.sh
@@ -8,7 +8,7 @@ echo "Triggering Simnet pipeline."
 curl --silent \
     -X POST \
     -F "token=${CI_JOB_TOKEN}" \
-    -F "ref=v1" `# trigger the pinned version of simnet CI config` \
+    -F "ref=v2" `# trigger the pinned version of simnet CI config` \
     -F "variables[TRGR_PROJECT]=${TRGR_PROJECT}" \
     -F "variables[TRGR_REF]=${TRGR_REF}" \
     -F "variables[IMAGE_NAME]=${IMAGE_NAME}" \


### PR DESCRIPTION
Simnet has stabilized, now we trigger a tagged version (`v3`) and it, in turn, uses a tagged versioned service image. Nothing can go wrong!