### PR TITLE
ci: use srtool-actions to build runtimes

### DIFF
--- a/.github/workflows/publish-draft-release.yml
+++ b/.github/workflows/publish-draft-release.yml
@@ -24,25 +24,17 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        runtime: ['polkadot', 'kusama', 'westend']
-    # container:
-    #   image: paritytech/srtool:nightly-2021-03-15
-    #   volumes:
-    #     - ${{ github.workspace }}:/build
-    #   env:
-    #     PACKAGE: ${{ matrix.runtime }}-runtime
-    #     RUSTC_VERSION: nightly-2020-10-27
+        runtime: ["polkadot", "kusama", "westend"]
     steps:
       - uses: actions/checkout@v2
       - name: Cache target dir
         uses: actions/cache@v2
         with:
-          path: '${{ github.workspace }}/runtime/${{ matrix.runtime }}/target'
+          path: "${{ github.workspace }}/runtime/${{ matrix.runtime }}/target"
           key: srtool-target-${{ matrix.runtime }}-${{ github.sha }}
           restore-keys: |
             srtool-target-${{ matrix.runtime }}-
             srtool-target-
-
       - name: Build ${{ matrix.runtime }} runtime
         id: srtool_build
         uses: chevdor/srtool-actions@v0.3.0
@@ -50,36 +42,14 @@ jobs:
           # This is the default with chevdor/srtool-actions@v0.3.0 but we make it clear
           image: paritytech/srtool
           chain: ${{ matrix.runtime }}
-
-      - name: Gather srtool artifacts
+      - name: Store srtool digest to disk
         run: |
           echo '${{ steps.srtool_build.outputs.json }}' | jq > ${{ matrix.runtime }}_srtool_output.json
-          pwd
-          ls -al ${{ matrix.runtime }}_srtool_output.json
-          ls -al ${{ steps.srtool_build.outputs.wasm }}
-          ls -al ${{ steps.srtool_build.outputs.wasm_compressed }}
-
-      # - name: Build ${{ matrix.runtime }} runtime
-      #   id: build-runtime
-      #   shell: bash
-      #   env:
-      #     srtool_output_filename: ${{ matrix.runtime }}_srtool_output.json
-      #   run: |
-      #     cd /build
-      #     pwd
-      #     ls -la
-      #     build --json | tee $srtool_output_filename
-      #     cat $srtool_output_filename
-      #     while IFS= read -r line; do
-      #       echo "::set-output name=$line::$(jq -r ".$line" < $srtool_output_filename)"
-      #     done <<< "$(jq -r 'keys[]' < $srtool_output_filename)"
-
       - name: Upload ${{ matrix.runtime }} srtool json
         uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.runtime }}-srtool-json
           path: ${{ matrix.runtime }}_srtool_output.json
-
       - name: Upload ${{ matrix.runtime }} runtime
         uses: actions/upload-artifact@v2
         with:
@@ -90,45 +60,46 @@ jobs:
 
   publish-draft-release:
     runs-on: ubuntu-latest
-    needs: ['get-rust-versions', 'build-runtimes']
+    needs: ["get-rust-versions", "build-runtimes"]
     outputs:
       release_url: ${{ steps.create-release.outputs.html_url }}
       asset_upload_url: ${{ steps.create-release.outputs.upload_url }}
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-        path: polkadot
-    - name: Set up Ruby 2.7
-      uses: actions/setup-ruby@v1
-      with:
-        ruby-version: 2.7
-    - name: Download srtool json output
-      uses: actions/download-artifact@v2
-    - name: Generate release text
-      env:
-        RUSTC_STABLE: ${{ needs.get-rust-versions.outputs.rustc-stable }}
-        RUSTC_NIGHTLY: ${{ needs.get-rust-versions.outputs.rustc-nightly }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        gem install changelogerator git toml
-        ruby $GITHUB_WORKSPACE/polkadot/scripts/github/generate_release_text.rb | tee release_text.md
-    - name: Create draft release
-      id: create-release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ github.ref }}
-        release_name: Polkadot ${{ github.ref }}
-        body_path: ./release_text.md
-        draft: true
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          path: polkadot
+      - name: Set up Ruby 2.7
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+      - name: Download srtool json output
+        uses: actions/download-artifact@v2
+      - name: Generate release text
+        env:
+          RUSTC_STABLE: ${{ needs.get-rust-versions.outputs.rustc-stable }}
+          RUSTC_NIGHTLY: ${{ needs.get-rust-versions.outputs.rustc-nightly }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gem install changelogerator git toml
+          ruby $GITHUB_WORKSPACE/polkadot/scripts/github/generate_release_text.rb | tee release_text.md
+      - name: Create draft release
+        id: create-release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Polkadot ${{ github.ref }}
+          body_path: ./release_text.md
+          draft: true
+
   publish-runtimes:
     runs-on: ubuntu-latest
-    needs: ['publish-draft-release']
+    needs: ["publish-draft-release"]
     strategy:
       matrix:
-        runtime: ['polkadot', 'kusama', 'westend']
+        runtime: ["polkadot", "kusama", "westend"]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
@@ -152,7 +123,6 @@ jobs:
           asset_path: "${{ matrix.runtime }}-runtime/${{ matrix.runtime }}_runtime.compact.wasm"
           asset_name: ${{ matrix.runtime }}_runtime-v${{ steps.get-runtime-ver.outputs.runtime_ver }}.compact.wasm
           asset_content_type: application/wasm
-
       - name: Upload compressed ${{ matrix.runtime }} wasm
         uses: actions/upload-release-asset@v1
         env:

--- a/.github/workflows/publish-draft-release.yml
+++ b/.github/workflows/publish-draft-release.yml
@@ -24,14 +24,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        runtime: ['polkadot', 'kusama']
-    container:
-      image: paritytech/srtool:nightly-2021-03-15
-      volumes:
-        - ${{ github.workspace }}:/build
-      env:
-        PACKAGE: ${{ matrix.runtime }}-runtime
-        RUSTC_VERSION: nightly-2020-10-27
+        runtime: ['polkadot', 'kusama', 'westend']
+    # container:
+    #   image: paritytech/srtool:nightly-2021-03-15
+    #   volumes:
+    #     - ${{ github.workspace }}:/build
+    #   env:
+    #     PACKAGE: ${{ matrix.runtime }}-runtime
+    #     RUSTC_VERSION: nightly-2020-10-27
     steps:
       - uses: actions/checkout@v2
       - name: Cache target dir
@@ -42,30 +42,51 @@ jobs:
           restore-keys: |
             srtool-target-${{ matrix.runtime }}-
             srtool-target-
+
       - name: Build ${{ matrix.runtime }} runtime
-        id: build-runtime
-        shell: bash
-        env:
-          srtool_output_filename: ${{ matrix.runtime }}_srtool_output.json
+        id: srtool_build
+        uses: chevdor/srtool-actions@v0.3.0
+        with:
+          # This is the default with chevdor/srtool-actions@v0.3.0 but we make it clear
+          image: paritytech/srtool
+          chain: ${{ matrix.runtime }}
+
+      - name: Gather srtool artifacts
         run: |
-          cd /build
+          echo '${{ steps.srtool_build.outputs.json }}' | jq > ${{ matrix.runtime }}_srtool_output.json
           pwd
-          ls -la
-          build --json | tee $srtool_output_filename
-          cat $srtool_output_filename
-          while IFS= read -r line; do
-            echo "::set-output name=$line::$(jq -r ".$line" < $srtool_output_filename)"
-          done <<< "$(jq -r 'keys[]' < $srtool_output_filename)"
+          ls -al ${{ matrix.runtime }}_srtool_output.json
+          ls -al ${{ steps.srtool_build.outputs.wasm }}
+          ls -al ${{ steps.srtool_build.outputs.wasm_compressed }}
+
+      # - name: Build ${{ matrix.runtime }} runtime
+      #   id: build-runtime
+      #   shell: bash
+      #   env:
+      #     srtool_output_filename: ${{ matrix.runtime }}_srtool_output.json
+      #   run: |
+      #     cd /build
+      #     pwd
+      #     ls -la
+      #     build --json | tee $srtool_output_filename
+      #     cat $srtool_output_filename
+      #     while IFS= read -r line; do
+      #       echo "::set-output name=$line::$(jq -r ".$line" < $srtool_output_filename)"
+      #     done <<< "$(jq -r 'keys[]' < $srtool_output_filename)"
+
       - name: Upload ${{ matrix.runtime }} srtool json
         uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.runtime }}-srtool-json
           path: ${{ matrix.runtime }}_srtool_output.json
+
       - name: Upload ${{ matrix.runtime }} runtime
         uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.runtime }}-runtime
-          path: "${{ steps.build-runtime.outputs.wasm }}"
+          path: |
+            ${{ steps.srtool_build.outputs.wasm }}
+            ${{ steps.srtool_build.outputs.wasm_compressed }}
 
   publish-draft-release:
     runs-on: ubuntu-latest
@@ -107,7 +128,7 @@ jobs:
     needs: ['publish-draft-release']
     strategy:
       matrix:
-        runtime: ['polkadot', 'kusama']
+        runtime: ['polkadot', 'kusama', 'westend']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
@@ -122,7 +143,7 @@ jobs:
           ls "${{ matrix.runtime }}-runtime"
           runtime_ver="$(ruby -e 'require "./scripts/github/lib.rb"; puts get_runtime("${{ matrix.runtime }}")')"
           echo "::set-output name=runtime_ver::$runtime_ver"
-      - name: Upload ${{ matrix.runtime }} wasm
+      - name: Upload compact ${{ matrix.runtime }} wasm
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -130,6 +151,16 @@ jobs:
           upload_url: ${{ needs.publish-draft-release.outputs.asset_upload_url }}
           asset_path: "${{ matrix.runtime }}-runtime/${{ matrix.runtime }}_runtime.compact.wasm"
           asset_name: ${{ matrix.runtime }}_runtime-v${{ steps.get-runtime-ver.outputs.runtime_ver }}.compact.wasm
+          asset_content_type: application/wasm
+
+      - name: Upload compressed ${{ matrix.runtime }} wasm
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.publish-draft-release.outputs.asset_upload_url }}
+          asset_path: "${{ matrix.runtime }}-runtime/${{ matrix.runtime }}_runtime.compact.compressed.wasm"
+          asset_name: ${{ matrix.runtime }}_runtime-v${{ steps.get-runtime-ver.outputs.runtime_ver }}.compact.compressed.wasm
           asset_content_type: application/wasm
 
   post_to_matrix:


### PR DESCRIPTION
- build westend as well
- switch to using srtool-actions@v0.3.0 which defaults to the `paritytech/srtool` docker image
- add compressed runtimes to the artifacts

I have tested at https://github.com/chevdor/polkadot/actions/runs/1007250044

![image](https://user-images.githubusercontent.com/738724/124723195-12eba700-df0b-11eb-85a2-211015499287.png)

The compressed runtime is added to the <chain>-runtime artifacts.

![image](https://user-images.githubusercontent.com/738724/124723287-2bf45800-df0b-11eb-8327-82817196aa83.png)
