### PR TITLE
SelectChain implementation for relay chains

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6703,6 +6703,7 @@ dependencies = [
 name = "polkadot-service"
 version = "0.9.5"
 dependencies = [
+ "async-trait",
  "beefy-gadget",
  "beefy-primitives",
  "env_logger 0.8.4",

--- a/node/overseer/src/lib.rs
+++ b/node/overseer/src/lib.rs
@@ -419,10 +419,23 @@ enum ExternalRequest {
 /// [`Overseer`]: struct.Overseer.html
 #[derive(Clone)]
 pub struct OverseerHandler {
-	events_tx: metered::MeteredSender<Event>,
+	events_tx: Option<metered::MeteredSender<Event>>,
 }
 
 impl OverseerHandler {
+	/// Create a disconnected overseer handler.
+	pub fn disconnected() -> Self {
+		OverseerHandler {
+			events_tx: None,
+		}
+	}
+
+	/// Using this handler, connect another handler to the same
+	/// overseer, if any.
+	pub fn connect_other(&self, other: &mut OverseerHandler) {
+		other.events_tx = self.events_tx.clone();
+	}
+
 	/// Inform the `Overseer` that that some block was imported.
 	pub async fn block_imported(&mut self, block: BlockInfo) {
 		self.send_and_log_error(Event::BlockImported(block)).await
@@ -457,8 +470,10 @@ impl OverseerHandler {
 	}
 
 	async fn send_and_log_error(&mut self, event: Event) {
-		if self.events_tx.send(event).await.is_err() {
-			tracing::info!(target: LOG_TARGET, "Failed to send an event to Overseer");
+		if let Some(ref mut events_tx) = self.events_tx {
+			if events_tx.send(event).await.is_err() {
+				tracing::info!(target: LOG_TARGET, "Failed to send an event to Overseer");
+			}
 		}
 	}
 }
@@ -1274,7 +1289,13 @@ where
 	S: SpawnNamed,
 	SupportsParachains: HeadSupportsParachains,
 {
-	/// Create a new instance of the `Overseer` with a fixed set of [`Subsystem`]s.
+	/// Create a new instance of the [`Overseer`] with a fixed set of [`Subsystem`]s.
+	///
+	/// This returns the overseer along with an [`OverseerHandler`] which can
+	/// be used to send messages from external parts of the codebase.
+	///
+	/// The [`OverseerHandler`] returned from this function is connected to
+	/// the returned [`Overseer`].
 	///
 	/// ```text
 	///                  +------------------------------------+
@@ -1393,7 +1414,7 @@ where
 		let (events_tx, events_rx) = metered::channel(CHANNEL_CAPACITY);
 
 		let handler = OverseerHandler {
-			events_tx: events_tx.clone(),
+			events_tx: Some(events_tx.clone()),
 		};
 
 		let metrics = <Metrics as metrics::Metrics>::register(prometheus_registry)?;

--- a/node/overseer/src/lib.rs
+++ b/node/overseer/src/lib.rs
@@ -430,6 +430,16 @@ impl OverseerHandler {
 		}
 	}
 
+	/// Whether the overseer handler is connected to an overseer.
+	pub fn is_connected(&self) -> bool {
+		self.events_tx.is_some()
+	}
+
+	/// Whether the handler is disconnected.
+	pub fn is_disconnected(&self) -> bool {
+		self.events_tx.is_none()
+	}
+
 	/// Using this handler, connect another handler to the same
 	/// overseer, if any.
 	pub fn connect_other(&self, other: &mut OverseerHandler) {

--- a/node/service/Cargo.toml
+++ b/node/service/Cargo.toml
@@ -67,6 +67,7 @@ serde = { version = "1.0.123", features = ["derive"] }
 thiserror = "1.0.23"
 kvdb = "0.9.0"
 kvdb-rocksdb = { version = "0.11.1", optional = true }
+async-trait = "0.1.42"
 
 # Polkadot
 polkadot-node-core-parachains-inherent = { path = "../core/parachains-inherent" }

--- a/node/service/src/grandpa_support.rs
+++ b/node/service/src/grandpa_support.rs
@@ -196,7 +196,7 @@ impl<B> grandpa::VotingRule<PolkadotBlock, B> for ApprovalCheckingVotingRule
 
 /// Returns the block hash of the block at the given `target_number` by walking
 /// backwards from the given `current_header`.
-fn walk_backwards_to_target_block<Block, B>(
+pub(super) fn walk_backwards_to_target_block<Block, B>(
 	backend: &B,
 	target_number: NumberFor<Block>,
 	current_header: &Block::Header,

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -21,6 +21,7 @@
 pub mod chain_spec;
 mod grandpa_support;
 mod parachains_db;
+mod relay_chain_selection;
 
 #[cfg(feature = "full-node")]
 mod overseer;

--- a/node/service/src/relay_chain_selection.rs
+++ b/node/service/src/relay_chain_selection.rs
@@ -108,11 +108,19 @@ impl<B> SelectChain<PolkadotBlock> for SelectRelayChain<B>
 	/// Get all leaves of the chain, i.e. block hashes that are suitable to
 	/// build upon and have no suitable children.
 	async fn leaves(&self) -> Result<Vec<Hash>, ConsensusError> {
+		if self.overseer.is_disconnected() {
+			return self.fallback.leaves().await
+		}
+
 		unimplemented!()
 	}
 
 	/// Among all leaves, pick the one which is the best chain to build upon.
 	async fn best_chain(&self) -> Result<PolkadotHeader, ConsensusError> {
+		if self.overseer.is_disconnected() {
+			return self.fallback.best_chain().await
+		}
+
 		unimplemented!()
 	}
 
@@ -130,6 +138,10 @@ impl<B> SelectChain<PolkadotBlock> for SelectRelayChain<B>
 		target_hash: Hash,
 		maybe_max_number: Option<BlockNumber>,
 	) -> Result<Option<Hash>, ConsensusError> {
+		if self.overseer.is_disconnected() {
+			return self.fallback.finality_target(target_hash, maybe_max_number).await
+		}
+
 		unimplemented!()
 	}
 }

--- a/node/service/src/relay_chain_selection.rs
+++ b/node/service/src/relay_chain_selection.rs
@@ -1,0 +1,113 @@
+// Copyright 2021 Parity Technologies (UK) Ltd.
+// This file is part of Polkadot.
+
+// Polkadot is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Polkadot is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
+
+//! A [`SelectChain`] implementation designed for relay chains.
+//!
+//! This uses information about parachains to inform GRANDPA and BABE
+//! about blocks which are safe to build on and blocks which are safe to
+//! finalize.
+//!
+//! To learn more about chain-selection rules for Relay Chains, please see the
+//! documentation on [chain-selection][chain-selection-guide]
+//! in the implementers' guide.
+//!
+//! This is mostly a wrapper around a subsystem which implements the
+//! chain-selection rule, which leaves the code to be very simple.
+//!
+//! However, this does apply the further finality constraints to the best
+//! leaf returned from the chain selection subsystem by calling into other
+//! subsystems which yield information about approvals and disputes.
+//!
+//! [chain-selection-guide]: https://w3f.github.io/parachain-implementers-guide/protocol-chain-selection.html
+
+#![cfg(feature = "full-node")]
+
+use {
+	polkadot_primitives::v1::{
+		Hash, BlockNumber, Block as PolkadotBlock, Header as PolkadotHeader,
+	},
+	polkadot_subsystem::messages::{ApprovalVotingMessage, ChainSelectionMessage},
+	prometheus_endpoint::{self, Registry},
+	polkadot_overseer::OverseerHandler,
+	futures::channel::oneshot,
+	consensus_common::{Error as ConsensusError, SelectChain},
+	std::sync::Arc,
+};
+
+/// The maximum amount of unfinalized blocks we are willing to allow due to approval checking
+/// or disputes.
+///
+/// This is a safety net that should be removed at some point in the future.
+const MAX_FINALITY_LAG: polkadot_primitives::v1::BlockNumber = 50;
+
+/// A chain-selection implementation which provides safety for relay chains.
+pub struct SelectRelayChain<B> {
+	backend: Arc<B>,
+	overseer: OverseerHandler,
+}
+
+impl<B> SelectRelayChain<B> {
+	/// Create a new [`SelectRelayChain`] wrapping the given chain backend
+	/// and a handle to the overseer.
+	pub fn new(backend: Arc<B>, overseer: OverseerHandler) -> Self {
+		SelectRelayChain {
+			backend,
+			overseer,
+		}
+	}
+}
+
+impl<B> Clone for SelectRelayChain<B> {
+	fn clone(&self) -> SelectRelayChain<B> {
+		SelectRelayChain {
+			backend: self.backend.clone(),
+			overseer: self.overseer.clone(),
+		}
+	}
+}
+
+#[async_trait::async_trait]
+impl<B> SelectChain<PolkadotBlock> for SelectRelayChain<B>
+	where B: sp_blockchain::HeaderBackend<PolkadotBlock> + 'static
+{
+	/// Get all leaves of the chain, i.e. block hashes that are suitable to
+	/// build upon and have no suitable children.
+	async fn leaves(&self) -> Result<Vec<Hash>, ConsensusError> {
+		unimplemented!()
+	}
+
+	/// Among all leaves, pick the one which is the best chain to build upon.
+	async fn best_chain(&self) -> Result<PolkadotHeader, ConsensusError> {
+		unimplemented!()
+	}
+
+	/// Get the best descendent of `target_hash` that we should attempt to
+	/// finalize next, if any. It is valid to return the `target_hash` if
+	/// no better block exists.
+	///
+	/// This will search all leaves to find the best one containing the
+	/// given target hash, and then constrain to the given block number.
+	///
+	/// It will also constrain the chain to only chains which are fully
+	/// approved, and chains which contain no disputes.
+	async fn finality_target(
+		&self,
+		target_hash: Hash,
+		maybe_max_number: Option<BlockNumber>,
+	) -> Result<Option<Hash>, ConsensusError> {
+		unimplemented!()
+	}
+}

--- a/node/service/src/relay_chain_selection.rs
+++ b/node/service/src/relay_chain_selection.rs
@@ -272,14 +272,6 @@ impl<B> SelectChain<PolkadotBlock> for SelectRelayChain<B>
 
 			match best {
 				// No viable leaves containing the block.
-				//
-				// REVIEW: should we return `Some(target_hash)` here
-				// or `None`? Docs are unclear. it seems from GRANDPA
-				// usage that `None` is treated as an error variant?
-				// Should probably be removed from the API.
-				//
-				// I think `target_hash` is fine as long as it's a
-				// round-estimate in practice.
 				None => return Ok(Some(target_hash)),
 				Some(best) => best,
 			}


### PR DESCRIPTION
Based on the new `ChainSelectionSubsystem` introduced in #3277, this implements a `SelectChain` implementation known as `RelaySelectChain`.

`RelaySelectChain` is intended to replace the `ApprovalCheckingVotingRule` by its implementation of `fn finality_target`, which will draw from the dispute coordinator in the future. I've also introduced a notion of `OverseerHandler`s being disconnected, which means that they are connected to no underlying overseer. This is necessary for when we actually integrate the `RelaySelectChain` in the service because it serves 2 purposes:
  1. The control flow of the service requires the `SelectChain` to be instantiated before the creation of the overseer. This lets us create the `SelectChain` instance and activate it later.
  2. A `RelaySelectChain` which is disconnected from the overseer will always fall back to a `LongestChain` fork-choice rule. This will be useful for Polkadot until parachains are launched, in the same vein as #3321 . 