### PR TITLE
New Github Workflow to check extrinsic ordering

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -113,7 +113,7 @@ The things to look for in the output are lines like:
   - If no indices have changed, every modules line should look something like `[Identity] idx 25 (calls 15)`
 
 Note: Adding new functions to the runtime does not constitute a breaking change
-as long as teh indexes did not change.
+as long as the indexes did not change.
 
 ### Proxy Filtering
 

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -105,26 +105,15 @@ functions. Compare the metadata of the current and new runtimes and ensure that
 the `module index, call index` tuples map to the same set of functions. In case
 of a breaking change, increase `transaction_version`.
 
-To verify the order has not changed:
+To verify the order has not changed, you may manually start the following [Github Action](https://github.com/paritytech/polkadot/actions/workflows/extrinsic-ordering-check-from-bin.yml). It takes around a minute to run and will produce the report as artifact you need to manually check.
 
-1. Download the latest release-candidate binary either from the draft-release
-on Github, or
-[AWS](https://releases.parity.io/polkadot/x86_64-debian:stretch/{{ env.VERSION }}-rc1/polkadot)
-(adjust the rc in this URL as necessary).
-2. Run the release-candidate binary using a local chain:
-`./polkadot --chain=polkadot-local` or `./polkadot --chain=kusama.local`
-3. Use [`polkadot-js-tools`](https://github.com/polkadot-js/tools) to compare
-the metadata:
-  - For Polkadot: `docker run --network host jacogr/polkadot-js-tools metadata wss://rpc.polkadot.io ws://localhost:9944`
-  - For Kusama: `docker run --network host jacogr/polkadot-js-tools metadata wss://kusama-rpc.polkadot.io ws://localhost:9944`
-4. Things to look for in the output are lines like:
+The things to look for in the output are lines like:
   - `[Identity] idx 28 -> 25 (calls 15)` - indicates the index for `Identity` has changed
   - `[+] Society, Recovery` - indicates the new version includes 2 additional modules/pallets.
   - If no indices have changed, every modules line should look something like `[Identity] idx 25 (calls 15)`
 
 Note: Adding new functions to the runtime does not constitute a breaking change
-as long as they are added to the end of a pallet (i.e., does not break any
-other call index).
+as long as teh indexes did not change.
 
 ### Proxy Filtering
 

--- a/.github/workflows/extrinsic-ordering-check-from-bin.yml
+++ b/.github/workflows/extrinsic-ordering-check-from-bin.yml
@@ -23,23 +23,11 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CHAIN: ${{github.event.inputs.chain}}
+      BIN_URL: ${{github.event.inputs.binary_url}}
+      REF_URL: ${{github.event.inputs.reference_url}}
 
     steps:
-      # - name: Ensure that the 'chain' is a local one
-      #   env:
-      #   run: |
-      #     if [[ $CHAIN == *"local"* ]] ; then
-      #       echo OK, we will run the test on $CHAIN
-      #       exit 0
-      #     else
-      #       echo Err, you need to pass a local chain such as 'polkadot-local', $CHAIN does not cut it
-      #       exit 1
-      #     fi
-
       - name: Fetch binary
-        env:
-          BIN_URL: ${{github.event.inputs.binary_url}}
-          REF_URL: ${{github.event.inputs.reference_url}}
         run: |
           echo Fetching $BIN_URL
           wget $BIN_URL

--- a/.github/workflows/extrinsic-ordering-check-from-bin.yml
+++ b/.github/workflows/extrinsic-ordering-check-from-bin.yml
@@ -54,7 +54,11 @@ jobs:
         run: |
           CMD="docker run --network host jacogr/polkadot-js-tools metadata wss://rpc.polkadot.io ws://localhost:9944"
           echo -e "Running:\n$CMD"
-          $CMD | tee output.txt
+          $CMD > output.txt
+          sed -z -i 's/\n\n/\n/g' output.txt
+
+      - name: Show result
+        run: cat output.txt
 
       - name: Stop our local node
         run: pkill polkadot

--- a/.github/workflows/extrinsic-ordering-check-from-bin.yml
+++ b/.github/workflows/extrinsic-ordering-check-from-bin.yml
@@ -1,0 +1,68 @@
+# This workflow performs the Extrinsic Ordering Check on demand using a binary
+
+name: Extrinsic Ordering Check from Binary
+on:
+  workflow_dispatch:
+    inputs:
+      reference_url:
+        description: The WebSocket url of the reference node
+        default: wss://rpc.polkadot.io
+        required: true
+      binary_url:
+        description: A url to a Linux binary for the node containing the runtime to test
+        default: https://some/url/polkadot
+        required: true
+      chain:
+        description: The name of the chain under test. Usually, you would pass a local chain
+        default: polkadot-local
+        required: true
+
+jobs:
+  check:
+    name: Run check
+    runs-on: ubuntu-latest
+    env:
+      CHAIN: ${{github.event.inputs.chain}}
+
+    steps:
+      # - name: Ensure that the 'chain' is a local one
+      #   env:
+      #   run: |
+      #     if [[ $CHAIN == *"local"* ]] ; then
+      #       echo OK, we will run the test on $CHAIN
+      #       exit 0
+      #     else
+      #       echo Err, you need to pass a local chain such as 'polkadot-local', $CHAIN does not cut it
+      #       exit 1
+      #     fi
+
+      - name: Fetch binary
+        env:
+          BIN_URL: ${{github.event.inputs.binary_url}}
+        run: |
+          echo Fetching $BIN_URL
+          wget $BIN_URL
+          chmod a+x polkadot
+          ./polkadot --version
+
+      - name: Start local node
+        run: |
+          echo Running on $CHAIN
+          ./polkadot --chain=$CHAIN &
+
+      - name: Compare the metadata
+        run: |
+          CMD="docker run --network host jacogr/polkadot-js-tools metadata wss://rpc.polkadot.io ws://localhost:9944"
+          echo Running $CMD
+          OUTPUT=$($CMD)
+          echo $OUTPUT | tee output.txt
+
+      - name: Stop our local node
+        run: pkill polkadot
+
+      - name: Save output as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: $CHAIN
+          path: |
+            output.txt

--- a/.github/workflows/extrinsic-ordering-check-from-bin.yml
+++ b/.github/workflows/extrinsic-ordering-check-from-bin.yml
@@ -10,7 +10,7 @@ on:
         required: true
       binary_url:
         description: A url to a Linux binary for the node containing the runtime to test
-        default: https://some/url/polkadot
+        default: https://releases.parity.io/polkadot/x86_64-debian:stretch/v0.9.9-rc1/polkadot
         required: true
       chain:
         description: The name of the chain under test. Usually, you would pass a local chain

--- a/.github/workflows/extrinsic-ordering-check-from-bin.yml
+++ b/.github/workflows/extrinsic-ordering-check-from-bin.yml
@@ -53,9 +53,8 @@ jobs:
       - name: Compare the metadata
         run: |
           CMD="docker run --network host jacogr/polkadot-js-tools metadata wss://rpc.polkadot.io ws://localhost:9944"
-          echo Running $CMD
-          OUTPUT=$($CMD)
-          echo $OUTPUT | tee output.txt
+          echo -e "Running:\n$CMD"
+          $CMD | tee output.txt
 
       - name: Stop our local node
         run: pkill polkadot
@@ -63,6 +62,6 @@ jobs:
       - name: Save output as artifact
         uses: actions/upload-artifact@v2
         with:
-          name: $CHAIN
+          name: ${{ env.CHAIN }}
           path: |
             output.txt

--- a/.github/workflows/extrinsic-ordering-check-from-bin.yml
+++ b/.github/workflows/extrinsic-ordering-check-from-bin.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           CMD="docker run --network host jacogr/polkadot-js-tools metadata $REF_URL ws://localhost:9944"
           echo -e "Running:\n$CMD"
-          $CMD > output.txt
+          $CMD >> output.txt
           sed -z -i 's/\n\n/\n/g' output.txt
 
       - name: Show result

--- a/.github/workflows/extrinsic-ordering-check-from-bin.yml
+++ b/.github/workflows/extrinsic-ordering-check-from-bin.yml
@@ -39,6 +39,7 @@ jobs:
       - name: Fetch binary
         env:
           BIN_URL: ${{github.event.inputs.binary_url}}
+          REF_URL: ${{github.event.inputs.reference_url}}
         run: |
           echo Fetching $BIN_URL
           wget $BIN_URL
@@ -50,9 +51,18 @@ jobs:
           echo Running on $CHAIN
           ./polkadot --chain=$CHAIN &
 
+      - name: Prepare output
+        run: |
+          VERSION=$(./polkadot --version)
+          echo "Metadata comparison:" >> output.txt
+          echo "Date: $(date)" >> output.txt
+          echo "Reference: $REF_URL" >> output.txt
+          echo "Target version: $VERSION" >> output.txt
+          echo "-------------------------------------------" >> output.txt
+
       - name: Compare the metadata
         run: |
-          CMD="docker run --network host jacogr/polkadot-js-tools metadata wss://rpc.polkadot.io ws://localhost:9944"
+          CMD="docker run --network host jacogr/polkadot-js-tools metadata $REF_URL ws://localhost:9944"
           echo -e "Running:\n$CMD"
           $CMD > output.txt
           sed -z -i 's/\n\n/\n/g' output.txt


### PR DESCRIPTION
This PR makes checking for extrinsic ordering easier by introducing a new Github Workflow that runs the steps required to produce a small report comparing the new runtime metadata and the current one.

Since it follows the steps previously mentioned in the release todos, the explanation there has been replaced by a simple call of the workflow.

The new workflow is called manually for now, mainly due to the need for inputs such a link to a built binary.