### PR TITLE
add rustfmt toml

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,22 @@
+# Basic
+hard_tabs = true
+max_width = 100
+use_small_heuristics = "Max"
+# Imports
+imports_granularity = "Crate"
+reorder_imports = true
+# Consistency
+newline_style = "Unix"
+normalize_comments = true
+normalize_doc_attributes = true
+# Misc
+chain_width = 80
+spaces_around_ranges = false
+binop_separator = "Back"
+reorder_impl_items = false
+match_arm_leading_pipes = "Preserve"
+match_arm_blocks = false
+match_block_trailing_comma = true
+trailing_comma = "Vertical"
+trailing_semicolon = false
+use_field_init_shorthand = true

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -7,8 +7,6 @@ imports_granularity = "Crate"
 reorder_imports = true
 # Consistency
 newline_style = "Unix"
-normalize_comments = true
-normalize_doc_attributes = true
 # Misc
 chain_width = 80
 spaces_around_ranges = false


### PR DESCRIPTION
Copies the substrate `rustfmt.toml` to polkadot, to be used with `cargo +nightly fmt` or `rustfmt +nightly file.rs`.

This PR does _NOT_ apply the format, it only provides it to eventually be applied subsystem by subsystem.

Ref https://github.com/paritytech/substrate/pull/8982