### PR TITLE
Add bridge team as codeowners of `bridges` Subtree

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+bridges/* @tomusdrw @svyatonik @hcastano


### PR DESCRIPTION
Since we will eventually need to upstream any changes made in
the Substree it's nice to be pinged whenever something happens.

This make the process automatic.
