### PR TITLE
Improve MultiLocation conversion functions in xcm-procedural

### DIFF
--- a/xcm/procedural/src/v0/multilocation.rs
+++ b/xcm/procedural/src/v0/multilocation.rs
@@ -96,7 +96,7 @@ fn generate_conversion_from_v1() -> TokenStream {
 		.collect::<TokenStream>();
 
 	quote! {
-		impl TryFrom<crate::v1::MultiLocation> for MultiLocation {
+		impl core::convert::TryFrom<crate::v1::MultiLocation> for MultiLocation {
 			type Error = ();
 			fn try_from(v1: crate::v1::MultiLocation) -> core::result::Result<Self, ()> {
 				let mut res = MultiLocation::Null;

--- a/xcm/procedural/src/v1/multilocation.rs
+++ b/xcm/procedural/src/v1/multilocation.rs
@@ -172,7 +172,7 @@ fn generate_conversion_from_v0() -> TokenStream {
 							if #( #parent_idents.is_parent() )&&* =>
 							Ok(MultiLocation {
 								parents: #parent_count,
-								interior: #junction_variant( #( #junction_idents.try_into()? ),* ),
+								interior: #junction_variant( #( core::convert::TryInto::try_into(#junction_idents)? ),* ),
 							}),
 					}
 				})
@@ -184,13 +184,13 @@ fn generate_conversion_from_v0() -> TokenStream {
 					Ok(MultiLocation::ancestor(#num_ancestors)),
 				#intermediate_match_arms
 				crate::v0::MultiLocation::#variant( #(#idents),* ) =>
-					Ok( #variant( #( #idents.try_into()? ),* ).into() ),
+					Ok( #variant( #( core::convert::TryInto::try_into(#idents)? ),* ).into() ),
 			}
 		})
 		.collect::<TokenStream>();
 
 	quote! {
-		impl TryFrom<crate::v0::MultiLocation> for MultiLocation {
+		impl core::convert::TryFrom<crate::v0::MultiLocation> for MultiLocation {
 			type Error = ();
 			fn try_from(v0: crate::v0::MultiLocation) -> core::result::Result<Self, ()> {
 				use Junctions::*;

--- a/xcm/procedural/src/v1/multilocation.rs
+++ b/xcm/procedural/src/v1/multilocation.rs
@@ -192,8 +192,10 @@ fn generate_conversion_from_v0() -> TokenStream {
 	quote! {
 		impl core::convert::TryFrom<crate::v0::MultiLocation> for MultiLocation {
 			type Error = ();
-			fn try_from(v0: crate::v0::MultiLocation) -> core::result::Result<Self, ()> {
+			fn try_from(mut v0: crate::v0::MultiLocation) -> core::result::Result<Self, ()> {
 				use Junctions::*;
+
+				v0.canonicalize();
 				match v0 {
 					crate::v0::MultiLocation::Null => Ok(Here.into()),
 					#match_variants

--- a/xcm/src/v0/multi_location.rs
+++ b/xcm/src/v0/multi_location.rs
@@ -17,7 +17,7 @@
 //! Cross-Consensus Message format data structures.
 
 use super::Junction;
-use core::{convert::TryFrom, mem, result};
+use core::{mem, result};
 use parity_scale_codec::{self, Decode, Encode};
 
 /// A relative path between state-bearing consensus systems.

--- a/xcm/src/v1/multilocation.rs
+++ b/xcm/src/v1/multilocation.rs
@@ -895,7 +895,7 @@ mod tests {
 		);
 		assert_eq!(
 			v0::MultiLocation::X2(v0::Junction::Parachain(88), v0::Junction::Parent).try_into(),
-			Err::<MultiLocation, ()>(()),
+			Ok(MultiLocation::here()),
 		);
 		assert_eq!(
 			v0::MultiLocation::X3(

--- a/xcm/src/v1/multilocation.rs
+++ b/xcm/src/v1/multilocation.rs
@@ -17,10 +17,7 @@
 //! Cross-Consensus Message format data structures.
 
 use super::Junction;
-use core::{
-	convert::{TryFrom, TryInto},
-	mem, result,
-};
+use core::{convert::TryFrom, mem, result};
 use parity_scale_codec::{Decode, Encode};
 
 /// A relative path between state-bearing consensus systems.


### PR DESCRIPTION
Make use of fully qualified paths when generating code in proc macros, and ensures a canonicalized v0 MultiLocation before converting to v1 MultiLocation.