### PR TITLE
Chore: Mass replace `,);` pattern

### DIFF
--- a/bridges/modules/currency-exchange/src/lib.rs
+++ b/bridges/modules/currency-exchange/src/lib.rs
@@ -470,7 +470,7 @@ mod tests {
 			assert_ok!(Exchange::import_peer_transaction(
 				Origin::signed(SUBMITTER),
 				(true, transaction),
-			),);
+			));
 
 			// ensure that the transfer has been marked as completed
 			assert!(<Exchange as crate::Store>::Transfers::contains_key(0u64));
@@ -485,7 +485,7 @@ mod tests {
 			assert_ok!(Exchange::import_peer_transaction(
 				Origin::signed(SUBMITTER),
 				(true, transaction(0)),
-			),);
+			));
 
 			// ensure that the transfer has been marked as completed
 			assert!(<Exchange as crate::Store>::Transfers::contains_key(0u64));

--- a/bridges/modules/ethereum/src/import.rs
+++ b/bridges/modules/ethereum/src/import.rs
@@ -336,7 +336,7 @@ mod tests {
 				Some(vec![validators_change_receipt(latest_block_id.hash)]),
 			)
 			.unwrap();
-			assert_eq!(finalized_blocks, vec![(parent_id, Some(100))],);
+			assert_eq!(finalized_blocks, vec![(parent_id, Some(100))]);
 			assert!(storage.header(&ctx.genesis.compute_hash()).is_none());
 			latest_block_id = rolling_last_block_id;
 
@@ -362,7 +362,7 @@ mod tests {
 					None,
 				)
 				.unwrap();
-				assert_eq!(finalized_blocks, vec![],);
+				assert_eq!(finalized_blocks, vec![]);
 				latest_block_id = rolling_last_block_id;
 				step += 3;
 			}

--- a/bridges/modules/ethereum/src/lib.rs
+++ b/bridges/modules/ethereum/src/lib.rs
@@ -1415,7 +1415,7 @@ pub(crate) mod tests {
 				example_header().compute_hash(),
 				1,
 				&[],
-			),);
+			));
 		});
 	}
 

--- a/bridges/modules/ethereum/src/validators.rs
+++ b/bridges/modules/ethereum/src/validators.rs
@@ -359,7 +359,7 @@ pub(crate) mod tests {
 
 		// when we're inside list range
 		header.number = 150;
-		assert_eq!(validators.extract_validators_change(&header, None), Ok((None, None)),);
+		assert_eq!(validators.extract_validators_change(&header, None), Ok((None, None)));
 
 		// when we're at the block that switches to contract source
 		header.number = 200;
@@ -459,7 +459,7 @@ pub(crate) mod tests {
 
 	#[test]
 	fn finalize_validators_change_does_not_finalize_when_changes_are_not_scheduled() {
-		assert_eq!(try_finalize_with_scheduled_change(None), None,);
+		assert_eq!(try_finalize_with_scheduled_change(None), None);
 	}
 
 	#[test]
@@ -468,6 +468,6 @@ pub(crate) mod tests {
 			number: 5,
 			..Default::default()
 		};
-		assert_eq!(try_finalize_with_scheduled_change(Some(id5)), None,);
+		assert_eq!(try_finalize_with_scheduled_change(Some(id5)), None);
 	}
 }

--- a/bridges/modules/grandpa/src/lib.rs
+++ b/bridges/modules/grandpa/src/lib.rs
@@ -777,7 +777,7 @@ mod tests {
 		run_test(|| {
 			<IsHalted<TestRuntime>>::put(true);
 
-			assert_noop!(submit_finality_proof(1), Error::<TestRuntime>::Halted,);
+			assert_noop!(submit_finality_proof(1), Error::<TestRuntime>::Halted);
 		})
 	}
 

--- a/bridges/modules/messages/src/lib.rs
+++ b/bridges/modules/messages/src/lib.rs
@@ -1301,7 +1301,7 @@ mod tests {
 				Ok(vec![message(1, REGULAR_PAYLOAD)]).into(),
 				1,
 				REGULAR_PAYLOAD.declared_weight,
-			),);
+			));
 
 			assert_ok!(Pallet::<TestRuntime>::receive_messages_delivery_proof(
 				Origin::signed(1),
@@ -1660,7 +1660,7 @@ mod tests {
 				Ok(vec![invalid_message]).into(),
 				1,
 				0, // weight may be zero in this case (all messages are improperly encoded)
-			),);
+			));
 
 			assert_eq!(
 				InboundLanes::<TestRuntime>::get(&TEST_LANE_ID).last_delivered_nonce(),
@@ -1686,7 +1686,7 @@ mod tests {
 				.into(),
 				3,
 				REGULAR_PAYLOAD.declared_weight + REGULAR_PAYLOAD.declared_weight,
-			),);
+			));
 
 			assert_eq!(
 				InboundLanes::<TestRuntime>::get(&TEST_LANE_ID).last_delivered_nonce(),
@@ -1802,7 +1802,7 @@ mod tests {
 				TEST_LANE_ID,
 				1,
 				100,
-			),);
+			));
 			assert!(TestMessageDeliveryAndDispatchPayment::is_fee_paid(1, 100));
 		});
 	}

--- a/bridges/modules/shift-session-manager/src/lib.rs
+++ b/bridges/modules/shift-session-manager/src/lib.rs
@@ -210,19 +210,19 @@ mod tests {
 			let all_accs = vec![1, 2, 3, 4, 5];
 
 			// at least 1 validator is selected
-			assert_eq!(Pallet::<TestRuntime>::select_validators(0, &[1]), vec![1],);
+			assert_eq!(Pallet::<TestRuntime>::select_validators(0, &[1]), vec![1]);
 
 			// at session#0, shift is also 0
-			assert_eq!(Pallet::<TestRuntime>::select_validators(0, &all_accs), vec![1, 2, 3],);
+			assert_eq!(Pallet::<TestRuntime>::select_validators(0, &all_accs), vec![1, 2, 3]);
 
 			// at session#1, shift is also 1
-			assert_eq!(Pallet::<TestRuntime>::select_validators(1, &all_accs), vec![2, 3, 4],);
+			assert_eq!(Pallet::<TestRuntime>::select_validators(1, &all_accs), vec![2, 3, 4]);
 
 			// at session#3, we're wrapping
-			assert_eq!(Pallet::<TestRuntime>::select_validators(3, &all_accs), vec![4, 5, 1],);
+			assert_eq!(Pallet::<TestRuntime>::select_validators(3, &all_accs), vec![4, 5, 1]);
 
 			// at session#5, we're starting from the beginning again
-			assert_eq!(Pallet::<TestRuntime>::select_validators(5, &all_accs), vec![1, 2, 3],);
+			assert_eq!(Pallet::<TestRuntime>::select_validators(5, &all_accs), vec![1, 2, 3]);
 		});
 	}
 }

--- a/bridges/primitives/ethereum-poa/src/lib.rs
+++ b/bridges/primitives/ethereum-poa/src/lib.rs
@@ -729,6 +729,6 @@ mod tests {
 		stream.append(&2u64);
 		stream.append(&3u64);
 
-		assert_eq!(Receipt::is_successful_raw_receipt(&stream.out()), Ok(false),);
+		assert_eq!(Receipt::is_successful_raw_receipt(&stream.out()), Ok(false));
 	}
 }

--- a/bridges/relays/bin-ethereum/src/ethereum_client.rs
+++ b/bridges/relays/bin-ethereum/src/ethereum_client.rs
@@ -431,7 +431,7 @@ async fn submit_substrate_headers_batch(
 	mut ids: Vec<RialtoHeaderId>,
 	mut headers: HeadersBatch,
 ) -> Option<RpcError> {
-	debug_assert_eq!(ids.len(), headers.len(),);
+	debug_assert_eq!(ids.len(), headers.len());
 
 	// if parent of first header is either incomplete, or rejected, we assume that contract
 	// will reject this header as well

--- a/bridges/relays/exchange/src/exchange.rs
+++ b/bridges/relays/exchange/src/exchange.rs
@@ -680,7 +680,7 @@ pub(crate) mod tests {
 			&target,
 			test_transaction_hash(0),
 		))
-		.is_err(),);
+		.is_err());
 		assert!(target.data.lock().submitted_proofs.is_empty());
 	}
 
@@ -861,7 +861,7 @@ pub(crate) mod tests {
 				failed: 1,
 			}),
 		);
-		assert_eq!(target.data.lock().submitted_proofs, vec![],);
+		assert_eq!(target.data.lock().submitted_proofs, vec![]);
 	}
 
 	#[test]

--- a/bridges/relays/finality/src/finality_loop_tests.rs
+++ b/bridges/relays/finality/src/finality_loop_tests.rs
@@ -456,25 +456,25 @@ fn prune_recent_finality_proofs_works() {
 	// when there's proof for justified header in the vec
 	let mut recent_finality_proofs = original_recent_finality_proofs.clone();
 	prune_recent_finality_proofs::<TestFinalitySyncPipeline>(10, &mut recent_finality_proofs, 1024);
-	assert_eq!(&original_recent_finality_proofs[1..], recent_finality_proofs,);
+	assert_eq!(&original_recent_finality_proofs[1..], recent_finality_proofs);
 
 	// when there are no proof for justified header in the vec
 	let mut recent_finality_proofs = original_recent_finality_proofs.clone();
 	prune_recent_finality_proofs::<TestFinalitySyncPipeline>(11, &mut recent_finality_proofs, 1024);
-	assert_eq!(&original_recent_finality_proofs[1..], recent_finality_proofs,);
+	assert_eq!(&original_recent_finality_proofs[1..], recent_finality_proofs);
 
 	// when there are too many entries after initial prune && they also need to be pruned
 	let mut recent_finality_proofs = original_recent_finality_proofs.clone();
 	prune_recent_finality_proofs::<TestFinalitySyncPipeline>(10, &mut recent_finality_proofs, 2);
-	assert_eq!(&original_recent_finality_proofs[3..], recent_finality_proofs,);
+	assert_eq!(&original_recent_finality_proofs[3..], recent_finality_proofs);
 
 	// when last entry is pruned
 	let mut recent_finality_proofs = original_recent_finality_proofs.clone();
 	prune_recent_finality_proofs::<TestFinalitySyncPipeline>(19, &mut recent_finality_proofs, 2);
-	assert_eq!(&original_recent_finality_proofs[5..], recent_finality_proofs,);
+	assert_eq!(&original_recent_finality_proofs[5..], recent_finality_proofs);
 
 	// when post-last entry is pruned
 	let mut recent_finality_proofs = original_recent_finality_proofs.clone();
 	prune_recent_finality_proofs::<TestFinalitySyncPipeline>(20, &mut recent_finality_proofs, 2);
-	assert_eq!(&original_recent_finality_proofs[5..], recent_finality_proofs,);
+	assert_eq!(&original_recent_finality_proofs[5..], recent_finality_proofs);
 }

--- a/bridges/relays/headers/src/sync_loop_tests.rs
+++ b/bridges/relays/headers/src/sync_loop_tests.rs
@@ -374,7 +374,7 @@ fn source_reject_extra(method: &SourceMethod) {
 
 fn target_accept_all_headers(method: &TargetMethod, data: &mut TargetData, requires_extra: bool) {
 	if let TargetMethod::SubmitHeaders(ref submitted) = method {
-		assert_eq!(submitted.iter().all(|header| header.extra().is_some()), requires_extra,);
+		assert_eq!(submitted.iter().all(|header| header.extra().is_some()), requires_extra);
 
 		data.submit_headers_result = Some(SubmittedHeaders {
 			submitted: submitted.iter().map(|header| header.id()).collect(),

--- a/bridges/relays/messages/src/message_lane_loop.rs
+++ b/bridges/relays/messages/src/message_lane_loop.rs
@@ -872,7 +872,7 @@ pub(crate) mod tests {
 			exit_receiver.into_future().map(|(_, _)| ()),
 		);
 
-		assert_eq!(result.submitted_messages_proofs, vec![(1..=1, None)],);
+		assert_eq!(result.submitted_messages_proofs, vec![(1..=1, None)]);
 	}
 
 	#[test]

--- a/bridges/relays/messages/src/message_race_strategy.rs
+++ b/bridges/relays/messages/src/message_race_strategy.rs
@@ -483,12 +483,12 @@ mod tests {
 		);
 
 		strategy.remove_le_nonces_from_source_queue(5);
-		assert_eq!(source_queue_nonces(&strategy.source_queue), vec![6, 7, 8, 9],);
+		assert_eq!(source_queue_nonces(&strategy.source_queue), vec![6, 7, 8, 9]);
 
 		strategy.remove_le_nonces_from_source_queue(9);
-		assert_eq!(source_queue_nonces(&strategy.source_queue), Vec::<MessageNonce>::new(),);
+		assert_eq!(source_queue_nonces(&strategy.source_queue), Vec::<MessageNonce>::new());
 
 		strategy.remove_le_nonces_from_source_queue(100);
-		assert_eq!(source_queue_nonces(&strategy.source_queue), Vec::<MessageNonce>::new(),);
+		assert_eq!(source_queue_nonces(&strategy.source_queue), Vec::<MessageNonce>::new());
 	}
 }

--- a/node/core/approval-voting/src/approval_db/v1/tests.rs
+++ b/node/core/approval-voting/src/approval_db/v1/tests.rs
@@ -524,7 +524,7 @@ fn force_approve_works() {
 		.unwrap()
 		.approved_bitfield
 		.not_any());
-	assert_eq!(approved_hashes, vec![block_hash_b, block_hash_a],);
+	assert_eq!(approved_hashes, vec![block_hash_b, block_hash_a]);
 }
 
 #[test]

--- a/node/core/approval-voting/src/import.rs
+++ b/node/core/approval-voting/src/import.rs
@@ -502,7 +502,7 @@ pub(crate) async fn handle_new_head(
 		};
 
 		if let Some(up_to) = force_approve {
-			tracing::debug!(target: LOG_TARGET, ?block_hash, up_to, "Enacting force-approve",);
+			tracing::debug!(target: LOG_TARGET, ?block_hash, up_to, "Enacting force-approve");
 
 			let approved_hashes = crate::ops::force_approve(db, block_hash, up_to)
 				.map_err(|e| SubsystemError::with_origin("approval-voting", e))?;

--- a/node/core/approval-voting/src/lib.rs
+++ b/node/core/approval-voting/src/lib.rs
@@ -961,7 +961,7 @@ fn distribution_messages_for_activation(
 		let block_entry = match db.load_block_entry(&block_hash)? {
 			Some(b) => b,
 			None => {
-				tracing::warn!(target: LOG_TARGET, ?block_hash, "Missing block entry",);
+				tracing::warn!(target: LOG_TARGET, ?block_hash, "Missing block entry");
 
 				continue
 			},
@@ -2223,7 +2223,7 @@ async fn launch_approval(
 				// Validation checked out. Issue an approval command. If the underlying service is unreachable,
 				// then there isn't anything we can do.
 
-				tracing::trace!(target: LOG_TARGET, ?candidate_hash, ?para_id, "Candidate Valid",);
+				tracing::trace!(target: LOG_TARGET, ?candidate_hash, ?para_id, "Candidate Valid");
 
 				let expected_commitments_hash = candidate.commitments_hash;
 				if commitments.hash() == expected_commitments_hash {

--- a/node/core/av-store/src/lib.rs
+++ b/node/core/av-store/src/lib.rs
@@ -707,7 +707,7 @@ fn note_block_backed(
 ) -> Result<(), Error> {
 	let candidate_hash = candidate.hash();
 
-	tracing::debug!(target: LOG_TARGET, ?candidate_hash, "Candidate backed",);
+	tracing::debug!(target: LOG_TARGET, ?candidate_hash, "Candidate backed");
 
 	if load_meta(db, config, &candidate_hash)?.is_none() {
 		let meta = CandidateMeta {
@@ -748,7 +748,7 @@ fn note_block_included(
 		Some(mut meta) => {
 			let be_block = (BEBlockNumber(block.0), block.1);
 
-			tracing::debug!(target: LOG_TARGET, ?candidate_hash, "Candidate included",);
+			tracing::debug!(target: LOG_TARGET, ?candidate_hash, "Candidate included");
 
 			meta.state = match meta.state {
 				State::Unavailable(at) => {
@@ -1194,7 +1194,7 @@ fn store_available_data(
 
 	subsystem.db.write(tx)?;
 
-	tracing::debug!(target: LOG_TARGET, ?candidate_hash, "Stored data and chunks",);
+	tracing::debug!(target: LOG_TARGET, ?candidate_hash, "Stored data and chunks");
 
 	Ok(())
 }

--- a/node/core/av-store/src/tests.rs
+++ b/node/core/av-store/src/tests.rs
@@ -720,7 +720,7 @@ fn stored_data_kept_until_finalized() {
 		test_state.wait_for_pruning().await;
 
 		// At this point data should be gone from the store.
-		assert!(query_available_data(&mut virtual_overseer, candidate_hash).await.is_none(),);
+		assert!(query_available_data(&mut virtual_overseer, candidate_hash).await.is_none());
 
 		assert!(has_all_chunks(&mut virtual_overseer, candidate_hash, n_validators, false).await);
 		virtual_overseer
@@ -964,9 +964,9 @@ fn forkfullness_works() {
 			available_data_2,
 		);
 
-		assert!(has_all_chunks(&mut virtual_overseer, candidate_1_hash, n_validators, true).await,);
+		assert!(has_all_chunks(&mut virtual_overseer, candidate_1_hash, n_validators, true).await);
 
-		assert!(has_all_chunks(&mut virtual_overseer, candidate_2_hash, n_validators, true).await,);
+		assert!(has_all_chunks(&mut virtual_overseer, candidate_2_hash, n_validators, true).await);
 
 		// Candidate 2 should now be considered unavailable and will be pruned.
 		test_state.clock.inc(test_state.pruning_config.keep_unavailable_for);
@@ -977,24 +977,24 @@ fn forkfullness_works() {
 			available_data_1,
 		);
 
-		assert!(query_available_data(&mut virtual_overseer, candidate_2_hash).await.is_none(),);
+		assert!(query_available_data(&mut virtual_overseer, candidate_2_hash).await.is_none());
 
-		assert!(has_all_chunks(&mut virtual_overseer, candidate_1_hash, n_validators, true).await,);
+		assert!(has_all_chunks(&mut virtual_overseer, candidate_1_hash, n_validators, true).await);
 
-		assert!(has_all_chunks(&mut virtual_overseer, candidate_2_hash, n_validators, false).await,);
+		assert!(has_all_chunks(&mut virtual_overseer, candidate_2_hash, n_validators, false).await);
 
 		// Wait for longer than finalized blocks should be kept for
 		test_state.clock.inc(test_state.pruning_config.keep_finalized_for);
 		test_state.wait_for_pruning().await;
 
 		// Everything should be pruned now.
-		assert!(query_available_data(&mut virtual_overseer, candidate_1_hash).await.is_none(),);
+		assert!(query_available_data(&mut virtual_overseer, candidate_1_hash).await.is_none());
 
-		assert!(query_available_data(&mut virtual_overseer, candidate_2_hash).await.is_none(),);
+		assert!(query_available_data(&mut virtual_overseer, candidate_2_hash).await.is_none());
 
-		assert!(has_all_chunks(&mut virtual_overseer, candidate_1_hash, n_validators, false).await,);
+		assert!(has_all_chunks(&mut virtual_overseer, candidate_1_hash, n_validators, false).await);
 
-		assert!(has_all_chunks(&mut virtual_overseer, candidate_2_hash, n_validators, false).await,);
+		assert!(has_all_chunks(&mut virtual_overseer, candidate_2_hash, n_validators, false).await);
 		virtual_overseer
 	});
 }

--- a/node/core/chain-selection/src/db_backend/v1.rs
+++ b/node/core/chain-selection/src/db_backend/v1.rs
@@ -481,7 +481,7 @@ mod tests {
 			.write(vec![BackendWriteOp::DeleteBlockEntry(block_entry.block_hash)])
 			.unwrap();
 
-		assert!(backend.load_block_entry(&block_entry.block_hash).unwrap().is_none(),);
+		assert!(backend.load_block_entry(&block_entry.block_hash).unwrap().is_none());
 	}
 
 	#[test]
@@ -491,7 +491,7 @@ mod tests {
 
 		let mut backend = DbBackend::new(db, config);
 
-		assert!(backend.load_first_block_number().unwrap().is_none(),);
+		assert!(backend.load_first_block_number().unwrap().is_none());
 
 		backend
 			.write(vec![
@@ -501,7 +501,7 @@ mod tests {
 			])
 			.unwrap();
 
-		assert_eq!(backend.load_first_block_number().unwrap(), Some(2),);
+		assert_eq!(backend.load_first_block_number().unwrap(), Some(2));
 
 		backend
 			.write(vec![
@@ -510,7 +510,7 @@ mod tests {
 			])
 			.unwrap();
 
-		assert_eq!(backend.load_first_block_number().unwrap(), Some(10),);
+		assert_eq!(backend.load_first_block_number().unwrap(), Some(10));
 	}
 
 	#[test]
@@ -521,7 +521,7 @@ mod tests {
 		let mut backend = DbBackend::new(db, config);
 
 		// Prove that it's cheap
-		assert!(backend.load_stagnant_at_up_to(Timestamp::max_value()).unwrap().is_empty(),);
+		assert!(backend.load_stagnant_at_up_to(Timestamp::max_value()).unwrap().is_empty());
 
 		backend
 			.write(vec![
@@ -584,9 +584,9 @@ mod tests {
 			])
 			.unwrap();
 
-		assert_eq!(backend.load_blocks_by_number(2).unwrap(), vec![Hash::repeat_byte(1)],);
+		assert_eq!(backend.load_blocks_by_number(2).unwrap(), vec![Hash::repeat_byte(1)]);
 
-		assert_eq!(backend.load_blocks_by_number(3).unwrap(), vec![],);
+		assert_eq!(backend.load_blocks_by_number(3).unwrap(), vec![]);
 
 		backend
 			.write(vec![
@@ -595,10 +595,10 @@ mod tests {
 			])
 			.unwrap();
 
-		assert_eq!(backend.load_blocks_by_number(2).unwrap(), vec![],);
+		assert_eq!(backend.load_blocks_by_number(2).unwrap(), vec![]);
 
-		assert_eq!(backend.load_blocks_by_number(5).unwrap(), vec![],);
+		assert_eq!(backend.load_blocks_by_number(5).unwrap(), vec![]);
 
-		assert_eq!(backend.load_blocks_by_number(10).unwrap(), vec![Hash::repeat_byte(3)],);
+		assert_eq!(backend.load_blocks_by_number(10).unwrap(), vec![Hash::repeat_byte(3)]);
 	}
 }

--- a/node/core/chain-selection/src/lib.rs
+++ b/node/core/chain-selection/src/lib.rs
@@ -497,7 +497,7 @@ async fn handle_active_leaf(
 
 	let header = match fetch_header(ctx, hash).await? {
 		None => {
-			tracing::warn!(target: LOG_TARGET, ?hash, "Missing header for new head",);
+			tracing::warn!(target: LOG_TARGET, ?hash, "Missing header for new head");
 			return Ok(Vec::new())
 		},
 		Some(h) => h,

--- a/node/core/chain-selection/src/tests.rs
+++ b/node/core/chain-selection/src/tests.rs
@@ -551,7 +551,7 @@ fn assert_backend_contains<'a>(
 			header.number,
 			hash,
 		);
-		assert!(backend.load_block_entry(&hash).unwrap().is_some(), "no entry found for {}", hash,);
+		assert!(backend.load_block_entry(&hash).unwrap().is_some(), "no entry found for {}", hash);
 	}
 }
 
@@ -1138,9 +1138,9 @@ fn finalize_viable_prunes_subtrees() {
 		assert_leaves(&backend, vec![a3_hash, x3_hash]);
 		assert_leaves_query(&mut virtual_overseer, vec![a3_hash, x3_hash]).await;
 
-		assert_eq!(backend.load_first_block_number().unwrap().unwrap(), 3,);
+		assert_eq!(backend.load_first_block_number().unwrap().unwrap(), 3);
 
-		assert_eq!(backend.load_blocks_by_number(3).unwrap(), vec![a3_hash, x3_hash],);
+		assert_eq!(backend.load_blocks_by_number(3).unwrap(), vec![a3_hash, x3_hash]);
 
 		virtual_overseer
 	});

--- a/node/core/dispute-coordinator/src/db/v1.rs
+++ b/node/core/dispute-coordinator/src/db/v1.rs
@@ -304,7 +304,7 @@ mod tests {
 		);
 
 		// Test that overlay returns the correct values before committing.
-		assert_eq!(overlay_db.load_earliest_session().unwrap().unwrap(), 1,);
+		assert_eq!(overlay_db.load_earliest_session().unwrap().unwrap(), 1);
 
 		assert_eq!(
 			overlay_db.load_recent_disputes().unwrap().unwrap(),
@@ -328,7 +328,7 @@ mod tests {
 		backend.write(write_ops).unwrap();
 
 		// Test that subsequent writes were written.
-		assert_eq!(backend.load_earliest_session().unwrap().unwrap(), 1,);
+		assert_eq!(backend.load_earliest_session().unwrap().unwrap(), 1);
 
 		assert_eq!(
 			backend.load_recent_disputes().unwrap().unwrap(),
@@ -457,7 +457,7 @@ mod tests {
 		let mut overlay_db = OverlayedBackend::new(&backend);
 		note_current_session(&mut overlay_db, current_session).unwrap();
 
-		assert_eq!(overlay_db.load_earliest_session().unwrap(), Some(new_earliest_session),);
+		assert_eq!(overlay_db.load_earliest_session().unwrap(), Some(new_earliest_session));
 
 		assert_eq!(
 			overlay_db.load_recent_disputes().unwrap().unwrap(),

--- a/node/core/dispute-coordinator/src/lib.rs
+++ b/node/core/dispute-coordinator/src/lib.rs
@@ -498,7 +498,7 @@ async fn handle_new_activations(
 			Ok(SessionWindowUpdate::Advanced { new_window_end: window_end, .. }) => {
 				let session = window_end;
 				if state.highest_session.map_or(true, |s| s < session) {
-					tracing::trace!(target: LOG_TARGET, session, "Observed new session. Pruning",);
+					tracing::trace!(target: LOG_TARGET, session, "Observed new session. Pruning");
 
 					state.highest_session = Some(session);
 

--- a/node/core/pvf/src/execute/queue.rs
+++ b/node/core/pvf/src/execute/queue.rs
@@ -258,7 +258,7 @@ async fn spawn_worker_task(program_path: PathBuf, spawn_timeout: Duration) -> Qu
 		match super::worker::spawn(&program_path, spawn_timeout).await {
 			Ok((idle, handle)) => break QueueEvent::Spawn((idle, handle)),
 			Err(err) => {
-				tracing::warn!(target: LOG_TARGET, "failed to spawn an execute worker: {:?}", err,);
+				tracing::warn!(target: LOG_TARGET, "failed to spawn an execute worker: {:?}", err);
 
 				// Assume that the failure intermittent and retry after a delay.
 				Delay::new(Duration::from_secs(3)).await;

--- a/node/core/pvf/src/prepare/pool.rs
+++ b/node/core/pvf/src/prepare/pool.rs
@@ -241,7 +241,7 @@ async fn spawn_worker_task(program_path: PathBuf, spawn_timeout: Duration) -> Po
 		match worker::spawn(&program_path, spawn_timeout).await {
 			Ok((idle, handle)) => break PoolEvent::Spawn(idle, handle),
 			Err(err) => {
-				tracing::warn!(target: LOG_TARGET, "failed to spawn a prepare worker: {:?}", err,);
+				tracing::warn!(target: LOG_TARGET, "failed to spawn a prepare worker: {:?}", err);
 
 				// Assume that the failure intermittent and retry after a delay.
 				Delay::new(Duration::from_secs(3)).await;

--- a/node/core/pvf/src/prepare/worker.rs
+++ b/node/core/pvf/src/prepare/worker.rs
@@ -262,7 +262,7 @@ fn renice(pid: u32, niceness: i32) {
 	unsafe {
 		if -1 == libc::setpriority(libc::PRIO_PROCESS, pid, niceness) {
 			let err = std::io::Error::last_os_error();
-			tracing::warn!(target: LOG_TARGET, "failed to set the priority: {:?}", err,);
+			tracing::warn!(target: LOG_TARGET, "failed to set the priority: {:?}", err);
 		}
 	}
 }

--- a/node/core/runtime-api/src/tests.rs
+++ b/node/core/runtime-api/src/tests.rs
@@ -368,7 +368,7 @@ fn requests_check_validation_outputs() {
 				),
 			})
 			.await;
-		assert_eq!(rx.await.unwrap().unwrap(), runtime_api.validation_outputs_results[&para_a],);
+		assert_eq!(rx.await.unwrap().unwrap(), runtime_api.validation_outputs_results[&para_a]);
 
 		let (tx, rx) = oneshot::channel();
 		ctx_handle
@@ -379,7 +379,7 @@ fn requests_check_validation_outputs() {
 				),
 			})
 			.await;
-		assert_eq!(rx.await.unwrap().unwrap(), runtime_api.validation_outputs_results[&para_b],);
+		assert_eq!(rx.await.unwrap().unwrap(), runtime_api.validation_outputs_results[&para_b]);
 
 		ctx_handle.send(FromOverseer::Signal(OverseerSignal::Conclude)).await;
 	};
@@ -664,7 +664,7 @@ fn requests_inbound_hrmp_channels_contents() {
 				),
 			})
 			.await;
-		assert_eq!(rx.await.unwrap().unwrap(), para_b_inbound_channels,);
+		assert_eq!(rx.await.unwrap().unwrap(), para_b_inbound_channels);
 
 		ctx_handle.send(FromOverseer::Signal(OverseerSignal::Conclude)).await;
 	};

--- a/node/network/approval-distribution/src/lib.rs
+++ b/node/network/approval-distribution/src/lib.rs
@@ -200,11 +200,11 @@ impl State {
 		match event {
 			NetworkBridgeEvent::PeerConnected(peer_id, role, _) => {
 				// insert a blank view if none already present
-				tracing::trace!(target: LOG_TARGET, ?peer_id, ?role, "Peer connected",);
+				tracing::trace!(target: LOG_TARGET, ?peer_id, ?role, "Peer connected");
 				self.peer_views.entry(peer_id).or_default();
 			},
 			NetworkBridgeEvent::PeerDisconnected(peer_id) => {
-				tracing::trace!(target: LOG_TARGET, ?peer_id, "Peer disconnected",);
+				tracing::trace!(target: LOG_TARGET, ?peer_id, "Peer disconnected");
 				self.peer_views.remove(&peer_id);
 				self.blocks.iter_mut().for_each(|(_hash, entry)| {
 					entry.known_by.remove(&peer_id);
@@ -224,7 +224,7 @@ impl State {
 				self.handle_peer_view_change(ctx, metrics, peer_id, view).await;
 			},
 			NetworkBridgeEvent::OurViewChange(view) => {
-				tracing::trace!(target: LOG_TARGET, ?view, "Own view change",);
+				tracing::trace!(target: LOG_TARGET, ?view, "Own view change");
 				for head in view.iter() {
 					if !self.blocks.contains_key(head) {
 						self.pending_known.entry(*head).or_default();
@@ -454,7 +454,7 @@ impl State {
 		peer_id: PeerId,
 		view: View,
 	) {
-		tracing::trace!(target: LOG_TARGET, ?view, "Peer view change",);
+		tracing::trace!(target: LOG_TARGET, ?view, "Peer view change");
 		let finalized_number = view.finalized_number;
 		let old_view = self.peer_views.insert(peer_id.clone(), view.clone());
 		let old_finalized_number = old_view.map(|v| v.finalized_number).unwrap_or(0);
@@ -570,7 +570,7 @@ impl State {
 			if entry.knowledge.known_messages.contains(&fingerprint) {
 				modify_reputation(ctx, peer_id.clone(), BENEFIT_VALID_MESSAGE).await;
 				if let Some(peer_knowledge) = entry.known_by.get_mut(&peer_id) {
-					tracing::trace!(target: LOG_TARGET, ?peer_id, ?fingerprint, "Known assignment",);
+					tracing::trace!(target: LOG_TARGET, ?peer_id, ?fingerprint, "Known assignment");
 					peer_knowledge.received.insert(fingerprint.clone());
 				}
 				return
@@ -589,7 +589,7 @@ impl State {
 			let result = match rx.await {
 				Ok(result) => result,
 				Err(_) => {
-					tracing::debug!(target: LOG_TARGET, "The approval voting subsystem is down",);
+					tracing::debug!(target: LOG_TARGET, "The approval voting subsystem is down");
 					return
 				},
 			};
@@ -805,7 +805,7 @@ impl State {
 
 			// if the approval is known to be valid, reward the peer
 			if entry.knowledge.contains(&fingerprint) {
-				tracing::trace!(target: LOG_TARGET, ?peer_id, ?fingerprint, "Known approval",);
+				tracing::trace!(target: LOG_TARGET, ?peer_id, ?fingerprint, "Known approval");
 				modify_reputation(ctx, peer_id.clone(), BENEFIT_VALID_MESSAGE).await;
 				if let Some(peer_knowledge) = entry.known_by.get_mut(&peer_id) {
 					peer_knowledge.received.insert(fingerprint.clone());
@@ -822,7 +822,7 @@ impl State {
 			let result = match rx.await {
 				Ok(result) => result,
 				Err(_) => {
-					tracing::debug!(target: LOG_TARGET, "The approval voting subsystem is down",);
+					tracing::debug!(target: LOG_TARGET, "The approval voting subsystem is down");
 					return
 				},
 			};
@@ -978,7 +978,7 @@ impl State {
 			);
 
 		if !lucky {
-			tracing::trace!(target: LOG_TARGET, ?peer_id, "Unlucky peer",);
+			tracing::trace!(target: LOG_TARGET, ?peer_id, "Unlucky peer");
 			return
 		}
 

--- a/node/network/approval-distribution/src/tests.rs
+++ b/node/network/approval-distribution/src/tests.rs
@@ -77,7 +77,7 @@ async fn overseer_send(overseer: &mut VirtualOverseer, msg: ApprovalDistribution
 }
 
 async fn overseer_signal_block_finalized(overseer: &mut VirtualOverseer, number: BlockNumber) {
-	tracing::trace!(?number, "Sending a finalized signal",);
+	tracing::trace!(?number, "Sending a finalized signal");
 	// we don't care about the block hash
 	overseer
 		.send(FromOverseer::Signal(OverseerSignal::BlockFinalized(Hash::zero(), number)))
@@ -249,7 +249,7 @@ fn try_import_the_same_assignment() {
 		expect_reputation_change(overseer, &peer_d, COST_UNEXPECTED_MESSAGE).await;
 		expect_reputation_change(overseer, &peer_d, BENEFIT_VALID_MESSAGE).await;
 
-		assert!(overseer.recv().timeout(TIMEOUT).await.is_none(), "no message should be sent",);
+		assert!(overseer.recv().timeout(TIMEOUT).await.is_none(), "no message should be sent");
 		virtual_overseer
 	});
 }
@@ -405,7 +405,7 @@ fn peer_sending_us_the_same_we_just_sent_them_is_ok() {
 		let msg = protocol_v1::ApprovalDistributionMessage::Assignments(assignments);
 		send_message_from_peer(overseer, peer, msg.clone()).await;
 
-		assert!(overseer.recv().timeout(TIMEOUT).await.is_none(), "we should not punish the peer",);
+		assert!(overseer.recv().timeout(TIMEOUT).await.is_none(), "we should not punish the peer");
 
 		// send the assignments again
 		send_message_from_peer(overseer, peer, msg).await;
@@ -860,7 +860,7 @@ fn import_remotely_then_locally() {
 		)
 		.await;
 
-		assert!(overseer.recv().timeout(TIMEOUT).await.is_none(), "no message should be sent",);
+		assert!(overseer.recv().timeout(TIMEOUT).await.is_none(), "no message should be sent");
 
 		// send the approval remotely
 		let approval = IndirectSignedApprovalVote {
@@ -887,7 +887,7 @@ fn import_remotely_then_locally() {
 		// import the same approval locally
 		overseer_send(overseer, ApprovalDistributionMessage::DistributeApproval(approval)).await;
 
-		assert!(overseer.recv().timeout(TIMEOUT).await.is_none(), "no message should be sent",);
+		assert!(overseer.recv().timeout(TIMEOUT).await.is_none(), "no message should be sent");
 		virtual_overseer
 	});
 }
@@ -966,7 +966,7 @@ fn sends_assignments_even_when_state_is_approved() {
 			}
 		);
 
-		assert!(overseer.recv().timeout(TIMEOUT).await.is_none(), "no message should be sent",);
+		assert!(overseer.recv().timeout(TIMEOUT).await.is_none(), "no message should be sent");
 		virtual_overseer
 	});
 }

--- a/node/network/availability-recovery/src/lib.rs
+++ b/node/network/availability-recovery/src/lib.rs
@@ -723,7 +723,7 @@ where
 			launch_interaction(state, ctx, session_info, receipt, backing_group, response_sender)
 				.await,
 		None => {
-			tracing::warn!(target: LOG_TARGET, "SessionInfo is `None` at {:?}", state.live_block,);
+			tracing::warn!(target: LOG_TARGET, "SessionInfo is `None` at {:?}", state.live_block);
 			response_sender
 				.send(Err(RecoveryError::Unavailable))
 				.map_err(|_| error::Error::CanceledResponseSender)?;

--- a/node/network/bitfield-distribution/src/lib.rs
+++ b/node/network/bitfield-distribution/src/lib.rs
@@ -460,7 +460,7 @@ async fn process_incoming_peer_message<Context>(
 	if !received_set.contains(&validator) {
 		received_set.insert(validator.clone());
 	} else {
-		tracing::trace!(target: LOG_TARGET, ?validator_index, ?origin, "Duplicate message",);
+		tracing::trace!(target: LOG_TARGET, ?validator_index, ?origin, "Duplicate message");
 		modify_reputation(ctx, origin, COST_PEER_DUPLICATE_MESSAGE).await;
 		return
 	};
@@ -512,12 +512,12 @@ async fn handle_network_msg<Context>(
 
 	match bridge_message {
 		NetworkBridgeEvent::PeerConnected(peerid, role, _) => {
-			tracing::trace!(target: LOG_TARGET, ?peerid, ?role, "Peer connected",);
+			tracing::trace!(target: LOG_TARGET, ?peerid, ?role, "Peer connected");
 			// insert if none already present
 			state.peer_views.entry(peerid).or_default();
 		},
 		NetworkBridgeEvent::PeerDisconnected(peerid) => {
-			tracing::trace!(target: LOG_TARGET, ?peerid, "Peer disconnected",);
+			tracing::trace!(target: LOG_TARGET, ?peerid, "Peer disconnected");
 			// get rid of superfluous data
 			state.peer_views.remove(&peerid);
 		},
@@ -531,11 +531,11 @@ async fn handle_network_msg<Context>(
 			}
 		},
 		NetworkBridgeEvent::PeerViewChange(peerid, view) => {
-			tracing::trace!(target: LOG_TARGET, ?peerid, ?view, "Peer view change",);
+			tracing::trace!(target: LOG_TARGET, ?peerid, ?view, "Peer view change");
 			handle_peer_view_change(ctx, state, peerid, view).await;
 		},
 		NetworkBridgeEvent::OurViewChange(view) => {
-			tracing::trace!(target: LOG_TARGET, ?view, "Our view change",);
+			tracing::trace!(target: LOG_TARGET, ?view, "Our view change");
 			handle_our_view_change(state, view);
 		},
 		NetworkBridgeEvent::PeerMessage(remote, message) =>
@@ -589,7 +589,7 @@ async fn handle_peer_view_change<Context>(
 		);
 
 	if !lucky {
-		tracing::trace!(target: LOG_TARGET, ?origin, "Peer view change is ignored",);
+		tracing::trace!(target: LOG_TARGET, ?origin, "Peer view change is ignored");
 		return
 	}
 

--- a/node/network/collator-protocol/src/collator_side/mod.rs
+++ b/node/network/collator-protocol/src/collator_side/mod.rs
@@ -777,7 +777,7 @@ async fn send_collation(
 	};
 
 	if let Err(_) = request.send_outgoing_response(response) {
-		tracing::warn!(target: LOG_TARGET, "Sending collation response failed",);
+		tracing::warn!(target: LOG_TARGET, "Sending collation response failed");
 	}
 
 	state.active_collation_fetches.push(
@@ -913,7 +913,7 @@ where
 		PeerConnected(peer_id, observed_role, maybe_authority) => {
 			// If it is possible that a disconnected validator would attempt a reconnect
 			// it should be handled here.
-			tracing::trace!(target: LOG_TARGET, ?peer_id, ?observed_role, "Peer connected",);
+			tracing::trace!(target: LOG_TARGET, ?peer_id, ?observed_role, "Peer connected");
 			if let Some(authority) = maybe_authority {
 				tracing::trace!(
 					target: LOG_TARGET,
@@ -927,16 +927,16 @@ where
 			}
 		},
 		PeerViewChange(peer_id, view) => {
-			tracing::trace!(target: LOG_TARGET, ?peer_id, ?view, "Peer view change",);
+			tracing::trace!(target: LOG_TARGET, ?peer_id, ?view, "Peer view change");
 			handle_peer_view_change(ctx, state, peer_id, view).await;
 		},
 		PeerDisconnected(peer_id) => {
-			tracing::trace!(target: LOG_TARGET, ?peer_id, "Peer disconnected",);
+			tracing::trace!(target: LOG_TARGET, ?peer_id, "Peer disconnected");
 			state.peer_views.remove(&peer_id);
 			state.peer_ids.remove(&peer_id);
 		},
 		OurViewChange(view) => {
-			tracing::trace!(target: LOG_TARGET, ?view, "Own view change",);
+			tracing::trace!(target: LOG_TARGET, ?view, "Own view change");
 			handle_our_view_change(state, view).await?;
 		},
 		PeerMessage(remote, msg) => {

--- a/node/network/collator-protocol/src/validator_side/mod.rs
+++ b/node/network/collator-protocol/src/validator_side/mod.rs
@@ -395,7 +395,7 @@ impl ActiveParas {
 						)
 					},
 					None => {
-						tracing::trace!(target: LOG_TARGET, ?relay_parent, "Not a validator",);
+						tracing::trace!(target: LOG_TARGET, ?relay_parent, "Not a validator");
 
 						continue
 					},

--- a/node/network/statement-distribution/src/lib.rs
+++ b/node/network/statement-distribution/src/lib.rs
@@ -1450,7 +1450,7 @@ async fn handle_network_update(
 ) {
 	match update {
 		NetworkBridgeEvent::PeerConnected(peer, role, maybe_authority) => {
-			tracing::trace!(target: LOG_TARGET, ?peer, ?role, "Peer connected",);
+			tracing::trace!(target: LOG_TARGET, ?peer, ?role, "Peer connected");
 			peers.insert(
 				peer,
 				PeerData {
@@ -1464,7 +1464,7 @@ async fn handle_network_update(
 			}
 		},
 		NetworkBridgeEvent::PeerDisconnected(peer) => {
-			tracing::trace!(target: LOG_TARGET, ?peer, "Peer disconnected",);
+			tracing::trace!(target: LOG_TARGET, ?peer, "Peer disconnected");
 			if let Some(auth_id) = peers.remove(&peer).and_then(|p| p.maybe_authority) {
 				authorities.remove(&auth_id);
 			}
@@ -1502,7 +1502,7 @@ async fn handle_network_update(
 			.await;
 		},
 		NetworkBridgeEvent::PeerViewChange(peer, view) => {
-			tracing::trace!(target: LOG_TARGET, ?peer, ?view, "Peer view change",);
+			tracing::trace!(target: LOG_TARGET, ?peer, ?view, "Peer view change");
 			match peers.get_mut(&peer) {
 				Some(data) =>
 					update_peer_view_and_maybe_send_unlocked(

--- a/node/network/statement-distribution/src/tests.rs
+++ b/node/network/statement-distribution/src/tests.rs
@@ -641,7 +641,7 @@ fn circulated_statement_goes_to_all_peers_with_view() {
 			.get(&hash_b)
 			.unwrap()
 			.sent_statements
-			.contains(&fingerprint),);
+			.contains(&fingerprint));
 
 		assert!(peer_data
 			.get(&peer_c)
@@ -650,7 +650,7 @@ fn circulated_statement_goes_to_all_peers_with_view() {
 			.get(&hash_b)
 			.unwrap()
 			.sent_statements
-			.contains(&fingerprint),);
+			.contains(&fingerprint));
 
 		let message = handle.recv().await;
 		assert_matches!(

--- a/node/subsystem-util/src/determine_new_blocks.rs
+++ b/node/subsystem-util/src/determine_new_blocks.rs
@@ -294,7 +294,7 @@ mod tests {
 			.await
 			.unwrap();
 
-			assert_eq!(ancestry, expected_ancestry,);
+			assert_eq!(ancestry, expected_ancestry);
 		});
 
 		let aux_fut = Box::pin(async move {
@@ -367,7 +367,7 @@ mod tests {
 			.await
 			.unwrap();
 
-			assert_eq!(ancestry, expected_ancestry,);
+			assert_eq!(ancestry, expected_ancestry);
 		});
 
 		let aux_fut = Box::pin(async move {
@@ -426,7 +426,7 @@ mod tests {
 			.await
 			.unwrap();
 
-			assert_eq!(ancestry, expected_ancestry,);
+			assert_eq!(ancestry, expected_ancestry);
 		});
 
 		futures::executor::block_on(test_fut);
@@ -462,7 +462,7 @@ mod tests {
 			.await
 			.unwrap();
 
-			assert_eq!(ancestry, expected_ancestry,);
+			assert_eq!(ancestry, expected_ancestry);
 		});
 
 		futures::executor::block_on(test_fut);
@@ -498,11 +498,11 @@ mod tests {
 					.await
 					.unwrap();
 
-			assert_eq!(after_finality, vec![(head_hash, head.clone())],);
+			assert_eq!(after_finality, vec![(head_hash, head.clone())]);
 
-			assert_eq!(at_finality, Vec::new(),);
+			assert_eq!(at_finality, Vec::new());
 
-			assert_eq!(before_finality, Vec::new(),);
+			assert_eq!(before_finality, Vec::new());
 		});
 
 		futures::executor::block_on(test_fut);

--- a/node/subsystem-util/src/rolling_session_window.rs
+++ b/node/subsystem-util/src/rolling_session_window.rs
@@ -564,7 +564,7 @@ mod tests {
 				window.cache_session_info_for_head(&mut ctx, hash, &header).await.unwrap();
 
 				assert_eq!(window.earliest_session, Some(session));
-				assert_eq!(window.session_info, vec![dummy_session_info(session)],);
+				assert_eq!(window.session_info, vec![dummy_session_info(session)]);
 			})
 		};
 

--- a/node/test/service/tests/call-function.rs
+++ b/node/test/service/tests/call-function.rs
@@ -34,7 +34,7 @@ async fn call_function_actually_work(task_executor: TaskExecutor) {
 	assert!(object.contains_key("jsonrpc"), "key jsonrpc exists");
 	let result = object.get("result");
 	let result = result.expect("key result exists");
-	assert_eq!(result.as_str().map(|x| x.starts_with("0x")), Some(true), "result starts with 0x",);
+	assert_eq!(result.as_str().map(|x| x.starts_with("0x")), Some(true), "result starts with 0x");
 
 	alice.task_manager.clean_shutdown().await;
 }

--- a/runtime/common/src/integration_tests.rs
+++ b/runtime/common/src/integration_tests.rs
@@ -374,7 +374,7 @@ fn basic_end_to_end_works() {
 			crowdloan::Event::<Test>::HandleBidResult(ParaId::from(para_2), Ok(())).into(),
 		);
 		run_to_block(110);
-		assert_eq!(last_event(), auctions::Event::<Test>::AuctionClosed(1).into(),);
+		assert_eq!(last_event(), auctions::Event::<Test>::AuctionClosed(1).into());
 
 		// Paras should have won slots
 		assert_eq!(

--- a/runtime/parachains/src/disputes.rs
+++ b/runtime/parachains/src/disputes.rs
@@ -1221,14 +1221,14 @@ mod tests {
 			VoteImportError::ValidatorIndexOutOfBounds,
 		);
 
-		assert_err!(importer.import(ValidatorIndex(0), true), VoteImportError::DuplicateStatement,);
+		assert_err!(importer.import(ValidatorIndex(0), true), VoteImportError::DuplicateStatement);
 		assert_ok!(importer.import(ValidatorIndex(0), false));
 
 		assert_ok!(importer.import(ValidatorIndex(2), true));
-		assert_err!(importer.import(ValidatorIndex(2), true), VoteImportError::DuplicateStatement,);
+		assert_err!(importer.import(ValidatorIndex(2), true), VoteImportError::DuplicateStatement);
 
 		assert_ok!(importer.import(ValidatorIndex(2), false));
-		assert_err!(importer.import(ValidatorIndex(2), false), VoteImportError::DuplicateStatement,);
+		assert_err!(importer.import(ValidatorIndex(2), false), VoteImportError::DuplicateStatement);
 
 		let summary = importer.finish();
 		assert_eq!(summary.new_flags, DisputeStateFlags::default());
@@ -1241,7 +1241,7 @@ mod tests {
 				concluded_at: None,
 			},
 		);
-		assert_eq!(summary.spam_slot_changes, vec![(ValidatorIndex(2), SpamSlotChange::Inc)],);
+		assert_eq!(summary.spam_slot_changes, vec![(ValidatorIndex(2), SpamSlotChange::Inc)]);
 		assert!(summary.slash_for.is_empty());
 		assert!(summary.slash_against.is_empty());
 		assert_eq!(summary.new_participants, bitvec![BitOrderLsb0, u8; 0, 0, 1, 0, 0, 0, 0, 0]);
@@ -1898,7 +1898,7 @@ mod tests {
 				)],
 			}];
 
-			assert_ok!(Pallet::<Test>::provide_multi_dispute_data(stmts), vec![],);
+			assert_ok!(Pallet::<Test>::provide_multi_dispute_data(stmts), vec![]);
 			assert_eq!(SpamSlots::<Test>::get(3), Some(vec![0, 0, 0, 0]));
 			assert_eq!(SpamSlots::<Test>::get(4), Some(vec![0, 0, 0, 1]));
 			assert_eq!(SpamSlots::<Test>::get(5), Some(vec![0, 0, 0, 0]));

--- a/runtime/parachains/src/hrmp.rs
+++ b/runtime/parachains/src/hrmp.rs
@@ -952,12 +952,12 @@ impl<T: Config> Pallet<T> {
 		);
 
 		let config = <configuration::Pallet<T>>::config();
-		ensure!(proposed_max_capacity > 0, Error::<T>::OpenHrmpChannelZeroCapacity,);
+		ensure!(proposed_max_capacity > 0, Error::<T>::OpenHrmpChannelZeroCapacity);
 		ensure!(
 			proposed_max_capacity <= config.hrmp_channel_max_capacity,
 			Error::<T>::OpenHrmpChannelCapacityExceedsLimit,
 		);
-		ensure!(proposed_max_message_size > 0, Error::<T>::OpenHrmpChannelZeroMessageSize,);
+		ensure!(proposed_max_message_size > 0, Error::<T>::OpenHrmpChannelZeroMessageSize);
 		ensure!(
 			proposed_max_message_size <= config.hrmp_channel_max_message_size,
 			Error::<T>::OpenHrmpChannelMessageSizeExceedsLimit,
@@ -1035,7 +1035,7 @@ impl<T: Config> Pallet<T> {
 		let channel_id = HrmpChannelId { sender, recipient: origin };
 		let mut channel_req = <Self as Store>::HrmpOpenChannelRequests::get(&channel_id)
 			.ok_or(Error::<T>::AcceptHrmpChannelDoesntExist)?;
-		ensure!(!channel_req.confirmed, Error::<T>::AcceptHrmpChannelAlreadyConfirmed,);
+		ensure!(!channel_req.confirmed, Error::<T>::AcceptHrmpChannelAlreadyConfirmed);
 
 		// check if by accepting this open channel request, this parachain would exceed the
 		// number of inbound channels.
@@ -1748,7 +1748,7 @@ mod tests {
 					.expect("the ingress index must be present for para_b");
 			let ingress_index = <Vec<ParaId>>::decode(&mut &raw_ingress_index[..])
 				.expect("ingress indexx should be decodable as a list of para ids");
-			assert_eq!(ingress_index, vec![para_a],);
+			assert_eq!(ingress_index, vec![para_a]);
 
 			// Now, verify that we can access and decode the egress index.
 			let raw_egress_index =
@@ -1756,7 +1756,7 @@ mod tests {
 					.expect("the egress index must be present for para_a");
 			let egress_index = <Vec<ParaId>>::decode(&mut &raw_egress_index[..])
 				.expect("egress index should be decodable as a list of para ids");
-			assert_eq!(egress_index, vec![para_b],);
+			assert_eq!(egress_index, vec![para_b]);
 		});
 	}
 

--- a/runtime/parachains/src/inclusion.rs
+++ b/runtime/parachains/src/inclusion.rs
@@ -581,7 +581,7 @@ impl<T: Config> Pallet<T> {
 				// end of loop reached means that the candidate didn't appear in the non-traversed
 				// section of the `scheduled` slice. either it was not scheduled or didn't appear in
 				// `candidates` in the correct order.
-				ensure!(false, Error::<T>::UnscheduledCandidate,);
+				ensure!(false, Error::<T>::UnscheduledCandidate);
 			}
 
 			// check remainder of scheduled cores, if any.
@@ -917,7 +917,7 @@ impl<T: Config> CandidateCheckContext<T> {
 						self.relay_parent_number.saturating_sub(last) >=
 							self.config.validation_upgrade_frequency
 				});
-			ensure!(valid_upgrade_attempt, AcceptanceCheckErr::PrematureCodeUpgrade,);
+			ensure!(valid_upgrade_attempt, AcceptanceCheckErr::PrematureCodeUpgrade);
 			ensure!(
 				new_validation_code.0.len() <= self.config.max_code_size as _,
 				AcceptanceCheckErr::NewCodeTooLarge,
@@ -1673,7 +1673,7 @@ mod tests {
 				*votes.get_mut(2).unwrap() = true;
 
 				votes
-			},);
+			});
 
 			// and check that chain head was enacted.
 			assert_eq!(Paras::para_head(&chain_a), Some(vec![1, 2, 3, 4].into()));

--- a/runtime/parachains/src/paras.rs
+++ b/runtime/parachains/src/paras.rs
@@ -1538,7 +1538,7 @@ mod tests {
 			{
 				Paras::note_new_head(para_id, Default::default(), expected_at);
 
-				assert_eq!(Paras::past_code_meta(&para_id).most_recent_change(), Some(expected_at),);
+				assert_eq!(Paras::past_code_meta(&para_id).most_recent_change(), Some(expected_at));
 				assert_eq!(
 					<Paras as Store>::PastCodeHash::get(&(para_id, expected_at)),
 					Some(original_code.hash()),
@@ -1629,7 +1629,7 @@ mod tests {
 
 				Paras::note_new_head(para_id, Default::default(), expected_at + 4);
 
-				assert_eq!(Paras::past_code_meta(&para_id).most_recent_change(), Some(expected_at),);
+				assert_eq!(Paras::past_code_meta(&para_id).most_recent_change(), Some(expected_at));
 
 				// Some hypothetical block which would have triggered the code change
 				// should still use the old code.
@@ -2000,7 +2000,7 @@ mod tests {
 			run_to_block(10, None);
 			Paras::note_new_head(para_id, Default::default(), 7);
 
-			assert_eq!(Paras::past_code_meta(&para_id).upgrade_times, vec![upgrade_at(2, 10)],);
+			assert_eq!(Paras::past_code_meta(&para_id).upgrade_times, vec![upgrade_at(2, 10)]);
 
 			assert_eq!(fetch_validation_code_at(para_id, 2, None), Some(old_code.clone()));
 			assert_eq!(fetch_validation_code_at(para_id, 3, None), Some(old_code.clone()));

--- a/runtime/parachains/src/paras_inherent.rs
+++ b/runtime/parachains/src/paras_inherent.rs
@@ -104,7 +104,7 @@ pub mod pallet {
 					Ok(Some(d)) => d,
 					Ok(None) => return None,
 					Err(_) => {
-						log::warn!(target: LOG_TARGET, "ParachainsInherentData failed to decode",);
+						log::warn!(target: LOG_TARGET, "ParachainsInherentData failed to decode");
 
 						return None
 					},
@@ -489,7 +489,7 @@ mod tests {
 				// we don't directly check the block's weight post-call. Instead, we check that the
 				// call has returned the appropriate post-dispatch weight for refund, and trust
 				// Substrate to do the right thing with that information.
-				assert_eq!(post_info.actual_weight.unwrap(), expected_weight,);
+				assert_eq!(post_info.actual_weight.unwrap(), expected_weight);
 			});
 		}
 	}

--- a/runtime/parachains/src/shared.rs
+++ b/runtime/parachains/src/shared.rs
@@ -181,7 +181,7 @@ mod tests {
 				])
 			);
 
-			assert_eq!(ParasShared::active_validator_keys(), validators,);
+			assert_eq!(ParasShared::active_validator_keys(), validators);
 
 			assert_eq!(
 				ParasShared::active_validator_indices(),
@@ -219,7 +219,7 @@ mod tests {
 				validator_pubkeys(&[Sr25519Keyring::Ferdie, Sr25519Keyring::Bob,])
 			);
 
-			assert_eq!(ParasShared::active_validator_keys(), validators,);
+			assert_eq!(ParasShared::active_validator_keys(), validators);
 
 			assert_eq!(
 				ParasShared::active_validator_indices(),


### PR DESCRIPTION
Mass replace `,);` pattern to `);`. 

This is an artifact left by rustfmt being conservative. Specifically, it is not dare to remove the comma from macro invocations because it cannot know if it changes the semantics.

The exception is with type declarations `(Type,);` which denotes type which is a tuple of one element. If we remove the comma it will become the type itself.

Obviously this PR doesn't intend to change semantics.