### PR TITLE
Follow-up PR: Count no-shows

### DIFF
--- a/node/core/approval-voting/src/approval_checking.rs
+++ b/node/core/approval-voting/src/approval_checking.rs
@@ -385,7 +385,10 @@ pub fn tranches_to_approve(
 				return None;
 			}
 
-			let n_assignments = assignments.len();
+			// Count the number of valid validator assignments.
+			let n_assignments = assignments.iter()
+				.filter(|(v_index, _)| v_index.0 < n_validators as u32)
+				.count();
 
 			// count no-shows. An assignment is a no-show if there is no corresponding approval vote
 			// after a fixed duration.
@@ -983,7 +986,7 @@ mod tests {
 	}
 
 	#[test]
-	fn validator_indexes_out_of_range_are_counted_in_assignments() {
+	fn validator_indexes_out_of_range_are_ignored_in_assignments() {
 		let block_tick = 20;
 		let no_show_duration = 10;
 		let needed_approvals = 3;
@@ -1026,7 +1029,12 @@ mod tests {
 				no_show_duration,
 				needed_approvals,
 			),
-			RequiredTranches::All,
+			RequiredTranches::Pending {
+				considered: 10,
+				next_no_show: None,
+				maximum_broadcast: DelayTranche::max_value(),
+				clock_drift: 0,
+			},
 		);
 	}
 


### PR DESCRIPTION
Quick follow up of #3264. In that PR we modified the `count_no_shows` method to ignore any `ValidatorIndex` that was greater than the length of the `approvals` bitvector. This adds a test showing the same behavior when counting `n_assignments`, where a `ValidatorIndex` that doesn't point to a valid slot in the `assignments` bitvector would be counted towards the number of assignments.

This is remedied by filtering out any indexes that are greater or equal to `n_validators` when counting the number of assignments. It still remains that `n_assignments` and `count_no_shows` inspect the number of validators and approvals, respectively.

Ideally we would add greater safety around ensuring these two values cannot differ.