### PR TITLE
Do not allow any crowdloan contributions during the VRF period

### DIFF
--- a/runtime/common/src/auctions.rs
+++ b/runtime/common/src/auctions.rs
@@ -319,7 +319,7 @@ impl<T: Config> Auctioneer for Pallet<T> {
 		let ending_period = T::EndingPeriod::get();
 		if after_early_end < ending_period {
 			let sample_length = T::SampleLength::get();
-			let sample = after_early_end / sample_length;
+			let sample = after_early_end / sample_length.max(1);
 			let sub_sample = after_early_end % sample_length;
 			return AuctionStatus::EndingPeriod(sample, sub_sample)
 		} else {

--- a/runtime/common/src/auctions.rs
+++ b/runtime/common/src/auctions.rs
@@ -405,6 +405,7 @@ impl<T: Config> Pallet<T> {
 		// Get the auction status and the current sample block. For the starting period, the sample
 		// block is zero.
 		let auction_status = Self::auction_status(frame_system::Pallet::<T>::block_number());
+		// The offset into the ending samples of the auction.
 		let offset = match auction_status {
 			AuctionStatus::NotStarted => return Err(Error::<T>::AuctionEnded.into()),
 			AuctionStatus::StartingPeriod => Zero::zero(),
@@ -416,7 +417,6 @@ impl<T: Config> Pallet<T> {
 		let range = SlotRange::new_bounded(first_lease_period, first_slot, last_slot)?;
 		// Range as an array index.
 		let range_index = range as u8 as usize;
-		// The offset into the ending samples of the auction.
 
 		// The current winning ranges.
 		let mut current_winning = Winning::<T>::get(offset)

--- a/runtime/common/src/auctions.rs
+++ b/runtime/common/src/auctions.rs
@@ -318,8 +318,8 @@ impl<T: Config> Auctioneer for Pallet<T> {
 
 		let ending_period = T::EndingPeriod::get();
 		if after_early_end < ending_period {
-			let sample_length = T::SampleLength::get();
-			let sample = after_early_end / sample_length.max(1);
+			let sample_length = T::SampleLength::get().max(One::one());
+			let sample = after_early_end / sample_length;
 			let sub_sample = after_early_end % sample_length;
 			return AuctionStatus::EndingPeriod(sample, sub_sample)
 		} else {
@@ -497,7 +497,7 @@ impl<T: Config> Pallet<T> {
 					// Our random seed was known only after the auction ended. Good to use.
 					let raw_offset_block_number = <T::BlockNumber>::decode(&mut raw_offset.as_ref())
 						.expect("secure hashes should always be bigger than the block number; qed");
-					let offset = (raw_offset_block_number % ending_period) / T::SampleLength::get();
+					let offset = (raw_offset_block_number % ending_period) / T::SampleLength::get().max(One::one());
 
 					let auction_counter = AuctionCounter::<T>::get();
 					Self::deposit_event(Event::<T>::WinningOffset(auction_counter, offset));

--- a/runtime/common/src/crowdloan.rs
+++ b/runtime/common/src/crowdloan.rs
@@ -905,7 +905,7 @@ mod tests {
 			};
 			let after_early_end = match now.checked_sub(early_end) {
 				Some(after_early_end) => after_early_end,
-				None => return AuctionStatus::OpeningPeriod,
+				None => return AuctionStatus::StartingPeriod,
 			};
 
 			let ending_period = ending_period();
@@ -1025,7 +1025,7 @@ mod tests {
 			assert_ok!(TestAuctioneer::place_bid(1, 2.into(), 0, 3, 6));
 			let b = BidPlaced { height: 0, bidder: 1, para: 2.into(), first_period: 0, last_period: 3, amount: 6 };
 			assert_eq!(bids(), vec![b]);
-			assert_eq!(TestAuctioneer::auction_status(4), AuctionStatus::<u64>::OpeningPeriod);
+			assert_eq!(TestAuctioneer::auction_status(4), AuctionStatus::<u64>::StartingPeriod);
 			assert_eq!(TestAuctioneer::auction_status(5), AuctionStatus::<u64>::EndingPeriod(0, 0));
 			assert_eq!(TestAuctioneer::auction_status(9), AuctionStatus::<u64>::EndingPeriod(4, 0));
 			assert_eq!(TestAuctioneer::auction_status(11), AuctionStatus::<u64>::NotStarted);

--- a/runtime/common/src/crowdloan.rs
+++ b/runtime/common/src/crowdloan.rs
@@ -1869,7 +1869,7 @@ mod benchmarking {
 				.ok_or("duration of auction less than zero")?;
 			T::Auctioneer::new_auction(duration, lease_period_index)?;
 
-			assert_eq!(T::Auctioneer::is_ending(end_block), Some(0u32.into()));
+			assert_eq!(T::Auctioneer::auction_status(end_block).is_ending(), Some((0u32.into(), 0u32.into())));
 			assert_eq!(NewRaise::<T>::get().len(), n as usize);
 			let old_endings_count = EndingsCount::<T>::get();
 		}: {

--- a/runtime/common/src/integration_tests.rs
+++ b/runtime/common/src/integration_tests.rs
@@ -41,7 +41,7 @@ use crate::{
 	auctions, crowdloan, slots, paras_registrar,
 	slot_range::SlotRange,
 	traits::{
-		Registrar as RegistrarT, Auctioneer,
+		Registrar as RegistrarT, Auctioneer, AuctionStatus,
 	},
 };
 
@@ -868,7 +868,7 @@ fn crowdloan_ending_period_bid() {
 		// Go to beginning of ending period
 		run_to_block(100);
 
-		assert_eq!(Auctions::is_ending(100), Some((0, 0)));
+		assert_eq!(Auctions::auction_status(100), AuctionStatus::<u32>::EndingPeriod(0, 0));
 		let mut winning = [None; SlotRange::SLOT_RANGE_COUNT];
 		winning[SlotRange::ZeroOne as u8 as usize] = Some((2, ParaId::from(2001), 900));
 		winning[SlotRange::ZeroThree as u8 as usize] = Some((crowdloan_account, ParaId::from(2000), total));

--- a/runtime/common/src/integration_tests.rs
+++ b/runtime/common/src/integration_tests.rs
@@ -868,7 +868,7 @@ fn crowdloan_ending_period_bid() {
 		// Go to beginning of ending period
 		run_to_block(100);
 
-		assert_eq!(Auctions::is_ending(100), Some(0));
+		assert_eq!(Auctions::is_ending(100), Some((0, 0)));
 		let mut winning = [None; SlotRange::SLOT_RANGE_COUNT];
 		winning[SlotRange::ZeroOne as u8 as usize] = Some((2, ParaId::from(2001), 900));
 		winning[SlotRange::ZeroThree as u8 as usize] = Some((crowdloan_account, ParaId::from(2000), total));

--- a/runtime/common/src/traits.rs
+++ b/runtime/common/src/traits.rs
@@ -156,17 +156,17 @@ pub enum AuctionStatus<BlockNumber> {
 }
 
 impl<BlockNumber> AuctionStatus<BlockNumber> {
+	/// Return true if the auction is in the opening period.
 	pub fn is_opening(&self) -> bool {
 		matches!(self, Self::OpeningPeriod)
 	}
+	/// Returns `Some(sample, sub_sample)` if the auction is in the `EndingPeriod`,
+	/// otherwise returns `None`.
 	pub fn is_ending(self) -> Option<(BlockNumber, BlockNumber)> {
 		match self {
 			Self::EndingPeriod(sample, sub_sample) => Some((sample, sub_sample)),
 			_ => None,
 		}
-	}
-	pub fn is_in_progress(&self) -> bool {
-		matches!(self, Self::OpeningPeriod | Self::EndingPeriod(_, _))
 	}
 }
 

--- a/runtime/common/src/traits.rs
+++ b/runtime/common/src/traits.rs
@@ -156,6 +156,10 @@ pub enum AuctionStatus<BlockNumber> {
 }
 
 impl<BlockNumber> AuctionStatus<BlockNumber> {
+	/// Returns true if the auction is in any state other than `NotStarted`.
+	pub fn is_in_progress(&self) -> bool {
+		!matches!(self, Self::NotStarted)
+	}
 	/// Return true if the auction is in the opening period.
 	pub fn is_opening(&self) -> bool {
 		matches!(self, Self::OpeningPeriod)
@@ -167,6 +171,10 @@ impl<BlockNumber> AuctionStatus<BlockNumber> {
 			Self::EndingPeriod(sample, sub_sample) => Some((sample, sub_sample)),
 			_ => None,
 		}
+	}
+	/// Returns true if the auction is in the `VrfDelay` period.
+	pub fn is_vrf(&self) -> bool {
+		matches!(self, Self::VrfDelay(_))
 	}
 }
 

--- a/runtime/common/src/traits.rs
+++ b/runtime/common/src/traits.rs
@@ -157,9 +157,14 @@ pub trait Auctioneer {
 	/// are to be auctioned.
 	fn new_auction(duration: Self::BlockNumber, lease_period_index: Self::LeasePeriod) -> DispatchResult;
 
-	/// Returns `Some(n)` if the `now` block is part of the ending period of an auction, where `n`
-	/// represents how far into the ending period this block is. Otherwise, returns `None`.
-	fn is_ending(now: Self::BlockNumber) -> Option<Self::BlockNumber>;
+	/// Returns `Some((n, sub_n))` if the `now` block is part of the ending period of an auction, where `n`
+	/// represents the ending period sample number, and `sub_n` represents how far into a sample we are.
+	///
+	/// For example, if we have a sample size of 20, block 19 of the first ending period will return
+	/// `(0, 19)`. `(0, 0)` will represent the first block of the entire ending period.
+	///
+	/// Otherwise, returns `None`.
+	fn is_ending(now: Self::BlockNumber) -> Option<(Self::BlockNumber, Self::BlockNumber)>;
 
 	/// Place a bid in the current auction.
 	///

--- a/runtime/common/src/traits.rs
+++ b/runtime/common/src/traits.rs
@@ -142,8 +142,8 @@ pub trait Leaser {
 pub enum AuctionStatus<BlockNumber> {
 	/// An auction has not started yet.
 	NotStarted,
-	/// We are in the opening period of the auction, collecting initial bids.
-	OpeningPeriod,
+	/// We are in the starting period of the auction, collecting initial bids.
+	StartingPeriod,
 	/// We are in the ending period of the auction, where we are taking snapshots of the winning
 	/// bids. This state supports "sampling", where we may only take a snapshot every N blocks.
 	/// In this case, the first number is the current sample number, and the second number
@@ -160,9 +160,9 @@ impl<BlockNumber> AuctionStatus<BlockNumber> {
 	pub fn is_in_progress(&self) -> bool {
 		!matches!(self, Self::NotStarted)
 	}
-	/// Return true if the auction is in the opening period.
-	pub fn is_opening(&self) -> bool {
-		matches!(self, Self::OpeningPeriod)
+	/// Return true if the auction is in the starting period.
+	pub fn is_starting(&self) -> bool {
+		matches!(self, Self::StartingPeriod)
 	}
 	/// Returns `Some(sample, sub_sample)` if the auction is in the `EndingPeriod`,
 	/// otherwise returns `None`.


### PR DESCRIPTION
After the ending period of an auction, there is a delay needed to select the random block used to win the auction.

During this time, a crowdloan could receive contributions which would not help win the auction whatsoever.

Because we cannot identify which crowdloans would win a current auction, we must stop all crowdloans from accepting contributions during this VRF delay period.

This PR refactors the way that the Auction pallet and the `Auctioneer` trait reports the status of an auction, making it easy to detect these scenarios, and improving the overall code structure and readability.

This PR also repairs a small bug where the `EndingsCount` was being incremented multiple times per auction. No harm done here, but this is a proper fix for that behavior.