### PR TITLE
Better overlength block handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6211,6 +6211,7 @@ dependencies = [
  "bitvec 0.20.1",
  "futures 0.3.16",
  "futures-timer 3.0.2",
+ "parity-scale-codec",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-test-helpers",
  "polkadot-node-subsystem-util",

--- a/node/core/provisioner/Cargo.toml
+++ b/node/core/provisioner/Cargo.toml
@@ -9,6 +9,7 @@ bitvec = { version = "0.20.1", default-features = false, features = ["alloc"] }
 futures = "0.3.15"
 tracing = "0.1.26"
 thiserror = "1.0.26"
+parity-scale-codec = "2.2.0"
 polkadot-primitives = { path = "../../../primitives" }
 polkadot-node-subsystem = { path = "../../subsystem" }
 polkadot-node-subsystem-util = { path = "../../subsystem-util" }


### PR DESCRIPTION
This PR should address the overlength block vulnerability raised by srlabs. In particular, this PR modifies the `select_candidates` function to keep track of two things:

1. The `cumulative_size` of all candidates in the selection
2. The single validation code containing candidate (if any)

In the issue, jakoblell mentions that it may be prudent to randomize the selection set so that the validation code containing candidate can not be influenced externally. This would be a suitable use of reservoir sampling.