### PR TITLE
more fine grained runtime api caching + a fix for av-store

### DIFF
--- a/node/core/av-store/src/lib.rs
+++ b/node/core/av-store/src/lib.rs
@@ -48,7 +48,7 @@ use polkadot_node_subsystem_util::{
 	metrics::{self, prometheus},
 };
 use polkadot_subsystem::messages::{
-	AvailabilityStoreMessage, ChainApiMessage, RuntimeApiMessage, RuntimeApiRequest,
+	AvailabilityStoreMessage, ChainApiMessage,
 };
 use bitvec::{vec::BitVec, order::Lsb0 as BitOrderLsb0};
 

--- a/node/core/av-store/src/lib.rs
+++ b/node/core/av-store/src/lib.rs
@@ -699,14 +699,10 @@ where
 
 	// We need to request the number of validators based on the parent state,
 	// as that is the number of validators used to create this block.
-	let n_validators = {
-		let (tx, rx) = oneshot::channel();
-		ctx.send_message(
-			RuntimeApiMessage::Request(header.parent_hash, RuntimeApiRequest::Validators(tx))
-		).await;
-
-		rx.await??.len()
-	};
+	let n_validators = util::request_validators(
+		header.parent_hash,
+		ctx.sender(),
+	).await.await??.len();
 
 	for event in candidate_events {
 		match event {

--- a/node/core/av-store/src/tests.rs
+++ b/node/core/av-store/src/tests.rs
@@ -32,8 +32,8 @@ use polkadot_primitives::v1::{
 use polkadot_node_primitives::{AvailableData, BlockData, PoV};
 use polkadot_node_subsystem_util::TimeoutExt;
 use polkadot_subsystem::{
-	ActiveLeavesUpdate, errors::RuntimeApiError, jaeger, messages::AllMessages, ActivatedLeaf,
-	LeafStatus,
+	ActiveLeavesUpdate, errors::RuntimeApiError, jaeger, ActivatedLeaf,
+	LeafStatus, messages::{AllMessages, RuntimeApiMessage, RuntimeApiRequest},
 };
 use polkadot_node_subsystem_test_helpers as test_helpers;
 use sp_keyring::Sr25519Keyring;

--- a/node/core/runtime-api/src/cache.rs
+++ b/node/core/runtime-api/src/cache.rs
@@ -77,10 +77,10 @@ pub(crate) struct RequestResultCache {
 	check_validation_outputs: MemoryLruCache<(Hash, ParaId, CandidateCommitments), ResidentSizeOf<bool>>,
 	session_index_for_child: MemoryLruCache<Hash, ResidentSizeOf<SessionIndex>>,
 	validation_code: MemoryLruCache<(Hash, ParaId, OccupiedCoreAssumption), ResidentSizeOf<Option<ValidationCode>>>,
-	validation_code_by_hash: MemoryLruCache<(Hash, ValidationCodeHash), ResidentSizeOf<Option<ValidationCode>>>,
+	validation_code_by_hash: MemoryLruCache<ValidationCodeHash, ResidentSizeOf<Option<ValidationCode>>>,
 	candidate_pending_availability: MemoryLruCache<(Hash, ParaId), ResidentSizeOf<Option<CommittedCandidateReceipt>>>,
 	candidate_events: MemoryLruCache<Hash, ResidentSizeOf<Vec<CandidateEvent>>>,
-	session_info: MemoryLruCache<(Hash, SessionIndex), ResidentSizeOf<Option<SessionInfo>>>,
+	session_info: MemoryLruCache<SessionIndex, ResidentSizeOf<Option<SessionInfo>>>,
 	dmq_contents: MemoryLruCache<(Hash, ParaId), ResidentSizeOf<Vec<InboundDownwardMessage<BlockNumber>>>>,
 	inbound_hrmp_channels_contents: MemoryLruCache<(Hash, ParaId), ResidentSizeOf<BTreeMap<ParaId, Vec<InboundHrmpMessage<BlockNumber>>>>>,
 	current_babe_epoch: MemoryLruCache<Hash, DoesNotAllocate<Epoch>>,
@@ -173,11 +173,13 @@ impl RequestResultCache {
 		self.validation_code.insert(key, ResidentSizeOf(value));
 	}
 
+	// the actual key is `ValidationCodeHash` (`Hash` is ignored),
+	// but we keep the interface that way to keep the macro simple
 	pub(crate) fn validation_code_by_hash(&mut self, key: (Hash, ValidationCodeHash)) -> Option<&Option<ValidationCode>> {
-		self.validation_code_by_hash.get(&key).map(|v| &v.0)
+		self.validation_code_by_hash.get(&key.1).map(|v| &v.0)
 	}
 
-	pub(crate) fn cache_validation_code_by_hash(&mut self, key: (Hash, ValidationCodeHash), value: Option<ValidationCode>) {
+	pub(crate) fn cache_validation_code_by_hash(&mut self, key: ValidationCodeHash, value: Option<ValidationCode>) {
 		self.validation_code_by_hash.insert(key, ResidentSizeOf(value));
 	}
 
@@ -198,10 +200,10 @@ impl RequestResultCache {
 	}
 
 	pub(crate) fn session_info(&mut self, key: (Hash, SessionIndex)) -> Option<&Option<SessionInfo>> {
-		self.session_info.get(&key).map(|v| &v.0)
+		self.session_info.get(&key.1).map(|v| &v.0)
 	}
 
-	pub(crate) fn cache_session_info(&mut self, key: (Hash, SessionIndex), value: Option<SessionInfo>) {
+	pub(crate) fn cache_session_info(&mut self, key: SessionIndex, value: Option<SessionInfo>) {
 		self.session_info.insert(key, ResidentSizeOf(value));
 	}
 

--- a/node/core/runtime-api/src/lib.rs
+++ b/node/core/runtime-api/src/lib.rs
@@ -125,14 +125,14 @@ impl<Client> RuntimeApiSubsystem<Client> where
 				self.requests_cache.cache_session_index_for_child(relay_parent, session_index),
 			ValidationCode(relay_parent, para_id, assumption, code) =>
 				self.requests_cache.cache_validation_code((relay_parent, para_id, assumption), code),
-			ValidationCodeByHash(relay_parent, validation_code_hash, code) =>
-				self.requests_cache.cache_validation_code_by_hash((relay_parent, validation_code_hash), code),
+			ValidationCodeByHash(_relay_parent, validation_code_hash, code) =>
+				self.requests_cache.cache_validation_code_by_hash(validation_code_hash, code),
 			CandidatePendingAvailability(relay_parent, para_id, candidate) =>
 				self.requests_cache.cache_candidate_pending_availability((relay_parent, para_id), candidate),
 			CandidateEvents(relay_parent, events) =>
 				self.requests_cache.cache_candidate_events(relay_parent, events),
-			SessionInfo(relay_parent, session_index, info) =>
-				self.requests_cache.cache_session_info((relay_parent, session_index), info),
+			SessionInfo(_relay_parent, session_index, info) =>
+				self.requests_cache.cache_session_info(session_index, info),
 			DmqContents(relay_parent, para_id, messages) =>
 				self.requests_cache.cache_dmq_contents((relay_parent, para_id), messages),
 			InboundHrmpChannelsContents(relay_parent, para_id, contents) =>


### PR DESCRIPTION
cc #2987 

In order to solve https://github.com/paritytech/polkadot/pull/3356#discussion_r657152326 IIUC we need to query a session_index_for_child for a grandparent of the head and then use the rolling session with that index, is that correct?

I guess we can also cache `authorities` based on `session_index_for_child`, but that would require an extra call to the runtime and probably warrant some tweaks to the runtime api macros.