### PR TITLE
Remove unused type

### DIFF
--- a/runtime/common/src/paras_registrar.rs
+++ b/runtime/common/src/paras_registrar.rs
@@ -641,7 +641,6 @@ mod tests {
 	parameter_types! {
 		pub const ParaDeposit: Balance = 10;
 		pub const DataDepositPerByte: Balance = 1;
-		pub const QueueSize: usize = 2;
 		pub const MaxRetries: u32 = 3;
 	}
 

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -802,7 +802,6 @@ impl<C> frame_system::offchain::SendTransactionTypes<C> for Runtime where Call: 
 
 parameter_types! {
 	pub const ParathreadDeposit: Balance = 500 * DOLLARS;
-	pub const QueueSize: usize = 2;
 	pub const MaxRetries: u32 = 3;
 }
 

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -426,7 +426,6 @@ impl<C> frame_system::offchain::SendTransactionTypes<C> for Runtime where
 }
 
 parameter_types! {
-	pub const QueueSize: usize = 2;
 	pub const MaxRetries: u32 = 3;
 }
 


### PR DESCRIPTION
the type QueueSize probably comes from an old configuration requirement, it is now not used and without doc, I don't see any reason not to remove it.

thanks @ascjones to find it.