### PR TITLE
Change pallet naming in test-runtime

### DIFF
--- a/node/test/service/src/chain_spec.rs
+++ b/node/test/service/src/chain_spec.rs
@@ -174,7 +174,7 @@ fn polkadot_testnet_genesis(
 		},
 		vesting: runtime::VestingConfig { vesting: vec![] },
 		sudo: runtime::SudoConfig { key: root_key },
-		configuration: runtime::ParachainsConfigurationConfig {
+		configuration: runtime::ConfigurationConfig {
 			config: polkadot_runtime_parachains::configuration::HostConfiguration {
 				validation_upgrade_frequency: 10u32,
 				validation_upgrade_delay: 5,

--- a/node/test/service/src/chain_spec.rs
+++ b/node/test/service/src/chain_spec.rs
@@ -174,7 +174,7 @@ fn polkadot_testnet_genesis(
 		},
 		vesting: runtime::VestingConfig { vesting: vec![] },
 		sudo: runtime::SudoConfig { key: root_key },
-		parachains_configuration: runtime::ParachainsConfigurationConfig {
+		configuration: runtime::ParachainsConfigurationConfig {
 			config: polkadot_runtime_parachains::configuration::HostConfiguration {
 				validation_upgrade_frequency: 10u32,
 				validation_upgrade_delay: 5,

--- a/runtime/parachains/src/configuration.rs
+++ b/runtime/parachains/src/configuration.rs
@@ -736,6 +736,18 @@ pub mod pallet {
 			Ok(())
 		}
 	}
+
+	#[pallet::hooks]
+	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+		fn integrity_test() {
+			assert_eq!(
+				&ActiveConfig::<T>::hashed_key(),
+				primitives::v1::well_known_keys::ACTIVE_CONFIG,
+				"`well_known_keys::ACTIVE_CONFIG` doesn't match key of `ActiveConfig`! Make sure that the name of the\
+				 configuration pallet is `Configuration` in the runtime!",
+			);
+		}
+	}
 }
 
 impl<T: Config> Pallet<T> {

--- a/runtime/test-runtime/src/lib.rs
+++ b/runtime/test-runtime/src/lib.rs
@@ -535,7 +535,7 @@ construct_runtime! {
 		Vesting: pallet_vesting::{Pallet, Call, Storage, Event<T>, Config<T>},
 
 		// Parachains runtime modules
-		ParachainsConfiguration: parachains_configuration::{Pallet, Call, Storage, Config<T>},
+		Configuration: parachains_configuration::{Pallet, Call, Storage, Config<T>},
 		ParaInclusion: parachains_inclusion::{Pallet, Call, Storage, Event<T>},
 		ParasInherent: parachains_paras_inherent::{Pallet, Call, Storage, Inherent},
 		Initializer: parachains_initializer::{Pallet, Call, Storage},


### PR DESCRIPTION
This is required to make the `well_know_keys::ACTIVE_CONFIG` match the
`ActiveConfig` key.