### PR TITLE
use WEIGHT_PER_SECOND in FixedRateOfFungible

### DIFF
--- a/xcm/xcm-builder/src/weight.rs
+++ b/xcm/xcm-builder/src/weight.rs
@@ -191,7 +191,8 @@ impl<T: Get<(AssetId, u128)>, R: TakeRevenue> WeightTrader for FixedRateOfFungib
 	fn refund_weight(&mut self, weight: Weight) -> Option<MultiAsset> {
 		let (id, units_per_second) = T::get();
 		let weight = weight.min(self.0);
-		let amount = units_per_second * (weight as u128) / 1_000_000_000_000u128;
+		use frame_support::weights::constants::WEIGHT_PER_SECOND;
+		let amount = units_per_second * (weight as u128) / (WEIGHT_PER_SECOND as u128);
 		self.0 -= weight;
 		self.1 = self.1.saturating_sub(amount);
 		if amount > 0 {

--- a/xcm/xcm-builder/src/weight.rs
+++ b/xcm/xcm-builder/src/weight.rs
@@ -16,7 +16,7 @@
 
 use frame_support::{
 	traits::{tokens::currency::Currency as CurrencyT, Get, OnUnbalanced as OnUnbalancedT},
-	weights::{GetDispatchInfo, Weight, WeightToFeePolynomial},
+	weights::{constants::WEIGHT_PER_SECOND, GetDispatchInfo, Weight, WeightToFeePolynomial},
 };
 use parity_scale_codec::Decode;
 use sp_runtime::traits::{SaturatedConversion, Saturating, Zero};
@@ -131,7 +131,6 @@ impl<T: Get<(MultiLocation, u128)>, R: TakeRevenue> WeightTrader
 
 	fn buy_weight(&mut self, weight: Weight, payment: Assets) -> Result<Assets, Error> {
 		let (id, units_per_second) = T::get();
-		use frame_support::weights::constants::WEIGHT_PER_SECOND;
 		let amount = units_per_second * (weight as u128) / (WEIGHT_PER_SECOND as u128);
 		let unused = payment.checked_sub((id, amount).into()).map_err(|_| Error::TooExpensive)?;
 		self.0 = self.0.saturating_add(weight);
@@ -177,7 +176,6 @@ impl<T: Get<(AssetId, u128)>, R: TakeRevenue> WeightTrader for FixedRateOfFungib
 
 	fn buy_weight(&mut self, weight: Weight, payment: Assets) -> Result<Assets, Error> {
 		let (id, units_per_second) = T::get();
-		use frame_support::weights::constants::WEIGHT_PER_SECOND;
 		let amount = units_per_second * (weight as u128) / (WEIGHT_PER_SECOND as u128);
 		if amount == 0 {
 			return Ok(payment)
@@ -191,7 +189,6 @@ impl<T: Get<(AssetId, u128)>, R: TakeRevenue> WeightTrader for FixedRateOfFungib
 	fn refund_weight(&mut self, weight: Weight) -> Option<MultiAsset> {
 		let (id, units_per_second) = T::get();
 		let weight = weight.min(self.0);
-		use frame_support::weights::constants::WEIGHT_PER_SECOND;
 		let amount = units_per_second * (weight as u128) / (WEIGHT_PER_SECOND as u128);
 		self.0 -= weight;
 		self.1 = self.1.saturating_sub(amount);


### PR DESCRIPTION
Presumably it should be the same as the usage of `WEIGHT_PER_SECOND` above?