### PR TITLE
Cleanup unused errors & events in lease coordination pallets

### DIFF
--- a/runtime/common/src/auctions.rs
+++ b/runtime/common/src/auctions.rs
@@ -118,13 +118,6 @@ pub mod pallet {
 		AuctionStarted(AuctionIndex, LeasePeriodOf<T>, T::BlockNumber),
 		/// An auction ended. All funds become unreserved. [auction_index]
 		AuctionClosed(AuctionIndex),
-		/// Someone won the right to deploy a parachain. Balance amount is deducted for deposit.
-		/// [bidder, range, parachain_id, amount]
-		WonDeploy(T::AccountId, SlotRange, ParaId, BalanceOf<T>),
-		/// An existing parachain won the right to continue.
-		/// First balance is the extra amount reserved. Second is the total amount reserved.
-		/// [parachain_id, begin, count, total_amount]
-		WonRenewal(ParaId, LeasePeriodOf<T>, LeasePeriodOf<T>, BalanceOf<T>),
 		/// Funds were reserved for a winning bid. First balance is the extra amount reserved.
 		/// Second is the total. [bidder, extra_reserved, total_amount]
 		Reserved(T::AccountId, BalanceOf<T>, BalanceOf<T>),
@@ -148,28 +141,12 @@ pub mod pallet {
 		AuctionInProgress,
 		/// The lease period is in the past.
 		LeasePeriodInPast,
-		/// The origin for this call must be a parachain.
-		NotParaOrigin,
 		/// Para is not registered
 		ParaNotRegistered,
-		/// The parachain ID is not on-boarding.
-		ParaNotOnboarding,
-		/// The origin for this call must be the origin who registered the parachain.
-		InvalidOrigin,
-		/// Parachain is already registered.
-		AlreadyRegistered,
-		/// The code must correspond to the hash.
-		InvalidCode,
-		/// Deployment data has not been set for this parachain.
-		UnsetDeployData,
 		/// Not a current auction.
 		NotCurrentAuction,
 		/// Not an auction.
 		NotAuction,
-		/// Given code size is too large.
-		CodeTooLarge,
-		/// Given initial head data is too large.
-		HeadDataTooLarge,
 		/// Auction has already ended.
 		AuctionEnded,
 	}

--- a/runtime/common/src/crowdloan.rs
+++ b/runtime/common/src/crowdloan.rs
@@ -236,10 +236,6 @@ pub mod pallet {
 		AllRefunded(ParaId),
 		/// Fund is dissolved. [fund_index]
 		Dissolved(ParaId),
-		/// The deploy data of the funded parachain is set. [fund_index]
-		DeployDataFixed(ParaId),
-		/// On-boarding process for a winning parachain fund is completed. [find_index, parachain_id]
-		Onboarded(ParaId, ParaId),
 		/// The result of trying to submit a new bid to the Slots pallet.
 		HandleBidResult(ParaId, DispatchResult),
 		/// The configuration to a crowdloan has been edited. [fund_index]
@@ -282,14 +278,10 @@ pub mod pallet {
 		LeaseActive,
 		/// This parachain's bid or lease is still active and withdraw cannot yet begin.
 		BidOrLeaseActive,
-		/// Funds have not yet been returned.
-		FundsNotReturned,
 		/// The crowdloan has not yet ended.
 		FundNotEnded,
 		/// There are no contributions stored in this crowdloan.
 		NoContributions,
-		/// This crowdloan has an active parachain and cannot be dissolved.
-		HasActiveParachain,
 		/// The crowdloan is not ready to dissolve. Potentially still has a slot or in retirement period.
 		NotReadyToDissolve,
 		/// Invalid signature.

--- a/runtime/common/src/paras_registrar.rs
+++ b/runtime/common/src/paras_registrar.rs
@@ -155,8 +155,6 @@ pub mod pallet {
 		CannotUpgrade,
 		/// Para is locked from manipulation by the manager. Must use parachain or relay chain governance.
 		ParaLocked,
-		/// The id you are trying to register is reserved for system parachains.
-		InvalidParaId,
 		/// The ID given for registration has not been reserved.
 		NotReserved,
 	}

--- a/runtime/common/src/slots.rs
+++ b/runtime/common/src/slots.rs
@@ -99,9 +99,10 @@ decl_event!(
 	{
 		/// A new [lease_period] is beginning.
 		NewLeasePeriod(LeasePeriod),
-		/// An existing parachain won the right to continue.
-		/// First balance is the extra amount reseved. Second is the total amount reserved.
-		/// \[parachain_id, leaser, period_begin, period_count, extra_reseved, total_amount\]
+		/// A para has won the right to a continuos set of lease periods as a parachain.
+		/// First balance is any extra amount reserved on top of the para's existing deposit.
+		/// Second balance is the total amount reserved.
+		/// \[parachain_id, leaser, period_begin, period_count, extra_reserved, total_amount\]
 		Leased(ParaId, AccountId, LeasePeriod, LeasePeriod, Balance, Balance),
 	}
 );

--- a/runtime/common/src/slots.rs
+++ b/runtime/common/src/slots.rs
@@ -99,7 +99,7 @@ decl_event!(
 	{
 		/// A new [lease_period] is beginning.
 		NewLeasePeriod(LeasePeriod),
-		/// A para has won the right to a continuos set of lease periods as a parachain.
+		/// A para has won the right to a continuous set of lease periods as a parachain.
 		/// First balance is any extra amount reserved on top of the para's existing deposit.
 		/// Second balance is the total amount reserved.
 		/// \[parachain_id, leaser, period_begin, period_count, extra_reserved, total_amount\]


### PR DESCRIPTION
This PR removes unused events and errors in the `auctions`, `crowdloan`, and `paras_registrar` pallets. Since the events and errors where not removed from the end of the enums, the events and error indexes will break - which I assume is ok because these pallets are not yet used in productions.

Additionally it improves the doc comment for the `slots` `Leased` event.