### PR TITLE
Fix sanity check in relay chain selection

### DIFF
--- a/node/service/src/relay_chain_selection.rs
+++ b/node/service/src/relay_chain_selection.rs
@@ -417,7 +417,7 @@ where
 
 		let lag = if cfg!(feature = "disputes") {
 			// Prevent sending flawed data to the dispute-coordinator.
-			if Some(subchain_block_descriptions.len() as _) !=
+			if Some(subchain_block_descriptions.len() as u32 - 1) !=
 				subchain_number.checked_sub(target_number)
 			{
 				tracing::error!(


### PR DESCRIPTION
Closes #3678

The sanity check was including the current unfinalized block in the sanity check for sending `subchain_block_descriptions` to the dispute coordinator.