### PR TITLE
Bypass chain-selection subsystem until disputes are enabled.

### DIFF
--- a/node/service/src/relay_chain_selection.rs
+++ b/node/service/src/relay_chain_selection.rs
@@ -185,7 +185,7 @@ where
 			return longest_chain_best
 		}
 		self.selection
-			.finality_target(target_hash, longest_chain_best, maybe_max_number)
+			.finality_target_with_fallback(target_hash, longest_chain_best, maybe_max_number)
 			.await
 	}
 }
@@ -309,6 +309,20 @@ where
 		self.block_header(best_leaf)
 	}
 
+	async fn finality_target(
+		&self,
+		_target_hash: Hash,
+		_maybe_max_number: Option<BlockNumber>,
+	) -> Result<Option<Hash>, ConsensusError> {
+		unreachable!("Must call finality_target_with_fallback instead. qed");
+	}
+}
+
+impl<B, OH> SelectRelayChain<B, OH>
+where
+	B: HeaderProviderProvider<PolkadotBlock>,
+	OH: OverseerHandleT,
+{
 	/// Get the best descendant of `target_hash` that we should attempt to
 	/// finalize next, if any. It is valid to return the `target_hash` if
 	/// no better block exists.
@@ -318,7 +332,7 @@ where
 	///
 	/// It will also constrain the chain to only chains which are fully
 	/// approved, and chains which contain no disputes.
-	async fn finality_target(
+	pub async fn finality_target_with_fallback(
 		&self,
 		target_hash: Hash,
 		best_leaf: Hash,

--- a/node/service/src/relay_chain_selection.rs
+++ b/node/service/src/relay_chain_selection.rs
@@ -455,7 +455,7 @@ where
 		};
 
 		// 4. Apply the maximum safeguard to the finality lag.
-		if lag < MAX_FINALITY_LAG {
+		if lag > MAX_FINALITY_LAG {
 			// We need to constrain our vote as a safety net to
 			// ensure the network continues to finalize.
 			let safe_target = initial_leaf_number - MAX_FINALITY_LAG;

--- a/node/service/src/relay_chain_selection.rs
+++ b/node/service/src/relay_chain_selection.rs
@@ -332,7 +332,7 @@ where
 	///
 	/// It will also constrain the chain to only chains which are fully
 	/// approved, and chains which contain no disputes.
-	pub async fn finality_target_with_fallback(
+	async fn finality_target_with_fallback(
 		&self,
 		target_hash: Hash,
 		best_leaf: Option<Hash>,

--- a/node/service/src/relay_chain_selection.rs
+++ b/node/service/src/relay_chain_selection.rs
@@ -182,7 +182,7 @@ where
 			self.fallback.finality_target(target_hash, maybe_max_number).await?;
 
 		if self.selection.overseer.is_disconnected() {
-			return longest_chain_best
+			return Ok(longest_chain_best)
 		}
 		self.selection
 			.finality_target_with_fallback(target_hash, longest_chain_best, maybe_max_number)
@@ -273,8 +273,7 @@ impl OverseerHandleT for Handle {
 	}
 }
 
-#[async_trait::async_trait]
-impl<B, OH> SelectChain<PolkadotBlock> for SelectRelayChain<B, OH>
+impl<B, OH> SelectRelayChain<B, OH>
 where
 	B: HeaderProviderProvider<PolkadotBlock>,
 	OH: OverseerHandleT,
@@ -309,20 +308,6 @@ where
 		self.block_header(best_leaf)
 	}
 
-	async fn finality_target(
-		&self,
-		_target_hash: Hash,
-		_maybe_max_number: Option<BlockNumber>,
-	) -> Result<Option<Hash>, ConsensusError> {
-		unreachable!("Must call finality_target_with_fallback instead. qed");
-	}
-}
-
-impl<B, OH> SelectRelayChain<B, OH>
-where
-	B: HeaderProviderProvider<PolkadotBlock>,
-	OH: OverseerHandleT,
-{
 	/// Get the best descendant of `target_hash` that we should attempt to
 	/// finalize next, if any. It is valid to return the `target_hash` if
 	/// no better block exists.
@@ -457,7 +442,7 @@ where
 					std::any::type_name::<Self>(),
 				)
 				.await;
-			let (subchain_number, subchain_head) = rx
+			let (subchain_number, _subchain_head) = rx
 				.await
 				.map_err(Error::OverseerDisconnected)
 				.map_err(|e| ConsensusError::Other(Box::new(e)))?

--- a/node/service/src/relay_chain_selection.rs
+++ b/node/service/src/relay_chain_selection.rs
@@ -317,7 +317,7 @@ where
 	///
 	/// It will also constrain the chain to only chains which are fully
 	/// approved, and chains which contain no disputes.
-	async fn finality_target_with_fallback(
+	pub(crate) async fn finality_target_with_fallback(
 		&self,
 		target_hash: Hash,
 		best_leaf: Option<Hash>,

--- a/node/service/src/relay_chain_selection.rs
+++ b/node/service/src/relay_chain_selection.rs
@@ -335,7 +335,7 @@ where
 	pub async fn finality_target_with_fallback(
 		&self,
 		target_hash: Hash,
-		best_leaf: Hash,
+		best_leaf: Option<Hash>,
 		maybe_max_number: Option<BlockNumber>,
 	) -> Result<Option<Hash>, ConsensusError> {
 		let mut overseer = self.overseer.clone();
@@ -360,7 +360,10 @@ where
 				Some(best) => best,
 			}
 		} else {
-			best_leaf
+			match best_leaf {
+				None => return Ok(Some(target_hash)),
+				Some(best_leaf) => best_leaf,
+			}
 		};
 
 		let target_number = self.block_number(target_hash)?;

--- a/node/service/src/tests.rs
+++ b/node/service/src/tests.rs
@@ -88,7 +88,10 @@ fn test_harness<T: Future<Output = VirtualOverseer>>(
 
 	let target_hash = case_vars.target_block.clone();
 	let selection_process = async move {
-		let best = select_relay_chain.finality_target_with_fallback(target_hash, target_hash, None).await.unwrap();
+		let best = select_relay_chain
+			.finality_target_with_fallback(target_hash, target_hash, None)
+			.await
+			.unwrap();
 		finality_target_tx.send(best).unwrap();
 		()
 	};

--- a/node/service/src/tests.rs
+++ b/node/service/src/tests.rs
@@ -88,7 +88,7 @@ fn test_harness<T: Future<Output = VirtualOverseer>>(
 	let target_hash = case_vars.target_block.clone();
 	let selection_process = async move {
 		let best = select_relay_chain
-			.finality_target_with_fallback(target_hash, target_hash, None)
+			.finality_target_with_fallback(target_hash, Some(target_hash), None)
 			.await
 			.unwrap();
 		finality_target_tx.send(best).unwrap();
@@ -729,21 +729,25 @@ fn chain_sel_0() {
 	run_specialized_test_w_harness(chain_0);
 }
 
+#[cfg(feature = "disputes")]
 #[test]
 fn chain_sel_1() {
 	run_specialized_test_w_harness(chain_1);
 }
 
+#[cfg(feature = "disputes")]
 #[test]
 fn chain_sel_2() {
 	run_specialized_test_w_harness(chain_2);
 }
 
+#[cfg(feature = "disputes")]
 #[test]
 fn chain_sel_3() {
 	run_specialized_test_w_harness(chain_3);
 }
 
+#[cfg(feature = "disputes")]
 #[test]
 fn chain_sel_4_target_hash_value_not_contained() {
 	run_specialized_test_w_harness(chain_4);

--- a/node/service/src/tests.rs
+++ b/node/service/src/tests.rs
@@ -88,7 +88,7 @@ fn test_harness<T: Future<Output = VirtualOverseer>>(
 
 	let target_hash = case_vars.target_block.clone();
 	let selection_process = async move {
-		let best = select_relay_chain.finality_target(target_hash, None).await.unwrap();
+		let best = select_relay_chain.finality_target_with_fallback(target_hash, target_hash, None).await.unwrap();
 		finality_target_tx.send(best).unwrap();
 		()
 	};

--- a/node/service/src/tests.rs
+++ b/node/service/src/tests.rs
@@ -35,7 +35,6 @@ use std::{
 use assert_matches::assert_matches;
 use std::{sync::Arc, time::Duration};
 
-use consensus_common::SelectChain;
 use futures::{channel::oneshot, prelude::*};
 use polkadot_primitives::v1::{Block, BlockNumber, Hash, Header};
 use polkadot_subsystem::messages::{

--- a/node/service/src/tests.rs
+++ b/node/service/src/tests.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 // Copyright 2021 Parity Technologies (UK) Ltd.
 // This file is part of Polkadot.
 
@@ -724,6 +725,7 @@ fn chain_6() -> CaseVars {
 	}
 }
 
+#[cfg(feature = "disputes")]
 #[test]
 fn chain_sel_0() {
 	run_specialized_test_w_harness(chain_0);
@@ -753,11 +755,13 @@ fn chain_sel_4_target_hash_value_not_contained() {
 	run_specialized_test_w_harness(chain_4);
 }
 
+#[cfg(feature = "disputes")]
 #[test]
 fn chain_sel_5_best_is_target_hash() {
 	run_specialized_test_w_harness(chain_5);
 }
 
+#[cfg(feature = "disputes")]
 #[test]
 fn chain_sel_6_approval_lag() {
 	run_specialized_test_w_harness(chain_6);


### PR DESCRIPTION
<del>The `cfg!(feature = "fx")` does not exist yet, but it does not matter for compilation.</del> Uses the `feature = "disputes"` as gate for the relay chain selection rule.