### PR TITLE
fix connections leak

### DIFF
--- a/node/network/bridge/src/network.rs
+++ b/node/network/bridge/src/network.rs
@@ -189,6 +189,7 @@ impl Network for Arc<NetworkService<Block, Hash>> {
 	}
 
 	async fn remove_from_peers_set(&mut self, protocol: Cow<'static, str>, multiaddresses: HashSet<Multiaddr>) -> Result<(), String> {
+		sc_network::NetworkService::remove_peers_from_reserved_set(&**self, protocol, multiaddresses)?;
 		sc_network::NetworkService::remove_from_peers_set(&**self, protocol, multiaddresses)
 	}
 

--- a/node/network/bridge/src/network.rs
+++ b/node/network/bridge/src/network.rs
@@ -189,7 +189,7 @@ impl Network for Arc<NetworkService<Block, Hash>> {
 	}
 
 	async fn remove_from_peers_set(&mut self, protocol: Cow<'static, str>, multiaddresses: HashSet<Multiaddr>) -> Result<(), String> {
-		sc_network::NetworkService::remove_peers_from_reserved_set(&**self, protocol, multiaddresses)?;
+		sc_network::NetworkService::remove_peers_from_reserved_set(&**self, protocol.clone(), multiaddresses.clone())?;
 		sc_network::NetworkService::remove_from_peers_set(&**self, protocol, multiaddresses)
 	}
 


### PR DESCRIPTION
https://github.com/paritytech/substrate/blob/2c210396dbf67968a5f631912fa4addefdc8d11a/client/peerset/src/lib.rs#L403

This was causing collators to connect to all validators over time.
The cleaner fix would be to expose `set_reserved_peers` on `NetworkService` in substrate.