### PR TITLE
GHA: extrinsic ordering, new filter to generate a summary

### DIFF
--- a/.github/workflows/extrinsic-ordering-check-from-bin.yml
+++ b/.github/workflows/extrinsic-ordering-check-from-bin.yml
@@ -6,7 +6,7 @@ on:
     inputs:
       reference_url:
         description: The WebSocket url of the reference node
-        default: wss://rpc.polkadot.io
+        default: wss://kusama-rpc.polkadot.io
         required: true
       binary_url:
         description: A url to a Linux binary for the node containing the runtime to test
@@ -14,7 +14,7 @@ on:
         required: true
       chain:
         description: The name of the chain under test. Usually, you would pass a local chain
-        default: polkadot-local
+        default: kusama-local
         required: true
 
 jobs:
@@ -27,6 +27,8 @@ jobs:
       REF_URL: ${{github.event.inputs.reference_url}}
 
     steps:
+      - uses: actions/checkout@v2
+
       - name: Fetch binary
         run: |
           echo Fetching $BIN_URL
@@ -46,17 +48,26 @@ jobs:
           echo "Date: $(date)" >> output.txt
           echo "Reference: $REF_URL" >> output.txt
           echo "Target version: $VERSION" >> output.txt
-          echo "-------------------------------------------" >> output.txt
+          echo "Chain: $CHAIN" >> output.txt
+          echo "----------------------------------------------------------------------" >> output.txt
+
+      - name: Pull polkadot-js-tools image
+        run: docker pull jacogr/polkadot-js-tools
 
       - name: Compare the metadata
         run: |
-          CMD="docker run --network host jacogr/polkadot-js-tools metadata $REF_URL ws://localhost:9944"
+          CMD="docker run --pull always --network host jacogr/polkadot-js-tools metadata $REF_URL ws://localhost:9944"
           echo -e "Running:\n$CMD"
           $CMD >> output.txt
           sed -z -i 's/\n\n/\n/g' output.txt
+          cat output.txt | egrep -n -i ''
+          SUMMARY=$(./scripts/github/extrinsic-ordering-filter.sh output.txt)
+          echo -e $SUMMARY
+          echo -e $SUMMARY >> output.txt
 
       - name: Show result
-        run: cat output.txt
+        run: |
+          cat output.txt
 
       - name: Stop our local node
         run: pkill polkadot

--- a/scripts/github/extrinsic-ordering-filter.sh
+++ b/scripts/github/extrinsic-ordering-filter.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# This script is used in a Github Workflow. It helps filtering out what is interesting
+# when comparing metadata and spot what would require a tx version bump.
+
+# shellcheck disable=SC2002,SC2086
+
+FILE=$1
+
+# Higlight indexes that were deleted
+function find_deletions() {
+    echo "\n## Deletions\n"
+    RES=$(cat "$FILE" | grep -n '\[\-\]' | tr -s " ")
+    if [ "$RES" ]; then
+        echo "$RES" | awk '{ printf "%s\\n", $0 }'
+    else
+        echo "n/a"
+    fi
+}
+
+# Highlight indexes that have been deleted
+function find_index_changes() {
+    echo "\n## Index changes\n"
+    RES=$(cat "$FILE" | grep -E -n -i 'idx:\s*([0-9]+)\s*(->)\s*([0-9]+)' | tr -s " ")
+    if [ "$RES" ]; then
+        echo "$RES" | awk '{ printf "%s\\n", $0 }'
+    else
+        echo "n/a"
+    fi
+}
+
+# Highlight values that decreased
+function find_decreases() {
+    echo "\n## Decreases\n"
+    OUT=$(cat "$FILE" | grep -E -i -o '([0-9]+)\s*(->)\s*([0-9]+)' | awk '$1 > $3 { printf "%s;", $0 }')
+    IFS=$';' LIST=("$OUT")
+    unset RES
+    for line in "${LIST[@]}"; do
+        RES="$RES\n$(cat "$FILE" | grep -E -i -n \"$line\" | tr -s " ")"
+    done
+
+    if [ "$RES" ]; then
+        echo "$RES" | awk '{ printf "%s\\n", $0 }' | sort -u -g | uniq
+    else
+        echo "n/a"
+    fi
+}
+
+echo "\n------------------------------ SUMMARY -------------------------------"
+echo "\n⚠️ This filter is here to help spotting changes that should be reviewed carefully."
+echo "\n⚠️ It catches only index changes, deletions and value decreases".
+
+find_deletions "$FILE"
+find_index_changes "$FILE"
+find_decreases "$FILE"
+echo "\n----------------------------------------------------------------------\n"


### PR DESCRIPTION
In #3620, a new Github Worflow was added to compare metadata between releases and catch changes that need to trigger a transaction version bump.

This PR appends a new `Summary` section where the *interesting* changes are highlighted (= the changes that needs special attention such as removal, index changes and indexes decreasing).

A sample output can be seen [here](https://github.com/chevdor/polkadot/runs/3311714422?check_suite_focus=true). Note that the CI run in this example was run to compare Westend and Kusama for the solely purpose to show case while working on more differences.

The summary for this (fantasy) run looks like:

------------------------------ SUMMARY ------------------------------- 
⚠️ This filter is here to help spotting changes that should be reviewed carefully. 
⚠️ It catches only index changes, deletions and index decreases. 
## Deletions
 14: [-] modules: Sudo, ParachainsConfiguration, ParasInclusion, ParasInherent, ParasScheduler

## Index changes
 27: [Identity] idx: 17 -> 25 (calls: 15, storage: 4)
28: [Recovery] idx: 18 -> 27 (calls: 9, storage: 3)
29: [Vesting] idx: 19 -> 28 (calls: 4, storage: 1)
30: [Scheduler] idx: 20 -> 29 (calls: 6, storage: 3)
31: [Proxy] idx: 22 -> 30 (calls: 10, storage: 2)
32: [Multisig] idx: 23 -> 31 (calls: 4, storage: 2)
33: [ElectionProviderMultiPhase] idx: 24 -> 37 (calls: 4, storage: 10)
36: [Paras] idx: 47 -> 56 (calls: 5, storage: 13 -> 17)
38: [Registrar] idx: 60 -> 70 (calls: 6, storage: 3)
39: [Slots] idx: 61 -> 71 (calls: 3, storage: 1)
40: [Auctions] idx: 63 -> 72 (calls: 3, storage: 4)
41: [Crowdloan] idx: 64 -> 73 (calls: 8, storage: 4)

## Decreases
 n/a 
----------------------------------------------------------------------



