### PR TITLE
Use associated constant for max

### DIFF
--- a/bridges/bin/rialto/runtime/src/exchange.rs
+++ b/bridges/bin/rialto/runtime/src/exchange.rs
@@ -250,7 +250,7 @@ mod tests {
 		assert_eq!(
 			EthTransaction::parse(
 				&prepare_ethereum_transaction(&ferdie(), |tx| {
-					tx.value = sp_core::U256::from(u128::max_value()) + sp_core::U256::from(1);
+					tx.value = sp_core::U256::from(u128::MAX) + sp_core::U256::from(1);
 				})
 				.0
 			),

--- a/bridges/bin/rialto/runtime/src/kovan.rs
+++ b/bridges/bin/rialto/runtime/src/kovan.rs
@@ -41,13 +41,13 @@ const FINALIZED_HEADERS_TO_KEEP: u64 = 20_000;
 /// Aura engine configuration for Kovan chain.
 pub fn kovan_aura_configuration() -> AuraConfiguration {
 	AuraConfiguration {
-		empty_steps_transition: u64::max_value(),
+		empty_steps_transition: u64::MAX,
 		strict_empty_steps_transition: 0,
 		validate_step_transition: 0x16e360,
 		validate_score_transition: 0x41a3c4,
-		two_thirds_majority_transition: u64::max_value(),
+		two_thirds_majority_transition: u64::MAX,
 		min_gas_limit: 0x1388.into(),
-		max_gas_limit: U256::max_value(),
+		max_gas_limit: U256::MAX,
 		maximum_extra_data_size: 0x20,
 	}
 }

--- a/bridges/bin/rialto/runtime/src/rialto_poa.rs
+++ b/bridges/bin/rialto/runtime/src/rialto_poa.rs
@@ -46,9 +46,9 @@ pub fn aura_configuration() -> AuraConfiguration {
 		strict_empty_steps_transition: 0,
 		validate_step_transition: 0,
 		validate_score_transition: 0,
-		two_thirds_majority_transition: u64::max_value(),
+		two_thirds_majority_transition: u64::MAX,
 		min_gas_limit: 0x1388.into(),
-		max_gas_limit: U256::max_value(),
+		max_gas_limit: U256::MAX,
 		maximum_extra_data_size: 0x20,
 	}
 }

--- a/bridges/modules/ethereum/src/finality.rs
+++ b/bridges/modules/ethereum/src/finality.rs
@@ -334,7 +334,7 @@ mod tests {
 					id1,
 					None,
 					&header_to_import.header,
-					u64::max_value(),
+					u64::MAX,
 				)
 				.map(|eff| eff.finalized_headers),
 				Ok(Vec::new()),
@@ -353,7 +353,7 @@ mod tests {
 					id2,
 					None,
 					&header_to_import.header,
-					u64::max_value(),
+					u64::MAX,
 				)
 				.map(|eff| eff.finalized_headers),
 				Ok(Vec::new()),
@@ -372,7 +372,7 @@ mod tests {
 					id3,
 					None,
 					&header_to_import.header,
-					u64::max_value(),
+					u64::MAX,
 				)
 				.map(|eff| eff.finalized_headers),
 				Ok(vec![(id1, None)]),

--- a/bridges/modules/ethereum/src/mock.rs
+++ b/bridges/modules/ethereum/src/mock.rs
@@ -112,13 +112,13 @@ pub struct TestContext {
 /// Aura configuration that is used in tests by default.
 pub fn test_aura_config() -> AuraConfiguration {
 	AuraConfiguration {
-		empty_steps_transition: u64::max_value(),
+		empty_steps_transition: u64::MAX,
 		strict_empty_steps_transition: 0,
 		validate_step_transition: 0x16e360,
 		validate_score_transition: 0x41a3c4,
-		two_thirds_majority_transition: u64::max_value(),
+		two_thirds_majority_transition: u64::MAX,
 		min_gas_limit: 0x1388.into(),
-		max_gas_limit: U256::max_value(),
+		max_gas_limit: U256::MAX,
 		maximum_extra_data_size: 0x20,
 	}
 }
@@ -186,7 +186,7 @@ pub struct ConstChainTime;
 
 impl ChainTime for ConstChainTime {
 	fn is_timestamp_ahead(&self, timestamp: u64) -> bool {
-		let now = i32::max_value() as u64 / 2;
+		let now = i32::MAX as u64 / 2;
 		timestamp > now
 	}
 }

--- a/bridges/modules/ethereum/src/validators.rs
+++ b/bridges/modules/ethereum/src/validators.rs
@@ -323,7 +323,7 @@ pub(crate) mod tests {
 		let config = ValidatorsConfiguration::Single(ValidatorsSource::Contract(Default::default(), Vec::new()));
 		let validators = Validators::new(&config);
 		let mut header = AuraHeader {
-			number: u64::max_value(),
+			number: u64::MAX,
 			..Default::default()
 		};
 		assert!(!validators.maybe_signals_validators_change(&header));

--- a/bridges/modules/ethereum/src/verification.rs
+++ b/bridges/modules/ethereum/src/verification.rs
@@ -191,7 +191,7 @@ fn contextless_checks<CT: ChainTime>(
 	if header.seal.len() != expected_seal_fields {
 		return Err(Error::InvalidSealArity);
 	}
-	if header.number >= u64::max_value() {
+	if header.number >= u64::MAX {
 		return Err(Error::RidiculousNumber);
 	}
 	if header.gas_used > header.gas_limit {
@@ -209,7 +209,7 @@ fn contextless_checks<CT: ChainTime>(
 
 	// we can't detect if block is from future in runtime
 	// => let's only do an overflow check
-	if header.timestamp > i32::max_value() as u64 {
+	if header.timestamp > i32::MAX as u64 {
 		return Err(Error::TimestampOverflow);
 	}
 
@@ -309,7 +309,7 @@ fn validator_checks(
 
 /// Returns expected number of seal fields in the header.
 fn expected_header_seal_fields(config: &AuraConfiguration, header: &AuraHeader) -> usize {
-	if header.number != u64::max_value() && header.number >= config.empty_steps_transition {
+	if header.number != u64::MAX && header.number >= config.empty_steps_transition {
 		3
 	} else {
 		2
@@ -323,9 +323,9 @@ fn verify_empty_step(parent_hash: &H256, step: &SealedEmptyStep, validators: &[A
 	verify_signature(&expected_validator, &step.signature, &message)
 }
 
-/// Chain scoring: total weight is sqrt(U256::max_value())*height - step
+/// Chain scoring: total weight is sqrt(U256::MAX)*height - step
 pub(crate) fn calculate_score(parent_step: u64, current_step: u64, current_empty_steps: usize) -> U256 {
-	U256::from(U128::max_value()) + U256::from(parent_step) - U256::from(current_step) + U256::from(current_empty_steps)
+	U256::from(U128::MAX) + U256::from(parent_step) - U256::from(current_step) + U256::from(current_empty_steps)
 }
 
 /// Verify that the signature over message has been produced by given validator.
@@ -491,12 +491,12 @@ mod tests {
 
 	#[test]
 	fn verifies_header_number() {
-		// when number is u64::max_value()
-		let header = HeaderBuilder::with_number(u64::max_value()).sign_by(&validator(0));
+		// when number is u64::MAX
+		let header = HeaderBuilder::with_number(u64::MAX).sign_by(&validator(0));
 		assert_eq!(default_verify(&header), Err(Error::RidiculousNumber));
 
-		// when header is < u64::max_value()
-		let header = HeaderBuilder::with_number(u64::max_value() - 1).sign_by(&validator(0));
+		// when header is < u64::MAX
+		let header = HeaderBuilder::with_number(u64::MAX - 1).sign_by(&validator(0));
 		assert_ne!(default_verify(&header), Err(Error::RidiculousNumber));
 	}
 
@@ -559,13 +559,13 @@ mod tests {
 	fn verifies_timestamp() {
 		// when timestamp overflows i32
 		let header = HeaderBuilder::with_number(1)
-			.timestamp(i32::max_value() as u64 + 1)
+			.timestamp(i32::MAX as u64 + 1)
 			.sign_by(&validator(0));
 		assert_eq!(default_verify(&header), Err(Error::TimestampOverflow));
 
 		// when timestamp doesn't overflow i32
 		let header = HeaderBuilder::with_number(1)
-			.timestamp(i32::max_value() as u64)
+			.timestamp(i32::MAX as u64)
 			.sign_by(&validator(0));
 		assert_ne!(default_verify(&header), Err(Error::TimestampOverflow));
 	}
@@ -597,19 +597,19 @@ mod tests {
 
 		// header is behind
 		let header = HeaderBuilder::with_parent(&genesis())
-			.timestamp(i32::max_value() as u64 / 2 - 100)
+			.timestamp(i32::MAX as u64 / 2 - 100)
 			.sign_by(&validator(1));
 		assert_eq!(default_verify(&header).unwrap(), expect);
 
 		// header is ahead
 		let header = HeaderBuilder::with_parent(&genesis())
-			.timestamp(i32::max_value() as u64 / 2 + 100)
+			.timestamp(i32::MAX as u64 / 2 + 100)
 			.sign_by(&validator(1));
 		assert_eq!(default_verify(&header), Err(Error::HeaderTimestampIsAhead));
 
 		// header has same timestamp as ConstChainTime
 		let header = HeaderBuilder::with_parent(&genesis())
-			.timestamp(i32::max_value() as u64 / 2)
+			.timestamp(i32::MAX as u64 / 2)
 			.sign_by(&validator(1));
 		assert_eq!(default_verify(&header).unwrap(), expect);
 	}

--- a/node/core/backing/src/lib.rs
+++ b/node/core/backing/src/lib.rs
@@ -223,7 +223,7 @@ impl TableContextTrait for TableContext {
 	}
 
 	fn requisite_votes(&self, group: &ParaId) -> usize {
-		self.groups.get(group).map_or(usize::max_value(), |g| group_quorum(g.len()))
+		self.groups.get(group).map_or(usize::MAX, |g| group_quorum(g.len()))
 	}
 }
 

--- a/node/network/protocol/src/reputation.rs
+++ b/node/network/protocol/src/reputation.rs
@@ -32,7 +32,7 @@ impl UnifiedReputationChange {
 			Self::CostMajor(_) => -300_000,
 			Self::CostMinorRepeated(_) => -200_000,
 			Self::CostMajorRepeated(_) => -600_000,
-			Self::Malicious(_) => i32::min_value(),
+			Self::Malicious(_) => i32::MIN,
 			Self::BenefitMajorFirst(_) => 300_000,
 			Self::BenefitMajor(_) => 200_000,
 			Self::BenefitMinorFirst(_) => 15_000,

--- a/primitives/src/v1/mod.rs
+++ b/primitives/src/v1/mod.rs
@@ -647,7 +647,7 @@ impl GroupRotationInfo {
 		if self.group_rotation_frequency == 0 { return GroupIndex(core_index.0) }
 		if cores == 0 { return GroupIndex(0) }
 
-		let cores = sp_std::cmp::min(cores, u32::max_value() as usize);
+		let cores = sp_std::cmp::min(cores, u32::MAX as usize);
 		let blocks_since_start = self.now.saturating_sub(self.session_start_block);
 		let rotations = blocks_since_start / self.group_rotation_frequency;
 
@@ -665,7 +665,7 @@ impl GroupRotationInfo {
 		if self.group_rotation_frequency == 0 { return CoreIndex(group_index.0) }
 		if cores == 0 { return CoreIndex(0) }
 
-		let cores = sp_std::cmp::min(cores, u32::max_value() as usize);
+		let cores = sp_std::cmp::min(cores, u32::MAX as usize);
 		let blocks_since_start = self.now.saturating_sub(self.session_start_block);
 		let rotations = blocks_since_start / self.group_rotation_frequency;
 		let rotations = rotations % cores as u32;

--- a/roadmap/implementers-guide/src/node/backing/pov-distribution.md
+++ b/roadmap/implementers-guide/src/node/backing/pov-distribution.md
@@ -1,0 +1,1 @@
+# PoV Distribution

--- a/runtime/common/src/claims.rs
+++ b/runtime/common/src/claims.rs
@@ -1224,7 +1224,7 @@ mod benchmarking {
 
 			for i in 0 .. c / 2 {
 				create_claim::<T>(c)?;
-				create_claim_attest::<T>(u32::max_value() - c)?;
+				create_claim_attest::<T>(u32::MAX - c)?;
 			}
 
 			let secret_key = secp256k1::SecretKey::parse(&keccak_256(&c.encode())).unwrap();
@@ -1250,7 +1250,7 @@ mod benchmarking {
 
 			for i in 0 .. c / 2 {
 				create_claim::<T>(c)?;
-				create_claim_attest::<T>(u32::max_value() - c)?;
+				create_claim_attest::<T>(u32::MAX - c)?;
 			}
 
 			let eth_address = account("eth_address", 0, SEED);
@@ -1267,11 +1267,11 @@ mod benchmarking {
 
 			for i in 0 .. c / 2 {
 				create_claim::<T>(c)?;
-				create_claim_attest::<T>(u32::max_value() - c)?;
+				create_claim_attest::<T>(u32::MAX - c)?;
 			}
 
 			// Crate signature
-			let attest_c = u32::max_value() - c;
+			let attest_c = u32::MAX - c;
 			let secret_key = secp256k1::SecretKey::parse(&keccak_256(&attest_c.encode())).unwrap();
 			let eth_address = eth(&secret_key);
 			let account: T::AccountId = account("user", c, SEED);
@@ -1296,10 +1296,10 @@ mod benchmarking {
 
 			for i in 0 .. c / 2 {
 				create_claim::<T>(c)?;
-				create_claim_attest::<T>(u32::max_value() - c)?;
+				create_claim_attest::<T>(u32::MAX - c)?;
 			}
 
-			let attest_c = u32::max_value() - c;
+			let attest_c = u32::MAX - c;
 			let secret_key = secp256k1::SecretKey::parse(&keccak_256(&attest_c.encode())).unwrap();
 			let eth_address = eth(&secret_key);
 			let account: T::AccountId = account("user", c, SEED);
@@ -1334,14 +1334,14 @@ mod benchmarking {
 
 			for i in 0 .. c / 2 {
 				create_claim::<T>(c)?;
-				create_claim_attest::<T>(u32::max_value() - c)?;
+				create_claim_attest::<T>(u32::MAX - c)?;
 			}
 
-			let attest_c = u32::max_value() - c;
+			let attest_c = u32::MAX - c;
 			let secret_key = secp256k1::SecretKey::parse(&keccak_256(&attest_c.encode())).unwrap();
 			let eth_address = eth(&secret_key);
 
-			let new_secret_key = secp256k1::SecretKey::parse(&keccak_256(&(u32::max_value()/2).encode())).unwrap();
+			let new_secret_key = secp256k1::SecretKey::parse(&keccak_256(&(u32::MAX/2).encode())).unwrap();
 			let new_eth_address = eth(&new_secret_key);
 
 			let account: T::AccountId = account("user", c, SEED);

--- a/runtime/common/src/purchase.rs
+++ b/runtime/common/src/purchase.rs
@@ -898,8 +898,8 @@ mod tests {
 			assert_noop!(Purchase::update_balance(
 				Origin::signed(validity_origin()),
 				alice(),
-				u64::max_value(),
-				u64::max_value(),
+				u64::MAX,
+				u64::MAX,
 				Permill::zero(),
 			), Error::<Test>::InvalidAccount);
 		});


### PR DESCRIPTION
min_value() and max_value() are deprecated in favour of the more terse and simpler associated consts of MIN and MAX. 
(This is a companion PR to a similar PR in substrate.)
(Also included U128 and U256 types.)