### PR TITLE
downgrade a warn log to debug

### DIFF
--- a/node/core/approval-voting/src/import.rs
+++ b/node/core/approval-voting/src/import.rs
@@ -319,7 +319,7 @@ pub(crate) async fn handle_new_head(
 
 	match state.session_window.cache_session_info_for_head(ctx, head, &header).await {
 		Err(e) => {
-			tracing::warn!(
+			tracing::debug!(
 				target: LOG_TARGET,
 				?head,
 				?e,

--- a/node/network/collator-protocol/src/collator_side/mod.rs
+++ b/node/network/collator-protocol/src/collator_side/mod.rs
@@ -395,8 +395,11 @@ async fn determine_our_validators(
 	cores: usize,
 	relay_parent: Hash,
 ) -> Result<(GroupValidators, GroupValidators)> {
-	let info = &runtime.get_session_info(ctx, relay_parent).await?.session_info;
-	tracing::debug!(target: LOG_TARGET, ?info, "Received info");
+	let session_index = runtime.get_session_index(ctx, relay_parent).await?;
+	let info = &runtime.get_session_info_by_index(ctx, relay_parent, session_index)
+		.await?
+		.session_info;
+	tracing::debug!(target: LOG_TARGET, ?session_index, "Received session info");
 	let groups = &info.validator_groups;
 	let rotation_info = get_group_rotation_info(ctx, relay_parent).await?;
 

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -120,7 +120,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("kusama"),
 	impl_name: create_runtime_str!("parity-kusama"),
 	authoring_version: 2,
-	spec_version: 9050,
+	spec_version: 9051,
 	impl_version: 0,
 	#[cfg(not(feature = "disable-runtime-api"))]
 	apis: RUNTIME_API_VERSIONS,

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -95,7 +95,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("polkadot"),
 	impl_name: create_runtime_str!("parity-polkadot"),
 	authoring_version: 0,
-	spec_version: 9050,
+	spec_version: 9051,
 	impl_version: 0,
 	#[cfg(not(feature = "disable-runtime-api"))]
 	apis: RUNTIME_API_VERSIONS,

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -119,7 +119,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("westend"),
 	impl_name: create_runtime_str!("parity-westend"),
 	authoring_version: 2,
-	spec_version: 9050,
+	spec_version: 9051,
 	impl_version: 0,
 	#[cfg(not(feature = "disable-runtime-api"))]
 	apis: RUNTIME_API_VERSIONS,


### PR DESCRIPTION
This warning might freak out Polkadot validators, but is harmless because Polkadot doesn't have parachain's runtime yet.
Also tweaks collator debug log not to include the whole session_info.