### PR TITLE
guide: changes for pre-registered code upgrades

### DIFF
--- a/roadmap/implementers-guide/src/node/backing/candidate-backing.md
+++ b/roadmap/implementers-guide/src/node/backing/candidate-backing.md
@@ -107,8 +107,6 @@ fn spawn_validation_work(candidate, parachain head, validation function) {
     if valid {
       // make PoV available for later distribution. Send data to the availability store to keep.
       // sign and dispatch `valid` statement to network if we have not seconded the given candidate.
-    } else {
-      // sign and dispatch `invalid` statement to network.
     }
   }
 }
@@ -123,7 +121,8 @@ Dispatch a [`AvailabilityDistributionMessage`][PDM]`::FetchPoV{ validator_index,
 ### Validate PoV Block
 
 Create a `(sender, receiver)` pair.
-Dispatch a `CandidateValidationMessage::Validate(validation function, candidate, pov, sender)` and listen on the receiver for a response.
+
+Dispatch a `CandidateValidationMessage::ValidateFromChainState(descriptor, pov, sender)` and listen on the receiver for a response.
 
 ### Distribute Signed Statement
 

--- a/roadmap/implementers-guide/src/node/collators/collation-generation.md
+++ b/roadmap/implementers-guide/src/node/collators/collation-generation.md
@@ -25,7 +25,7 @@ pub struct Collation {
   /// Messages destined to be interpreted by the Relay chain itself.
   pub upward_messages: Vec<UpwardMessage>,
   /// New validation code.
-  pub new_validation_code: Option<ValidationCode>,
+  pub new_validation_code: CodeUpgradeSignal,
   /// The head-data produced as a result of execution.
   pub head_data: HeadData,
   /// Proof to verify the state transition of the parachain.
@@ -76,8 +76,9 @@ On `ActiveLeavesUpdate`:
     > TODO: figure out what to do in the case of occupied cores; see [this issue](https://github.com/paritytech/polkadot/issues/1573).
   * Determine an occupied core assumption to make about the para. Scheduled cores can make `OccupiedCoreAssumption::Free`.
   * Use the Runtime API subsystem to fetch the full validation data.
-  * Invoke the `collator`, and use its outputs to produce a `CandidateReceipt`, signed with the configuration's `key`.
+  * Invoke the `collator`, and use its outputs to produce a `CandidateReceipt`, signed with the configuration's `key`. If the candidate receipt has an associated code upgrade which is indirect, and a [`RuntimeApiMessage`][RAM]`::ValidationCodeByHash` query for the code hash returns `None`, then the collation cannot be included under the relay parent.
   * Dispatch a [`CollatorProtocolMessage`][CPM]`::DistributeCollation(receipt, pov)`.
 
 [CP]: collator-protocol.md
 [CPM]: ../../types/overseer-protocol.md#collatorprotocolmessage
+[RAM]: ../../types/overseer-protocol.md#runtimeapimessage

--- a/roadmap/implementers-guide/src/node/utility/provisioner.md
+++ b/roadmap/implementers-guide/src/node/utility/provisioner.md
@@ -67,9 +67,10 @@ To determine availability:
   - Now compute the core's `validation_data_hash`: get the `PersistedValidationData` from the runtime, given the known `ParaId` and `OccupiedCoreAssumption`;
   - Find an appropriate candidate for the core.
     - There are two constraints: `backed_candidate.candidate.descriptor.para_id == scheduled_core.para_id && candidate.candidate.descriptor.validation_data_hash == computed_validation_data_hash`.
+    - If the [`CodeUpgradeSignal`](../../types/candidate.md#codeupgradesignal) is indirect, only candidates which yield a positive result from [`RuntimeApiMessage::ValidationCodeByHash`](../../types/overseer-protocol.md#runtimeapimessage) may be included.
     - In the event that more than one candidate meets the constraints, selection between the candidates is arbitrary. However, not more than one candidate can be selected per core.
 
-The end result of this process is a vector of `BackedCandidate`s, sorted in order of their core index. Furthermore, this process should select at maximum one candidate which upgrades the runtime validation code.
+The end result of this process is a vector of `BackedCandidate`s, sorted in order of their core index. Furthermore, this process should select at maximum one candidate which upgrades the runtime validation code. 
 
 ### Dispute Statement Selection
 

--- a/roadmap/implementers-guide/src/runtime/inclusion.md
+++ b/roadmap/implementers-guide/src/runtime/inclusion.md
@@ -33,6 +33,10 @@ bitfields: map ValidatorIndex => AvailabilityBitfield;
 PendingAvailability: map ParaId => CandidatePendingAvailability;
 /// The commitments of candidates pending availability, by ParaId.
 PendingAvailabilityCommitments: map ParaId => CandidateCommitments;
+
+/// EXTERNAL: a pluggable backend for drawing parachain code out of other sections of the runtime
+/// the parachains modules are embedded in.
+ExternallyRegisteredCode: fn(Hash) -> Option<ValidationCode>;
 ```
 
 ## Session Change
@@ -60,6 +64,7 @@ All failed checks should lead to an unrecoverable error making the block invalid
     > NOTE: With contextual execution in place, validation data will be obtained as of the state of the context block. However, only the state of the current block can be used for such a query.
   1. If the core assignment includes a specific collator, ensure the backed candidate is issued by that collator.
   1. Ensure that any code upgrade scheduled by the candidate does not happen within `config.validation_upgrade_frequency` of `Paras::last_code_upgrade(para_id, true)`, if any, comparing against the value of `Paras::FutureCodeUpgrades` for the given para ID.
+    1. If the code upgrade is of the type [`CodeUpgradeSignal`]::Indirect, then the underlying code should be drawn out of the `ExternallyRegisteredCode` interface. If that is not present, then the candidate is invalid.
   1. Check the collator's signature on the candidate data.
   1. check the backing of the candidate using the signatures and the bitfields, comparing against the validators assigned to the groups, fetched with the `group_validators` lookup.
   1. call `Ump::check_upward_messages(para, commitments.upward_messages)` to check that the upward messages are valid.

--- a/roadmap/implementers-guide/src/runtime/paras.md
+++ b/roadmap/implementers-guide/src/runtime/paras.md
@@ -144,7 +144,7 @@ UpcomingParasGenesis: map ParaId => Option<ParaGenesisArgs>;
 /// The number of references on the validation code in `CodeByHash` storage.
 CodeByHashRefs: map Hash => u32;
 /// Validation code stored by its hash.
-CoeByHash: map Hash => Option<ValidationCode>
+CodeByHash: map Hash => Option<ValidationCode>;
 ```
 
 ## Session Change

--- a/roadmap/implementers-guide/src/types/candidate.md
+++ b/roadmap/implementers-guide/src/types/candidate.md
@@ -130,6 +130,21 @@ Head data is a type-safe abstraction around bytes (`Vec<u8>`) for the purposes o
 struct HeadData(Vec<u8>);
 ```
 
+## CodeUpgradeSignal
+
+A code upgrade signal which either signals no upgrade, an upgrade directly referencing the new code by value, or an upgrade indirectly referencing the new code by hash.
+
+```rust
+enum CodeUpgradeSignal {
+	/// A signal that no code upgrade is being scheduled at this point.
+	NoUpgrade,
+	/// A signal that a code upgrade to the provided code is being scheduled.
+	Direct(ValidationCode),
+	/// A signal that a code upgrade to the code referenced by hash is being scheduled.
+	Indirect(Hash),
+}
+```
+
 ## Candidate Commitments
 
 The execution and validation of parachain or parathread candidates produces a number of values which either must be committed to on the relay chain or committed to the state of the relay chain.
@@ -144,7 +159,7 @@ struct CandidateCommitments {
 	/// Messages destined to be interpreted by the Relay chain itself.
 	upward_messages: Vec<UpwardMessage>,
 	/// New validation code.
-	new_validation_code: Option<ValidationCode>,
+	new_validation_code: CodeUpgradeSignal,
 	/// The head-data produced as a result of execution.
 	head_data: HeadData,
 	/// The number of messages processed from the DMQ.

--- a/roadmap/implementers-guide/src/types/overseer-protocol.md
+++ b/roadmap/implementers-guide/src/types/overseer-protocol.md
@@ -608,6 +608,10 @@ enum RuntimeApiRequest {
     SessionIndexForChild(ResponseChannel<SessionIndex>),
     /// Get the validation code for a specific para, using the given occupied core assumption.
     ValidationCode(ParaId, OccupiedCoreAssumption, ResponseChannel<Option<ValidationCode>>),
+    /// Get any registered validation code from the on-chain environment. This should not be used
+    /// for any para in particular and should only be used when the hash of the code for the para
+    /// in question is already known.
+    ValidationCodeByHash(Hash, ResponseChannel<Option<ValidationCode>>),
     /// Fetch the historical validation code used by a para for candidates executed in
     /// the context of a given block height in the current chain.
     HistoricalValidationCode(ParaId, BlockNumber, ResponseChannel<Option<ValidationCode>>),
@@ -657,7 +661,6 @@ enum StatementDistributionMessage {
 Various modules request that the [Candidate Validation subsystem](../node/utility/candidate-validation.md) validate a block with this message. It returns [`ValidationOutputs`](candidate.md#validationoutputs) for successful validation.
 
 ```rust
-
 /// Result of the validation of the candidate.
 enum ValidationResult {
     /// Candidate is valid, and here are the outputs and the validation data used to form inputs.


### PR DESCRIPTION
These changes are an optimization for Parachain runtime upgrades revolving around the ability to pre-publish code to the relay chain through the regular transaction system. This feature acts as an intermediate step before moving validation code entirely off-chain.