### PR TITLE
Track historical vrfs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6971,6 +6971,8 @@ dependencies = [
  "serde_json",
  "sp-api",
  "sp-application-crypto",
+ "sp-consensus-babe",
+ "sp-consensus-vrf",
  "sp-core",
  "sp-inherents",
  "sp-io",

--- a/runtime/parachains/Cargo.toml
+++ b/runtime/parachains/Cargo.toml
@@ -21,6 +21,8 @@ sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master
 sp-session = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 sp-staking = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+sp-consensus-babe = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-consensus-vrf = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sp-keystore = { git = "https://github.com/paritytech/substrate", branch = "master", optional = true }
 
 pallet-authority-discovery = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }

--- a/runtime/parachains/src/disputes.rs
+++ b/runtime/parachains/src/disputes.rs
@@ -619,10 +619,12 @@ impl<T: Config> Pallet<T> {
 			for to_prune in to_prune {
 				// This should be small, as disputes are rare, so `None` is fine.
 				<Disputes<T>>::remove_prefix(to_prune, None);
-
-				// This is larger, and will be extracted to the `shared` module for more proper pruning.
-				// TODO: https://github.com/paritytech/polkadot/issues/3469
-				shared::Pallet::<T>::prune_included_candidates(to_prune);
+				// Mark the session as pruneable so that its candidates can be incrementally
+				// removed over the course of many block inclusions.
+				shared::Pallet::<T>::mark_session_pruneable(to_prune);
+				// TODO(ladi): remove this call, currently allows unit tests to pass. Need to
+				// figure out how to invoke paras_inherent::enter in run_to_block.
+				shared::Pallet::<T>::prune_ancient_sessions(shared::MAX_CANDIDATES_TO_PRUNE);
 				SpamSlots::<T>::remove(to_prune);
 			}
 

--- a/runtime/parachains/src/paras_inherent.rs
+++ b/runtime/parachains/src/paras_inherent.rs
@@ -222,11 +222,7 @@ pub mod pallet {
 					None => continue,
 				};
 
-				T::DisputesHandler::process_included(
-					current_session,
-					*candidate_hash,
-					revert_to,
-				);
+				T::DisputesHandler::process_included(current_session, *candidate_hash, revert_to);
 			}
 
 			// Handle timeouts for any availability core work.
@@ -280,6 +276,9 @@ pub mod pallet {
 
 			// And track that we've finished processing the inherent for this block.
 			Included::<T>::set(Some(()));
+
+			// Prune candidates incrementally with each block inclusion.
+			shared::Pallet::<T>::prune_ancient_sessions(shared::MAX_CANDIDATES_TO_PRUNE);
 
 			Ok(Some(
 				MINIMAL_INCLUSION_INHERENT_WEIGHT +

--- a/runtime/parachains/src/shared.rs
+++ b/runtime/parachains/src/shared.rs
@@ -21,8 +21,8 @@
 
 use frame_support::pallet_prelude::*;
 use primitives::v1::{CandidateHash, CoreIndex, SessionIndex, ValidatorId, ValidatorIndex};
-use sp_std::vec::Vec;
 use sp_runtime::traits::{One, Zero};
+use sp_std::vec::Vec;
 
 use rand::{seq::SliceRandom, SeedableRng};
 use rand_chacha::ChaCha20Rng;
@@ -72,8 +72,10 @@ pub mod pallet {
 	#[pallet::getter(fn included_candidates)]
 	pub(super) type IncludedCandidates<T: Config> = StorageDoubleMap<
 		_,
-		Twox64Concat, SessionIndex,
-		Blake2_128Concat, CandidateHash,
+		Twox64Concat,
+		SessionIndex,
+		Blake2_128Concat,
+		CandidateHash,
 		(T::BlockNumber, CoreIndex),
 	>;
 
@@ -136,7 +138,9 @@ impl<T: Config> Pallet<T> {
 		included_in: T::BlockNumber,
 		core_index: CoreIndex,
 	) -> Option<T::BlockNumber> {
-		if included_in.is_zero() { return None }
+		if included_in.is_zero() {
+			return None
+		}
 
 		let revert_to = included_in - One::one();
 		<IncludedCandidates<T>>::insert(&session, &candidate_hash, (revert_to, core_index));
@@ -168,7 +172,7 @@ impl<T: Config> Pallet<T> {
 	#[cfg(test)]
 	pub(crate) fn included_candidates_iter_prefix(
 		session: SessionIndex,
-	) -> impl Iterator<Item=(CandidateHash, (T::BlockNumber, CoreIndex))> {
+	) -> impl Iterator<Item = (CandidateHash, (T::BlockNumber, CoreIndex))> {
 		<IncludedCandidates<T>>::iter_prefix(session)
 	}
 
@@ -291,7 +295,8 @@ mod tests {
 		new_test_ext(MockGenesisConfig::default()).execute_with(|| {
 			let session = 1;
 			let candidate_hash = CandidateHash(sp_core::H256::repeat_byte(1));
-			assert!(ParasShared::note_included_candidate(session, candidate_hash, 0, CoreIndex(0)).is_none());
+			assert!(ParasShared::note_included_candidate(session, candidate_hash, 0, CoreIndex(0))
+				.is_none());
 			assert!(!ParasShared::is_included_candidate(&session, &candidate_hash));
 			assert!(ParasShared::get_included_candidate(&session, &candidate_hash).is_none());
 		});
@@ -305,7 +310,12 @@ mod tests {
 			let block_number = 1;
 			let core_index = CoreIndex(2);
 			assert_eq!(
-				ParasShared::note_included_candidate(session, candidate_hash, block_number, core_index),
+				ParasShared::note_included_candidate(
+					session,
+					candidate_hash,
+					block_number,
+					core_index
+				),
 				Some(block_number - 1),
 			);
 			assert!(ParasShared::is_included_candidate(&session, &candidate_hash));
@@ -323,9 +333,15 @@ mod tests {
 			let candidate_hash2 = CandidateHash(sp_core::H256::repeat_byte(2));
 			let candidate_hash3 = CandidateHash(sp_core::H256::repeat_byte(3));
 
-			assert!(ParasShared::note_included_candidate(1, candidate_hash1, 1, CoreIndex(0)).is_some());
-			assert!(ParasShared::note_included_candidate(1, candidate_hash2, 1, CoreIndex(0)).is_some());
-			assert!(ParasShared::note_included_candidate(2, candidate_hash3, 2, CoreIndex(0)).is_some());
+			assert!(
+				ParasShared::note_included_candidate(1, candidate_hash1, 1, CoreIndex(0)).is_some()
+			);
+			assert!(
+				ParasShared::note_included_candidate(1, candidate_hash2, 1, CoreIndex(0)).is_some()
+			);
+			assert!(
+				ParasShared::note_included_candidate(2, candidate_hash3, 2, CoreIndex(0)).is_some()
+			);
 
 			assert_eq!(ParasShared::included_candidates_iter_prefix(1).count(), 2);
 			assert_eq!(ParasShared::included_candidates_iter_prefix(2).count(), 1);


### PR DESCRIPTION
Part of #3463 

This PR intends to add a `StorageDoubleMap` to the `shared` module which keeps track of historical Babe VRFs for the purpose of comparing these VRFs against the Approval Assignments that are issued throughout the Approval Voting process.