### PR TITLE
dockerfiles: upgrade to ubuntu:20.04; some chore

### DIFF
--- a/bridges/Dockerfile
+++ b/bridges/Dockerfile
@@ -8,7 +8,7 @@
 #
 # See the `deployments/README.md` for all the available `PROJECT` values.
 
-FROM paritytech/bridges-ci:latest as builder
+FROM docker.io/paritytech/bridges-ci:latest as builder
 WORKDIR /parity-bridges-common
 
 COPY . .
@@ -19,7 +19,7 @@ RUN cargo build --release --verbose -p ${PROJECT} && \
 
 # In this final stage we copy over the final binary and do some checks
 # to make sure that everything looks good.
-FROM ubuntu:20.04 as runtime
+FROM docker.io/library/ubuntu:20.04 as runtime
 
 # show backtraces
 ENV RUST_BACKTRACE 1

--- a/bridges/ci.Dockerfile
+++ b/bridges/ci.Dockerfile
@@ -1,7 +1,7 @@
 # This file is a "runtime" part from a builder-pattern in Dockerfile, it's used in CI.
 # The only different part is that the compilation happens externally,
 # so COPY has a different source.
-FROM ubuntu:20.04
+FROM docker.io/library/ubuntu:20.04
 
 # show backtraces
 ENV RUST_BACKTRACE 1

--- a/bridges/deployments/BridgeDeps.Dockerfile
+++ b/bridges/deployments/BridgeDeps.Dockerfile
@@ -2,7 +2,7 @@
 #
 # This image is meant to be used as a building block when building images for
 # the various components in the bridge repo, such as nodes and relayers.
-FROM ubuntu:20.04
+FROM docker.io/library/ubuntu:20.04
 
 ENV LAST_DEPS_UPDATE 2021-04-01
 ENV DEBIAN_FRONTEND=noninteractive

--- a/bridges/deployments/bridges/poa-rialto/Front-end.Dockerfile
+++ b/bridges/deployments/bridges/poa-rialto/Front-end.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12 as build-deps
+FROM docker.io/library/node:12 as build-deps
 
 # install tools and dependencies
 RUN set -eux; \
@@ -19,7 +19,7 @@ ENV EXPECTED_ETHEREUM_NETWORK_ID $EXPECTED_ETHEREUM_NETWORK_ID
 RUN yarn build:docker
 
 # Stage 2 - the production environment
-FROM nginx:1.12
+FROM docker.io/library/nginx:1.12
 COPY --from=build-deps /usr/src/bridge-ui/nginx/*.conf /etc/nginx/conf.d/
 COPY --from=build-deps /usr/src/bridge-ui/dist /usr/share/nginx/html
 EXPOSE 80

--- a/bridges/deployments/monitoring/GrafanaMatrix.Dockerfile
+++ b/bridges/deployments/monitoring/GrafanaMatrix.Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:alpine
+FROM docker.io/library/ruby:alpine
 
 RUN apk add --no-cache git
 

--- a/bridges/deployments/networks/OpenEthereum.Dockerfile
+++ b/bridges/deployments/networks/OpenEthereum.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:xenial AS builder
+FROM docker.io/library/ubuntu:xenial AS builder
 
 # show backtraces
 ENV RUST_BACKTRACE 1
@@ -60,7 +60,7 @@ WORKDIR /openethereum
 RUN cargo build --release --verbose
 RUN strip ./target/release/openethereum
 
-FROM ubuntu:xenial
+FROM docker.io/library/ubuntu:xenial
 
 # show backtraces
 ENV RUST_BACKTRACE 1

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM paritytech/ci-linux:production as builder
+FROM docker.io/paritytech/ci-linux:production as builder
 LABEL description="This is the build stage for Polkadot. Here we create the binary."
 
 ARG PROFILE=release
@@ -10,7 +10,7 @@ RUN cargo build --$PROFILE
 
 # ===== SECOND STAGE ======
 
-FROM ubuntu:20.04
+FROM docker.io/library/ubuntu:20.04
 LABEL description="This is the 2nd stage: a very small image where we copy the Polkadot binary."
 ARG PROFILE=release
 COPY --from=builder /polkadot/target/$PROFILE/polkadot /usr/local/bin

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,7 +10,7 @@ RUN cargo build --$PROFILE
 
 # ===== SECOND STAGE ======
 
-FROM debian:buster-slim
+FROM ubuntu:20.04
 LABEL description="This is the 2nd stage: a very small image where we copy the Polkadot binary."
 ARG PROFILE=release
 COPY --from=builder /polkadot/target/$PROFILE/polkadot /usr/local/bin

--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM docker.io/library/ubuntu:20.04
 
 # metadata
 ARG VCS_REF

--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM ubuntu:20.04
 
 # metadata
 ARG VCS_REF
@@ -8,7 +8,7 @@ ARG IMAGE_NAME
 LABEL io.parity.image.authors="devops-team@parity.io" \
 	io.parity.image.vendor="Parity Technologies" \
 	io.parity.image.title="${IMAGE_NAME}" \
-	io.parity.image.description="polkadot: a platform for web3" \
+	io.parity.image.description="Polkadot: a platform for web3" \
 	io.parity.image.source="https://github.com/paritytech/polkadot/blob/${VCS_REF}/scripts/docker/Dockerfile" \
 	io.parity.image.revision="${VCS_REF}" \
 	io.parity.image.created="${BUILD_DATE}" \

--- a/scripts/docker/collator.Dockerfile
+++ b/scripts/docker/collator.Dockerfile
@@ -1,4 +1,5 @@
-FROM debian:buster-slim
+# this file copies from scripts/docker/Dockerfile and changes only the binary name
+FROM ubuntu:20.04
 
 # metadata
 ARG VCS_REF
@@ -8,8 +9,8 @@ ARG IMAGE_NAME
 LABEL io.parity.image.authors="devops-team@parity.io" \
 	io.parity.image.vendor="Parity Technologies" \
 	io.parity.image.title="${IMAGE_NAME}" \
-	io.parity.image.description="polkadot: a platform for web3" \
-	io.parity.image.source="https://github.com/paritytech/polkadot/blob/${VCS_REF}/scripts/docker/Dockerfile" \
+	io.parity.image.description="adder-collator image" \
+	io.parity.image.source="https://github.com/paritytech/polkadot/blob/${VCS_REF}/scripts/docker/collator.Dockerfile" \
 	io.parity.image.revision="${VCS_REF}" \
 	io.parity.image.created="${BUILD_DATE}" \
 	io.parity.image.documentation="https://github.com/paritytech/polkadot/"

--- a/scripts/docker/collator.Dockerfile
+++ b/scripts/docker/collator.Dockerfile
@@ -1,5 +1,5 @@
 # this file copies from scripts/docker/Dockerfile and changes only the binary name
-FROM ubuntu:20.04
+FROM docker.io/library/ubuntu:20.04
 
 # metadata
 ARG VCS_REF

--- a/scripts/docker/release.Dockerfile
+++ b/scripts/docker/release.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM docker.io/library/ubuntu:20.04
 
 # metadata
 ARG VCS_REF

--- a/scripts/docker/release.Dockerfile
+++ b/scripts/docker/release.Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM ubuntu:20.04
 
 # metadata
 ARG VCS_REF
@@ -8,7 +8,7 @@ ARG POLKADOT_VERSION
 LABEL io.parity.image.authors="devops-team@parity.io" \
 	io.parity.image.vendor="Parity Technologies" \
 	io.parity.image.title="parity/polkadot" \
-	io.parity.image.description="polkadot: a platform for web3" \
+	io.parity.image.description="Polkadot: a platform for web3" \
 	io.parity.image.source="https://github.com/paritytech/polkadot/blob/${VCS_REF}/scripts/docker/Dockerfile" \
 	io.parity.image.revision="${VCS_REF}" \
 	io.parity.image.created="${BUILD_DATE}" \
@@ -19,24 +19,25 @@ ENV RUST_BACKTRACE 1
 
 # install tools and dependencies
 RUN apt-get update && \
-		DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-			libssl1.1 \
-			ca-certificates \
-			curl \
-			gnupg && \
-		useradd -m -u 1000 -U -s /bin/sh -d /polkadot polkadot && \
-		gpg --recv-keys --keyserver hkps://keys.mailvelope.com 9D4B2B6EB8F97156D19669A9FF0812D491B96798 && \
-		gpg --export 9D4B2B6EB8F97156D19669A9FF0812D491B96798 > /usr/share/keyrings/parity.gpg && \
-		echo 'deb [signed-by=/usr/share/keyrings/parity.gpg] https://releases.parity.io/deb release main' > /etc/apt/sources.list.d/parity.list && \
-		apt-get update && \
-		apt-get install -y --no-install-recommends polkadot=${POLKADOT_VERSION#?} && \
+	DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+		libssl1.1 \
+		ca-certificates \
+		curl \
+		gnupg && \
+	useradd -m -u 1000 -U -s /bin/sh -d /polkadot polkadot && \
+# add repo's gpg keys and install the published polkadot binary
+	gpg --recv-keys --keyserver hkps://keys.mailvelope.com 9D4B2B6EB8F97156D19669A9FF0812D491B96798 && \
+	gpg --export 9D4B2B6EB8F97156D19669A9FF0812D491B96798 > /usr/share/keyrings/parity.gpg && \
+	echo 'deb [signed-by=/usr/share/keyrings/parity.gpg] https://releases.parity.io/deb release main' > /etc/apt/sources.list.d/parity.list && \
+	apt-get update && \
+	apt-get install -y --no-install-recommends polkadot=${POLKADOT_VERSION#?} && \
 # apt cleanup
-		apt-get autoremove -y && \
-		apt-get clean && \
-		rm -rf /var/lib/apt/lists/* ; \
-		mkdir -p /data /polkadot/.local/share && \
-		chown -R polkadot:polkadot /data && \
-		ln -s /data /polkadot/.local/share/polkadot
+	apt-get autoremove -y && \
+	apt-get clean && \
+	rm -rf /var/lib/apt/lists/* ; \
+	mkdir -p /data /polkadot/.local/share && \
+	chown -R polkadot:polkadot /data && \
+	ln -s /data /polkadot/.local/share/polkadot
 
 USER polkadot
 
@@ -47,4 +48,3 @@ EXPOSE 30333 9933 9944
 VOLUME ["/polkadot"]
 
 ENTRYPOINT ["/usr/bin/polkadot"]
-

--- a/scripts/docker/staking-miner/staking_miner-builder.Dockerfile
+++ b/scripts/docker/staking-miner/staking_miner-builder.Dockerfile
@@ -14,7 +14,7 @@ RUN cargo build --locked --$PROFILE --package staking-miner
 
 # ===== SECOND STAGE ======
 
-FROM debian:buster-slim
+FROM ubuntu:20.04
 LABEL description="This is the 2nd stage: a very small image where we copy the binary."
 LABEL io.parity.image.authors="devops-team@parity.io" \
 	io.parity.image.vendor="Parity Technologies" \
@@ -43,4 +43,4 @@ ENV RUST_LOG="info"
 # check if the binary works in this container
 RUN /usr/local/bin/staking-miner --version
 
-ENTRYPOINT [ "/usr/local/bin/staking-miner"]
+ENTRYPOINT [ "/usr/local/bin/staking-miner" ]

--- a/scripts/docker/staking-miner/staking_miner-builder.Dockerfile
+++ b/scripts/docker/staking-miner/staking_miner-builder.Dockerfile
@@ -14,7 +14,7 @@ RUN cargo build --locked --$PROFILE --package staking-miner
 
 # ===== SECOND STAGE ======
 
-FROM ubuntu:20.04
+FROM docker.io/library/ubuntu:20.04
 LABEL description="This is the 2nd stage: a very small image where we copy the binary."
 LABEL io.parity.image.authors="devops-team@parity.io" \
 	io.parity.image.vendor="Parity Technologies" \

--- a/scripts/docker/staking-miner/staking_miner-injected.Dockerfile
+++ b/scripts/docker/staking-miner/staking_miner-injected.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM docker.io/library/ubuntu:20.04
 
 # metadata
 ARG VCS_REF

--- a/scripts/docker/staking-miner/staking_miner-injected.Dockerfile
+++ b/scripts/docker/staking-miner/staking_miner-injected.Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM ubuntu:20.04
 
 # metadata
 ARG VCS_REF
@@ -22,6 +22,7 @@ RUN apt-get update && \
 	DEBIAN_FRONTEND=noninteractive apt-get install -y \
 		libssl1.1 \
 		ca-certificates && \
+# apt cleanup
 	apt-get autoremove -y && \
 	apt-get clean && \
 	find /var/lib/apt/lists/ -type f -not -name lock -delete; \


### PR DESCRIPTION
I'm upgrading the CI image from being based on `debian:buster` to `ubuntu:20.04`, some details: https://github.com/paritytech/scripts/pull/309
The binaries produced in our new CI image will be linked by the newer `GLIBC` so won't be executable in debian:
```
/usr/local/bin/adder-collator: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.29' not found (required by /usr/local/bin/adder-collator)
/usr/local/bin/adder-collator: /usr/lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.26' not found (required by /usr/local/bin/adder-collator)
```