### PR TITLE
parchain initializer.rs to FrameV2

### DIFF
--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -321,7 +321,7 @@ impl_opaque_keys! {
 		pub grandpa: Grandpa,
 		pub babe: Babe,
 		pub im_online: ImOnline,
-		pub para_validator: ParasInitializer,
+		pub para_validator: Initializer,
 		pub para_assignment: ParasSessionInfo,
 		pub authority_discovery: AuthorityDiscovery,
 	}
@@ -1487,7 +1487,7 @@ construct_runtime! {
 		ParasInherent: parachains_paras_inherent::{Pallet, Call, Storage, Inherent} = 54,
 		ParasScheduler: parachains_scheduler::{Pallet, Call, Storage} = 55,
 		Paras: parachains_paras::{Pallet, Call, Storage, Event, Config<T>} = 56,
-		ParasInitializer: parachains_initializer::{Pallet, Call, Storage} = 57,
+		Initializer: parachains_initializer::{Pallet, Call, Storage} = 57,
 		ParasDmp: parachains_dmp::{Pallet, Call, Storage} = 58,
 		ParasUmp: parachains_ump::{Pallet, Call, Storage, Event} = 59,
 		ParasHrmp: parachains_hrmp::{Pallet, Call, Storage, Event} = 60,

--- a/runtime/parachains/src/initializer.rs
+++ b/runtime/parachains/src/initializer.rs
@@ -20,17 +20,15 @@
 //! This module can throw fatal errors if session-change notifications are received after initialization.
 
 use sp_std::prelude::*;
-use frame_support::weights::{Weight, DispatchClass};
-use frame_support::traits::EnsureOrigin;
 use primitives::v1::{ValidatorId, SessionIndex, ConsensusLog, BlockNumber};
-use frame_support::{
-	decl_storage, decl_module, decl_error, traits::{OneSessionHandler, Randomness},
-};
+use frame_support::traits::{Randomness, OneSessionHandler};
 use parity_scale_codec::{Encode, Decode};
 use crate::{
 	configuration::{self, HostConfiguration},
 	shared, paras, scheduler, inclusion, session_info, dmp, ump, hrmp,
 };
+
+pub use pallet::*;
 
 /// Information about a session change that has just occurred.
 #[derive(Clone)]
@@ -63,61 +61,65 @@ impl<BlockNumber: Default + From<u32>> Default for SessionChangeNotification<Blo
 }
 
 #[derive(Encode, Decode)]
-struct BufferedSessionChange {
+pub struct BufferedSessionChange {
 	validators: Vec<ValidatorId>,
 	queued: Vec<ValidatorId>,
 	session_index: SessionIndex,
 }
 
-pub trait Config:
-	frame_system::Config
-	+ configuration::Config
-	+ shared::Config
-	+ paras::Config
-	+ scheduler::Config
-	+ inclusion::Config
-	+ session_info::Config
-	+ dmp::Config
-	+ ump::Config
-	+ hrmp::Config
-{
-	/// A randomness beacon.
-	type Randomness: Randomness<Self::Hash, Self::BlockNumber>;
-	/// An origin which is allowed to force updates to parachains.
-	type ForceOrigin: EnsureOrigin<<Self as frame_system::Config>::Origin>;
-}
+#[frame_support::pallet]
+pub mod pallet {
+	use frame_support::pallet_prelude::*;
+	use frame_system::pallet_prelude::*;
+	use super::*;
 
-decl_storage! {
-	trait Store for Module<T: Config> as Initializer {
-		/// Whether the parachains modules have been initialized within this block.
-		///
-		/// Semantically a bool, but this guarantees it should never hit the trie,
-		/// as this is cleared in `on_finalize` and Frame optimizes `None` values to be empty values.
-		///
-		/// As a bool, `set(false)` and `remove()` both lead to the next `get()` being false, but one of
-		/// them writes to the trie and one does not. This confusion makes `Option<()>` more suitable for
-		/// the semantics of this variable.
-		HasInitialized: Option<()>;
-		/// Buffered session changes along with the block number at which they should be applied.
-		///
-		/// Typically this will be empty or one element long. Apart from that this item never hits
-		/// the storage.
-		///
-		/// However this is a `Vec` regardless to handle various edge cases that may occur at runtime
-		/// upgrade boundaries or if governance intervenes.
-		BufferedSessionChanges: Vec<BufferedSessionChange>;
+	#[pallet::pallet]
+	#[pallet::generate_store(pub(super) trait Store)]
+	pub struct Pallet<T>(_);
+
+	#[pallet::config]
+	pub trait Config:
+		frame_system::Config
+		+ configuration::Config
+		+ shared::Config
+		+ paras::Config
+		+ scheduler::Config
+		+ inclusion::Config
+		+ session_info::Config
+		+ dmp::Config
+		+ ump::Config
+		+ hrmp::Config
+	{
+		/// A randomness beacon.
+		type Randomness: Randomness<Self::Hash, Self::BlockNumber>;
+		/// An origin which is allowed to force updates to parachains.
+		type ForceOrigin: EnsureOrigin<<Self as frame_system::Config>::Origin>;
 	}
-}
 
-decl_error! {
-	pub enum Error for Module<T: Config> { }
-}
 
-decl_module! {
-	/// The initializer module.
-	pub struct Module<T: Config> for enum Call where origin: <T as frame_system::Config>::Origin {
-		type Error = Error<T>;
+	/// Whether the parachains modules have been initialized within this block.
+	///
+	/// Semantically a bool, but this guarantees it should never hit the trie,
+	/// as this is cleared in `on_finalize` and Frame optimizes `None` values to be empty values.
+	///
+	/// As a bool, `set(false)` and `remove()` both lead to the next `get()` being false, but one of
+	/// them writes to the trie and one does not. This confusion makes `Option<()>` more suitable for
+	/// the semantics of this variable.
+	#[pallet::storage]
+	pub type HasInitialized<T: Config> = StorageValue<_, ()>;
 
+	/// Buffered session changes along with the block number at which they should be applied.
+	///
+	/// Typically this will be empty or one element long. Apart from that this item never hits
+	/// the storage.
+	///
+	/// However this is a `Vec` regardless to handle various edge cases that may occur at runtime
+	/// upgrade boundaries or if governance intervenes.
+	#[pallet::storage]
+	pub type BufferedSessionChanges<T: Config> = StorageValue<_, Vec<BufferedSessionChange>, ValueQuery>;
+
+	#[pallet::hooks]
+	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
 		fn on_initialize(now: T::BlockNumber) -> Weight {
 			// The other modules are initialized in this order:
 			// - Configuration
@@ -139,12 +141,12 @@ decl_module! {
 				ump::Module::<T>::initializer_initialize(now) +
 				hrmp::Module::<T>::initializer_initialize(now);
 
-			HasInitialized::set(Some(()));
+			HasInitialized::<T>::set(Some(()));
 
 			total_weight
 		}
 
-		fn on_finalize() {
+		fn on_finalize(_: T::BlockNumber) {
 			// reverse initialization order.
 			hrmp::Module::<T>::initializer_finalize();
 			ump::Module::<T>::initializer_finalize();
@@ -164,27 +166,31 @@ decl_module! {
 				session_index,
 				validators,
 				queued,
-			}) = BufferedSessionChanges::take().pop()
+			}) = BufferedSessionChanges::<T>::take().pop()
 			{
 				Self::apply_new_session(session_index, validators, queued);
 			}
 
-			HasInitialized::take();
+			HasInitialized::<T>::take();
 		}
+	}
 
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
 		/// Issue a signal to the consensus engine to forcibly act as though all parachain
 		/// blocks in all relay chain blocks up to and including the given number in the current
 		/// chain are valid and should be finalized.
-		#[weight = (0, DispatchClass::Operational)]
-		fn force_approve(origin, up_to: BlockNumber) {
+		#[pallet::weight((0, DispatchClass::Operational))]
+		pub fn force_approve(origin: OriginFor<T>, up_to: BlockNumber) -> DispatchResult {
 			T::ForceOrigin::ensure_origin(origin)?;
 
 			frame_system::Pallet::<T>::deposit_log(ConsensusLog::ForceApprove(up_to).into());
+			Ok(())
 		}
 	}
 }
 
-impl<T: Config> Module<T> {
+impl<T: Config> Pallet<T> {
 	fn apply_new_session(
 		session_index: SessionIndex,
 		all_validators: Vec<ValidatorId>,
@@ -254,7 +260,7 @@ impl<T: Config> Module<T> {
 			// Genesis session should be immediately enacted.
 			Self::apply_new_session(0, validators, queued);
 		} else {
-			BufferedSessionChanges::mutate(|v| v.push(BufferedSessionChange {
+			BufferedSessionChanges::<T>::mutate(|v| v.push(BufferedSessionChange {
 				validators,
 				queued,
 				session_index,
@@ -264,24 +270,24 @@ impl<T: Config> Module<T> {
 	}
 }
 
-impl<T: Config> sp_runtime::BoundToRuntimeAppPublic for Module<T> {
+impl<T: Config> sp_runtime::BoundToRuntimeAppPublic for Pallet<T> {
 	type Public = ValidatorId;
 }
 
-impl<T: pallet_session::Config + Config> OneSessionHandler<T::AccountId> for Module<T> {
+impl<T: pallet_session::Config + Config> OneSessionHandler<T::AccountId> for Pallet<T> {
 	type Key = ValidatorId;
 
 	fn on_genesis_session<'a, I: 'a>(validators: I)
 		where I: Iterator<Item=(&'a T::AccountId, Self::Key)>
 	{
-		<Module<T>>::on_new_session(false, 0, validators, None);
+		<Pallet<T>>::on_new_session(false, 0, validators, None);
 	}
 
 	fn on_new_session<'a, I: 'a>(changed: bool, validators: I, queued: I)
 		where I: Iterator<Item=(&'a T::AccountId, Self::Key)>
 	{
-		let session_index = <pallet_session::Module<T>>::current_index();
-		<Module<T>>::on_new_session(changed, session_index, validators, Some(queued));
+		let session_index = <pallet_session::Pallet<T>>::current_index();
+		<Pallet<T>>::on_new_session(changed, session_index, validators, Some(queued));
 	}
 
 	fn on_disabled(_i: usize) { }
@@ -311,7 +317,7 @@ mod tests {
 				Some(Vec::new().into_iter()),
 			);
 
-			let v = <BufferedSessionChanges>::get();
+			let v = <Initializer as Store>::BufferedSessionChanges::get();
 			assert!(v.is_empty());
 
 			assert_eq!(SessionInfo::earliest_stored_session(), 0);
@@ -332,7 +338,7 @@ mod tests {
 			let now = System::block_number();
 			Initializer::on_initialize(now);
 
-			let v = <BufferedSessionChanges>::get();
+			let v = <Initializer as Store>::BufferedSessionChanges::get();
 			assert_eq!(v.len(), 1);
 		});
 	}
@@ -350,7 +356,7 @@ mod tests {
 
 			Initializer::on_finalize(1);
 
-			assert!(<BufferedSessionChanges>::get().is_empty());
+			assert!(<Initializer as Store>::BufferedSessionChanges::get().is_empty());
 		});
 	}
 
@@ -359,7 +365,7 @@ mod tests {
 		new_test_ext(Default::default()).execute_with(|| {
 			Initializer::on_initialize(1);
 
-			assert!(HasInitialized::get().is_some());
+			assert!(<Initializer as Store>::HasInitialized::get().is_some());
 		})
 	}
 
@@ -369,7 +375,7 @@ mod tests {
 			Initializer::on_initialize(1);
 			Initializer::on_finalize(1);
 
-			assert!(HasInitialized::get().is_none());
+			assert!(<Initializer as Store>::HasInitialized::get().is_none());
 		})
 	}
 

--- a/runtime/parachains/src/initializer.rs
+++ b/runtime/parachains/src/initializer.rs
@@ -61,7 +61,7 @@ impl<BlockNumber: Default + From<u32>> Default for SessionChangeNotification<Blo
 }
 
 #[derive(Encode, Decode)]
-pub struct BufferedSessionChange {
+struct BufferedSessionChange {
 	validators: Vec<ValidatorId>,
 	queued: Vec<ValidatorId>,
 	session_index: SessionIndex,
@@ -106,7 +106,7 @@ pub mod pallet {
 	/// them writes to the trie and one does not. This confusion makes `Option<()>` more suitable for
 	/// the semantics of this variable.
 	#[pallet::storage]
-	pub type HasInitialized<T: Config> = StorageValue<_, ()>;
+	pub(super) type HasInitialized<T: Config> = StorageValue<_, ()>;
 
 	/// Buffered session changes along with the block number at which they should be applied.
 	///
@@ -116,7 +116,7 @@ pub mod pallet {
 	/// However this is a `Vec` regardless to handle various edge cases that may occur at runtime
 	/// upgrade boundaries or if governance intervenes.
 	#[pallet::storage]
-	pub type BufferedSessionChanges<T: Config> = StorageValue<_, Vec<BufferedSessionChange>, ValueQuery>;
+	pub(super) type BufferedSessionChanges<T: Config> = StorageValue<_, Vec<BufferedSessionChange>, ValueQuery>;
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -306,7 +306,7 @@ impl_opaque_keys! {
 		pub grandpa: Grandpa,
 		pub babe: Babe,
 		pub im_online: ImOnline,
-		pub para_validator: ParasInitializer,
+		pub para_validator: Initializer,
 		pub para_assignment: ParasSessionInfo,
 		pub authority_discovery: AuthorityDiscovery,
 	}
@@ -1078,7 +1078,7 @@ construct_runtime! {
 		ParasInherent: parachains_paras_inherent::{Pallet, Call, Storage, Inherent} = 45,
 		ParasScheduler: parachains_scheduler::{Pallet, Call, Storage} = 46,
 		Paras: parachains_paras::{Pallet, Call, Storage, Event, Config<T>} = 47,
-		ParasInitializer: parachains_initializer::{Pallet, Call, Storage} = 48,
+		Initializer: parachains_initializer::{Pallet, Call, Storage} = 48,
 		ParasDmp: parachains_dmp::{Pallet, Call, Storage} = 49,
 		ParasUmp: parachains_ump::{Pallet, Call, Storage, Event} = 50,
 		ParasHrmp: parachains_hrmp::{Pallet, Call, Storage, Event} = 51,


### PR DESCRIPTION
relates: #2882 

Following the upgrade guidelines here: https://crates.parity.io/frame_support/attr.pallet.html#upgrade-guidelines.

# :warning: Breaking Change :warning: 
From https://crates.parity.io/frame_support/attr.pallet.html#checking-upgrade-guidelines

 >storages now use PalletInfo for module_prefix instead of the one given to decl_storage: Thus any use of this pallet in construct_runtime! should be careful to update name in order not to break storage or to upgrade storage (moreover for instantiable pallet). If pallet is published, make sure to warn about this breaking change.

So users of the `Initializer` pallet must be careful about the name they used in `construct_runtime!.` Hence the runtime-migration label, which might not be needed depending on the configuration of the `Initializer` pallet.

Kusama and westend both use `ParasInitializer` in `construct_runtime!`. Therefore I migrated kusama and westend's respective `construct_runtime!` to `Initializer` to match the previously hard-coded name in `decl_storage!` of `Initializer`