### PR TITLE
demote warnings due to disconnected dispute coordinator

### DIFF
--- a/node/core/approval-voting/src/lib.rs
+++ b/node/core/approval-voting/src/lib.rs
@@ -920,7 +920,7 @@ async fn handle_actions(
 
 				match confirmation_rx.await {
 					Err(oneshot::Canceled) => {
-						tracing::warn!(target: LOG_TARGET, "Dispute coordinator confirmation lost",)
+						tracing::debug!(target: LOG_TARGET, "Dispute coordinator confirmation lost",)
 					},
 					Ok(ImportStatementsResult::ValidImport) => {},
 					Ok(ImportStatementsResult::InvalidImport) => tracing::warn!(

--- a/node/core/backing/src/lib.rs
+++ b/node/core/backing/src/lib.rs
@@ -901,7 +901,7 @@ impl CandidateBackingJob {
 
 			match confirmation_rx.await {
 				Err(oneshot::Canceled) =>
-					tracing::warn!(target: LOG_TARGET, "Dispute coordinator confirmation lost",),
+					tracing::debug!(target: LOG_TARGET, "Dispute coordinator confirmation lost",),
 				Ok(ImportStatementsResult::ValidImport) => {},
 				Ok(ImportStatementsResult::InvalidImport) =>
 					tracing::warn!(target: LOG_TARGET, "Failed to import statements of validity",),

--- a/node/network/dispute-distribution/src/receiver/error.rs
+++ b/node/network/dispute-distribution/src/receiver/error.rs
@@ -106,6 +106,10 @@ pub type NonFatalResult<T> = std::result::Result<T, NonFatal>;
 pub fn log_error(result: Result<()>) -> std::result::Result<(), Fatal> {
 	match result {
 		Err(Error::Fatal(f)) => Err(f),
+		Err(Error::NonFatal(error @ NonFatal::ImportCanceled(_))) => {
+			tracing::debug!(target: LOG_TARGET, error = ?error);
+			Ok(())
+		}
 		Err(Error::NonFatal(error)) => {
 			tracing::warn!(target: LOG_TARGET, error = ?error);
 			Ok(())

--- a/node/network/dispute-distribution/src/receiver/error.rs
+++ b/node/network/dispute-distribution/src/receiver/error.rs
@@ -109,7 +109,7 @@ pub fn log_error(result: Result<()>) -> std::result::Result<(), Fatal> {
 		Err(Error::NonFatal(error @ NonFatal::ImportCanceled(_))) => {
 			tracing::debug!(target: LOG_TARGET, error = ?error);
 			Ok(())
-		}
+		},
 		Err(Error::NonFatal(error)) => {
 			tracing::warn!(target: LOG_TARGET, error = ?error);
 			Ok(())


### PR DESCRIPTION
Can be reinstated afterwards but is necessary for the moment, as the dispute coordinator is disconnected.