### PR TITLE
Approval voting resume on restart

### DIFF
--- a/node/core/approval-voting/src/approval_db/v1/mod.rs
+++ b/node/core/approval-voting/src/approval_db/v1/mod.rs
@@ -35,6 +35,9 @@ use crate::{
 };
 
 const STORED_BLOCKS_KEY: &[u8] = b"Approvals_StoredBlocks";
+const BLOCK_ENTRY_PREFIX: [u8; 14] = *b"Approvals_blck";
+const CANDIDATE_ENTRY_PREFIX: [u8; 14] = *b"Approvals_cand";
+const BLOCKS_AT_HEIGHT_PREFIX: [u8; 12] = *b"Approvals_at";
 
 #[cfg(test)]
 pub mod tests;
@@ -74,6 +77,10 @@ impl Backend for DbBackend {
 
 	fn load_all_blocks(&self) -> SubsystemResult<Vec<Hash>> {
 		load_all_blocks(&*self.inner, &self.config)
+	}
+
+	fn load_all_candidates(&self) -> SubsystemResult<Vec<persisted_entries::CandidateEntry>> {
+		Ok(load_all_candidates(&*self.inner, &self.config)?.into_iter().map(Into::into).collect())
 	}
 
 	fn load_stored_blocks(&self) -> SubsystemResult<Option<StoredBlockRange>> {
@@ -251,8 +258,6 @@ pub(crate) fn load_decode<D: Decode>(
 
 /// The key a given block entry is stored under.
 pub(crate) fn block_entry_key(block_hash: &Hash) -> [u8; 46] {
-	const BLOCK_ENTRY_PREFIX: [u8; 14] = *b"Approvals_blck";
-
 	let mut key = [0u8; 14 + 32];
 	key[0..14].copy_from_slice(&BLOCK_ENTRY_PREFIX);
 	key[14..][..32].copy_from_slice(block_hash.as_ref());
@@ -262,8 +267,6 @@ pub(crate) fn block_entry_key(block_hash: &Hash) -> [u8; 46] {
 
 /// The key a given candidate entry is stored under.
 pub(crate) fn candidate_entry_key(candidate_hash: &CandidateHash) -> [u8; 46] {
-	const CANDIDATE_ENTRY_PREFIX: [u8; 14] = *b"Approvals_cand";
-
 	let mut key = [0u8; 14 + 32];
 	key[0..14].copy_from_slice(&CANDIDATE_ENTRY_PREFIX);
 	key[14..][..32].copy_from_slice(candidate_hash.0.as_ref());
@@ -273,8 +276,6 @@ pub(crate) fn candidate_entry_key(candidate_hash: &CandidateHash) -> [u8; 46] {
 
 /// The key a set of block hashes corresponding to a block number is stored under.
 pub(crate) fn blocks_at_height_key(block_number: BlockNumber) -> [u8; 16] {
-	const BLOCKS_AT_HEIGHT_PREFIX: [u8; 12] = *b"Approvals_at";
-
 	let mut key = [0u8; 12 + 4];
 	key[0..12].copy_from_slice(&BLOCKS_AT_HEIGHT_PREFIX);
 	block_number.using_encoded(|s| key[12..16].copy_from_slice(s));
@@ -293,6 +294,21 @@ pub fn load_all_blocks(store: &dyn KeyValueDB, config: &Config) -> SubsystemResu
 	}
 
 	Ok(hashes)
+}
+
+/// Return all candidate entries stored in the database.
+pub fn load_all_candidates(
+	store: &dyn KeyValueDB,
+	config: &Config,
+) -> SubsystemResult<Vec<CandidateEntry>> {
+	let mut candidate_entries = Vec::new();
+	for (_, candidate_data) in store.iter_with_prefix(config.col_data, &CANDIDATE_ENTRY_PREFIX) {
+		let candidate = CandidateEntry::decode(&mut &candidate_data[..])
+			.map_err(|e| SubsystemError::with_origin("approval-voting", e))?;
+		candidate_entries.push(candidate);
+	}
+
+	Ok(candidate_entries)
 }
 
 /// Load the stored-blocks key from the state.

--- a/node/core/approval-voting/src/approval_db/v1/mod.rs
+++ b/node/core/approval-voting/src/approval_db/v1/mod.rs
@@ -80,7 +80,10 @@ impl Backend for DbBackend {
 	}
 
 	fn load_all_candidates(&self) -> SubsystemResult<Vec<persisted_entries::CandidateEntry>> {
-		Ok(load_all_candidates(&*self.inner, &self.config)?.into_iter().map(Into::into).collect())
+		Ok(load_all_candidates(&*self.inner, &self.config)?
+			.into_iter()
+			.map(Into::into)
+			.collect())
 	}
 
 	fn load_stored_blocks(&self) -> SubsystemResult<Option<StoredBlockRange>> {

--- a/node/core/approval-voting/src/approval_db/v1/tests.rs
+++ b/node/core/approval-voting/src/approval_db/v1/tests.rs
@@ -23,7 +23,7 @@ use crate::{
 };
 use kvdb::KeyValueDB;
 use polkadot_primitives::v1::Id as ParaId;
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::{HashMap, HashSet}, sync::Arc};
 
 const DATA_COL: u32 = 0;
 const NUM_COLUMNS: u32 = 1;
@@ -561,4 +561,57 @@ fn load_all_blocks_works() {
 		load_all_blocks(store.as_ref(), &TEST_CONFIG).unwrap(),
 		vec![block_hash_a, block_hash_b, block_hash_c],
 	)
+}
+
+#[test]
+fn load_all_candidates_works() {
+	let (mut db, store) = make_db();
+
+	let block_hash = Hash::repeat_byte(1);
+
+	let make_candidate = |para_id: u32| {
+		let mut candidate = CandidateReceipt::<Hash>::default();
+		candidate.descriptor.para_id = para_id.into();
+
+		CandidateEntry {
+			candidate,
+			session: 5,
+			block_assignments: vec![(
+				block_hash,
+				ApprovalEntry {
+					tranches: Vec::new(),
+					backing_group: GroupIndex(1),
+					our_assignment: None,
+					our_approval_sig: None,
+					assignments: Default::default(),
+					approved: false,
+				},
+			)]
+			.into_iter()
+			.collect(),
+			approvals: Default::default(),
+		}
+	};
+
+	let candidates = vec![
+		make_candidate(1),
+		make_candidate(2),
+		make_candidate(3),
+	];
+	let candidate_hashes: HashSet<_> = candidates.iter().map(|c| c.candidate.hash()).collect();
+
+	let mut overlay_db = OverlayedBackend::new(&db);
+	for candidate in candidates {
+		overlay_db.write_candidate_entry(candidate.into());
+	}
+	let write_ops = overlay_db.into_write_ops();
+	db.write(write_ops).unwrap();
+
+	let all_candidate_hashes: HashSet<_> = load_all_candidates(store.as_ref(), &TEST_CONFIG)
+		.unwrap()
+		.iter()
+		.map(|c| c.candidate.hash())
+		.collect();
+
+	assert_eq!(candidate_hashes, all_candidate_hashes);
 }

--- a/node/core/approval-voting/src/approval_db/v1/tests.rs
+++ b/node/core/approval-voting/src/approval_db/v1/tests.rs
@@ -23,7 +23,10 @@ use crate::{
 };
 use kvdb::KeyValueDB;
 use polkadot_primitives::v1::Id as ParaId;
-use std::{collections::{HashMap, HashSet}, sync::Arc};
+use std::{
+	collections::{HashMap, HashSet},
+	sync::Arc,
+};
 
 const DATA_COL: u32 = 0;
 const NUM_COLUMNS: u32 = 1;
@@ -593,11 +596,7 @@ fn load_all_candidates_works() {
 		}
 	};
 
-	let candidates = vec![
-		make_candidate(1),
-		make_candidate(2),
-		make_candidate(3),
-	];
+	let candidates = vec![make_candidate(1), make_candidate(2), make_candidate(3)];
 	let candidate_hashes: HashSet<_> = candidates.iter().map(|c| c.candidate.hash()).collect();
 
 	let mut overlay_db = OverlayedBackend::new(&db);

--- a/node/core/approval-voting/src/backend.rs
+++ b/node/core/approval-voting/src/backend.rs
@@ -55,6 +55,8 @@ pub trait Backend {
 	fn load_blocks_at_height(&self, height: &BlockNumber) -> SubsystemResult<Vec<Hash>>;
 	/// Load all block from the DB.
 	fn load_all_blocks(&self) -> SubsystemResult<Vec<Hash>>;
+	/// Load all candidates from the DB.
+	fn load_all_candidates(&self) -> SubsystemResult<Vec<CandidateEntry>>;
 	/// Load stored block range form the DB.
 	fn load_stored_blocks(&self) -> SubsystemResult<Option<StoredBlockRange>>;
 	/// Atomically write the list of operations, with later operations taking precedence over prior.
@@ -108,6 +110,28 @@ impl<'a, B: 'a + Backend> OverlayedBackend<'a, B> {
 		}
 
 		Ok(hashes)
+	}
+
+	pub fn load_all_candidates(&self) -> SubsystemResult<Vec<CandidateEntry>> {
+		// Load all candidates from disk.
+		let mut candidates: HashMap<_, _> = self.inner.load_all_candidates()?
+			.into_iter()
+			.map(|c| (c.candidate.hash(), c))
+			.collect();
+
+		// Modify the set to reflect any unpersisted changes.
+		for (c_hash, c_entry) in self.candidate_entries.iter() {
+			match c_entry {
+				Some(c_entry) => {
+					let _ = candidates.insert(*c_hash, c_entry.clone());
+				}
+				None => {
+					let _ = candidates.remove(c_hash);
+				}
+			}
+		}
+
+		Ok(candidates.into_iter().map(|(_, c_entry)| c_entry).collect())
 	}
 
 	pub fn load_stored_blocks(&self) -> SubsystemResult<Option<StoredBlockRange>> {

--- a/node/core/approval-voting/src/backend.rs
+++ b/node/core/approval-voting/src/backend.rs
@@ -114,7 +114,9 @@ impl<'a, B: 'a + Backend> OverlayedBackend<'a, B> {
 
 	pub fn load_all_candidates(&self) -> SubsystemResult<Vec<CandidateEntry>> {
 		// Load all candidates from disk.
-		let mut candidates: HashMap<_, _> = self.inner.load_all_candidates()?
+		let mut candidates: HashMap<_, _> = self
+			.inner
+			.load_all_candidates()?
 			.into_iter()
 			.map(|c| (c.candidate.hash(), c))
 			.collect();
@@ -124,10 +126,10 @@ impl<'a, B: 'a + Backend> OverlayedBackend<'a, B> {
 			match c_entry {
 				Some(c_entry) => {
 					let _ = candidates.insert(*c_hash, c_entry.clone());
-				}
+				},
 				None => {
 					let _ = candidates.remove(c_hash);
-				}
+				},
 			}
 		}
 

--- a/node/core/approval-voting/src/import.rs
+++ b/node/core/approval-voting/src/import.rs
@@ -586,8 +586,8 @@ pub(crate) mod tests {
 	use std::{pin::Pin, sync::Arc};
 
 	use crate::{
-		RecoveryState,
-		approval_db::v1::Config as DatabaseConfig, criteria, BlockEntry, APPROVAL_SESSIONS,
+		approval_db::v1::Config as DatabaseConfig, criteria, BlockEntry, RecoveryState,
+		APPROVAL_SESSIONS,
 	};
 
 	const DATA_COL: u32 = 0;

--- a/node/core/approval-voting/src/import.rs
+++ b/node/core/approval-voting/src/import.rs
@@ -586,6 +586,7 @@ pub(crate) mod tests {
 	use std::{pin::Pin, sync::Arc};
 
 	use crate::{
+		RecoveryState,
 		approval_db::v1::Config as DatabaseConfig, criteria, BlockEntry, APPROVAL_SESSIONS,
 	};
 
@@ -613,6 +614,7 @@ pub(crate) mod tests {
 			slot_duration_millis: 6_000,
 			clock: Box::new(MockClock::default()),
 			assignment_criteria: Box::new(MockAssignmentCriteria),
+			recovery_state: RecoveryState::Pending,
 		}
 	}
 

--- a/node/core/approval-voting/src/tests.rs
+++ b/node/core/approval-voting/src/tests.rs
@@ -278,6 +278,10 @@ impl Backend for TestStoreInner {
 		Ok(hashes)
 	}
 
+	fn load_all_candidates(&self) -> SubsystemResult<Vec<CandidateEntry>> {
+		Ok(self.candidate_entries.values().cloned().collect())
+	}
+
 	fn load_stored_blocks(&self) -> SubsystemResult<Option<StoredBlockRange>> {
 		Ok(self.stored_block_range.clone())
 	}
@@ -344,6 +348,11 @@ impl Backend for TestStore {
 	fn load_all_blocks(&self) -> SubsystemResult<Vec<Hash>> {
 		let store = self.store.lock();
 		store.load_all_blocks()
+	}
+
+	fn load_all_candidates(&self) -> SubsystemResult<Vec<CandidateEntry>> {
+		let store = self.store.lock();
+		store.load_all_candidates()
 	}
 
 	fn load_stored_blocks(&self) -> SubsystemResult<Option<StoredBlockRange>> {


### PR DESCRIPTION
Same as #3481 

The approvals work is not resumed on startup based on local assignments for approvals in the current node implementation.

This diff bridges that gap similarly to how it was handled for the dispute coordinator. Most notably, the `test_harness` in the `approval-voting` crate is modified to simulate restarts.