### PR TITLE
Dispute vote filtering for block authors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9485,9 +9485,9 @@ dependencies = [
 
 [[package]]
 name = "slotmap"
-version = "1.0.2"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3003725ae562cf995f3dc82bb99e70926e09000396816765bb6d7adbe740b1"
+checksum = "a952280edbecfb1d4bd3cf2dbc309dc6ab523e53487c438ae21a6df09fe84bc4"
 dependencies = [
  "version_check",
 ]

--- a/primitives/src/v1/mod.rs
+++ b/primitives/src/v1/mod.rs
@@ -1124,6 +1124,22 @@ impl DisputeStatement {
 			Err(())
 		}
 	}
+
+	/// Whether the statement indicates validity.
+	pub fn indicates_validity(&self) -> bool {
+		match *self {
+			DisputeStatement::Valid(_) => true,
+			DisputeStatement::Invalid(_) => false,
+		}
+	}
+
+	/// Whether the statement indicates invalidity.
+	pub fn indicates_invalidity(&self) -> bool {
+		match *self {
+			DisputeStatement::Valid(_) => false,
+			DisputeStatement::Invalid(_) => true,
+		}
+	}
 }
 
 /// Different kinds of statements of validity on  a candidate.

--- a/roadmap/implementers-guide/src/runtime/disputes.md
+++ b/roadmap/implementers-guide/src/runtime/disputes.md
@@ -66,6 +66,11 @@ Frozen: Option<BlockNumber>,
 
 ## Routines
 
+* `filter_multi_dispute_data(MultiDisputeStatementSet) -> MultiDisputeStatementSet`:
+  1. Takes a `MultiDisputeStatementSet` and filters it down to a `MultiDisputeStatementSet`
+    that satisfies all the criteria of `provide_multi_dispute_data`. That is, eliminating
+    ancient votes, votes which overwhelm the maximum amount of spam slots, and duplicates. 
+
 * `provide_multi_dispute_data(MultiDisputeStatementSet) -> Vec<(SessionIndex, Hash)>`:
   1. Pass on each dispute statement set to `provide_dispute_data`, propagating failure.
   1. Return a list of all candidates who just had disputes initiated.

--- a/roadmap/implementers-guide/src/runtime/disputes.md
+++ b/roadmap/implementers-guide/src/runtime/disputes.md
@@ -70,6 +70,8 @@ Frozen: Option<BlockNumber>,
   1. Takes a `MultiDisputeStatementSet` and filters it down to a `MultiDisputeStatementSet`
     that satisfies all the criteria of `provide_multi_dispute_data`. That is, eliminating
     ancient votes, votes which overwhelm the maximum amount of spam slots, and duplicates. 
+    This can be used by block authors to create the final submission in a block which is 
+    guaranteed to pass the `provide_multi_dispute_data` checks.
 
 * `provide_multi_dispute_data(MultiDisputeStatementSet) -> Vec<(SessionIndex, Hash)>`:
   1. Pass on each dispute statement set to `provide_dispute_data`, propagating failure.

--- a/runtime/parachains/src/disputes.rs
+++ b/runtime/parachains/src/disputes.rs
@@ -761,10 +761,7 @@ impl<T: Config> Pallet<T> {
 					Some(v) => v,
 				};
 
-				let valid = match statement {
-					DisputeStatement::Valid(_) => true,
-					DisputeStatement::Invalid(_) => false,
-				};
+				let valid = statement.indicates_validity();
 
 				if let Err(_) = importer.import(*validator_index, valid) {
 					filter.remove_index(i);
@@ -911,10 +908,7 @@ impl<T: Config> Pallet<T> {
 					signature,
 				).map_err(|()| Error::<T>::InvalidSignature)?;
 
-				let valid = match statement {
-					DisputeStatement::Valid(_) => true,
-					DisputeStatement::Invalid(_) => false,
-				};
+				let valid = statement.indicates_validity();
 
 				importer.import(*validator_index, valid).map_err(Error::<T>::from)?;
 			}

--- a/runtime/parachains/src/disputes.rs
+++ b/runtime/parachains/src/disputes.rs
@@ -17,6 +17,7 @@
 //! Runtime component for handling disputes of parachain candidates.
 
 use sp_std::prelude::*;
+use sp_std::collections::btree_set::BTreeSet;
 use primitives::v1::{
 	byzantine_threshold, supermajority_threshold, ApprovalVote, CandidateHash, CompactStatement,
 	ConsensusLog, DisputeState, DisputeStatement, DisputeStatementSet, ExplicitDisputeStatement,
@@ -689,15 +690,10 @@ impl<T: Config> Pallet<T> {
 
 		// Deduplicate.
 		let dedup_iter = {
-			let mut targets = Vec::new();
+			let mut targets = BTreeSet::new();
 			old_statement_sets.into_iter().filter(move |set| {
 				let target = (set.candidate_hash, set.session);
-				let dup = targets.contains(&target);
-				if !dup {
-					targets.push(target);
-				}
-
-				!dup
+				targets.insert(target)
 			})
 		};
 

--- a/runtime/parachains/src/disputes.rs
+++ b/runtime/parachains/src/disputes.rs
@@ -534,7 +534,8 @@ impl StatementSetFilter {
 
 				// reverse order ensures correctness
 				for index in indices.into_iter().rev() {
-					statement_set.statements.remove(index);
+					// swap_remove guarantees linear complexity.
+					statement_set.statements.swap_remove(index);
 				}
 
 				if statement_set.statements.is_empty() {

--- a/runtime/parachains/src/disputes.rs
+++ b/runtime/parachains/src/disputes.rs
@@ -684,7 +684,7 @@ impl<T: Config> Pallet<T> {
 	fn filter_multi_dispute_data(statement_sets: &mut MultiDisputeStatementSet) {
 		let config = <configuration::Pallet<T>>::config();
 
-		let old_statement_sets = std::mem::replace(statement_sets, Vec::new());
+		let old_statement_sets = sp_std::mem::replace(statement_sets, Vec::new());
 
 		// Deduplicate.
 		let dedup_iter = {


### PR DESCRIPTION
Closes #3472 

When the node-side is authoring a block, it passes _all votes_ from _all disputes from recent sessions_ to an instance of the runtime as `InherentData`. The `ProvideInherent` implementation for the `ParasInherent` [here](https://github.com/paritytech/polkadot/blob/master/runtime/parachains/src/paras_inherent.rs#L290) invokes the filtering function, which is intended to detect duplicates and spam and so on.

This pull request actually provides the implementation of that filtering logic, to be used to create `ParasInherent` inherents that actually contain dispute votes so the chain can witness disputes.