### PR TITLE
XCM: Automatic Version Negotiation

### DIFF
--- a/roadmap/implementers-guide/src/types/overseer-protocol.md
+++ b/roadmap/implementers-guide/src/types/overseer-protocol.md
@@ -441,7 +441,7 @@ enum DisputeCoordinatorMessage {
         pending_confirmation: oneshot::Sender<ImportStatementsResult>
     },
     /// Fetch a list of all recent disputes that the co-ordinator is aware of.
-    /// These are disputes which have occured any time in recent sessions, which may have already concluded.
+    /// These are disputes which have occurerd any time in recent sessions, which may have already concluded.
     RecentDisputes(ResponseChannel<Vec<(SessionIndex, CandidateHash)>>),
     /// Fetch a list of all active disputes that the co-ordinator is aware of.
     /// These disputes are either unconcluded or recently concluded.

--- a/roadmap/implementers-guide/src/types/overseer-protocol.md
+++ b/roadmap/implementers-guide/src/types/overseer-protocol.md
@@ -699,7 +699,7 @@ The Runtime API subsystem is responsible for providing an interface to the state
 
 This is fueled by an auxiliary type encapsulating all request types defined in the Runtime API section of the guide.
 
-> TODO: link to the Runtime API section. Not possible currently because of https://github.com/Michael-F-Bryan/mdbook-linkcheck/issues/25. Once v0.7.1 is released it will work.
+> To do: link to the Runtime API section. Not possible currently because of https://github.com/Michael-F-Bryan/mdbook-linkcheck/issues/25. Once v0.7.1 is released it will work.
 
 ```rust
 enum RuntimeApiRequest {

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -1340,6 +1340,7 @@ impl pallet_xcm::Config for Runtime {
 	type Origin = Origin;
 	type Call = Call;
 	type VersionDiscoveryQueueSize = VersionDiscoveryQueueSize;
+	type AdvertizeXcmVersion = pallet_xcm::CurrentXcmVersion;
 }
 
 parameter_types! {

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -1319,11 +1319,6 @@ pub type LocalOriginToLocation = (
 	// And a usual Signed origin to be used in XCM as a corresponding AccountId32
 	SignedToAccountId32<Origin, AccountId, KusamaNetwork>,
 );
-
-parameter_types! {
-	pub const VersionDiscoveryQueueSize: u32 = 100;
-}
-
 impl pallet_xcm::Config for Runtime {
 	type Event = Event;
 	type SendXcmOrigin = xcm_builder::EnsureXcmOrigin<Origin, LocalOriginToLocation>;
@@ -1339,8 +1334,8 @@ impl pallet_xcm::Config for Runtime {
 	type LocationInverter = LocationInverter<Ancestry>;
 	type Origin = Origin;
 	type Call = Call;
-	type VersionDiscoveryQueueSize = VersionDiscoveryQueueSize;
-	type AdvertizeXcmVersion = pallet_xcm::CurrentXcmVersion;
+	const VERSION_DISCOVERY_QUEUE_SIZE: u32 = 100;
+	type AdvertisedXcmVersion = pallet_xcm::CurrentXcmVersion;
 }
 
 parameter_types! {

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -1320,6 +1320,10 @@ pub type LocalOriginToLocation = (
 	SignedToAccountId32<Origin, AccountId, KusamaNetwork>,
 );
 
+parameter_types! {
+	pub const VersionDiscoveryQueueSize: u32 = 100;
+}
+
 impl pallet_xcm::Config for Runtime {
 	type Event = Event;
 	type SendXcmOrigin = xcm_builder::EnsureXcmOrigin<Origin, LocalOriginToLocation>;
@@ -1335,6 +1339,7 @@ impl pallet_xcm::Config for Runtime {
 	type LocationInverter = LocationInverter<Ancestry>;
 	type Origin = Origin;
 	type Call = Call;
+	type VersionDiscoveryQueueSize = VersionDiscoveryQueueSize;
 }
 
 parameter_types! {

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -1299,6 +1299,7 @@ impl xcm_executor::Config for XcmConfig {
 	type ResponseHandler = XcmPallet;
 	type AssetTrap = XcmPallet;
 	type AssetClaims = XcmPallet;
+	type SubscriptionService = XcmPallet;
 }
 
 parameter_types! {

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -689,10 +689,6 @@ pub type LocalOriginToLocation = (
 	SignedToAccountId32<Origin, AccountId, RococoNetwork>,
 );
 
-parameter_types! {
-	pub const VersionDiscoveryQueueSize: u32 = 100;
-}
-
 impl pallet_xcm::Config for Runtime {
 	type Event = Event;
 	type SendXcmOrigin = xcm_builder::EnsureXcmOrigin<Origin, LocalOriginToLocation>;
@@ -708,8 +704,8 @@ impl pallet_xcm::Config for Runtime {
 	type LocationInverter = LocationInverter<Ancestry>;
 	type Origin = Origin;
 	type Call = Call;
-	type VersionDiscoveryQueueSize = VersionDiscoveryQueueSize;
-	type AdvertizeXcmVersion = pallet_xcm::CurrentXcmVersion;
+	const VERSION_DISCOVERY_QUEUE_SIZE: u32 = 100;
+	type AdvertisedXcmVersion = pallet_xcm::CurrentXcmVersion;
 }
 
 impl parachains_session_info::Config for Runtime {}

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -689,6 +689,10 @@ pub type LocalOriginToLocation = (
 	SignedToAccountId32<Origin, AccountId, RococoNetwork>,
 );
 
+parameter_types! {
+	pub const VersionDiscoveryQueueSize: u32 = 100;
+}
+
 impl pallet_xcm::Config for Runtime {
 	type Event = Event;
 	type SendXcmOrigin = xcm_builder::EnsureXcmOrigin<Origin, LocalOriginToLocation>;
@@ -704,6 +708,7 @@ impl pallet_xcm::Config for Runtime {
 	type LocationInverter = LocationInverter<Ancestry>;
 	type Origin = Origin;
 	type Call = Call;
+	type VersionDiscoveryQueueSize = VersionDiscoveryQueueSize;
 }
 
 impl parachains_session_info::Config for Runtime {}

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -709,6 +709,7 @@ impl pallet_xcm::Config for Runtime {
 	type Origin = Origin;
 	type Call = Call;
 	type VersionDiscoveryQueueSize = VersionDiscoveryQueueSize;
+	type AdvertizeXcmVersion = pallet_xcm::CurrentXcmVersion;
 }
 
 impl parachains_session_info::Config for Runtime {}

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -672,6 +672,7 @@ impl xcm_executor::Config for XcmConfig {
 	type ResponseHandler = XcmPallet;
 	type AssetTrap = XcmPallet;
 	type AssetClaims = XcmPallet;
+	type SubscriptionService = XcmPallet;
 }
 
 parameter_types! {

--- a/runtime/test-runtime/src/lib.rs
+++ b/runtime/test-runtime/src/lib.rs
@@ -537,7 +537,7 @@ impl pallet_test_notifier::Config for Runtime {
 pub mod pallet_test_notifier {
 	use frame_support::pallet_prelude::*;
 	use frame_system::pallet_prelude::*;
-	use pallet_xcm::{ensure_response, QueryId};
+	use pallet_xcm::ensure_response;
 	use sp_runtime::DispatchResult;
 	use xcm::latest::prelude::*;
 

--- a/runtime/test-runtime/src/lib.rs
+++ b/runtime/test-runtime/src/lib.rs
@@ -500,6 +500,10 @@ parameter_types! {
 
 pub type LocalOriginToLocation = xcm_builder::SignedToAccountId32<Origin, AccountId, AnyNetwork>;
 
+parameter_types! {
+	pub const VersionDiscoveryQueueSize: u32 = 100;
+}
+
 impl pallet_xcm::Config for Runtime {
 	// The config types here are entirely configurable, since the only one that is sorely needed
 	// is `XcmExecutor`, which will be used in unit tests located in xcm-executor.
@@ -515,6 +519,7 @@ impl pallet_xcm::Config for Runtime {
 	type XcmReserveTransferFilter = Everything;
 	type Origin = Origin;
 	type Call = Call;
+	type VersionDiscoveryQueueSize = VersionDiscoveryQueueSize;
 }
 
 impl parachains_hrmp::Config for Runtime {

--- a/runtime/test-runtime/src/lib.rs
+++ b/runtime/test-runtime/src/lib.rs
@@ -500,10 +500,6 @@ parameter_types! {
 
 pub type LocalOriginToLocation = xcm_builder::SignedToAccountId32<Origin, AccountId, AnyNetwork>;
 
-parameter_types! {
-	pub const VersionDiscoveryQueueSize: u32 = 100;
-}
-
 impl pallet_xcm::Config for Runtime {
 	// The config types here are entirely configurable, since the only one that is sorely needed
 	// is `XcmExecutor`, which will be used in unit tests located in xcm-executor.
@@ -519,8 +515,8 @@ impl pallet_xcm::Config for Runtime {
 	type XcmReserveTransferFilter = Everything;
 	type Origin = Origin;
 	type Call = Call;
-	type VersionDiscoveryQueueSize = VersionDiscoveryQueueSize;
-	type AdvertizeXcmVersion = pallet_xcm::CurrentXcmVersion;
+	const VERSION_DISCOVERY_QUEUE_SIZE: u32 = 100;
+	type AdvertisedXcmVersion = pallet_xcm::CurrentXcmVersion;
 }
 
 impl parachains_hrmp::Config for Runtime {

--- a/runtime/test-runtime/src/lib.rs
+++ b/runtime/test-runtime/src/lib.rs
@@ -520,6 +520,7 @@ impl pallet_xcm::Config for Runtime {
 	type Origin = Origin;
 	type Call = Call;
 	type VersionDiscoveryQueueSize = VersionDiscoveryQueueSize;
+	type AdvertizeXcmVersion = pallet_xcm::CurrentXcmVersion;
 }
 
 impl parachains_hrmp::Config for Runtime {

--- a/runtime/test-runtime/src/xcm_config.rs
+++ b/runtime/test-runtime/src/xcm_config.rs
@@ -88,4 +88,5 @@ impl xcm_executor::Config for XcmConfig {
 	type ResponseHandler = super::Xcm;
 	type AssetTrap = super::Xcm;
 	type AssetClaims = super::Xcm;
+	type SubscriptionService = super::Xcm;
 }

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -951,6 +951,10 @@ pub type LocalOriginToLocation = (
 	SignedToAccountId32<Origin, AccountId, WestendNetwork>,
 );
 
+parameter_types! {
+	pub const VersionDiscoveryQueueSize: u32 = 100;
+}
+
 impl pallet_xcm::Config for Runtime {
 	type Event = Event;
 	type SendXcmOrigin = xcm_builder::EnsureXcmOrigin<Origin, LocalOriginToLocation>;
@@ -966,6 +970,7 @@ impl pallet_xcm::Config for Runtime {
 	type LocationInverter = LocationInverter<Ancestry>;
 	type Origin = Origin;
 	type Call = Call;
+	type VersionDiscoveryQueueSize = VersionDiscoveryQueueSize;
 }
 
 construct_runtime! {

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -971,6 +971,7 @@ impl pallet_xcm::Config for Runtime {
 	type Origin = Origin;
 	type Call = Call;
 	type VersionDiscoveryQueueSize = VersionDiscoveryQueueSize;
+	type AdvertizeXcmVersion = pallet_xcm::CurrentXcmVersion;
 }
 
 construct_runtime! {

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -951,10 +951,6 @@ pub type LocalOriginToLocation = (
 	SignedToAccountId32<Origin, AccountId, WestendNetwork>,
 );
 
-parameter_types! {
-	pub const VersionDiscoveryQueueSize: u32 = 100;
-}
-
 impl pallet_xcm::Config for Runtime {
 	type Event = Event;
 	type SendXcmOrigin = xcm_builder::EnsureXcmOrigin<Origin, LocalOriginToLocation>;
@@ -970,8 +966,8 @@ impl pallet_xcm::Config for Runtime {
 	type LocationInverter = LocationInverter<Ancestry>;
 	type Origin = Origin;
 	type Call = Call;
-	type VersionDiscoveryQueueSize = VersionDiscoveryQueueSize;
-	type AdvertizeXcmVersion = pallet_xcm::CurrentXcmVersion;
+	const VERSION_DISCOVERY_QUEUE_SIZE: u32 = 100;
+	type AdvertisedXcmVersion = pallet_xcm::CurrentXcmVersion;
 }
 
 construct_runtime! {

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -941,6 +941,7 @@ impl xcm_executor::Config for XcmConfig {
 	type ResponseHandler = XcmPallet;
 	type AssetTrap = XcmPallet;
 	type AssetClaims = XcmPallet;
+	type SubscriptionService = XcmPallet;
 }
 
 /// Type to convert an `Origin` type value into a `MultiLocation` value which represents an interior location

--- a/xcm/pallet-xcm/src/lib.rs
+++ b/xcm/pallet-xcm/src/lib.rs
@@ -260,9 +260,6 @@ pub mod pallet {
 		}
 	}
 
-	/// Value of a query, must be unique for each query.
-	pub type QueryId = u64;
-
 	/// The latest available query index.
 	#[pallet::storage]
 	pub(super) type QueryCount<T: Config> = StorageValue<_, QueryId, ValueQuery>;

--- a/xcm/pallet-xcm/src/lib.rs
+++ b/xcm/pallet-xcm/src/lib.rs
@@ -780,16 +780,15 @@ pub mod pallet {
 			if stage == NotifyCurrentTargets {
 				for (key, value) in VersionNotifyTargets::<T>::iter_prefix(XCM_VERSION) {
 					let (query_id, max_weight, mut target_xcm_version) = value;
-					let new_key: MultiLocation =
-						match key.clone().try_into() {
-							Ok(k) if target_xcm_version != xcm_version => k,
-							_ => {
-								// We don't early return here since we need to be certain that we
-								// make some progress.
-								weight_used.saturating_accrue(todo_vnt_already_notified_weight);
-								continue
-							},
-						};
+					let new_key: MultiLocation = match key.clone().try_into() {
+						Ok(k) if target_xcm_version != xcm_version => k,
+						_ => {
+							// We don't early return here since we need to be certain that we
+							// make some progress.
+							weight_used.saturating_accrue(todo_vnt_already_notified_weight);
+							continue
+						},
+					};
 					let response = Response::Version(xcm_version);
 					let message = Xcm(vec![QueryResponse { query_id, response, max_weight }]);
 					let event = match T::XcmRouter::send_xcm(new_key.clone(), message) {
@@ -836,7 +835,8 @@ pub mod pallet {
 						} else {
 							// Need to notify target.
 							let response = Response::Version(xcm_version);
-							let message = Xcm(vec![QueryResponse { query_id, response, max_weight }]);
+							let message =
+								Xcm(vec![QueryResponse { query_id, response, max_weight }]);
 							let event = match T::XcmRouter::send_xcm(new_key.clone(), message) {
 								Ok(()) => {
 									VersionNotifyTargets::<T>::insert(

--- a/xcm/pallet-xcm/src/lib.rs
+++ b/xcm/pallet-xcm/src/lib.rs
@@ -342,9 +342,13 @@ pub mod pallet {
 					let new_key = match MultiLocation::try_from(old_key.clone()) {
 						Ok(k) => k,
 						Err(()) => {
-        					Self::deposit_event(Event::NotifyTargetDropped(old_key, value.0, XcmError::InvalidLocation));
-							return 0;
-    					},
+							Self::deposit_event(Event::NotifyTargetDropped(
+								old_key,
+								value.0,
+								XcmError::InvalidLocation,
+							));
+							return 0
+						},
 					};
 					let instruction = QueryResponse {
 						query_id: value.0,
@@ -362,8 +366,12 @@ pub mod pallet {
 						},
 						Err(e) => {
 							let new_key = new_key.into();
-							Self::deposit_event(Event::NotifyTargetDropped(new_key, value.0, e.into()));
-						}
+							Self::deposit_event(Event::NotifyTargetDropped(
+								new_key,
+								value.0,
+								e.into(),
+							));
+						},
 					}
 				}
 			}

--- a/xcm/pallet-xcm/src/lib.rs
+++ b/xcm/pallet-xcm/src/lib.rs
@@ -810,7 +810,7 @@ pub mod pallet {
 					weight_used.saturating_accrue(todo_vnt_notify_weight);
 					if weight_used >= weight_cutoff {
 						let last = Some(iter.last_raw_key().into());
-						return (weight_used, Some(NotifyCurrentTargets(last)));
+						return (weight_used, Some(NotifyCurrentTargets(last)))
 					}
 				}
 				stage = MigrateAndNotifyOldTargets;

--- a/xcm/pallet-xcm/src/lib.rs
+++ b/xcm/pallet-xcm/src/lib.rs
@@ -292,15 +292,15 @@ pub mod pallet {
 
 	#[derive(Copy, Clone, Encode, Decode, Eq, PartialEq, Ord, PartialOrd)]
 	pub enum VersionMigrationStage {
-		MigratateSupportedVersion,
-		MigratateVersionNotifiers,
+		MigrateSupportedVersion,
+		MigrateVersionNotifiers,
 		NotifyCurrentTargets,
 		MigrateAndNotifyOldTargets,
 	}
 
 	impl Default for VersionMigrationStage {
 		fn default() -> Self {
-			Self::MigratateSupportedVersion
+			Self::MigrateSupportedVersion
 		}
 	}
 
@@ -748,7 +748,7 @@ pub mod pallet {
 
 			use VersionMigrationStage::*;
 
-			if stage == MigratateSupportedVersion {
+			if stage == MigrateSupportedVersion {
 				// We assume that supported XCM version only ever increases, so just cycle through lower
 				// XCM versioned from the current.
 				for v in 0..XCM_VERSION {
@@ -762,9 +762,9 @@ pub mod pallet {
 						}
 					}
 				}
-				stage = MigratateVersionNotifiers;
+				stage = MigrateVersionNotifiers;
 			}
-			if stage == MigratateVersionNotifiers {
+			if stage == MigrateVersionNotifiers {
 				for v in 0..XCM_VERSION {
 					for (old_key, value) in VersionNotifiers::<T>::drain_prefix(v) {
 						if let Ok(new_key) = old_key.into_latest() {

--- a/xcm/pallet-xcm/src/lib.rs
+++ b/xcm/pallet-xcm/src/lib.rs
@@ -186,7 +186,7 @@ pub mod pallet {
 		/// The supported version of a location has been changed. This might be through an
 		/// automatic notification or a manual intervention.
 		///
-		/// \[ location, xcm_version \]
+		/// \[ location, XCM version \]
 		SupportedVersionChanged(MultiLocation, XcmVersion),
 	}
 

--- a/xcm/pallet-xcm/src/lib.rs
+++ b/xcm/pallet-xcm/src/lib.rs
@@ -46,7 +46,11 @@ pub use pallet::*;
 #[frame_support::pallet]
 pub mod pallet {
 	use super::*;
-	use frame_support::{dispatch::{Dispatchable, GetDispatchInfo, PostDispatchInfo}, pallet_prelude::*, parameter_types};
+	use frame_support::{
+		dispatch::{Dispatchable, GetDispatchInfo, PostDispatchInfo},
+		pallet_prelude::*,
+		parameter_types,
+	};
 	use frame_system::{pallet_prelude::*, Config as SysConfig};
 	use sp_core::H256;
 	use sp_runtime::traits::{AccountIdConversion, BlakeTwo256, BlockNumberProvider, Hash};
@@ -679,11 +683,11 @@ pub mod pallet {
 			let response = Response::Version(xcm_version);
 			for (key, mut value) in VersionNotifyTargets::<T>::iter_prefix(XCM_VERSION) {
 				if value.2 == xcm_version {
-					continue;
+					continue
 				}
 				let new_key: MultiLocation = match key.clone().try_into() {
 					Ok(k) => k,
-					Err(_) => continue,	// will never happen since it's the latest version already.
+					Err(_) => continue, // will never happen since it's the latest version already.
 				};
 				value.2 = xcm_version;
 				let message = Xcm(vec![QueryResponse {
@@ -698,7 +702,11 @@ pub mod pallet {
 						Self::deposit_event(Event::VersionChangeNotified(new_key, xcm_version));
 					},
 					Err(e) => {
-						Self::deposit_event(Event::NotifyTargetSendFail(new_key, value.0, e.into()));
+						Self::deposit_event(Event::NotifyTargetSendFail(
+							new_key,
+							value.0,
+							e.into(),
+						));
 					},
 				}
 			}

--- a/xcm/pallet-xcm/src/lib.rs
+++ b/xcm/pallet-xcm/src/lib.rs
@@ -561,10 +561,11 @@ pub mod pallet {
 		#[pallet::weight(100_000_000u64)]
 		pub fn force_xcm_version(
 			origin: OriginFor<T>,
-			location: MultiLocation,
+			location: Box<MultiLocation>,
 			xcm_version: XcmVersion,
 		) -> DispatchResult {
 			ensure_root(origin)?;
+			let location = *location;
 			SupportedVersion::<T>::insert(
 				XCM_VERSION,
 				LatestVersionedMultiLocation(&location),

--- a/xcm/pallet-xcm/src/lib.rs
+++ b/xcm/pallet-xcm/src/lib.rs
@@ -627,10 +627,13 @@ pub mod pallet {
 		) -> DispatchResult {
 			ensure_root(origin)?;
 			let location = *location;
-			Self::unrequest_version_notify(location).map_err(|e| match e {
-				XcmError::InvalidLocation => Error::<T>::NoSubscription,
-				_ => Error::<T>::InvalidOrigin,
-			}.into())
+			Self::unrequest_version_notify(location).map_err(|e| {
+				match e {
+					XcmError::InvalidLocation => Error::<T>::NoSubscription,
+					_ => Error::<T>::InvalidOrigin,
+				}
+				.into()
+			})
 		}
 	}
 

--- a/xcm/pallet-xcm/src/lib.rs
+++ b/xcm/pallet-xcm/src/lib.rs
@@ -25,7 +25,10 @@ mod tests;
 
 use codec::{Decode, Encode, EncodeLike};
 use frame_support::traits::{Contains, EnsureOrigin, Get, OriginTrait};
-use sp_runtime::{traits::{BadOrigin, Saturating}, RuntimeDebug};
+use sp_runtime::{
+	traits::{BadOrigin, Saturating},
+	RuntimeDebug,
+};
 use sp_std::{
 	boxed::Box,
 	convert::{TryFrom, TryInto},
@@ -347,7 +350,7 @@ pub mod pallet {
 			while let Some((versioned_dest, _)) = q.pop() {
 				if let Ok(dest) = versioned_dest.try_into() {
 					if Self::request_version_notify(dest).is_ok() {
-						break;
+						break
 					}
 				}
 			}

--- a/xcm/pallet-xcm/src/lib.rs
+++ b/xcm/pallet-xcm/src/lib.rs
@@ -264,11 +264,12 @@ pub mod pallet {
 	}
 
 	#[derive(Copy, Clone)]
-	struct LatestVersionedMultiLocation<'a>(&'a MultiLocation);
+	pub(crate) struct LatestVersionedMultiLocation<'a>(pub(crate) &'a MultiLocation);
 	impl<'a> EncodeLike<VersionedMultiLocation> for LatestVersionedMultiLocation<'a> {}
 	impl<'a> Encode for LatestVersionedMultiLocation<'a> {
 		fn encode(&self) -> Vec<u8> {
-			let mut r = vec![XCM_VERSION as u8];
+			let mut r = VersionedMultiLocation::from(MultiLocation::default()).encode();
+			r.truncate(1);
 			self.0.using_encoded(|d| r.extend_from_slice(d));
 			r
 		}

--- a/xcm/pallet-xcm/src/mock.rs
+++ b/xcm/pallet-xcm/src/mock.rs
@@ -258,6 +258,10 @@ impl xcm_executor::Config for XcmConfig {
 
 pub type LocalOriginToLocation = SignedToAccountId32<Origin, AccountId, AnyNetwork>;
 
+parameter_types! {
+	pub const VersionDiscoveryQueueSize: u32 = 100;
+}
+
 impl pallet_xcm::Config for Test {
 	type Event = Event;
 	type SendXcmOrigin = xcm_builder::EnsureXcmOrigin<Origin, LocalOriginToLocation>;
@@ -271,6 +275,7 @@ impl pallet_xcm::Config for Test {
 	type LocationInverter = LocationInverter<Ancestry>;
 	type Origin = Origin;
 	type Call = Call;
+	type VersionDiscoveryQueueSize = VersionDiscoveryQueueSize;
 }
 
 impl origin::Config for Test {}

--- a/xcm/pallet-xcm/src/mock.rs
+++ b/xcm/pallet-xcm/src/mock.rs
@@ -253,6 +253,7 @@ impl xcm_executor::Config for XcmConfig {
 	type ResponseHandler = XcmPallet;
 	type AssetTrap = XcmPallet;
 	type AssetClaims = XcmPallet;
+	type SubscriptionService = XcmPallet;
 }
 
 pub type LocalOriginToLocation = SignedToAccountId32<Origin, AccountId, AnyNetwork>;

--- a/xcm/pallet-xcm/src/mock.rs
+++ b/xcm/pallet-xcm/src/mock.rs
@@ -268,6 +268,7 @@ pub type LocalOriginToLocation = SignedToAccountId32<Origin, AccountId, AnyNetwo
 
 parameter_types! {
 	pub const VersionDiscoveryQueueSize: u32 = 100;
+	pub static AdvertizeXcmVersion: pallet_xcm::XcmVersion = 2;
 }
 
 impl pallet_xcm::Config for Test {
@@ -284,6 +285,7 @@ impl pallet_xcm::Config for Test {
 	type Origin = Origin;
 	type Call = Call;
 	type VersionDiscoveryQueueSize = VersionDiscoveryQueueSize;
+	type AdvertizeXcmVersion = AdvertizeXcmVersion;
 }
 
 impl origin::Config for Test {}

--- a/xcm/pallet-xcm/src/mock.rs
+++ b/xcm/pallet-xcm/src/mock.rs
@@ -322,14 +322,3 @@ pub(crate) fn new_test_ext_with_balances(
 	ext.execute_with(|| System::set_block_number(1));
 	ext
 }
-/*
-pub(crate) fn run_to_block(n: BlockNumber) {
-	while System::block_number() < n {
-		XcmPallet::on_finalize(System::block_number());
-		System::on_finalize(System::block_number());
-		System::set_block_number(System::block_number() + 1);
-		System::on_initialize(System::block_number());
-		XcmPallet::on_initialize(System::block_number());
-	}
-}
-*/

--- a/xcm/pallet-xcm/src/mock.rs
+++ b/xcm/pallet-xcm/src/mock.rs
@@ -267,8 +267,7 @@ impl xcm_executor::Config for XcmConfig {
 pub type LocalOriginToLocation = SignedToAccountId32<Origin, AccountId, AnyNetwork>;
 
 parameter_types! {
-	pub const VersionDiscoveryQueueSize: u32 = 100;
-	pub static AdvertizeXcmVersion: pallet_xcm::XcmVersion = 2;
+	pub static AdvertisedXcmVersion: pallet_xcm::XcmVersion = 2;
 }
 
 impl pallet_xcm::Config for Test {
@@ -284,8 +283,8 @@ impl pallet_xcm::Config for Test {
 	type LocationInverter = LocationInverter<Ancestry>;
 	type Origin = Origin;
 	type Call = Call;
-	type VersionDiscoveryQueueSize = VersionDiscoveryQueueSize;
-	type AdvertizeXcmVersion = AdvertizeXcmVersion;
+	const VERSION_DISCOVERY_QUEUE_SIZE: u32 = 100;
+	type AdvertisedXcmVersion = AdvertisedXcmVersion;
 }
 
 impl origin::Config for Test {}

--- a/xcm/pallet-xcm/src/mock.rs
+++ b/xcm/pallet-xcm/src/mock.rs
@@ -22,11 +22,11 @@ use sp_runtime::{testing::Header, traits::IdentityLookup, AccountId32};
 pub use sp_std::{cell::RefCell, fmt::Debug, marker::PhantomData};
 use xcm::latest::prelude::*;
 use xcm_builder::{
-	AccountId32Aliases, AllowKnownQueryResponses, AllowTopLevelPaidExecutionFrom, Case,
-	ChildParachainAsNative, ChildParachainConvertsVia, ChildSystemParachainAsSuperuser,
-	CurrencyAdapter as XcmCurrencyAdapter, FixedRateOfFungible, FixedWeightBounds, IsConcrete,
-	LocationInverter, SignedAccountId32AsNative, SignedToAccountId32, SovereignSignedViaLocation,
-	TakeWeightCredit, AllowSubscriptionsFrom,
+	AccountId32Aliases, AllowKnownQueryResponses, AllowSubscriptionsFrom,
+	AllowTopLevelPaidExecutionFrom, Case, ChildParachainAsNative, ChildParachainConvertsVia,
+	ChildSystemParachainAsSuperuser, CurrencyAdapter as XcmCurrencyAdapter, FixedRateOfFungible,
+	FixedWeightBounds, IsConcrete, LocationInverter, SignedAccountId32AsNative,
+	SignedToAccountId32, SovereignSignedViaLocation, TakeWeightCredit,
 };
 use xcm_executor::XcmExecutor;
 
@@ -137,7 +137,11 @@ pub(crate) fn sent_xcm() -> Vec<(MultiLocation, Xcm<()>)> {
 	SENT_XCM.with(|q| (*q.borrow()).clone())
 }
 pub(crate) fn take_sent_xcm() -> Vec<(MultiLocation, Xcm<()>)> {
-	SENT_XCM.with(|q| { let mut r = Vec::new(); std::mem::swap(&mut r, &mut *q.borrow_mut()); r })
+	SENT_XCM.with(|q| {
+		let mut r = Vec::new();
+		std::mem::swap(&mut r, &mut *q.borrow_mut());
+		r
+	})
 }
 /// Sender that never returns error, always sends
 pub struct TestSendXcm;

--- a/xcm/pallet-xcm/src/tests.rs
+++ b/xcm/pallet-xcm/src/tests.rs
@@ -18,7 +18,10 @@ use crate::{
 	mock::*, AssetTraps, Error, LatestVersionedMultiLocation, Queries, QueryStatus,
 	VersionNotifiers, VersionNotifyTargets,
 };
-use frame_support::{assert_noop, assert_ok, traits::{Currency, Hooks}};
+use frame_support::{
+	assert_noop, assert_ok,
+	traits::{Currency, Hooks},
+};
 use polkadot_parachain::primitives::{AccountIdConversion, Id as ParaId};
 use sp_runtime::traits::{BlakeTwo256, Hash};
 use std::convert::TryInto;
@@ -565,20 +568,29 @@ fn subscription_side_upgrades_work_with_notify() {
 		let instr1 = QueryResponse { query_id: 70, max_weight: 0, response: Response::Version(2) };
 		let instr2 = QueryResponse { query_id: 71, max_weight: 0, response: Response::Version(2) };
 		let mut sent = take_sent_xcm();
-		sent.sort_by_key(|k| match (k.1).0[0] { QueryResponse { query_id: q, .. } => q, _ => 0 });
-		assert_eq!(sent, vec![
-			(Parachain(1000).into(), Xcm(vec![instr0])),
-			(Parachain(1001).into(), Xcm(vec![instr1])),
-			(Parachain(1002).into(), Xcm(vec![instr2])),
-		]);
+		sent.sort_by_key(|k| match (k.1).0[0] {
+			QueryResponse { query_id: q, .. } => q,
+			_ => 0,
+		});
+		assert_eq!(
+			sent,
+			vec![
+				(Parachain(1000).into(), Xcm(vec![instr0])),
+				(Parachain(1001).into(), Xcm(vec![instr1])),
+				(Parachain(1002).into(), Xcm(vec![instr2])),
+			]
+		);
 
 		let mut contents = VersionNotifyTargets::<Test>::iter().collect::<Vec<_>>();
 		contents.sort_by_key(|k| k.2);
-		assert_eq!(contents, vec![
-			(2, Parachain(1000).into().versioned(), (69, 0, 2)),
-			(2, Parachain(1001).into().versioned(), (70, 0, 2)),
-			(2, Parachain(1002).into().versioned(), (71, 0, 2)),
-		]);
+		assert_eq!(
+			contents,
+			vec![
+				(2, Parachain(1000).into().versioned(), (69, 0, 2)),
+				(2, Parachain(1001).into().versioned(), (70, 0, 2)),
+				(2, Parachain(1002).into().versioned(), (71, 0, 2)),
+			]
+		);
 	});
 }
 
@@ -598,11 +610,14 @@ fn subscription_side_upgrades_work_without_notify() {
 		XcmPallet::on_runtime_upgrade();
 		let mut contents = VersionNotifyTargets::<Test>::iter().collect::<Vec<_>>();
 		contents.sort_by_key(|k| k.2);
-		assert_eq!(contents, vec![
-			(2, Parachain(1000).into().versioned(), (69, 0, 2)),
-			(2, Parachain(1001).into().versioned(), (70, 0, 2)),
-			(2, Parachain(1002).into().versioned(), (71, 0, 2)),
-		]);
+		assert_eq!(
+			contents,
+			vec![
+				(2, Parachain(1000).into().versioned(), (69, 0, 2)),
+				(2, Parachain(1001).into().versioned(), (70, 0, 2)),
+				(2, Parachain(1002).into().versioned(), (71, 0, 2)),
+			]
+		);
 	});
 }
 
@@ -649,7 +664,5 @@ fn subscriber_side_subscription_works() {
 /// We should autosubscribe when we don't know the remote's version.
 #[test]
 fn auto_subscription_works() {
-	new_test_ext_with_balances(vec![]).execute_with(|| {
-
-	})
+	new_test_ext_with_balances(vec![]).execute_with(|| {})
 }

--- a/xcm/pallet-xcm/src/tests.rs
+++ b/xcm/pallet-xcm/src/tests.rs
@@ -14,7 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::{mock::*, AssetTraps, Error, QueryStatus, Queries, VersionNotifiers, LatestVersionedMultiLocation};
+use crate::{
+	mock::*, AssetTraps, Error, LatestVersionedMultiLocation, Queries, QueryStatus,
+	VersionNotifiers,
+};
 use frame_support::{assert_noop, assert_ok, traits::Currency};
 use polkadot_parachain::primitives::{AccountIdConversion, Id as ParaId};
 use sp_runtime::traits::{BlakeTwo256, Hash};
@@ -394,24 +397,24 @@ fn basic_subscription_works() {
 			Box::new(remote.clone().into()),
 		));
 
-		assert_eq!(Queries::<Test>::iter().collect::<Vec<_>>(), vec![
-			(0, QueryStatus::VersionNotifier {
-				origin: remote.clone().into(),
-				is_active: false,
-			})
-		]);
-		assert_eq!(VersionNotifiers::<Test>::iter().collect::<Vec<_>>(), vec![
-			(2, remote.clone().into(), 0)
-		]);
+		assert_eq!(
+			Queries::<Test>::iter().collect::<Vec<_>>(),
+			vec![(
+				0,
+				QueryStatus::VersionNotifier { origin: remote.clone().into(), is_active: false }
+			)]
+		);
+		assert_eq!(
+			VersionNotifiers::<Test>::iter().collect::<Vec<_>>(),
+			vec![(2, remote.clone().into(), 0)]
+		);
 
 		assert_eq!(
 			take_sent_xcm(),
-			vec![
-				(
-					remote.clone(),
-					Xcm(vec![SubscribeVersion { query_id: 0, max_response_weight: 0 }]),
-				),
-			]
+			vec![(
+				remote.clone(),
+				Xcm(vec![SubscribeVersion { query_id: 0, max_response_weight: 0 }]),
+			),]
 		);
 
 		let weight = BaseXcmWeight::get();
@@ -485,12 +488,10 @@ fn unsubscribe_works() {
 			Origin::root(),
 			Box::new(remote.clone().into()),
 		));
-		assert_ok!(
-			XcmPallet::force_unsubscribe_version_notify(
-				Origin::root(),
-				Box::new(remote.clone().into())
-			)
-		);
+		assert_ok!(XcmPallet::force_unsubscribe_version_notify(
+			Origin::root(),
+			Box::new(remote.clone().into())
+		));
 		assert_noop!(
 			XcmPallet::force_unsubscribe_version_notify(
 				Origin::root(),
@@ -506,10 +507,7 @@ fn unsubscribe_works() {
 					remote.clone(),
 					Xcm(vec![SubscribeVersion { query_id: 0, max_response_weight: 0 }]),
 				),
-				(
-					remote.clone(),
-					Xcm(vec![UnsubscribeVersion]),
-				),
+				(remote.clone(), Xcm(vec![UnsubscribeVersion]),),
 			]
 		);
 	});
@@ -553,4 +551,3 @@ fn subscriber_side_subscription_works() {
 		);
 	});
 }
-

--- a/xcm/pallet-xcm/src/tests.rs
+++ b/xcm/pallet-xcm/src/tests.rs
@@ -15,8 +15,8 @@
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
 use crate::{
-	mock::*, AssetTraps, Error, LatestVersionedMultiLocation, Queries, QueryStatus,
-	VersionDiscoveryQueue, VersionNotifiers, VersionNotifyTargets, CurrentMigration,
+	mock::*, AssetTraps, CurrentMigration, Error, LatestVersionedMultiLocation, Queries,
+	QueryStatus, VersionDiscoveryQueue, VersionNotifiers, VersionNotifyTargets,
 };
 use frame_support::{
 	assert_noop, assert_ok,
@@ -772,7 +772,7 @@ fn subscription_side_upgrades_work_with_multistage_notify() {
 			maybe_migration = m;
 		}
 		assert_eq!(counter, 4);
-		
+
 		let instr0 = QueryResponse { query_id: 69, max_weight: 0, response: Response::Version(2) };
 		let instr1 = QueryResponse { query_id: 70, max_weight: 0, response: Response::Version(2) };
 		let instr2 = QueryResponse { query_id: 71, max_weight: 0, response: Response::Version(2) };

--- a/xcm/pallet-xcm/src/tests.rs
+++ b/xcm/pallet-xcm/src/tests.rs
@@ -520,7 +520,7 @@ fn unsubscribe_works() {
 #[test]
 fn subscription_side_works() {
 	new_test_ext_with_balances(vec![]).execute_with(|| {
-		AdvertizeXcmVersion::set(1);
+		AdvertisedXcmVersion::set(1);
 
 		let remote = Parachain(1000).into();
 		let weight = BaseXcmWeight::get();
@@ -536,7 +536,7 @@ fn subscription_side_works() {
 		assert_eq!(take_sent_xcm(), vec![]);
 
 		// New version.
-		AdvertizeXcmVersion::set(2);
+		AdvertisedXcmVersion::set(2);
 
 		// A runtime upgrade which alters the version does send notifications.
 		XcmPallet::on_runtime_upgrade();
@@ -548,7 +548,7 @@ fn subscription_side_works() {
 #[test]
 fn subscription_side_upgrades_work_with_notify() {
 	new_test_ext_with_balances(vec![]).execute_with(|| {
-		AdvertizeXcmVersion::set(1);
+		AdvertisedXcmVersion::set(1);
 
 		// An entry from a previous runtime with v0 XCM.
 		let v0_location = xcm::v0::MultiLocation::X1(xcm::v0::Junction::Parachain(1000));
@@ -560,7 +560,7 @@ fn subscription_side_upgrades_work_with_notify() {
 		VersionNotifyTargets::<Test>::insert(2, v2_location, (71, 0, 1));
 
 		// New version.
-		AdvertizeXcmVersion::set(2);
+		AdvertisedXcmVersion::set(2);
 
 		// A runtime upgrade which alters the version does send notifications.
 		XcmPallet::on_runtime_upgrade();

--- a/xcm/pallet-xcm/src/tests.rs
+++ b/xcm/pallet-xcm/src/tests.rs
@@ -521,6 +521,7 @@ fn subscriber_side_subscription_works() {
 			Origin::root(),
 			Box::new(remote.clone().into()),
 		));
+		take_sent_xcm();
 
 		// Assume subscription target is working ok.
 

--- a/xcm/pallet-xcm/src/tests.rs
+++ b/xcm/pallet-xcm/src/tests.rs
@@ -14,14 +14,14 @@
 // You should have received a copy of the GNU General Public License
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::{mock::*, AssetTraps, QueryStatus, Error};
+use crate::{mock::*, AssetTraps, Error, QueryStatus};
 use frame_support::{assert_noop, assert_ok, traits::Currency};
 use polkadot_parachain::primitives::{AccountIdConversion, Id as ParaId};
 use sp_runtime::traits::{BlakeTwo256, Hash};
 use std::convert::TryInto;
 use xcm::prelude::*;
-use xcm_executor::{XcmExecutor, traits::ShouldExecute};
 use xcm_builder::AllowKnownQueryResponses;
+use xcm_executor::{traits::ShouldExecute, XcmExecutor};
 
 const ALICE: AccountId = AccountId::new([0u8; 32]);
 const BOB: AccountId = AccountId::new([1u8; 32]);
@@ -382,7 +382,7 @@ fn subscribe_unsubscribe_works() {
 	new_test_ext_with_balances(vec![]).execute_with(|| {
 		let remote = Parachain(1000).into();
 		assert_ok!(XcmPallet::request_version_notify(remote.clone()));
-		assert_noop!(XcmPallet::request_version_notify(remote.clone()), XcmError::InvalidLocation);	
+		assert_noop!(XcmPallet::request_version_notify(remote.clone()), XcmError::InvalidLocation);
 
 		let remote2 = Parachain(1001).into();
 		assert_ok!(XcmPallet::request_version_notify(remote2.clone()));
@@ -397,10 +397,13 @@ fn subscriber_side_subscription_works() {
 			Origin::root(),
 			Box::new(remote.clone().into()),
 		));
-		assert_noop!(XcmPallet::force_subscribe_version_notify(
-			Origin::root(),
-			Box::new(remote.clone().into())
-		), Error::<Test>::AlreadySubscribed);	
+		assert_noop!(
+			XcmPallet::force_subscribe_version_notify(
+				Origin::root(),
+				Box::new(remote.clone().into())
+			),
+			Error::<Test>::AlreadySubscribed
+		);
 
 		let remote2 = Parachain(1001).into();
 		assert_ok!(XcmPallet::force_subscribe_version_notify(
@@ -408,16 +411,19 @@ fn subscriber_side_subscription_works() {
 			Box::new(remote2.clone().into()),
 		));
 
-		assert_eq!(take_sent_xcm(), vec![
-			(
-				remote.clone(),
-				Xcm(vec![SubscribeVersion { query_id: 0, max_response_weight: 0 }]),
-			),
-			(
-				remote2.clone(),
-				Xcm(vec![SubscribeVersion { query_id: 1, max_response_weight: 0 }]),
-			),
-		]);
+		assert_eq!(
+			take_sent_xcm(),
+			vec![
+				(
+					remote.clone(),
+					Xcm(vec![SubscribeVersion { query_id: 0, max_response_weight: 0 }]),
+				),
+				(
+					remote2.clone(),
+					Xcm(vec![SubscribeVersion { query_id: 1, max_response_weight: 0 }]),
+				),
+			]
+		);
 
 		// Assume subscription target is working ok.
 
@@ -426,7 +432,12 @@ fn subscriber_side_subscription_works() {
 			// Remote supports XCM v1
 			QueryResponse { query_id: 0, max_weight: 0, response: Response::Version(1) },
 		]);
-		assert_ok!(AllowKnownQueryResponses::<XcmPallet>::should_execute(&remote, &mut message, weight, &mut 0));
+		assert_ok!(AllowKnownQueryResponses::<XcmPallet>::should_execute(
+			&remote,
+			&mut message,
+			weight,
+			&mut 0
+		));
 		let r = XcmExecutor::<XcmConfig>::execute_xcm(remote.clone(), message, weight);
 		assert_eq!(r, Outcome::Complete(weight));
 		assert_eq!(take_sent_xcm(), vec![]);
@@ -443,6 +454,9 @@ fn subscriber_side_subscription_works() {
 		assert_eq!(r, Outcome::Complete(weight));
 
 		// This message can now be sent to remote as it's v2.
-		assert_eq!(XcmPallet::wrap_version(&remote, v2_msg.clone()), Ok(VersionedXcm::from(v2_msg)));
+		assert_eq!(
+			XcmPallet::wrap_version(&remote, v2_msg.clone()),
+			Ok(VersionedXcm::from(v2_msg))
+		);
 	});
 }

--- a/xcm/pallet-xcm/src/tests.rs
+++ b/xcm/pallet-xcm/src/tests.rs
@@ -16,7 +16,7 @@
 
 use crate::{
 	mock::*, AssetTraps, Error, LatestVersionedMultiLocation, Queries, QueryStatus,
-	VersionNotifiers, VersionNotifyTargets, VersionDiscoveryQueue,
+	VersionDiscoveryQueue, VersionNotifiers, VersionNotifyTargets,
 };
 use frame_support::{
 	assert_noop, assert_ok,
@@ -683,7 +683,7 @@ fn auto_subscription_works() {
 		assert_eq!(XcmPallet::wrap_version(&remote0, v2_msg.clone()), Err(()));
 		let expected = vec![(remote0.clone().into(), 2)];
 		assert_eq!(VersionDiscoveryQueue::<Test>::get().into_inner(), expected);
-		
+
 		assert_eq!(XcmPallet::wrap_version(&remote0, v2_msg.clone()), Err(()));
 		assert_eq!(XcmPallet::wrap_version(&remote1, v2_msg.clone()), Err(()));
 		let expected = vec![(remote0.clone().into(), 3), (remote1.clone().into(), 1)];
@@ -712,8 +712,8 @@ fn auto_subscription_works() {
 		assert_eq!(
 			XcmPallet::wrap_version(&remote0, v2_msg.clone()),
 			Ok(VersionedXcm::from(v2_msg.clone()))
-		);		
-		
+		);
+
 		XcmPallet::on_initialize(2);
 		assert_eq!(
 			take_sent_xcm(),

--- a/xcm/src/lib.rs
+++ b/xcm/src/lib.rs
@@ -45,12 +45,26 @@ pub use double_encoded::DoubleEncoded;
 /// Maximum nesting level for XCM decoding.
 pub const MAX_XCM_DECODE_DEPTH: u32 = 8;
 
+/// A version of XCM.
+pub type Version = u32;
+
 #[derive(Clone, Eq, PartialEq, Debug)]
 pub enum Unsupported {}
 impl Encode for Unsupported {}
 impl Decode for Unsupported {
 	fn decode<I: Input>(_: &mut I) -> Result<Self, CodecError> {
 		Err("Not decodable".into())
+	}
+}
+
+/// Attempt to convert `self` into a particular version of itself.
+pub trait IntoVersion: Sized {
+	/// Consume `self` and return same value expressed in some particular `version` of XCM.
+	fn into_version(self, version: Version) -> Result<Self, ()>;
+
+	/// Consume `self` and return same value expressed the latest version of XCM.
+	fn into_latest(self) -> Result<Self, ()> {
+		self.into_version(latest::VERSION)
 	}
 }
 
@@ -62,6 +76,16 @@ impl Decode for Unsupported {
 pub enum VersionedMultiLocation {
 	V0(v0::MultiLocation),
 	V1(v1::MultiLocation),
+}
+
+impl IntoVersion for VersionedMultiLocation {
+	fn into_version(self, n: Version) -> Result<Self, ()> {
+		Ok(match n {
+			0 => Self::V0(self.try_into()?),
+			1 | 2 => Self::V1(self.try_into()?),
+			_ => return Err(()),
+		})
+	}
 }
 
 impl From<v0::MultiLocation> for VersionedMultiLocation {
@@ -107,6 +131,17 @@ pub enum VersionedResponse {
 	V0(v0::Response),
 	V1(v1::Response),
 	V2(v2::Response),
+}
+
+impl IntoVersion for VersionedResponse {
+	fn into_version(self, n: Version) -> Result<Self, ()> {
+		Ok(match n {
+			0 => Self::V0(self.try_into()?),
+			1 => Self::V1(self.try_into()?),
+			2 => Self::V2(self.try_into()?),
+			_ => return Err(()),
+		})
+	}
 }
 
 impl From<v0::Response> for VersionedResponse {
@@ -173,6 +208,16 @@ pub enum VersionedMultiAsset {
 	V1(v1::MultiAsset),
 }
 
+impl IntoVersion for VersionedMultiAsset {
+	fn into_version(self, n: Version) -> Result<Self, ()> {
+		Ok(match n {
+			0 => Self::V0(self.try_into()?),
+			1 | 2 => Self::V1(self.try_into()?),
+			_ => return Err(()),
+		})
+	}
+}
+
 impl From<v0::MultiAsset> for VersionedMultiAsset {
 	fn from(x: v0::MultiAsset) -> Self {
 		VersionedMultiAsset::V0(x)
@@ -217,8 +262,8 @@ pub enum VersionedMultiAssets {
 	V1(v1::MultiAssets),
 }
 
-impl VersionedMultiAssets {
-	pub fn into_version(self, n: u32) -> Result<Self, ()> {
+impl IntoVersion for VersionedMultiAssets {
+	fn into_version(self, n: Version) -> Result<Self, ()> {
 		Ok(match n {
 			0 => Self::V0(self.try_into()?),
 			1 | 2 => Self::V1(self.try_into()?),
@@ -270,6 +315,17 @@ pub enum VersionedXcm<Call> {
 	V0(v0::Xcm<Call>),
 	V1(v1::Xcm<Call>),
 	V2(v2::Xcm<Call>),
+}
+
+impl<C> IntoVersion for VersionedXcm<C> {
+	fn into_version(self, n: Version) -> Result<Self, ()> {
+		Ok(match n {
+			0 => Self::V0(self.try_into()?),
+			1 => Self::V1(self.try_into()?),
+			2 => Self::V2(self.try_into()?),
+			_ => return Err(()),
+		})
+	}
 }
 
 impl<Call> From<v0::Xcm<Call>> for VersionedXcm<Call> {
@@ -382,6 +438,15 @@ pub type AlwaysLatest = AlwaysV1;
 
 /// `WrapVersion` implementation which attempts to always convert the XCM to the release version before wrapping it.
 pub type AlwaysRelease = AlwaysV0;
+
+pub mod prelude {
+	pub use super::latest::prelude::*;
+	pub use super::{
+		VersionedXcm, VersionedMultiAsset, VersionedMultiAssets, VersionedMultiLocation,
+		VersionedResponse, Version as XcmVersion, IntoVersion, Unsupported,
+		WrapVersion, AlwaysLatest, AlwaysRelease, AlwaysV0, AlwaysV1, AlwaysV2, 
+	};
+}
 
 pub mod opaque {
 	pub mod v0 {

--- a/xcm/src/lib.rs
+++ b/xcm/src/lib.rs
@@ -440,11 +440,10 @@ pub type AlwaysLatest = AlwaysV1;
 pub type AlwaysRelease = AlwaysV0;
 
 pub mod prelude {
-	pub use super::latest::prelude::*;
 	pub use super::{
-		VersionedXcm, VersionedMultiAsset, VersionedMultiAssets, VersionedMultiLocation,
-		VersionedResponse, Version as XcmVersion, IntoVersion, Unsupported,
-		WrapVersion, AlwaysLatest, AlwaysRelease, AlwaysV0, AlwaysV1, AlwaysV2, 
+		latest::prelude::*, AlwaysLatest, AlwaysRelease, AlwaysV0, AlwaysV1, AlwaysV2, IntoVersion,
+		Unsupported, Version as XcmVersion, VersionedMultiAsset, VersionedMultiAssets,
+		VersionedMultiLocation, VersionedResponse, VersionedXcm, WrapVersion,
 	};
 }
 

--- a/xcm/src/v0/mod.rs
+++ b/xcm/src/v0/mod.rs
@@ -326,6 +326,7 @@ impl TryFrom<Response1> for Response {
 	fn try_from(new_response: Response1) -> result::Result<Self, ()> {
 		Ok(match new_response {
 			Response1::Assets(assets) => Self::Assets(assets.try_into()?),
+			Response1::Version(..) => return Err(()),
 		})
 	}
 }
@@ -379,6 +380,7 @@ impl<Call> TryFrom<Xcm1<Call>> for Xcm<Call> {
 				who: MultiLocation1 { interior: who, parents: 0 }.try_into()?,
 				message: alloc::boxed::Box::new((*message).try_into()?),
 			},
+			Xcm1::SubscribeVersion{..} | Xcm1::UnsubscribeVersion => return Err(()),
 		})
 	}
 }

--- a/xcm/src/v0/mod.rs
+++ b/xcm/src/v0/mod.rs
@@ -380,7 +380,7 @@ impl<Call> TryFrom<Xcm1<Call>> for Xcm<Call> {
 				who: MultiLocation1 { interior: who, parents: 0 }.try_into()?,
 				message: alloc::boxed::Box::new((*message).try_into()?),
 			},
-			Xcm1::SubscribeVersion{..} | Xcm1::UnsubscribeVersion => return Err(()),
+			Xcm1::SubscribeVersion { .. } | Xcm1::UnsubscribeVersion => return Err(()),
 		})
 	}
 }

--- a/xcm/src/v1/multilocation.rs
+++ b/xcm/src/v1/multilocation.rs
@@ -71,6 +71,11 @@ impl MultiLocation {
 		MultiLocation { parents, interior: junctions }
 	}
 
+	/// Consume `self` and return the equivalent `VersionedMultiLocation` value.
+	pub fn versioned(self) -> crate::VersionedMultiLocation {
+		self.into()
+	}
+
 	/// Creates a new `MultiLocation` with 0 parents and a `Here` interior.
 	///
 	/// The resulting `MultiLocation` can be interpreted as the "current consensus system".

--- a/xcm/src/v1/multilocation.rs
+++ b/xcm/src/v1/multilocation.rs
@@ -54,16 +54,16 @@ pub struct MultiLocation {
 	pub interior: Junctions,
 }
 
+impl Default for MultiLocation {
+	fn default() -> Self {
+		Self { parents: 0, interior: Junctions::Here }
+	}
+}
+
 /// A relative location which is constrained to be an interior location of the context.
 ///
 /// See also `MultiLocation`.
 pub type InteriorMultiLocation = Junctions;
-
-impl Default for MultiLocation {
-	fn default() -> Self {
-		Self::here()
-	}
-}
 
 impl MultiLocation {
 	/// Creates a new `MultiLocation` with the given number of parents and interior junctions.

--- a/xcm/src/v2/mod.rs
+++ b/xcm/src/v2/mod.rs
@@ -37,6 +37,8 @@ pub use super::v1::{
 	MultiLocation, NetworkId, OriginKind, Parent, ParentThen, WildFungibility, WildMultiAsset,
 };
 
+pub const VERSION: super::Version = 2;
+
 #[derive(Derivative, Default, Encode, Decode)]
 #[derivative(Clone(bound = ""), Eq(bound = ""), PartialEq(bound = ""), Debug(bound = ""))]
 #[codec(encode_bound())]
@@ -121,6 +123,7 @@ pub mod prelude {
 			WeightLimit::{self, *},
 			WildFungibility::{self, Fungible as WildFungible, NonFungible as WildNonFungible},
 			WildMultiAsset::{self, *},
+			VERSION as XCM_VERSION,
 		};
 	}
 	pub use super::{Instruction, Xcm};

--- a/xcm/src/v2/mod.rs
+++ b/xcm/src/v2/mod.rs
@@ -19,11 +19,7 @@
 use super::v1::{Order as OldOrder, Response as OldResponse, Xcm as OldXcm};
 use crate::DoubleEncoded;
 use alloc::{vec, vec::Vec};
-use core::{
-	convert::{TryFrom, TryInto},
-	fmt::Debug,
-	result,
-};
+use core::{convert::{TryFrom, TryInto}, fmt::Debug, ops::Sub, result};
 use derivative::Derivative;
 use parity_scale_codec::{self, Decode, Encode};
 
@@ -686,6 +682,7 @@ impl TryFrom<OldResponse> for Response {
 	fn try_from(old_response: OldResponse) -> result::Result<Self, ()> {
 		match old_response {
 			OldResponse::Assets(assets) => Ok(Self::Assets(assets)),
+			OldResponse::Version(version) => Ok(Self::Version(version)),
 		}
 	}
 }
@@ -735,6 +732,9 @@ impl<Call> TryFrom<OldXcm<Call>> for Xcm<Call> {
 				vec![Transact { origin_type, require_weight_at_most, call }],
 			// We don't handle this one at all due to nested XCM.
 			OldXcm::RelayedFrom { .. } => return Err(()),
+			OldXcm::SubscribeVersion { query_id, max_response_weight } =>
+				vec![SubscribeVersion { query_id, max_response_weight }],
+			OldXcm::UnsubscribeVersion => vec![UnsubscribeVersion],
 		}))
 	}
 }

--- a/xcm/src/v2/mod.rs
+++ b/xcm/src/v2/mod.rs
@@ -19,7 +19,11 @@
 use super::v1::{Order as OldOrder, Response as OldResponse, Xcm as OldXcm};
 use crate::DoubleEncoded;
 use alloc::{vec, vec::Vec};
-use core::{convert::{TryFrom, TryInto}, fmt::Debug, result};
+use core::{
+	convert::{TryFrom, TryInto},
+	fmt::Debug,
+	result,
+};
 use derivative::Derivative;
 use parity_scale_codec::{self, Decode, Encode};
 

--- a/xcm/src/v2/mod.rs
+++ b/xcm/src/v2/mod.rs
@@ -122,13 +122,12 @@ pub mod prelude {
 			MultiAssetFilter::{self, *},
 			MultiAssets, MultiLocation,
 			NetworkId::{self, *},
-			OriginKind, Outcome, Parent, ParentThen, Response, Result as XcmResult, SendError,
-			SendResult, SendXcm,
+			OriginKind, Outcome, Parent, ParentThen, QueryId, Response, Result as XcmResult,
+			SendError, SendResult, SendXcm,
 			WeightLimit::{self, *},
 			WildFungibility::{self, Fungible as WildFungible, NonFungible as WildNonFungible},
 			WildMultiAsset::{self, *},
 			VERSION as XCM_VERSION,
-			QueryId,
 		};
 	}
 	pub use super::{Instruction, Xcm};
@@ -597,12 +596,17 @@ pub enum Instruction<Call> {
 	/// Ask the destination system to respond with the most recent version of XCM that they
 	/// support in a `QueryResponse` instruction. Any changes to this should also ellicit similar
 	/// responses when they happen.
-	/// 
+	///
 	/// Kind: *Instruction*
-	SubscribeVersion { #[codec(compact)] query_id: QueryId, #[codec(compact)] max_response_weight: u64 },
+	SubscribeVersion {
+		#[codec(compact)]
+		query_id: QueryId,
+		#[codec(compact)]
+		max_response_weight: u64,
+	},
 
 	/// Cancel the effect of a previous `SubscribeVersion` instruction.
-	/// 
+	///
 	/// Kind: *Instruction*
 	UnsubscribeVersion,
 }
@@ -659,7 +663,8 @@ impl<Call> Instruction<Call> {
 			ClearError => ClearError,
 			ClaimAsset { assets, ticket } => ClaimAsset { assets, ticket },
 			Trap(code) => Trap(code),
-			SubscribeVersion { query_id, max_response_weight } => SubscribeVersion { query_id, max_response_weight },
+			SubscribeVersion { query_id, max_response_weight } =>
+				SubscribeVersion { query_id, max_response_weight },
 			UnsubscribeVersion => UnsubscribeVersion,
 		}
 	}

--- a/xcm/src/v2/mod.rs
+++ b/xcm/src/v2/mod.rs
@@ -594,7 +594,7 @@ pub enum Instruction<Call> {
 	Trap(#[codec(compact)] u64),
 
 	/// Ask the destination system to respond with the most recent version of XCM that they
-	/// support in a `QueryResponse` instruction. Any changes to this should also ellicit similar
+	/// support in a `QueryResponse` instruction. Any changes to this should also elicit similar
 	/// responses when they happen.
 	///
 	/// Kind: *Instruction*

--- a/xcm/src/v2/mod.rs
+++ b/xcm/src/v2/mod.rs
@@ -301,7 +301,12 @@ pub enum Instruction<Call> {
 	/// Kind: *Instruction*.
 	///
 	/// Errors:
-	Transact { origin_type: OriginKind, require_weight_at_most: u64, call: DoubleEncoded<Call> },
+	Transact {
+		origin_type: OriginKind,
+		#[codec(compact)]
+		require_weight_at_most: u64,
+		call: DoubleEncoded<Call>,
+	},
 
 	/// A message to notify about a new incoming HRMP channel. This message is meant to be sent by the
 	/// relay-chain to a para.
@@ -405,7 +410,12 @@ pub enum Instruction<Call> {
 	/// Kind: *Instruction*
 	///
 	/// Errors:
-	DepositAsset { assets: MultiAssetFilter, max_assets: u32, beneficiary: MultiLocation },
+	DepositAsset {
+		assets: MultiAssetFilter,
+		#[codec(compact)]
+		max_assets: u32,
+		beneficiary: MultiLocation,
+	},
 
 	/// Remove the asset(s) (`assets`) from the Holding Register and place equivalent assets under
 	/// the ownership of `dest` within this consensus system (i.e. deposit them into its sovereign
@@ -428,6 +438,7 @@ pub enum Instruction<Call> {
 	/// Errors:
 	DepositReserveAsset {
 		assets: MultiAssetFilter,
+		#[codec(compact)]
 		max_assets: u32,
 		dest: MultiLocation,
 		xcm: Xcm<()>,
@@ -581,14 +592,14 @@ pub enum Instruction<Call> {
 	///
 	/// Errors:
 	/// - `Trap`: All circumstances, whose inner value is the same as this item's inner value.
-	Trap(u64),
+	Trap(#[codec(compact)] u64),
 
 	/// Ask the destination system to respond with the most recent version of XCM that they
 	/// support in a `QueryResponse` instruction. Any changes to this should also ellicit similar
 	/// responses when they happen.
 	/// 
 	/// Kind: *Instruction*
-	SubscribeVersion { query_id: QueryId, max_response_weight: u64 },
+	SubscribeVersion { #[codec(compact)] query_id: QueryId, #[codec(compact)] max_response_weight: u64 },
 
 	/// Cancel the effect of a previous `SubscribeVersion` instruction.
 	/// 

--- a/xcm/src/v2/mod.rs
+++ b/xcm/src/v2/mod.rs
@@ -19,7 +19,7 @@
 use super::v1::{Order as OldOrder, Response as OldResponse, Xcm as OldXcm};
 use crate::DoubleEncoded;
 use alloc::{vec, vec::Vec};
-use core::{convert::{TryFrom, TryInto}, fmt::Debug, ops::Sub, result};
+use core::{convert::{TryFrom, TryInto}, fmt::Debug, result};
 use derivative::Derivative;
 use parity_scale_codec::{self, Decode, Encode};
 

--- a/xcm/src/v2/mod.rs
+++ b/xcm/src/v2/mod.rs
@@ -593,7 +593,7 @@ pub enum Instruction<Call> {
 	/// Cancel the effect of a previous `SubscribeVersion` instruction.
 	/// 
 	/// Kind: *Instruction*
-	UnsubscribeVersion(QueryId),
+	UnsubscribeVersion,
 }
 
 impl<Call> Xcm<Call> {
@@ -649,7 +649,7 @@ impl<Call> Instruction<Call> {
 			ClaimAsset { assets, ticket } => ClaimAsset { assets, ticket },
 			Trap(code) => Trap(code),
 			SubscribeVersion { query_id, max_response_weight } => SubscribeVersion { query_id, max_response_weight },
-			UnsubscribeVersion(query_id) => UnsubscribeVersion(query_id),
+			UnsubscribeVersion => UnsubscribeVersion,
 		}
 	}
 }

--- a/xcm/src/v2/traits.rs
+++ b/xcm/src/v2/traits.rs
@@ -99,6 +99,8 @@ pub enum Error {
 	Trap(u64),
 	/// The given claim could not be recognized/found.
 	UnknownClaim,
+	/// The location given was invalid for some reason specific to the operation at hand.
+	InvalidLocation,
 }
 
 impl From<()> for Error {

--- a/xcm/xcm-builder/src/barriers.rs
+++ b/xcm/xcm-builder/src/barriers.rs
@@ -81,24 +81,6 @@ impl<T: Contains<MultiLocation>> ShouldExecute for AllowTopLevelPaidExecutionFro
 	}
 }
 
-/// Allows execution from `origin` if it is just a straight `SubscribeVerison` or
-/// `UnsubscribeVersion` instruction.
-pub struct AllowSubscriptionsFrom<T>(PhantomData<T>);
-impl<T: Contains<MultiLocation>> ShouldExecute for AllowSubscriptionsFrom<T> {
-	fn should_execute<Call>(
-		origin: &MultiLocation,
-		message: &mut Xcm<Call>,
-		_max_weight: Weight,
-		_weight_credit: &mut Weight,
-	) -> Result<(), ()> {
-		ensure!(T::contains(origin), ());
-		match (message.0.len(), message.0.first()) {
-			(1, Some(SubscribeVersion { .. })) | (1, Some(UnsubscribeVersion)) => Ok(()),
-			_ => Err(()),
-		}
-	}
-}
-
 /// Allows execution from any origin that is contained in `T` (i.e. `T::Contains(origin)`) without any payments.
 /// Use only for executions from trusted origin groups.
 pub struct AllowUnpaidExecutionFrom<T>(PhantomData<T>);
@@ -139,6 +121,24 @@ impl<ResponseHandler: OnResponse> ShouldExecute for AllowKnownQueryResponses<Res
 			Some(QueryResponse { query_id, .. })
 				if ResponseHandler::expecting_response(origin, *query_id) =>
 				Ok(()),
+			_ => Err(()),
+		}
+	}
+}
+
+/// Allows execution from `origin` if it is just a straight `SubscribeVerison` or
+/// `UnsubscribeVersion` instruction.
+pub struct AllowSubscriptionsFrom<T>(PhantomData<T>);
+impl<T: Contains<MultiLocation>> ShouldExecute for AllowSubscriptionsFrom<T> {
+	fn should_execute<Call>(
+		origin: &MultiLocation,
+		message: &mut Xcm<Call>,
+		_max_weight: Weight,
+		_weight_credit: &mut Weight,
+	) -> Result<(), ()> {
+		ensure!(T::contains(origin), ());
+		match (message.0.len(), message.0.first()) {
+			(1, Some(SubscribeVersion { .. })) | (1, Some(UnsubscribeVersion)) => Ok(()),
 			_ => Err(()),
 		}
 	}

--- a/xcm/xcm-builder/src/barriers.rs
+++ b/xcm/xcm-builder/src/barriers.rs
@@ -31,7 +31,6 @@ pub struct TakeWeightCredit;
 impl ShouldExecute for TakeWeightCredit {
 	fn should_execute<Call>(
 		_origin: &MultiLocation,
-		_top_level: bool,
 		_message: &mut Xcm<Call>,
 		max_weight: Weight,
 		weight_credit: &mut Weight,
@@ -50,13 +49,11 @@ pub struct AllowTopLevelPaidExecutionFrom<T>(PhantomData<T>);
 impl<T: Contains<MultiLocation>> ShouldExecute for AllowTopLevelPaidExecutionFrom<T> {
 	fn should_execute<Call>(
 		origin: &MultiLocation,
-		top_level: bool,
 		message: &mut Xcm<Call>,
 		max_weight: Weight,
 		_weight_credit: &mut Weight,
 	) -> Result<(), ()> {
 		ensure!(T::contains(origin), ());
-		ensure!(top_level, ());
 		let mut iter = message.0.iter_mut();
 		let i = iter.next().ok_or(())?;
 		match i {
@@ -90,7 +87,6 @@ pub struct AllowSubscriptionsFrom<T>(PhantomData<T>);
 impl<T: Contains<MultiLocation>> ShouldExecute for AllowSubscriptionsFrom<T> {
 	fn should_execute<Call>(
 		origin: &MultiLocation,
-		_top_level: bool,
 		message: &mut Xcm<Call>,
 		_max_weight: Weight,
 		_weight_credit: &mut Weight,
@@ -111,7 +107,6 @@ pub struct AllowUnpaidExecutionFrom<T>(PhantomData<T>);
 impl<T: Contains<MultiLocation>> ShouldExecute for AllowUnpaidExecutionFrom<T> {
 	fn should_execute<Call>(
 		origin: &MultiLocation,
-		_top_level: bool,
 		_message: &mut Xcm<Call>,
 		_max_weight: Weight,
 		_weight_credit: &mut Weight,
@@ -138,7 +133,6 @@ pub struct AllowKnownQueryResponses<ResponseHandler>(PhantomData<ResponseHandler
 impl<ResponseHandler: OnResponse> ShouldExecute for AllowKnownQueryResponses<ResponseHandler> {
 	fn should_execute<Call>(
 		origin: &MultiLocation,
-		_top_level: bool,
 		message: &mut Xcm<Call>,
 		_max_weight: Weight,
 		_weight_credit: &mut Weight,

--- a/xcm/xcm-builder/src/barriers.rs
+++ b/xcm/xcm-builder/src/barriers.rs
@@ -93,9 +93,7 @@ impl<T: Contains<MultiLocation>> ShouldExecute for AllowSubscriptionsFrom<T> {
 	) -> Result<(), ()> {
 		ensure!(T::contains(origin), ());
 		match (message.0.len(), message.0.first()) {
-			(1, Some(SubscribeVersion { .. }))
-			| (1, Some(UnsubscribeVersion))
-			=> Ok(()),
+			(1, Some(SubscribeVersion { .. })) | (1, Some(UnsubscribeVersion)) => Ok(()),
 			_ => Err(()),
 		}
 	}

--- a/xcm/xcm-builder/src/barriers.rs
+++ b/xcm/xcm-builder/src/barriers.rs
@@ -86,8 +86,8 @@ impl<T: Contains<MultiLocation>> ShouldExecute for AllowTopLevelPaidExecutionFro
 
 /// Allows execution from `origin` if it is just a straight `SubscribeVerison` or
 /// `UnsubscribeVersion` instruction.
-pub struct AllowJustSubscriptionsFrom<T>(PhantomData<T>);
-impl<T: Contains<MultiLocation>> ShouldExecute for AllowJustSubscriptionsFrom<T> {
+pub struct AllowSubscriptionsFrom<T>(PhantomData<T>);
+impl<T: Contains<MultiLocation>> ShouldExecute for AllowSubscriptionsFrom<T> {
 	fn should_execute<Call>(
 		origin: &MultiLocation,
 		_top_level: bool,

--- a/xcm/xcm-builder/src/lib.rs
+++ b/xcm/xcm-builder/src/lib.rs
@@ -42,7 +42,7 @@ pub use origin_conversion::{
 mod barriers;
 pub use barriers::{
 	AllowKnownQueryResponses, AllowTopLevelPaidExecutionFrom, AllowUnpaidExecutionFrom,
-	IsChildSystemParachain, TakeWeightCredit,
+	IsChildSystemParachain, TakeWeightCredit, AllowSubscriptionsFrom,
 };
 
 mod currency_adapter;

--- a/xcm/xcm-builder/src/lib.rs
+++ b/xcm/xcm-builder/src/lib.rs
@@ -41,8 +41,8 @@ pub use origin_conversion::{
 
 mod barriers;
 pub use barriers::{
-	AllowKnownQueryResponses, AllowTopLevelPaidExecutionFrom, AllowUnpaidExecutionFrom,
-	IsChildSystemParachain, TakeWeightCredit, AllowSubscriptionsFrom,
+	AllowKnownQueryResponses, AllowSubscriptionsFrom, AllowTopLevelPaidExecutionFrom,
+	AllowUnpaidExecutionFrom, IsChildSystemParachain, TakeWeightCredit,
 };
 
 mod currency_adapter;

--- a/xcm/xcm-builder/src/mock.rs
+++ b/xcm/xcm-builder/src/mock.rs
@@ -316,4 +316,5 @@ impl Config for TestConfig {
 	type ResponseHandler = TestResponseHandler;
 	type AssetTrap = TestAssetTrap;
 	type AssetClaims = TestAssetTrap;
+	type SubscriptionService = ();	// TODO TestSubscriptionService
 }

--- a/xcm/xcm-builder/src/mock.rs
+++ b/xcm/xcm-builder/src/mock.rs
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
+use crate::barriers::AllowSubscriptionsFrom;
 pub use crate::{
 	AllowKnownQueryResponses, AllowTopLevelPaidExecutionFrom, AllowUnpaidExecutionFrom,
 	FixedRateOfFungible, FixedWeightBounds, LocationInverter, TakeWeightCredit,
@@ -35,7 +36,7 @@ pub use sp_std::{
 	marker::PhantomData,
 };
 pub use xcm::latest::prelude::*;
-use xcm_executor::traits::{ClaimAssets, DropAssets};
+use xcm_executor::traits::{ClaimAssets, DropAssets, VersionChangeNotifier};
 pub use xcm_executor::{
 	traits::{ConvertOrigin, FilterAssetLocation, InvertLocation, OnResponse, TransactAsset},
 	Assets, Config,
@@ -258,6 +259,7 @@ parameter_types! {
 	// Nothing is allowed to be paid/unpaid by default.
 	pub static AllowUnpaidFrom: Vec<MultiLocation> = vec![];
 	pub static AllowPaidFrom: Vec<MultiLocation> = vec![];
+	pub static AllowSubsFrom: Vec<MultiLocation> = vec![];
 	// 1_000_000_000_000 => 1 unit of asset for 1 unit of Weight.
 	pub static WeightPrice: (AssetId, u128) = (From::from(Here), 1_000_000_000_000);
 	pub static MaxInstructions: u32 = 100;
@@ -268,6 +270,7 @@ pub type TestBarrier = (
 	AllowKnownQueryResponses<TestResponseHandler>,
 	AllowTopLevelPaidExecutionFrom<IsInVec<AllowPaidFrom>>,
 	AllowUnpaidExecutionFrom<IsInVec<AllowUnpaidFrom>>,
+	AllowSubscriptionsFrom<IsInVec<AllowSubsFrom>>
 );
 
 parameter_types! {
@@ -301,6 +304,27 @@ impl ClaimAssets for TestAssetTrap {
 	}
 }
 
+parameter_types! {
+	pub static SubscriptionRequests: Vec<(MultiLocation, Option<(QueryId, u64)>)> = vec![];
+}
+pub struct TestSubscriptionService;
+
+impl VersionChangeNotifier for TestSubscriptionService {
+	fn start(location: &MultiLocation, query_id: QueryId, max_weight: u64) -> XcmResult {
+		let mut r = SubscriptionRequests::get();
+		r.push((location.clone(), Some((query_id, max_weight))));
+		SubscriptionRequests::set(r);
+		Ok(())
+	}
+	fn stop(location: &MultiLocation) -> XcmResult {
+		let mut r = SubscriptionRequests::get();
+		r.push((location.clone(), None));
+		SubscriptionRequests::set(r);
+		Ok(())
+	}
+}
+
+
 pub struct TestConfig;
 impl Config for TestConfig {
 	type Call = TestCall;
@@ -316,5 +340,5 @@ impl Config for TestConfig {
 	type ResponseHandler = TestResponseHandler;
 	type AssetTrap = TestAssetTrap;
 	type AssetClaims = TestAssetTrap;
-	type SubscriptionService = (); // TODO TestSubscriptionService
+	type SubscriptionService = TestSubscriptionService;
 }

--- a/xcm/xcm-builder/src/mock.rs
+++ b/xcm/xcm-builder/src/mock.rs
@@ -270,7 +270,7 @@ pub type TestBarrier = (
 	AllowKnownQueryResponses<TestResponseHandler>,
 	AllowTopLevelPaidExecutionFrom<IsInVec<AllowPaidFrom>>,
 	AllowUnpaidExecutionFrom<IsInVec<AllowUnpaidFrom>>,
-	AllowSubscriptionsFrom<IsInVec<AllowSubsFrom>>
+	AllowSubscriptionsFrom<IsInVec<AllowSubsFrom>>,
 );
 
 parameter_types! {
@@ -323,7 +323,6 @@ impl VersionChangeNotifier for TestSubscriptionService {
 		Ok(())
 	}
 }
-
 
 pub struct TestConfig;
 impl Config for TestConfig {

--- a/xcm/xcm-builder/src/mock.rs
+++ b/xcm/xcm-builder/src/mock.rs
@@ -316,5 +316,5 @@ impl Config for TestConfig {
 	type ResponseHandler = TestResponseHandler;
 	type AssetTrap = TestAssetTrap;
 	type AssetClaims = TestAssetTrap;
-	type SubscriptionService = ();	// TODO TestSubscriptionService
+	type SubscriptionService = (); // TODO TestSubscriptionService
 }

--- a/xcm/xcm-builder/src/tests.rs
+++ b/xcm/xcm-builder/src/tests.rs
@@ -487,17 +487,6 @@ fn simple_version_subscriptions_should_work() {
 	assert_eq!(r, Outcome::Complete(10));
 
 	assert_eq!(SubscriptionRequests::get(), vec![(Parent.into(), Some((42, 5000)))]);
-	assert_eq!(
-		sent_xcm(),
-		vec![(
-			Parent.into(),
-			Xcm(vec![QueryResponse {
-				query_id: 42,
-				max_weight: 5000,
-				response: Response::Version(XCM_VERSION),
-			}])
-		),]
-	);
 }
 
 #[test]
@@ -529,17 +518,6 @@ fn version_subscription_instruction_should_work() {
 	assert_eq!(r, Outcome::Complete(20));
 
 	assert_eq!(SubscriptionRequests::get(), vec![(Parachain(1000).into(), Some((42, 5000)))]);
-	assert_eq!(
-		sent_xcm(),
-		vec![(
-			Parachain(1000).into(),
-			Xcm(vec![QueryResponse {
-				query_id: 42,
-				max_weight: 5000,
-				response: Response::Version(XCM_VERSION),
-			}])
-		),]
-	);
 }
 
 #[test]

--- a/xcm/xcm-builder/src/tests.rs
+++ b/xcm/xcm-builder/src/tests.rs
@@ -476,9 +476,8 @@ fn simple_version_subscriptions_should_work() {
 	assert_eq!(r, Outcome::Error(XcmError::Barrier));
 
 	let origin = Parachain(1000).into();
-	let message = Xcm::<TestCall>(vec![
-		SubscribeVersion { query_id: 42, max_response_weight: 5000 }
-	]);
+	let message =
+		Xcm::<TestCall>(vec![SubscribeVersion { query_id: 42, max_response_weight: 5000 }]);
 	let weight_limit = 10;
 	let r = XcmExecutor::<TestConfig>::execute_xcm(origin, message.clone(), weight_limit);
 	assert_eq!(r, Outcome::Error(XcmError::Barrier));
@@ -488,15 +487,17 @@ fn simple_version_subscriptions_should_work() {
 	assert_eq!(r, Outcome::Complete(10));
 
 	assert_eq!(SubscriptionRequests::get(), vec![(Parent.into(), Some((42, 5000)))]);
-	assert_eq!(sent_xcm(), vec![
-		(Parent.into(), Xcm(vec![
-			QueryResponse {
+	assert_eq!(
+		sent_xcm(),
+		vec![(
+			Parent.into(),
+			Xcm(vec![QueryResponse {
 				query_id: 42,
 				max_weight: 5000,
 				response: Response::Version(XCM_VERSION),
-			}
-		])),
-	]);
+			}])
+		),]
+	);
 }
 
 #[test]
@@ -507,26 +508,38 @@ fn version_subscription_instruction_should_work() {
 		SubscribeVersion { query_id: 42, max_response_weight: 5000 },
 	]);
 	let weight_limit = 20;
-	let r = XcmExecutor::<TestConfig>::execute_xcm_in_credit(origin.clone(), message.clone(), weight_limit, weight_limit);
+	let r = XcmExecutor::<TestConfig>::execute_xcm_in_credit(
+		origin.clone(),
+		message.clone(),
+		weight_limit,
+		weight_limit,
+	);
 	assert_eq!(r, Outcome::Incomplete(20, XcmError::BadOrigin));
 
 	let message = Xcm::<TestCall>(vec![
 		SetAppendix(Xcm(vec![])),
-		SubscribeVersion { query_id: 42, max_response_weight: 5000 }
+		SubscribeVersion { query_id: 42, max_response_weight: 5000 },
 	]);
-	let r = XcmExecutor::<TestConfig>::execute_xcm_in_credit(origin, message.clone(), weight_limit, weight_limit);
+	let r = XcmExecutor::<TestConfig>::execute_xcm_in_credit(
+		origin,
+		message.clone(),
+		weight_limit,
+		weight_limit,
+	);
 	assert_eq!(r, Outcome::Complete(20));
 
 	assert_eq!(SubscriptionRequests::get(), vec![(Parachain(1000).into(), Some((42, 5000)))]);
-	assert_eq!(sent_xcm(), vec![
-		(Parachain(1000).into(), Xcm(vec![
-			QueryResponse {
+	assert_eq!(
+		sent_xcm(),
+		vec![(
+			Parachain(1000).into(),
+			Xcm(vec![QueryResponse {
 				query_id: 42,
 				max_weight: 5000,
 				response: Response::Version(XCM_VERSION),
-			}
-		])),
-	]);
+			}])
+		),]
+	);
 }
 
 #[test]
@@ -534,18 +547,13 @@ fn simple_version_unsubscriptions_should_work() {
 	AllowSubsFrom::set(vec![Parent.into()]);
 
 	let origin = Parachain(1000).into();
-	let message = Xcm::<TestCall>(vec![
-		SetAppendix(Xcm(vec![])),
-		UnsubscribeVersion,
-	]);
+	let message = Xcm::<TestCall>(vec![SetAppendix(Xcm(vec![])), UnsubscribeVersion]);
 	let weight_limit = 20;
 	let r = XcmExecutor::<TestConfig>::execute_xcm(origin, message, weight_limit);
 	assert_eq!(r, Outcome::Error(XcmError::Barrier));
 
 	let origin = Parachain(1000).into();
-	let message = Xcm::<TestCall>(vec![
-		UnsubscribeVersion,
-	]);
+	let message = Xcm::<TestCall>(vec![UnsubscribeVersion]);
 	let weight_limit = 10;
 	let r = XcmExecutor::<TestConfig>::execute_xcm(origin, message.clone(), weight_limit);
 	assert_eq!(r, Outcome::Error(XcmError::Barrier));
@@ -568,15 +576,22 @@ fn version_unsubscription_instruction_should_work() {
 		UnsubscribeVersion,
 	]);
 	let weight_limit = 20;
-	let r = XcmExecutor::<TestConfig>::execute_xcm_in_credit(origin.clone(), message.clone(), weight_limit, weight_limit);
+	let r = XcmExecutor::<TestConfig>::execute_xcm_in_credit(
+		origin.clone(),
+		message.clone(),
+		weight_limit,
+		weight_limit,
+	);
 	assert_eq!(r, Outcome::Incomplete(20, XcmError::BadOrigin));
 
 	// Fine to do it when origin is untouched.
-	let message = Xcm::<TestCall>(vec![
-		SetAppendix(Xcm(vec![])),
-		UnsubscribeVersion,
-	]);
-	let r = XcmExecutor::<TestConfig>::execute_xcm_in_credit(origin, message.clone(), weight_limit, weight_limit);
+	let message = Xcm::<TestCall>(vec![SetAppendix(Xcm(vec![])), UnsubscribeVersion]);
+	let r = XcmExecutor::<TestConfig>::execute_xcm_in_credit(
+		origin,
+		message.clone(),
+		weight_limit,
+		weight_limit,
+	);
 	assert_eq!(r, Outcome::Complete(20));
 
 	assert_eq!(SubscriptionRequests::get(), vec![(Parachain(1000).into(), None)]);

--- a/xcm/xcm-builder/src/tests.rs
+++ b/xcm/xcm-builder/src/tests.rs
@@ -57,21 +57,11 @@ fn take_weight_credit_barrier_should_work() {
 	let mut message =
 		Xcm::<()>(vec![TransferAsset { assets: (Parent, 100).into(), beneficiary: Here.into() }]);
 	let mut weight_credit = 10;
-	let r = TakeWeightCredit::should_execute(
-		&Parent.into(),
-		&mut message,
-		10,
-		&mut weight_credit,
-	);
+	let r = TakeWeightCredit::should_execute(&Parent.into(), &mut message, 10, &mut weight_credit);
 	assert_eq!(r, Ok(()));
 	assert_eq!(weight_credit, 0);
 
-	let r = TakeWeightCredit::should_execute(
-		&Parent.into(),
-		&mut message,
-		10,
-		&mut weight_credit,
-	);
+	let r = TakeWeightCredit::should_execute(&Parent.into(), &mut message, 10, &mut weight_credit);
 	assert_eq!(r, Err(()));
 	assert_eq!(weight_credit, 0);
 }

--- a/xcm/xcm-builder/src/tests.rs
+++ b/xcm/xcm-builder/src/tests.rs
@@ -59,7 +59,6 @@ fn take_weight_credit_barrier_should_work() {
 	let mut weight_credit = 10;
 	let r = TakeWeightCredit::should_execute(
 		&Parent.into(),
-		true,
 		&mut message,
 		10,
 		&mut weight_credit,
@@ -69,7 +68,6 @@ fn take_weight_credit_barrier_should_work() {
 
 	let r = TakeWeightCredit::should_execute(
 		&Parent.into(),
-		true,
 		&mut message,
 		10,
 		&mut weight_credit,
@@ -87,7 +85,6 @@ fn allow_unpaid_should_work() {
 
 	let r = AllowUnpaidExecutionFrom::<IsInVec<AllowUnpaidFrom>>::should_execute(
 		&Parachain(1).into(),
-		true,
 		&mut message,
 		10,
 		&mut 0,
@@ -96,7 +93,6 @@ fn allow_unpaid_should_work() {
 
 	let r = AllowUnpaidExecutionFrom::<IsInVec<AllowUnpaidFrom>>::should_execute(
 		&Parent.into(),
-		true,
 		&mut message,
 		10,
 		&mut 0,
@@ -113,7 +109,6 @@ fn allow_paid_should_work() {
 
 	let r = AllowTopLevelPaidExecutionFrom::<IsInVec<AllowPaidFrom>>::should_execute(
 		&Parachain(1).into(),
-		true,
 		&mut message,
 		10,
 		&mut 0,
@@ -129,7 +124,6 @@ fn allow_paid_should_work() {
 
 	let r = AllowTopLevelPaidExecutionFrom::<IsInVec<AllowPaidFrom>>::should_execute(
 		&Parent.into(),
-		true,
 		&mut underpaying_message,
 		30,
 		&mut 0,
@@ -145,7 +139,6 @@ fn allow_paid_should_work() {
 
 	let r = AllowTopLevelPaidExecutionFrom::<IsInVec<AllowPaidFrom>>::should_execute(
 		&Parachain(1).into(),
-		true,
 		&mut paying_message,
 		30,
 		&mut 0,
@@ -154,7 +147,6 @@ fn allow_paid_should_work() {
 
 	let r = AllowTopLevelPaidExecutionFrom::<IsInVec<AllowPaidFrom>>::should_execute(
 		&Parent.into(),
-		true,
 		&mut paying_message,
 		30,
 		&mut 0,

--- a/xcm/xcm-builder/tests/mock/mod.rs
+++ b/xcm/xcm-builder/tests/mock/mod.rs
@@ -193,6 +193,7 @@ impl pallet_xcm::Config for Runtime {
 	type Call = Call;
 	type Origin = Origin;
 	type VersionDiscoveryQueueSize = VersionDiscoveryQueueSize;
+	type AdvertizeXcmVersion = pallet_xcm::CurrentXcmVersion;
 }
 
 impl origin::Config for Runtime {}

--- a/xcm/xcm-builder/tests/mock/mod.rs
+++ b/xcm/xcm-builder/tests/mock/mod.rs
@@ -174,6 +174,10 @@ impl xcm_executor::Config for XcmConfig {
 
 pub type LocalOriginToLocation = SignedToAccountId32<Origin, AccountId, KusamaNetwork>;
 
+parameter_types! {
+	pub const VersionDiscoveryQueueSize: u32 = 100;
+}
+
 impl pallet_xcm::Config for Runtime {
 	type Event = Event;
 	type LocationInverter = LocationInverter<Ancestry>;
@@ -188,6 +192,7 @@ impl pallet_xcm::Config for Runtime {
 	type Weigher = FixedWeightBounds<BaseXcmWeight, Call, MaxInstructions>;
 	type Call = Call;
 	type Origin = Origin;
+	type VersionDiscoveryQueueSize = VersionDiscoveryQueueSize;
 }
 
 impl origin::Config for Runtime {}

--- a/xcm/xcm-builder/tests/mock/mod.rs
+++ b/xcm/xcm-builder/tests/mock/mod.rs
@@ -174,10 +174,6 @@ impl xcm_executor::Config for XcmConfig {
 
 pub type LocalOriginToLocation = SignedToAccountId32<Origin, AccountId, KusamaNetwork>;
 
-parameter_types! {
-	pub const VersionDiscoveryQueueSize: u32 = 100;
-}
-
 impl pallet_xcm::Config for Runtime {
 	type Event = Event;
 	type LocationInverter = LocationInverter<Ancestry>;
@@ -192,8 +188,8 @@ impl pallet_xcm::Config for Runtime {
 	type Weigher = FixedWeightBounds<BaseXcmWeight, Call, MaxInstructions>;
 	type Call = Call;
 	type Origin = Origin;
-	type VersionDiscoveryQueueSize = VersionDiscoveryQueueSize;
-	type AdvertizeXcmVersion = pallet_xcm::CurrentXcmVersion;
+	const VERSION_DISCOVERY_QUEUE_SIZE: u32 = 100;
+	type AdvertisedXcmVersion = pallet_xcm::CurrentXcmVersion;
 }
 
 impl origin::Config for Runtime {}

--- a/xcm/xcm-builder/tests/mock/mod.rs
+++ b/xcm/xcm-builder/tests/mock/mod.rs
@@ -169,6 +169,7 @@ impl xcm_executor::Config for XcmConfig {
 	type ResponseHandler = XcmPallet;
 	type AssetTrap = XcmPallet;
 	type AssetClaims = XcmPallet;
+	type SubscriptionService = XcmPallet;
 }
 
 pub type LocalOriginToLocation = SignedToAccountId32<Origin, AccountId, KusamaNetwork>;

--- a/xcm/xcm-executor/src/config.rs
+++ b/xcm/xcm-executor/src/config.rs
@@ -16,7 +16,7 @@
 
 use crate::traits::{
 	ClaimAssets, ConvertOrigin, DropAssets, FilterAssetLocation, InvertLocation, OnResponse,
-	ShouldExecute, TransactAsset, WeightBounds, WeightTrader,
+	ShouldExecute, TransactAsset, WeightBounds, WeightTrader, VersionSubscription,
 };
 use frame_support::{
 	dispatch::{Dispatchable, Parameter},
@@ -65,4 +65,7 @@ pub trait Config {
 
 	/// The handler for when there is an instruction to claim assets.
 	type AssetClaims: ClaimAssets;
+
+	/// How we handle version subscription requests.
+	type SubscriptionService: VersionSubscription;
 }

--- a/xcm/xcm-executor/src/config.rs
+++ b/xcm/xcm-executor/src/config.rs
@@ -16,7 +16,7 @@
 
 use crate::traits::{
 	ClaimAssets, ConvertOrigin, DropAssets, FilterAssetLocation, InvertLocation, OnResponse,
-	ShouldExecute, TransactAsset, WeightBounds, WeightTrader, VersionSubscription,
+	ShouldExecute, TransactAsset, WeightBounds, WeightTrader, VersionChangeNotifier,
 };
 use frame_support::{
 	dispatch::{Dispatchable, Parameter},
@@ -67,5 +67,5 @@ pub trait Config {
 	type AssetClaims: ClaimAssets;
 
 	/// How we handle version subscription requests.
-	type SubscriptionService: VersionSubscription;
+	type SubscriptionService: VersionChangeNotifier;
 }

--- a/xcm/xcm-executor/src/config.rs
+++ b/xcm/xcm-executor/src/config.rs
@@ -16,7 +16,7 @@
 
 use crate::traits::{
 	ClaimAssets, ConvertOrigin, DropAssets, FilterAssetLocation, InvertLocation, OnResponse,
-	ShouldExecute, TransactAsset, WeightBounds, WeightTrader, VersionChangeNotifier,
+	ShouldExecute, TransactAsset, VersionChangeNotifier, WeightBounds, WeightTrader,
 };
 use frame_support::{
 	dispatch::{Dispatchable, Parameter},

--- a/xcm/xcm-executor/src/lib.rs
+++ b/xcm/xcm-executor/src/lib.rs
@@ -88,12 +88,9 @@ impl<Config: config::Config> ExecuteXcm<Config::Call> for XcmExecutor<Config> {
 			return Outcome::Error(XcmError::WeightLimitReached(xcm_weight))
 		}
 
-		if let Err(_) = Config::Barrier::should_execute(
-			&origin,
-			&mut message,
-			xcm_weight,
-			&mut weight_credit,
-		) {
+		if let Err(_) =
+			Config::Barrier::should_execute(&origin, &mut message, xcm_weight, &mut weight_credit)
+		{
 			return Outcome::Error(XcmError::Barrier)
 		}
 

--- a/xcm/xcm-executor/src/lib.rs
+++ b/xcm/xcm-executor/src/lib.rs
@@ -431,6 +431,7 @@ impl<Config: config::Config> XcmExecutor<Config> {
 			},
 			UnsubscribeVersion => {
 				let origin = self.origin.as_ref().ok_or(XcmError::BadOrigin)?;
+				ensure!(&self.original_origin == origin, XcmError::BadOrigin);
 				Config::SubscriptionService::stop(origin)
 			},
 			ExchangeAsset { .. } => Err(XcmError::Unimplemented),

--- a/xcm/xcm-executor/src/lib.rs
+++ b/xcm/xcm-executor/src/lib.rs
@@ -420,16 +420,16 @@ impl<Config: config::Config> XcmExecutor<Config> {
 			},
 			Trap(code) => Err(XcmError::Trap(code)),
 			SubscribeVersion { query_id, max_response_weight } => {
-				let origin = self.origin.as_ref().ok_or(XcmError::BadOrigin)?;
-				Config::SubscriptionService::start(origin, query_id, max_response_weight)?;
+				let origin = self.origin.as_ref().ok_or(XcmError::BadOrigin)?.clone();
+				Config::SubscriptionService::start(&origin, query_id, max_response_weight)?;
 				let max_weight = max_response_weight;
 				let response = Response::Version(XCM_VERSION);
 				let instruction = QueryResponse { query_id, response, max_weight };
-				Config::XcmSender::send_xcm(dest, Xcm(vec![instruction])).map_err(Into::into)
+				Config::XcmSender::send_xcm(origin, Xcm(vec![instruction])).map_err(Into::into)
 			}
-			UnsubscribeVersion(query_id) => {
+			UnsubscribeVersion => {
 				let origin = self.origin.as_ref().ok_or(XcmError::BadOrigin)?;
-				Config::SubscriptionService::stop(origin, query_id)
+				Config::SubscriptionService::stop(origin)
 			}
 			ExchangeAsset { .. } => Err(XcmError::Unimplemented),
 			HrmpNewChannelOpenRequest { .. } => Err(XcmError::Unimplemented),

--- a/xcm/xcm-executor/src/lib.rs
+++ b/xcm/xcm-executor/src/lib.rs
@@ -26,7 +26,7 @@ use sp_std::{marker::PhantomData, prelude::*};
 use xcm::latest::{
 	Error as XcmError, ExecuteXcm,
 	Instruction::{self, *},
-	MultiAssets, MultiLocation, Outcome, Response, SendXcm, Xcm, VERSION as XCM_VERSION,
+	MultiAssets, MultiLocation, Outcome, Response, SendXcm, Xcm,
 };
 
 pub mod traits;
@@ -423,11 +423,7 @@ impl<Config: config::Config> XcmExecutor<Config> {
 				// We don't allow derivative origins to subscribe since it would otherwise pose a
 				// DoS risk.
 				ensure!(self.original_origin == origin, XcmError::BadOrigin);
-				Config::SubscriptionService::start(&origin, query_id, max_response_weight)?;
-				let max_weight = max_response_weight;
-				let response = Response::Version(XCM_VERSION);
-				let instruction = QueryResponse { query_id, response, max_weight };
-				Config::XcmSender::send_xcm(origin, Xcm(vec![instruction])).map_err(Into::into)
+				Config::SubscriptionService::start(&origin, query_id, max_response_weight)
 			},
 			UnsubscribeVersion => {
 				let origin = self.origin.as_ref().ok_or(XcmError::BadOrigin)?;

--- a/xcm/xcm-executor/src/lib.rs
+++ b/xcm/xcm-executor/src/lib.rs
@@ -90,7 +90,6 @@ impl<Config: config::Config> ExecuteXcm<Config::Call> for XcmExecutor<Config> {
 
 		if let Err(_) = Config::Barrier::should_execute(
 			&origin,
-			true,
 			&mut message,
 			xcm_weight,
 			&mut weight_credit,

--- a/xcm/xcm-executor/src/lib.rs
+++ b/xcm/xcm-executor/src/lib.rs
@@ -32,7 +32,7 @@ use xcm::latest::{
 pub mod traits;
 use traits::{
 	ClaimAssets, ConvertOrigin, DropAssets, FilterAssetLocation, InvertLocation, OnResponse,
-	ShouldExecute, TransactAsset, WeightBounds, WeightTrader, VersionSubscription,
+	ShouldExecute, TransactAsset, WeightBounds, WeightTrader, VersionChangeNotifier,
 };
 
 mod assets;

--- a/xcm/xcm-executor/src/lib.rs
+++ b/xcm/xcm-executor/src/lib.rs
@@ -46,7 +46,7 @@ pub struct XcmExecutor<Config: config::Config> {
 	origin: Option<MultiLocation>,
 	original_origin: MultiLocation,
 	trader: Config::Trader,
-	/// The most recent error result and instruction index into the fragment in which it occured,
+	/// The most recent error result and instruction index into the fragment in which it occurred,
 	/// if any.
 	error: Option<(u32, XcmError)>,
 	/// The surplus weight, defined as the amount by which `max_weight` is

--- a/xcm/xcm-executor/src/lib.rs
+++ b/xcm/xcm-executor/src/lib.rs
@@ -26,13 +26,13 @@ use sp_std::{marker::PhantomData, prelude::*};
 use xcm::latest::{
 	Error as XcmError, ExecuteXcm,
 	Instruction::{self, *},
-	MultiAssets, MultiLocation, Outcome, Response, SendXcm, Xcm, VERSION as XCM_VERSION
+	MultiAssets, MultiLocation, Outcome, Response, SendXcm, Xcm, VERSION as XCM_VERSION,
 };
 
 pub mod traits;
 use traits::{
 	ClaimAssets, ConvertOrigin, DropAssets, FilterAssetLocation, InvertLocation, OnResponse,
-	ShouldExecute, TransactAsset, WeightBounds, WeightTrader, VersionChangeNotifier,
+	ShouldExecute, TransactAsset, VersionChangeNotifier, WeightBounds, WeightTrader,
 };
 
 mod assets;
@@ -426,11 +426,11 @@ impl<Config: config::Config> XcmExecutor<Config> {
 				let response = Response::Version(XCM_VERSION);
 				let instruction = QueryResponse { query_id, response, max_weight };
 				Config::XcmSender::send_xcm(origin, Xcm(vec![instruction])).map_err(Into::into)
-			}
+			},
 			UnsubscribeVersion => {
 				let origin = self.origin.as_ref().ok_or(XcmError::BadOrigin)?;
 				Config::SubscriptionService::stop(origin)
-			}
+			},
 			ExchangeAsset { .. } => Err(XcmError::Unimplemented),
 			HrmpNewChannelOpenRequest { .. } => Err(XcmError::Unimplemented),
 			HrmpChannelAccepted { .. } => Err(XcmError::Unimplemented),

--- a/xcm/xcm-executor/src/traits/mod.rs
+++ b/xcm/xcm-executor/src/traits/mod.rs
@@ -27,7 +27,7 @@ pub use matches_fungible::MatchesFungible;
 mod matches_fungibles;
 pub use matches_fungibles::{Error, MatchesFungibles};
 mod on_response;
-pub use on_response::{OnResponse, VersionSubscription};
+pub use on_response::{OnResponse, VersionChangeNotifier};
 mod should_execute;
 pub use should_execute::ShouldExecute;
 mod transact_asset;

--- a/xcm/xcm-executor/src/traits/mod.rs
+++ b/xcm/xcm-executor/src/traits/mod.rs
@@ -27,7 +27,7 @@ pub use matches_fungible::MatchesFungible;
 mod matches_fungibles;
 pub use matches_fungibles::{Error, MatchesFungibles};
 mod on_response;
-pub use on_response::OnResponse;
+pub use on_response::{OnResponse, VersionSubscription};
 mod should_execute;
 pub use should_execute::ShouldExecute;
 mod transact_asset;

--- a/xcm/xcm-executor/src/traits/on_response.rs
+++ b/xcm/xcm-executor/src/traits/on_response.rs
@@ -15,7 +15,7 @@
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
 use frame_support::weights::Weight;
-use xcm::latest::{MultiLocation, Response, QueryId, Result as XcmResult, Error as XcmError};
+use xcm::latest::{Error as XcmError, MultiLocation, QueryId, Response, Result as XcmResult};
 
 /// Define what needs to be done upon receiving a query response.
 pub trait OnResponse {
@@ -46,11 +46,11 @@ impl OnResponse for () {
 /// Trait for a type which handles notifying a destination of XCM version changes.
 pub trait VersionChangeNotifier {
 	/// Start notifying `location` should the XCM version of this chain change.
-	/// 
+	///
 	/// When it does, this type should ensure an `QueryResponse` message is sent with the given
 	/// `query_id` & `max_weight` and with a `response` of `Repsonse::Version`. This should happen
 	/// until/unless `stop` is called with the correct `query_id`.
-	/// 
+	///
 	/// If the `location` has an ongoing notification and when this function is called, then an
 	/// error should be returned.
 	fn start(location: &MultiLocation, query_id: QueryId, max_weight: u64) -> XcmResult;

--- a/xcm/xcm-executor/src/traits/on_response.rs
+++ b/xcm/xcm-executor/src/traits/on_response.rs
@@ -43,7 +43,19 @@ impl OnResponse for () {
 	}
 }
 
-pub trait VersionSubscription {
-	fn start(location: &MultiLocation, query_id: QueryId, max_response_weight: u64) -> XcmResult;
-	fn stop(location: &MultiLocation, query_id: QueryId) -> XcmResult;
+/// Trait for a type which handles notifying a destination of XCM version changes.
+pub trait VersionChangeNotifier {
+	/// Start notifying `location` should the XCM version of this chain change.
+	/// 
+	/// When it does, this type should ensure an `QueryResponse` message is sent with the given
+	/// `query_id` & `max_weight` and with a `response` of `Repsonse::Version`. This should happen
+	/// until/unless `stop` is called with the correct `query_id`.
+	/// 
+	/// If the `location` has an ongoing notification and when this function is called, then an
+	/// error should be returned.
+	fn start(location: &MultiLocation, query_id: QueryId, max_weight: u64) -> XcmResult;
+
+	/// Stop notifying `location` should the XCM change. Returns an error if there is no existing
+	/// notification set up.
+	fn stop(location: &MultiLocation) -> XcmResult;
 }

--- a/xcm/xcm-executor/src/traits/on_response.rs
+++ b/xcm/xcm-executor/src/traits/on_response.rs
@@ -15,7 +15,7 @@
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
 use frame_support::weights::Weight;
-use xcm::latest::{MultiLocation, Response, QueryId, Result as XcmResult};
+use xcm::latest::{MultiLocation, Response, QueryId, Result as XcmResult, Error as XcmError};
 
 /// Define what needs to be done upon receiving a query response.
 pub trait OnResponse {
@@ -58,4 +58,13 @@ pub trait VersionChangeNotifier {
 	/// Stop notifying `location` should the XCM change. Returns an error if there is no existing
 	/// notification set up.
 	fn stop(location: &MultiLocation) -> XcmResult;
+}
+
+impl VersionChangeNotifier for () {
+	fn start(_: &MultiLocation, _: QueryId, _: u64) -> XcmResult {
+		Err(XcmError::Unimplemented)
+	}
+	fn stop(_: &MultiLocation) -> XcmResult {
+		Err(XcmError::Unimplemented)
+	}
 }

--- a/xcm/xcm-executor/src/traits/on_response.rs
+++ b/xcm/xcm-executor/src/traits/on_response.rs
@@ -47,7 +47,7 @@ impl OnResponse for () {
 pub trait VersionChangeNotifier {
 	/// Start notifying `location` should the XCM version of this chain change.
 	///
-	/// When it does, this type should ensure an `QueryResponse` message is sent with the given
+	/// When it does, this type should ensure a `QueryResponse` message is sent with the given
 	/// `query_id` & `max_weight` and with a `response` of `Repsonse::Version`. This should happen
 	/// until/unless `stop` is called with the correct `query_id`.
 	///

--- a/xcm/xcm-executor/src/traits/on_response.rs
+++ b/xcm/xcm-executor/src/traits/on_response.rs
@@ -15,7 +15,7 @@
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
 use frame_support::weights::Weight;
-use xcm::latest::{MultiLocation, Response};
+use xcm::latest::{MultiLocation, Response, QueryId, Result as XcmResult};
 
 /// Define what needs to be done upon receiving a query response.
 pub trait OnResponse {
@@ -41,4 +41,9 @@ impl OnResponse for () {
 	) -> Weight {
 		0
 	}
+}
+
+pub trait VersionSubscription {
+	fn start(location: &MultiLocation, query_id: QueryId, max_response_weight: u64) -> XcmResult;
+	fn stop(location: &MultiLocation, query_id: QueryId) -> XcmResult;
 }

--- a/xcm/xcm-executor/src/traits/should_execute.rs
+++ b/xcm/xcm-executor/src/traits/should_execute.rs
@@ -26,8 +26,6 @@ pub trait ShouldExecute {
 	/// Returns `true` if the given `message` may be executed.
 	///
 	/// - `origin`: The origin (sender) of the message.
-	/// - `top_level`: `true` indicates the initial XCM coming from the `origin`, `false` indicates
-	///   an embedded XCM executed internally as part of another message or an `Order`.
 	/// - `message`: The message itself.
 	/// - `max_weight`: The (possibly over-) estimation of the weight of execution of the message.
 	/// - `weight_credit`: The pre-established amount of weight that the system has determined this
@@ -35,7 +33,6 @@ pub trait ShouldExecute {
 	///   payment, but could in principle be due to other factors.
 	fn should_execute<Call>(
 		origin: &MultiLocation,
-		top_level: bool,
 		message: &mut Xcm<Call>,
 		max_weight: Weight,
 		weight_credit: &mut Weight,
@@ -46,22 +43,20 @@ pub trait ShouldExecute {
 impl ShouldExecute for Tuple {
 	fn should_execute<Call>(
 		origin: &MultiLocation,
-		top_level: bool,
 		message: &mut Xcm<Call>,
 		max_weight: Weight,
 		weight_credit: &mut Weight,
 	) -> Result<(), ()> {
 		for_tuples!( #(
-			match Tuple::should_execute(origin, top_level, message, max_weight, weight_credit) {
+			match Tuple::should_execute(origin, message, max_weight, weight_credit) {
 				Ok(()) => return Ok(()),
 				_ => (),
 			}
 		)* );
 		log::trace!(
 			target: "xcm::should_execute",
-			"did not pass barrier: origin: {:?}, top_level: {:?}, message: {:?}, max_weight: {:?}, weight_credit: {:?}",
+			"did not pass barrier: origin: {:?}, message: {:?}, max_weight: {:?}, weight_credit: {:?}",
 			origin,
-			top_level,
 			message,
 			max_weight,
 			weight_credit,

--- a/xcm/xcm-simulator/example/src/parachain.rs
+++ b/xcm/xcm-simulator/example/src/parachain.rs
@@ -311,6 +311,7 @@ impl pallet_xcm::Config for Runtime {
 	type Origin = Origin;
 	type Call = Call;
 	type VersionDiscoveryQueueSize = VersionDiscoveryQueueSize;
+	type AdvertizeXcmVersion = pallet_xcm::CurrentXcmVersion;
 }
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;

--- a/xcm/xcm-simulator/example/src/parachain.rs
+++ b/xcm/xcm-simulator/example/src/parachain.rs
@@ -293,6 +293,10 @@ impl mock_msg_queue::Config for Runtime {
 
 pub type LocalOriginToLocation = SignedToAccountId32<Origin, AccountId, RelayNetwork>;
 
+parameter_types! {
+	pub const VersionDiscoveryQueueSize: u32 = 100;
+}
+
 impl pallet_xcm::Config for Runtime {
 	type Event = Event;
 	type SendXcmOrigin = EnsureXcmOrigin<Origin, LocalOriginToLocation>;
@@ -306,6 +310,7 @@ impl pallet_xcm::Config for Runtime {
 	type LocationInverter = LocationInverter<Ancestry>;
 	type Origin = Origin;
 	type Call = Call;
+	type VersionDiscoveryQueueSize = VersionDiscoveryQueueSize;
 }
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;

--- a/xcm/xcm-simulator/example/src/parachain.rs
+++ b/xcm/xcm-simulator/example/src/parachain.rs
@@ -145,6 +145,7 @@ impl Config for XcmConfig {
 	type ResponseHandler = ();
 	type AssetTrap = ();
 	type AssetClaims = ();
+	type SubscriptionService = ();
 }
 
 #[frame_support::pallet]

--- a/xcm/xcm-simulator/example/src/parachain.rs
+++ b/xcm/xcm-simulator/example/src/parachain.rs
@@ -293,10 +293,6 @@ impl mock_msg_queue::Config for Runtime {
 
 pub type LocalOriginToLocation = SignedToAccountId32<Origin, AccountId, RelayNetwork>;
 
-parameter_types! {
-	pub const VersionDiscoveryQueueSize: u32 = 100;
-}
-
 impl pallet_xcm::Config for Runtime {
 	type Event = Event;
 	type SendXcmOrigin = EnsureXcmOrigin<Origin, LocalOriginToLocation>;
@@ -310,8 +306,8 @@ impl pallet_xcm::Config for Runtime {
 	type LocationInverter = LocationInverter<Ancestry>;
 	type Origin = Origin;
 	type Call = Call;
-	type VersionDiscoveryQueueSize = VersionDiscoveryQueueSize;
-	type AdvertizeXcmVersion = pallet_xcm::CurrentXcmVersion;
+	const VERSION_DISCOVERY_QUEUE_SIZE: u32 = 100;
+	type AdvertisedXcmVersion = pallet_xcm::CurrentXcmVersion;
 }
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;

--- a/xcm/xcm-simulator/example/src/relay_chain.rs
+++ b/xcm/xcm-simulator/example/src/relay_chain.rs
@@ -135,6 +135,7 @@ impl Config for XcmConfig {
 	type ResponseHandler = ();
 	type AssetTrap = ();
 	type AssetClaims = ();
+	type SubscriptionService = ();
 }
 
 pub type LocalOriginToLocation = SignedToAccountId32<Origin, AccountId, KusamaNetwork>;

--- a/xcm/xcm-simulator/example/src/relay_chain.rs
+++ b/xcm/xcm-simulator/example/src/relay_chain.rs
@@ -159,6 +159,7 @@ impl pallet_xcm::Config for Runtime {
 	type Origin = Origin;
 	type Call = Call;
 	type VersionDiscoveryQueueSize = VersionDiscoveryQueueSize;
+	type AdvertizeXcmVersion = pallet_xcm::CurrentXcmVersion;
 }
 
 parameter_types! {

--- a/xcm/xcm-simulator/example/src/relay_chain.rs
+++ b/xcm/xcm-simulator/example/src/relay_chain.rs
@@ -140,10 +140,6 @@ impl Config for XcmConfig {
 
 pub type LocalOriginToLocation = SignedToAccountId32<Origin, AccountId, KusamaNetwork>;
 
-parameter_types! {
-	pub const VersionDiscoveryQueueSize: u32 = 100;
-}
-
 impl pallet_xcm::Config for Runtime {
 	type Event = Event;
 	type SendXcmOrigin = xcm_builder::EnsureXcmOrigin<Origin, LocalOriginToLocation>;
@@ -158,8 +154,8 @@ impl pallet_xcm::Config for Runtime {
 	type LocationInverter = LocationInverter<Ancestry>;
 	type Origin = Origin;
 	type Call = Call;
-	type VersionDiscoveryQueueSize = VersionDiscoveryQueueSize;
-	type AdvertizeXcmVersion = pallet_xcm::CurrentXcmVersion;
+	const VERSION_DISCOVERY_QUEUE_SIZE: u32 = 100;
+	type AdvertisedXcmVersion = pallet_xcm::CurrentXcmVersion;
 }
 
 parameter_types! {

--- a/xcm/xcm-simulator/example/src/relay_chain.rs
+++ b/xcm/xcm-simulator/example/src/relay_chain.rs
@@ -140,6 +140,10 @@ impl Config for XcmConfig {
 
 pub type LocalOriginToLocation = SignedToAccountId32<Origin, AccountId, KusamaNetwork>;
 
+parameter_types! {
+	pub const VersionDiscoveryQueueSize: u32 = 100;
+}
+
 impl pallet_xcm::Config for Runtime {
 	type Event = Event;
 	type SendXcmOrigin = xcm_builder::EnsureXcmOrigin<Origin, LocalOriginToLocation>;
@@ -154,6 +158,7 @@ impl pallet_xcm::Config for Runtime {
 	type LocationInverter = LocationInverter<Ancestry>;
 	type Origin = Origin;
 	type Call = Call;
+	type VersionDiscoveryQueueSize = VersionDiscoveryQueueSize;
 }
 
 parameter_types! {


### PR DESCRIPTION
This introduces autonomous version negotiation in XCM, removing the need for manual intervention in order to ensure that chains use the most recent common version of XCM which they support.

It introduces a stateful `WrapVersion` implementation through the XCM Pallet, together with a new `SubscribeVersion` instruction (as well as `UnsubscribeVersion`) to provide a `QueryResponse` with the latest XCM a runtime supports together with further similar notifications when the version changes. When a message is sent to a destination whose version is unknown, the pallet queues up this destination for version querying and each block drains some number from this queue and posts a query. As they come in, it checks for responses and (assuming it knowingly subscribed for it) records it.

The Pallet maintains a list of locations which have asked for version notification subscriptions and whenever there is an upgrade sends them notifications of the new upgrade. This is done through a new trait `VersionChangeNotifier`.

## Migration

### XCM Pallet

`pallet_xcm::Config` trait get one new const `VERSION_DISCOVERY_QUEUE_SIZE` and one new type `AdvertizeXcmVersion`. A sensible value for the former is 100. For the latter, it's best to just reference `pallet_xcm::CurrentXcmVersion`. e.g.:

```rust
impl pallet_xcm::Config for Runtime {
	/* snip */
	const VERSION_DISCOVERY_QUEUE_SIZE: u32 = 100;
	type AdvertizeXcmVersion = pallet_xcm::CurrentXcmVersion;
}
```

### XCM Config

Ensure that any `xcm_executor::Config` implementations includes a definition for the new type `SubscriptionService`. Generally this should be set to `PalletXcm`, the `pallet_xcm` concrete type. i.e.:

```rust
impl xcm_executor::Config for XcmConfig {
	/* snip */
	type SubscriptionService = XcmPallet;
}
```

### Routers & `WrapVersion`

Any routers (XCM transport methods) which have a `WrapVersion` item (including `cumulus_pallet_xcmp_queue` and `ParentAsUmp`) should have that item set to be implemented by `PalletXcm`, the `pallet_xcm` concrete type. e.g.:

```rust
impl cumulus_pallet_xcmp_queue::Config for Runtime {
	/* snip */
	type VersionWrapper = ();
}
/* snip */
pub type XcmRouter = (
	cumulus_primitives_utility::ParentAsUmp<ParachainSystem, ()>,
	XcmpQueue,
);
```

would become:

```rust
impl cumulus_pallet_xcmp_queue::Config for Runtime {
	/* snip */
	type VersionWrapper = XcmPallet;
}
/* snip */
pub type XcmRouter = (
	cumulus_primitives_utility::ParentAsUmp<ParachainSystem, XcmPallet>,
	XcmpQueue,
);
```
**NOTE** In addition to this change, you should do at least one of two things to initialize your chain and ensure that XCM messages can be sent:

- Whitelist destinations to which you wish to send messages with the `force_xcm_version` (root-callable) extrinsic.
- Provide a general fallback version with the `force_xcm_default_version` (root-callable) extrinsic.

If you do the latter, then the automatic XCM version tracking code with work as expected and destination XCM versions will be kept up to date.

### Barrier

An additional barrier `AlllowSubscriptionsFrom` should be included in your `Barriers` tuple. You can probably set the origin filter to `Everything`, unless you want to filter which locations can ask to be notified of your chain's XCM version changes:

```rust
pub type Barrier = (
	TakeWeightCredit,
	/* snip */
	AllowSubscriptionsFrom<Everything>,
);
```

## TODO

- [x] Automatic subscription
- [x] Automatic unsubscription
- [x] Unsubscription extrinsic
- [x] Barrier
- [x] Expose remote origin in VM and ensure it is unchanged from actual origin in subscription instructions.
- [x] Cleanup for orphaned subscription requests
- [x] Unit tests for XCM executor
- [x] Unit tests for XCM pallet

Maybe here or another PR:
- [x] Remove `top_level`
- [x] Allow `on_runtime_upgrade` notifications to happen over multiple blocks
- [ ] Break apart `fn on_response`
