### PR TITLE
CI: fix rustdoc publishing

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -144,7 +144,7 @@ test-build-linux-stable:
     # we're using the bin built here, instead of having a parallel `build-linux-release`
     - time cargo build --release --verbose --bin polkadot
     - sccache -s
-    # pack-artifacts
+    # pack artifacts
     - mkdir -p ./artifacts
     - VERSION="${CI_COMMIT_REF_NAME}" # will be tag or branch name
     - mv ./target/release/polkadot ./artifacts/.
@@ -430,6 +430,11 @@ publish-rustdoc:
   rules:
     - if: $CI_PIPELINE_SOURCE == "web" && $CI_COMMIT_REF_NAME == "master"
     - if: $CI_COMMIT_REF_NAME == "master"
+  # `needs:` can be removed after CI image gets nonroot. In this case `needs:` stops other
+  # artifacts from being dowloaded by this job.
+  needs:
+    - job:                         build-rustdoc
+      artifacts:                   true
   script:
     - rm -rf /tmp/*
     # Set git config


### PR DESCRIPTION
It [turned out](https://gitlab.parity.io/parity/polkadot/-/jobs/1061671) that the artifacts produced by the jobs with a sudo user (in CI image) are not only being downloaded, but also can't be removed by a nonroot user.
Returning `needs:` fixes this by downloading only artifacts from a mentioned job, where they are cured.