### PR TITLE
Use correct syntax for bridge CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-bridges/* @tomusdrw @svyatonik @hcastano
+bridges/ @tomusdrw @svyatonik @hcastano


### PR DESCRIPTION
From the [GitHub docs](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners):

> #The `docs/*` pattern will match files like
> #`docs/getting-started.md` but not further nested files like
> #`docs/build-app/troubleshooting.md`.
> docs/*  docs@example.com
>
>
> #In this example, @octocat owns any file in an apps directory
> #anywhere in your repository.
> apps/ @octocat
