### PR TITLE
Larger timeouts for collation fetching

### DIFF
--- a/node/network/collator-protocol/src/collator_side/mod.rs
+++ b/node/network/collator-protocol/src/collator_side/mod.rs
@@ -70,6 +70,10 @@ const COST_APPARENT_FLOOD: Rep =
 /// the transfer should be possible within 0.1 seconds. 400 milliseconds should therefore be
 /// plenty and should be low enough for later validators to still be able to finish on time.
 ///
+/// NOTE: We choose a smaller timeout here, as all validators in the backing group will need the
+/// PoV anyway, so a parallel upload is not necessarily wasteful here. The situation is differently
+/// on the validator side, where we pick a slightly larger timeout.
+///
 /// There is debug logging output, so we can adjust this value based on production results.
 const MAX_UNSHARED_UPLOAD_TIME: Duration = Duration::from_millis(400);
 

--- a/node/network/collator-protocol/src/validator_side/mod.rs
+++ b/node/network/collator-protocol/src/validator_side/mod.rs
@@ -80,12 +80,15 @@ const BENEFIT_NOTIFY_GOOD: Rep =
 /// This is to protect from a single slow collator preventing collations from happening.
 ///
 /// With a collation size of 5MB and bandwidth of 500Mbit/s (requirement for Kusama validators),
-/// the transfer should be possible within 0.1 seconds. 400 milliseconds should therefore be
+/// the transfer should be possible within 0.1 seconds. 600 milliseconds should therefore be
 /// plenty, even with multiple heads and should be low enough for later collators to still be able
 /// to finish on time.
 ///
+/// We pick a larger timeout here, as parallel downloads here are purely wasteful (we will only
+/// ever second one collation per block).
+///
 /// There is debug logging output, so we can adjust this value based on production results.
-const MAX_UNSHARED_DOWNLOAD_TIME: Duration = Duration::from_millis(400);
+const MAX_UNSHARED_DOWNLOAD_TIME: Duration = Duration::from_millis(600);
 
 // How often to check all peers with activity.
 #[cfg(not(test))]
@@ -1187,7 +1190,7 @@ where
 				tracing::debug!(
 					target: LOG_TARGET,
 					?relay_parent,
-					"Fetch for collation took too long, starting parallel download for next collator as well."
+					"Fetching collation took too long, starting parallel download for next collator as well."
 				);
 				dequeue_next_collation_and_fetch(&mut ctx, &mut state, relay_parent, collator_id).await;
 			}

--- a/node/network/collator-protocol/src/validator_side/mod.rs
+++ b/node/network/collator-protocol/src/validator_side/mod.rs
@@ -88,7 +88,10 @@ const BENEFIT_NOTIFY_GOOD: Rep =
 /// ever second one collation per block).
 ///
 /// There is debug logging output, so we can adjust this value based on production results.
+#[cfg(not(test))]
 const MAX_UNSHARED_DOWNLOAD_TIME: Duration = Duration::from_millis(600);
+#[cfg(test)]
+const MAX_UNSHARED_DOWNLOAD_TIME: Duration = Duration::from_millis(60);
 
 // How often to check all peers with activity.
 #[cfg(not(test))]


### PR DESCRIPTION
We saw that soft timeout trigger on Rococo on a regular basis, so this PR increases it a bit. Long term we should really dive into, why we take so long and should fix that. -> Maybe it is related to those other networking issues. E.g. if we are not connected and we need to establish the connection first, that might explain it. Also see #3748 