### PR TITLE
XCM Account Derivation

### DIFF
--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -60,7 +60,7 @@ use xcm_builder::{
 	AccountId32Aliases, ChildParachainConvertsVia, SovereignSignedViaLocation, CurrencyAdapter as XcmCurrencyAdapter,
 	ChildParachainAsNative, SignedAccountId32AsNative, ChildSystemParachainAsSuperuser, LocationInverter,
 	IsConcrete, FixedWeightBounds, TakeWeightCredit, AllowTopLevelPaidExecutionFrom, AllowUnpaidExecutionFrom,
-	IsChildSystemParachain, UsingComponents, BackingToPlurality, SignedToAccountId32,
+	IsChildSystemParachain, UsingComponents, BackingToPlurality, SignedToAccountId32, DerivedParachainAccountId32,
 };
 use xcm_executor::XcmExecutor;
 use sp_arithmetic::Perquintill;
@@ -1222,6 +1222,8 @@ pub type SovereignAccountOf = (
 	ChildParachainConvertsVia<ParaId, AccountId>,
 	// We can directly alias an `AccountId32` into a local account.
 	AccountId32Aliases<KusamaNetwork, AccountId>,
+	// We can generate local account ids for accounts originating on parachains.
+	DerivedParachainAccountId32<KusamaNetwork, AccountId>,
 );
 
 /// Our asset transactor. This is what allows us to interest with the runtime facilities from the point of

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -94,7 +94,7 @@ use xcm_builder::{
 	AccountId32Aliases, ChildParachainConvertsVia, SovereignSignedViaLocation,
 	CurrencyAdapter as XcmCurrencyAdapter, ChildParachainAsNative, SignedAccountId32AsNative,
 	ChildSystemParachainAsSuperuser, LocationInverter, IsConcrete, FixedWeightBounds,
-	BackingToPlurality, SignedToAccountId32, UsingComponents,
+	BackingToPlurality, SignedToAccountId32, UsingComponents, DerivedParachainAccountId32,
 };
 use constants::{time::*, currency::*, fee::*};
 use frame_support::traits::InstanceFilter;
@@ -608,6 +608,8 @@ parameter_types! {
 pub type SovereignAccountOf = (
 	ChildParachainConvertsVia<ParaId, AccountId>,
 	AccountId32Aliases<RococoNetwork, AccountId>,
+	// We can generate local account ids for accounts originating on parachains.
+	DerivedParachainAccountId32<RococoNetwork, AccountId>,
 );
 
 pub type LocalAssetTransactor =

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -61,7 +61,7 @@ use xcm_builder::{
 	AccountId32Aliases, ChildParachainConvertsVia, SovereignSignedViaLocation, CurrencyAdapter as XcmCurrencyAdapter,
 	ChildParachainAsNative, SignedAccountId32AsNative, ChildSystemParachainAsSuperuser, LocationInverter, IsConcrete,
 	FixedWeightBounds, TakeWeightCredit, AllowTopLevelPaidExecutionFrom, AllowUnpaidExecutionFrom,
-	IsChildSystemParachain, UsingComponents, SignedToAccountId32,
+	IsChildSystemParachain, UsingComponents, SignedToAccountId32, DerivedParachainAccountId32,
 };
 
 use sp_runtime::{
@@ -880,6 +880,8 @@ parameter_types! {
 pub type LocationConverter = (
 	ChildParachainConvertsVia<ParaId, AccountId>,
 	AccountId32Aliases<WestendNetwork, AccountId>,
+	// We can generate local account ids for accounts originating on parachains.
+	DerivedParachainAccountId32<WestendNetwork, AccountId>,
 );
 
 pub type LocalAssetTransactor =

--- a/xcm/xcm-builder/src/lib.rs
+++ b/xcm/xcm-builder/src/lib.rs
@@ -28,7 +28,7 @@ mod tests;
 mod location_conversion;
 pub use location_conversion::{
 	Account32Hash, ParentIsDefault, ChildParachainConvertsVia, SiblingParachainConvertsVia, AccountId32Aliases,
-	AccountKey20Aliases, LocationInverter,
+	AccountKey20Aliases, LocationInverter, DerivedParachainAccountId32,
 };
 
 mod origin_conversion;


### PR DESCRIPTION
This PR adds a struct to derive a local account id from a parachain + account combination and adds it to Kusama, Rococo and Westend.