### PR TITLE
Return `relay_parent` as result of collation seconded signal as well

### DIFF
--- a/node/network/collator-protocol/src/collator_side/mod.rs
+++ b/node/network/collator-protocol/src/collator_side/mod.rs
@@ -32,7 +32,7 @@ use polkadot_node_network_protocol::{
 	},
 	v1 as protocol_v1, OurView, PeerId, UnifiedReputationChange as Rep, View,
 };
-use polkadot_node_primitives::{PoV, Statement, CollationSecondedSignal};
+use polkadot_node_primitives::{CollationSecondedSignal, PoV, Statement};
 use polkadot_node_subsystem_util::{
 	metrics::{self, prometheus},
 	runtime::{get_availability_cores, get_group_rotation_info, RuntimeInfo},

--- a/node/network/collator-protocol/src/collator_side/mod.rs
+++ b/node/network/collator-protocol/src/collator_side/mod.rs
@@ -32,7 +32,7 @@ use polkadot_node_network_protocol::{
 	},
 	v1 as protocol_v1, OurView, PeerId, UnifiedReputationChange as Rep, View,
 };
-use polkadot_node_primitives::{PoV, SignedFullStatement, Statement};
+use polkadot_node_primitives::{PoV, Statement, CollationSecondedSignal};
 use polkadot_node_subsystem_util::{
 	metrics::{self, prometheus},
 	runtime::{get_availability_cores, get_group_rotation_info, RuntimeInfo},
@@ -266,7 +266,7 @@ struct State {
 	collations: HashMap<Hash, Collation>,
 
 	/// The result senders per collation.
-	collation_result_senders: HashMap<CandidateHash, oneshot::Sender<SignedFullStatement>>,
+	collation_result_senders: HashMap<CandidateHash, oneshot::Sender<CollationSecondedSignal>>,
 
 	/// Our validator groups per active leaf.
 	our_validators_groups: HashMap<Hash, ValidatorGroup>,
@@ -336,7 +336,7 @@ async fn distribute_collation<Context>(
 	id: ParaId,
 	receipt: CandidateReceipt,
 	pov: PoV,
-	result_sender: Option<oneshot::Sender<SignedFullStatement>>,
+	result_sender: Option<oneshot::Sender<CollationSecondedSignal>>,
 ) -> Result<()>
 where
 	Context: SubsystemContext<Message = CollatorProtocolMessage>,
@@ -866,7 +866,7 @@ where
 						?origin,
 						"received a `CollationSeconded`",
 					);
-					let _ = sender.send(statement);
+					let _ = sender.send(CollationSecondedSignal { statement, relay_parent });
 				}
 			}
 		},

--- a/node/primitives/src/lib.rs
+++ b/node/primitives/src/lib.rs
@@ -215,6 +215,17 @@ pub struct Collation<BlockNumber = polkadot_primitives::v1::BlockNumber> {
 	pub hrmp_watermark: BlockNumber,
 }
 
+/// Signal that is being returned back when a collation was seconded by a validator.
+#[derive(Debug)]
+pub struct CollationSecondedSignal {
+	/// The hash of the relay chain block that was used as context to sign [`Self::statement`].
+	pub relay_parent: Hash,
+	/// The statement about seconding the collation.
+	///
+	/// Anything else than [`Statement::Seconded`](Statement::Seconded) is forbidden here.
+	pub statement: SignedFullStatement,
+}
+
 /// Result of the [`CollatorFn`] invocation.
 pub struct CollationResult {
 	/// The collation that was build.
@@ -224,14 +235,14 @@ pub struct CollationResult {
 	/// There is no guarantee that this sender is informed ever about any result, it is completely okay to just drop it.
 	/// However, if it is called, it should be called with the signed statement of a parachain validator seconding the
 	/// collation.
-	pub result_sender: Option<futures::channel::oneshot::Sender<SignedFullStatement>>,
+	pub result_sender: Option<futures::channel::oneshot::Sender<CollationSecondedSignal>>,
 }
 
 impl CollationResult {
 	/// Convert into the inner values.
 	pub fn into_inner(
 		self,
-	) -> (Collation, Option<futures::channel::oneshot::Sender<SignedFullStatement>>) {
+	) -> (Collation, Option<futures::channel::oneshot::Sender<CollationSecondedSignal>>) {
 		(self.collation, self.result_sender)
 	}
 }

--- a/node/subsystem-types/src/messages.rs
+++ b/node/subsystem-types/src/messages.rs
@@ -35,8 +35,8 @@ use polkadot_node_network_protocol::{
 use polkadot_node_primitives::{
 	approval::{BlockApprovalMeta, IndirectAssignmentCert, IndirectSignedApprovalVote},
 	AvailableData, BabeEpoch, BlockWeight, CandidateVotes, CollationGenerationConfig,
-	DisputeMessage, ErasureChunk, PoV, SignedDisputeStatement, SignedFullStatement,
-	ValidationResult,
+	CollationSecondedSignal, DisputeMessage, ErasureChunk, PoV, SignedDisputeStatement,
+	SignedFullStatement, ValidationResult,
 };
 use polkadot_primitives::v1::{
 	AuthorityDiscoveryId, BackedCandidate, BlockNumber, CandidateDescriptor, CandidateEvent,
@@ -158,7 +158,7 @@ pub enum CollatorProtocolMessage {
 	///
 	/// The result sender should be informed when at least one parachain validator seconded the collation. It is also
 	/// completely okay to just drop the sender.
-	DistributeCollation(CandidateReceipt, PoV, Option<oneshot::Sender<SignedFullStatement>>),
+	DistributeCollation(CandidateReceipt, PoV, Option<oneshot::Sender<CollationSecondedSignal>>),
 	/// Report a collator as having provided an invalid collation. This should lead to disconnect
 	/// and blacklist of the collator.
 	ReportCollator(CollatorId),

--- a/roadmap/implementers-guide/src/types/overseer-protocol.md
+++ b/roadmap/implementers-guide/src/types/overseer-protocol.md
@@ -387,7 +387,7 @@ enum CollatorProtocolMessage {
     ///
     /// The result sender should be informed when at least one parachain validator seconded the collation. It is also
     /// completely okay to just drop the sender.
-    DistributeCollation(CandidateReceipt, PoV, Option<oneshot::Sender<SignedFullStatement>>),
+    DistributeCollation(CandidateReceipt, PoV, Option<oneshot::Sender<CollationSecondedSignal>>),
     /// Fetch a collation under the given relay-parent for the given ParaId.
     FetchCollation(Hash, ParaId, ResponseChannel<(CandidateReceipt, PoV)>),
     /// Report a collator as having provided an invalid collation. This should lead to disconnect


### PR DESCRIPTION
Before we only returned the seconded statement. However, to verify the
statement in a future proof way, we also need the relay parent that was
used as a context to sign the statement.