### PR TITLE
Avoid bad pattern of wildcard fees

### DIFF
--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -1380,6 +1380,7 @@ impl pallet_xcm::Config for Runtime {
 	type XcmTeleportFilter = All<(MultiLocation, Vec<MultiAsset>)>;
 	type XcmReserveTransferFilter = All<(MultiLocation, Vec<MultiAsset>)>;
 	type Weigher = FixedWeightBounds<BaseXcmWeight, Call>;
+	type LocationInverter = LocationInverter<Ancestry>;
 }
 
 parameter_types! {

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -755,6 +755,7 @@ impl pallet_xcm::Config for Runtime {
 	type XcmTeleportFilter = All<(MultiLocation, Vec<MultiAsset>)>;
 	type XcmReserveTransferFilter = All<(MultiLocation, Vec<MultiAsset>)>;
 	type Weigher = FixedWeightBounds<BaseXcmWeight, Call>;
+	type LocationInverter = LocationInverter<Ancestry>;
 }
 
 impl parachains_session_info::Config for Runtime {}

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -1012,6 +1012,7 @@ impl pallet_xcm::Config for Runtime {
 	type XcmTeleportFilter = All<(MultiLocation, Vec<MultiAsset>)>;
 	type XcmReserveTransferFilter = All<(MultiLocation, Vec<MultiAsset>)>;
 	type Weigher = FixedWeightBounds<BaseXcmWeight, Call>;
+	type LocationInverter = LocationInverter<Ancestry>;
 }
 
 construct_runtime! {

--- a/xcm/pallet-xcm/src/lib.rs
+++ b/xcm/pallet-xcm/src/lib.rs
@@ -122,6 +122,8 @@ pub mod pallet {
 
 		/// Teleport some assets from the local chain to some destination chain.
 		///
+		/// Fee payment on the destination side is made from the first asset listed in the `assets` vector.
+		///
 		/// - `origin`: Must be capable of withdrawing the `assets` and executing XCM.
 		/// - `dest`: Destination context for the assets. Will typically be `X2(Parent, Parachain(..))` to send
 		///   from parachain to parachain, or `X1(Parachain(..))` to send from relay to parachain.
@@ -188,6 +190,8 @@ pub mod pallet {
 
 		/// Transfer some assets from the local chain to the sovereign account of a destination chain and forward
 		/// a notification XCM.
+		///
+		/// Fee payment on the destination side is made from the first asset listed in the `assets` vector.
 		///
 		/// - `origin`: Must be capable of withdrawing the `assets` and executing XCM.
 		/// - `dest`: Destination context for the assets. Will typically be `X2(Parent, Parachain(..))` to send

--- a/xcm/pallet-xcm/src/lib.rs
+++ b/xcm/pallet-xcm/src/lib.rs
@@ -156,12 +156,8 @@ pub mod pallet {
 			ensure!(T::XcmTeleportFilter::contains(&value), Error::<T>::Filtered);
 			let (origin_location, assets) = value;
 			let inv_dest = T::LocationInverter::invert_location(&dest);
-			let mut fees = assets
-				.first()
-				.ok_or(Error::<T>::Empty)?
-				.clone();
-			fees.reanchor(&inv_dest)
-				.map_err(|_| Error::<T>::CannotReanchor)?;
+			let mut fees = assets.first().ok_or(Error::<T>::Empty)?.clone();
+			fees.reanchor(&inv_dest).map_err(|_| Error::<T>::CannotReanchor)?;
 			let mut message = Xcm::WithdrawAsset {
 				assets,
 				effects: vec![InitiateTeleport {
@@ -222,12 +218,8 @@ pub mod pallet {
 			ensure!(T::XcmReserveTransferFilter::contains(&value), Error::<T>::Filtered);
 			let (origin_location, assets) = value;
 			let inv_dest = T::LocationInverter::invert_location(&dest);
-			let mut fees = assets
-				.first()
-				.ok_or(Error::<T>::Empty)?
-				.clone();
-			fees.reanchor(&inv_dest)
-				.map_err(|_| Error::<T>::CannotReanchor)?;
+			let mut fees = assets.first().ok_or(Error::<T>::Empty)?.clone();
+			fees.reanchor(&inv_dest).map_err(|_| Error::<T>::CannotReanchor)?;
 			let mut message = Xcm::TransferReserveAsset {
 				assets,
 				dest,

--- a/xcm/pallet-xcm/src/mock.rs
+++ b/xcm/pallet-xcm/src/mock.rs
@@ -186,6 +186,7 @@ impl pallet_xcm::Config for Test {
 	type XcmTeleportFilter = All<(MultiLocation, Vec<MultiAsset>)>;
 	type XcmReserveTransferFilter = All<(MultiLocation, Vec<MultiAsset>)>;
 	type Weigher = FixedWeightBounds<BaseXcmWeight, Call>;
+	type LocationInverter = LocationInverter<Ancestry>;
 }
 
 impl origin::Config for Test {}
@@ -194,9 +195,9 @@ pub(crate) fn last_event() -> Event {
 	System::events().pop().expect("Event expected").event
 }
 
-pub(crate) fn buy_execution<C>(debt: Weight) -> Order<C> {
+pub(crate) fn buy_execution<C>(debt: Weight, fees: MultiAsset) -> Order<C> {
 	use xcm::opaque::v0::prelude::*;
-	Order::BuyExecution { fees: All, weight: 0, debt, halt_on_error: false, xcm: vec![] }
+	Order::BuyExecution { fees, weight: 0, debt, halt_on_error: false, xcm: vec![] }
 }
 
 pub(crate) fn new_test_ext_with_balances(

--- a/xcm/pallet-xcm/src/tests.rs
+++ b/xcm/pallet-xcm/src/tests.rs
@@ -42,7 +42,10 @@ fn send_works() {
 		let message = Xcm::ReserveAssetDeposit {
 			assets: vec![ConcreteFungible { id: Parent.into(), amount: SEND_AMOUNT }],
 			effects: vec![
-				buy_execution(weight, ConcreteFungible { id: MultiLocation::Null, amount: SEND_AMOUNT }),
+				buy_execution(
+					weight,
+					ConcreteFungible { id: MultiLocation::Null, amount: SEND_AMOUNT },
+				),
 				DepositAsset { assets: vec![All], dest: sender.clone() },
 			],
 		};
@@ -76,7 +79,10 @@ fn send_fails_when_xcm_router_blocks() {
 		let message = Xcm::ReserveAssetDeposit {
 			assets: vec![ConcreteFungible { id: Parent.into(), amount: SEND_AMOUNT }],
 			effects: vec![
-				buy_execution(weight, ConcreteFungible { id: MultiLocation::Null, amount: SEND_AMOUNT }),
+				buy_execution(
+					weight,
+					ConcreteFungible { id: MultiLocation::Null, amount: SEND_AMOUNT },
+				),
 				DepositAsset { assets: vec![All], dest: sender.clone() },
 			],
 		};
@@ -158,7 +164,10 @@ fn reserve_transfer_assets_works() {
 				Xcm::ReserveAssetDeposit {
 					assets: vec![ConcreteFungible { id: Parent.into(), amount: SEND_AMOUNT }],
 					effects: vec![
-						buy_execution(weight, ConcreteFungible { id: Parent.into(), amount: SEND_AMOUNT }),
+						buy_execution(
+							weight,
+							ConcreteFungible { id: Parent.into(), amount: SEND_AMOUNT }
+						),
 						DepositAsset { assets: vec![All], dest },
 					]
 				}
@@ -189,7 +198,10 @@ fn execute_withdraw_to_deposit_works() {
 			Box::new(Xcm::WithdrawAsset {
 				assets: vec![ConcreteFungible { id: MultiLocation::Null, amount: SEND_AMOUNT }],
 				effects: vec![
-					buy_execution(weight, ConcreteFungible { id: MultiLocation::Null, amount: SEND_AMOUNT }),
+					buy_execution(
+						weight,
+						ConcreteFungible { id: MultiLocation::Null, amount: SEND_AMOUNT }
+					),
 					DepositAsset { assets: vec![All], dest },
 				],
 			}),

--- a/xcm/pallet-xcm/src/tests.rs
+++ b/xcm/pallet-xcm/src/tests.rs
@@ -42,7 +42,7 @@ fn send_works() {
 		let message = Xcm::ReserveAssetDeposit {
 			assets: vec![ConcreteFungible { id: Parent.into(), amount: SEND_AMOUNT }],
 			effects: vec![
-				buy_execution(weight),
+				buy_execution(weight, ConcreteFungible { id: MultiLocation::Null, amount: SEND_AMOUNT }),
 				DepositAsset { assets: vec![All], dest: sender.clone() },
 			],
 		};
@@ -76,7 +76,7 @@ fn send_fails_when_xcm_router_blocks() {
 		let message = Xcm::ReserveAssetDeposit {
 			assets: vec![ConcreteFungible { id: Parent.into(), amount: SEND_AMOUNT }],
 			effects: vec![
-				buy_execution(weight),
+				buy_execution(weight, ConcreteFungible { id: MultiLocation::Null, amount: SEND_AMOUNT }),
 				DepositAsset { assets: vec![All], dest: sender.clone() },
 			],
 		};
@@ -157,7 +157,10 @@ fn reserve_transfer_assets_works() {
 				Parachain(PARA_ID).into(),
 				Xcm::ReserveAssetDeposit {
 					assets: vec![ConcreteFungible { id: Parent.into(), amount: SEND_AMOUNT }],
-					effects: vec![buy_execution(weight), DepositAsset { assets: vec![All], dest },]
+					effects: vec![
+						buy_execution(weight, ConcreteFungible { id: Parent.into(), amount: SEND_AMOUNT }),
+						DepositAsset { assets: vec![All], dest },
+					]
 				}
 			)]
 		);
@@ -185,7 +188,10 @@ fn execute_withdraw_to_deposit_works() {
 			Origin::signed(ALICE),
 			Box::new(Xcm::WithdrawAsset {
 				assets: vec![ConcreteFungible { id: MultiLocation::Null, amount: SEND_AMOUNT }],
-				effects: vec![buy_execution(weight), DepositAsset { assets: vec![All], dest }],
+				effects: vec![
+					buy_execution(weight, ConcreteFungible { id: MultiLocation::Null, amount: SEND_AMOUNT }),
+					DepositAsset { assets: vec![All], dest },
+				],
 			}),
 			weight
 		));

--- a/xcm/xcm-simulator/example/src/parachain.rs
+++ b/xcm/xcm-simulator/example/src/parachain.rs
@@ -187,7 +187,7 @@ pub mod mock_msg_queue {
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]
 	pub enum Event<T: Config> {
 		// XCMP
-		/// Some XCM was executed ok.
+		/// Some XCM was executed OK.
 		Success(Option<T::Hash>),
 		/// Some XCM failed.
 		Fail(Option<T::Hash>, XcmError),

--- a/xcm/xcm-simulator/example/src/parachain.rs
+++ b/xcm/xcm-simulator/example/src/parachain.rs
@@ -302,6 +302,7 @@ impl pallet_xcm::Config for Runtime {
 	type XcmTeleportFilter = ();
 	type XcmReserveTransferFilter = All<(MultiLocation, Vec<MultiAsset>)>;
 	type Weigher = FixedWeightBounds<UnitWeightCost, Call>;
+	type LocationInverter = LocationInverter<Ancestry>;
 }
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;

--- a/xcm/xcm-simulator/example/src/relay_chain.rs
+++ b/xcm/xcm-simulator/example/src/relay_chain.rs
@@ -148,6 +148,7 @@ impl pallet_xcm::Config for Runtime {
 	type XcmTeleportFilter = All<(MultiLocation, Vec<MultiAsset>)>;
 	type XcmReserveTransferFilter = All<(MultiLocation, Vec<MultiAsset>)>;
 	type Weigher = FixedWeightBounds<BaseXcmWeight, Call>;
+	type LocationInverter = LocationInverter<Ancestry>;
 }
 
 parameter_types! {


### PR DESCRIPTION
Alters the two XCM dispatchables so that the `BuyExecution` uses the first Asset in the list to purchase fees, rather than `MultiAsset::All`, which is not a pattern that will be supported in the upcoming XCM v1.

## Migration

`pallet_xcm::Config` has an extra item `type LocationInverter`. This should be the same definition as declared in the `xcm_executor::Config`, typically:

```
type LocationInverter = LocationInverter<Ancestry>;
```