### PR TITLE
Add XCM Tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5259,6 +5259,7 @@ version = "0.1.0"
 dependencies = [
  "frame-support",
  "frame-system",
+ "log",
  "parity-scale-codec",
  "serde",
  "sp-runtime",
@@ -11862,6 +11863,7 @@ version = "0.9.5"
 dependencies = [
  "derivative",
  "impl-trait-for-tuples",
+ "log",
  "parity-scale-codec",
 ]
 

--- a/bridges/modules/dispatch/src/lib.rs
+++ b/bridges/modules/dispatch/src/lib.rs
@@ -142,6 +142,7 @@ impl<T: Config<I>, I: Instance> MessageDispatch<T::MessageId> for Pallet<T, I> {
 		let expected_version = <T as frame_system::Config>::Version::get().spec_version;
 		if message.spec_version != expected_version {
 			log::trace!(
+				target: "runtime::bridge-dispatch",
 				"Message {:?}/{:?}: spec_version mismatch. Expected {:?}, got {:?}",
 				bridge,
 				id,

--- a/bridges/modules/dispatch/src/lib.rs
+++ b/bridges/modules/dispatch/src/lib.rs
@@ -142,7 +142,6 @@ impl<T: Config<I>, I: Instance> MessageDispatch<T::MessageId> for Pallet<T, I> {
 		let expected_version = <T as frame_system::Config>::Version::get().spec_version;
 		if message.spec_version != expected_version {
 			log::trace!(
-				target: "runtime::bridge-dispatch",
 				"Message {:?}/{:?}: spec_version mismatch. Expected {:?}, got {:?}",
 				bridge,
 				id,

--- a/xcm/Cargo.toml
+++ b/xcm/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 impl-trait-for-tuples = "0.2.0"
 parity-scale-codec = { version = "2.0.0", default-features = false, features = [ "derive" ] }
 derivative = {version = "2.2.0", default-features = false, features = [ "use_core" ] }
+log = { version = "0.4.14", default-features = false }
 
 [features]
 default = ["std"]

--- a/xcm/pallet-xcm/Cargo.toml
+++ b/xcm/pallet-xcm/Cargo.toml
@@ -7,6 +7,7 @@ version = "0.1.0"
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
+log = { version = "0.4.14", default-features = false }
 
 sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
 sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }

--- a/xcm/pallet-xcm/src/lib.rs
+++ b/xcm/pallet-xcm/src/lib.rs
@@ -254,6 +254,7 @@ pub mod pallet {
 				MultiLocation::Null => message,
 				who => Xcm::<()>::RelayedFrom { who, message: Box::new(message) },
 			};
+			log::trace!(target: "xcm::send_xcm", "dest: {:?}, message: {:?}", &dest, &message);
 			T::XcmRouter::send_xcm(dest, message)
 		}
 

--- a/xcm/src/v0/traits.rs
+++ b/xcm/src/v0/traits.rs
@@ -137,7 +137,9 @@ pub trait ExecuteXcm<Call> {
 		log::debug!(
 			target: "xcm::execute_xcm",
 			"origin: {:?}, message: {:?}, weight_limit: {:?}",
-			&origin, &message, weight_limit,
+			origin,
+			message,
+			weight_limit,
 		);
 		Self::execute_xcm_in_credit(origin, message, weight_limit, 0)
 	}

--- a/xcm/src/v0/traits.rs
+++ b/xcm/src/v0/traits.rs
@@ -134,6 +134,11 @@ pub trait ExecuteXcm<Call> {
 	/// a basic hard-limit and the implementation may place further restrictions or requirements on weight and
 	/// other aspects.
 	fn execute_xcm(origin: MultiLocation, message: Xcm<Call>, weight_limit: Weight) -> Outcome {
+		log::debug!(
+			target: "xcm::execute_xcm",
+			"origin: {:?}, message: {:?}, weight_limit: {:?}",
+			&origin, &message, weight_limit,
+		);
 		Self::execute_xcm_in_credit(origin, message, weight_limit, 0)
 	}
 

--- a/xcm/xcm-executor/src/lib.rs
+++ b/xcm/xcm-executor/src/lib.rs
@@ -47,6 +47,11 @@ impl<Config: config::Config> ExecuteXcm<Config::Call> for XcmExecutor<Config> {
 		weight_limit: Weight,
 		mut weight_credit: Weight,
 	) -> Outcome {
+		log::trace!(
+			target: "xcm::execute_xcm_in_credit",
+			"origin: {:?}, message: {:?}, weight_limit: {:?}, weight_credit: {:?}",
+			&origin, &message, weight_limit, weight_credit,
+		);
 		// TODO: #2841 #HARDENXCM We should identify recursive bombs here and bail.
 		let mut message = Xcm::<Config::Call>::from(message);
 		let shallow_weight = match Config::Weigher::shallow(&mut message) {
@@ -67,6 +72,7 @@ impl<Config: config::Config> ExecuteXcm<Config::Call> for XcmExecutor<Config> {
 		let mut trader = Config::Trader::new();
 		let result = Self::do_execute_xcm(origin, true, message, &mut weight_credit, Some(shallow_weight), &mut trader);
 		drop(trader);
+		log::trace!(target: "xcm::execute_xcm", "result: {:?}", &result);
 		match result {
 			Ok(surplus) => Outcome::Complete(maximum_weight.saturating_sub(surplus)),
 			// TODO: #2841 #REALWEIGHT We can do better than returning `maximum_weight` here, and we should otherwise
@@ -94,6 +100,11 @@ impl<Config: config::Config> XcmExecutor<Config> {
 		maybe_shallow_weight: Option<Weight>,
 		trader: &mut Config::Trader,
 	) -> Result<Weight, XcmError> {
+		log::trace!(
+			target: "xcm::do_execute_xcm",
+			"origin: {:?}, top_level: {:?}, message: {:?}, weight_credit: {:?}, maybe_shallow_weight: {:?}",
+			&origin, top_level, &message, weight_credit, maybe_shallow_weight,
+		);
 		// This is the weight of everything that cannot be paid for. This basically means all computation
 		// except any XCM which is behind an Order::BuyExecution.
 		let shallow_weight = maybe_shallow_weight
@@ -165,7 +176,7 @@ impl<Config: config::Config> XcmExecutor<Config> {
 				}
 				Some((Assets::from(assets), effects))
 			}
-			(origin, Xcm::Transact { origin_type, require_weight_at_most,  mut call }) => {
+			(origin, Xcm::Transact { origin_type, require_weight_at_most, mut call }) => {
 				// We assume that the Relay-chain is allowed to use transact on this parachain.
 
 				// TODO: #2841 #TRANSACTFILTER allow the trait to issue filters for the relay-chain
@@ -225,6 +236,11 @@ impl<Config: config::Config> XcmExecutor<Config> {
 		effect: Order<Config::Call>,
 		trader: &mut Config::Trader,
 	) -> Result<Weight, XcmError> {
+		log::trace!(
+			target: "xcm::execute_effects",
+			"origin: {:?}, holding: {:?}, effect: {:?}",
+			origin, holding, &effect,
+		);
 		let mut total_surplus = 0;
 		match effect {
 			Order::DepositAsset { assets, dest } => {

--- a/xcm/xcm-executor/src/lib.rs
+++ b/xcm/xcm-executor/src/lib.rs
@@ -50,7 +50,10 @@ impl<Config: config::Config> ExecuteXcm<Config::Call> for XcmExecutor<Config> {
 		log::trace!(
 			target: "xcm::execute_xcm_in_credit",
 			"origin: {:?}, message: {:?}, weight_limit: {:?}, weight_credit: {:?}",
-			&origin, &message, weight_limit, weight_credit,
+			origin,
+			message,
+			weight_limit,
+			weight_credit,
 		);
 		// TODO: #2841 #HARDENXCM We should identify recursive bombs here and bail.
 		let mut message = Xcm::<Config::Call>::from(message);
@@ -103,7 +106,11 @@ impl<Config: config::Config> XcmExecutor<Config> {
 		log::trace!(
 			target: "xcm::do_execute_xcm",
 			"origin: {:?}, top_level: {:?}, message: {:?}, weight_credit: {:?}, maybe_shallow_weight: {:?}",
-			&origin, top_level, &message, weight_credit, maybe_shallow_weight,
+			origin, 
+			top_level, 
+			message, 
+			weight_credit, 
+			maybe_shallow_weight,
 		);
 		// This is the weight of everything that cannot be paid for. This basically means all computation
 		// except any XCM which is behind an Order::BuyExecution.
@@ -239,7 +246,9 @@ impl<Config: config::Config> XcmExecutor<Config> {
 		log::trace!(
 			target: "xcm::execute_effects",
 			"origin: {:?}, holding: {:?}, effect: {:?}",
-			origin, holding, &effect,
+			origin,
+			holding,
+			effect,
 		);
 		let mut total_surplus = 0;
 		match effect {

--- a/xcm/xcm-executor/src/traits/conversion.rs
+++ b/xcm/xcm-executor/src/traits/conversion.rs
@@ -176,7 +176,8 @@ impl<O> ConvertOrigin<O> for Tuple {
 		log::trace!(
 			target: "xcm::convert_origin",
 			"could not convert: origin: {:?}, kind: {:?}",
-			&origin, &kind
+			origin,
+			kind,
 		);
 		Err(origin)
 	}

--- a/xcm/xcm-executor/src/traits/conversion.rs
+++ b/xcm/xcm-executor/src/traits/conversion.rs
@@ -173,6 +173,11 @@ impl<O> ConvertOrigin<O> for Tuple {
 				r => return r
 			};
 		)* );
+		log::trace!(
+			target: "xcm::convert_origin",
+			"could not convert: origin: {:?}, kind: {:?}",
+			&origin, &kind
+		);
 		Err(origin)
 	}
 }

--- a/xcm/xcm-executor/src/traits/filter_asset_location.rs
+++ b/xcm/xcm-executor/src/traits/filter_asset_location.rs
@@ -30,6 +30,11 @@ impl FilterAssetLocation for Tuple {
 		for_tuples!( #(
 			if Tuple::filter_asset_location(what, origin) { return true }
 		)* );
+		log::trace!(
+			target: "xcm::filter_asset_location",
+			"got filtered: what: {:?}, origin: {:?}",
+			&what, &origin,
+		);
 		false
 	}
 }

--- a/xcm/xcm-executor/src/traits/filter_asset_location.rs
+++ b/xcm/xcm-executor/src/traits/filter_asset_location.rs
@@ -33,7 +33,8 @@ impl FilterAssetLocation for Tuple {
 		log::trace!(
 			target: "xcm::filter_asset_location",
 			"got filtered: what: {:?}, origin: {:?}",
-			&what, &origin,
+			what,
+			origin,
 		);
 		false
 	}

--- a/xcm/xcm-executor/src/traits/matches_fungible.rs
+++ b/xcm/xcm-executor/src/traits/matches_fungible.rs
@@ -26,6 +26,7 @@ impl<Balance> MatchesFungible<Balance> for Tuple {
 		for_tuples!( #(
 			match Tuple::matches_fungible(a) { o @ Some(_) => return o, _ => () }
 		)* );
+		log::trace!(target: "xcm::matches_fungible", "did not match fungible asset: {:?}", &a);
 		None
 	}
 }

--- a/xcm/xcm-executor/src/traits/matches_fungibles.rs
+++ b/xcm/xcm-executor/src/traits/matches_fungibles.rs
@@ -54,6 +54,7 @@ impl<
 		for_tuples!( #(
 			match Tuple::matches_fungibles(a) { o @ Ok(_) => return o, _ => () }
 		)* );
+		log::trace!(target: "xcm::matches_fungibles", "did not match fungibles asset: {:?}", &a);
 		Err(Error::AssetNotFound)
 	}
 }

--- a/xcm/xcm-executor/src/traits/should_execute.rs
+++ b/xcm/xcm-executor/src/traits/should_execute.rs
@@ -58,6 +58,11 @@ impl ShouldExecute for Tuple {
 				_ => (),
 			}
 		)* );
+		log::trace!(
+			target: "xcm::should_execute",
+			"did not pass barrier: origin: {:?}, top_level: {:?}, message: {:?}, shallow_weight: {:?}, weight_credit: {:?}",
+			&origin, top_level, &message, shallow_weight, weight_credit
+		);
 		Err(())
 	}
 }

--- a/xcm/xcm-executor/src/traits/should_execute.rs
+++ b/xcm/xcm-executor/src/traits/should_execute.rs
@@ -61,7 +61,11 @@ impl ShouldExecute for Tuple {
 		log::trace!(
 			target: "xcm::should_execute",
 			"did not pass barrier: origin: {:?}, top_level: {:?}, message: {:?}, shallow_weight: {:?}, weight_credit: {:?}",
-			&origin, top_level, &message, shallow_weight, weight_credit
+			origin,
+			top_level,
+			message,
+			shallow_weight,
+			weight_credit,
 		);
 		Err(())
 	}

--- a/xcm/xcm-executor/src/traits/transact_asset.rs
+++ b/xcm/xcm-executor/src/traits/transact_asset.rs
@@ -110,7 +110,8 @@ impl TransactAsset for Tuple {
 		log::trace!(
 			target: "xcm::TransactAsset::can_check_in",
 			"asset not found: what: {:?}, origin: {:?}",
-			&what, &origin,
+			what,
+			origin,
 		);
 		Err(XcmError::AssetNotFound)
 	}
@@ -134,7 +135,8 @@ impl TransactAsset for Tuple {
 		log::trace!(
 			target: "xcm::TransactAsset::deposit_asset",
 			"did not deposit asset: what: {:?}, who: {:?}",
-			&what, &who,
+			what,
+			who,
 		);
 		Err(XcmError::Unimplemented)
 	}
@@ -146,7 +148,8 @@ impl TransactAsset for Tuple {
 		log::trace!(
 			target: "xcm::TransactAsset::withdraw_asset",
 			"did not withdraw asset: what: {:?}, who: {:?}",
-			&what, &who,
+			what, 
+			who,
 		);
 		Err(XcmError::Unimplemented)
 	}
@@ -158,7 +161,9 @@ impl TransactAsset for Tuple {
 		log::trace!(
 			target: "xcm::TransactAsset::transfer_asset",
 			"did not transfer asset: what: {:?}, from: {:?}, to: {:?}",
-			&what, &from, &to,
+			what,
+			from,
+			to,
 		);
 		Err(XcmError::Unimplemented)
 	}

--- a/xcm/xcm-executor/src/traits/transact_asset.rs
+++ b/xcm/xcm-executor/src/traits/transact_asset.rs
@@ -107,34 +107,59 @@ impl TransactAsset for Tuple {
 				r => return r,
 			}
 		)* );
+		log::trace!(
+			target: "xcm::TransactAsset::can_check_in",
+			"asset not found: what: {:?}, origin: {:?}",
+			&what, &origin,
+		);
 		Err(XcmError::AssetNotFound)
 	}
+
 	fn check_in(origin: &MultiLocation, what: &MultiAsset) {
 		for_tuples!( #(
 			Tuple::check_in(origin, what);
 		)* );
 	}
+
 	fn check_out(dest: &MultiLocation, what: &MultiAsset) {
 		for_tuples!( #(
 			Tuple::check_out(dest, what);
 		)* );
 	}
+
 	fn deposit_asset(what: &MultiAsset, who: &MultiLocation) -> XcmResult {
 		for_tuples!( #(
 			match Tuple::deposit_asset(what, who) { o @ Ok(_) => return o, _ => () }
 		)* );
+		log::trace!(
+			target: "xcm::TransactAsset::deposit_asset",
+			"did not deposit asset: what: {:?}, who: {:?}",
+			&what, &who,
+		);
 		Err(XcmError::Unimplemented)
 	}
+
 	fn withdraw_asset(what: &MultiAsset, who: &MultiLocation) -> Result<Assets, XcmError> {
 		for_tuples!( #(
 			match Tuple::withdraw_asset(what, who) { o @ Ok(_) => return o, _ => () }
 		)* );
+		log::trace!(
+			target: "xcm::TransactAsset::withdraw_asset",
+			"did not withdraw asset: what: {:?}, who: {:?}",
+			&what, &who,
+		);
 		Err(XcmError::Unimplemented)
 	}
+
 	fn transfer_asset(what: &MultiAsset, from: &MultiLocation, to: &MultiLocation) -> Result<Assets, XcmError> {
 		for_tuples!( #(
 			match Tuple::transfer_asset(what, from, to) { o @ Ok(_) => return o, _ => () }
 		)* );
+		log::trace!(
+			target: "xcm::TransactAsset::transfer_asset",
+			"did not transfer asset: what: {:?}, from: {:?}, to: {:?}",
+			&what, &from, &to,
+		);
 		Err(XcmError::Unimplemented)
 	}
 }


### PR DESCRIPTION
This PR adds `log::trace` logging for a selection of XCM methods.
This includes:
+ `log::debug` (should this also be trace?) the generic `execute_xcm` implementation
+ trace the relevant methods in the xcm-executor
+ trace the tuple implementations of various traits in case of failure/filter/miss

The logging choices are tentative and open for feedback. Let me know what should be added/removed.

#### Usage
Add `-lxcm=trace` to any Polkadot node.