### PR TITLE
[CI] Add manual Gitlab job for running all benchmarks

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -134,8 +134,22 @@ date to include them.
 
 ### Benchmarks
 
-Run the benchmarking suite with the new runtime and update any function weights
-if necessary.
+There are three benchmarking machines reserved for updating the weights at
+release-time. To initialise a benchmark run for each production runtime
+(westend, kusama, polkadot):
+* Go to https://gitlab.parity.io/parity/polkadot/-/pipelines?page=1&scope=branches&ref=master
+* Click the link to the last pipeline run for master
+* Start each of the manual jobs:
+  * 'update_westend_weights'
+  * 'update_polkadot_weights'
+  * 'update_kusama_weights'
+* When these jobs have completed (it takes a few hours), a git PATCH file will
+    be available to download as an artifact. 
+* On your local machine, branch off master
+* Download the patch file and apply it to your branch with `git patch patchfile.patch`
+* Commit the changes to your branch and submit a PR against master
+* The weights should be (Currently manually) checked to make sure there are no
+    big outliers (i.e., twice or half the weight).
 
 ### Polkadot JS
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -335,6 +335,16 @@ publish-adder-collator-image:
 update_polkadot_weights:
   <<:                              *update-weights
 
+update_kusama_weights:
+  <<:                              *update-weights
+  variables:
+    RUNTIME:                       kusama
+
+update_westend_weights:
+  <<:                              *update-weights
+  variables:
+    RUNTIME:                       westend
+
 #### stage:                        publish
 
 publish-s3-release:                &publish-s3

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -125,7 +125,6 @@ test-build-linux-stable:
     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
     - if: $CI_COMMIT_REF_NAME == "rococo-v1"
-    - if: $CI_COMMIT_REF_NAME == "mp-weights-CI"
   script:
     - ./scripts/gitlab/test_linux_stable.sh
     # we're using the bin built here, instead of having a parallel `build-linux-release`
@@ -320,7 +319,7 @@ publish-adder-collator-image:
       dotenv: ./artifacts/collator.env
 
 .update_weights:                   &update-weights
-  stage:                           test
+  stage:                           build
   when:                            manual
   tags:
     - weights

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -326,6 +326,8 @@ publish-adder-collator-image:
     - weights
   variables:
     RUNTIME:                       polkadot
+    # sccache causing issues...
+    RUSTC_WRAPPER:                 ""
   artifacts:
     paths:
       - ${RUNTIME}_weights_${CI_COMMIT_SHORT_SHA}.patch

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -125,7 +125,6 @@ test-build-linux-stable:
     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
     - if: $CI_COMMIT_REF_NAME == "rococo-v1"
-    - if: $CI_COMMIT_REF_NAME == "mp-weights-CI"
   script:
     - ./scripts/gitlab/test_linux_stable.sh
     # we're using the bin built here, instead of having a parallel `build-linux-release`
@@ -320,7 +319,7 @@ publish-adder-collator-image:
       dotenv: ./artifacts/collator.env
 
 .update_weights:                   &update-weights
-  stage:                           test
+  stage:                           build
   when:                            manual
   tags:
     - weights
@@ -335,16 +334,6 @@ publish-adder-collator-image:
 
 update_polkadot_weights:
   <<:                              *update-weights
-
-update_kusama_weights:
-  <<:                              *update-weights
-  variables:
-    RUNTIME:                       kusama
-
-update_westend_weights:
-  <<:                              *update-weights
-  variables:
-    RUNTIME:                       westend
 
 #### stage:                        publish
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -125,6 +125,7 @@ test-build-linux-stable:
     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
     - if: $CI_COMMIT_REF_NAME == "rococo-v1"
+    - if: $CI_COMMIT_REF_NAME == "mp-weights-CI"
   script:
     - ./scripts/gitlab/test_linux_stable.sh
     # we're using the bin built here, instead of having a parallel `build-linux-release`
@@ -319,7 +320,7 @@ publish-adder-collator-image:
       dotenv: ./artifacts/collator.env
 
 .update_weights:                   &update-weights
-  stage:                           build
+  stage:                           test
   when:                            manual
   tags:
     - weights

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -326,8 +326,6 @@ publish-adder-collator-image:
     - weights
   variables:
     RUNTIME:                       polkadot
-    # sccache causing issues...
-    RUSTC_WRAPPER:                 ""
   artifacts:
     paths:
       - ${RUNTIME}_weights_${CI_COMMIT_SHORT_SHA}.patch

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -321,10 +321,16 @@ publish-adder-collator-image:
 .update_weights:                   &update-weights
   stage:                           build
   when:                            manual
+  tags:
+    - weights
   variables:
     RUNTIME:                       polkadot
-  script:
+  artifacts:
+    paths:
+      - ${RUNTIMES}_weights_${CI_COMMIT_SHORT_SHA}.patch
+  script: |
     ./scripts/run_benches_for_runtime.sh $RUNTIME
+    git diff -P > ${RUNTIMES}_weights_${CI_COMMIT_SHORT_SHA}.patch
 
 update_polkadot_weights:
   <<:                              *update-weights

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -172,7 +172,7 @@ spellcheck:
     - cargo spellcheck --version
     # compare with the commit parent to the PR, given it's from a default branch
     - git fetch origin +${CI_DEFAULT_BRANCH}:${CI_DEFAULT_BRANCH}
-    - time cargo spellcheck check -vvv --cfg=scripts/gitlab/spellcheck.toml --checkers hunspell --code 1 
+    - time cargo spellcheck check -vvv --cfg=scripts/gitlab/spellcheck.toml --checkers hunspell --code 1
         -r $(git diff --name-only ${CI_COMMIT_SHA} $(git merge-base ${CI_COMMIT_SHA} ${CI_DEFAULT_BRANCH}))
   allow_failure:                   true
 
@@ -317,6 +317,17 @@ publish-adder-collator-image:
     reports:
       # this artifact is used in trigger-simnet job
       dotenv: ./artifacts/collator.env
+
+.update_weights:                   &update-weights
+  stage:                           build
+  when:                            manual
+  variables:
+    RUNTIME:                       polkadot
+  script:
+    ./scripts/run_benches_for_runtime.sh $RUNTIME
+
+update_polkadot_weights:
+  <<:                              *update-weights
 
 #### stage:                        publish
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -327,10 +327,10 @@ publish-adder-collator-image:
     RUNTIME:                       polkadot
   artifacts:
     paths:
-      - ${RUNTIMES}_weights_${CI_COMMIT_SHORT_SHA}.patch
+      - ${RUNTIME}_weights_${CI_COMMIT_SHORT_SHA}.patch
   script: |
     ./scripts/run_benches_for_runtime.sh $RUNTIME
-    git diff -P > ${RUNTIMES}_weights_${CI_COMMIT_SHORT_SHA}.patch
+    git diff -P > ${RUNTIME}_weights_${CI_COMMIT_SHORT_SHA}.patch
 
 update_polkadot_weights:
   <<:                              *update-weights

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -125,6 +125,7 @@ test-build-linux-stable:
     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
     - if: $CI_COMMIT_REF_NAME == "rococo-v1"
+    - if: $CI_COMMIT_REF_NAME == "mp-weights-CI"
   script:
     - ./scripts/gitlab/test_linux_stable.sh
     # we're using the bin built here, instead of having a parallel `build-linux-release`
@@ -319,7 +320,7 @@ publish-adder-collator-image:
       dotenv: ./artifacts/collator.env
 
 .update_weights:                   &update-weights
-  stage:                           build
+  stage:                           test
   when:                            manual
   tags:
     - weights
@@ -334,6 +335,16 @@ publish-adder-collator-image:
 
 update_polkadot_weights:
   <<:                              *update-weights
+
+update_kusama_weights:
+  <<:                              *update-weights
+  variables:
+    RUNTIME:                       kusama
+
+update_westend_weights:
+  <<:                              *update-weights
+  variables:
+    RUNTIME:                       westend
 
 #### stage:                        publish
 

--- a/scripts/run_all_benches.sh
+++ b/scripts/run_all_benches.sh
@@ -10,13 +10,6 @@ runtimes=(
   westend
 )
 
-# cargo build --locked --release
 for runtime in "${runtimes[@]}"; do
-  cargo +nightly run --release --features=runtime-benchmarks --locked benchmark --chain "${runtime}-dev" --execution=wasm --wasm-execution=compiled --pallet "*" --extrinsic "*" --repeat 0 | sed -r -e 's/Pallet: "([a-z_:]+)".*/\1/' | uniq | grep -v frame_system > "${runtime}_pallets"
-  while read -r line; do
-    pallet="$(echo "$line" | cut -d' ' -f1)";
-    echo "Runtime: $runtime. Pallet: $pallet";
-    cargo +nightly run --release --features=runtime-benchmarks -- benchmark --chain="${runtime}-dev" --steps=50 --repeat=20 --pallet="$pallet" --extrinsic="*" --execution=wasm --wasm-execution=compiled --heap-pages=4096 --header=./file_header.txt --output="./runtime/${runtime}/src/weights/${pallet/::/_}.rs"
-  done < "${runtime}_pallets"
-  rm "${runtime}_pallets"
+  "$(dirname "$0")/run_benches_for_runtime.sh" "$runtime"
 done

--- a/scripts/run_benches_for_runtime.sh
+++ b/scripts/run_benches_for_runtime.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Runs all benchmarks for all pallets, for a given runtime, provided by $1
+# Should be run on a reference machine to gain accurate benchmarks
+# current reference machine: https://github.com/paritytech/substrate/pull/5848
+
+runtime="$1"
+
+echo "[+] Running all benchmarks for $runtime"
+
+cargo +nightly run --release --features=runtime-benchmarks --locked benchmark --chain "${runtime}-dev" --execution=wasm --wasm-execution=compiled --pallet "*" --extrinsic "*" --repeat 0 | sed -r -e 's/Pallet: "([a-z_:]+)".*/\1/' | uniq | grep -v frame_system > "${runtime}_pallets"
+while read -r line; do
+  pallet="$(echo "$line" | cut -d' ' -f1)";
+  echo "Runtime: $runtime. Pallet: $pallet";
+  cargo +nightly run --release --features=runtime-benchmarks -- benchmark --chain="${runtime}-dev" --steps=50 --repeat=20 --pallet="$pallet" --extrinsic="*" --execution=wasm --wasm-execution=compiled --heap-pages=4096 --header=./file_header.txt --output="./runtime/${runtime}/src/weights/${pallet/::/_}.rs"
+done < "${runtime}_pallets"
+rm "${runtime}_pallets"

--- a/scripts/run_benches_for_runtime.sh
+++ b/scripts/run_benches_for_runtime.sh
@@ -5,13 +5,16 @@
 # current reference machine: https://github.com/paritytech/substrate/pull/5848
 
 runtime="$1"
+standard_args="--release --locked --features=runtime-benchmarks"
 
 echo "[+] Running all benchmarks for $runtime"
 
-cargo +nightly run --release --features=runtime-benchmarks --locked benchmark --chain "${runtime}-dev" --execution=wasm --wasm-execution=compiled --pallet "*" --extrinsic "*" --repeat 0 | sed -r -e 's/Pallet: "([a-z_:]+)".*/\1/' | uniq | grep -v frame_system > "${runtime}_pallets"
+# shellcheck disable=SC2086
+cargo +nightly run $standard_args benchmark --chain "${runtime}-dev" --execution=wasm --wasm-execution=compiled --pallet "*" --extrinsic "*" --repeat 0 | sed -r -e 's/Pallet: "([a-z_:]+)".*/\1/' | uniq | grep -v frame_system > "${runtime}_pallets"
 while read -r line; do
   pallet="$(echo "$line" | cut -d' ' -f1)";
   echo "Runtime: $runtime. Pallet: $pallet";
-  cargo +nightly run --release --features=runtime-benchmarks -- benchmark --chain="${runtime}-dev" --steps=50 --repeat=20 --pallet="$pallet" --extrinsic="*" --execution=wasm --wasm-execution=compiled --heap-pages=4096 --header=./file_header.txt --output="./runtime/${runtime}/src/weights/${pallet/::/_}.rs"
+# shellcheck disable=SC2086
+  cargo +nightly run $standard_args -- benchmark --chain="${runtime}-dev" --steps=50 --repeat=20 --pallet="$pallet" --extrinsic="*" --execution=wasm --wasm-execution=compiled --heap-pages=4096 --header=./file_header.txt --output="./runtime/${runtime}/src/weights/${pallet/::/_}.rs"
 done < "${runtime}_pallets"
 rm "${runtime}_pallets"

--- a/scripts/run_benches_for_runtime.sh
+++ b/scripts/run_benches_for_runtime.sh
@@ -20,6 +20,8 @@ cargo +nightly run $standard_args benchmark \
   sed -r -e 's/Pallet: "([a-z_:]+)".*/\1/' | \
   uniq | \
   grep -v frame_system > "${runtime}_pallets"
+
+# For each pallet found in the previous command, run benches on each function
 while read -r line; do
   pallet="$(echo "$line" | cut -d' ' -f1)";
   echo "Runtime: $runtime. Pallet: $pallet";

--- a/scripts/run_benches_for_runtime.sh
+++ b/scripts/run_benches_for_runtime.sh
@@ -10,7 +10,7 @@ standard_args="--release --locked --features=runtime-benchmarks"
 echo "[+] Running all benchmarks for $runtime"
 
 # shellcheck disable=SC2086
-RUSTC_WRAPPER="" cargo +nightly run $standard_args benchmark \
+cargo +nightly run $standard_args benchmark \
     --chain "${runtime}-dev" \
     --execution=wasm \
     --wasm-execution=compiled \
@@ -24,7 +24,7 @@ while read -r line; do
   pallet="$(echo "$line" | cut -d' ' -f1)";
   echo "Runtime: $runtime. Pallet: $pallet";
 # shellcheck disable=SC2086
-RUSTC_WRAPPER="" cargo +nightly run $standard_args -- benchmark \
+cargo +nightly run $standard_args -- benchmark \
   --chain="${runtime}-dev" \
   --steps=50 \
   --repeat=20 \

--- a/scripts/run_benches_for_runtime.sh
+++ b/scripts/run_benches_for_runtime.sh
@@ -10,11 +10,30 @@ standard_args="--release --locked --features=runtime-benchmarks"
 echo "[+] Running all benchmarks for $runtime"
 
 # shellcheck disable=SC2086
-cargo +nightly run $standard_args benchmark --chain "${runtime}-dev" --execution=wasm --wasm-execution=compiled --pallet "*" --extrinsic "*" --repeat 0 | sed -r -e 's/Pallet: "([a-z_:]+)".*/\1/' | uniq | grep -v frame_system > "${runtime}_pallets"
+RUSTC_WRAPPER="" cargo +nightly run $standard_args benchmark \
+    --chain "${runtime}-dev" \
+    --execution=wasm \
+    --wasm-execution=compiled \
+    --pallet "*" \
+    --extrinsic "*" \
+    --repeat 0 | \
+  sed -r -e 's/Pallet: "([a-z_:]+)".*/\1/' | \
+  uniq | \
+  grep -v frame_system > "${runtime}_pallets"
 while read -r line; do
   pallet="$(echo "$line" | cut -d' ' -f1)";
   echo "Runtime: $runtime. Pallet: $pallet";
 # shellcheck disable=SC2086
-  cargo +nightly run $standard_args -- benchmark --chain="${runtime}-dev" --steps=50 --repeat=20 --pallet="$pallet" --extrinsic="*" --execution=wasm --wasm-execution=compiled --heap-pages=4096 --header=./file_header.txt --output="./runtime/${runtime}/src/weights/${pallet/::/_}.rs"
+RUSTC_WRAPPER="" cargo +nightly run $standard_args -- benchmark \
+  --chain="${runtime}-dev" \
+  --steps=50 \
+  --repeat=20 \
+  --pallet="$pallet" \
+  --extrinsic="*" \
+  --execution=wasm \
+  --wasm-execution=compiled \
+  --heap-pages=4096 \
+  --header=./file_header.txt \
+  --output="./runtime/${runtime}/src/weights/${pallet/::/_}.rs"
 done < "${runtime}_pallets"
 rm "${runtime}_pallets"


### PR DESCRIPTION
This change adds a Gitlab CI job for running *all* benchmarks for westend, kusama and polkadot. 
Three new benchmark machines got provisioned [as requested](https://github.com/paritytech/devops/issues/989) and I've [added](https://gitlab.parity.io/parity/devops/-/merge_requests/176) them to Gitlab as runners, restricted to *only* running the jobs added in this PR.

I also added instructions for how to use these new jobs at the point of initiating a release - Currently, it will actually just generate a git patch file that we can manually apply and create a commit out of. This was done to avoid getting into the mess of having CI create commits and pull requests, though this could definitely be worked on and expanded.
This is more like an MVP to just get *something* automated for running all our benchmarks to update weights prior to a release.

WIP while I wait for the job to complete and can actually verify the patch files work and the weights aren't ridiculous due to something unforeseen.