### PR TITLE
Add an empty `.cargo/config` file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,3 @@ polkadot.*
 !polkadot.service
 !.rpm/*
 .DS_Store
-.cargo


### PR DESCRIPTION
This makes it slightly easier to do substrate companion PRs, as one only has to add `paths = ["path/to/substrate"]` to this file in order to override the sources.

https://github.com/paritytech/substrate/blob/master/docs/CONTRIBUTING.adoc#updating-polkadot-as-well should be updated as well.