### PR TITLE
try improving ci

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,10 +88,61 @@ exclude = ["bridges/relays/bin-substrate", "bridges/bin/rialto/runtime", "bridge
 [badges]
 maintenance = { status = "actively-developed" }
 
-# make sure dev builds with backtrace do
-# not slow us down
-[profile.dev.package.backtrace]
-opt-level = 3
+# The list of dependencies below (which can be both direct and indirect dependencies) are crates
+# that are suspected to be CPU-intensive, and that are unlikely to require debugging (as some of
+# their debug info might be missing) or to require to be frequently recompiled. We compile these
+# dependencies with `opt-level=3` even in "dev" mode in order to make "dev" mode more usable.
+#
+# This list is ordered alphabetically.
+[profile.dev.package]
+aes-soft = { opt-level = 3 }
+aesni = { opt-level = 3 }
+backtrace = { opt-level = 3 }
+blake2 = { opt-level = 3 }
+blake2-rfc = { opt-level = 3 }
+blake2b_simd = { opt-level = 3 }
+chacha20poly1305 = { opt-level = 3 }
+cranelift-codegen = { opt-level = 3 }
+cranelift-wasm = { opt-level = 3 }
+crc32fast = { opt-level = 3 }
+crossbeam-deque = { opt-level = 3 }
+crossbeam-queue = { opt-level = 3 }
+crypto-mac = { opt-level = 3 }
+curve25519-dalek = { opt-level = 3 }
+ed25519-dalek = { opt-level = 3 }
+flate2 = { opt-level = 3 }
+futures-channel = { opt-level = 3 }
+hashbrown = { opt-level = 3 }
+h2 = { opt-level = 3 }
+hash-db = { opt-level = 3 }
+hmac = { opt-level = 3 }
+httparse = { opt-level = 3 }
+integer-sqrt = { opt-level = 3 }
+keccak = { opt-level = 3 }
+libm = { opt-level = 3 }
+librocksdb-sys = { opt-level = 3 }
+libsecp256k1 = { opt-level = 3 }
+libz-sys = { opt-level = 3 }
+mio = { opt-level = 3 }
+nalgebra = { opt-level = 3 }
+num-bigint = { opt-level = 3 }
+parking_lot = { opt-level = 3 }
+parking_lot_core = { opt-level = 3 }
+percent-encoding = { opt-level = 3 }
+primitive-types = { opt-level = 3 }
+reed-solomon-novelpoly = { opt-level = 3 }
+ring = { opt-level = 3 }
+rustls = { opt-level = 3 }
+sha2 = { opt-level = 3 }
+sha3 = { opt-level = 3 }
+smallvec = { opt-level = 3 }
+snow = { opt-level = 3 }
+twox-hash = { opt-level = 3 }
+uint = { opt-level = 3 }
+wasmi = { opt-level = 3 }
+x25519-dalek = { opt-level = 3 }
+yamux = { opt-level = 3 }
+zeroize = { opt-level = 3 }
 
 [profile.release]
 # Polkadot runtime requires unwinding.

--- a/scripts/gitlab/test_linux_stable.sh
+++ b/scripts/gitlab/test_linux_stable.sh
@@ -4,4 +4,4 @@ set -e
 #shellcheck source=../common/lib.sh
 source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/../common/lib.sh"
 
-time cargo test --workspace --release --verbose --locked --features=runtime-benchmarks
+time cargo test --workspace --verbose --locked --features=runtime-benchmarks


### PR DESCRIPTION
This PR adds a list of deps from https://github.com/paritytech/substrate/blob/0982f101642ef3ea9899a0779eef43a87d6c9c07/Cargo.toml#L213-L274 plus some polkadot-specific dependencies to dev profile of polkadot to compile with `opt-level=3` and switches tests on CI to run in debug mode.
We'll see if this makes CI a bit faster.