### PR TITLE
Fix `pallet-xcm` Origin

### DIFF
--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -1474,7 +1474,7 @@ construct_runtime! {
 		Crowdloan: crowdloan::{Pallet, Call, Storage, Event<T>} = 73,
 
 		// Pallet for sending XCM.
-		XcmPallet: pallet_xcm::{Pallet, Call, Storage, Event<T>} = 99,
+		XcmPallet: pallet_xcm::{Pallet, Call, Storage, Event<T>, Origin} = 99,
 	}
 }
 

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -253,7 +253,7 @@ construct_runtime! {
 		Proxy: pallet_proxy::{Pallet, Call, Storage, Event<T>} = 91,
 
 		// Pallet for sending XCM.
-		XcmPallet: pallet_xcm::{Pallet, Call, Storage, Event<T>} = 99,
+		XcmPallet: pallet_xcm::{Pallet, Call, Storage, Event<T>, Origin} = 99,
 	}
 }
 

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -1072,7 +1072,7 @@ construct_runtime! {
 		Crowdloan: crowdloan::{Pallet, Call, Storage, Event<T>} = 64,
 
 		// Pallet for sending XCM.
-		XcmPallet: pallet_xcm::{Pallet, Call, Storage, Event<T>} = 99,
+		XcmPallet: pallet_xcm::{Pallet, Call, Storage, Event<T>, Origin} = 99,
 	}
 }
 

--- a/xcm/pallet-xcm/src/lib.rs
+++ b/xcm/pallet-xcm/src/lib.rs
@@ -262,18 +262,19 @@ pub mod pallet {
 			AccountIdConversion::<T::AccountId>::into_account(&ID)
 		}
 	}
-}
 
-/// Origin for the parachains module.
-#[derive(PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug)]
-pub enum Origin {
-	/// It comes from somewhere in the XCM space.
-	Xcm(MultiLocation),
-}
+	/// Origin for the parachains module.
+	#[derive(PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug)]
+	#[pallet::origin]
+	pub enum Origin {
+		/// It comes from somewhere in the XCM space.
+		Xcm(MultiLocation),
+	}
 
-impl From<MultiLocation> for Origin {
-	fn from(location: MultiLocation) -> Origin {
-		Origin::Xcm(location)
+	impl From<MultiLocation> for Origin {
+		fn from(location: MultiLocation) -> Origin {
+			Origin::Xcm(location)
+		}
 	}
 }
 


### PR DESCRIPTION
This places the custom `Origin` from `pallet-xcm` into the `#[pallet]` macro with the proper `#[pallet::origin]` tag.