### PR TITLE
paras.rs to FRAME V2

### DIFF
--- a/node/service/src/chain_spec.rs
+++ b/node/service/src/chain_spec.rs
@@ -975,7 +975,6 @@ fn rococo_staging_testnet_config_genesis(wasm_binary: &[u8]) -> rococo_runtime::
 		},
 		paras: rococo_runtime::ParasConfig {
 			paras: vec![],
-			_phdata: Default::default(),
 		},
 		hrmp: Default::default(),
 		parachains_configuration: rococo_runtime::ParachainsConfigurationConfig {
@@ -1516,7 +1515,6 @@ pub fn rococo_testnet_genesis(
 		hrmp: Default::default(),
 		paras: rococo_runtime::ParasConfig {
 			paras: vec![],
-			_phdata: Default::default(),
 		},
 		bridge_rococo_grandpa: rococo_runtime::BridgeRococoGrandpaConfig {
 			owner: Some(root_key.clone()),

--- a/runtime/common/src/integration_tests.rs
+++ b/runtime/common/src/integration_tests.rs
@@ -65,7 +65,7 @@ frame_support::construct_runtime!(
 
 		// Parachains Runtime
 		Configuration: configuration::{Pallet, Call, Storage, Config<T>},
-		Paras: paras::{Pallet, Call, Storage, Event, Config},
+		Paras: paras::{Pallet, Origin, Call, Storage, Event, Config},
 
 		// Para Onboarding Pallets
 		Registrar: paras_registrar::{Pallet, Call, Storage, Event<T>},

--- a/runtime/common/src/integration_tests.rs
+++ b/runtime/common/src/integration_tests.rs
@@ -65,7 +65,7 @@ frame_support::construct_runtime!(
 
 		// Parachains Runtime
 		Configuration: configuration::{Pallet, Call, Storage, Config<T>},
-		Paras: paras::{Pallet, Origin, Call, Storage, Event, Config<T>},
+		Paras: paras::{Pallet, Call, Storage, Event, Config},
 
 		// Para Onboarding Pallets
 		Registrar: paras_registrar::{Pallet, Call, Storage, Event<T>},

--- a/runtime/common/src/paras_registrar.rs
+++ b/runtime/common/src/paras_registrar.rs
@@ -689,7 +689,7 @@ mod tests {
 				shared::Pallet::<Test>::set_session_index(
 					shared::Pallet::<Test>::session_index() + 1
 				);
-				Parachains::test_on_new_session();
+				Paras::test_on_new_session();
 			}
 			System::set_block_number(b + 1);
 			System::on_initialize(System::block_number());
@@ -736,7 +736,7 @@ mod tests {
 			let para_id = LOWEST_PUBLIC_ID;
 			run_to_block(1);
 			// first para is not yet registered
-			assert!(!Parachains::is_parathread(para_id));
+			assert!(!Paras::is_parathread(para_id));
 			// We register the Para ID
 			assert_ok!(Registrar::reserve(Origin::signed(1)));
 			assert_ok!(Registrar::register(
@@ -747,19 +747,19 @@ mod tests {
 			));
 			run_to_session(2);
 			// It is now a parathread.
-			assert!(Parachains::is_parathread(para_id));
-			assert!(!Parachains::is_parachain(para_id));
+			assert!(Paras::is_parathread(para_id));
+			assert!(!Paras::is_parachain(para_id));
 			// Some other external process will elevate parathread to parachain
 			assert_ok!(Registrar::make_parachain(para_id));
 			run_to_session(4);
 			// It is now a parachain.
-			assert!(!Parachains::is_parathread(para_id));
-			assert!(Parachains::is_parachain(para_id));
+			assert!(!Paras::is_parathread(para_id));
+			assert!(Paras::is_parachain(para_id));
 			// Turn it back into a parathread
 			assert_ok!(Registrar::make_parathread(para_id));
 			run_to_session(6);
-			assert!(Parachains::is_parathread(para_id));
-			assert!(!Parachains::is_parachain(para_id));
+			assert!(Paras::is_parathread(para_id));
+			assert!(!Paras::is_parachain(para_id));
 			// Deregister it
 			assert_ok!(Registrar::deregister(
 				Origin::root(),
@@ -767,8 +767,8 @@ mod tests {
 			));
 			run_to_session(8);
 			// It is nothing
-			assert!(!Parachains::is_parathread(para_id));
-			assert!(!Parachains::is_parachain(para_id));
+			assert!(!Paras::is_parathread(para_id));
+			assert!(!Paras::is_parachain(para_id));
 		});
 	}
 
@@ -777,7 +777,7 @@ mod tests {
 		new_test_ext().execute_with(|| {
 			run_to_block(1);
 			let para_id = LOWEST_PUBLIC_ID;
-			assert!(!Parachains::is_parathread(para_id));
+			assert!(!Paras::is_parathread(para_id));
 			assert_ok!(Registrar::reserve(Origin::signed(1)));
 			assert_eq!(Balances::reserved_balance(&1), <Test as Config>::ParaDeposit::get());
 			assert_ok!(Registrar::register(
@@ -787,7 +787,7 @@ mod tests {
 				test_validation_code(32),
 			));
 			run_to_session(2);
-			assert!(Parachains::is_parathread(para_id));
+			assert!(Paras::is_parathread(para_id));
 			assert_eq!(
 				Balances::reserved_balance(&1),
 				<Test as Config>::ParaDeposit::get() + 64 * <Test as Config>::DataDepositPerByte::get()
@@ -863,7 +863,7 @@ mod tests {
 		new_test_ext().execute_with(|| {
 			run_to_block(1);
 			let para_id = LOWEST_PUBLIC_ID;
-			assert!(!Parachains::is_parathread(para_id));
+			assert!(!Paras::is_parathread(para_id));
 			assert_ok!(Registrar::reserve(Origin::signed(1)));
 			assert_ok!(Registrar::register(
 				Origin::signed(1),
@@ -872,7 +872,7 @@ mod tests {
 				test_validation_code(32),
 			));
 			run_to_session(2);
-			assert!(Parachains::is_parathread(para_id));
+			assert!(Paras::is_parathread(para_id));
 			assert_ok!(Registrar::deregister(
 				Origin::root(),
 				para_id,
@@ -888,7 +888,7 @@ mod tests {
 		new_test_ext().execute_with(|| {
 			run_to_block(1);
 			let para_id = LOWEST_PUBLIC_ID;
-			assert!(!Parachains::is_parathread(para_id));
+			assert!(!Paras::is_parathread(para_id));
 			assert_ok!(Registrar::reserve(Origin::signed(1)));
 			assert_ok!(Registrar::register(
 				Origin::signed(1),
@@ -897,7 +897,7 @@ mod tests {
 				test_validation_code(32),
 			));
 			run_to_session(2);
-			assert!(Parachains::is_parathread(para_id));
+			assert!(Paras::is_parathread(para_id));
 			// Owner check
 			assert_noop!(Registrar::deregister(
 				Origin::signed(2),
@@ -941,10 +941,10 @@ mod tests {
 			run_to_session(4);
 
 			// Roles are as we expect
-			assert!(Parachains::is_parachain(para_1));
-			assert!(!Parachains::is_parathread(para_1));
-			assert!(!Parachains::is_parachain(para_2));
-			assert!(Parachains::is_parathread(para_2));
+			assert!(Paras::is_parachain(para_1));
+			assert!(!Paras::is_parathread(para_1));
+			assert!(!Paras::is_parachain(para_2));
+			assert!(Paras::is_parathread(para_2));
 
 			// Both paras initiate a swap
 			assert_ok!(Registrar::swap(
@@ -961,16 +961,16 @@ mod tests {
 			run_to_session(6);
 
 			// Deregister a parathread that was originally a parachain
-			assert_eq!(Parachains::lifecycle(para_1), Some(ParaLifecycle::Parathread));
+			assert_eq!(Paras::lifecycle(para_1), Some(ParaLifecycle::Parathread));
 			assert_ok!(Registrar::deregister(runtime_parachains::Origin::Parachain(para_1).into(), para_1));
 
 			run_to_block(21);
 
 			// Roles are swapped
-			assert!(!Parachains::is_parachain(para_1));
-			assert!(Parachains::is_parathread(para_1));
-			assert!(Parachains::is_parachain(para_2));
-			assert!(!Parachains::is_parathread(para_2));
+			assert!(!Paras::is_parachain(para_1));
+			assert!(Paras::is_parathread(para_1));
+			assert!(Paras::is_parachain(para_2));
+			assert!(!Paras::is_parathread(para_2));
 		});
 	}
 
@@ -993,7 +993,7 @@ mod tests {
 
 			// 2 session changes to fully onboard.
 			run_to_session(2);
-			assert_eq!(Parachains::lifecycle(para_id), Some(ParaLifecycle::Parathread));
+			assert_eq!(Paras::lifecycle(para_id), Some(ParaLifecycle::Parathread));
 
 			// Once they begin onboarding, we lock them in.
 			assert_ok!(Registrar::make_parachain(para_id));

--- a/runtime/common/src/paras_registrar.rs
+++ b/runtime/common/src/paras_registrar.rs
@@ -572,7 +572,7 @@ mod tests {
 			System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 			Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
 			ParachainsConfiguration: configuration::{Pallet, Call, Storage, Config<T>},
-			Paras: paras::{Pallet, Origin, Call, Storage, Config, Event},
+			Parachains: paras::{Pallet, Origin, Call, Storage, Config, Event},
 			Registrar: paras_registrar::{Pallet, Call, Storage, Event<T>},
 		}
 	);
@@ -689,7 +689,7 @@ mod tests {
 				shared::Pallet::<Test>::set_session_index(
 					shared::Pallet::<Test>::session_index() + 1
 				);
-				Paras::test_on_new_session();
+				Parachains::test_on_new_session();
 			}
 			System::set_block_number(b + 1);
 			System::on_initialize(System::block_number());
@@ -736,7 +736,7 @@ mod tests {
 			let para_id = LOWEST_PUBLIC_ID;
 			run_to_block(1);
 			// first para is not yet registered
-			assert!(!Paras::is_parathread(para_id));
+			assert!(!Parachains::is_parathread(para_id));
 			// We register the Para ID
 			assert_ok!(Registrar::reserve(Origin::signed(1)));
 			assert_ok!(Registrar::register(
@@ -747,19 +747,19 @@ mod tests {
 			));
 			run_to_session(2);
 			// It is now a parathread.
-			assert!(Paras::is_parathread(para_id));
-			assert!(!Paras::is_parachain(para_id));
+			assert!(Parachains::is_parathread(para_id));
+			assert!(!Parachains::is_parachain(para_id));
 			// Some other external process will elevate parathread to parachain
 			assert_ok!(Registrar::make_parachain(para_id));
 			run_to_session(4);
 			// It is now a parachain.
-			assert!(!Paras::is_parathread(para_id));
-			assert!(Paras::is_parachain(para_id));
+			assert!(!Parachains::is_parathread(para_id));
+			assert!(Parachains::is_parachain(para_id));
 			// Turn it back into a parathread
 			assert_ok!(Registrar::make_parathread(para_id));
 			run_to_session(6);
-			assert!(Paras::is_parathread(para_id));
-			assert!(!Paras::is_parachain(para_id));
+			assert!(Parachains::is_parathread(para_id));
+			assert!(!Parachains::is_parachain(para_id));
 			// Deregister it
 			assert_ok!(Registrar::deregister(
 				Origin::root(),
@@ -767,8 +767,8 @@ mod tests {
 			));
 			run_to_session(8);
 			// It is nothing
-			assert!(!Paras::is_parathread(para_id));
-			assert!(!Paras::is_parachain(para_id));
+			assert!(!Parachains::is_parathread(para_id));
+			assert!(!Parachains::is_parachain(para_id));
 		});
 	}
 
@@ -777,7 +777,7 @@ mod tests {
 		new_test_ext().execute_with(|| {
 			run_to_block(1);
 			let para_id = LOWEST_PUBLIC_ID;
-			assert!(!Paras::is_parathread(para_id));
+			assert!(!Parachains::is_parathread(para_id));
 			assert_ok!(Registrar::reserve(Origin::signed(1)));
 			assert_eq!(Balances::reserved_balance(&1), <Test as Config>::ParaDeposit::get());
 			assert_ok!(Registrar::register(
@@ -787,7 +787,7 @@ mod tests {
 				test_validation_code(32),
 			));
 			run_to_session(2);
-			assert!(Paras::is_parathread(para_id));
+			assert!(Parachains::is_parathread(para_id));
 			assert_eq!(
 				Balances::reserved_balance(&1),
 				<Test as Config>::ParaDeposit::get() + 64 * <Test as Config>::DataDepositPerByte::get()
@@ -863,7 +863,7 @@ mod tests {
 		new_test_ext().execute_with(|| {
 			run_to_block(1);
 			let para_id = LOWEST_PUBLIC_ID;
-			assert!(!Paras::is_parathread(para_id));
+			assert!(!Parachains::is_parathread(para_id));
 			assert_ok!(Registrar::reserve(Origin::signed(1)));
 			assert_ok!(Registrar::register(
 				Origin::signed(1),
@@ -872,7 +872,7 @@ mod tests {
 				test_validation_code(32),
 			));
 			run_to_session(2);
-			assert!(Paras::is_parathread(para_id));
+			assert!(Parachains::is_parathread(para_id));
 			assert_ok!(Registrar::deregister(
 				Origin::root(),
 				para_id,
@@ -888,7 +888,7 @@ mod tests {
 		new_test_ext().execute_with(|| {
 			run_to_block(1);
 			let para_id = LOWEST_PUBLIC_ID;
-			assert!(!Paras::is_parathread(para_id));
+			assert!(!Parachains::is_parathread(para_id));
 			assert_ok!(Registrar::reserve(Origin::signed(1)));
 			assert_ok!(Registrar::register(
 				Origin::signed(1),
@@ -897,7 +897,7 @@ mod tests {
 				test_validation_code(32),
 			));
 			run_to_session(2);
-			assert!(Paras::is_parathread(para_id));
+			assert!(Parachains::is_parathread(para_id));
 			// Owner check
 			assert_noop!(Registrar::deregister(
 				Origin::signed(2),
@@ -941,10 +941,10 @@ mod tests {
 			run_to_session(4);
 
 			// Roles are as we expect
-			assert!(Paras::is_parachain(para_1));
-			assert!(!Paras::is_parathread(para_1));
-			assert!(!Paras::is_parachain(para_2));
-			assert!(Paras::is_parathread(para_2));
+			assert!(Parachains::is_parachain(para_1));
+			assert!(!Parachains::is_parathread(para_1));
+			assert!(!Parachains::is_parachain(para_2));
+			assert!(Parachains::is_parathread(para_2));
 
 			// Both paras initiate a swap
 			assert_ok!(Registrar::swap(
@@ -961,16 +961,16 @@ mod tests {
 			run_to_session(6);
 
 			// Deregister a parathread that was originally a parachain
-			assert_eq!(Paras::lifecycle(para_1), Some(ParaLifecycle::Parathread));
+			assert_eq!(Parachains::lifecycle(para_1), Some(ParaLifecycle::Parathread));
 			assert_ok!(Registrar::deregister(runtime_parachains::Origin::Parachain(para_1).into(), para_1));
 
 			run_to_block(21);
 
 			// Roles are swapped
-			assert!(!Paras::is_parachain(para_1));
-			assert!(Paras::is_parathread(para_1));
-			assert!(Paras::is_parachain(para_2));
-			assert!(!Paras::is_parathread(para_2));
+			assert!(!Parachains::is_parachain(para_1));
+			assert!(Parachains::is_parathread(para_1));
+			assert!(Parachains::is_parachain(para_2));
+			assert!(!Parachains::is_parathread(para_2));
 		});
 	}
 
@@ -993,7 +993,7 @@ mod tests {
 
 			// 2 session changes to fully onboard.
 			run_to_session(2);
-			assert_eq!(Paras::lifecycle(para_id), Some(ParaLifecycle::Parathread));
+			assert_eq!(Parachains::lifecycle(para_id), Some(ParaLifecycle::Parathread));
 
 			// Once they begin onboarding, we lock them in.
 			assert_ok!(Registrar::make_parachain(para_id));

--- a/runtime/common/src/paras_registrar.rs
+++ b/runtime/common/src/paras_registrar.rs
@@ -572,7 +572,7 @@ mod tests {
 			System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 			Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
 			ParachainsConfiguration: configuration::{Pallet, Call, Storage, Config<T>},
-			Parachains: paras::{Pallet, Origin, Call, Storage, Config<T>, Event},
+			Parachains: paras::{Pallet, Call, Storage, Config, Event},
 			Registrar: paras_registrar::{Pallet, Call, Storage, Event<T>},
 		}
 	);

--- a/runtime/common/src/paras_registrar.rs
+++ b/runtime/common/src/paras_registrar.rs
@@ -572,7 +572,7 @@ mod tests {
 			System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 			Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
 			ParachainsConfiguration: configuration::{Pallet, Call, Storage, Config<T>},
-			Parachains: paras::{Pallet, Origin, Call, Storage, Config, Event},
+			Paras: paras::{Pallet, Origin, Call, Storage, Config, Event},
 			Registrar: paras_registrar::{Pallet, Call, Storage, Event<T>},
 		}
 	);

--- a/runtime/common/src/paras_registrar.rs
+++ b/runtime/common/src/paras_registrar.rs
@@ -572,7 +572,7 @@ mod tests {
 			System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 			Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
 			ParachainsConfiguration: configuration::{Pallet, Call, Storage, Config<T>},
-			Parachains: paras::{Pallet, Call, Storage, Config, Event},
+			Parachains: paras::{Pallet, Origin, Call, Storage, Config, Event},
 			Registrar: paras_registrar::{Pallet, Call, Storage, Event<T>},
 		}
 	);

--- a/runtime/common/src/paras_registrar.rs
+++ b/runtime/common/src/paras_registrar.rs
@@ -572,7 +572,7 @@ mod tests {
 			System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 			Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
 			ParachainsConfiguration: configuration::{Pallet, Call, Storage, Config<T>},
-			Parachains: paras::{Pallet, Origin, Call, Storage, Config, Event},
+			Parachains: paras::{Pallet, Call, Storage, Config, Event},
 			Registrar: paras_registrar::{Pallet, Call, Storage, Event<T>},
 		}
 	);

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -1486,7 +1486,7 @@ construct_runtime! {
 		ParasInclusion: parachains_inclusion::{Pallet, Call, Storage, Event<T>} = 53,
 		ParasInherent: parachains_paras_inherent::{Pallet, Call, Storage, Inherent} = 54,
 		ParasScheduler: parachains_scheduler::{Pallet, Call, Storage} = 55,
-		Paras: parachains_paras::{Pallet, Call, Storage, Event, Config<T>} = 56,
+		Paras: parachains_paras::{Pallet, Call, Storage, Event, Config} = 56,
 		ParasInitializer: parachains_initializer::{Pallet, Call, Storage} = 57,
 		ParasDmp: parachains_dmp::{Pallet, Call, Storage} = 58,
 		ParasUmp: parachains_ump::{Pallet, Call, Storage, Event} = 59,

--- a/runtime/parachains/src/hrmp.rs
+++ b/runtime/parachains/src/hrmp.rs
@@ -573,8 +573,8 @@ impl<T: Config> Module<T> {
 			);
 
 			if request.confirmed {
-				if <paras::Module<T>>::is_valid_para(channel_id.sender)
-					&& <paras::Module<T>>::is_valid_para(channel_id.recipient)
+				if <paras::Pallet<T>>::is_valid_para(channel_id.sender)
+					&& <paras::Pallet<T>>::is_valid_para(channel_id.recipient)
 				{
 					<Self as Store>::HrmpChannels::insert(
 						&channel_id,
@@ -972,7 +972,7 @@ impl<T: Config> Module<T> {
 	) -> DispatchResult {
 		ensure!(origin != recipient, Error::<T>::OpenHrmpChannelToSelf);
 		ensure!(
-			<paras::Module<T>>::is_valid_para(recipient),
+			<paras::Pallet<T>>::is_valid_para(recipient),
 			Error::<T>::OpenHrmpChannelInvalidRecipient,
 		);
 
@@ -1010,7 +1010,7 @@ impl<T: Config> Module<T> {
 		let egress_cnt =
 			<Self as Store>::HrmpEgressChannelsIndex::decode_len(&origin).unwrap_or(0) as u32;
 		let open_req_cnt = <Self as Store>::HrmpOpenChannelRequestCount::get(&origin);
-		let channel_num_limit = if <paras::Module<T>>::is_parathread(origin) {
+		let channel_num_limit = if <paras::Pallet<T>>::is_parathread(origin) {
 			config.hrmp_max_parathread_outbound_channels
 		} else {
 			config.hrmp_max_parachain_outbound_channels
@@ -1080,7 +1080,7 @@ impl<T: Config> Module<T> {
 		// check if by accepting this open channel request, this parachain would exceed the
 		// number of inbound channels.
 		let config = <configuration::Module<T>>::config();
-		let channel_num_limit = if <paras::Module<T>>::is_parathread(origin) {
+		let channel_num_limit = if <paras::Pallet<T>>::is_parathread(origin) {
 			config.hrmp_max_parathread_inbound_channels
 		} else {
 			config.hrmp_max_parachain_inbound_channels

--- a/runtime/parachains/src/inclusion.rs
+++ b/runtime/parachains/src/inclusion.rs
@@ -453,7 +453,7 @@ impl<T: Config> Module<T> {
 				);
 
 				let validation_code_hash =
-					<paras::Module<T>>::validation_code_hash_at(para_id, now, None)
+					<paras::Pallet<T>>::validation_code_hash_at(para_id, now, None)
 					// A candidate for a parachain without current validation code is not scheduled.
 					.ok_or_else(|| Error::<T>::UnscheduledCandidate)?;
 				ensure!(
@@ -679,7 +679,7 @@ impl<T: Config> Module<T> {
 		// initial weight is config read.
 		let mut weight = T::DbWeight::get().reads_writes(1, 0);
 		if let Some(new_code) = commitments.new_validation_code {
-			weight += <paras::Module<T>>::schedule_code_upgrade(
+			weight += <paras::Pallet<T>>::schedule_code_upgrade(
 				receipt.descriptor.para_id,
 				new_code,
 				relay_parent_number + config.validation_upgrade_delay,
@@ -708,7 +708,7 @@ impl<T: Config> Module<T> {
 			Event::<T>::CandidateIncluded(plain, commitments.head_data.clone(), core_index, backing_group)
 		);
 
-		weight + <paras::Module<T>>::note_new_head(
+		weight + <paras::Pallet<T>>::note_new_head(
 			receipt.descriptor.para_id,
 			commitments.head_data,
 			relay_parent_number,
@@ -869,7 +869,7 @@ impl<T: Config> CandidateCheckContext<T> {
 
 		// if any, the code upgrade attempt is allowed.
 		if let Some(new_validation_code) = new_validation_code {
-			let valid_upgrade_attempt = <paras::Module<T>>::last_code_upgrade(para_id, true)
+			let valid_upgrade_attempt = <paras::Pallet<T>>::last_code_upgrade(para_id, true)
 				.map_or(true, |last| {
 					last <= self.relay_parent_number
 						&& self.relay_parent_number.saturating_sub(last)

--- a/runtime/parachains/src/initializer.rs
+++ b/runtime/parachains/src/initializer.rs
@@ -131,7 +131,7 @@ decl_module! {
 			// - HRMP
 			let total_weight = configuration::Module::<T>::initializer_initialize(now) +
 				shared::Module::<T>::initializer_initialize(now) +
-				paras::Module::<T>::initializer_initialize(now) +
+				paras::Pallet::<T>::initializer_initialize(now) +
 				scheduler::Module::<T>::initializer_initialize(now) +
 				inclusion::Module::<T>::initializer_initialize(now) +
 				session_info::Module::<T>::initializer_initialize(now) +
@@ -152,7 +152,7 @@ decl_module! {
 			session_info::Module::<T>::initializer_finalize();
 			inclusion::Module::<T>::initializer_finalize();
 			scheduler::Module::<T>::initializer_finalize();
-			paras::Module::<T>::initializer_finalize();
+			paras::Pallet::<T>::initializer_finalize();
 			shared::Module::<T>::initializer_finalize();
 			configuration::Module::<T>::initializer_finalize();
 
@@ -224,7 +224,7 @@ impl<T: Config> Module<T> {
 			session_index,
 		};
 
-		let outgoing_paras = paras::Module::<T>::initializer_on_new_session(&notification);
+		let outgoing_paras = paras::Pallet::<T>::initializer_on_new_session(&notification);
 		scheduler::Module::<T>::initializer_on_new_session(&notification);
 		inclusion::Module::<T>::initializer_on_new_session(&notification);
 		session_info::Module::<T>::initializer_on_new_session(&notification);

--- a/runtime/parachains/src/lib.rs
+++ b/runtime/parachains/src/lib.rs
@@ -52,20 +52,20 @@ pub fn schedule_para_initialize<T: paras::Config>(
 	id: ParaId,
 	genesis: paras::ParaGenesisArgs,
 ) -> Result<(), ()> {
-	<paras::Module<T>>::schedule_para_initialize(id, genesis).map_err(|_| ())
+	<paras::Pallet<T>>::schedule_para_initialize(id, genesis).map_err(|_| ())
 }
 
 /// Schedule a para to be cleaned up at the start of the next session.
 pub fn schedule_para_cleanup<T: paras::Config>(id: primitives::v1::Id) -> Result<(), ()> {
-	<paras::Module<T>>::schedule_para_cleanup(id).map_err(|_| ())
+	<paras::Pallet<T>>::schedule_para_cleanup(id).map_err(|_| ())
 }
 
 /// Schedule a parathread to be upgraded to a parachain.
 pub fn schedule_parathread_upgrade<T: paras::Config>(id: ParaId) -> Result<(), ()> {
-	paras::Module::<T>::schedule_parathread_upgrade(id).map_err(|_| ())
+	paras::Pallet::<T>::schedule_parathread_upgrade(id).map_err(|_| ())
 }
 
 /// Schedule a parachain to be downgraded to a parathread.
 pub fn schedule_parachain_downgrade<T: paras::Config>(id: ParaId) -> Result<(), ()> {
-	paras::Module::<T>::schedule_parachain_downgrade(id).map_err(|_| ())
+	paras::Pallet::<T>::schedule_parachain_downgrade(id).map_err(|_| ())
 }

--- a/runtime/parachains/src/mock.rs
+++ b/runtime/parachains/src/mock.rs
@@ -217,5 +217,5 @@ pub fn new_test_ext(state: MockGenesisConfig) -> TestExternalities {
 pub struct MockGenesisConfig {
 	pub system: frame_system::GenesisConfig,
 	pub configuration: crate::configuration::GenesisConfig<Test>,
-	pub paras: crate::paras::GenesisConfig<Test>,
+	pub paras: crate::paras::GenesisConfig,
 }

--- a/runtime/parachains/src/mock.rs
+++ b/runtime/parachains/src/mock.rs
@@ -208,7 +208,7 @@ pub fn new_test_ext(state: MockGenesisConfig) -> TestExternalities {
 
 	let mut t = state.system.build_storage::<Test>().unwrap();
 	state.configuration.assimilate_storage(&mut t).unwrap();
-	state.paras.assimilate_storage(&mut t).unwrap();
+	state.paras.assimilate_storage::<Test>(&mut t).unwrap();
 
 	t.into()
 }

--- a/runtime/parachains/src/mock.rs
+++ b/runtime/parachains/src/mock.rs
@@ -42,7 +42,7 @@ frame_support::construct_runtime!(
 	{
 		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
-		Paras: paras::{Pallet, Origin, Call, Storage, Event, Config},
+		Paras: paras::{Pallet, Call, Storage, Event, Config},
 		Configuration: configuration::{Pallet, Call, Storage, Config<T>},
 		Shared: shared::{Pallet, Call, Storage},
 		Inclusion: inclusion::{Pallet, Call, Storage, Event<T>},

--- a/runtime/parachains/src/mock.rs
+++ b/runtime/parachains/src/mock.rs
@@ -42,7 +42,7 @@ frame_support::construct_runtime!(
 	{
 		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
-		Paras: paras::{Pallet, Call, Storage, Event, Config},
+		Paras: paras::{Pallet, Origin, Call, Storage, Event, Config},
 		Configuration: configuration::{Pallet, Call, Storage, Config<T>},
 		Shared: shared::{Pallet, Call, Storage},
 		Inclusion: inclusion::{Pallet, Call, Storage, Event<T>},

--- a/runtime/parachains/src/mock.rs
+++ b/runtime/parachains/src/mock.rs
@@ -23,6 +23,7 @@ use sp_runtime::traits::{
 };
 use primitives::v1::{AuthorityDiscoveryId, Balance, BlockNumber, Header, ValidatorIndex};
 use frame_support::parameter_types;
+use frame_support::traits::GenesisBuild;
 use frame_support_test::TestRandomness;
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -208,7 +209,7 @@ pub fn new_test_ext(state: MockGenesisConfig) -> TestExternalities {
 
 	let mut t = state.system.build_storage::<Test>().unwrap();
 	state.configuration.assimilate_storage(&mut t).unwrap();
-	state.paras.assimilate_storage::<Test>(&mut t).unwrap();
+	GenesisBuild::<Test>::assimilate_storage(&state.paras, &mut t).unwrap();
 
 	t.into()
 }

--- a/runtime/parachains/src/mock.rs
+++ b/runtime/parachains/src/mock.rs
@@ -42,7 +42,7 @@ frame_support::construct_runtime!(
 	{
 		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
-		Paras: paras::{Pallet, Origin, Call, Storage, Event, Config<T>},
+		Paras: paras::{Pallet, Origin, Call, Storage, Event, Config},
 		Configuration: configuration::{Pallet, Call, Storage, Config<T>},
 		Shared: shared::{Pallet, Call, Storage},
 		Inclusion: inclusion::{Pallet, Call, Storage, Event<T>},

--- a/runtime/parachains/src/paras.rs
+++ b/runtime/parachains/src/paras.rs
@@ -44,7 +44,7 @@ use sp_core::RuntimeDebug;
 #[cfg(feature = "std")]
 use serde::{Serialize, Deserialize};
 
-pub use crate::Origin;
+pub use crate::Origin as ParachainOrigin;
 
 pub use pallet::*;
 
@@ -450,8 +450,8 @@ pub mod pallet {
 		}
 	}
 
-	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+	#[pallet::origin]
+	pub type Origin = ParachainOrigin;
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {

--- a/runtime/parachains/src/paras.rs
+++ b/runtime/parachains/src/paras.rs
@@ -14,26 +14,26 @@
 // You should have received a copy of the GNU General Public License
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
-//! The paras module is responsible for storing data on parachains and parathreads.
+//! The paras pallet is responsible for storing data on parachains and parathreads.
 //!
 //! It tracks which paras are parachains, what their current head data is in
 //! this fork of the relay chain, what their validation code is, and what their past and upcoming
 //! validation code is.
 //!
-//! A para is not considered live until it is registered and activated in this module. Activation can
+//! A para is not considered live until it is registered and activated in this pallet. Activation can
 //! only occur at session boundaries.
 
 use sp_std::prelude::*;
 use sp_std::result;
-#[cfg(feature = "std")]
-use sp_std::marker::PhantomData;
 use primitives::v1::{
 	Id as ParaId, ValidationCode, ValidationCodeHash, HeadData, SessionIndex, ConsensusLog,
 };
 use sp_runtime::{traits::One, DispatchResult, SaturatedConversion};
 use frame_system::ensure_root;
+use frame_system::pallet_prelude::*;
 use frame_support::{
-	decl_storage, decl_module, decl_error, decl_event, ensure,
+	ensure,
+	pallet_prelude::*,
 	traits::Get,
 	weights::Weight,
 };
@@ -46,18 +46,7 @@ use serde::{Serialize, Deserialize};
 
 pub use crate::Origin;
 
-pub trait Config:
-	frame_system::Config +
-	configuration::Config +
-	shared::Config
-{
-	/// The outer origin type.
-	type Origin: From<Origin>
-		+ From<<Self as frame_system::Config>::Origin>
-		+ Into<result::Result<Origin, <Self as Config>::Origin>>;
-
-	type Event: From<Event> + Into<<Self as frame_system::Config>::Event>;
-}
+pub use pallet::*;
 
 // the two key times necessary to track for every code replacement.
 #[derive(Default, Encode, Decode)]
@@ -279,105 +268,30 @@ pub struct ParaGenesisArgs {
 	pub parachain: bool,
 }
 
-decl_storage! {
-	trait Store for Module<T: Config> as Paras {
-		/// All parachains. Ordered ascending by ParaId. Parathreads are not included.
-		Parachains get(fn parachains): Vec<ParaId>;
-		/// The current lifecycle of a all known Para IDs.
-		ParaLifecycles: map hasher(twox_64_concat) ParaId => Option<ParaLifecycle>;
-		/// The head-data of every registered para.
-		Heads get(fn para_head): map hasher(twox_64_concat) ParaId => Option<HeadData>;
-		/// The validation code hash of every live para.
-		///
-		/// Corresponding code can be retrieved with [`CodeByHash`].
-		CurrentCodeHash: map hasher(twox_64_concat) ParaId => Option<ValidationCodeHash>;
-		/// Actual past code hash, indicated by the para id as well as the block number at which it
-		/// became outdated.
-		///
-		/// Corresponding code can be retrieved with [`CodeByHash`].
-		PastCodeHash: map hasher(twox_64_concat) (ParaId, T::BlockNumber) => Option<ValidationCodeHash>;
-		/// Past code of parachains. The parachains themselves may not be registered anymore,
-		/// but we also keep their code on-chain for the same amount of time as outdated code
-		/// to keep it available for secondary checkers.
-		PastCodeMeta get(fn past_code_meta):
-			map hasher(twox_64_concat) ParaId => ParaPastCodeMeta<T::BlockNumber>;
-		/// Which paras have past code that needs pruning and the relay-chain block at which the code was replaced.
-		/// Note that this is the actual height of the included block, not the expected height at which the
-		/// code upgrade would be applied, although they may be equal.
-		/// This is to ensure the entire acceptance period is covered, not an offset acceptance period starting
-		/// from the time at which the parachain perceives a code upgrade as having occurred.
-		/// Multiple entries for a single para are permitted. Ordered ascending by block number.
-		PastCodePruning: Vec<(ParaId, T::BlockNumber)>;
-		/// The block number at which the planned code change is expected for a para.
-		/// The change will be applied after the first parablock for this ID included which executes
-		/// in the context of a relay chain block with a number >= `expected_at`.
-		FutureCodeUpgrades get(fn future_code_upgrade_at): map hasher(twox_64_concat) ParaId => Option<T::BlockNumber>;
-		/// The actual future code hash of a para.
-		///
-		/// Corresponding code can be retrieved with [`CodeByHash`].
-		FutureCodeHash: map hasher(twox_64_concat) ParaId => Option<ValidationCodeHash>;
-		/// The actions to perform during the start of a specific session index.
-		ActionsQueue get(fn actions_queue): map hasher(twox_64_concat) SessionIndex => Vec<ParaId>;
-		/// Upcoming paras instantiation arguments.
-		UpcomingParasGenesis: map hasher(twox_64_concat) ParaId => Option<ParaGenesisArgs>;
-		/// The number of reference on the validation code in [`CodeByHash`] storage.
-		CodeByHashRefs: map hasher(identity) ValidationCodeHash => u32;
-		/// Validation code stored by its hash.
-		///
-		/// This storage is consistent with [`FutureCodeHash`], [`CurrentCodeHash`] and
-		/// [`PastCodeHash`].
-		CodeByHash get(fn code_by_hash): map hasher(identity) ValidationCodeHash => Option<ValidationCode>;
+#[frame_support::pallet]
+pub mod pallet {
+	use super::*;
+
+	#[pallet::pallet]
+	#[pallet::generate_store(pub(super) trait Store)]
+	pub struct Pallet<T>(_);
+
+	#[pallet::config]
+	pub trait Config:
+		frame_system::Config +
+		configuration::Config +
+		shared::Config
+	{
+		/// The outer origin type.
+		type Origin: From<Origin>
+			+ From<<Self as frame_system::Config>::Origin>
+			+ Into<result::Result<Origin, <Self as Config>::Origin>>;
+
+		type Event: From<Event> + IsType<<Self as frame_system::Config>::Event>;
 	}
-	add_extra_genesis {
-		config(paras): Vec<(ParaId, ParaGenesisArgs)>;
-		config(_phdata): PhantomData<T>;
-		build(build::<T>);
-	}
-}
 
-#[cfg(feature = "std")]
-fn build<T: Config>(config: &GenesisConfig<T>) {
-	let mut parachains: Vec<_> = config.paras
-		.iter()
-		.filter(|(_, args)| args.parachain)
-		.map(|&(ref id, _)| id)
-		.cloned()
-		.collect();
-
-	parachains.sort();
-	parachains.dedup();
-
-	Parachains::put(&parachains);
-
-	for (id, genesis_args) in &config.paras {
-		let code_hash = genesis_args.validation_code.hash();
-		<Module<T>>::increase_code_ref(&code_hash, &genesis_args.validation_code);
-		<Module<T> as Store>::CurrentCodeHash::insert(&id, &code_hash);
-		<Module<T> as Store>::Heads::insert(&id, &genesis_args.genesis_head);
-		if genesis_args.parachain {
-			ParaLifecycles::insert(&id, ParaLifecycle::Parachain);
-		} else {
-			ParaLifecycles::insert(&id, ParaLifecycle::Parathread);
-		}
-	}
-}
-
-decl_error! {
-	pub enum Error for Module<T: Config> {
-		/// Para is not registered in our system.
-		NotRegistered,
-		/// Para cannot be onboarded because it is already tracked by our system.
-		CannotOnboard,
-		/// Para cannot be offboarded at this time.
-		CannotOffboard,
-		/// Para cannot be upgraded to a parachain.
-		CannotUpgrade,
-		/// Para cannot be downgraded to a parathread.
-		CannotDowngrade,
-	}
-}
-
-decl_event! {
+	#[pallet::event]
+	#[pallet::generate_deposit(pub(super) fn deposit_event)]
 	pub enum Event {
 		/// Current code has been updated for a Para. \[para_id\]
 		CurrentCodeUpdated(ParaId),
@@ -390,18 +304,146 @@ decl_event! {
 		/// A para has been queued to execute pending actions. \[para_id\]
 		ActionQueued(ParaId, SessionIndex),
 	}
-}
 
-decl_module! {
-	/// The parachains configuration module.
-	pub struct Module<T: Config> for enum Call where origin: <T as frame_system::Config>::Origin {
-		type Error = Error<T>;
+	#[pallet::error]
+	pub enum Error<T> {
+		/// Para is not registered in our system.
+		NotRegistered,
+		/// Para cannot be onboarded because it is already tracked by our system.
+		CannotOnboard,
+		/// Para cannot be offboarded at this time.
+		CannotOffboard,
+		/// Para cannot be upgraded to a parachain.
+		CannotUpgrade,
+		/// Para cannot be downgraded to a parathread.
+		CannotDowngrade,
+	}
 
-		fn deposit_event() = default;
+	/// All parachains. Ordered ascending by ParaId. Parathreads are not included.
+	#[pallet::storage]
+	#[pallet::getter(fn parachains)]
+	pub(super) type Parachains<T: Config> = StorageValue<_, Vec<ParaId>, ValueQuery>;
 
+	/// The current lifecycle of a all known Para IDs.
+	#[pallet::storage]
+	pub(super) type ParaLifecycles<T: Config> = StorageMap<_, Twox64Concat, ParaId, ParaLifecycle>;
+
+	/// The head-data of every registered para.
+	#[pallet::storage]
+	#[pallet::getter(fn para_head)]
+	pub(super) type Heads<T: Config> = StorageMap<_, Twox64Concat, ParaId, HeadData>;
+
+	/// The validation code hash of every live para.
+	///
+	/// Corresponding code can be retrieved with [`CodeByHash`].
+	#[pallet::storage]
+	pub(super) type CurrentCodeHash<T: Config> = StorageMap<_, Twox64Concat, ParaId, ValidationCodeHash>;
+
+	/// Actual past code hash, indicated by the para id as well as the block number at which it
+	/// became outdated.
+	///
+	/// Corresponding code can be retrieved with [`CodeByHash`].
+	#[pallet::storage]
+	pub(super) type PastCodeHash<T: Config> = StorageMap<_, Twox64Concat, (ParaId, T::BlockNumber), ValidationCodeHash>;
+
+	/// Past code of parachains. The parachains themselves may not be registered anymore,
+	/// but we also keep their code on-chain for the same amount of time as outdated code
+	/// to keep it available for secondary checkers.
+	#[pallet::storage]
+	#[pallet::getter(fn past_code_meta)]
+	pub(super) type PastCodeMeta<T: Config> = StorageMap<_, Twox64Concat, ParaId, ParaPastCodeMeta<T::BlockNumber>, ValueQuery>;
+
+	/// Which paras have past code that needs pruning and the relay-chain block at which the code was replaced.
+	/// Note that this is the actual height of the included block, not the expected height at which the
+	/// code upgrade would be applied, although they may be equal.
+	/// This is to ensure the entire acceptance period is covered, not an offset acceptance period starting
+	/// from the time at which the parachain perceives a code upgrade as having occurred.
+	/// Multiple entries for a single para are permitted. Ordered ascending by block number.
+	#[pallet::storage]
+	pub(super) type PastCodePruning<T: Config> = StorageValue<_, Vec<(ParaId, T::BlockNumber)>, ValueQuery>;
+
+	/// The block number at which the planned code change is expected for a para.
+	/// The change will be applied after the first parablock for this ID included which executes
+	/// in the context of a relay chain block with a number >= `expected_at`.
+	#[pallet::storage]
+	#[pallet::getter(fn future_code_upgrade_at)]
+	pub(super) type FutureCodeUpgrades<T: Config> = StorageMap<_, Twox64Concat, ParaId, T::BlockNumber>;
+
+	/// The actual future code hash of a para.
+	///
+	/// Corresponding code can be retrieved with [`CodeByHash`].
+	#[pallet::storage]
+	pub(super) type FutureCodeHash<T: Config> = StorageMap<_, Twox64Concat, ParaId, ValidationCodeHash>;
+
+	/// The actions to perform during the start of a specific session index.
+	#[pallet::storage]
+	#[pallet::getter(fn actions_queue)]
+	pub(super) type ActionsQueue<T: Config> = StorageMap<_, Twox64Concat, SessionIndex, Vec<ParaId>, ValueQuery>;
+
+	/// Upcoming paras instantiation arguments.
+	#[pallet::storage]
+	pub(super) type UpcomingParasGenesis<T: Config> = StorageMap<_, Twox64Concat, ParaId, ParaGenesisArgs>;
+
+	/// The number of reference on the validation code in [`CodeByHash`] storage.
+	#[pallet::storage]
+	pub(super) type CodeByHashRefs<T: Config> = StorageMap<_, Identity, ValidationCodeHash, u32, ValueQuery>;
+
+	/// Validation code stored by its hash.
+	///
+	/// This storage is consistent with [`FutureCodeHash`], [`CurrentCodeHash`] and
+	/// [`PastCodeHash`].
+	#[pallet::storage]
+	#[pallet::getter(fn code_by_hash)]
+	pub(super) type CodeByHash<T: Config> =  StorageMap<_, Identity, ValidationCodeHash, ValidationCode>;
+
+	#[pallet::genesis_config]
+	pub struct GenesisConfig {
+		pub paras: Vec<(ParaId, ParaGenesisArgs)>,
+	}
+
+	#[cfg(feature = "std")]
+	impl Default for GenesisConfig {
+		fn default() -> Self {
+			GenesisConfig {
+				paras: Default::default(),
+			}
+		}
+	}
+
+	#[pallet::genesis_build]
+	impl<T: Config> GenesisBuild<T> for GenesisConfig {
+		fn build(&self) {
+			let mut parachains: Vec<_> = self.paras
+				.iter()
+				.filter(|(_, args)| args.parachain)
+				.map(|&(ref id, _)| id)
+				.cloned()
+				.collect();
+
+			parachains.sort();
+			parachains.dedup();
+
+			Parachains::<T>::put(&parachains);
+
+			for (id, genesis_args) in &self.paras {
+				let code_hash = genesis_args.validation_code.hash();
+				<Pallet<T>>::increase_code_ref(&code_hash, &genesis_args.validation_code);
+				<Pallet<T> as Store>::CurrentCodeHash::insert(&id, &code_hash);
+				<Pallet<T> as Store>::Heads::insert(&id, &genesis_args.genesis_head);
+				if genesis_args.parachain {
+					ParaLifecycles::<T>::insert(&id, ParaLifecycle::Parachain);
+				} else {
+					ParaLifecycles::<T>::insert(&id, ParaLifecycle::Parathread);
+				}
+			}
+		}
+	}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
 		/// Set the storage for the parachain validation code immediately.
-		#[weight = 0]
-		fn force_set_current_code(origin, para: ParaId, new_code: ValidationCode) {
+		#[pallet::weight(0)]
+		pub fn force_set_current_code(origin: OriginFor<T>, para: ParaId, new_code: ValidationCode) -> DispatchResult {
 			ensure_root(origin)?;
 			let prior_code_hash = <Self as Store>::CurrentCodeHash::get(&para).unwrap_or_default();
 			let new_code_hash = new_code.hash();
@@ -411,57 +453,62 @@ decl_module! {
 			let now = frame_system::Pallet::<T>::block_number();
 			Self::note_past_code(para, now, now, prior_code_hash);
 			Self::deposit_event(Event::CurrentCodeUpdated(para));
+			Ok(())
 		}
 
 		/// Set the storage for the current parachain head data immediately.
-		#[weight = 0]
-		fn force_set_current_head(origin, para: ParaId, new_head: HeadData) {
+		#[pallet::weight(0)]
+		pub fn force_set_current_head(origin: OriginFor<T>, para: ParaId, new_head: HeadData) -> DispatchResult {
 			ensure_root(origin)?;
 			<Self as Store>::Heads::insert(&para, new_head);
 			Self::deposit_event(Event::CurrentHeadUpdated(para));
+			Ok(())
 		}
 
 		/// Schedule a code upgrade for block `expected_at`.
-		#[weight = 0]
-		fn force_schedule_code_upgrade(origin, para: ParaId, new_code: ValidationCode, expected_at: T::BlockNumber) {
+		#[pallet::weight(0)]
+		pub fn force_schedule_code_upgrade(origin: OriginFor<T>, para: ParaId, new_code: ValidationCode, expected_at: T::BlockNumber) -> DispatchResult {
 			ensure_root(origin)?;
 			Self::schedule_code_upgrade(para, new_code, expected_at);
 			Self::deposit_event(Event::CodeUpgradeScheduled(para));
+			Ok(())
 		}
 
 		/// Note a new block head for para within the context of the current block.
-		#[weight = 0]
-		fn force_note_new_head(origin, para: ParaId, new_head: HeadData) {
+		#[pallet::weight(0)]
+		pub fn force_note_new_head(origin: OriginFor<T>, para: ParaId, new_head: HeadData) -> DispatchResult {
 			ensure_root(origin)?;
 			let now = frame_system::Pallet::<T>::block_number();
 			Self::note_new_head(para, new_head, now);
 			Self::deposit_event(Event::NewHeadNoted(para));
+			Ok(())
 		}
 
 		/// Put a parachain directly into the next session's action queue.
 		/// We can't queue it any sooner than this without going into the
 		/// initializer...
-		#[weight = 0]
-		fn force_queue_action(origin, para: ParaId) {
+		#[pallet::weight(0)]
+		pub fn force_queue_action(origin: OriginFor<T>, para: ParaId) -> DispatchResult {
 			ensure_root(origin)?;
-			let next_session = shared::Module::<T>::session_index().saturating_add(One::one());
-			ActionsQueue::mutate(next_session, |v| {
+			let next_session = shared::Pallet::<T>::session_index().saturating_add(One::one());
+			ActionsQueue::<T>::mutate(next_session, |v| {
 				if let Err(i) = v.binary_search(&para) {
 					v.insert(i, para);
 				}
 			});
 			Self::deposit_event(Event::ActionQueued(para, next_session));
+			Ok(())
 		}
 	}
 }
 
-impl<T: Config> Module<T> {
-	/// Called by the initializer to initialize the configuration module.
+impl<T: Config> Pallet<T> {
+	/// Called by the initializer to initialize the configuration pallet.
 	pub(crate) fn initializer_initialize(now: T::BlockNumber) -> Weight {
 		Self::prune_old_code(now)
 	}
 
-	/// Called by the initializer to finalize the configuration module.
+	/// Called by the initializer to finalize the configuration pallet.
 	pub(crate) fn initializer_finalize() { }
 
 	/// Called by the initializer to note that a new session has started.
@@ -474,8 +521,8 @@ impl<T: Config> Module<T> {
 
 	/// The validation code of live para.
 	pub(crate) fn current_code(para_id: &ParaId) -> Option<ValidationCode> {
-		CurrentCodeHash::get(para_id).and_then(|code_hash| {
-			let code = CodeByHash::get(&code_hash);
+		CurrentCodeHash::<T>::get(para_id).and_then(|code_hash| {
+			let code = CodeByHash::<T>::get(&code_hash);
 			if code.is_none() {
 				log::error!(
 					"Pallet paras storage is inconsistent, code not found for hash {}",
@@ -496,13 +543,13 @@ impl<T: Config> Module<T> {
 	//
 	// Returns the list of outgoing paras from the actions queue.
 	fn apply_actions_queue(session: SessionIndex) -> Vec<ParaId> {
-		let actions = ActionsQueue::take(session);
+		let actions = ActionsQueue::<T>::take(session);
 		let mut parachains = <Self as Store>::Parachains::get();
 		let now = <frame_system::Pallet<T>>::block_number();
 		let mut outgoing = Vec::new();
 
 		for para in actions {
-			let lifecycle = ParaLifecycles::get(&para);
+			let lifecycle = ParaLifecycles::<T>::get(&para);
 			match lifecycle {
 				None | Some(ParaLifecycle::Parathread) | Some(ParaLifecycle::Parachain) => { /* Nothing to do... */ },
 				// Onboard a new parathread or parachain.
@@ -512,9 +559,9 @@ impl<T: Config> Module<T> {
 							if let Err(i) = parachains.binary_search(&para) {
 								parachains.insert(i, para);
 							}
-							ParaLifecycles::insert(&para, ParaLifecycle::Parachain);
+							ParaLifecycles::<T>::insert(&para, ParaLifecycle::Parachain);
 						} else {
-							ParaLifecycles::insert(&para, ParaLifecycle::Parathread);
+							ParaLifecycles::<T>::insert(&para, ParaLifecycle::Parathread);
 						}
 
 						let code_hash = genesis_data.validation_code.hash();
@@ -528,14 +575,14 @@ impl<T: Config> Module<T> {
 					if let Err(i) = parachains.binary_search(&para) {
 						parachains.insert(i, para);
 					}
-					ParaLifecycles::insert(&para, ParaLifecycle::Parachain);
+					ParaLifecycles::<T>::insert(&para, ParaLifecycle::Parachain);
 				},
 				// Downgrade a parachain to a parathread
 				Some(ParaLifecycle::DowngradingParachain) => {
 					if let Ok(i) = parachains.binary_search(&para) {
 						parachains.remove(i);
 					}
-					ParaLifecycles::insert(&para, ParaLifecycle::Parathread);
+					ParaLifecycles::<T>::insert(&para, ParaLifecycle::Parathread);
 				},
 				// Offboard a parathread or parachain from the system
 				Some(ParaLifecycle::OffboardingParachain) | Some(ParaLifecycle::OffboardingParathread) => {
@@ -545,7 +592,7 @@ impl<T: Config> Module<T> {
 
 					<Self as Store>::Heads::remove(&para);
 					<Self as Store>::FutureCodeUpgrades::remove(&para);
-					ParaLifecycles::remove(&para);
+					ParaLifecycles::<T>::remove(&para);
 					let removed_future_code_hash = <Self as Store>::FutureCodeHash::take(&para);
 					if let Some(removed_future_code_hash) = removed_future_code_hash {
 						Self::decrease_code_ref(&removed_future_code_hash);
@@ -599,7 +646,7 @@ impl<T: Config> Module<T> {
 	// looks at old code metadata, compares them to the current acceptance window, and prunes those
 	// that are too old.
 	fn prune_old_code(now: T::BlockNumber) -> Weight {
-		let config = configuration::Module::<T>::config();
+		let config = configuration::Pallet::<T>::config();
 		let code_retention_period = config.code_retention_period;
 		if now <= code_retention_period {
 			let weight = T::DbWeight::get().reads_writes(1, 0);
@@ -658,7 +705,7 @@ impl<T: Config> Module<T> {
 	///
 	/// Returns false if para is already registered in the system.
 	pub fn can_schedule_para_initialize(id: &ParaId, _: &ParaGenesisArgs) -> bool {
-		let lifecycle = ParaLifecycles::get(id);
+		let lifecycle = ParaLifecycles::<T>::get(id);
 		lifecycle.is_none()
 	}
 
@@ -671,9 +718,9 @@ impl<T: Config> Module<T> {
 		// Make sure parachain isn't already in our system.
 		ensure!(Self::can_schedule_para_initialize(&id, &genesis), Error::<T>::CannotOnboard);
 
-		ParaLifecycles::insert(&id, ParaLifecycle::Onboarding);
-		UpcomingParasGenesis::insert(&id, genesis);
-		ActionsQueue::mutate(scheduled_session, |v| {
+		ParaLifecycles::<T>::insert(&id, ParaLifecycle::Onboarding);
+		UpcomingParasGenesis::<T>::insert(&id, genesis);
+		ActionsQueue::<T>::mutate(scheduled_session, |v| {
 			if let Err(i) = v.binary_search(&id) {
 				v.insert(i, id);
 			}
@@ -688,23 +735,23 @@ impl<T: Config> Module<T> {
 	///
 	/// No-op if para is not registered at all.
 	pub(crate) fn schedule_para_cleanup(id: ParaId) -> DispatchResult {
-		let lifecycle = ParaLifecycles::get(&id);
+		let lifecycle = ParaLifecycles::<T>::get(&id);
 		match lifecycle {
 			// If para is not registered, nothing to do!
 			None => {
 				return Ok(())
 			},
 			Some(ParaLifecycle::Parathread) => {
-				ParaLifecycles::insert(&id, ParaLifecycle::OffboardingParathread);
+				ParaLifecycles::<T>::insert(&id, ParaLifecycle::OffboardingParathread);
 			},
 			Some(ParaLifecycle::Parachain) => {
-				ParaLifecycles::insert(&id, ParaLifecycle::OffboardingParachain);
+				ParaLifecycles::<T>::insert(&id, ParaLifecycle::OffboardingParachain);
 			},
 			_ => return Err(Error::<T>::CannotOffboard)?,
 		}
 
 		let scheduled_session = Self::scheduled_session();
-		ActionsQueue::mutate(scheduled_session, |v| {
+		ActionsQueue::<T>::mutate(scheduled_session, |v| {
 			if let Err(i) = v.binary_search(&id) {
 				v.insert(i, id);
 			}
@@ -718,12 +765,12 @@ impl<T: Config> Module<T> {
 	/// Will return error if `ParaLifecycle` is not `Parathread`.
 	pub(crate) fn schedule_parathread_upgrade(id: ParaId) -> DispatchResult {
 		let scheduled_session = Self::scheduled_session();
-		let lifecycle = ParaLifecycles::get(&id).ok_or(Error::<T>::NotRegistered)?;
+		let lifecycle = ParaLifecycles::<T>::get(&id).ok_or(Error::<T>::NotRegistered)?;
 
 		ensure!(lifecycle == ParaLifecycle::Parathread, Error::<T>::CannotUpgrade);
 
-		ParaLifecycles::insert(&id, ParaLifecycle::UpgradingParathread);
-		ActionsQueue::mutate(scheduled_session, |v| {
+		ParaLifecycles::<T>::insert(&id, ParaLifecycle::UpgradingParathread);
+		ActionsQueue::<T>::mutate(scheduled_session, |v| {
 			if let Err(i) = v.binary_search(&id) {
 				v.insert(i, id);
 			}
@@ -737,12 +784,12 @@ impl<T: Config> Module<T> {
 	/// Noop if `ParaLifecycle` is not `Parachain`.
 	pub(crate) fn schedule_parachain_downgrade(id: ParaId) -> DispatchResult {
 		let scheduled_session = Self::scheduled_session();
-		let lifecycle = ParaLifecycles::get(&id).ok_or(Error::<T>::NotRegistered)?;
+		let lifecycle = ParaLifecycles::<T>::get(&id).ok_or(Error::<T>::NotRegistered)?;
 
 		ensure!(lifecycle == ParaLifecycle::Parachain, Error::<T>::CannotDowngrade);
 
-		ParaLifecycles::insert(&id, ParaLifecycle::DowngradingParachain);
-		ActionsQueue::mutate(scheduled_session, |v| {
+		ParaLifecycles::<T>::insert(&id, ParaLifecycle::DowngradingParachain);
+		ActionsQueue::<T>::mutate(scheduled_session, |v| {
 			if let Err(i) = v.binary_search(&id) {
 				v.insert(i, id);
 			}
@@ -773,7 +820,7 @@ impl<T: Config> Module<T> {
 				<frame_system::Pallet<T>>::deposit_log(log.into());
 
 				let (reads, writes) = Self::increase_code_ref(&new_code_hash, &new_code);
-				FutureCodeHash::insert(&id, new_code_hash);
+				FutureCodeHash::<T>::insert(&id, new_code_hash);
 				T::DbWeight::get().reads_writes(1 + reads, 2 + writes)
 			}
 		})
@@ -787,16 +834,16 @@ impl<T: Config> Module<T> {
 		new_head: HeadData,
 		execution_context: T::BlockNumber,
 	) -> Weight {
-		Heads::insert(&id, new_head);
+		Heads::<T>::insert(&id, new_head);
 
 		if let Some(expected_at) = <Self as Store>::FutureCodeUpgrades::get(&id) {
 			if expected_at <= execution_context {
 				<Self as Store>::FutureCodeUpgrades::remove(&id);
 
 				// Both should always be `Some` in this case, since a code upgrade is scheduled.
-				let new_code_hash = FutureCodeHash::take(&id).unwrap_or_default();
-				let prior_code_hash = CurrentCodeHash::get(&id).unwrap_or_default();
-				CurrentCodeHash::insert(&id, &new_code_hash);
+				let new_code_hash = FutureCodeHash::<T>::take(&id).unwrap_or_default();
+				let prior_code_hash = CurrentCodeHash::<T>::get(&id).unwrap_or_default();
+				CurrentCodeHash::<T>::insert(&id, &new_code_hash);
 
 				let log = ConsensusLog::ParaUpgradeCode(id, new_code_hash);
 				<frame_system::Pallet<T>>::deposit_log(log.into());
@@ -847,11 +894,11 @@ impl<T: Config> Module<T> {
 		};
 
 		if upgrade_applied_intermediate {
-			FutureCodeHash::get(&id)
+			FutureCodeHash::<T>::get(&id)
 		} else {
 			match Self::past_code_meta(&id).code_at(at) {
 				None => None,
-				Some(UseCodeAt::Current) => CurrentCodeHash::get(&id),
+				Some(UseCodeAt::Current) => CurrentCodeHash::<T>::get(&id),
 				Some(UseCodeAt::ReplacedAt(replaced)) => <Self as Store>::PastCodeHash::get(&(id, replaced)),
 			}
 		}
@@ -859,14 +906,14 @@ impl<T: Config> Module<T> {
 
 	/// Returns the current lifecycle state of the para.
 	pub fn lifecycle(id: ParaId) -> Option<ParaLifecycle> {
-		ParaLifecycles::get(&id)
+		ParaLifecycles::<T>::get(&id)
 	}
 
 	/// Returns whether the given ID refers to a valid para.
 	///
 	/// Paras that are onboarding or offboarding are not included.
 	pub fn is_valid_para(id: ParaId) -> bool {
-		if let Some(state) = ParaLifecycles::get(&id) {
+		if let Some(state) = ParaLifecycles::<T>::get(&id) {
 			!state.is_onboarding() && !state.is_offboarding()
 		} else {
 			false
@@ -877,7 +924,7 @@ impl<T: Config> Module<T> {
 	///
 	/// Includes parachains which will downgrade to a parathread in the future.
 	pub fn is_parachain(id: ParaId) -> bool {
-		if let Some(state) = ParaLifecycles::get(&id) {
+		if let Some(state) = ParaLifecycles::<T>::get(&id) {
 			state.is_parachain()
 		} else {
 			false
@@ -888,7 +935,7 @@ impl<T: Config> Module<T> {
 	///
 	/// Includes parathreads which will upgrade to parachains in the future.
 	pub fn is_parathread(id: ParaId) -> bool {
-		if let Some(state) = ParaLifecycles::get(&id) {
+		if let Some(state) = ParaLifecycles::<T>::get(&id) {
 			state.is_parathread()
 		} else {
 			false
@@ -909,7 +956,7 @@ impl<T: Config> Module<T> {
 
 	/// Return the session index that should be used for any future scheduled changes.
 	fn scheduled_session() -> SessionIndex {
-		shared::Module::<T>::scheduled_session()
+		shared::Pallet::<T>::scheduled_session()
 	}
 
 	/// Store the validation code if not already stored, and increase the number of reference.
@@ -944,7 +991,7 @@ impl<T: Config> Module<T> {
 	#[cfg(any(feature = "std", feature = "runtime-benchmarks", test))]
 	pub fn test_on_new_session() {
 		Self::initializer_on_new_session(&SessionChangeNotification {
-			session_index: shared::Module::<T>::session_index(),
+			session_index: shared::Pallet::<T>::session_index(),
 			..Default::default()
 		});
 	}

--- a/runtime/parachains/src/paras.rs
+++ b/runtime/parachains/src/paras.rs
@@ -29,14 +29,8 @@ use primitives::v1::{
 	Id as ParaId, ValidationCode, ValidationCodeHash, HeadData, SessionIndex, ConsensusLog,
 };
 use sp_runtime::{traits::One, DispatchResult, SaturatedConversion};
-use frame_system::ensure_root;
 use frame_system::pallet_prelude::*;
-use frame_support::{
-	ensure,
-	pallet_prelude::*,
-	traits::Get,
-	weights::Weight,
-};
+use frame_support::pallet_prelude::*;
 use parity_scale_codec::{Encode, Decode};
 use crate::{configuration, shared, initializer::SessionChangeNotification};
 use sp_core::RuntimeDebug;

--- a/runtime/parachains/src/paras.rs
+++ b/runtime/parachains/src/paras.rs
@@ -1010,16 +1010,6 @@ impl<T: Config> Pallet<T> {
 	}
 }
 
-#[cfg(feature = "std")]
-impl GenesisConfig {
-	pub fn assimilate_storage<T: Config>(
-		&self,
-		storage: &mut sp_runtime::Storage
-	) -> Result<(), String> {
-		<Self as GenesisBuild<T>>::assimilate_storage(self, storage)
-	}
-}
-
 #[cfg(test)]
 mod tests {
 	use super::*;

--- a/runtime/parachains/src/paras.rs
+++ b/runtime/parachains/src/paras.rs
@@ -1686,9 +1686,9 @@ mod tests {
 			);
 
 			// Lifecycle is tracked correctly
-			assert_eq!(ParaLifecycles::get(&a), Some(ParaLifecycle::Onboarding));
-			assert_eq!(ParaLifecycles::get(&b), Some(ParaLifecycle::Onboarding));
-			assert_eq!(ParaLifecycles::get(&c), Some(ParaLifecycle::Onboarding));
+			assert_eq!(<Paras as Store>::ParaLifecycles::get(&a), Some(ParaLifecycle::Onboarding));
+			assert_eq!(<Paras as Store>::ParaLifecycles::get(&b), Some(ParaLifecycle::Onboarding));
+			assert_eq!(<Paras as Store>::ParaLifecycles::get(&c), Some(ParaLifecycle::Onboarding));
 
 			// run to block without session change.
 			run_to_block(2, None);
@@ -1700,9 +1700,9 @@ mod tests {
 			);
 
 			// Lifecycle is tracked correctly
-			assert_eq!(ParaLifecycles::get(&a), Some(ParaLifecycle::Onboarding));
-			assert_eq!(ParaLifecycles::get(&b), Some(ParaLifecycle::Onboarding));
-			assert_eq!(ParaLifecycles::get(&c), Some(ParaLifecycle::Onboarding));
+			assert_eq!(<Paras as Store>::ParaLifecycles::get(&a), Some(ParaLifecycle::Onboarding));
+			assert_eq!(<Paras as Store>::ParaLifecycles::get(&b), Some(ParaLifecycle::Onboarding));
+			assert_eq!(<Paras as Store>::ParaLifecycles::get(&c), Some(ParaLifecycle::Onboarding));
 
 
 			// Two sessions pass, so action queue is triggered
@@ -1712,9 +1712,9 @@ mod tests {
 			assert_eq!(<Paras as Store>::ActionsQueue::get(Paras::scheduled_session()), Vec::new());
 
 			// Lifecycle is tracked correctly
-			assert_eq!(ParaLifecycles::get(&a), Some(ParaLifecycle::Parathread));
-			assert_eq!(ParaLifecycles::get(&b), Some(ParaLifecycle::Parachain));
-			assert_eq!(ParaLifecycles::get(&c), Some(ParaLifecycle::Parachain));
+			assert_eq!(<Paras as Store>::ParaLifecycles::get(&a), Some(ParaLifecycle::Parathread));
+			assert_eq!(<Paras as Store>::ParaLifecycles::get(&b), Some(ParaLifecycle::Parachain));
+			assert_eq!(<Paras as Store>::ParaLifecycles::get(&c), Some(ParaLifecycle::Parachain));
 
 			assert_eq!(Paras::current_code(&a), Some(vec![2].into()));
 			assert_eq!(Paras::current_code(&b), Some(vec![1].into()));
@@ -1850,18 +1850,18 @@ mod tests {
 			Paras::increase_code_ref(&code.hash(), &code);
 			Paras::increase_code_ref(&code.hash(), &code);
 
-			assert!(CodeByHash::contains_key(code.hash()));
-			assert_eq!(CodeByHashRefs::get(code.hash()), 2);
+			assert!(<Paras as Store>::CodeByHash::contains_key(code.hash()));
+			assert_eq!(<Paras as Store>::CodeByHashRefs::get(code.hash()), 2);
 
 			Paras::decrease_code_ref(&code.hash());
 
-			assert!(CodeByHash::contains_key(code.hash()));
-			assert_eq!(CodeByHashRefs::get(code.hash()), 1);
+			assert!(<Paras as Store>::CodeByHash::contains_key(code.hash()));
+			assert_eq!(<Paras as Store>::CodeByHashRefs::get(code.hash()), 1);
 
 			Paras::decrease_code_ref(&code.hash());
 
-			assert!(!CodeByHash::contains_key(code.hash()));
-			assert!(!CodeByHashRefs::contains_key(code.hash()));
+			assert!(!<Paras as Store>::CodeByHash::contains_key(code.hash()));
+			assert!(!<Paras as Store>::CodeByHashRefs::contains_key(code.hash()));
 		});
 	}
 }

--- a/runtime/parachains/src/paras.rs
+++ b/runtime/parachains/src/paras.rs
@@ -450,6 +450,9 @@ pub mod pallet {
 		}
 	}
 
+	#[pallet::hooks]
+	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
 		/// Set the storage for the parachain validation code immediately.

--- a/runtime/parachains/src/paras.rs
+++ b/runtime/parachains/src/paras.rs
@@ -1016,6 +1016,16 @@ impl<T: Config> Pallet<T> {
 	}
 }
 
+#[cfg(feature = "std")]
+impl GenesisConfig {
+	pub fn assimilate_storage<T: Config>(
+		&self,
+		storage: &mut sp_runtime::Storage
+	) -> Result<(), String> {
+		<Self as GenesisBuild<T>>::assimilate_storage(self, storage)
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;

--- a/runtime/parachains/src/paras.rs
+++ b/runtime/parachains/src/paras.rs
@@ -1689,9 +1689,9 @@ mod tests {
 			);
 
 			// Lifecycle is tracked correctly
-			assert_eq!(ParaLifecycles::get(&a), Some(ParaLifecycle::Onboarding));
-			assert_eq!(ParaLifecycles::get(&b), Some(ParaLifecycle::Onboarding));
-			assert_eq!(ParaLifecycles::get(&c), Some(ParaLifecycle::Onboarding));
+			assert_eq!(ParaLifecycles::<T>::get(&a), Some(ParaLifecycle::Onboarding));
+			assert_eq!(ParaLifecycles::<T>::get(&b), Some(ParaLifecycle::Onboarding));
+			assert_eq!(ParaLifecycles::<T>::get(&c), Some(ParaLifecycle::Onboarding));
 
 			// run to block without session change.
 			run_to_block(2, None);
@@ -1703,9 +1703,9 @@ mod tests {
 			);
 
 			// Lifecycle is tracked correctly
-			assert_eq!(ParaLifecycles::get(&a), Some(ParaLifecycle::Onboarding));
-			assert_eq!(ParaLifecycles::get(&b), Some(ParaLifecycle::Onboarding));
-			assert_eq!(ParaLifecycles::get(&c), Some(ParaLifecycle::Onboarding));
+			assert_eq!(ParaLifecycles::<T>::get(&a), Some(ParaLifecycle::Onboarding));
+			assert_eq!(ParaLifecycles::<T>::get(&b), Some(ParaLifecycle::Onboarding));
+			assert_eq!(ParaLifecycles::<T>::get(&c), Some(ParaLifecycle::Onboarding));
 
 
 			// Two sessions pass, so action queue is triggered
@@ -1715,9 +1715,9 @@ mod tests {
 			assert_eq!(<Paras as Store>::ActionsQueue::get(Paras::scheduled_session()), Vec::new());
 
 			// Lifecycle is tracked correctly
-			assert_eq!(ParaLifecycles::get(&a), Some(ParaLifecycle::Parathread));
-			assert_eq!(ParaLifecycles::get(&b), Some(ParaLifecycle::Parachain));
-			assert_eq!(ParaLifecycles::get(&c), Some(ParaLifecycle::Parachain));
+			assert_eq!(ParaLifecycles::<T>::get(&a), Some(ParaLifecycle::Parathread));
+			assert_eq!(ParaLifecycles::<T>::get(&b), Some(ParaLifecycle::Parachain));
+			assert_eq!(ParaLifecycles::<T>::get(&c), Some(ParaLifecycle::Parachain));
 
 			assert_eq!(Paras::current_code(&a), Some(vec![2].into()));
 			assert_eq!(Paras::current_code(&b), Some(vec![1].into()));
@@ -1853,18 +1853,18 @@ mod tests {
 			Paras::increase_code_ref(&code.hash(), &code);
 			Paras::increase_code_ref(&code.hash(), &code);
 
-			assert!(CodeByHash::contains_key(code.hash()));
-			assert_eq!(CodeByHashRefs::get(code.hash()), 2);
+			assert!(CodeByHash::<T>::contains_key(code.hash()));
+			assert_eq!(CodeByHashRefs::<T>::get(code.hash()), 2);
 
 			Paras::decrease_code_ref(&code.hash());
 
-			assert!(CodeByHash::contains_key(code.hash()));
-			assert_eq!(CodeByHashRefs::get(code.hash()), 1);
+			assert!(CodeByHash::<T>::contains_key(code.hash()));
+			assert_eq!(CodeByHashRefs::<T>::get(code.hash()), 1);
 
 			Paras::decrease_code_ref(&code.hash());
 
-			assert!(!CodeByHash::contains_key(code.hash()));
-			assert!(!CodeByHashRefs::contains_key(code.hash()));
+			assert!(!CodeByHash::<T>::contains_key(code.hash()));
+			assert!(!CodeByHashRefs::<T>::contains_key(code.hash()));
 		});
 	}
 }

--- a/runtime/parachains/src/paras.rs
+++ b/runtime/parachains/src/paras.rs
@@ -277,14 +277,14 @@ pub mod pallet {
 	pub struct Pallet<T>(_);
 
 	#[pallet::config]
+	#[pallet::disable_frame_system_supertrait_check]
 	pub trait Config:
 		frame_system::Config +
 		configuration::Config +
 		shared::Config
 	{
 		/// The outer origin type.
-		type Origin: From<Origin>
-			+ From<<Self as frame_system::Config>::Origin>
+		type Origin: From<<Self as frame_system::Config>::Origin>
 			+ Into<result::Result<Origin, <Self as Config>::Origin>>;
 
 		type Event: From<Event> + IsType<<Self as frame_system::Config>::Event>;
@@ -1030,10 +1030,7 @@ impl GenesisConfig {
 mod tests {
 	use super::*;
 	use primitives::v1::BlockNumber;
-	use frame_support::{
-		assert_ok,
-		traits::{OnFinalize, OnInitialize}
-	};
+	use frame_support::assert_ok;
 
 	use crate::mock::{new_test_ext, Paras, Shared, System, MockGenesisConfig};
 	use crate::configuration::HostConfiguration;
@@ -1689,9 +1686,9 @@ mod tests {
 			);
 
 			// Lifecycle is tracked correctly
-			assert_eq!(ParaLifecycles::<T>::get(&a), Some(ParaLifecycle::Onboarding));
-			assert_eq!(ParaLifecycles::<T>::get(&b), Some(ParaLifecycle::Onboarding));
-			assert_eq!(ParaLifecycles::<T>::get(&c), Some(ParaLifecycle::Onboarding));
+			assert_eq!(ParaLifecycles::get(&a), Some(ParaLifecycle::Onboarding));
+			assert_eq!(ParaLifecycles::get(&b), Some(ParaLifecycle::Onboarding));
+			assert_eq!(ParaLifecycles::get(&c), Some(ParaLifecycle::Onboarding));
 
 			// run to block without session change.
 			run_to_block(2, None);
@@ -1703,9 +1700,9 @@ mod tests {
 			);
 
 			// Lifecycle is tracked correctly
-			assert_eq!(ParaLifecycles::<T>::get(&a), Some(ParaLifecycle::Onboarding));
-			assert_eq!(ParaLifecycles::<T>::get(&b), Some(ParaLifecycle::Onboarding));
-			assert_eq!(ParaLifecycles::<T>::get(&c), Some(ParaLifecycle::Onboarding));
+			assert_eq!(ParaLifecycles::get(&a), Some(ParaLifecycle::Onboarding));
+			assert_eq!(ParaLifecycles::get(&b), Some(ParaLifecycle::Onboarding));
+			assert_eq!(ParaLifecycles::get(&c), Some(ParaLifecycle::Onboarding));
 
 
 			// Two sessions pass, so action queue is triggered
@@ -1715,9 +1712,9 @@ mod tests {
 			assert_eq!(<Paras as Store>::ActionsQueue::get(Paras::scheduled_session()), Vec::new());
 
 			// Lifecycle is tracked correctly
-			assert_eq!(ParaLifecycles::<T>::get(&a), Some(ParaLifecycle::Parathread));
-			assert_eq!(ParaLifecycles::<T>::get(&b), Some(ParaLifecycle::Parachain));
-			assert_eq!(ParaLifecycles::<T>::get(&c), Some(ParaLifecycle::Parachain));
+			assert_eq!(ParaLifecycles::get(&a), Some(ParaLifecycle::Parathread));
+			assert_eq!(ParaLifecycles::get(&b), Some(ParaLifecycle::Parachain));
+			assert_eq!(ParaLifecycles::get(&c), Some(ParaLifecycle::Parachain));
 
 			assert_eq!(Paras::current_code(&a), Some(vec![2].into()));
 			assert_eq!(Paras::current_code(&b), Some(vec![1].into()));
@@ -1853,18 +1850,18 @@ mod tests {
 			Paras::increase_code_ref(&code.hash(), &code);
 			Paras::increase_code_ref(&code.hash(), &code);
 
-			assert!(CodeByHash::<T>::contains_key(code.hash()));
-			assert_eq!(CodeByHashRefs::<T>::get(code.hash()), 2);
+			assert!(CodeByHash::contains_key(code.hash()));
+			assert_eq!(CodeByHashRefs::get(code.hash()), 2);
 
 			Paras::decrease_code_ref(&code.hash());
 
-			assert!(CodeByHash::<T>::contains_key(code.hash()));
-			assert_eq!(CodeByHashRefs::<T>::get(code.hash()), 1);
+			assert!(CodeByHash::contains_key(code.hash()));
+			assert_eq!(CodeByHashRefs::get(code.hash()), 1);
 
 			Paras::decrease_code_ref(&code.hash());
 
-			assert!(!CodeByHash::<T>::contains_key(code.hash()));
-			assert!(!CodeByHashRefs::<T>::contains_key(code.hash()));
+			assert!(!CodeByHash::contains_key(code.hash()));
+			assert!(!CodeByHashRefs::contains_key(code.hash()));
 		});
 	}
 }

--- a/runtime/parachains/src/paras.rs
+++ b/runtime/parachains/src/paras.rs
@@ -277,14 +277,14 @@ pub mod pallet {
 	pub struct Pallet<T>(_);
 
 	#[pallet::config]
-	#[pallet::disable_frame_system_supertrait_check]
 	pub trait Config:
 		frame_system::Config +
 		configuration::Config +
 		shared::Config
 	{
 		/// The outer origin type.
-		type Origin: From<<Self as frame_system::Config>::Origin>
+		type Origin: From<Origin>
+			+ From<<Self as frame_system::Config>::Origin>
 			+ Into<result::Result<Origin, <Self as Config>::Origin>>;
 
 		type Event: From<Event> + IsType<<Self as frame_system::Config>::Event>;

--- a/runtime/parachains/src/paras.rs
+++ b/runtime/parachains/src/paras.rs
@@ -344,14 +344,25 @@ pub mod pallet {
 	///
 	/// Corresponding code can be retrieved with [`CodeByHash`].
 	#[pallet::storage]
-	pub(super) type PastCodeHash<T: Config> = StorageMap<_, Twox64Concat, (ParaId, T::BlockNumber), ValidationCodeHash>;
+	pub(super) type PastCodeHash<T: Config> = StorageMap<
+		_,
+		Twox64Concat,
+		(ParaId, T::BlockNumber),
+		ValidationCodeHash
+	>;
 
 	/// Past code of parachains. The parachains themselves may not be registered anymore,
 	/// but we also keep their code on-chain for the same amount of time as outdated code
 	/// to keep it available for secondary checkers.
 	#[pallet::storage]
 	#[pallet::getter(fn past_code_meta)]
-	pub(super) type PastCodeMeta<T: Config> = StorageMap<_, Twox64Concat, ParaId, ParaPastCodeMeta<T::BlockNumber>, ValueQuery>;
+	pub(super) type PastCodeMeta<T: Config> = StorageMap<
+		_,
+		Twox64Concat,
+		ParaId,
+		ParaPastCodeMeta<T::BlockNumber>,
+		ValueQuery
+	>;
 
 	/// Which paras have past code that needs pruning and the relay-chain block at which the code was replaced.
 	/// Note that this is the actual height of the included block, not the expected height at which the
@@ -467,7 +478,12 @@ pub mod pallet {
 
 		/// Schedule a code upgrade for block `expected_at`.
 		#[pallet::weight(0)]
-		pub fn force_schedule_code_upgrade(origin: OriginFor<T>, para: ParaId, new_code: ValidationCode, expected_at: T::BlockNumber) -> DispatchResult {
+		pub fn force_schedule_code_upgrade(
+			origin: OriginFor<T>,
+			para: ParaId,
+			new_code: ValidationCode,
+			expected_at: T::BlockNumber
+		) -> DispatchResult {
 			ensure_root(origin)?;
 			Self::schedule_code_upgrade(para, new_code, expected_at);
 			Self::deposit_event(Event::CodeUpgradeScheduled(para));

--- a/runtime/parachains/src/runtime_api_impl/v1.rs
+++ b/runtime/parachains/src/runtime_api_impl/v1.rs
@@ -51,7 +51,7 @@ pub fn validator_groups<T: initializer::Config>() -> (
 /// Implementation for the `availability_cores` function of the runtime API.
 pub fn availability_cores<T: initializer::Config>() -> Vec<CoreState<T::Hash, T::BlockNumber>> {
 	let cores = <scheduler::Module<T>>::availability_cores();
-	let parachains = <paras::Module<T>>::parachains();
+	let parachains = <paras::Pallet<T>>::parachains();
 	let config = <configuration::Module<T>>::config();
 
 	let now = <frame_system::Pallet<T>>::block_number() + One::one();
@@ -270,7 +270,7 @@ pub fn validation_code<T: initializer::Config>(
 	with_assumption::<T, _, _>(
 		para_id,
 		assumption,
-		|| <paras::Module<T>>::current_code(&para_id),
+		|| <paras::Pallet<T>>::current_code(&para_id),
 	)
 }
 
@@ -327,5 +327,5 @@ pub fn inbound_hrmp_channels_contents<T: hrmp::Config>(
 pub fn validation_code_by_hash<T: paras::Config>(
 	hash: ValidationCodeHash,
 ) -> Option<ValidationCode> {
-	<paras::Module<T>>::code_by_hash(hash)
+	<paras::Pallet<T>>::code_by_hash(hash)
 }

--- a/runtime/parachains/src/scheduler.rs
+++ b/runtime/parachains/src/scheduler.rs
@@ -228,7 +228,7 @@ impl<T: Config> Module<T> {
 		let config = new_config;
 
 		let mut thread_queue = ParathreadQueue::get();
-		let n_parachains = <paras::Module<T>>::parachains().len() as u32;
+		let n_parachains = <paras::Pallet<T>>::parachains().len() as u32;
 		let n_cores = core::cmp::max(
 			n_parachains + config.parathread_cores,
 			match config.max_validators_per_core {
@@ -297,7 +297,7 @@ impl<T: Config> Module<T> {
 			// prune out all entries beyond retry or that no longer correspond to live parathread.
 			thread_queue.queue.retain(|queued| {
 				let will_keep = queued.claim.retries <= config.parathread_retries
-					&& <paras::Module<T>>::is_parathread(queued.claim.claim.0);
+					&& <paras::Pallet<T>>::is_parathread(queued.claim.claim.0);
 
 				if !will_keep {
 					let claim_para = queued.claim.claim.0;
@@ -333,7 +333,7 @@ impl<T: Config> Module<T> {
 	/// Fails if the claim does not correspond to any live parathread.
 	#[allow(unused)]
 	pub fn add_parathread_claim(claim: ParathreadClaim) {
-		if !<paras::Module<T>>::is_parathread(claim.0) { return }
+		if !<paras::Pallet<T>>::is_parathread(claim.0) { return }
 
 		let config = <configuration::Module<T>>::config();
 		let queue_max_size = config.parathread_cores * config.scheduling_lookahead;
@@ -399,7 +399,7 @@ impl<T: Config> Module<T> {
 			}
 		}
 
-		let parachains = <paras::Module<T>>::parachains();
+		let parachains = <paras::Pallet<T>>::parachains();
 		let mut scheduled = Scheduled::get();
 		let mut parathread_queue = ParathreadQueue::get();
 
@@ -537,7 +537,7 @@ impl<T: Config> Module<T> {
 		match cores.get(core_index.0 as usize).and_then(|c| c.as_ref()) {
 			None => None,
 			Some(CoreOccupied::Parachain) => {
-				let parachains = <paras::Module<T>>::parachains();
+				let parachains = <paras::Pallet<T>>::parachains();
 				Some(parachains[core_index.0 as usize])
 			}
 			Some(CoreOccupied::Parathread(ref entry)) => Some(entry.claim.0),
@@ -647,7 +647,7 @@ impl<T: Config> Module<T> {
 	/// For parathreads, this is based on the next item in the ParathreadQueue assigned to that
 	/// core, and is None if there isn't one.
 	pub(crate) fn next_up_on_available(core: CoreIndex) -> Option<ScheduledCore> {
-		let parachains = <paras::Module<T>>::parachains();
+		let parachains = <paras::Pallet<T>>::parachains();
 		if (core.0 as usize) < parachains.len() {
 			Some(ScheduledCore {
 				para_id: parachains[core.0 as usize],
@@ -671,7 +671,7 @@ impl<T: Config> Module<T> {
 	/// core, or if there isn't one, the claim that is currently occupying the core, as long
 	/// as the claim's retries would not exceed the limit. Otherwise None.
 	pub(crate) fn next_up_on_time_out(core: CoreIndex) -> Option<ScheduledCore> {
-		let parachains = <paras::Module<T>>::parachains();
+		let parachains = <paras::Pallet<T>>::parachains();
 		if (core.0 as usize) < parachains.len() {
 			Some(ScheduledCore {
 				para_id: parachains[core.0 as usize],
@@ -712,7 +712,7 @@ impl<T: Config> Module<T> {
 		ParathreadQueue::mutate(|queue| {
 			for core_assignment in Scheduled::take() {
 				if let AssignmentKind::Parathread(collator, retries) = core_assignment.kind {
-					if !<paras::Module<T>>::is_parathread(core_assignment.para_id) { continue }
+					if !<paras::Pallet<T>>::is_parathread(core_assignment.para_id) { continue }
 
 					let entry = ParathreadEntry {
 						claim: ParathreadClaim(core_assignment.para_id, collator),

--- a/runtime/parachains/src/util.rs
+++ b/runtime/parachains/src/util.rs
@@ -34,7 +34,7 @@ pub fn make_persisted_validation_data<T: paras::Config + hrmp::Config>(
 	let config = <configuration::Module<T>>::config();
 
 	Some(PersistedValidationData {
-		parent_head: <paras::Module<T>>::para_head(&para_id)?,
+		parent_head: <paras::Pallet<T>>::para_head(&para_id)?,
 		relay_parent_number,
 		relay_parent_storage_root,
 		max_pov_size: config.max_pov_size,

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -214,7 +214,7 @@ construct_runtime! {
 		Inclusion: parachains_inclusion::{Pallet, Call, Storage, Event<T>},
 		ParasInherent: parachains_paras_inherent::{Pallet, Call, Storage, Inherent},
 		Scheduler: parachains_scheduler::{Pallet, Call, Storage},
-		Paras: parachains_paras::{Pallet, Call, Storage, Event, Config<T>},
+		Paras: parachains_paras::{Pallet, Call, Storage, Event, Config},
 		Initializer: parachains_initializer::{Pallet, Call, Storage},
 		Dmp: parachains_dmp::{Pallet, Call, Storage},
 		Ump: parachains_ump::{Pallet, Call, Storage, Event},

--- a/runtime/test-runtime/src/lib.rs
+++ b/runtime/test-runtime/src/lib.rs
@@ -531,7 +531,7 @@ construct_runtime! {
 		Inclusion: parachains_inclusion::{Pallet, Call, Storage, Event<T>},
 		ParasInherent: parachains_paras_inherent::{Pallet, Call, Storage, Inherent},
 		Initializer: parachains_initializer::{Pallet, Call, Storage},
-		Paras: parachains_paras::{Pallet, Call, Storage, Event},
+		Paras: parachains_paras::{Pallet, Call, Storage, Origin, Event},
 		Scheduler: parachains_scheduler::{Pallet, Call, Storage},
 		ParasSudoWrapper: paras_sudo_wrapper::{Pallet, Call},
 		SessionInfo: parachains_session_info::{Pallet, Call, Storage},

--- a/runtime/test-runtime/src/lib.rs
+++ b/runtime/test-runtime/src/lib.rs
@@ -531,7 +531,7 @@ construct_runtime! {
 		Inclusion: parachains_inclusion::{Pallet, Call, Storage, Event<T>},
 		ParasInherent: parachains_paras_inherent::{Pallet, Call, Storage, Inherent},
 		Initializer: parachains_initializer::{Pallet, Call, Storage},
-		Paras: parachains_paras::{Pallet, Call, Storage, Origin, Event},
+		Paras: parachains_paras::{Pallet, Call, Storage, Event},
 		Scheduler: parachains_scheduler::{Pallet, Call, Storage},
 		ParasSudoWrapper: paras_sudo_wrapper::{Pallet, Call},
 		SessionInfo: parachains_session_info::{Pallet, Call, Storage},

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -1077,7 +1077,7 @@ construct_runtime! {
 		ParasInclusion: parachains_inclusion::{Pallet, Call, Storage, Event<T>} = 44,
 		ParasInherent: parachains_paras_inherent::{Pallet, Call, Storage, Inherent} = 45,
 		ParasScheduler: parachains_scheduler::{Pallet, Call, Storage} = 46,
-		Paras: parachains_paras::{Pallet, Call, Storage, Event, Config<T>} = 47,
+		Paras: parachains_paras::{Pallet, Call, Storage, Event, Config} = 47,
 		ParasInitializer: parachains_initializer::{Pallet, Call, Storage} = 48,
 		ParasDmp: parachains_dmp::{Pallet, Call, Storage} = 49,
 		ParasUmp: parachains_ump::{Pallet, Call, Storage, Event} = 50,


### PR DESCRIPTION
relates: #2882 

Following the upgrade guidelines here: https://crates.parity.io/frame_support/attr.pallet.html#upgrade-guidelines.

# :warning: Breaking Change :warning: 
From https://crates.parity.io/frame_support/attr.pallet.html#checking-upgrade-guidelines

 >storages now use PalletInfo for module_prefix instead of the one given to decl_storage: Thus any use of this pallet in construct_runtime! should be careful to update name in order not to break storage or to upgrade storage (moreover for instantiable pallet). If pallet is published, make sure to warn about this breaking change.

So users of the `Paras` pallet must be careful about the name they used in `construct_runtime!`. Hence the `runtime-migration label`, which might not be needed depending on the configuration of the `Paras` pallet.

Edit: Ok should work