### PR TITLE
XCM docstring typo fix

### DIFF
--- a/xcm/pallet-xcm/src/lib.rs
+++ b/xcm/pallet-xcm/src/lib.rs
@@ -53,8 +53,8 @@ pub mod pallet {
 		/// The type used to actually dispatch an XCM to its destination.
 		type XcmRouter: SendXcm;
 
-		/// Required origin for executing XCM messages, includng the teleport functionality. If successful,
-		/// the it resolves to `MultiLocation` which exists as an interior location within this chain's XCM
+		/// Required origin for executing XCM messages, including the teleport functionality. If successful,
+		/// then it resolves to `MultiLocation` which exists as an interior location within this chain's XCM
 		/// context.
 		type ExecuteXcmOrigin: EnsureOrigin<Self::Origin, Success=MultiLocation>;
 
@@ -300,7 +300,7 @@ impl<Prefix: Get<MultiLocation>, Body: Get<BodyId>> Filter<MultiLocation> for Is
 	}
 }
 
-/// `EnsureOrigin` implementation succeeding with a `MultiLocation` value to recognise and filter the
+/// `EnsureOrigin` implementation succeeding with a `MultiLocation` value to recognize and filter the
 /// `Origin::Xcm` item.
 pub struct EnsureXcm<F>(PhantomData<F>);
 impl<O: OriginTrait + From<Origin>, F: Filter<MultiLocation>> EnsureOrigin<O> for EnsureXcm<F>

--- a/xcm/src/v0/junction.rs
+++ b/xcm/src/v0/junction.rs
@@ -114,7 +114,7 @@ pub enum Junction {
 	///
 	/// Generally used when the context is a Frame-based chain.
 	PalletInstance(u8),
-	/// A non-descript index within the context location.
+	/// A non-descriptive index within the context location.
 	///
 	/// Usage will vary widely owing to its generality.
 	///

--- a/xcm/src/v0/junction.rs
+++ b/xcm/src/v0/junction.rs
@@ -114,7 +114,7 @@ pub enum Junction {
 	///
 	/// Generally used when the context is a Frame-based chain.
 	PalletInstance(u8),
-	/// A non-descriptive index within the context location.
+	/// A non-descript index within the context location.
 	///
 	/// Usage will vary widely owing to its generality.
 	///

--- a/xcm/src/v0/mod.rs
+++ b/xcm/src/v0/mod.rs
@@ -229,7 +229,7 @@ pub enum Xcm<Call> {
 	},
 
 	/// A message to notify that the other party in an open channel decided to close it. In particular,
-	/// `inititator` is going to close the channel opened from `sender` to the `recipient`. The close
+	/// `initiator` is going to close the channel opened from `sender` to the `recipient`. The close
 	/// will be enacted at the next relay-chain session change. This message is meant to be sent by
 	/// the relay-chain to a para.
 	///

--- a/xcm/src/v0/multi_location.rs
+++ b/xcm/src/v0/multi_location.rs
@@ -553,7 +553,7 @@ impl MultiLocation {
 		}
 	}
 
-	/// Mutate `self` so that it is suffixed with `prefix`. The correct normalised form is returned, removing any
+	/// Mutate `self` so that it is suffixed with `prefix`. The correct normalized form is returned, removing any
 	/// internal `Parent`s.
 	///
 	/// Does not modify `self` and returns `Err` with `prefix` in case of overflow.
@@ -570,7 +570,7 @@ impl MultiLocation {
 		}
 	}
 
-	/// Mutate `self` so that it is prefixed with `prefix`. The correct normalised form is returned, removing any
+	/// Mutate `self` so that it is prefixed with `prefix`. The correct normalized form is returned, removing any
 	/// internal `Parent`s.
 	///
 	/// Does not modify `self` and returns `Err` with `prefix` in case of overflow.

--- a/xcm/src/v0/traits.rs
+++ b/xcm/src/v0/traits.rs
@@ -34,10 +34,10 @@ pub enum Error {
 	UntrustedReserveLocation,
 	UntrustedTeleportLocation,
 	DestinationBufferOverflow,
-	/// The message and destination was recognised as being reachable but the operation could not be completed.
+	/// The message and destination was recognized as being reachable but the operation could not be completed.
 	/// A human-readable explanation of the specific issue is provided.
 	SendFailed(#[codec(skip)] &'static str),
-	/// The message and destination combination was not recognised as being reachable.
+	/// The message and destination combination was not recognized as being reachable.
 	CannotReachDestination(MultiLocation, Xcm<()>),
 	MultiLocationFull,
 	FailedToDecode,
@@ -92,7 +92,7 @@ pub type Result = result::Result<(), Error>;
 /// Local weight type; execution time in picoseconds.
 pub type Weight = u64;
 
-/// Outcome of an XCM excution.
+/// Outcome of an XCM execution.
 #[derive(Clone, Encode, Decode, Eq, PartialEq, Debug)]
 pub enum Outcome {
 	/// Execution completed successfully; given weight was used.
@@ -162,7 +162,7 @@ impl<C> ExecuteXcm<C> for () {
 
 /// Utility for sending an XCM message.
 ///
-/// These can be amalgamted in tuples to form sophisticated routing systems.
+/// These can be amalgamated in tuples to form sophisticated routing systems.
 pub trait SendXcm {
 	/// Send an XCM `message` to a given `destination`.
 	///


### PR DESCRIPTION
Also converted some British English words into American.