### PR TITLE
thiserror annotations + spelling

### DIFF
--- a/.config/lingua.dic
+++ b/.config/lingua.dic
@@ -23,7 +23,8 @@ debian/M
 decodable/MS
 dispatchable/SM
 DMP/SM
-DOT/S
+DOTs
+DOT/SM
 ed25519
 enum/MS
 ERC-20
@@ -72,6 +73,7 @@ PoV/MS
 promethius
 promethius'
 provisioner/MS
+PVF/S
 redhat/M
 repo/MS
 RPC/MS
@@ -94,7 +96,7 @@ tuple/SM
 ubuntu/M
 UDP
 UI
-unfinalize/B
+unfinalize/BD
 union/MSG
 unservable/B
 validator/SM

--- a/node/core/approval-voting/src/criteria.rs
+++ b/node/core/approval-voting/src/criteria.rs
@@ -437,7 +437,7 @@ impl std::error::Error for InvalidAssignment { }
 ///   * Validator is present in backing group.
 ///
 /// This function does not check whether the core is actually a valid assignment or not. That should be done
-/// outside of the scope of this function.
+/// outside the scope of this function.
 pub(crate) fn check_assignment_cert(
 	claimed_core_index: CoreIndex,
 	validator_index: ValidatorIndex,

--- a/node/core/chain-selection/src/backend.rs
+++ b/node/core/chain-selection/src/backend.rs
@@ -45,7 +45,7 @@ pub(super) trait Backend {
 	fn load_leaves(&self) -> Result<LeafEntrySet, Error>;
 	/// Load the stagnant list at the given timestamp.
 	fn load_stagnant_at(&self, timestamp: Timestamp) -> Result<Vec<Hash>, Error>;
-	/// Load all stagnant lists up to and including the given unix timestamp
+	/// Load all stagnant lists up to and including the given UNIX timestamp
 	/// in ascending order.
 	fn load_stagnant_at_up_to(&self, up_to: Timestamp)
 		-> Result<Vec<(Timestamp, Vec<Hash>)>, Error>;

--- a/node/network/availability-distribution/src/error.rs
+++ b/node/network/availability-distribution/src/error.rs
@@ -65,7 +65,7 @@ pub enum Fatal {
 
 	/// Errors coming from runtime::Runtime.
 	#[error("Error while accessing runtime information")]
-	Runtime(#[from] #[source] runtime::Fatal),
+	Runtime(#[from] runtime::Fatal),
 }
 
 /// Non-fatal errors of this subsystem.
@@ -104,7 +104,7 @@ pub enum NonFatal {
 
 	/// Errors coming from runtime::Runtime.
 	#[error("Error while accessing runtime information")]
-	Runtime(#[from] #[source] runtime::NonFatal),
+	Runtime(#[from] runtime::NonFatal),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/node/network/collator-protocol/src/error.rs
+++ b/node/network/collator-protocol/src/error.rs
@@ -63,7 +63,7 @@ pub enum Fatal {
 
 	/// Errors coming from runtime::Runtime.
 	#[error("Error while accessing runtime information")]
-	Runtime(#[from] #[source] runtime::Fatal),
+	Runtime(#[from] runtime::Fatal),
 }
 
 /// Errors for fetching of runtime information.
@@ -75,7 +75,7 @@ pub enum NonFatal {
 
 	/// Errors coming from runtime::Runtime.
 	#[error("Error while accessing runtime information")]
-	Runtime(#[from] #[source] runtime::NonFatal),
+	Runtime(#[from] runtime::NonFatal),
 }
 
 /// Utility for eating top level errors and log them.

--- a/node/network/dispute-distribution/src/error.rs
+++ b/node/network/dispute-distribution/src/error.rs
@@ -68,11 +68,11 @@ pub enum Fatal {
 
 	/// Errors coming from runtime::Runtime.
 	#[error("Error while accessing runtime information")]
-	Runtime(#[from] #[source] runtime::Fatal),
+	Runtime(#[from] runtime::Fatal),
 
 	/// Errors coming from DisputeSender
 	#[error("Error while accessing runtime information")]
-	Sender(#[from] #[source] sender::Fatal),
+	Sender(#[from] sender::Fatal),
 }
 
 /// Non-fatal errors of this subsystem.
@@ -80,7 +80,7 @@ pub enum Fatal {
 pub enum NonFatal {
 	/// Errors coming from DisputeSender
 	#[error("Error while accessing runtime information")]
-	Sender(#[from] #[source] sender::NonFatal),
+	Sender(#[from] sender::NonFatal),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/node/network/dispute-distribution/src/metrics.rs
+++ b/node/network/dispute-distribution/src/metrics.rs
@@ -40,7 +40,7 @@ struct MetricsInner {
 
 	/// Number of requests for which `ImportStatements` returned.
 	///
-	/// We both have success full imports and failed imports here.
+	/// We both have successful imports and failed imports here.
 	imported_requests: CounterVec<U64>,
 }
 

--- a/node/network/dispute-distribution/src/receiver/error.rs
+++ b/node/network/dispute-distribution/src/receiver/error.rs
@@ -56,7 +56,7 @@ pub enum Fatal {
 
 	/// Errors coming from runtime::Runtime.
 	#[error("Error while accessing runtime information")]
-	Runtime(#[from] #[source] runtime::Fatal),
+	Runtime(#[from] runtime::Fatal),
 }
 
 /// Non-fatal errors of this subsystem.
@@ -88,7 +88,7 @@ pub enum NonFatal {
 
 	/// Errors coming from runtime::Runtime.
 	#[error("Error while accessing runtime information")]
-	Runtime(#[from] #[source] runtime::NonFatal),
+	Runtime(#[from] runtime::NonFatal),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/node/network/dispute-distribution/src/sender/error.rs
+++ b/node/network/dispute-distribution/src/sender/error.rs
@@ -56,7 +56,7 @@ pub enum Fatal {
 
 	/// Errors coming from runtime::Runtime.
 	#[error("Error while accessing runtime information")]
-	Runtime(#[from] #[source] runtime::Fatal),
+	Runtime(#[from] runtime::Fatal),
 }
 
 /// Non-fatal errors of this subsystem.
@@ -100,7 +100,7 @@ pub enum NonFatal {
 
 	/// Errors coming from runtime::Runtime.
 	#[error("Error while accessing runtime information")]
-	Runtime(#[from] #[source] runtime::NonFatal),
+	Runtime(#[from] runtime::NonFatal),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/node/network/dispute-distribution/src/sender/mod.rs
+++ b/node/network/dispute-distribution/src/sender/mod.rs
@@ -46,7 +46,7 @@ use self::error::NonFatalResult;
 
 /// The `DisputeSender` keeps track of all ongoing disputes we need to send statements out.
 ///
-/// For each dispute a `SendTask` is responsible of sending to the concerned validators for that
+/// For each dispute a `SendTask` is responsible for sending to the concerned validators for that
 /// particular dispute. The `DisputeSender` keeps track of those tasks, informs them about new
 /// sessions/validator sets and cleans them up when they become obsolete.
 pub struct DisputeSender {
@@ -318,7 +318,7 @@ impl DisputeSender
 
 /// Retrieve the currently active sessions.
 ///
-/// List is all indeces of all active sessions together with the head that was used for the query.
+/// List is all indices of all active sessions together with the head that was used for the query.
 async fn get_active_session_indeces<Context: SubsystemContext>(
 	ctx: &mut Context,
 	runtime: &mut RuntimeInfo,

--- a/node/network/dispute-distribution/src/sender/send_task.rs
+++ b/node/network/dispute-distribution/src/sender/send_task.rs
@@ -59,7 +59,7 @@ pub struct SendTask {
 	/// dispute happened and the authorities of the current sessions as determined by active heads.
 	deliveries: HashMap<AuthorityDiscoveryId, DeliveryStatus>,
 
-	/// Whether or not we have any tasks failed since the last refresh.
+	/// Whether we have any tasks failed since the last refresh.
 	has_failed_sends: bool,
 
 	/// Sender to be cloned for tasks.
@@ -162,7 +162,7 @@ impl SendTask
 		Ok(())
 	}
 
-	/// Whether or not any sends have failed since the last refreshed.
+	/// Whether any sends have failed since the last refreshed.
 	pub fn has_failed_sends(&self) -> bool {
 		self.has_failed_sends
 	}
@@ -247,7 +247,7 @@ impl SendTask
 }
 
 
-/// Start sending of the given msg to all given authorities.
+/// Start sending of the given message to all given authorities.
 ///
 /// And spawn tasks for handling the response.
 async fn send_requests<Context: SubsystemContext>(

--- a/node/network/statement-distribution/src/error.rs
+++ b/node/network/statement-distribution/src/error.rs
@@ -77,7 +77,7 @@ pub enum Fatal {
 
 	/// Errors coming from runtime::Runtime.
 	#[error("Error while accessing runtime information")]
-	Runtime(#[from] #[source] runtime::Fatal),
+	Runtime(#[from] runtime::Fatal),
 }
 
 /// Errors for fetching of runtime information.
@@ -85,7 +85,7 @@ pub enum Fatal {
 pub enum NonFatal {
 	/// Errors coming from runtime::Runtime.
 	#[error("Error while accessing runtime information")]
-	Runtime(#[from] #[source] runtime::NonFatal),
+	Runtime(#[from] runtime::NonFatal),
 
 	/// Relay parent was not present in active heads.
 	#[error("Relay parent could not be found in active heads")]

--- a/node/subsystem-util/src/error_handling.rs
+++ b/node/subsystem-util/src/error_handling.rs
@@ -86,7 +86,7 @@ use thiserror::Error;
 ///		SomeFatalError,
 ///		/// Errors coming from runtime::Runtime.
 ///		#[error("Error while accessing runtime information")]
-///		Runtime(#[from] #[source] runtime::Fatal),
+///		Runtime(#[from] runtime::Fatal),
 /// }
 ///
 /// #[derive(Debug, Error)]
@@ -98,7 +98,7 @@ use thiserror::Error;
 ///
 ///		/// Errors coming from runtime::Runtime.
 ///		#[error("Error while accessing runtime information")]
-///		Runtime(#[from] #[source] runtime::NonFatal),
+///		Runtime(#[from] runtime::NonFatal),
 /// }
 /// ```
 /// Then mostly use `Error` in functions, you may also use `NonFatal` and `Fatal` directly in


### PR DESCRIPTION
Just boring chores.

* `#[from]` implies the inner type is also the `source`, so `#[from] #[source]` is redundant, see https://docs.rs/thiserror/1.0.26/thiserror/index.html
* some spelling + grammar fixes