### PR TITLE
Add XCM Decode Limit

### DIFF
--- a/xcm/src/double_encoded.rs
+++ b/xcm/src/double_encoded.rs
@@ -15,7 +15,10 @@
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
 use alloc::vec::Vec;
-use parity_scale_codec::{Encode, Decode};
+use parity_scale_codec::{Encode, Decode, DecodeLimit};
+
+/// Maximum nesting level for XCM decoding.
+pub const MAX_XCM_DECODE_DEPTH: u32 = 256;
 
 /// Wrapper around the encoded and decoded versions of a value.
 /// Caches the decoded value once computed.
@@ -69,14 +72,22 @@ impl<T: Decode> DoubleEncoded<T> {
 	/// Returns a reference to the value in case of success and `Err(())` in case the decoding fails.
 	pub fn ensure_decoded(&mut self) -> Result<&T, ()> {
 		if self.decoded.is_none() {
-			self.decoded = T::decode(&mut &self.encoded[..]).ok();
+			self.decoded = T::decode_with_depth_limit(
+				MAX_XCM_DECODE_DEPTH,
+				&mut &self.encoded[..],
+			).ok();
 		}
 		self.decoded.as_ref().ok_or(())
 	}
 
 	/// Move the decoded value out or (if not present) decode `encoded`.
 	pub fn take_decoded(&mut self) -> Result<T, ()> {
-		self.decoded.take().or_else(|| T::decode(&mut &self.encoded[..]).ok()).ok_or(())
+		self.decoded.take().or_else(|| {
+			T::decode_with_depth_limit(
+				MAX_XCM_DECODE_DEPTH,
+				&mut &self.encoded[..],
+			).ok()
+		}).ok_or(())
 	}
 
 	/// Provides an API similar to `TryInto` that allows fallible conversion to the inner value type.

--- a/xcm/src/double_encoded.rs
+++ b/xcm/src/double_encoded.rs
@@ -72,7 +72,7 @@ impl<T: Decode> DoubleEncoded<T> {
 	/// Returns a reference to the value in case of success and `Err(())` in case the decoding fails.
 	pub fn ensure_decoded(&mut self) -> Result<&T, ()> {
 		if self.decoded.is_none() {
-			self.decoded = T::decode_with_depth_limit(
+			self.decoded = T::decode_all_with_depth_limit(
 				MAX_XCM_DECODE_DEPTH,
 				&mut &self.encoded[..],
 			).ok();
@@ -83,7 +83,7 @@ impl<T: Decode> DoubleEncoded<T> {
 	/// Move the decoded value out or (if not present) decode `encoded`.
 	pub fn take_decoded(&mut self) -> Result<T, ()> {
 		self.decoded.take().or_else(|| {
-			T::decode_with_depth_limit(
+			T::decode_all_with_depth_limit(
 				MAX_XCM_DECODE_DEPTH,
 				&mut &self.encoded[..],
 			).ok()

--- a/xcm/src/double_encoded.rs
+++ b/xcm/src/double_encoded.rs
@@ -18,7 +18,7 @@ use alloc::vec::Vec;
 use parity_scale_codec::{Encode, Decode, DecodeLimit};
 
 /// Maximum nesting level for XCM decoding.
-pub const MAX_XCM_DECODE_DEPTH: u32 = 256;
+pub const MAX_XCM_DECODE_DEPTH: u32 = 8;
 
 /// Wrapper around the encoded and decoded versions of a value.
 /// Caches the decoded value once computed.


### PR DESCRIPTION
This PR adds a maximum XCM decode depth of 256. This prevents deeply nested XCMs which can be complex to decode.

https://github.com/paritytech/srlabs_findings/issues/94