### PR TITLE
approval-distribution: send all messages on unify

### DIFF
--- a/roadmap/implementers-guide/src/node/approval/approval-distribution.md
+++ b/roadmap/implementers-guide/src/node/approval/approval-distribution.md
@@ -247,8 +247,6 @@ For each block in the view:
   2. Load the `BlockEntry` for the block. If the block is unknown, or the number is less than or equal to the view's finalized number go to step 6.
   3. Inspect the `known_by` set of the `BlockEntry`. If the peer is already present, go to step 6.
   4. Add the peer to `known_by` with a cloned version of `block_entry.knowledge`. and add the hash of the block to `fresh_blocks`.
-  5. Return to step 2 with the ancestor of the block, keeping track of the block depth (+1).
+  5. Return to step 2 with the ancestor of the block.
 
-6. For each block in `fresh_blocks`, send all assignments and approvals for all candidates in those blocks to the peer if the block depth threshold is not reached, otherwise, send only assignments and approvals origination with the local source.
-
-The reason we only send our local assignments and approvals when a certain block depth is reached when unifying with a peer is to avoid DoS attacks. It also helps when a node starts with a large difference between finalized and the highest block.
+6. For each block in `fresh_blocks`, send all assignments and approvals for all candidates in those blocks to the peer.


### PR DESCRIPTION
Eventually, every peer should send all their assignments and approvals to every other connected peer. We limited the amount of sent messages as an optimization, but that might actually do more harm than good. Also with #3175 it might not be necessary.