### PR TITLE
XCM: Introduce versioning to dispatchables' params

### DIFF
--- a/bridges/primitives/chain-rococo/src/lib.rs
+++ b/bridges/primitives/chain-rococo/src/lib.rs
@@ -42,7 +42,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: sp_version::create_runtime_str!("rococo"),
 	impl_name: sp_version::create_runtime_str!("parity-rococo-v1.6"),
 	authoring_version: 0,
-	spec_version: 9004,
+	spec_version: 9100,
 	impl_version: 0,
 	apis: sp_version::create_apis_vec![[]],
 	transaction_version: 0,

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -115,7 +115,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("kusama"),
 	impl_name: create_runtime_str!("parity-kusama"),
 	authoring_version: 2,
-	spec_version: 9090,
+	spec_version: 9100,
 	impl_version: 0,
 	#[cfg(not(feature = "disable-runtime-api"))]
 	apis: RUNTIME_API_VERSIONS,

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -96,7 +96,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("polkadot"),
 	impl_name: create_runtime_str!("parity-polkadot"),
 	authoring_version: 0,
-	spec_version: 9090,
+	spec_version: 9100,
 	impl_version: 0,
 	#[cfg(not(feature = "disable-runtime-api"))]
 	apis: RUNTIME_API_VERSIONS,

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -105,7 +105,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("rococo"),
 	impl_name: create_runtime_str!("parity-rococo-v1.6"),
 	authoring_version: 0,
-	spec_version: 9004,
+	spec_version: 9100,
 	impl_version: 0,
 	#[cfg(not(feature = "disable-runtime-api"))]
 	apis: RUNTIME_API_VERSIONS,

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -114,7 +114,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("westend"),
 	impl_name: create_runtime_str!("parity-westend"),
 	authoring_version: 2,
-	spec_version: 9090,
+	spec_version: 9100,
 	impl_version: 0,
 	#[cfg(not(feature = "disable-runtime-api"))]
 	apis: RUNTIME_API_VERSIONS,

--- a/xcm/pallet-xcm/src/lib.rs
+++ b/xcm/pallet-xcm/src/lib.rs
@@ -26,8 +26,8 @@ mod tests;
 use codec::{Decode, Encode};
 use frame_support::traits::{Contains, EnsureOrigin, Get, OriginTrait};
 use sp_runtime::{traits::BadOrigin, RuntimeDebug};
-use sp_std::{boxed::Box, convert::TryInto, marker::PhantomData, prelude::*, vec};
-use xcm::latest::prelude::*;
+use sp_std::{boxed::Box, convert::{TryInto, TryFrom}, marker::PhantomData, prelude::*, vec};
+use xcm::{latest::prelude::*, VersionedXcm, VersionedMultiAssets, VersionedMultiLocation};
 use xcm_executor::traits::ConvertOrigin;
 
 use frame_support::PalletId;
@@ -108,6 +108,8 @@ pub mod pallet {
 		TooManyAssets,
 		/// Origin is invalid for sending.
 		InvalidOrigin,
+		/// The version of the `Versioned` value used is not able to be interpreted.
+		BadVersion,
 	}
 
 	#[pallet::hooks]
@@ -118,17 +120,20 @@ pub mod pallet {
 		#[pallet::weight(100_000_000)]
 		pub fn send(
 			origin: OriginFor<T>,
-			dest: Box<MultiLocation>,
-			message: Box<Xcm<()>>,
+			dest: Box<VersionedMultiLocation>,
+			message: Box<VersionedXcm<()>>,
 		) -> DispatchResult {
 			let origin_location = T::SendXcmOrigin::ensure_origin(origin)?;
 			let interior =
 				origin_location.clone().try_into().map_err(|_| Error::<T>::InvalidOrigin)?;
-			Self::send_xcm(interior, *dest.clone(), *message.clone()).map_err(|e| match e {
+			let dest = MultiLocation::try_from(*dest).map_err(|()| Error::<T>::BadVersion)?;
+			let message: Xcm<()> = (*message).try_into().map_err(|()| Error::<T>::BadVersion)?;
+
+			Self::send_xcm(interior, dest.clone(), message.clone()).map_err(|e| match e {
 				XcmError::CannotReachDestination(..) => Error::<T>::Unreachable,
 				_ => Error::<T>::SendFailure,
 			})?;
-			Self::deposit_event(Event::Sent(origin_location, *dest, *message));
+			Self::deposit_event(Event::Sent(origin_location, dest, message));
 			Ok(())
 		}
 
@@ -146,25 +151,36 @@ pub mod pallet {
 		/// - `dest_weight`: Equal to the total weight on `dest` of the XCM message
 		///   `Teleport { assets, effects: [ BuyExecution{..}, DepositAsset{..} ] }`.
 		#[pallet::weight({
-			let mut message = Xcm::WithdrawAsset {
-				assets: assets.clone(),
-				effects: sp_std::vec![ InitiateTeleport {
-					assets: Wild(All),
-					dest: *dest.clone(),
-					effects: sp_std::vec![],
-				} ]
-			};
-			T::Weigher::weight(&mut message).map_or(Weight::max_value(), |w| 100_000_000 + w)
+			let maybe_assets: Result<MultiAssets, ()> = (*assets.clone()).try_into();
+			let maybe_dest: Result<MultiLocation, ()> = (*dest.clone()).try_into();
+			match (maybe_assets, maybe_dest) {
+				(Ok(assets), Ok(dest)) => {
+					let mut message = Xcm::WithdrawAsset {
+						assets,
+						effects: sp_std::vec![ InitiateTeleport {
+							assets: Wild(All),
+							dest,
+							effects: sp_std::vec![],
+						} ]
+					};
+					T::Weigher::weight(&mut message).map_or(Weight::max_value(), |w| 100_000_000 + w)
+				},
+				_ => Weight::max_value(),
+			}
 		})]
 		pub fn teleport_assets(
 			origin: OriginFor<T>,
-			dest: Box<MultiLocation>,
-			beneficiary: Box<MultiLocation>,
-			assets: MultiAssets,
+			dest: Box<VersionedMultiLocation>,
+			beneficiary: Box<VersionedMultiLocation>,
+			assets: Box<VersionedMultiAssets>,
 			fee_asset_item: u32,
 			dest_weight: Weight,
 		) -> DispatchResult {
 			let origin_location = T::ExecuteXcmOrigin::ensure_origin(origin)?;
+			let dest = MultiLocation::try_from(*dest).map_err(|()| Error::<T>::BadVersion)?;
+			let beneficiary = MultiLocation::try_from(*beneficiary).map_err(|()| Error::<T>::BadVersion)?;
+			let assets = MultiAssets::try_from(*assets).map_err(|()| Error::<T>::BadVersion)?;
+
 			ensure!(assets.len() <= MAX_ASSETS_FOR_TRANSFER, Error::<T>::TooManyAssets);
 			let value = (origin_location, assets.drain());
 			ensure!(T::XcmTeleportFilter::contains(&value), Error::<T>::Filtered);
@@ -182,7 +198,7 @@ pub mod pallet {
 				assets,
 				effects: vec![InitiateTeleport {
 					assets: Wild(All),
-					dest: *dest,
+					dest,
 					effects: vec![
 						BuyExecution {
 							fees,
@@ -192,7 +208,7 @@ pub mod pallet {
 							halt_on_error: false,
 							instructions: vec![],
 						},
-						DepositAsset { assets: Wild(All), max_assets, beneficiary: *beneficiary },
+						DepositAsset { assets: Wild(All), max_assets, beneficiary },
 					],
 				}],
 			};
@@ -219,22 +235,28 @@ pub mod pallet {
 		/// - `dest_weight`: Equal to the total weight on `dest` of the XCM message
 		///   `ReserveAssetDeposited { assets, effects: [ BuyExecution{..}, DepositAsset{..} ] }`.
 		#[pallet::weight({
-			let mut message = Xcm::TransferReserveAsset {
-				assets: assets.clone(),
-				dest: *dest.clone(),
-				effects: sp_std::vec![],
-			};
-			T::Weigher::weight(&mut message).map_or(Weight::max_value(), |w| 100_000_000 + w)
+			match ((*assets.clone()).try_into(), (*dest.clone()).try_into()) {
+				(Ok(assets), Ok(dest)) => {
+					let effects = sp_std::vec![];
+					let mut message = Xcm::TransferReserveAsset { assets, dest, effects };
+					T::Weigher::weight(&mut message).map_or(Weight::max_value(), |w| 100_000_000 + w)
+				},
+				_ => Weight::max_value(),
+			}
 		})]
 		pub fn reserve_transfer_assets(
 			origin: OriginFor<T>,
-			dest: Box<MultiLocation>,
-			beneficiary: Box<MultiLocation>,
-			assets: MultiAssets,
+			dest: Box<VersionedMultiLocation>,
+			beneficiary: Box<VersionedMultiLocation>,
+			assets: Box<VersionedMultiAssets>,
 			fee_asset_item: u32,
 			dest_weight: Weight,
 		) -> DispatchResult {
 			let origin_location = T::ExecuteXcmOrigin::ensure_origin(origin)?;
+			let dest = (*dest).try_into().map_err(|()| Error::<T>::BadVersion)?;
+			let beneficiary = (*beneficiary).try_into().map_err(|()| Error::<T>::BadVersion)?;
+			let assets: MultiAssets = (*assets).try_into().map_err(|()| Error::<T>::BadVersion)?;
+			
 			ensure!(assets.len() <= MAX_ASSETS_FOR_TRANSFER, Error::<T>::TooManyAssets);
 			let value = (origin_location, assets.drain());
 			ensure!(T::XcmReserveTransferFilter::contains(&value), Error::<T>::Filtered);
@@ -250,7 +272,7 @@ pub mod pallet {
 			let assets = assets.into();
 			let mut message = Xcm::TransferReserveAsset {
 				assets,
-				dest: *dest,
+				dest,
 				effects: vec![
 					BuyExecution {
 						fees,
@@ -260,7 +282,7 @@ pub mod pallet {
 						halt_on_error: false,
 						instructions: vec![],
 					},
-					DepositAsset { assets: Wild(All), max_assets, beneficiary: *beneficiary },
+					DepositAsset { assets: Wild(All), max_assets, beneficiary },
 				],
 			};
 			let weight =
@@ -285,11 +307,12 @@ pub mod pallet {
 		#[pallet::weight(max_weight.saturating_add(100_000_000u64))]
 		pub fn execute(
 			origin: OriginFor<T>,
-			message: Box<Xcm<T::Call>>,
+			message: Box<VersionedXcm<T::Call>>,
 			max_weight: Weight,
 		) -> DispatchResult {
 			let origin_location = T::ExecuteXcmOrigin::ensure_origin(origin)?;
-			let value = (origin_location, *message);
+			let message = (*message).try_into().map_err(|()| Error::<T>::BadVersion)?;
+			let value = (origin_location, message);
 			ensure!(T::XcmExecuteFilter::contains(&value), Error::<T>::Filtered);
 			let (origin_location, message) = value;
 			let outcome = T::XcmExecutor::execute_xcm(origin_location, message, max_weight);

--- a/xcm/pallet-xcm/src/lib.rs
+++ b/xcm/pallet-xcm/src/lib.rs
@@ -26,8 +26,14 @@ mod tests;
 use codec::{Decode, Encode};
 use frame_support::traits::{Contains, EnsureOrigin, Get, OriginTrait};
 use sp_runtime::{traits::BadOrigin, RuntimeDebug};
-use sp_std::{boxed::Box, convert::{TryInto, TryFrom}, marker::PhantomData, prelude::*, vec};
-use xcm::{latest::prelude::*, VersionedXcm, VersionedMultiAssets, VersionedMultiLocation};
+use sp_std::{
+	boxed::Box,
+	convert::{TryFrom, TryInto},
+	marker::PhantomData,
+	prelude::*,
+	vec,
+};
+use xcm::{latest::prelude::*, VersionedMultiAssets, VersionedMultiLocation, VersionedXcm};
 use xcm_executor::traits::ConvertOrigin;
 
 use frame_support::PalletId;
@@ -178,7 +184,8 @@ pub mod pallet {
 		) -> DispatchResult {
 			let origin_location = T::ExecuteXcmOrigin::ensure_origin(origin)?;
 			let dest = MultiLocation::try_from(*dest).map_err(|()| Error::<T>::BadVersion)?;
-			let beneficiary = MultiLocation::try_from(*beneficiary).map_err(|()| Error::<T>::BadVersion)?;
+			let beneficiary =
+				MultiLocation::try_from(*beneficiary).map_err(|()| Error::<T>::BadVersion)?;
 			let assets = MultiAssets::try_from(*assets).map_err(|()| Error::<T>::BadVersion)?;
 
 			ensure!(assets.len() <= MAX_ASSETS_FOR_TRANSFER, Error::<T>::TooManyAssets);
@@ -256,7 +263,7 @@ pub mod pallet {
 			let dest = (*dest).try_into().map_err(|()| Error::<T>::BadVersion)?;
 			let beneficiary = (*beneficiary).try_into().map_err(|()| Error::<T>::BadVersion)?;
 			let assets: MultiAssets = (*assets).try_into().map_err(|()| Error::<T>::BadVersion)?;
-			
+
 			ensure!(assets.len() <= MAX_ASSETS_FOR_TRANSFER, Error::<T>::TooManyAssets);
 			let value = (origin_location, assets.drain());
 			ensure!(T::XcmReserveTransferFilter::contains(&value), Error::<T>::Filtered);

--- a/xcm/src/lib.rs
+++ b/xcm/src/lib.rs
@@ -27,6 +27,7 @@ use core::{
 	convert::{TryFrom, TryInto},
 	result::Result,
 };
+use alloc::vec::Vec;
 use derivative::Derivative;
 use parity_scale_codec::{Decode, Encode, Error as CodecError, Input};
 
@@ -49,6 +50,140 @@ impl Encode for Unsupported {}
 impl Decode for Unsupported {
 	fn decode<I: Input>(_: &mut I) -> Result<Self, CodecError> {
 		Err("Not decodable".into())
+	}
+}
+
+/// A single `MultiLocation` value, together with its version code.
+#[derive(Derivative, Encode, Decode)]
+#[derivative(Clone(bound = ""), Eq(bound = ""), PartialEq(bound = ""), Debug(bound = ""))]
+#[codec(encode_bound())]
+#[codec(decode_bound())]
+pub enum VersionedMultiLocation {
+	V0(v0::MultiLocation),
+	V1(v1::MultiLocation),
+}
+
+impl From<v0::MultiLocation> for VersionedMultiLocation {
+	fn from(x: v0::MultiLocation) -> Self {
+		VersionedMultiLocation::V0(x)
+	}
+}
+
+impl<T: Into<v1::MultiLocation>> From<T> for VersionedMultiLocation {
+	fn from(x: T) -> Self {
+		VersionedMultiLocation::V1(x.into())
+	}
+}
+
+impl TryFrom<VersionedMultiLocation> for v0::MultiLocation {
+	type Error = ();
+	fn try_from(x: VersionedMultiLocation) -> Result<Self, ()> {
+		use VersionedMultiLocation::*;
+		match x {
+			V0(x) => Ok(x),
+			V1(x) => x.try_into(),
+		}
+	}
+}
+
+impl TryFrom<VersionedMultiLocation> for v1::MultiLocation {
+	type Error = ();
+	fn try_from(x: VersionedMultiLocation) -> Result<Self, ()> {
+		use VersionedMultiLocation::*;
+		match x {
+			V0(x) => x.try_into(),
+			V1(x) => Ok(x),
+		}
+	}
+}
+
+/// A single `MultiAsset` value, together with its version code.
+#[derive(Derivative, Encode, Decode)]
+#[derivative(Clone(bound = ""), Eq(bound = ""), PartialEq(bound = ""), Debug(bound = ""))]
+#[codec(encode_bound())]
+#[codec(decode_bound())]
+pub enum VersionedMultiAsset {
+	V0(v0::MultiAsset),
+	V1(v1::MultiAsset),
+}
+
+impl From<v0::MultiAsset> for VersionedMultiAsset {
+	fn from(x: v0::MultiAsset) -> Self {
+		VersionedMultiAsset::V0(x)
+	}
+}
+
+impl<T: Into<v1::MultiAsset>> From<T> for VersionedMultiAsset {
+	fn from(x: T) -> Self {
+		VersionedMultiAsset::V1(x.into())
+	}
+}
+
+impl TryFrom<VersionedMultiAsset> for v0::MultiAsset {
+	type Error = ();
+	fn try_from(x: VersionedMultiAsset) -> Result<Self, ()> {
+		use VersionedMultiAsset::*;
+		match x {
+			V0(x) => Ok(x),
+			V1(x) => x.try_into(),
+		}
+	}
+}
+
+impl TryFrom<VersionedMultiAsset> for v1::MultiAsset {
+	type Error = ();
+	fn try_from(x: VersionedMultiAsset) -> Result<Self, ()> {
+		use VersionedMultiAsset::*;
+		match x {
+			V0(x) => x.try_into(),
+			V1(x) => Ok(x),
+		}
+	}
+}
+
+/// A single `MultiAssets` value, together with its version code.
+/// 
+/// NOTE: For XCM v0, this was `Vec<MultiAsset>`.
+#[derive(Derivative, Encode, Decode)]
+#[derivative(Clone(bound = ""), Eq(bound = ""), PartialEq(bound = ""), Debug(bound = ""))]
+#[codec(encode_bound())]
+#[codec(decode_bound())]
+pub enum VersionedMultiAssets {
+	V0(Vec<v0::MultiAsset>),
+	V1(v1::MultiAssets),
+}
+
+impl From<Vec<v0::MultiAsset>> for VersionedMultiAssets {
+	fn from(x: Vec<v0::MultiAsset>) -> Self {
+		VersionedMultiAssets::V0(x)
+	}
+}
+
+impl<T: Into<v1::MultiAssets>> From<T> for VersionedMultiAssets {
+	fn from(x: T) -> Self {
+		VersionedMultiAssets::V1(x.into())
+	}
+}
+
+impl TryFrom<VersionedMultiAssets> for Vec<v0::MultiAsset> {
+	type Error = ();
+	fn try_from(x: VersionedMultiAssets) -> Result<Self, ()> {
+		use VersionedMultiAssets::*;
+		match x {
+			V0(x) => Ok(x),
+			V1(x) => x.try_into(),
+		}
+	}
+}
+
+impl TryFrom<VersionedMultiAssets> for v1::MultiAssets {
+	type Error = ();
+	fn try_from(x: VersionedMultiAssets) -> Result<Self, ()> {
+		use VersionedMultiAssets::*;
+		match x {
+			V0(x) => x.try_into(),
+			V1(x) => Ok(x),
+		}
 	}
 }
 

--- a/xcm/src/lib.rs
+++ b/xcm/src/lib.rs
@@ -23,11 +23,11 @@
 #![no_std]
 extern crate alloc;
 
+use alloc::vec::Vec;
 use core::{
 	convert::{TryFrom, TryInto},
 	result::Result,
 };
-use alloc::vec::Vec;
 use derivative::Derivative;
 use parity_scale_codec::{Decode, Encode, Error as CodecError, Input};
 
@@ -142,7 +142,7 @@ impl TryFrom<VersionedMultiAsset> for v1::MultiAsset {
 }
 
 /// A single `MultiAssets` value, together with its version code.
-/// 
+///
 /// NOTE: For XCM v0, this was `Vec<MultiAsset>`.
 #[derive(Derivative, Encode, Decode)]
 #[derivative(Clone(bound = ""), Eq(bound = ""), PartialEq(bound = ""), Debug(bound = ""))]

--- a/xcm/xcm-executor/integration-tests/src/lib.rs
+++ b/xcm/xcm-executor/integration-tests/src/lib.rs
@@ -24,7 +24,7 @@ use polkadot_test_client::{
 use polkadot_test_service::construct_extrinsic;
 use sp_runtime::{generic::BlockId, traits::Block};
 use sp_state_machine::InspectState;
-use xcm::latest::prelude::*;
+use xcm::{latest::prelude::*, VersionedXcm};
 use xcm_executor::MAX_RECURSION_LIMIT;
 
 // This is the inflection point where the test should either fail or pass.
@@ -57,7 +57,7 @@ fn execute_within_recursion_limit() {
 	let execute = construct_extrinsic(
 		&client,
 		polkadot_test_runtime::Call::Xcm(pallet_xcm::Call::execute(
-			Box::new(msg.clone()),
+			Box::new(VersionedXcm::from(msg.clone())),
 			1_000_000_000,
 		)),
 		sp_keyring::Sr25519Keyring::Alice,
@@ -111,7 +111,7 @@ fn exceed_recursion_limit() {
 	let execute = construct_extrinsic(
 		&client,
 		polkadot_test_runtime::Call::Xcm(pallet_xcm::Call::execute(
-			Box::new(msg.clone()),
+			Box::new(VersionedXcm::from(msg.clone())),
 			1_000_000_000,
 		)),
 		sp_keyring::Sr25519Keyring::Alice,

--- a/xcm/xcm-simulator/example/src/lib.rs
+++ b/xcm/xcm-simulator/example/src/lib.rs
@@ -211,9 +211,9 @@ mod tests {
 		Relay::execute_with(|| {
 			assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 				relay_chain::Origin::signed(ALICE),
-				Box::new(X1(Parachain(1)).into()),
-				Box::new(X1(AccountId32 { network: Any, id: ALICE.into() }).into()),
-				(Here, withdraw_amount).into(),
+				Box::new(X1(Parachain(1)).into().into()),
+				Box::new(X1(AccountId32 { network: Any, id: ALICE.into() }).into().into()),
+				Box::new((Here, withdraw_amount).into()),
 				0,
 				max_weight_for_execution,
 			));


### PR DESCRIPTION
Ensure that dispatchables (which can be used for transactions) have versioned XCM params, since bare XCM datatypes are expected to change between runtimes which can cause problems with queued transactions which persist between runtime versions.

This should go in prior to the release of a version with XCM v1 to minimise alterations to transactions that infrastructure providers need to manage.

CC @s3krit @jacogr 