### PR TITLE
Add `wococo-local` chain spec

### DIFF
--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -111,6 +111,8 @@ impl SubstrateCli for Cli {
 			"wococo" => Box::new(service::chain_spec::wococo_config()?),
 			#[cfg(feature = "rococo-native")]
 			"wococo-dev" => Box::new(service::chain_spec::wococo_development_config()?),
+			#[cfg(feature = "rococo-native")]
+			"wococo-local" => Box::new(service::chain_spec::wococo_local_testnet_config()?),
 			#[cfg(not(feature = "rococo-native"))]
 			name if name.starts_with("wococo-") =>
 				Err(format!("`{}` only supported with `rococo-native` feature enabled.", name))?,

--- a/node/service/src/chain_spec.rs
+++ b/node/service/src/chain_spec.rs
@@ -1805,3 +1805,39 @@ pub fn rococo_local_testnet_config() -> Result<RococoChainSpec, String> {
 		Default::default(),
 	))
 }
+
+/// Wococo is a temporary testnet that uses the same runtime as rococo.
+#[cfg(feature = "rococo-native")]
+fn wococo_local_testnet_genesis(wasm_binary: &[u8]) -> rococo_runtime::GenesisConfig {
+	rococo_testnet_genesis(
+		wasm_binary,
+		vec![
+			get_authority_keys_from_seed("Alice"),
+			get_authority_keys_from_seed("Bob"),
+		],
+		get_account_id_from_seed::<sr25519::Public>("Alice"),
+		None,
+	)
+}
+
+/// Wococo local testnet config (multivalidator Alice + Bob)
+#[cfg(feature = "rococo-native")]
+pub fn wococo_local_testnet_config() -> Result<RococoChainSpec, String> {
+	let wasm_binary = rococo::WASM_BINARY.ok_or("Wococo development wasm not available")?;
+
+	Ok(RococoChainSpec::from_genesis(
+		"Wococo Local Testnet",
+		"wococo_local_testnet",
+		ChainType::Local,
+		move || RococoGenesisExt {
+			runtime_genesis_config: wococo_local_testnet_genesis(wasm_binary),
+			// Use 1 minute session length.
+			session_length_in_blocks: Some(10),
+		},
+		vec![],
+		None,
+		Some(DEFAULT_PROTOCOL_ID),
+		None,
+		Default::default(),
+	))
+}


### PR DESCRIPTION
`BEEFY` testing will continue on `Wococo`

Add a `wococo-local` chain spec, so there is a multi-validator local test chain as well.