### PR TITLE
use the Barrier type in Westend XcmConfig

### DIFF
--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -913,7 +913,7 @@ impl xcm_executor::Config for XcmConfig {
 	type IsReserve = ();
 	type IsTeleporter = TrustedTeleporters;
 	type LocationInverter = LocationInverter<Ancestry>;
-	type Barrier = ();
+	type Barrier = Barrier;
 	type Weigher = FixedWeightBounds<BaseXcmWeight, Call>;
 	type Trader = UsingComponents<WeightToFee, WndLocation, AccountId, Balances, ToAuthor<Runtime>>;
 	type ResponseHandler = ();


### PR DESCRIPTION
Westend currently doesn't allow for e.g. XCM teleports.