### PR TITLE
Make parts of the xcm-executor public

### DIFF
--- a/xcm/xcm-executor/src/lib.rs
+++ b/xcm/xcm-executor/src/lib.rs
@@ -42,23 +42,23 @@ pub use config::Config;
 
 /// The XCM executor.
 pub struct XcmExecutor<Config: config::Config> {
-	holding: Assets,
-	origin: Option<MultiLocation>,
-	original_origin: MultiLocation,
-	trader: Config::Trader,
+	pub holding: Assets,
+	pub origin: Option<MultiLocation>,
+	pub original_origin: MultiLocation,
+	pub trader: Config::Trader,
 	/// The most recent error result and instruction index into the fragment in which it occurred,
 	/// if any.
-	error: Option<(u32, XcmError)>,
+	pub error: Option<(u32, XcmError)>,
 	/// The surplus weight, defined as the amount by which `max_weight` is
 	/// an over-estimate of the actual weight consumed. We do it this way to avoid needing the
 	/// execution engine to keep track of all instructions' weights (it only needs to care about
 	/// the weight of dynamically determined instructions such as `Transact`).
-	total_surplus: u64,
-	total_refunded: u64,
-	error_handler: Xcm<Config::Call>,
-	error_handler_weight: u64,
-	appendix: Xcm<Config::Call>,
-	appendix_weight: u64,
+	pub total_surplus: u64,
+	pub total_refunded: u64,
+	pub error_handler: Xcm<Config::Call>,
+	pub error_handler_weight: u64,
+	pub appendix: Xcm<Config::Call>,
+	pub appendix_weight: u64,
 	_config: PhantomData<Config>,
 }
 
@@ -99,9 +99,9 @@ impl<Config: config::Config> ExecuteXcm<Config::Call> for XcmExecutor<Config> {
 		while !message.0.is_empty() {
 			let result = vm.execute(message);
 			log::trace!(target: "xcm::execute_xcm_in_credit", "result: {:?}", result);
-			message = if let Err((i, e, w)) = result {
-				vm.total_surplus.saturating_accrue(w);
-				vm.error = Some((i, e));
+			message = if let Err(error) = result {
+				vm.total_surplus.saturating_accrue(error.weight);
+				vm.error = Some((error.index, error.xcm_error));
 				vm.take_error_handler().or_else(|| vm.take_appendix())
 			} else {
 				vm.drop_error_handler();
@@ -128,8 +128,28 @@ impl<Config: config::Config> ExecuteXcm<Config::Call> for XcmExecutor<Config> {
 	}
 }
 
+#[derive(Debug)]
+pub struct ExecutorError {
+	index: u32,
+	xcm_error: XcmError,
+	weight: u64,
+}
+
+#[cfg(feature = "runtime-benchmarks")]
+impl From<ExecutorError> for frame_benchmarking::BenchmarkError {
+	fn from(error: ExecutorError) -> Self {
+		log::error!(
+			"XCM ERROR >> Index: {:?}, Error: {:?}, Weight: {:?}",
+			error.index,
+			error.xcm_error,
+			error.weight
+		);
+		Self::Stop("xcm executor error: see error logs")
+	}
+}
+
 impl<Config: config::Config> XcmExecutor<Config> {
-	fn new(origin: MultiLocation) -> Self {
+	pub fn new(origin: MultiLocation) -> Self {
 		Self {
 			holding: Assets::new(),
 			origin: Some(origin.clone()),
@@ -148,7 +168,7 @@ impl<Config: config::Config> XcmExecutor<Config> {
 
 	/// Execute the XCM program fragment and report back the error and which instruction caused it,
 	/// or `Ok` if there was no error.
-	fn execute(&mut self, xcm: Xcm<Config::Call>) -> Result<(), (u32, XcmError, u64)> {
+	pub fn execute(&mut self, xcm: Xcm<Config::Call>) -> Result<(), ExecutorError> {
 		log::trace!(
 			target: "xcm::execute",
 			"origin: {:?}, total_surplus/refunded: {:?}/{:?}, error_handler_weight: {:?}",
@@ -162,11 +182,11 @@ impl<Config: config::Config> XcmExecutor<Config> {
 			match &mut result {
 				r @ Ok(()) =>
 					if let Err(e) = self.process_instruction(instr) {
-						*r = Err((i as u32, e, 0));
+						*r = Err(ExecutorError { index: i as u32, xcm_error: e, weight: 0 });
 					},
-				Err((_, _, ref mut w)) =>
+				Err(ref mut error) =>
 					if let Ok(x) = Config::Weigher::instr_weight(&instr) {
-						w.saturating_accrue(x)
+						error.weight.saturating_accrue(x)
 					},
 			}
 		}


### PR DESCRIPTION
This makes it easier to do benchmarking, by instantiating an executor and controlling the specific internals.

For example:

```
	refund_surplus {
		let (sender_account, sender_location) = account_and_location::<T>(1);
		let mut executor = new_executor::<T>(sender_location);
		executor.total_surplus = 1337;
		executor.total_refunded = 0;

		let instruction = Instruction::<XcmCallOf<T>>::RefundSurplus;
		let xcm = Xcm(vec![instruction]);
	} : {
		executor.execute(xcm)?;
	} verify {
		assert_eq!(executor.total_surplus, 1337);
		assert_eq!(executor.total_refunded, 1337);
	}
```