### PR TITLE
Don't drop UMP queue items if weight exhausted

### DIFF
--- a/runtime/parachains/src/mock.rs
+++ b/runtime/parachains/src/mock.rs
@@ -236,7 +236,6 @@ pub fn availability_rewards() -> HashMap<ValidatorIndex, usize> {
 }
 
 std::thread_local! {
-	// `Some` here indicates that there is an active probe.
 	static PROCESSED: RefCell<Vec<(ParaId, UpwardMessage)>> = RefCell::new(vec![]);
 }
 

--- a/runtime/parachains/src/mock.rs
+++ b/runtime/parachains/src/mock.rs
@@ -16,15 +16,22 @@
 
 //! Mocks for all the traits.
 
-use crate::{configuration, disputes, dmp, hrmp, inclusion, initializer, paras, paras_inherent, scheduler, session_info, shared, ump::{self, MessageId, UmpSink}, ParaId};
+use crate::{
+	configuration, disputes, dmp, hrmp, inclusion, initializer, paras, paras_inherent, scheduler,
+	session_info, shared,
+	ump::{self, MessageId, UmpSink},
+	ParaId,
+};
 use frame_support::{parameter_types, traits::GenesisBuild, weights::Weight};
 use frame_support_test::TestRandomness;
-use primitives::v1::{AuthorityDiscoveryId, Balance, BlockNumber, Header, SessionIndex, UpwardMessage, ValidatorIndex};
+use parity_scale_codec::Decode;
+use primitives::v1::{
+	AuthorityDiscoveryId, Balance, BlockNumber, Header, SessionIndex, UpwardMessage, ValidatorIndex,
+};
 use sp_core::H256;
 use sp_io::TestExternalities;
 use sp_runtime::traits::{BlakeTwo256, IdentityLookup};
 use std::{cell::RefCell, collections::HashMap};
-use parity_scale_codec::Decode;
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
@@ -244,7 +251,7 @@ pub fn take_processed() -> Vec<(ParaId, UpwardMessage)> {
 }
 
 /// An implementation of a UMP sink that just records which messages were processed.
-/// 
+///
 /// A message's weight is defined by the first 4 bytes of its data, which we decode into a
 /// `u32`.
 pub struct TestUmpSink;

--- a/runtime/parachains/src/mock.rs
+++ b/runtime/parachains/src/mock.rs
@@ -16,19 +16,15 @@
 
 //! Mocks for all the traits.
 
-use crate::{
-	configuration, disputes, dmp, hrmp, inclusion, initializer, paras, paras_inherent, scheduler,
-	session_info, shared, ump,
-};
-use frame_support::{parameter_types, traits::GenesisBuild};
+use crate::{configuration, disputes, dmp, hrmp, inclusion, initializer, paras, paras_inherent, scheduler, session_info, shared, ump::{self, MessageId, UmpSink}, ParaId};
+use frame_support::{parameter_types, traits::GenesisBuild, weights::Weight};
 use frame_support_test::TestRandomness;
-use primitives::v1::{
-	AuthorityDiscoveryId, Balance, BlockNumber, Header, SessionIndex, ValidatorIndex,
-};
+use primitives::v1::{AuthorityDiscoveryId, Balance, BlockNumber, Header, SessionIndex, UpwardMessage, ValidatorIndex};
 use sp_core::H256;
 use sp_io::TestExternalities;
 use sp_runtime::traits::{BlakeTwo256, IdentityLookup};
 use std::{cell::RefCell, collections::HashMap};
+use parity_scale_codec::Decode;
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
@@ -128,7 +124,7 @@ parameter_types! {
 
 impl crate::ump::Config for Test {
 	type Event = Event;
-	type UmpSink = crate::ump::mock_sink::MockUmpSink;
+	type UmpSink = TestUmpSink;
 	type FirstMessageFactorPercent = FirstMessageFactorPercent;
 }
 
@@ -230,6 +226,47 @@ pub fn backing_rewards() -> HashMap<ValidatorIndex, usize> {
 
 pub fn availability_rewards() -> HashMap<ValidatorIndex, usize> {
 	AVAILABILITY_REWARDS.with(|r| r.borrow().clone())
+}
+
+std::thread_local! {
+	// `Some` here indicates that there is an active probe.
+	static PROCESSED: RefCell<Vec<(ParaId, UpwardMessage)>> = RefCell::new(vec![]);
+}
+
+/// Return which messages have been processed by `pocess_upward_message` and clear the buffer.
+pub fn take_processed() -> Vec<(ParaId, UpwardMessage)> {
+	PROCESSED.with(|opt_hook| {
+		let mut r = vec![];
+		let mut processed = opt_hook.borrow_mut();
+		std::mem::swap(processed.as_mut(), &mut r);
+		r
+	})
+}
+
+/// An implementation of a UMP sink that just records which messages were processed.
+/// 
+/// A message's weight is defined by the first 4 bytes of its data, which we decode into a
+/// `u32`.
+pub struct TestUmpSink;
+impl UmpSink for TestUmpSink {
+	fn process_upward_message(
+		actual_origin: ParaId,
+		actual_msg: &[u8],
+		max_weight: Weight,
+	) -> Result<Weight, (MessageId, Weight)> {
+		let weight = match u32::decode(&mut &actual_msg[..]) {
+			Ok(w) => w as Weight,
+			Err(_) => return Ok(0), // same as the real `UmpSink`
+		};
+		if weight > max_weight {
+			let id = sp_io::hashing::blake2_256(actual_msg);
+			return Err((id, weight))
+		}
+		PROCESSED.with(|opt_hook| {
+			opt_hook.borrow_mut().push((actual_origin, actual_msg.to_owned()));
+		});
+		Ok(weight)
+	}
 }
 
 pub struct TestRewardValidators;

--- a/runtime/parachains/src/mock.rs
+++ b/runtime/parachains/src/mock.rs
@@ -241,12 +241,7 @@ std::thread_local! {
 
 /// Return which messages have been processed by `pocess_upward_message` and clear the buffer.
 pub fn take_processed() -> Vec<(ParaId, UpwardMessage)> {
-	PROCESSED.with(|opt_hook| {
-		let mut r = vec![];
-		let mut processed = opt_hook.borrow_mut();
-		std::mem::swap(processed.as_mut(), &mut r);
-		r
-	})
+	PROCESSED.with(|opt_hook| std::mem::take(&mut *opt_hook.borrow_mut()))
 }
 
 /// An implementation of a UMP sink that just records which messages were processed.

--- a/runtime/parachains/src/ump.rs
+++ b/runtime/parachains/src/ump.rs
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
-
 use crate::{
 	configuration::{self, HostConfiguration},
 	initializer,
@@ -22,11 +21,7 @@ use crate::{
 use frame_support::pallet_prelude::*;
 use primitives::v1::{Id as ParaId, UpwardMessage};
 use sp_std::{
-	collections::btree_map::BTreeMap,
-	convert::TryFrom,
-	fmt,
-	marker::PhantomData,
-	prelude::*,
+	collections::btree_map::BTreeMap, convert::TryFrom, fmt, marker::PhantomData, prelude::*,
 };
 use xcm::latest::Outcome;
 
@@ -482,7 +477,7 @@ impl QueueCache {
 	}
 
 	/// Returns the message at the front of `para`'s queue, or `None` if the queue is empty.
-	/// 
+	///
 	/// Does not mutate the queue.
 	fn peek_front<T: Config>(&mut self, para: ParaId) -> Option<&UpwardMessage> {
 		let entry = self.ensure_cached::<T>(para);

--- a/runtime/parachains/src/ump.rs
+++ b/runtime/parachains/src/ump.rs
@@ -601,12 +601,12 @@ impl NeedsDispatchCursor {
 }
 
 #[cfg(test)]
-pub (crate) mod tests {
+pub(crate) mod tests {
 	use super::*;
-	use crate::mock::{new_test_ext, Configuration, MockGenesisConfig, Ump, take_processed};
-	use std::collections::HashSet;
+	use crate::mock::{new_test_ext, take_processed, Configuration, MockGenesisConfig, Ump};
 	use frame_support::weights::Weight;
-	
+	use std::collections::HashSet;
+
 	struct GenesisConfigBuilder {
 		max_upward_message_size: u32,
 		max_upward_message_num_per_candidate: u32,

--- a/runtime/parachains/src/ump.rs
+++ b/runtime/parachains/src/ump.rs
@@ -406,11 +406,7 @@ impl<T: Config> Pallet<T> {
 			// dequeue the next message from the queue of the dispatchee
 			let maybe_next = queue_cache.peek_front::<T>(dispatchee);
 			let became_empty = if let Some(upward_message) = maybe_next {
-				match T::UmpSink::process_upward_message(
-					dispatchee,
-					&upward_message[..],
-					max_weight,
-				) {
+				match T::UmpSink::process_upward_message(dispatchee, upward_message, max_weight) {
 					Ok(used) => {
 						weight_used += used;
 						queue_cache.consume_front::<T>(dispatchee)

--- a/runtime/parachains/src/ump.rs
+++ b/runtime/parachains/src/ump.rs
@@ -623,8 +623,8 @@ pub(crate) mod mock_sink {
 
 	use super::{MessageId, ParaId, UmpSink, UpwardMessage};
 	use frame_support::weights::Weight;
-	use std::cell::RefCell;
 	use parity_scale_codec::Decode;
+	use std::cell::RefCell;
 
 	std::thread_local! {
 		// `Some` here indicates that there is an active probe.
@@ -649,7 +649,7 @@ pub(crate) mod mock_sink {
 		) -> Result<Weight, (MessageId, Weight)> {
 			let weight = match u32::decode(&mut &actual_msg[..]) {
 				Ok(w) => w as Weight,
-				Err(_) => return Ok(0),	// same as the real `UmpSink`
+				Err(_) => return Ok(0), // same as the real `UmpSink`
 			};
 			if weight > max_weight {
 				let id = sp_io::hashing::blake2_256(actual_msg);


### PR DESCRIPTION
Closes #3782

Takes items from the queue in a two-part "peek/remove" mechanism, which means no need faff around popping/pushing/passing `UpwardMessage`s back and forth.

Since there's actually only one place in on-chain code that `pop_front` was used and since that isn't necessary if we just stick to using cursors, then we can replace the `VecDeque` with a straight `Vec` which should give better performance characteristics. This code also avoids the O(N) `VecDeque::split` call.

In the case that the first item cannot be consumed, this will also avoid a storage write.

Revamps the tests so that this condition can actually be tested for.