### PR TITLE
PVF: unresponsive worker doesn't mean the candidate is bad

### DIFF
--- a/node/core/pvf/src/prepare/pool.rs
+++ b/node/core/pvf/src/prepare/pool.rs
@@ -179,7 +179,7 @@ async fn purge_dead(
 		}
 	}
 	for w in to_remove {
-		if let Some(_) = spawned.remove(w) {
+		if spawned.remove(w).is_some() {
 			reply(from_pool, FromPool::Rip(w))?;
 		}
 	}
@@ -313,14 +313,14 @@ fn handle_mux(
 					Ok(())
 				}
 				Outcome::Unreachable => {
-					if let Some(_data) = spawned.remove(worker) {
+					if spawned.remove(worker).is_some() {
 						reply(from_pool, FromPool::Rip(worker))?;
 					}
 
 					Ok(())
 				}
 				Outcome::DidntMakeIt => {
-					if let Some(_data) = spawned.remove(worker) {
+					if spawned.remove(worker).is_some() {
 						reply(from_pool, FromPool::Concluded(worker, true))?;
 					}
 

--- a/node/core/pvf/src/prepare/pool.rs
+++ b/node/core/pvf/src/prepare/pool.rs
@@ -60,8 +60,11 @@ pub enum ToPool {
 	/// Request the given worker to start working on the given code.
 	///
 	/// Once the job either succeeded or failed, a [`FromPool::Concluded`] message will be sent back.
+	/// It's also possible that the worker dies before handling the message in which case [`FromPool::Rip`]
+	/// will be sent back.
 	///
-	/// This should not be sent again until the concluded message is received.
+	/// In either case, the worker is considered busy and no further `StartWork` messages should be
+	/// sent until either `Concluded` or `Rip` message is received.
 	StartWork {
 		worker: Worker,
 		code: Arc<Vec<u8>>,
@@ -176,8 +179,9 @@ async fn purge_dead(
 		}
 	}
 	for w in to_remove {
-		let _ = spawned.remove(w);
-		reply(from_pool, FromPool::Rip(w))?;
+		if let Some(_) = spawned.remove(w) {
+			reply(from_pool, FromPool::Rip(w))?;
+		}
 	}
 	Ok(())
 }
@@ -305,6 +309,13 @@ fn handle_mux(
 					assert_matches!(old, None, "attempt to overwrite an idle worker");
 
 					reply(from_pool, FromPool::Concluded(worker, false))?;
+
+					Ok(())
+				}
+				Outcome::Unreachable => {
+					if let Some(_data) = spawned.remove(worker) {
+						reply(from_pool, FromPool::Rip(worker))?;
+					}
 
 					Ok(())
 				}

--- a/node/core/pvf/src/prepare/worker.rs
+++ b/node/core/pvf/src/prepare/worker.rs
@@ -55,6 +55,9 @@ pub async fn spawn(
 pub enum Outcome {
 	/// The worker has finished the work assigned to it.
 	Concluded(IdleWorker),
+	/// The host tried to reach the worker but failed. This is most likely because the worked was
+	/// killed by the system.
+	Unreachable,
 	/// The execution was interrupted abruptly and the worker is not available anymore. For example,
 	/// this could've happen because the worker hadn't finished the work until the given deadline.
 	///
@@ -96,7 +99,7 @@ pub async fn start_work(
 				"failed to send a prepare request: {:?}",
 				err,
 			);
-			return Outcome::DidntMakeIt;
+			return Outcome::Unreachable;
 		}
 
 		// Wait for the result from the worker, keeping in mind that there may be a timeout, the


### PR DESCRIPTION
Closes https://github.com/paritytech/polkadot/issues/3192

This new behavior should be exercised by an existing test: `rip_for_start_work`

https://github.com/paritytech/polkadot/blob/0eb7905aeab120273b795659f34d1d0efcf0ac15/node/core/pvf/src/prepare/queue.rs#L863-L893

However, it is not clear how to test it end-to-end. Here is an entire issue about that https://github.com/paritytech/polkadot/issues/3417

