### PR TITLE
XCM: Allow reclaim of assets dropped from holding

### DIFF
--- a/runtime/common/src/claims.rs
+++ b/runtime/common/src/claims.rs
@@ -1044,7 +1044,7 @@ mod tests {
 	}
 
 	#[test]
-	fn invalid_attest_transactions_are_recognised() {
+	fn invalid_attest_transactions_are_recognized() {
 		new_test_ext().execute_with(|| {
 			let p = PrevalidateAttests::<Test>::new();
 			let c = Call::Claims(ClaimsCall::attest(StatementKind::Regular.to_text().to_vec()));

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -1296,7 +1296,9 @@ impl xcm_executor::Config for XcmConfig {
 	type Weigher = FixedWeightBounds<BaseXcmWeight, Call, MaxInstructions>;
 	// The weight trader piggybacks on the existing transaction-fee conversion logic.
 	type Trader = UsingComponents<WeightToFee, KsmLocation, AccountId, Balances, ToAuthor<Runtime>>;
-	type ResponseHandler = ();
+	type ResponseHandler = XcmPallet;
+	type AssetTrap = XcmPallet;
+	type AssetClaims = XcmPallet;
 }
 
 parameter_types! {

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -669,7 +669,9 @@ impl xcm_executor::Config for XcmConfig {
 	type Barrier = Barrier;
 	type Weigher = FixedWeightBounds<BaseXcmWeight, Call, MaxInstructions>;
 	type Trader = UsingComponents<WeightToFee, RocLocation, AccountId, Balances, ToAuthor<Runtime>>;
-	type ResponseHandler = ();
+	type ResponseHandler = XcmPallet;
+	type AssetTrap = XcmPallet;
+	type AssetClaims = XcmPallet;
 }
 
 parameter_types! {

--- a/runtime/test-runtime/src/xcm_config.rs
+++ b/runtime/test-runtime/src/xcm_config.rs
@@ -86,4 +86,6 @@ impl xcm_executor::Config for XcmConfig {
 	type Weigher = FixedWeightBounds<super::BaseXcmWeight, super::Call, MaxInstructions>;
 	type Trader = DummyWeightTrader;
 	type ResponseHandler = super::Xcm;
+	type AssetTrap = super::Xcm;
+	type AssetClaims = super::Xcm;
 }

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -938,7 +938,9 @@ impl xcm_executor::Config for XcmConfig {
 	type Barrier = Barrier;
 	type Weigher = FixedWeightBounds<BaseXcmWeight, Call, MaxInstructions>;
 	type Trader = UsingComponents<WeightToFee, WndLocation, AccountId, Balances, ToAuthor<Runtime>>;
-	type ResponseHandler = ();
+	type ResponseHandler = XcmPallet;
+	type AssetTrap = XcmPallet;
+	type AssetClaims = XcmPallet;
 }
 
 /// Type to convert an `Origin` type value into a `MultiLocation` value which represents an interior location

--- a/xcm/pallet-xcm/Cargo.toml
+++ b/xcm/pallet-xcm/Cargo.toml
@@ -11,6 +11,7 @@ log = { version = "0.4.14", default-features = false }
 
 sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
 sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
 frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
 frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
 
@@ -20,7 +21,6 @@ xcm-executor = { path = "../xcm-executor", default-features = false }
 [dev-dependencies]
 pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "master" }
 polkadot-runtime-parachains = { path = "../../runtime/parachains" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sp-io = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 xcm-builder = { path = "../xcm-builder" }
 polkadot-parachain = { path = "../../parachain" }
@@ -31,6 +31,7 @@ std = [
 	"codec/std",
 	"serde",
 	"sp-std/std",
+	"sp-core/std",
 	"sp-runtime/std",
 	"frame-support/std",
 	"frame-system/std",

--- a/xcm/pallet-xcm/src/lib.rs
+++ b/xcm/pallet-xcm/src/lib.rs
@@ -249,7 +249,7 @@ pub mod pallet {
 
 	/// The existing asset traps.
 	///
-	/// Key is the blake2 256 hash of (origin, versioned multiassets) pair. Value is the number of
+	/// Key is the blake2 256 hash of (origin, versioned `MultiAssets`) pair. Value is the number of
 	/// times this pair has been trapped (usually just 1 if it exists at all).
 	#[pallet::storage]
 	#[pallet::getter(fn asset_trap)]

--- a/xcm/pallet-xcm/src/lib.rs
+++ b/xcm/pallet-xcm/src/lib.rs
@@ -234,9 +234,6 @@ pub mod pallet {
 	/// Value of a query, must be unique for each query.
 	pub type QueryId = u64;
 
-	/// Identifier for an asset trap.
-	pub type TrapId = u64;
-
 	/// The latest available query index.
 	#[pallet::storage]
 	pub(super) type QueryCount<T: Config> = StorageValue<_, QueryId, ValueQuery>;

--- a/xcm/pallet-xcm/src/mock.rs
+++ b/xcm/pallet-xcm/src/mock.rs
@@ -251,6 +251,8 @@ impl xcm_executor::Config for XcmConfig {
 	type Weigher = FixedWeightBounds<BaseXcmWeight, Call, MaxInstructions>;
 	type Trader = FixedRateOfFungible<CurrencyPerSecond, ()>;
 	type ResponseHandler = XcmPallet;
+	type AssetTrap = XcmPallet;
+	type AssetClaims = XcmPallet;
 }
 
 pub type LocalOriginToLocation = SignedToAccountId32<Origin, AccountId, AnyNetwork>;

--- a/xcm/pallet-xcm/src/tests.rs
+++ b/xcm/pallet-xcm/src/tests.rs
@@ -14,12 +14,12 @@
 // You should have received a copy of the GNU General Public License
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::{mock::*, QueryStatus, AssetTraps};
+use crate::{mock::*, AssetTraps, QueryStatus};
 use frame_support::{assert_noop, assert_ok, traits::Currency};
 use polkadot_parachain::primitives::{AccountIdConversion, Id as ParaId};
 use sp_runtime::traits::{BlakeTwo256, Hash};
 use std::convert::TryInto;
-use xcm::{VersionedMultiAssets, VersionedXcm, latest::prelude::*};
+use xcm::{latest::prelude::*, VersionedMultiAssets, VersionedXcm};
 use xcm_executor::XcmExecutor;
 
 const ALICE: AccountId = AccountId::new([0u8; 32]);
@@ -300,8 +300,7 @@ fn execute_withdraw_to_deposit_works() {
 /// Test drop/claim assets.
 #[test]
 fn trapped_assets_can_be_claimed() {
-	let balances =
-		vec![(ALICE, INITIAL_BALANCE), (BOB, INITIAL_BALANCE)];
+	let balances = vec![(ALICE, INITIAL_BALANCE), (BOB, INITIAL_BALANCE)];
 	new_test_ext_with_balances(balances).execute_with(|| {
 		let weight = 6 * BaseXcmWeight::get();
 		let dest: MultiLocation =
@@ -330,9 +329,9 @@ fn trapped_assets_can_be_claimed() {
 			last_events(2),
 			vec![
 				Event::XcmPallet(crate::Event::AssetsTrapped(hash.clone(), source, vma)),
-				Event::XcmPallet(crate::Event::Attempted(
-					Outcome::Complete(5 * BaseXcmWeight::get())
-				))
+				Event::XcmPallet(crate::Event::Attempted(Outcome::Complete(
+					5 * BaseXcmWeight::get()
+				)))
 			]
 		);
 		assert_eq!(Balances::total_balance(&ALICE), INITIAL_BALANCE - SEND_AMOUNT);
@@ -368,9 +367,10 @@ fn trapped_assets_can_be_claimed() {
 		));
 		assert_eq!(
 			last_event(),
-			Event::XcmPallet(crate::Event::Attempted(
-				Outcome::Incomplete(BaseXcmWeight::get(), XcmError::UnknownClaim)
-			))
+			Event::XcmPallet(crate::Event::Attempted(Outcome::Incomplete(
+				BaseXcmWeight::get(),
+				XcmError::UnknownClaim
+			)))
 		);
 	});
 }

--- a/xcm/src/lib.rs
+++ b/xcm/src/lib.rs
@@ -217,6 +217,16 @@ pub enum VersionedMultiAssets {
 	V1(v1::MultiAssets),
 }
 
+impl VersionedMultiAssets {
+	pub fn into_version(self, n: u32) -> Result<Self, ()> {
+		Ok(match n {
+			0 => Self::V0(self.try_into()?),
+			1 | 2 => Self::V1(self.try_into()?),
+			_ => return Err(())
+		})
+	}
+}
+
 impl From<Vec<v0::MultiAsset>> for VersionedMultiAssets {
 	fn from(x: Vec<v0::MultiAsset>) -> Self {
 		VersionedMultiAssets::V0(x)

--- a/xcm/src/lib.rs
+++ b/xcm/src/lib.rs
@@ -222,7 +222,7 @@ impl VersionedMultiAssets {
 		Ok(match n {
 			0 => Self::V0(self.try_into()?),
 			1 | 2 => Self::V1(self.try_into()?),
-			_ => return Err(())
+			_ => return Err(()),
 		})
 	}
 }

--- a/xcm/src/v2/mod.rs
+++ b/xcm/src/v2/mod.rs
@@ -226,11 +226,11 @@ pub enum Instruction<Call> {
 	/// Errors:
 	ReceiveTeleportedAsset(MultiAssets),
 
-	/// Indication of the contents of the holding register corresponding to the `QueryHolding`
-	/// order of `query_id`.
+	/// Respond with information that the local system is expecting.
 	///
 	/// - `query_id`: The identifier of the query that resulted in this message being sent.
-	/// - `assets`: The message content.
+	/// - `response`: The message content.
+	/// - `max_weight`: The maximum weight that handling this response should take.
 	///
 	/// Safety: No concerns.
 	///

--- a/xcm/src/v2/mod.rs
+++ b/xcm/src/v2/mod.rs
@@ -37,9 +37,6 @@ pub use super::v1::{
 	MultiLocation, NetworkId, OriginKind, Parent, ParentThen, WildFungibility, WildMultiAsset,
 };
 
-/// Identifier for assets that were trapped.
-pub type TrapId = u64;
-
 #[derive(Derivative, Default, Encode, Decode)]
 #[derivative(Clone(bound = ""), Eq(bound = ""), PartialEq(bound = ""), Debug(bound = ""))]
 #[codec(encode_bound())]
@@ -558,9 +555,10 @@ pub enum Instruction<Call> {
 
 	/// Create some assets which are being held on behalf of the origin.
 	/// 
-	/// - `ticket`: An identifier for the assets to be claimed.
 	/// - `assets`: The assets which are to be claimed. This must match exactly with the assets
 	///   claimable by the origin of the ticket.
+	/// - `ticket`: The ticket of the asset; this is an abstract identifier to help locate the
+	///   asset.
 	///
 	/// Kind: *Instruction*
 	///

--- a/xcm/src/v2/mod.rs
+++ b/xcm/src/v2/mod.rs
@@ -226,11 +226,11 @@ pub enum Instruction<Call> {
 	/// Errors:
 	ReceiveTeleportedAsset(MultiAssets),
 
-	/// Respond with information that the local system is expecting.
+	/// Indication of the contents of the holding register corresponding to the `QueryHolding`
+	/// order of `query_id`.
 	///
 	/// - `query_id`: The identifier of the query that resulted in this message being sent.
-	/// - `response`: The message content.
-	/// - `max_weight`: The maximum weight that handling this response should take.
+	/// - `assets`: The message content.
 	///
 	/// Safety: No concerns.
 	///

--- a/xcm/src/v2/mod.rs
+++ b/xcm/src/v2/mod.rs
@@ -510,7 +510,7 @@ pub enum Instruction<Call> {
 	/// Refund any surplus weight previously bought with `BuyExecution`.
 	///
 	/// Kind: *Instruction*
-	/// 
+	///
 	/// Errors: None.
 	RefundSurplus,
 
@@ -526,7 +526,7 @@ pub enum Instruction<Call> {
 	/// handler, which can reasonably be negative, which would result in a surplus.
 	///
 	/// Kind: *Instruction*
-	/// 
+	///
 	/// Errors: None.
 	SetErrorHandler(Xcm<Call>),
 
@@ -554,7 +554,7 @@ pub enum Instruction<Call> {
 	ClearError,
 
 	/// Create some assets which are being held on behalf of the origin.
-	/// 
+	///
 	/// - `assets`: The assets which are to be claimed. This must match exactly with the assets
 	///   claimable by the origin of the ticket.
 	/// - `ticket`: The ticket of the asset; this is an abstract identifier to help locate the
@@ -566,9 +566,9 @@ pub enum Instruction<Call> {
 	ClaimAsset { assets: MultiAssets, ticket: MultiLocation },
 
 	/// Always throws an error of type `Trap`.
-	/// 
+	///
 	/// Kind: *Instruction*
-	/// 
+	///
 	/// Errors:
 	/// - `Trap`: All circumstances, whose inner value is the same as this item's inner value.
 	Trap(u64),

--- a/xcm/src/v2/mod.rs
+++ b/xcm/src/v2/mod.rs
@@ -37,6 +37,9 @@ pub use super::v1::{
 	MultiLocation, NetworkId, OriginKind, Parent, ParentThen, WildFungibility, WildMultiAsset,
 };
 
+/// Identifier for assets that were trapped.
+pub type TrapId = u64;
+
 #[derive(Derivative, Default, Encode, Decode)]
 #[derivative(Clone(bound = ""), Eq(bound = ""), PartialEq(bound = ""), Debug(bound = ""))]
 #[codec(encode_bound())]
@@ -392,6 +395,8 @@ pub enum Instruction<Call> {
 	///   prioritized under standard asset ordering. Any others will remain in holding.
 	/// - `beneficiary`: The new owner for the assets.
 	///
+	/// Kind: *Instruction*
+	///
 	/// Errors:
 	DepositAsset { assets: MultiAssetFilter, max_assets: u32, beneficiary: MultiLocation },
 
@@ -411,6 +416,8 @@ pub enum Instruction<Call> {
 	/// - `xcm`: The orders that should follow the `ReserveAssetDeposited` instruction
 	///   which is sent onwards to `dest`.
 	///
+	/// Kind: *Instruction*
+	///
 	/// Errors:
 	DepositReserveAsset {
 		assets: MultiAssetFilter,
@@ -428,6 +435,8 @@ pub enum Instruction<Call> {
 	/// - `give`: The asset(s) to remove from holding.
 	/// - `receive`: The minimum amount of assets(s) which `give` should be exchanged for.
 	///
+	/// Kind: *Instruction*
+	///
 	/// Errors:
 	ExchangeAsset { give: MultiAssetFilter, receive: MultiAssets },
 
@@ -442,6 +451,8 @@ pub enum Instruction<Call> {
 	/// - `xcm`: The instructions to execute on the assets once withdrawn *on the reserve
 	///   location*.
 	///
+	/// Kind: *Instruction*
+	///
 	/// Errors:
 	InitiateReserveWithdraw { assets: MultiAssetFilter, reserve: MultiLocation, xcm: Xcm<()> },
 
@@ -455,6 +466,8 @@ pub enum Instruction<Call> {
 	///
 	/// NOTE: The `dest` location *MUST* respect this origin as a valid teleportation origin for all
 	/// `assets`. If it does not, then the assets may be lost.
+	///
+	/// Kind: *Instruction*
 	///
 	/// Errors:
 	InitiateTeleport { assets: MultiAssetFilter, dest: MultiLocation, xcm: Xcm<()> },
@@ -471,6 +484,8 @@ pub enum Instruction<Call> {
 	/// - `max_response_weight`: The maximum amount of weight that the `QueryResponse` item which
 	///   is sent as a reply may take to execute. NOTE: If this is unexpectedly large then the
 	///   response may not execute at all.
+	///
+	/// Kind: *Instruction*
 	///
 	/// Errors:
 	QueryHolding {
@@ -490,13 +505,20 @@ pub enum Instruction<Call> {
 	///   expected maximum weight of the total XCM to be executed for the
 	///   `AllowTopLevelPaidExecutionFrom` barrier to allow the XCM be executed.
 	///
+	/// Kind: *Instruction*
+	///
 	/// Errors:
 	BuyExecution { fees: MultiAsset, weight_limit: WeightLimit },
 
 	/// Refund any surplus weight previously bought with `BuyExecution`.
+	///
+	/// Kind: *Instruction*
+	/// 
+	/// Errors: None.
 	RefundSurplus,
 
-	/// Set code that should be called in the case of an error happening.
+	/// Set the Error Handler Register. This is code that should be called in the case of an error
+	/// happening.
 	///
 	/// An error occurring within execution of this code will _NOT_ result in the error register
 	/// being set, nor will an error handler be called due to it. The error handler and appendix
@@ -505,10 +527,15 @@ pub enum Instruction<Call> {
 	/// The apparent weight of this instruction is inclusive of the inner `Xcm`; the executing
 	/// weight however includes only the difference between the previous handler and the new
 	/// handler, which can reasonably be negative, which would result in a surplus.
+	///
+	/// Kind: *Instruction*
+	/// 
+	/// Errors: None.
 	SetErrorHandler(Xcm<Call>),
 
-	/// Set code that should be called after code execution (including the error handler if any)
-	/// is finished. This will be called regardless of whether an error occurred.
+	/// Set the Appendix Register. This is code that should be called after code execution
+	/// (including the error handler if any) is finished. This will be called regardless of whether
+	/// an error occurred.
 	///
 	/// Any error occurring due to execution of this code will result in the error register being
 	/// set, and the error handler (if set) firing.
@@ -516,10 +543,37 @@ pub enum Instruction<Call> {
 	/// The apparent weight of this instruction is inclusive of the inner `Xcm`; the executing
 	/// weight however includes only the difference between the previous appendix and the new
 	/// appendix, which can reasonably be negative, which would result in a surplus.
+	///
+	/// Kind: *Instruction*
+	///
+	/// Errors: None.
 	SetAppendix(Xcm<Call>),
 
-	/// Clear the error register.
+	/// Clear the Error Register.
+	///
+	/// Kind: *Instruction*
+	///
+	/// Errors: None.
 	ClearError,
+
+	/// Create some assets which are being held on behalf of the origin.
+	/// 
+	/// - `ticket`: An identifier for the assets to be claimed.
+	/// - `assets`: The assets which are to be claimed. This must match exactly with the assets
+	///   claimable by the origin of the ticket.
+	///
+	/// Kind: *Instruction*
+	///
+	/// Errors:
+	ClaimAsset { assets: MultiAssets, ticket: MultiLocation },
+
+	/// Always throws an error of type `Trap`.
+	/// 
+	/// Kind: *Instruction*
+	/// 
+	/// Errors:
+	/// - `Trap`: All circumstances, whose inner value is the same as this item's inner value.
+	Trap(u64),
 }
 
 impl<Call> Xcm<Call> {
@@ -572,6 +626,8 @@ impl<Call> Instruction<Call> {
 			SetErrorHandler(xcm) => SetErrorHandler(xcm.into()),
 			SetAppendix(xcm) => SetAppendix(xcm.into()),
 			ClearError => ClearError,
+			ClaimAsset { assets, ticket } => ClaimAsset { assets, ticket },
+			Trap(code) => Trap(code),
 		}
 	}
 }

--- a/xcm/src/v2/traits.rs
+++ b/xcm/src/v2/traits.rs
@@ -96,7 +96,7 @@ pub enum Error {
 	UnknownWeightRequired,
 	/// An error was intentionally forced. A code is included.
 	Trap(u64),
-	/// The given claim could not be recognised/found.
+	/// The given claim could not be recognized/found.
 	UnknownClaim,
 }
 

--- a/xcm/src/v2/traits.rs
+++ b/xcm/src/v2/traits.rs
@@ -96,6 +96,8 @@ pub enum Error {
 	UnknownWeightRequired,
 	/// An error was intentionally forced. A code is included.
 	Trap(u64),
+	/// The given claim could not be recognised/found.
+	UnknownClaim,
 }
 
 impl From<()> for Error {

--- a/xcm/src/v2/traits.rs
+++ b/xcm/src/v2/traits.rs
@@ -94,6 +94,8 @@ pub enum Error {
 	Unroutable,
 	/// The weight required was not specified when it should have been.
 	UnknownWeightRequired,
+	/// An error was intentionally forced. A code is included.
+	Trap(u64),
 }
 
 impl From<()> for Error {

--- a/xcm/xcm-builder/src/barriers.rs
+++ b/xcm/xcm-builder/src/barriers.rs
@@ -60,7 +60,10 @@ impl<T: Contains<MultiLocation>> ShouldExecute for AllowTopLevelPaidExecutionFro
 		let mut iter = message.0.iter_mut();
 		let i = iter.next().ok_or(())?;
 		match i {
-			ReceiveTeleportedAsset(..) | WithdrawAsset(..) | ReserveAssetDeposited(..) | ClaimAsset{..} => (),
+			ReceiveTeleportedAsset(..) |
+			WithdrawAsset(..) |
+			ReserveAssetDeposited(..) |
+			ClaimAsset { .. } => (),
 			_ => return Err(()),
 		}
 		let mut i = iter.next().ok_or(())?;

--- a/xcm/xcm-builder/src/barriers.rs
+++ b/xcm/xcm-builder/src/barriers.rs
@@ -60,7 +60,7 @@ impl<T: Contains<MultiLocation>> ShouldExecute for AllowTopLevelPaidExecutionFro
 		let mut iter = message.0.iter_mut();
 		let i = iter.next().ok_or(())?;
 		match i {
-			ReceiveTeleportedAsset(..) | WithdrawAsset(..) | ReserveAssetDeposited(..) => (),
+			ReceiveTeleportedAsset(..) | WithdrawAsset(..) | ReserveAssetDeposited(..) | ClaimAsset{..} => (),
 			_ => return Err(()),
 		}
 		let mut i = iter.next().ok_or(())?;

--- a/xcm/xcm-builder/src/barriers.rs
+++ b/xcm/xcm-builder/src/barriers.rs
@@ -30,7 +30,7 @@ use xcm_executor::traits::{OnResponse, ShouldExecute};
 pub struct TakeWeightCredit;
 impl ShouldExecute for TakeWeightCredit {
 	fn should_execute<Call>(
-		_origin: &Option<MultiLocation>,
+		_origin: &MultiLocation,
 		_top_level: bool,
 		_message: &mut Xcm<Call>,
 		max_weight: Weight,
@@ -49,13 +49,12 @@ impl ShouldExecute for TakeWeightCredit {
 pub struct AllowTopLevelPaidExecutionFrom<T>(PhantomData<T>);
 impl<T: Contains<MultiLocation>> ShouldExecute for AllowTopLevelPaidExecutionFrom<T> {
 	fn should_execute<Call>(
-		origin: &Option<MultiLocation>,
+		origin: &MultiLocation,
 		top_level: bool,
 		message: &mut Xcm<Call>,
 		max_weight: Weight,
 		_weight_credit: &mut Weight,
 	) -> Result<(), ()> {
-		let origin = origin.as_ref().ok_or(())?;
 		ensure!(T::contains(origin), ());
 		ensure!(top_level, ());
 		let mut iter = message.0.iter_mut();
@@ -87,13 +86,12 @@ impl<T: Contains<MultiLocation>> ShouldExecute for AllowTopLevelPaidExecutionFro
 pub struct AllowUnpaidExecutionFrom<T>(PhantomData<T>);
 impl<T: Contains<MultiLocation>> ShouldExecute for AllowUnpaidExecutionFrom<T> {
 	fn should_execute<Call>(
-		origin: &Option<MultiLocation>,
+		origin: &MultiLocation,
 		_top_level: bool,
 		_message: &mut Xcm<Call>,
 		_max_weight: Weight,
 		_weight_credit: &mut Weight,
 	) -> Result<(), ()> {
-		let origin = origin.as_ref().ok_or(())?;
 		ensure!(T::contains(origin), ());
 		Ok(())
 	}
@@ -115,13 +113,12 @@ impl<ParaId: IsSystem + From<u32>> Contains<MultiLocation> for IsChildSystemPara
 pub struct AllowKnownQueryResponses<ResponseHandler>(PhantomData<ResponseHandler>);
 impl<ResponseHandler: OnResponse> ShouldExecute for AllowKnownQueryResponses<ResponseHandler> {
 	fn should_execute<Call>(
-		origin: &Option<MultiLocation>,
+		origin: &MultiLocation,
 		_top_level: bool,
 		message: &mut Xcm<Call>,
 		_max_weight: Weight,
 		_weight_credit: &mut Weight,
 	) -> Result<(), ()> {
-		let origin = origin.as_ref().ok_or(())?;
 		match message.0.first() {
 			Some(QueryResponse { query_id, .. })
 				if ResponseHandler::expecting_response(origin, *query_id) =>

--- a/xcm/xcm-builder/src/mock.rs
+++ b/xcm/xcm-builder/src/mock.rs
@@ -282,6 +282,6 @@ impl Config for TestConfig {
 	type Weigher = FixedWeightBounds<UnitWeightCost, TestCall, MaxInstructions>;
 	type Trader = FixedRateOfFungible<WeightPrice, ()>;
 	type ResponseHandler = TestResponseHandler;
-	type AssetTrap = (); // TODO: TestAssetTrap
-	type AssetClaims = (); // TODO: TestAssetClaims
+	type AssetTrap = ();
+	type AssetClaims = ();
 }

--- a/xcm/xcm-builder/src/mock.rs
+++ b/xcm/xcm-builder/src/mock.rs
@@ -283,4 +283,5 @@ impl Config for TestConfig {
 	type Trader = FixedRateOfFungible<WeightPrice, ()>;
 	type ResponseHandler = TestResponseHandler;
 	type AssetTrap = ();	// TODO: TestAssetTrap
+	type AssetClaims = ();	// TODO: TestAssetClaims
 }

--- a/xcm/xcm-builder/src/mock.rs
+++ b/xcm/xcm-builder/src/mock.rs
@@ -35,6 +35,7 @@ pub use sp_std::{
 	marker::PhantomData,
 };
 pub use xcm::latest::prelude::*;
+use xcm_executor::traits::{ClaimAssets, DropAssets};
 pub use xcm_executor::{
 	traits::{ConvertOrigin, FilterAssetLocation, InvertLocation, OnResponse, TransactAsset},
 	Assets, Config,
@@ -269,6 +270,37 @@ pub type TestBarrier = (
 	AllowUnpaidExecutionFrom<IsInVec<AllowUnpaidFrom>>,
 );
 
+parameter_types! {
+	pub static TrappedAssets: Vec<(MultiLocation, MultiAssets)> = vec![];
+}
+
+pub struct TestAssetTrap;
+
+impl DropAssets for TestAssetTrap {
+	fn drop_assets(origin: &MultiLocation, assets: Assets) -> Weight {
+		let mut t: Vec<(MultiLocation, MultiAssets)> = TrappedAssets::get();
+		t.push((origin.clone(), assets.into()));
+		TrappedAssets::set(t);
+		5
+	}
+}
+
+impl ClaimAssets for TestAssetTrap {
+	fn claim_assets(origin: &MultiLocation, ticket: &MultiLocation, what: &MultiAssets) -> bool {
+		let mut t: Vec<(MultiLocation, MultiAssets)> = TrappedAssets::get();
+		if let (0, X1(GeneralIndex(i))) = (ticket.parents, &ticket.interior) {
+			if let Some((l, a)) = t.get(*i as usize) {
+				if l == origin && a == what {
+					t.swap_remove(*i as usize);
+					TrappedAssets::set(t);
+					return true;
+				}
+			}
+		}
+		false
+	}
+}
+
 pub struct TestConfig;
 impl Config for TestConfig {
 	type Call = TestCall;
@@ -282,6 +314,6 @@ impl Config for TestConfig {
 	type Weigher = FixedWeightBounds<UnitWeightCost, TestCall, MaxInstructions>;
 	type Trader = FixedRateOfFungible<WeightPrice, ()>;
 	type ResponseHandler = TestResponseHandler;
-	type AssetTrap = ();
-	type AssetClaims = ();
+	type AssetTrap = TestAssetTrap;
+	type AssetClaims = TestAssetTrap;
 }

--- a/xcm/xcm-builder/src/mock.rs
+++ b/xcm/xcm-builder/src/mock.rs
@@ -293,7 +293,7 @@ impl ClaimAssets for TestAssetTrap {
 				if l == origin && a == what {
 					t.swap_remove(*i as usize);
 					TrappedAssets::set(t);
-					return true;
+					return true
 				}
 			}
 		}

--- a/xcm/xcm-builder/src/mock.rs
+++ b/xcm/xcm-builder/src/mock.rs
@@ -282,4 +282,5 @@ impl Config for TestConfig {
 	type Weigher = FixedWeightBounds<UnitWeightCost, TestCall, MaxInstructions>;
 	type Trader = FixedRateOfFungible<WeightPrice, ()>;
 	type ResponseHandler = TestResponseHandler;
+	type AssetTrap = ();	// TODO: TestAssetTrap
 }

--- a/xcm/xcm-builder/src/mock.rs
+++ b/xcm/xcm-builder/src/mock.rs
@@ -282,6 +282,6 @@ impl Config for TestConfig {
 	type Weigher = FixedWeightBounds<UnitWeightCost, TestCall, MaxInstructions>;
 	type Trader = FixedRateOfFungible<WeightPrice, ()>;
 	type ResponseHandler = TestResponseHandler;
-	type AssetTrap = ();	// TODO: TestAssetTrap
-	type AssetClaims = ();	// TODO: TestAssetClaims
+	type AssetTrap = (); // TODO: TestAssetTrap
+	type AssetClaims = (); // TODO: TestAssetClaims
 }

--- a/xcm/xcm-builder/src/tests.rs
+++ b/xcm/xcm-builder/src/tests.rs
@@ -58,7 +58,7 @@ fn take_weight_credit_barrier_should_work() {
 		Xcm::<()>(vec![TransferAsset { assets: (Parent, 100).into(), beneficiary: Here.into() }]);
 	let mut weight_credit = 10;
 	let r = TakeWeightCredit::should_execute(
-		&Some(Parent.into()),
+		&Parent.into(),
 		true,
 		&mut message,
 		10,
@@ -68,7 +68,7 @@ fn take_weight_credit_barrier_should_work() {
 	assert_eq!(weight_credit, 0);
 
 	let r = TakeWeightCredit::should_execute(
-		&Some(Parent.into()),
+		&Parent.into(),
 		true,
 		&mut message,
 		10,
@@ -86,7 +86,7 @@ fn allow_unpaid_should_work() {
 	AllowUnpaidFrom::set(vec![Parent.into()]);
 
 	let r = AllowUnpaidExecutionFrom::<IsInVec<AllowUnpaidFrom>>::should_execute(
-		&Some(Parachain(1).into()),
+		&Parachain(1).into(),
 		true,
 		&mut message,
 		10,
@@ -95,7 +95,7 @@ fn allow_unpaid_should_work() {
 	assert_eq!(r, Err(()));
 
 	let r = AllowUnpaidExecutionFrom::<IsInVec<AllowUnpaidFrom>>::should_execute(
-		&Some(Parent.into()),
+		&Parent.into(),
 		true,
 		&mut message,
 		10,
@@ -112,7 +112,7 @@ fn allow_paid_should_work() {
 		Xcm::<()>(vec![TransferAsset { assets: (Parent, 100).into(), beneficiary: Here.into() }]);
 
 	let r = AllowTopLevelPaidExecutionFrom::<IsInVec<AllowPaidFrom>>::should_execute(
-		&Some(Parachain(1).into()),
+		&Parachain(1).into(),
 		true,
 		&mut message,
 		10,
@@ -128,7 +128,7 @@ fn allow_paid_should_work() {
 	]);
 
 	let r = AllowTopLevelPaidExecutionFrom::<IsInVec<AllowPaidFrom>>::should_execute(
-		&Some(Parent.into()),
+		&Parent.into(),
 		true,
 		&mut underpaying_message,
 		30,
@@ -144,7 +144,7 @@ fn allow_paid_should_work() {
 	]);
 
 	let r = AllowTopLevelPaidExecutionFrom::<IsInVec<AllowPaidFrom>>::should_execute(
-		&Some(Parachain(1).into()),
+		&Parachain(1).into(),
 		true,
 		&mut paying_message,
 		30,
@@ -153,7 +153,7 @@ fn allow_paid_should_work() {
 	assert_eq!(r, Err(()));
 
 	let r = AllowTopLevelPaidExecutionFrom::<IsInVec<AllowPaidFrom>>::should_execute(
-		&Some(Parent.into()),
+		&Parent.into(),
 		true,
 		&mut paying_message,
 		30,

--- a/xcm/xcm-builder/src/tests.rs
+++ b/xcm/xcm-builder/src/tests.rs
@@ -255,6 +255,31 @@ fn errors_should_return_unused_weight() {
 }
 
 #[test]
+fn weight_bounds_should_respect_instructions_limit() {
+	MaxInstructions::set(3);
+	let mut message = Xcm(vec![ClearOrigin; 4]);
+	// 4 instructions are too many.
+	assert_eq!(<TestConfig as Config>::Weigher::weight(&mut message), Err(()));
+
+	let mut message =
+		Xcm(vec![SetErrorHandler(Xcm(vec![ClearOrigin])), SetAppendix(Xcm(vec![ClearOrigin]))]);
+	// 4 instructions are too many, even when hidden within 2.
+	assert_eq!(<TestConfig as Config>::Weigher::weight(&mut message), Err(()));
+
+	let mut message =
+		Xcm(vec![SetErrorHandler(Xcm(vec![SetErrorHandler(Xcm(vec![SetErrorHandler(Xcm(
+			vec![ClearOrigin],
+		))]))]))]);
+	// 4 instructions are too many, even when it's just one that's 3 levels deep.
+	assert_eq!(<TestConfig as Config>::Weigher::weight(&mut message), Err(()));
+
+	let mut message =
+		Xcm(vec![SetErrorHandler(Xcm(vec![SetErrorHandler(Xcm(vec![ClearOrigin]))]))]);
+	// 3 instructions are OK.
+	assert_eq!(<TestConfig as Config>::Weigher::weight(&mut message), Ok(30));
+}
+
+#[test]
 fn code_registers_should_work() {
 	// we'll let them have message execution for free.
 	AllowUnpaidFrom::set(vec![Here.into()]);

--- a/xcm/xcm-builder/src/tests.rs
+++ b/xcm/xcm-builder/src/tests.rs
@@ -216,7 +216,7 @@ fn basic_asset_trap_should_work() {
 			WithdrawAsset((Here, 100).into()),
 			DepositAsset {
 				assets: Wild(All),
-				max_assets: 0,	//< Whoops!
+				max_assets: 0, //< Whoops!
 				beneficiary: AccountIndex64 { index: 3, network: Any }.into(),
 			},
 		]),
@@ -263,7 +263,7 @@ fn basic_asset_trap_should_work() {
 	assert_eq!(assets(1001), vec![(Here, 900).into()]);
 	assert_eq!(assets(3), vec![]);
 	assert_eq!(old_trapped_assets, TrappedAssets::get());
-	
+
 	// Incorrect assets doesn't work.
 	let old_trapped_assets = TrappedAssets::get();
 	let r = XcmExecutor::<TestConfig>::execute_xcm(
@@ -282,7 +282,7 @@ fn basic_asset_trap_should_work() {
 	assert_eq!(assets(1001), vec![(Here, 900).into()]);
 	assert_eq!(assets(3), vec![]);
 	assert_eq!(old_trapped_assets, TrappedAssets::get());
-	
+
 	let r = XcmExecutor::<TestConfig>::execute_xcm(
 		Parachain(1).into(),
 		Xcm(vec![

--- a/xcm/xcm-builder/src/tests.rs
+++ b/xcm/xcm-builder/src/tests.rs
@@ -255,31 +255,6 @@ fn errors_should_return_unused_weight() {
 }
 
 #[test]
-fn weight_bounds_should_respect_instructions_limit() {
-	MaxInstructions::set(3);
-	let mut message = Xcm(vec![ClearOrigin; 4]);
-	// 4 instructions are too many.
-	assert_eq!(<TestConfig as Config>::Weigher::weight(&mut message), Err(()));
-
-	let mut message =
-		Xcm(vec![SetErrorHandler(Xcm(vec![ClearOrigin])), SetAppendix(Xcm(vec![ClearOrigin]))]);
-	// 4 instructions are too many, even when hidden within 2.
-	assert_eq!(<TestConfig as Config>::Weigher::weight(&mut message), Err(()));
-
-	let mut message =
-		Xcm(vec![SetErrorHandler(Xcm(vec![SetErrorHandler(Xcm(vec![SetErrorHandler(Xcm(
-			vec![ClearOrigin],
-		))]))]))]);
-	// 4 instructions are too many, even when it's just one that's 3 levels deep.
-	assert_eq!(<TestConfig as Config>::Weigher::weight(&mut message), Err(()));
-
-	let mut message =
-		Xcm(vec![SetErrorHandler(Xcm(vec![SetErrorHandler(Xcm(vec![ClearOrigin]))]))]);
-	// 3 instructions are OK.
-	assert_eq!(<TestConfig as Config>::Weigher::weight(&mut message), Ok(30));
-}
-
-#[test]
 fn code_registers_should_work() {
 	// we'll let them have message execution for free.
 	AllowUnpaidFrom::set(vec![Here.into()]);

--- a/xcm/xcm-builder/tests/mock/mod.rs
+++ b/xcm/xcm-builder/tests/mock/mod.rs
@@ -166,7 +166,7 @@ impl xcm_executor::Config for XcmConfig {
 	type Barrier = Barrier;
 	type Weigher = FixedWeightBounds<BaseXcmWeight, Call, MaxInstructions>;
 	type Trader = FixedRateOfFungible<KsmPerSecond, ()>;
-	type ResponseHandler = ();
+	type ResponseHandler = XcmPallet;
 	type AssetTrap = XcmPallet;
 	type AssetClaims = XcmPallet;
 }

--- a/xcm/xcm-builder/tests/mock/mod.rs
+++ b/xcm/xcm-builder/tests/mock/mod.rs
@@ -167,6 +167,8 @@ impl xcm_executor::Config for XcmConfig {
 	type Weigher = FixedWeightBounds<BaseXcmWeight, Call, MaxInstructions>;
 	type Trader = FixedRateOfFungible<KsmPerSecond, ()>;
 	type ResponseHandler = ();
+	type AssetTrap = XcmPallet;
+	type AssetClaims = XcmPallet;
 }
 
 pub type LocalOriginToLocation = SignedToAccountId32<Origin, AccountId, KusamaNetwork>;

--- a/xcm/xcm-executor/src/assets.rs
+++ b/xcm/xcm-executor/src/assets.rs
@@ -94,6 +94,11 @@ impl Assets {
 		self.fungible.len() + self.non_fungible.len()
 	}
 
+	/// Returns `true` if `self` contains no assets.
+	pub fn is_empty(&self) -> bool {
+		self.fungible.is_empty() && self.non_fungible.is_empty()
+	}
+
 	/// A borrowing iterator over the fungible assets.
 	pub fn fungible_assets_iter<'a>(&'a self) -> impl Iterator<Item = MultiAsset> + 'a {
 		self.fungible

--- a/xcm/xcm-executor/src/config.rs
+++ b/xcm/xcm-executor/src/config.rs
@@ -63,7 +63,6 @@ pub trait Config {
 	/// end of execution.
 	type AssetTrap: DropAssets;
 
-	/// The general asset trap - handler for when assets are left in the Holding Register at the
-	/// end of execution.
+	/// The handler for when there is an instruction to claim assets.
 	type AssetClaims: ClaimAssets;
 }

--- a/xcm/xcm-executor/src/config.rs
+++ b/xcm/xcm-executor/src/config.rs
@@ -16,7 +16,7 @@
 
 use crate::traits::{
 	ConvertOrigin, FilterAssetLocation, InvertLocation, OnResponse, ShouldExecute, TransactAsset,
-	WeightBounds, WeightTrader, DropAssets,
+	WeightBounds, WeightTrader, DropAssets, ClaimAssets,
 };
 use frame_support::{
 	dispatch::{Dispatchable, Parameter},
@@ -62,4 +62,8 @@ pub trait Config {
 	/// The general asset trap - handler for when assets are left in the Holding Register at the
 	/// end of execution.
 	type AssetTrap: DropAssets;
+
+	/// The general asset trap - handler for when assets are left in the Holding Register at the
+	/// end of execution.
+	type AssetClaims: ClaimAssets;
 }

--- a/xcm/xcm-executor/src/config.rs
+++ b/xcm/xcm-executor/src/config.rs
@@ -16,7 +16,7 @@
 
 use crate::traits::{
 	ConvertOrigin, FilterAssetLocation, InvertLocation, OnResponse, ShouldExecute, TransactAsset,
-	WeightBounds, WeightTrader,
+	WeightBounds, WeightTrader, DropAssets,
 };
 use frame_support::{
 	dispatch::{Dispatchable, Parameter},
@@ -58,4 +58,8 @@ pub trait Config {
 
 	/// What to do when a response of a query is found.
 	type ResponseHandler: OnResponse;
+
+	/// The general asset trap - handler for when assets are left in the Holding Register at the
+	/// end of execution.
+	type AssetTrap: DropAssets;
 }

--- a/xcm/xcm-executor/src/config.rs
+++ b/xcm/xcm-executor/src/config.rs
@@ -15,8 +15,8 @@
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
 use crate::traits::{
-	ConvertOrigin, FilterAssetLocation, InvertLocation, OnResponse, ShouldExecute, TransactAsset,
-	WeightBounds, WeightTrader, DropAssets, ClaimAssets,
+	ClaimAssets, ConvertOrigin, DropAssets, FilterAssetLocation, InvertLocation, OnResponse,
+	ShouldExecute, TransactAsset, WeightBounds, WeightTrader,
 };
 use frame_support::{
 	dispatch::{Dispatchable, Parameter},

--- a/xcm/xcm-executor/src/lib.rs
+++ b/xcm/xcm-executor/src/lib.rs
@@ -31,8 +31,8 @@ use xcm::latest::{
 
 pub mod traits;
 use traits::{
-	ConvertOrigin, FilterAssetLocation, InvertLocation, OnResponse, ShouldExecute, TransactAsset,
-	WeightBounds, WeightTrader, DropAssets, ClaimAssets,
+	ClaimAssets, ConvertOrigin, DropAssets, FilterAssetLocation, InvertLocation, OnResponse,
+	ShouldExecute, TransactAsset, WeightBounds, WeightTrader,
 };
 
 mod assets;
@@ -416,10 +416,8 @@ impl<Config: config::Config> XcmExecutor<Config> {
 					self.holding.subsume(asset);
 				}
 				Ok(())
-			}
-			Trap(code) => {
-				Err(XcmError::Trap(code))
-			}
+			},
+			Trap(code) => Err(XcmError::Trap(code)),
 			ExchangeAsset { .. } => Err(XcmError::Unimplemented),
 			HrmpNewChannelOpenRequest { .. } => Err(XcmError::Unimplemented),
 			HrmpChannelAccepted { .. } => Err(XcmError::Unimplemented),

--- a/xcm/xcm-executor/src/lib.rs
+++ b/xcm/xcm-executor/src/lib.rs
@@ -411,7 +411,7 @@ impl<Config: config::Config> XcmExecutor<Config> {
 			ClaimAsset { assets, ticket } => {
 				let origin = self.origin.as_ref().ok_or(XcmError::BadOrigin)?;
 				let ok = Config::AssetClaims::claim_assets(origin, &ticket, &assets);
-				ensure!(ok, XcmError::AssetNotFound);
+				ensure!(ok, XcmError::UnknownClaim);
 				for asset in assets.drain().into_iter() {
 					self.holding.subsume(asset);
 				}

--- a/xcm/xcm-executor/src/traits/drop_assets.rs
+++ b/xcm/xcm-executor/src/traits/drop_assets.rs
@@ -35,10 +35,7 @@ impl DropAssets for () {
 /// be used to ensure that `Assets` values which hold no value are ignores.
 pub struct FilterAssets<D, A>(PhantomData<(D, A)>);
 
-impl<
-	D: DropAssets,
-	A: Contains<Assets>,
-> DropAssets for FilterAssets<D, A> {
+impl<D: DropAssets, A: Contains<Assets>> DropAssets for FilterAssets<D, A> {
 	fn drop_assets(origin: &MultiLocation, assets: Assets) -> Weight {
 		if A::contains(&assets) {
 			D::drop_assets(origin, assets)
@@ -53,10 +50,7 @@ impl<
 /// asset trap facility don't get to use it.
 pub struct FilterOrigin<D, O>(PhantomData<(D, O)>);
 
-impl<
-	D: DropAssets,
-	O: Contains<MultiLocation>,
-> DropAssets for FilterOrigin<D, O> {
+impl<D: DropAssets, O: Contains<MultiLocation>> DropAssets for FilterOrigin<D, O> {
 	fn drop_assets(origin: &MultiLocation, assets: Assets) -> Weight {
 		if O::contains(origin) {
 			D::drop_assets(origin, assets)

--- a/xcm/xcm-executor/src/traits/drop_assets.rs
+++ b/xcm/xcm-executor/src/traits/drop_assets.rs
@@ -1,0 +1,55 @@
+// Copyright 2020 Parity Technologies (UK) Ltd.
+// This file is part of Polkadot.
+
+// Polkadot is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Polkadot is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
+
+use crate::Assets;
+use frame_support::weights::Weight;
+use xcm::latest::{MultiAssets, MultiLocation};
+
+/// Define a handler for when some non-empty `Assets` value should be dropped.
+pub trait DropAssets {
+	/// Handler for receiving dropped assets. Returns the weight consumed by this operation.
+	fn drop_assets(
+		origin: &MultiLocation,
+		assets: Assets,
+	) -> Weight;
+}
+impl DropAssets for () {
+	fn drop_assets(
+		_origin: &MultiLocation,
+		_assets: Assets,
+	) -> Weight {
+		0
+	}
+}
+
+/// Define any handlers for the `AssetClaim` instruction.
+pub trait ClaimAssets {
+	/// Claim any assets available to `origin` and return them in a single `Assets` value, together
+	/// with the weight used by this operation.
+	fn claim_assets(origin: &MultiLocation, ticket: &MultiLocation, what: &MultiAssets) -> bool;
+}
+
+#[impl_trait_for_tuples::impl_for_tuples(30)]
+impl ClaimAssets for Tuple {
+	fn claim_assets(origin: &MultiLocation, ticket: &MultiLocation, what: &MultiAssets) -> bool {
+		for_tuples!( #(
+			if Tuple::claim_assets(origin, ticket, what) {
+				return true;
+			}
+		)* );
+		false
+	}
+}

--- a/xcm/xcm-executor/src/traits/drop_assets.rs
+++ b/xcm/xcm-executor/src/traits/drop_assets.rs
@@ -14,9 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::marker::PhantomData;
-
 use crate::Assets;
+use core::marker::PhantomData;
 use frame_support::{traits::Contains, weights::Weight};
 use xcm::latest::{MultiAssets, MultiLocation};
 

--- a/xcm/xcm-executor/src/traits/drop_assets.rs
+++ b/xcm/xcm-executor/src/traits/drop_assets.rs
@@ -31,7 +31,7 @@ impl DropAssets for () {
 }
 
 /// Morph a given `DropAssets` implementation into one which can filter based on assets. This can
-/// be used to ensure that `Assets` values which hold no value are ignores.
+/// be used to ensure that `Assets` values which hold no value are ignored.
 pub struct FilterAssets<D, A>(PhantomData<(D, A)>);
 
 impl<D: DropAssets, A: Contains<Assets>> DropAssets for FilterAssets<D, A> {

--- a/xcm/xcm-executor/src/traits/drop_assets.rs
+++ b/xcm/xcm-executor/src/traits/drop_assets.rs
@@ -21,16 +21,10 @@ use xcm::latest::{MultiAssets, MultiLocation};
 /// Define a handler for when some non-empty `Assets` value should be dropped.
 pub trait DropAssets {
 	/// Handler for receiving dropped assets. Returns the weight consumed by this operation.
-	fn drop_assets(
-		origin: &MultiLocation,
-		assets: Assets,
-	) -> Weight;
+	fn drop_assets(origin: &MultiLocation, assets: Assets) -> Weight;
 }
 impl DropAssets for () {
-	fn drop_assets(
-		_origin: &MultiLocation,
-		_assets: Assets,
-	) -> Weight {
+	fn drop_assets(_origin: &MultiLocation, _assets: Assets) -> Weight {
 		0
 	}
 }

--- a/xcm/xcm-executor/src/traits/mod.rs
+++ b/xcm/xcm-executor/src/traits/mod.rs
@@ -18,6 +18,8 @@
 
 mod conversion;
 pub use conversion::{Convert, ConvertOrigin, Decoded, Encoded, Identity, InvertLocation, JustTry};
+mod drop_assets;
+pub use drop_assets::DropAssets;
 mod filter_asset_location;
 pub use filter_asset_location::FilterAssetLocation;
 mod matches_fungible;

--- a/xcm/xcm-executor/src/traits/mod.rs
+++ b/xcm/xcm-executor/src/traits/mod.rs
@@ -19,7 +19,7 @@
 mod conversion;
 pub use conversion::{Convert, ConvertOrigin, Decoded, Encoded, Identity, InvertLocation, JustTry};
 mod drop_assets;
-pub use drop_assets::{DropAssets, ClaimAssets};
+pub use drop_assets::{ClaimAssets, DropAssets};
 mod filter_asset_location;
 pub use filter_asset_location::FilterAssetLocation;
 mod matches_fungible;

--- a/xcm/xcm-executor/src/traits/mod.rs
+++ b/xcm/xcm-executor/src/traits/mod.rs
@@ -19,7 +19,7 @@
 mod conversion;
 pub use conversion::{Convert, ConvertOrigin, Decoded, Encoded, Identity, InvertLocation, JustTry};
 mod drop_assets;
-pub use drop_assets::DropAssets;
+pub use drop_assets::{DropAssets, ClaimAssets};
 mod filter_asset_location;
 pub use filter_asset_location::FilterAssetLocation;
 mod matches_fungible;

--- a/xcm/xcm-executor/src/traits/should_execute.rs
+++ b/xcm/xcm-executor/src/traits/should_execute.rs
@@ -34,7 +34,7 @@ pub trait ShouldExecute {
 	///   message may utilize in its execution. Typically non-zero only because of prior fee
 	///   payment, but could in principle be due to other factors.
 	fn should_execute<Call>(
-		origin: &Option<MultiLocation>,
+		origin: &MultiLocation,
 		top_level: bool,
 		message: &mut Xcm<Call>,
 		max_weight: Weight,
@@ -45,7 +45,7 @@ pub trait ShouldExecute {
 #[impl_trait_for_tuples::impl_for_tuples(30)]
 impl ShouldExecute for Tuple {
 	fn should_execute<Call>(
-		origin: &Option<MultiLocation>,
+		origin: &MultiLocation,
 		top_level: bool,
 		message: &mut Xcm<Call>,
 		max_weight: Weight,

--- a/xcm/xcm-simulator/example/src/parachain.rs
+++ b/xcm/xcm-simulator/example/src/parachain.rs
@@ -143,6 +143,7 @@ impl Config for XcmConfig {
 	type Weigher = FixedWeightBounds<UnitWeightCost, Call, MaxInstructions>;
 	type Trader = FixedRateOfFungible<KsmPerSecond, ()>;
 	type ResponseHandler = ();
+	type AssetTrap = ();
 }
 
 #[frame_support::pallet]

--- a/xcm/xcm-simulator/example/src/parachain.rs
+++ b/xcm/xcm-simulator/example/src/parachain.rs
@@ -144,6 +144,7 @@ impl Config for XcmConfig {
 	type Trader = FixedRateOfFungible<KsmPerSecond, ()>;
 	type ResponseHandler = ();
 	type AssetTrap = ();
+	type AssetClaims = ();
 }
 
 #[frame_support::pallet]

--- a/xcm/xcm-simulator/example/src/relay_chain.rs
+++ b/xcm/xcm-simulator/example/src/relay_chain.rs
@@ -133,6 +133,7 @@ impl Config for XcmConfig {
 	type Weigher = FixedWeightBounds<BaseXcmWeight, Call, MaxInstructions>;
 	type Trader = FixedRateOfFungible<KsmPerSecond, ()>;
 	type ResponseHandler = ();
+	type AssetTrap = ();
 }
 
 pub type LocalOriginToLocation = SignedToAccountId32<Origin, AccountId, KusamaNetwork>;

--- a/xcm/xcm-simulator/example/src/relay_chain.rs
+++ b/xcm/xcm-simulator/example/src/relay_chain.rs
@@ -134,6 +134,7 @@ impl Config for XcmConfig {
 	type Trader = FixedRateOfFungible<KsmPerSecond, ()>;
 	type ResponseHandler = ();
 	type AssetTrap = ();
+	type AssetClaims = ();
 }
 
 pub type LocalOriginToLocation = SignedToAccountId32<Origin, AccountId, KusamaNetwork>;


### PR DESCRIPTION
Introduces a mechanism for systematically allowing the rescue of lost contents of the Holding Register.

Fixes #3694 

## Trapping assets

XCM Executor's config now includes `AssetTrap` type which is a hook to which the contents of the Holding Register is passed at the close of execution. Like `OnResponse`, a (recommended) implementation is provided by the XCM pallet.

This will record a hash of the assets left in the Holding Register at the finish of execution together with the origin. A later claim may be made from the origin in order to resurrect the assets. This is done through the single-function trait `ClaimAssets` which verifies that the assets to be claimed match a hash placed by the same origin.

If the version with which the `MultiAssets` have been stored is not the most recent version, then the version index must be included within the claim `ticket` parameter, a `MultiLocation` as a `GeneralIndex`.

## `ClaimAsset`

A new instruction is provided, `ClaimAsset`, which gains access to any `ClaimAssets` implementations exposed to the XCM Executor. If the `pallet_xcm::Pallet` implementation is exposed and the origin has unclaimed assets trapped, then those assets may be provided (exactly, as a hash of them is used to validate the claim) together with a ticket reflecting the version of XCM at the time of the trap (or `Here` if unchanged) and they will be resurrected into the Holding Register.

## Additional

Also introduces the `Trap` instruction and error type to force an error to be thrown, and be able to recognise it. It comes with a `u64` parameter to allow some degree of information to be conveyed with it (without bloating the stack footprint of `XcmError`).

## Migration

### `xcm_executor::Config`

Two new type definitions are required, and they'll generally want to point at the XCM Pallet concrete type if there is one, e.g.:

```rust
impl xcm_executor::Config for ExecuteXcm {
	/* snip */
	type AssetTrap = XcmPallet;
	type AssetClaims = XcmPallet;
}
```

Note that destinations which use v1 or v0 for message transport will not be able to use these features (even if the destination supports v2).

## TODO
- [x] `ShouldTrap` filter type to allow runtimes to dictate which assets/origins should be trapped.
- [x] Unit test.
