### PR TITLE
Update para sudo wrapper pallet to FRAME v2

### DIFF
--- a/runtime/common/src/paras_sudo_wrapper.rs
+++ b/runtime/common/src/paras_sudo_wrapper.rs
@@ -16,13 +16,8 @@
 
 //! A simple wrapper allowing `Sudo` to call into `paras` routines.
 
-use sp_std::prelude::*;
-use frame_support::{
-	decl_error, decl_module, ensure,
-	dispatch::DispatchResult,
-	weights::DispatchClass,
-};
-use frame_system::ensure_root;
+use frame_support::{pallet_prelude::*, ensure, dispatch::DispatchResult, weights::DispatchClass};
+use frame_system::{pallet_prelude::*, ensure_root};
 use runtime_parachains::{
 	configuration, dmp, ump, hrmp,
 	ParaLifecycle,
@@ -30,15 +25,24 @@ use runtime_parachains::{
 };
 use primitives::v1::Id as ParaId;
 use parity_scale_codec::Encode;
+pub use pallet::*;
 
-/// The module's configuration trait.
-pub trait Config:
-	configuration::Config + paras::Config + dmp::Config + ump::Config + hrmp::Config
-{
-}
+#[frame_support::pallet]
+pub mod pallet {
+	use super::*;
 
-decl_error! {
-	pub enum Error for Module<T: Config> {
+	#[pallet::pallet]
+	#[pallet::generate_store(pub(super) trait Store)]
+	pub struct Pallet<T>(_);
+
+	#[pallet::config]
+	#[pallet::disable_frame_system_supertrait_check]
+	pub trait Config:
+		configuration::Config + paras::Config + dmp::Config + ump::Config + hrmp::Config {}
+
+
+	#[pallet::error]
+	pub enum Error<T> {
 		/// The specified parachain or parathread is not registered.
 		ParaDoesntExist,
 		/// The specified parachain or parathread is already registered.
@@ -57,50 +61,58 @@ decl_error! {
 		/// Cannot downgrade parachain.
 		CannotDowngrade,
 	}
-}
 
-decl_module! {
-	/// A sudo wrapper to call into v1 paras module.
-	pub struct Module<T: Config> for enum Call where origin: <T as frame_system::Config>::Origin {
-		type Error = Error<T>;
+	#[pallet::hooks]
+	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
 
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
 		/// Schedule a para to be initialized at the start of the next session.
-		#[weight = (1_000, DispatchClass::Operational)]
+		#[pallet::weight((1_000, DispatchClass::Operational))]
 		pub fn sudo_schedule_para_initialize(
-			origin,
+			origin: OriginFor<T>,
 			id: ParaId,
 			genesis: ParaGenesisArgs,
 		) -> DispatchResult {
 			ensure_root(origin)?;
-			runtime_parachains::schedule_para_initialize::<T>(id, genesis).map_err(|_| Error::<T>::ParaAlreadyExists)?;
+			runtime_parachains::schedule_para_initialize::<T>(id, genesis)
+				.map_err(|_| Error::<T>::ParaAlreadyExists)?;
 			Ok(())
 		}
 
 		/// Schedule a para to be cleaned up at the start of the next session.
-		#[weight = (1_000, DispatchClass::Operational)]
-		pub fn sudo_schedule_para_cleanup(origin, id: ParaId) -> DispatchResult {
+		#[pallet::weight((1_000, DispatchClass::Operational))]
+		pub fn sudo_schedule_para_cleanup(origin: OriginFor<T>, id: ParaId) -> DispatchResult {
 			ensure_root(origin)?;
 			runtime_parachains::schedule_para_cleanup::<T>(id).map_err(|_| Error::<T>::CouldntCleanup)?;
 			Ok(())
 		}
 
 		/// Upgrade a parathread to a parachain
-		#[weight = (1_000, DispatchClass::Operational)]
-		pub fn sudo_schedule_parathread_upgrade(origin, id: ParaId) -> DispatchResult {
+		#[pallet::weight((1_000, DispatchClass::Operational))]
+		pub fn sudo_schedule_parathread_upgrade(origin: OriginFor<T>, id: ParaId) -> DispatchResult {
 			ensure_root(origin)?;
 			// Para backend should think this is a parathread...
-			ensure!(paras::Module::<T>::lifecycle(id) == Some(ParaLifecycle::Parathread), Error::<T>::NotParathread);
-			runtime_parachains::schedule_parathread_upgrade::<T>(id).map_err(|_| Error::<T>::CannotUpgrade)?;
+			ensure!(
+				paras::Pallet::<T>::lifecycle(id) == Some(ParaLifecycle::Parathread),
+				Error::<T>::NotParathread,
+			);
+			runtime_parachains::schedule_parathread_upgrade::<T>(id)
+				.map_err(|_| Error::<T>::CannotUpgrade)?;
 			Ok(())
 		}
 
 		/// Downgrade a parachain to a parathread
-		#[weight = (1_000, DispatchClass::Operational)]
-		pub fn sudo_schedule_parachain_downgrade(origin, id: ParaId) -> DispatchResult {
+		#[pallet::weight((1_000, DispatchClass::Operational))]
+		pub fn sudo_schedule_parachain_downgrade(origin: OriginFor<T>, id: ParaId) -> DispatchResult {
 			ensure_root(origin)?;
 			// Para backend should think this is a parachain...
-			ensure!(paras::Module::<T>::lifecycle(id) == Some(ParaLifecycle::Parachain), Error::<T>::NotParachain);
-			runtime_parachains::schedule_parachain_downgrade::<T>(id).map_err(|_| Error::<T>::CannotDowngrade)?;
+			ensure!(
+				paras::Pallet::<T>::lifecycle(id) == Some(ParaLifecycle::Parachain),
+				Error::<T>::NotParachain,
+			);
+			runtime_parachains::schedule_parachain_downgrade::<T>(id)
+				.map_err(|_| Error::<T>::CannotDowngrade)?;
 			Ok(())
 		}
 
@@ -108,12 +120,16 @@ decl_module! {
 		///
 		/// The given parachain should exist and the payload should not exceed the preconfigured size
 		/// `config.max_downward_message_size`.
-		#[weight = (1_000, DispatchClass::Operational)]
-		pub fn sudo_queue_downward_xcm(origin, id: ParaId, xcm: xcm::opaque::VersionedXcm) -> DispatchResult {
+		#[pallet::weight((1_000, DispatchClass::Operational))]
+		pub fn sudo_queue_downward_xcm(
+			origin: OriginFor<T>,
+			id: ParaId,
+			xcm: xcm::opaque::VersionedXcm,
+		) -> DispatchResult {
 			ensure_root(origin)?;
-			ensure!(<paras::Module<T>>::is_valid_para(id), Error::<T>::ParaDoesntExist);
-			let config = <configuration::Module<T>>::config();
-			<dmp::Module<T>>::queue_downward_message(&config, id, xcm.encode())
+			ensure!(<paras::Pallet<T>>::is_valid_para(id), Error::<T>::ParaDoesntExist);
+			let config = <configuration::Pallet<T>>::config();
+			<dmp::Pallet<T>>::queue_downward_message(&config, id, xcm.encode())
 				.map_err(|e| match e {
 					dmp::QueueDownwardMessageError::ExceedsMaxMessageSize =>
 						Error::<T>::ExceedsMaxMessageSize.into(),
@@ -124,9 +140,9 @@ decl_module! {
 		///
 		/// This is equivalent to sending an `Hrmp::hrmp_init_open_channel` extrinsic followed by
 		/// `Hrmp::hrmp_accept_open_channel`.
-		#[weight = (1_000, DispatchClass::Operational)]
+		#[pallet::weight((1_000, DispatchClass::Operational))]
 		pub fn sudo_establish_hrmp_channel(
-			origin,
+			origin: OriginFor<T>,
 			sender: ParaId,
 			recipient: ParaId,
 			max_capacity: u32,
@@ -134,13 +150,13 @@ decl_module! {
 		) -> DispatchResult {
 			ensure_root(origin)?;
 
-			<hrmp::Module<T>>::init_open_channel(
+			<hrmp::Pallet<T>>::init_open_channel(
 				sender,
 				recipient,
 				max_capacity,
 				max_message_size,
 			)?;
-			<hrmp::Module<T>>::accept_open_channel(recipient, sender)?;
+			<hrmp::Pallet<T>>::accept_open_channel(recipient, sender)?;
 			Ok(())
 		}
 	}

--- a/runtime/common/src/paras_sudo_wrapper.rs
+++ b/runtime/common/src/paras_sudo_wrapper.rs
@@ -16,8 +16,8 @@
 
 //! A simple wrapper allowing `Sudo` to call into `paras` routines.
 
-use frame_support::{pallet_prelude::*, ensure, dispatch::DispatchResult, weights::DispatchClass};
-use frame_system::{pallet_prelude::*, ensure_root};
+use frame_support::pallet_prelude::*;
+use frame_system::pallet_prelude::*;
 use runtime_parachains::{
 	configuration, dmp, ump, hrmp,
 	ParaLifecycle,


### PR DESCRIPTION
Part of #2882 

Converts the `ParaSudoWrapper` pallet to the new pallet attribute macro introduced in #6877.

Following the upgrade guidelines here: https://crates.parity.io/frame_support/attr.pallet.html#upgrade-guidelines.

## ⚠️ Breaking Change ⚠️ 

From https://crates.parity.io/frame_support/attr.pallet.html#checking-upgrade-guidelines

> storages now use PalletInfo for module_prefix instead of the one given to decl_storage: Thus any use of this pallet in construct_runtime! should be careful to update name in order not to break storage or to upgrade storage (moreover for instantiable pallet). If pallet is published, make sure to warn about this breaking change.

So users of the `ParaSudoWrapper ` pallet must be careful about the name they used in `construct_runtime!`. Hence the `runtime-migration` label, which might not be needed depending on the configuration of the `ParaSudoWrapper ` pallet.