### PR TITLE
Dispute Coordinator: Move to batch Request - Response model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6251,6 +6251,7 @@ dependencies = [
  "bitvec",
  "futures 0.3.15",
  "futures-timer 3.0.2",
+ "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-test-helpers",
  "polkadot-node-subsystem-util",

--- a/node/core/dispute-coordinator/src/lib.rs
+++ b/node/core/dispute-coordinator/src/lib.rs
@@ -437,18 +437,21 @@ async fn handle_incoming(
 			let _ = rx.send(collect_active(recent_disputes, now));
 		}
 		DisputeCoordinatorMessage::QueryCandidateVotes(
-			session,
-			candidate_hash,
+			query,
 			rx
 		) => {
-			let candidate_votes = db::v1::load_candidate_votes(
-				store,
-				&config.column_config(),
-				session,
-				&candidate_hash,
-			)?;
-
-			let _ = rx.send(candidate_votes.map(Into::into));
+			let mut query_output = Vec::new();
+			for (session_index, candidate_hash) in query.into_iter() {
+				if let Some(v) = db::v1::load_candidate_votes(
+					store,
+					&config.column_config(),
+					session_index,
+					&candidate_hash,
+				)? {
+					query_output.push(v.into());
+				}
+			}
+			let _ = rx.send(query_output);
 		}
 		DisputeCoordinatorMessage::IssueLocalStatement(
 			session,

--- a/node/core/dispute-coordinator/src/tests.rs
+++ b/node/core/dispute-coordinator/src/tests.rs
@@ -326,13 +326,12 @@ fn conflicting_votes_lead_to_dispute_participation() {
 			let (tx, rx) = oneshot::channel();
 			virtual_overseer.send(FromOverseer::Communication {
 				msg: DisputeCoordinatorMessage::QueryCandidateVotes(
-					session,
-					candidate_hash,
+					vec![(session, candidate_hash)],
 					tx,
 				),
 			}).await;
 
-			let votes = rx.await.unwrap().unwrap();
+			let votes = rx.await.unwrap().get(0).unwrap().clone();
 			assert_eq!(votes.valid.len(), 1);
 			assert_eq!(votes.invalid.len(), 1);
 		}
@@ -352,13 +351,12 @@ fn conflicting_votes_lead_to_dispute_participation() {
 			let (tx, rx) = oneshot::channel();
 			virtual_overseer.send(FromOverseer::Communication {
 				msg: DisputeCoordinatorMessage::QueryCandidateVotes(
-					session,
-					candidate_hash,
+					vec![(session, candidate_hash)],
 					tx,
 				),
 			}).await;
 
-			let votes = rx.await.unwrap().unwrap();
+			let votes = rx.await.unwrap().get(0).unwrap().clone();
 			assert_eq!(votes.valid.len(), 1);
 			assert_eq!(votes.invalid.len(), 2);
 		}
@@ -420,13 +418,12 @@ fn positive_votes_dont_trigger_participation() {
 			let (tx, rx) = oneshot::channel();
 			virtual_overseer.send(FromOverseer::Communication {
 				msg: DisputeCoordinatorMessage::QueryCandidateVotes(
-					session,
-					candidate_hash,
+					vec![(session, candidate_hash)],
 					tx,
 				),
 			}).await;
 
-			let votes = rx.await.unwrap().unwrap();
+			let votes = rx.await.unwrap().get(0).unwrap().clone();
 			assert_eq!(votes.valid.len(), 1);
 			assert!(votes.invalid.is_empty());
 		}
@@ -453,13 +450,12 @@ fn positive_votes_dont_trigger_participation() {
 			let (tx, rx) = oneshot::channel();
 			virtual_overseer.send(FromOverseer::Communication {
 				msg: DisputeCoordinatorMessage::QueryCandidateVotes(
-					session,
-					candidate_hash,
+					vec![(session, candidate_hash)],
 					tx,
 				),
 			}).await;
 
-			let votes = rx.await.unwrap().unwrap();
+			let votes = rx.await.unwrap().get(0).unwrap().clone();
 			assert_eq!(votes.valid.len(), 2);
 			assert!(votes.invalid.is_empty());
 		}
@@ -522,13 +518,12 @@ fn wrong_validator_index_is_ignored() {
 			let (tx, rx) = oneshot::channel();
 			virtual_overseer.send(FromOverseer::Communication {
 				msg: DisputeCoordinatorMessage::QueryCandidateVotes(
-					session,
-					candidate_hash,
+					vec![(session, candidate_hash)],
 					tx,
 				),
 			}).await;
 
-			let votes = rx.await.unwrap().unwrap();
+			let votes = rx.await.unwrap().get(0).unwrap().clone();
 			assert!(votes.valid.is_empty());
 			assert!(votes.invalid.is_empty());
 		}

--- a/node/core/provisioner/Cargo.toml
+++ b/node/core/provisioner/Cargo.toml
@@ -10,6 +10,7 @@ futures = "0.3.15"
 tracing = "0.1.26"
 thiserror = "1.0.23"
 polkadot-primitives = { path = "../../../primitives" }
+polkadot-node-primitives = { path = "../../primitives" }
 polkadot-node-subsystem = { path = "../../subsystem" }
 polkadot-node-subsystem-util = { path = "../../subsystem-util" }
 futures-timer = "3.0.2"

--- a/node/core/provisioner/src/lib.rs
+++ b/node/core/provisioner/src/lib.rs
@@ -39,8 +39,9 @@ use polkadot_node_subsystem_util::{
 use polkadot_primitives::v1::{
 	BackedCandidate, BlockNumber, CandidateReceipt, CoreState, Hash, OccupiedCoreAssumption,
 	SignedAvailabilityBitfield, ValidatorIndex, MultiDisputeStatementSet, DisputeStatementSet,
-	DisputeStatement,
+	DisputeStatement, SessionIndex, CandidateHash,
 };
+use polkadot_node_primitives::CandidateVotes;
 use std::{pin::Pin, collections::BTreeMap, sync::Arc};
 use thiserror::Error;
 use futures_timer::Delay;
@@ -567,38 +568,16 @@ async fn select_disputes(
 	};
 
 	// Load all votes for all disputes from the coordinator.
-	let dispute_candidate_votes = {
-		let mut awaited_votes = FuturesOrdered::new();
+	let dispute_candidate_votes: Vec<_> = {
+		let (tx, rx) = oneshot::channel();
+		sender.send_message(DisputeCoordinatorMessage::QueryCandidateVotes(
+			recent_disputes.clone(),
+			tx,
+		).into()).await;
 
-		let n_disputes = recent_disputes.len();
-		for (session_index, candidate_hash) in recent_disputes {
-			let (tx, rx) = oneshot::channel();
-			sender.send_message(DisputeCoordinatorMessage::QueryCandidateVotes(
-				session_index,
-				candidate_hash,
-				tx,
-			).into()).await;
-
-			awaited_votes.push(async move {
-				rx.await
-					.map_err(Error::CanceledCandidateVotes)
-					.map(|maybe_votes| maybe_votes.map(|v| (session_index, candidate_hash, v)))
-			});
-		}
-
-		// Sadly `StreamExt::collect` requires `Default`, so we have to do this more
-		// manually.
-		let mut vote_sets = Vec::with_capacity(n_disputes);
-		while let Some(res) = awaited_votes.next().await {
-			// sanity check - anything present in recent disputes should have
-			// candidate votes. but we might race with block import on
-			// session boundaries.
-			if let Some(vote_set) = res? {
-				vote_sets.push(vote_set);
-			}
-		}
-
-		vote_sets
+		rx.await.unwrap_or_default().into_iter().zip(recent_disputes.into_iter())
+			.map(|(vote, (session_index, candidate_hash))| (session_index, candidate_hash, vote))
+			.collect::<Vec<(SessionIndex, CandidateHash, CandidateVotes)>>()
 	};
 
 	// Transform all `CandidateVotes` into `MultiDisputeStatementSet`.

--- a/node/subsystem/src/messages.rs
+++ b/node/subsystem/src/messages.rs
@@ -224,7 +224,7 @@ pub enum DisputeCoordinatorMessage {
 	/// These disputes are either unconcluded or recently concluded.
 	ActiveDisputes(oneshot::Sender<Vec<(SessionIndex, CandidateHash)>>),
 	/// Get candidate votes for a candidate.
-	QueryCandidateVotes(SessionIndex, CandidateHash, oneshot::Sender<Option<CandidateVotes>>),
+	QueryCandidateVotes(Vec<(SessionIndex, CandidateHash)>, oneshot::Sender<Vec<CandidateVotes>>),
 	/// Sign and issue local dispute votes. A value of `true` indicates validity, and `false` invalidity.
 	IssueLocalStatement(SessionIndex, CandidateHash, CandidateReceipt, bool),
 	/// Determine the highest undisputed block within the given chain, based on where candidates


### PR DESCRIPTION
This PR modifies the communication protocol between the provisioner and the dispute-coordinator. In the past, the dispute-coordinator kept track of a FuturesOrdered of oneshot-receivers and constructed a view of the recent disputes in this fashion.

Instead, it is more efficient to allow batch queries and only iterator over the recent disputes once. We leverage a single oneshot channel to reply to the batch `Vec<(SessionIndex, CandidateHash)>` request with the `Vec<(SessionIndex, Candidatehash, CandidateVotes)>` batch response.

Closes #3439 . Depends on #3348 merge.