### PR TITLE
dependabot: ignore beefy git updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,5 +11,6 @@ updates:
       - dependency-name: "frame-*"
       - dependency-name: "fork-tree"
       - dependency-name: "pallet-*"
+      - dependency-name: "beefy-*"
     schedule:
       interval: "daily"


### PR DESCRIPTION
It should rather be updated manually with proper `Cargo.lock` updates at least until we switch to crates.io versions. See #3109 as an example of that (bad) update.