### PR TITLE
Export `fungibles_adapter` Types

### DIFF
--- a/xcm/xcm-builder/src/lib.rs
+++ b/xcm/xcm-builder/src/lib.rs
@@ -48,7 +48,10 @@ mod currency_adapter;
 pub use currency_adapter::CurrencyAdapter;
 
 mod fungibles_adapter;
-pub use fungibles_adapter::{AsPrefixedGeneralIndex, ConvertedAbstractAssetId, ConvertedConcreteAssetId, FungiblesAdapter, FungiblesMutateAdapter, FungiblesTransferAdapter};
+pub use fungibles_adapter::{
+	AsPrefixedGeneralIndex, ConvertedAbstractAssetId, ConvertedConcreteAssetId, FungiblesAdapter,
+	FungiblesMutateAdapter, FungiblesTransferAdapter
+};
 
 mod weight;
 pub use weight::{FixedRateOfConcreteFungible, FixedWeightBounds, UsingComponents, TakeRevenue};

--- a/xcm/xcm-builder/src/lib.rs
+++ b/xcm/xcm-builder/src/lib.rs
@@ -48,7 +48,7 @@ mod currency_adapter;
 pub use currency_adapter::CurrencyAdapter;
 
 mod fungibles_adapter;
-pub use fungibles_adapter::FungiblesAdapter;
+pub use fungibles_adapter::{AsPrefixedGeneralIndex, ConvertedAbstractAssetId, ConvertedConcreteAssetId, FungiblesAdapter, FungiblesMutateAdapter, FungiblesTransferAdapter};
 
 mod weight;
 pub use weight::{FixedRateOfConcreteFungible, FixedWeightBounds, UsingComponents, TakeRevenue};


### PR DESCRIPTION
This PR exports types that should be usable from parachain runtimes but were private before.