### PR TITLE
Back port of connectivity warnings to 0.9.8

### DIFF
--- a/node/network/bridge/src/lib.rs
+++ b/node/network/bridge/src/lib.rs
@@ -441,8 +441,10 @@ where
 								?rep,
 								action = "ReportPeer"
 							);
+							// Test - don't punish peers on a node, to see what happens to our
+							// network errors.
+							network_service.report_peer(peer, rep);
 						}
-						network_service.report_peer(peer, rep);
 					}
 					NetworkBridgeMessage::DisconnectPeer(peer, peer_set) => {
 						tracing::trace!(

--- a/node/network/bridge/src/lib.rs
+++ b/node/network/bridge/src/lib.rs
@@ -434,16 +434,17 @@ where
 				}
 				Ok(FromOverseer::Communication { msg }) => match msg {
 					NetworkBridgeMessage::ReportPeer(peer, rep) => {
-						if !rep.is_benefit() {
+						if rep.is_benefit() {
+							// Test - don't punish peers on a node, to see what happens to our
+							// network errors.
+							network_service.report_peer(peer, rep);
+						} else {
 							tracing::debug!(
 								target: LOG_TARGET,
 								?peer,
 								?rep,
 								action = "ReportPeer"
 							);
-							// Test - don't punish peers on a node, to see what happens to our
-							// network errors.
-							network_service.report_peer(peer, rep);
 						}
 					}
 					NetworkBridgeMessage::DisconnectPeer(peer, peer_set) => {

--- a/node/network/gossip-support/src/lib.rs
+++ b/node/network/gossip-support/src/lib.rs
@@ -59,7 +59,6 @@ const BACKOFF_DURATION: Duration = Duration::from_secs(5);
 /// should be fine:
 ///
 /// https://github.com/paritytech/substrate/blob/fc49802f263529160635471c8a17888846035f5d/client/authority-discovery/src/lib.rs#L88
-///
 const LOW_CONNECTIVITY_WARN_DELAY: Duration = Duration::from_secs(600);
 
 /// The Gossip Support subsystem.
@@ -327,6 +326,12 @@ impl State {
 		// we await for the request to be processed
 		// this is fine, it should take much less time than one session
 		let failures = failures.await.unwrap_or(num);
+
+		tracing::debug!(
+			target: LOG_TARGET,
+			?failures,
+			"Failures when connecting to authorities"
+		);
 
 		// issue another request for the same session
 		// if at least a third of the authorities were not resolved


### PR DESCRIPTION
* Warn on low connectivity.

* Better timeout and docs.

* Review remarks.