### PR TITLE
Fix test environment

### DIFF
--- a/runtime/common/src/impls.rs
+++ b/runtime/common/src/impls.rs
@@ -94,6 +94,7 @@ mod tests {
 	parameter_types! {
 		pub const BlockHashCount: u64 = 250;
 		pub BlockWeights: limits::BlockWeights = limits::BlockWeights::builder()
+			.base_block(10)
 			.for_class(DispatchClass::all(), |weight| {
 				weight.base_extrinsic = 100;
 			})


### PR DESCRIPTION
The test has invalid block limits. It is currently accepted as the block limits is never used in the test, but this PR https://github.com/paritytech/substrate/pull/9104 will trigger the check for the block limits.

This PR fixed by giving a correct limit.

kind of companion for: https://github.com/paritytech/substrate/pull/9104