### PR TITLE
[CI] Fix listing pallets for benchmarks jobs

### DIFF
--- a/scripts/run_benches_for_runtime.sh
+++ b/scripts/run_benches_for_runtime.sh
@@ -11,7 +11,8 @@ echo "[+] Running all benchmarks for $runtime"
 
 # shellcheck disable=SC2086
 cargo +nightly run $standard_args benchmark \
-  --chain "${runtime}-dev" --list |\
+    --chain "${runtime}-dev" \
+    --list |\
   tail -n+2 |\
   cut -d',' -f1 |\
   uniq | \

--- a/scripts/run_benches_for_runtime.sh
+++ b/scripts/run_benches_for_runtime.sh
@@ -11,13 +11,9 @@ echo "[+] Running all benchmarks for $runtime"
 
 # shellcheck disable=SC2086
 cargo +nightly run $standard_args benchmark \
-    --chain "${runtime}-dev" \
-    --execution=wasm \
-    --wasm-execution=compiled \
-    --pallet "*" \
-    --extrinsic "*" \
-    --repeat 0 | \
-  sed -r -e 's/Pallet: "([a-z_:]+)".*/\1/' | \
+  --chain "${runtime}-dev" --list |\
+  tail -n+2 |\
+  cut -d',' -f1 |\
   uniq | \
   grep -v frame_system > "${runtime}_pallets"
 


### PR DESCRIPTION
Due to https://github.com/paritytech/substrate/pull/9373 we now have a `--list` flag for the benchmarks command, and the previous method no longer works, yielding an empty list.