### PR TITLE
overseer gen minor

### DIFF
--- a/node/overseer/Cargo.toml
+++ b/node/overseer/Cargo.toml
@@ -21,10 +21,8 @@ tracing = "0.1.26"
 lru = "0.6"
 
 [dev-dependencies]
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
-polkadot-node-network-protocol = { path = "../network/protocol" }
-polkadot-node-metrics = { path = "../metrics" }
 metered-channel = { path = "../metered-channel" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
 futures = { version = "0.3.15", features = ["thread-pool"] }
 femme = "2.1.1"
 kv-log-macro = "1.0.7"

--- a/node/overseer/overseer-gen/proc-macro/src/impl_misc.rs
+++ b/node/overseer/overseer-gen/proc-macro/src/impl_misc.rs
@@ -118,7 +118,7 @@ pub(crate) fn impl_misc(info: &OverseerInfo) -> proc_macro2::TokenStream {
 				signals: #support_crate ::metered::MeteredReceiver< #signal >,
 				messages: SubsystemIncomingMessages<M>,
 				to_subsystems: ChannelsOut,
-				to_overseer: #support_crate ::metered::UnboundedMeteredSender<ToOverseer>,
+				to_overseer: #support_crate ::metered::UnboundedMeteredSender<#support_crate:: ToOverseer>,
 			) -> Self {
 				let signals_received = SignalsReceived::default();
 				#subsystem_ctx_name {
@@ -136,7 +136,7 @@ pub(crate) fn impl_misc(info: &OverseerInfo) -> proc_macro2::TokenStream {
 		}
 
 		#[#support_crate ::async_trait]
-		impl<M: std::fmt::Debug + Send + 'static> SubsystemContext for #subsystem_ctx_name<M>
+		impl<M: std::fmt::Debug + Send + 'static> #support_crate ::SubsystemContext for #subsystem_ctx_name<M>
 		where
 			#subsystem_sender_name: #support_crate ::SubsystemSender< #wrapper_message >,
 			#wrapper_message: From<M>,

--- a/node/overseer/overseer-gen/proc-macro/src/impl_overseer.rs
+++ b/node/overseer/overseer-gen/proc-macro/src/impl_overseer.rs
@@ -90,7 +90,7 @@ pub(crate) fn impl_overseer_struct(info: &OverseerInfo) -> proc_macro2::TokenStr
 
 			/// Gather running subsystems' outbound streams into one.
 			to_overseer_rx: #support_crate ::stream::Fuse<
-				#support_crate ::metered::UnboundedMeteredReceiver< ToOverseer >
+				#support_crate ::metered::UnboundedMeteredReceiver< #support_crate ::ToOverseer >
 			>,
 
 			/// Events that are sent to the overseer from the outside world.

--- a/node/overseer/src/lib.rs
+++ b/node/overseer/src/lib.rs
@@ -58,7 +58,6 @@
 // unused dependencies can not work for test and examples at the same time
 // yielding false positives
 #![warn(missing_docs)]
-#![deny(unused_crate_dependencies)]
 
 use std::fmt::{self, Debug};
 use std::pin::Pin;

--- a/node/overseer/src/lib.rs
+++ b/node/overseer/src/lib.rs
@@ -58,6 +58,7 @@
 // unused dependencies can not work for test and examples at the same time
 // yielding false positives
 #![warn(missing_docs)]
+#![deny(unused_crate_dependencies)]
 
 use std::fmt::{self, Debug};
 use std::pin::Pin;


### PR DESCRIPTION
Minor adjustments, mostly missing `#support_crate ::` prefixes which became apparent when refactoring again in a larger scope