### PR TITLE
Better metrics for approval voting

### DIFF
--- a/node/core/approval-voting/src/persisted_entries.rs
+++ b/node/core/approval-voting/src/persisted_entries.rs
@@ -93,7 +93,7 @@ impl ApprovalEntry {
 
 	// Note that our assignment is triggered. No-op if already triggered.
 	pub fn trigger_our_assignment(&mut self, tick_now: Tick)
-		-> Option<(AssignmentCert, ValidatorIndex)>
+		-> Option<(AssignmentCert, ValidatorIndex, DelayTranche)>
 	{
 		let our = self.our_assignment.as_mut().and_then(|a| {
 			if a.triggered() { return None }
@@ -105,7 +105,7 @@ impl ApprovalEntry {
 		our.map(|a| {
 			self.import_assignment(a.tranche(), a.validator_index(), tick_now);
 
-			(a.cert().clone(), a.validator_index())
+			(a.cert().clone(), a.validator_index(), a.tranche())
 		})
 	}
 


### PR DESCRIPTION
1. Add failure modes for the approvals produced metric. We're observing that the amount of approvals produced is far below the number of assignments when they should be 1:1. This change should help us see what's happening to these approvals.
2. Change the assignments produced metric to a histogram, which records the tranche of the local assignment. If things are working correctly we should only be producing assignments for tranche 0 and maybe tranches 1-3 when there are no-shows. This change will let us see if we're being overeager in assignments which is putting unnecessary load on the network.