### PR TITLE
remove connected disconnected state only

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6768,6 +6768,7 @@ dependencies = [
  "kvdb",
  "kvdb-rocksdb",
  "log",
+ "lru",
  "pallet-babe",
  "pallet-im-online",
  "pallet-mmr-primitives",

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -185,6 +185,7 @@ struct BehaveMaleficient;
 impl OverseerGen for BehaveMaleficient {
 	fn generate<'a, Spawner, RuntimeClient>(
 		&self,
+		connector: OverseerConnector,
 		args: OverseerGenArgs<'a, Spawner, RuntimeClient>,
 	) -> Result<(Overseer<Spawner, Arc<RuntimeClient>>, OverseerHandler), Error>
 	where
@@ -213,7 +214,7 @@ impl OverseerGen for BehaveMaleficient {
 			),
 		);
 
-		Overseer::new(leaves, all_subsystems, registry, runtime_client, spawner)
+		Overseer::new(leaves, all_subsystems, registry, runtime_client, spawner, connector)
 			.map_err(|e| e.into())
 
         // A builder pattern will simplify this further

--- a/node/malus/src/variant-a.rs
+++ b/node/malus/src/variant-a.rs
@@ -37,7 +37,7 @@ use polkadot_cli::{
 use polkadot_node_core_candidate_validation::CandidateValidationSubsystem;
 use polkadot_node_subsystem::{
 	messages::{AllMessages, CandidateValidationMessage},
-	overseer::{self, OverseerHandle},
+	overseer::{self, OverseerConnector, OverseerHandle},
 	FromOverseer,
 };
 
@@ -86,6 +86,7 @@ struct BehaveMaleficient;
 impl OverseerGen for BehaveMaleficient {
 	fn generate<'a, Spawner, RuntimeClient>(
 		&self,
+		connector: OverseerConnector,
 		args: OverseerGenArgs<'a, Spawner, RuntimeClient>,
 	) -> Result<(Overseer<Spawner, Arc<RuntimeClient>>, OverseerHandle), Error>
 	where
@@ -113,7 +114,7 @@ impl OverseerGen for BehaveMaleficient {
 			},
 		);
 
-		Overseer::new(leaves, all_subsystems, registry, runtime_client, spawner)
+		Overseer::new(leaves, all_subsystems, registry, runtime_client, spawner, connector)
 			.map_err(|e| e.into())
 	}
 }

--- a/node/overseer/examples/minimal-example.rs
+++ b/node/overseer/examples/minimal-example.rs
@@ -29,7 +29,8 @@ use polkadot_node_subsystem_types::messages::{
 use polkadot_overseer::{
 	self as overseer,
 	gen::{FromOverseer, SpawnedSubsystem},
-	AllMessages, AllSubsystems, HeadSupportsParachains, Overseer, OverseerSignal, SubsystemError,
+	AllMessages, AllSubsystems, HeadSupportsParachains, Overseer, OverseerConnector,
+	OverseerSignal, SubsystemError,
 };
 use polkadot_primitives::v1::Hash;
 
@@ -173,8 +174,15 @@ fn main() {
 			.replace_candidate_validation(|_| Subsystem2)
 			.replace_candidate_backing(|orig| orig);
 
-		let (overseer, _handle) =
-			Overseer::new(vec![], all_subsystems, None, AlwaysSupportsParachains, spawner).unwrap();
+		let (overseer, _handle) = Overseer::new(
+			vec![],
+			all_subsystems,
+			None,
+			AlwaysSupportsParachains,
+			spawner,
+			OverseerConnector::default(),
+		)
+		.unwrap();
 		let overseer_fut = overseer.run().fuse();
 		let timer_stream = timer_stream;
 

--- a/node/overseer/overseer-gen/proc-macro/src/impl_builder.rs
+++ b/node/overseer/overseer-gen/proc-macro/src/impl_builder.rs
@@ -130,7 +130,7 @@ pub(crate) fn impl_builder(info: &OverseerInfo) -> proc_macro2::TokenStream {
 				&mut self.handle
 			}
 			/// Obtain access to the overseer handle.
-			pub fn as_handle(&mut self) -> &#handle {
+			pub fn as_handle(&self) -> &#handle {
 				&self.handle
 			}
 		}

--- a/node/overseer/src/dummy.rs
+++ b/node/overseer/src/dummy.rs
@@ -1,0 +1,54 @@
+// Copyright 2020 Parity Technologies (UK) Ltd.
+// This file is part of Polkadot.
+
+// Polkadot is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Polkadot is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
+
+use crate::{AllMessages, OverseerSignal};
+use polkadot_node_subsystem_types::errors::SubsystemError;
+use polkadot_overseer_gen::{FromOverseer, SpawnedSubsystem, Subsystem, SubsystemContext};
+
+/// A dummy subsystem that implements [`Subsystem`] for all
+/// types of messages. Used for tests or as a placeholder.
+#[derive(Clone, Copy, Debug)]
+pub struct DummySubsystem;
+
+impl<Context> Subsystem<Context, SubsystemError> for DummySubsystem
+where
+	Context: SubsystemContext<
+		Signal = OverseerSignal,
+		Error = SubsystemError,
+		AllMessages = AllMessages,
+	>,
+{
+	fn start(self, mut ctx: Context) -> SpawnedSubsystem<SubsystemError> {
+		let future = Box::pin(async move {
+			loop {
+				match ctx.recv().await {
+					Err(_) => return Ok(()),
+					Ok(FromOverseer::Signal(OverseerSignal::Conclude)) => return Ok(()),
+					Ok(overseer_msg) => {
+						tracing::debug!(
+							target: "dummy-subsystem",
+							"Discarding a message sent from overseer {:?}",
+							overseer_msg
+						);
+						continue
+					},
+				}
+			}
+		});
+
+		SpawnedSubsystem { name: "dummy-subsystem", future }
+	}
+}

--- a/node/overseer/src/lib.rs
+++ b/node/overseer/src/lib.rs
@@ -493,6 +493,7 @@ where
 	///     None,
 	///     AlwaysSupportsParachains,
 	///     spawner,
+	///     OverseerConnector::default(),
 	/// ).unwrap();
 	///
 	/// let timer = Delay::new(Duration::from_millis(50)).fuse();
@@ -559,6 +560,7 @@ where
 		prometheus_registry: Option<&prometheus::Registry>,
 		supports_parachains: SupportsParachains,
 		s: S,
+		connector: OverseerConnector,
 	) -> SubsystemResult<(Self, OverseerHandle)>
 	where
 		CV: Subsystem<OverseerSubsystemContext<CandidateValidationMessage>, SubsystemError> + Send,
@@ -623,7 +625,7 @@ where
 			.supports_parachains(supports_parachains)
 			.metrics(metrics.clone())
 			.spawner(s)
-			.build()?;
+			.build_with_connector(connector)?;
 
 		// spawn the metrics metronome task
 		{

--- a/node/overseer/src/lib.rs
+++ b/node/overseer/src/lib.rs
@@ -439,12 +439,13 @@ where
 	/// # use polkadot_primitives::v1::Hash;
 	/// # use polkadot_overseer::{
 	/// # 	self as overseer,
+	/// # 	Overseer,
 	/// #   OverseerSignal,
+	/// # 	OverseerConnector,
 	/// # 	SubsystemSender as _,
 	/// # 	AllMessages,
 	/// # 	AllSubsystems,
 	/// # 	HeadSupportsParachains,
-	/// # 	Overseer,
 	/// # 	SubsystemError,
 	/// # 	gen::{
 	/// # 		SubsystemContext,

--- a/node/overseer/src/lib.rs
+++ b/node/overseer/src/lib.rs
@@ -90,12 +90,17 @@ pub use polkadot_node_subsystem_types::{
 	jaeger, ActivatedLeaf, ActiveLeavesUpdate, LeafStatus, OverseerSignal,
 };
 
+/// Test helper supplements.
+pub mod dummy;
+pub use self::dummy::DummySubsystem;
+
 // TODO legacy, to be deleted, left for easier integration
 // TODO https://github.com/paritytech/polkadot/issues/3427
 mod subsystems;
-pub use self::subsystems::{AllSubsystems, DummySubsystem};
+pub use self::subsystems::AllSubsystems;
 
-mod metrics;
+/// Metrics re-exports of `polkadot-metrics`.
+pub mod metrics;
 use self::metrics::Metrics;
 
 use polkadot_node_metrics::{
@@ -115,7 +120,7 @@ pub use polkadot_overseer_gen::{
 
 /// Store 2 days worth of blocks, not accounting for forks,
 /// in the LRU cache. Assumes a 6-second block time.
-const KNOWN_LEAVES_CACHE_SIZE: usize = 2 * 24 * 3600 / 6;
+pub const KNOWN_LEAVES_CACHE_SIZE: usize = 2 * 24 * 3600 / 6;
 
 #[cfg(test)]
 mod tests;

--- a/node/overseer/src/metrics.rs
+++ b/node/overseer/src/metrics.rs
@@ -17,7 +17,7 @@
 //! Prometheus metrics related to the overseer and its channels.
 
 use super::*;
-use polkadot_node_metrics::metrics::{self, prometheus};
+pub use polkadot_node_metrics::metrics::{self, prometheus, Metrics as MetricsTrait};
 
 #[cfg(feature = "memory-stats")]
 use polkadot_node_metrics::MemoryAllocationSnapshot;
@@ -117,7 +117,7 @@ impl Metrics {
 	}
 }
 
-impl metrics::Metrics for Metrics {
+impl MetricsTrait for Metrics {
 	fn try_register(registry: &prometheus::Registry) -> Result<Self, prometheus::PrometheusError> {
 		let metrics = MetricsInner {
 			activated_heads_total: prometheus::register(

--- a/node/overseer/src/subsystems.rs
+++ b/node/overseer/src/subsystems.rs
@@ -19,47 +19,9 @@
 //! In the future, everything should be set up using the generated
 //! overseer builder pattern instead.
 
-use crate::{AllMessages, OverseerSignal};
-use polkadot_node_subsystem_types::errors::SubsystemError;
+use crate::dummy::DummySubsystem;
 use polkadot_overseer_all_subsystems_gen::AllSubsystemsGen;
-use polkadot_overseer_gen::{
-	FromOverseer, MapSubsystem, SpawnedSubsystem, Subsystem, SubsystemContext,
-};
-
-/// A dummy subsystem that implements [`Subsystem`] for all
-/// types of messages. Used for tests or as a placeholder.
-#[derive(Clone, Copy, Debug)]
-pub struct DummySubsystem;
-
-impl<Context> Subsystem<Context, SubsystemError> for DummySubsystem
-where
-	Context: SubsystemContext<
-		Signal = OverseerSignal,
-		Error = SubsystemError,
-		AllMessages = AllMessages,
-	>,
-{
-	fn start(self, mut ctx: Context) -> SpawnedSubsystem<SubsystemError> {
-		let future = Box::pin(async move {
-			loop {
-				match ctx.recv().await {
-					Err(_) => return Ok(()),
-					Ok(FromOverseer::Signal(OverseerSignal::Conclude)) => return Ok(()),
-					Ok(overseer_msg) => {
-						tracing::debug!(
-							target: "dummy-subsystem",
-							"Discarding a message sent from overseer {:?}",
-							overseer_msg
-						);
-						continue
-					},
-				}
-			}
-		});
-
-		SpawnedSubsystem { name: "dummy-subsystem", future }
-	}
-}
+use polkadot_overseer_gen::MapSubsystem;
 
 /// This struct is passed as an argument to create a new instance of an [`Overseer`].
 ///

--- a/node/overseer/src/tests.rs
+++ b/node/overseer/src/tests.rs
@@ -173,7 +173,7 @@ fn overseer_works() {
 			OverseerConnector::default(),
 		)
 		.unwrap();
-		let mut handle = Handle::Connected(handle);
+		let mut handle = Handle(handle);
 		let overseer_fut = overseer.run().fuse();
 
 		pin_mut!(overseer_fut);
@@ -237,7 +237,7 @@ fn overseer_metrics_work() {
 			OverseerConnector::default(),
 		)
 		.unwrap();
-		let mut handle = Handle::Connected(handle);
+		let mut handle = Handle(handle);
 		let overseer_fut = overseer.run().fuse();
 
 		pin_mut!(overseer_fut);
@@ -406,7 +406,7 @@ fn overseer_start_stop_works() {
 			OverseerConnector::default(),
 		)
 		.unwrap();
-		let mut handle = Handle::Connected(handle);
+		let mut handle = Handle(handle);
 
 		let overseer_fut = overseer.run().fuse();
 		pin_mut!(overseer_fut);
@@ -510,7 +510,7 @@ fn overseer_finalize_works() {
 			OverseerConnector::default(),
 		)
 		.unwrap();
-		let mut handle = Handle::Connected(handle);
+		let mut handle = Handle(handle);
 
 		let overseer_fut = overseer.run().fuse();
 		pin_mut!(overseer_fut);
@@ -604,7 +604,7 @@ fn do_not_send_empty_leaves_update_on_block_finalization() {
 			OverseerConnector::default(),
 		)
 		.unwrap();
-		let mut handle = Handle::Connected(handle);
+		let mut handle = Handle(handle);
 
 		let overseer_fut = overseer.run().fuse();
 		pin_mut!(overseer_fut);
@@ -877,6 +877,7 @@ fn overseer_all_subsystems_receive_signals_and_messages() {
 			dispute_distribution: subsystem.clone(),
 			chain_selection: subsystem.clone(),
 		};
+
 		let (overseer, handle) = Overseer::new(
 			vec![],
 			all_subsystems,
@@ -886,7 +887,7 @@ fn overseer_all_subsystems_receive_signals_and_messages() {
 			OverseerConnector::default(),
 		)
 		.unwrap();
-		let mut handle = Handle::Connected(handle);
+		let mut handle = Handle(handle);
 		let overseer_fut = overseer.run().fuse();
 
 		pin_mut!(overseer_fut);

--- a/node/overseer/src/tests.rs
+++ b/node/overseer/src/tests.rs
@@ -32,7 +32,7 @@ use polkadot_primitives::v1::{
 	ValidatorIndex,
 };
 
-use crate::{self as overseer, gen::Delay, HeadSupportsParachains, Overseer};
+use crate::{self as overseer, gen::Delay, HeadSupportsParachains, Overseer, OverseerConnector};
 use metered_channel as metered;
 
 use assert_matches::assert_matches;
@@ -164,8 +164,15 @@ fn overseer_works() {
 			.replace_candidate_validation(move |_| TestSubsystem1(s1_tx))
 			.replace_candidate_backing(move |_| TestSubsystem2(s2_tx));
 
-		let (overseer, handle) =
-			Overseer::new(vec![], all_subsystems, None, MockSupportsParachains, spawner).unwrap();
+		let (overseer, handle) = Overseer::new(
+			vec![],
+			all_subsystems,
+			None,
+			MockSupportsParachains,
+			spawner,
+			OverseerConnector::default(),
+		)
+		.unwrap();
 		let mut handle = Handle::Connected(handle);
 		let overseer_fut = overseer.run().fuse();
 
@@ -227,6 +234,7 @@ fn overseer_metrics_work() {
 			Some(&registry),
 			MockSupportsParachains,
 			spawner,
+			OverseerConnector::default(),
 		)
 		.unwrap();
 		let mut handle = Handle::Connected(handle);
@@ -280,8 +288,15 @@ fn overseer_ends_on_subsystem_exit() {
 	executor::block_on(async move {
 		let all_subsystems =
 			AllSubsystems::<()>::dummy().replace_candidate_backing(|_| ReturnOnStart);
-		let (overseer, _handle) =
-			Overseer::new(vec![], all_subsystems, None, MockSupportsParachains, spawner).unwrap();
+		let (overseer, _handle) = Overseer::new(
+			vec![],
+			all_subsystems,
+			None,
+			MockSupportsParachains,
+			spawner,
+			OverseerConnector::default(),
+		)
+		.unwrap();
 
 		overseer.run().await.unwrap();
 	})
@@ -382,9 +397,15 @@ fn overseer_start_stop_works() {
 		let all_subsystems = AllSubsystems::<()>::dummy()
 			.replace_candidate_validation(move |_| TestSubsystem5(tx_5))
 			.replace_candidate_backing(move |_| TestSubsystem6(tx_6));
-		let (overseer, handle) =
-			Overseer::new(vec![first_block], all_subsystems, None, MockSupportsParachains, spawner)
-				.unwrap();
+		let (overseer, handle) = Overseer::new(
+			vec![first_block],
+			all_subsystems,
+			None,
+			MockSupportsParachains,
+			spawner,
+			OverseerConnector::default(),
+		)
+		.unwrap();
 		let mut handle = Handle::Connected(handle);
 
 		let overseer_fut = overseer.run().fuse();
@@ -486,6 +507,7 @@ fn overseer_finalize_works() {
 			None,
 			MockSupportsParachains,
 			spawner,
+			OverseerConnector::default(),
 		)
 		.unwrap();
 		let mut handle = Handle::Connected(handle);
@@ -573,9 +595,15 @@ fn do_not_send_empty_leaves_update_on_block_finalization() {
 		let all_subsystems =
 			AllSubsystems::<()>::dummy().replace_candidate_backing(move |_| TestSubsystem6(tx_5));
 
-		let (overseer, handle) =
-			Overseer::new(Vec::new(), all_subsystems, None, MockSupportsParachains, spawner)
-				.unwrap();
+		let (overseer, handle) = Overseer::new(
+			Vec::new(),
+			all_subsystems,
+			None,
+			MockSupportsParachains,
+			spawner,
+			OverseerConnector::default(),
+		)
+		.unwrap();
 		let mut handle = Handle::Connected(handle);
 
 		let overseer_fut = overseer.run().fuse();
@@ -849,8 +877,15 @@ fn overseer_all_subsystems_receive_signals_and_messages() {
 			dispute_distribution: subsystem.clone(),
 			chain_selection: subsystem.clone(),
 		};
-		let (overseer, handle) =
-			Overseer::new(vec![], all_subsystems, None, MockSupportsParachains, spawner).unwrap();
+		let (overseer, handle) = Overseer::new(
+			vec![],
+			all_subsystems,
+			None,
+			MockSupportsParachains,
+			spawner,
+			OverseerConnector::default(),
+		)
+		.unwrap();
 		let mut handle = Handle::Connected(handle);
 		let overseer_fut = overseer.run().fuse();
 

--- a/node/service/Cargo.toml
+++ b/node/service/Cargo.toml
@@ -26,6 +26,7 @@ sc-keystore = { git = "https://github.com/paritytech/substrate", branch = "maste
 sc-basic-authorship = { git = "https://github.com/paritytech/substrate", branch = "master" }
 service = { package = "sc-service", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 telemetry = { package = "sc-telemetry", git = "https://github.com/paritytech/substrate", branch = "master" }
+lru = "0.6"
 
 # Substrate Primitives
 sp-authority-discovery = { git = "https://github.com/paritytech/substrate", branch = "master" }

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -1340,7 +1340,13 @@ pub fn new_chain_ops(
 		return chain_ops!(config, jaeger_agent, telemetry_worker_handle; westend_runtime, WestendExecutorDispatch, Westend)
 	}
 
-	chain_ops!(config, jaeger_agent, telemetry_worker_handle; polkadot_runtime, PolkadotExecutorDispatch, Polkadot)
+	#[cfg(feature = "polkadot-native")]
+	{
+		chain_ops!(config, jaeger_agent, telemetry_worker_handle; polkadot_runtime, PolkadotExecutorDispatch, Polkadot)
+	}
+	
+	#[cfg(not(feature = "polkadot-native"))]
+	Err(Error::NoRuntime)
 }
 
 /// Build a new light node.

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -321,6 +321,7 @@ type LightBackend = service::TLightBackendWithHash<Block, sp_runtime::traits::Bl
 type LightClient<RuntimeApi, ExecutorDispatch> =
 	service::TLightClientWithBackend<Block, RuntimeApi, ExecutorDispatch, LightBackend>;
 
+#[cfg(feature = "full-node")]
 struct Basics<RuntimeApi, ExecutorDispatch>
 where
 	RuntimeApi: ConstructRuntimeApi<Block, FullClient<RuntimeApi, ExecutorDispatch>>

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -302,7 +302,7 @@ fn jaeger_launch_collector_with_agent(
 }
 
 #[cfg(feature = "full-node")]
-type FullSelectChain = relay_chain_selection::SelectRelayChainWithFallback<FullBackend>;
+type FullSelectChain = relay_chain_selection::SelectRelayChain<FullBackend>;
 #[cfg(feature = "full-node")]
 type FullGrandpaBlockImport<RuntimeApi, ExecutorDispatch> = grandpa::GrandpaBlockImport<
 	FullBackend,
@@ -400,8 +400,17 @@ where
 
 	jaeger_launch_collector_with_agent(task_manager.spawn_handle(), &*config, jaeger_agent)?;
 
-	let select_chain = relay_chain_selection::SelectRelayChainWithFallback::new(
+	// we should remove this check before we deploy parachains on polkadot
+	// TODO: https://github.com/paritytech/polkadot/issues/3326
+	let chain_spec = config.chain_spec.as_ref();
+	let is_relay_chain = chain_spec.is_kusama() ||
+		chain_spec.is_westend() ||
+		chain_spec.is_rococo() ||
+		chain_spec.is_wococo();
+
+	let select_chain = relay_chain_selection::SelectRelayChain::new(
 		backend.clone(),
+		is_relay_chain,
 		Handle::new_disconnected(),
 		polkadot_node_subsystem_util::metrics::Metrics::register(config.prometheus_registry())?,
 	);
@@ -679,7 +688,7 @@ where
 		backend,
 		mut task_manager,
 		keystore_container,
-		mut select_chain,
+		select_chain,
 		import_queue,
 		transaction_pool,
 		other: (rpc_extensions_builder, import_setup, rpc_setup, slot_duration, mut telemetry),
@@ -850,7 +859,8 @@ where
 		local_keystore.and_then(move |k| authority_discovery_service.map(|a| (a, k)));
 
 	let overseer_handle = if let Some((authority_discovery_service, keystore)) = maybe_params {
-		let (overseer, overseer_handle) = overseer_gen
+		// already have access to the handle
+		let (overseer, _handle) = overseer_gen
 			.generate::<service::SpawnTaskHandle, FullClient<RuntimeApi, ExecutorDispatch>>(
 				OverseerGenArgs {
 					leaves: active_leaves,
@@ -875,40 +885,29 @@ where
 					dispute_coordinator_config,
 				},
 			)?;
-		let handle = Handle::Connected(overseer_handle.clone());
-		let handle_clone = handle.clone();
 
-		task_manager.spawn_essential_handle().spawn_blocking(
-			"overseer",
-			Box::pin(async move {
-				use futures::{pin_mut, select, FutureExt};
+		{
+			let handle = handle.clone();
+			task_manager.spawn_essential_handle().spawn_blocking(
+				"overseer",
+				Box::pin(async move {
+					use futures::{pin_mut, select, FutureExt};
 
-				let forward = polkadot_overseer::forward_events(overseer_client, handle_clone);
+					let forward = polkadot_overseer::forward_events(overseer_client, handle);
 
-				let forward = forward.fuse();
-				let overseer_fut = overseer.run().fuse();
+					let forward = forward.fuse();
+					let overseer_fut = overseer.run().fuse();
 
-				pin_mut!(overseer_fut);
-				pin_mut!(forward);
+					pin_mut!(overseer_fut);
+					pin_mut!(forward);
 
-				select! {
-					_ = forward => (),
-					_ = overseer_fut => (),
-					complete => (),
-				}
-			}),
-		);
-		// we should remove this check before we deploy parachains on polkadot
-		// TODO: https://github.com/paritytech/polkadot/issues/3326
-		let should_connect_overseer = chain_spec.is_kusama() ||
-			chain_spec.is_westend() ||
-			chain_spec.is_rococo() ||
-			chain_spec.is_wococo();
-
-		if should_connect_overseer {
-			select_chain.connect_to_overseer(overseer_handle.clone());
-		} else {
-			tracing::info!("Overseer is running in the disconnected state");
+					select! {
+						_ = forward => (),
+						_ = overseer_fut => (),
+						complete => (),
+					}
+				}),
+			);
 		}
 		Some(handle)
 	} else {
@@ -1244,6 +1243,10 @@ pub fn new_chain_ops(
 > {
 	config.keystore = service::config::KeystoreConfig::InMemory;
 
+	// FIXME no overseer is ever constructed here
+	let overseer_connector = OverseerConnector::default();
+	let handle = Handle(overseer_connector.as_handle().clone());
+	let handle = &handle;
 	#[cfg(feature = "rococo-native")]
 	if config.chain_spec.is_rococo() || config.chain_spec.is_wococo() {
 		let service::PartialComponents { client, backend, import_queue, task_manager, .. } =

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -402,7 +402,10 @@ where
 #[cfg(feature = "full-node")]
 fn new_partial<RuntimeApi, ExecutorDispatch, ChainSelection>(
 	config: &mut Configuration,
-	basics: Basics<RuntimeApi, ExecutorDispatch>,
+	Basics { task_manager, backend, client, keystore_container, telemetry }: Basics<
+		RuntimeApi,
+		ExecutorDispatch,
+	>,
 	select_chain: ChainSelection,
 ) -> Result<
 	service::PartialComponents<
@@ -440,8 +443,6 @@ where
 	ExecutorDispatch: NativeExecutionDispatch + 'static,
 	ChainSelection: 'static + SelectChain<Block>,
 {
-	let Basics { task_manager, backend, client, keystore_container, telemetry, .. } = basics;
-
 	let transaction_pool = sc_transaction_pool::BasicPool::new_full(
 		config.transaction_pool.clone(),
 		config.role.is_authority().into(),

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -938,7 +938,7 @@ where
 			)?;
 
 		{
-			let handle = overseer_connector.as_handle().clone();
+			let handle = handle.clone();
 			task_manager.spawn_essential_handle().spawn_blocking(
 				"overseer",
 				Box::pin(async move {

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -54,7 +54,7 @@ use {
 pub use sp_core::traits::SpawnNamed;
 #[cfg(feature = "full-node")]
 pub use {
-	polkadot_overseer::{Handle, Overseer, OverseerHandle},
+	polkadot_overseer::{Handle, Overseer, OverseerConnector, OverseerHandle},
 	polkadot_primitives::v1::ParachainHost,
 	sc_client_api::AuxStore,
 	sp_authority_discovery::AuthorityDiscoveryApi,
@@ -862,6 +862,7 @@ where
 		// already have access to the handle
 		let (overseer, _handle) = overseer_gen
 			.generate::<service::SpawnTaskHandle, FullClient<RuntimeApi, ExecutorDispatch>>(
+				overseer_connector,
 				OverseerGenArgs {
 					leaves: active_leaves,
 					keystore,
@@ -887,7 +888,7 @@ where
 			)?;
 
 		{
-			let handle = handle.clone();
+			let handle = overseer_connector.as_handle().clone();
 			task_manager.spawn_essential_handle().spawn_blocking(
 				"overseer",
 				Box::pin(async move {

--- a/node/service/src/overseer.rs
+++ b/node/service/src/overseer.rs
@@ -15,6 +15,7 @@
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
 use super::{AuthorityDiscoveryApi, Block, Error, Hash, IsCollator, Registry, SpawnNamed};
+use lru::LruCache;
 use polkadot_availability_distribution::IncomingRequestReceivers;
 use polkadot_node_core_approval_voting::Config as ApprovalVotingConfig;
 use polkadot_node_core_av_store::Config as AvailabilityConfig;
@@ -22,7 +23,15 @@ use polkadot_node_core_candidate_validation::Config as CandidateValidationConfig
 use polkadot_node_core_chain_selection::Config as ChainSelectionConfig;
 use polkadot_node_core_dispute_coordinator::Config as DisputeCoordinatorConfig;
 use polkadot_node_network_protocol::request_response::{v1 as request_v1, IncomingRequestReceiver};
-use polkadot_overseer::{AllSubsystems, BlockInfo, Overseer, OverseerConnector, OverseerHandle};
+#[cfg(feature = "malus")]
+pub use polkadot_overseer::{
+	dummy::{dummy_overseer_builder, DummySubsystem},
+	HeadSupportsParachains,
+};
+pub use polkadot_overseer::{
+	BlockInfo, MetricsTrait, Overseer, OverseerBuilder, OverseerConnector, OverseerHandle,
+};
+
 use polkadot_primitives::v1::ParachainHost;
 use sc_authority_discovery::Service as AuthorityDiscoveryService;
 use sc_client_api::AuxStore;
@@ -99,12 +108,11 @@ where
 	pub dispute_coordinator_config: DisputeCoordinatorConfig,
 }
 
-/// Create a default, unaltered set of subsystems.
-///
-/// A convenience for usage with malus, to avoid
-/// repetitive code across multiple behavior strain implementations.
-pub fn create_default_subsystems<'a, Spawner, RuntimeClient>(
+/// Obtain a prepared `OverseerBuilder`, that is initialized
+/// with all default values.
+pub fn prepared_overseer_builder<'a, Spawner, RuntimeClient>(
 	OverseerGenArgs {
+		leaves,
 		keystore,
 		runtime_client,
 		parachains_db,
@@ -124,10 +132,11 @@ pub fn create_default_subsystems<'a, Spawner, RuntimeClient>(
 		candidate_validation_config,
 		chain_selection_config,
 		dispute_coordinator_config,
-		..
 	}: OverseerGenArgs<'a, Spawner, RuntimeClient>,
 ) -> Result<
-	AllSubsystems<
+	OverseerBuilder<
+		Spawner,
+		Arc<RuntimeClient>,
 		CandidateValidationSubsystem,
 		CandidateBackingSubsystem<Spawner>,
 		StatementDistributionSubsystem,
@@ -161,41 +170,45 @@ where
 	Spawner: 'static + SpawnNamed + Clone + Unpin,
 {
 	use polkadot_node_subsystem_util::metrics::Metrics;
+	use std::iter::FromIterator;
 
-	let all_subsystems = AllSubsystems {
-		availability_distribution: AvailabilityDistributionSubsystem::new(
+	let metrics: polkadot_overseer::Metrics =
+		<polkadot_overseer::Metrics as MetricsTrait>::register(registry)?;
+
+	let builder = Overseer::builder()
+		.availability_distribution(AvailabilityDistributionSubsystem::new(
 			keystore.clone(),
 			IncomingRequestReceivers { pov_req_receiver, chunk_req_receiver },
 			Metrics::register(registry)?,
-		),
-		availability_recovery: AvailabilityRecoverySubsystem::with_chunks_only(
+		))
+		.availability_recovery(AvailabilityRecoverySubsystem::with_chunks_only(
 			available_data_req_receiver,
 			Metrics::register(registry)?,
-		),
-		availability_store: AvailabilityStoreSubsystem::new(
+		))
+		.availability_store(AvailabilityStoreSubsystem::new(
 			parachains_db.clone(),
 			availability_config,
 			Metrics::register(registry)?,
-		),
-		bitfield_distribution: BitfieldDistributionSubsystem::new(Metrics::register(registry)?),
-		bitfield_signing: BitfieldSigningSubsystem::new(
+		))
+		.bitfield_distribution(BitfieldDistributionSubsystem::new(Metrics::register(registry)?))
+		.bitfield_signing(BitfieldSigningSubsystem::new(
 			spawner.clone(),
 			keystore.clone(),
 			Metrics::register(registry)?,
-		),
-		candidate_backing: CandidateBackingSubsystem::new(
+		))
+		.candidate_backing(CandidateBackingSubsystem::new(
 			spawner.clone(),
 			keystore.clone(),
 			Metrics::register(registry)?,
-		),
-		candidate_validation: CandidateValidationSubsystem::with_config(
+		))
+		.candidate_validation(CandidateValidationSubsystem::with_config(
 			candidate_validation_config,
 			Metrics::register(registry)?, // candidate-validation metrics
 			Metrics::register(registry)?, // validation host metrics
-		),
-		chain_api: ChainApiSubsystem::new(runtime_client.clone(), Metrics::register(registry)?),
-		collation_generation: CollationGenerationSubsystem::new(Metrics::register(registry)?),
-		collator_protocol: {
+		))
+		.chain_api(ChainApiSubsystem::new(runtime_client.clone(), Metrics::register(registry)?))
+		.collation_generation(CollationGenerationSubsystem::new(Metrics::register(registry)?))
+		.collator_protocol({
 			let side = match is_collator {
 				IsCollator::Yes(collator_pair) => ProtocolSide::Collator(
 					network_service.local_peer_id().clone(),
@@ -210,49 +223,60 @@ where
 				},
 			};
 			CollatorProtocolSubsystem::new(side)
-		},
-		network_bridge: NetworkBridgeSubsystem::new(
+		})
+		.network_bridge(NetworkBridgeSubsystem::new(
 			network_service.clone(),
 			authority_discovery_service.clone(),
 			Box::new(network_service.clone()),
 			Metrics::register(registry)?,
-		),
-		provisioner: ProvisionerSubsystem::new(spawner.clone(), (), Metrics::register(registry)?),
-		runtime_api: RuntimeApiSubsystem::new(
+		))
+		.provisioner(ProvisionerSubsystem::new(spawner.clone(), (), Metrics::register(registry)?))
+		.runtime_api(RuntimeApiSubsystem::new(
 			runtime_client.clone(),
 			Metrics::register(registry)?,
 			spawner.clone(),
-		),
-		statement_distribution: StatementDistributionSubsystem::new(
+		))
+		.statement_distribution(StatementDistributionSubsystem::new(
 			keystore.clone(),
 			statement_req_receiver,
 			Metrics::register(registry)?,
-		),
-		approval_distribution: ApprovalDistributionSubsystem::new(Metrics::register(registry)?),
-		approval_voting: ApprovalVotingSubsystem::with_config(
+		))
+		.approval_distribution(ApprovalDistributionSubsystem::new(Metrics::register(registry)?))
+		.approval_voting(ApprovalVotingSubsystem::with_config(
 			approval_voting_config,
 			parachains_db.clone(),
 			keystore.clone(),
 			Box::new(network_service.clone()),
 			Metrics::register(registry)?,
-		),
-		gossip_support: GossipSupportSubsystem::new(keystore.clone()),
-		dispute_coordinator: DisputeCoordinatorSubsystem::new(
+		))
+		.gossip_support(GossipSupportSubsystem::new(keystore.clone()))
+		.dispute_coordinator(DisputeCoordinatorSubsystem::new(
 			parachains_db.clone(),
 			dispute_coordinator_config,
 			keystore.clone(),
 			Metrics::register(registry)?,
-		),
-		dispute_participation: DisputeParticipationSubsystem::new(),
-		dispute_distribution: DisputeDistributionSubsystem::new(
+		))
+		.dispute_participation(DisputeParticipationSubsystem::new())
+		.dispute_distribution(DisputeDistributionSubsystem::new(
 			keystore.clone(),
 			dispute_req_receiver,
 			authority_discovery_service.clone(),
 			Metrics::register(registry)?,
-		),
-		chain_selection: ChainSelectionSubsystem::new(chain_selection_config, parachains_db),
-	};
-	Ok(all_subsystems)
+		))
+		.chain_selection(ChainSelectionSubsystem::new(chain_selection_config, parachains_db))
+		.leaves(Vec::from_iter(
+			leaves
+				.into_iter()
+				.map(|BlockInfo { hash, parent_hash: _, number }| (hash, number)),
+		))
+		.activation_external_listeners(Default::default())
+		.span_per_active_leaf(Default::default())
+		.active_leaves(Default::default())
+		.supports_parachains(runtime_client)
+		.known_leaves(LruCache::new(KNOWN_LEAVES_CACHE_SIZE))
+		.metrics(metrics)
+		.spawner(spawner);
+	Ok(builder)
 }
 
 /// Trait for the `fn` generating the overseer.
@@ -279,6 +303,8 @@ pub trait OverseerGen {
 	// as consequence make this rather annoying to implement and use.
 }
 
+use polkadot_overseer::KNOWN_LEAVES_CACHE_SIZE;
+
 /// The regular set of subsystems.
 pub struct RealOverseerGen;
 
@@ -293,132 +319,7 @@ impl OverseerGen for RealOverseerGen {
 		RuntimeClient::Api: ParachainHost<Block> + BabeApi<Block> + AuthorityDiscoveryApi<Block>,
 		Spawner: 'static + SpawnNamed + Clone + Unpin,
 	{
-		use polkadot_node_subsystem_util::metrics::Metrics;
-		use std::iter::FromIterator;
-
-		let OverseerGenArgs {
-			leaves,
-			keystore,
-			runtime_client,
-			parachains_db,
-			network_service,
-			authority_discovery_service,
-			pov_req_receiver,
-			chunk_req_receiver,
-			collation_req_receiver,
-			available_data_req_receiver,
-			statement_req_receiver,
-			dispute_req_receiver,
-			registry,
-			spawner,
-			is_collator,
-			approval_voting_config,
-			availability_config,
-			candidate_validation_config,
-			chain_selection_config,
-			dispute_coordinator_config,
-		} = args;
-
-		Overseer::builder()
-			.availability_distribution(AvailabilityDistributionSubsystem::new(
-				keystore.clone(),
-				IncomingRequestReceivers { pov_req_receiver, chunk_req_receiver },
-				Metrics::register(registry)?,
-			))
-			.availability_recovery(AvailabilityRecoverySubsystem::with_chunks_only(
-				available_data_req_receiver,
-				Metrics::register(registry)?,
-			))
-			.availability_store(AvailabilityStoreSubsystem::new(
-				parachains_db.clone(),
-				availability_config,
-				Metrics::register(registry)?,
-			))
-			.bitfield_distribution(BitfieldDistributionSubsystem::new(Metrics::register(registry)?))
-			.bitfield_signing(BitfieldSigningSubsystem::new(
-				spawner.clone(),
-				keystore.clone(),
-				Metrics::register(registry)?,
-			))
-			.candidate_backing(CandidateBackingSubsystem::new(
-				spawner.clone(),
-				keystore.clone(),
-				Metrics::register(registry)?,
-			))
-			.candidate_validation(CandidateValidationSubsystem::with_config(
-				candidate_validation_config,
-				Metrics::register(registry)?, // candidate-validation metrics
-				Metrics::register(registry)?, // validation host metrics
-			))
-			.chain_api(ChainApiSubsystem::new(runtime_client.clone(), Metrics::register(registry)?))
-			.collation_generation(CollationGenerationSubsystem::new(Metrics::register(registry)?))
-			.collator_protocol({
-				let side = match is_collator {
-					IsCollator::Yes(collator_pair) => ProtocolSide::Collator(
-						network_service.local_peer_id().clone(),
-						collator_pair,
-						collation_req_receiver,
-						Metrics::register(registry)?,
-					),
-					IsCollator::No => ProtocolSide::Validator {
-						keystore: keystore.clone(),
-						eviction_policy: Default::default(),
-						metrics: Metrics::register(registry)?,
-					},
-				};
-				CollatorProtocolSubsystem::new(side)
-			})
-			.network_bridge(NetworkBridgeSubsystem::new(
-				network_service.clone(),
-				authority_discovery_service.clone(),
-				Box::new(network_service.clone()),
-				Metrics::register(registry)?,
-			))
-			.provisioner(ProvisionerSubsystem::new(
-				spawner.clone(),
-				(),
-				Metrics::register(registry)?,
-			))
-			.runtime_api(RuntimeApiSubsystem::new(
-				runtime_client.clone(),
-				Metrics::register(registry)?,
-				spawner.clone(),
-			))
-			.statement_distribution(StatementDistributionSubsystem::new(
-				keystore.clone(),
-				statement_req_receiver,
-				Metrics::register(registry)?,
-			))
-			.approval_distribution(ApprovalDistributionSubsystem::new(Metrics::register(registry)?))
-			.approval_voting(ApprovalVotingSubsystem::with_config(
-				approval_voting_config,
-				parachains_db.clone(),
-				keystore.clone(),
-				Box::new(network_service.clone()),
-				Metrics::register(registry)?,
-			))
-			.gossip_support(GossipSupportSubsystem::new(keystore.clone()))
-			.dispute_coordinator(DisputeCoordinatorSubsystem::new(
-				parachains_db.clone(),
-				dispute_coordinator_config,
-				keystore.clone(),
-				Metrics::register(registry)?,
-			))
-			.dispute_participation(DisputeParticipationSubsystem::new())
-			.dispute_distribution(DisputeDistributionSubsystem::new(
-				keystore.clone(),
-				dispute_req_receiver,
-				authority_discovery_service.clone(),
-				Metrics::register(registry)?,
-			))
-			.chain_selection(ChainSelectionSubsystem::new(chain_selection_config, parachains_db))
-			.leaves(Vec::from_iter(
-				leaves
-					.into_iter()
-					.map(|BlockInfo { hash, parent_hash: _, number }| (hash, number)),
-			))
-			.spawner(spawner)
-			.activation_external_listeners(Default::default())
+		prepared_overseer_builder(args)?
 			.build_with_connector(connector)
 			.map_err(|e| e.into())
 	}

--- a/node/service/src/overseer.rs
+++ b/node/service/src/overseer.rs
@@ -23,11 +23,12 @@ use polkadot_node_core_candidate_validation::Config as CandidateValidationConfig
 use polkadot_node_core_chain_selection::Config as ChainSelectionConfig;
 use polkadot_node_core_dispute_coordinator::Config as DisputeCoordinatorConfig;
 use polkadot_node_network_protocol::request_response::{v1 as request_v1, IncomingRequestReceiver};
-#[cfg(feature = "malus")]
-pub use polkadot_overseer::{dummy::DummySubsystem, AllSubsystems, HeadSupportsParachains};
+#[cfg(any(feature = "malus", test))]
+pub use polkadot_overseer::dummy::DummySubsystem;
 pub use polkadot_overseer::{
 	metrics::{Metrics, MetricsTrait},
-	BlockInfo, Overseer, OverseerBuilder, OverseerConnector, OverseerHandle,
+	AllSubsystems, BlockInfo, HeadSupportsParachains, Overseer, OverseerBuilder, OverseerConnector,
+	OverseerHandle,
 };
 
 use polkadot_primitives::v1::ParachainHost;

--- a/node/service/src/overseer.rs
+++ b/node/service/src/overseer.rs
@@ -22,7 +22,7 @@ use polkadot_node_core_candidate_validation::Config as CandidateValidationConfig
 use polkadot_node_core_chain_selection::Config as ChainSelectionConfig;
 use polkadot_node_core_dispute_coordinator::Config as DisputeCoordinatorConfig;
 use polkadot_node_network_protocol::request_response::{v1 as request_v1, IncomingRequestReceiver};
-use polkadot_overseer::{AllSubsystems, BlockInfo, Overseer, OverseerHandle};
+use polkadot_overseer::{AllSubsystems, BlockInfo, Overseer, OverseerConnector, OverseerHandle};
 use polkadot_primitives::v1::ParachainHost;
 use sc_authority_discovery::Service as AuthorityDiscoveryService;
 use sc_client_api::AuxStore;
@@ -263,6 +263,7 @@ pub trait OverseerGen {
 	/// Overwrite the full generation of the overseer, including the subsystems.
 	fn generate<'a, Spawner, RuntimeClient>(
 		&self,
+		connector: OverseerConnector,
 		args: OverseerGenArgs<'a, Spawner, RuntimeClient>,
 	) -> Result<(Overseer<Spawner, Arc<RuntimeClient>>, OverseerHandle), Error>
 	where
@@ -271,7 +272,7 @@ pub trait OverseerGen {
 		Spawner: 'static + SpawnNamed + Clone + Unpin,
 	{
 		let gen = RealOverseerGen;
-		RealOverseerGen::generate::<Spawner, RuntimeClient>(&gen, args)
+		RealOverseerGen::generate::<Spawner, RuntimeClient>(&gen, connector, args)
 	}
 	// It would be nice to make `create_subsystems` part of this trait,
 	// but the amount of generic arguments that would be required as
@@ -284,6 +285,7 @@ pub struct RealOverseerGen;
 impl OverseerGen for RealOverseerGen {
 	fn generate<'a, Spawner, RuntimeClient>(
 		&self,
+		connector: OverseerConnector,
 		args: OverseerGenArgs<'a, Spawner, RuntimeClient>,
 	) -> Result<(Overseer<Spawner, Arc<RuntimeClient>>, OverseerHandle), Error>
 	where
@@ -291,14 +293,131 @@ impl OverseerGen for RealOverseerGen {
 		RuntimeClient::Api: ParachainHost<Block> + BabeApi<Block> + AuthorityDiscoveryApi<Block>,
 		Spawner: 'static + SpawnNamed + Clone + Unpin,
 	{
-		let spawner = args.spawner.clone();
-		let leaves = args.leaves.clone();
-		let runtime_client = args.runtime_client.clone();
-		let registry = args.registry.clone();
+		use polkadot_node_subsystem_util::metrics::Metrics;
+		use std::iter::FromIterator;
 
-		let all_subsystems = create_default_subsystems::<Spawner, RuntimeClient>(args)?;
+		let OverseerGenArgs {
+			leaves,
+			keystore,
+			runtime_client,
+			parachains_db,
+			network_service,
+			authority_discovery_service,
+			pov_req_receiver,
+			chunk_req_receiver,
+			collation_req_receiver,
+			available_data_req_receiver,
+			statement_req_receiver,
+			dispute_req_receiver,
+			registry,
+			spawner,
+			is_collator,
+			approval_voting_config,
+			availability_config,
+			candidate_validation_config,
+			chain_selection_config,
+			dispute_coordinator_config,
+		} = args;
 
-		Overseer::new(leaves, all_subsystems, registry, runtime_client, spawner)
+		Overseer::builder()
+			.availability_distribution(AvailabilityDistributionSubsystem::new(
+				keystore.clone(),
+				IncomingRequestReceivers { pov_req_receiver, chunk_req_receiver },
+				Metrics::register(registry)?,
+			))
+			.availability_recovery(AvailabilityRecoverySubsystem::with_chunks_only(
+				available_data_req_receiver,
+				Metrics::register(registry)?,
+			))
+			.availability_store(AvailabilityStoreSubsystem::new(
+				parachains_db.clone(),
+				availability_config,
+				Metrics::register(registry)?,
+			))
+			.bitfield_distribution(BitfieldDistributionSubsystem::new(Metrics::register(registry)?))
+			.bitfield_signing(BitfieldSigningSubsystem::new(
+				spawner.clone(),
+				keystore.clone(),
+				Metrics::register(registry)?,
+			))
+			.candidate_backing(CandidateBackingSubsystem::new(
+				spawner.clone(),
+				keystore.clone(),
+				Metrics::register(registry)?,
+			))
+			.candidate_validation(CandidateValidationSubsystem::with_config(
+				candidate_validation_config,
+				Metrics::register(registry)?, // candidate-validation metrics
+				Metrics::register(registry)?, // validation host metrics
+			))
+			.chain_api(ChainApiSubsystem::new(runtime_client.clone(), Metrics::register(registry)?))
+			.collation_generation(CollationGenerationSubsystem::new(Metrics::register(registry)?))
+			.collator_protocol({
+				let side = match is_collator {
+					IsCollator::Yes(collator_pair) => ProtocolSide::Collator(
+						network_service.local_peer_id().clone(),
+						collator_pair,
+						collation_req_receiver,
+						Metrics::register(registry)?,
+					),
+					IsCollator::No => ProtocolSide::Validator {
+						keystore: keystore.clone(),
+						eviction_policy: Default::default(),
+						metrics: Metrics::register(registry)?,
+					},
+				};
+				CollatorProtocolSubsystem::new(side)
+			})
+			.network_bridge(NetworkBridgeSubsystem::new(
+				network_service.clone(),
+				authority_discovery_service.clone(),
+				Box::new(network_service.clone()),
+				Metrics::register(registry)?,
+			))
+			.provisioner(ProvisionerSubsystem::new(
+				spawner.clone(),
+				(),
+				Metrics::register(registry)?,
+			))
+			.runtime_api(RuntimeApiSubsystem::new(
+				runtime_client.clone(),
+				Metrics::register(registry)?,
+				spawner.clone(),
+			))
+			.statement_distribution(StatementDistributionSubsystem::new(
+				keystore.clone(),
+				statement_req_receiver,
+				Metrics::register(registry)?,
+			))
+			.approval_distribution(ApprovalDistributionSubsystem::new(Metrics::register(registry)?))
+			.approval_voting(ApprovalVotingSubsystem::with_config(
+				approval_voting_config,
+				parachains_db.clone(),
+				keystore.clone(),
+				Box::new(network_service.clone()),
+				Metrics::register(registry)?,
+			))
+			.gossip_support(GossipSupportSubsystem::new(keystore.clone()))
+			.dispute_coordinator(DisputeCoordinatorSubsystem::new(
+				parachains_db.clone(),
+				dispute_coordinator_config,
+				keystore.clone(),
+			))
+			.dispute_participation(DisputeParticipationSubsystem::new())
+			.dispute_distribution(DisputeDistributionSubsystem::new(
+				keystore.clone(),
+				dispute_req_receiver,
+				authority_discovery_service.clone(),
+				Metrics::register(registry)?,
+			))
+			.chain_selection(ChainSelectionSubsystem::new(chain_selection_config, parachains_db))
+			.leaves(Vec::from_iter(
+				leaves
+					.into_iter()
+					.map(|BlockInfo { hash, parent_hash: _, number }| (hash, number)),
+			))
+			.spawner(spawner)
+			.build_with_connector(connector)
 			.map_err(|e| e.into())
 	}
 }

--- a/node/service/src/overseer.rs
+++ b/node/service/src/overseer.rs
@@ -24,12 +24,10 @@ use polkadot_node_core_chain_selection::Config as ChainSelectionConfig;
 use polkadot_node_core_dispute_coordinator::Config as DisputeCoordinatorConfig;
 use polkadot_node_network_protocol::request_response::{v1 as request_v1, IncomingRequestReceiver};
 #[cfg(feature = "malus")]
+pub use polkadot_overseer::{dummy::DummySubsystem, AllSubsystems, HeadSupportsParachains};
 pub use polkadot_overseer::{
-	dummy::{dummy_overseer_builder, DummySubsystem},
-	HeadSupportsParachains,
-};
-pub use polkadot_overseer::{
-	BlockInfo, MetricsTrait, Overseer, OverseerBuilder, OverseerConnector, OverseerHandle,
+	metrics::{Metrics, MetricsTrait},
+	BlockInfo, Overseer, OverseerBuilder, OverseerConnector, OverseerHandle,
 };
 
 use polkadot_primitives::v1::ParachainHost;
@@ -328,8 +326,7 @@ where
 	use polkadot_node_subsystem_util::metrics::Metrics;
 	use std::iter::FromIterator;
 
-	let metrics: polkadot_overseer::Metrics =
-		<polkadot_overseer::Metrics as MetricsTrait>::register(registry)?;
+	let metrics = <polkadot_overseer::metrics::Metrics as MetricsTrait>::register(registry)?;
 
 	let builder = Overseer::builder()
 		.availability_distribution(AvailabilityDistributionSubsystem::new(

--- a/node/service/src/overseer.rs
+++ b/node/service/src/overseer.rs
@@ -418,6 +418,7 @@ impl OverseerGen for RealOverseerGen {
 					.map(|BlockInfo { hash, parent_hash: _, number }| (hash, number)),
 			))
 			.spawner(spawner)
+			.activation_external_listeners(Default::default())
 			.build_with_connector(connector)
 			.map_err(|e| e.into())
 	}

--- a/node/service/src/overseer.rs
+++ b/node/service/src/overseer.rs
@@ -402,6 +402,7 @@ impl OverseerGen for RealOverseerGen {
 				parachains_db.clone(),
 				dispute_coordinator_config,
 				keystore.clone(),
+				Metrics::register(registry)?,
 			))
 			.dispute_participation(DisputeParticipationSubsystem::new())
 			.dispute_distribution(DisputeDistributionSubsystem::new(

--- a/node/service/src/relay_chain_selection.rs
+++ b/node/service/src/relay_chain_selection.rs
@@ -172,7 +172,7 @@ where
 		let longest_chain_best =
 			self.longest_chain.finality_target(target_hash, maybe_max_number).await?;
 
-		if self.is_relay_chain {
+		if !self.is_relay_chain {
 			return Ok(longest_chain_best)
 		}
 		self.selection

--- a/node/service/src/relay_chain_selection.rs
+++ b/node/service/src/relay_chain_selection.rs
@@ -39,7 +39,7 @@ use super::{HeaderProvider, HeaderProviderProvider};
 use consensus_common::{Error as ConsensusError, SelectChain};
 use futures::channel::oneshot;
 use polkadot_node_subsystem_util::metrics::{self, prometheus};
-use polkadot_overseer::{AllMessages, Handle, OverseerHandle};
+use polkadot_overseer::{AllMessages, Handle};
 use polkadot_primitives::v1::{
 	Block as PolkadotBlock, BlockNumber, Hash, Header as PolkadotHeader,
 };
@@ -109,66 +109,57 @@ impl Metrics {
 }
 
 /// A chain-selection implementation which provides safety for relay chains.
-pub struct SelectRelayChainWithFallback<B: sc_client_api::Backend<PolkadotBlock>> {
-	// A fallback to use in case the overseer is disconnected.
-	//
-	// This is used on relay chains which have not yet enabled
-	// parachains as well as situations where the node is offline.
-	fallback: sc_consensus::LongestChain<B, PolkadotBlock>,
-	selection: SelectRelayChain<B, Handle>,
+pub struct SelectRelayChain<B: sc_client_api::Backend<PolkadotBlock>> {
+	is_relay_chain: bool,
+	longest_chain: sc_consensus::LongestChain<B, PolkadotBlock>,
+	selection: SelectRelayChainInner<B, Handle>,
 }
 
-impl<B> Clone for SelectRelayChainWithFallback<B>
+impl<B> Clone for SelectRelayChain<B>
 where
 	B: sc_client_api::Backend<PolkadotBlock>,
-	SelectRelayChain<B, Handle>: Clone,
+	SelectRelayChainInner<B, Handle>: Clone,
 {
 	fn clone(&self) -> Self {
-		Self { fallback: self.fallback.clone(), selection: self.selection.clone() }
-	}
-}
-
-impl<B> SelectRelayChainWithFallback<B>
-where
-	B: sc_client_api::Backend<PolkadotBlock> + 'static,
-{
-	/// Create a new [`SelectRelayChainWithFallback`] wrapping the given chain backend
-	/// and a handle to the overseer.
-	pub fn new(backend: Arc<B>, overseer: Handle, metrics: Metrics) -> Self {
-		SelectRelayChainWithFallback {
-			fallback: sc_consensus::LongestChain::new(backend.clone()),
-			selection: SelectRelayChain::new(backend, overseer, metrics),
+		Self {
+			is_relay_chain: self.is_relay_chain,
+			longest_chain: self.longest_chain.clone(),
+			selection: self.selection.clone(),
 		}
 	}
 }
 
-impl<B> SelectRelayChainWithFallback<B>
+impl<B> SelectRelayChain<B>
 where
 	B: sc_client_api::Backend<PolkadotBlock> + 'static,
 {
-	/// Given an overseer handle, this connects the [`SelectRelayChainWithFallback`]'s
-	/// internal handle and its clones to the same overseer.
-	pub fn connect_to_overseer(&mut self, handle: OverseerHandle) {
-		self.selection.overseer.connect_to_overseer(handle);
+	/// Create a new [`SelectRelayChain`] wrapping the given chain backend
+	/// and a handle to the overseer.
+	pub fn new(backend: Arc<B>, is_relay_chain: bool, overseer: Handle, metrics: Metrics) -> Self {
+		SelectRelayChain {
+			is_relay_chain,
+			longest_chain: sc_consensus::LongestChain::new(backend.clone()),
+			selection: SelectRelayChainInner::new(backend, overseer, metrics),
+		}
 	}
 }
 
 #[async_trait::async_trait]
-impl<B> SelectChain<PolkadotBlock> for SelectRelayChainWithFallback<B>
+impl<B> SelectChain<PolkadotBlock> for SelectRelayChain<B>
 where
 	B: sc_client_api::Backend<PolkadotBlock> + 'static,
 {
 	async fn leaves(&self) -> Result<Vec<Hash>, ConsensusError> {
-		if self.selection.overseer.is_disconnected() {
-			return self.fallback.leaves().await
+		if !self.is_relay_chain {
+			return self.longest_chain.leaves().await
 		}
 
 		self.selection.leaves().await
 	}
 
 	async fn best_chain(&self) -> Result<PolkadotHeader, ConsensusError> {
-		if self.selection.overseer.is_disconnected() {
-			return self.fallback.best_chain().await
+		if !self.is_relay_chain {
+			return self.longest_chain.best_chain().await
 		}
 		self.selection.best_chain().await
 	}
@@ -179,34 +170,34 @@ where
 		maybe_max_number: Option<BlockNumber>,
 	) -> Result<Option<Hash>, ConsensusError> {
 		let longest_chain_best =
-			self.fallback.finality_target(target_hash, maybe_max_number).await?;
+			self.longest_chain.finality_target(target_hash, maybe_max_number).await?;
 
-		if self.selection.overseer.is_disconnected() {
+		if self.is_relay_chain {
 			return Ok(longest_chain_best)
 		}
 		self.selection
-			.finality_target_with_fallback(target_hash, longest_chain_best, maybe_max_number)
+			.finality_target_with_longest_chain(target_hash, longest_chain_best, maybe_max_number)
 			.await
 	}
 }
 
 /// A chain-selection implementation which provides safety for relay chains
 /// but does not handle situations where the overseer is not yet connected.
-pub struct SelectRelayChain<B, OH> {
+pub struct SelectRelayChainInner<B, OH> {
 	backend: Arc<B>,
 	overseer: OH,
 	metrics: Metrics,
 }
 
-impl<B, OH> SelectRelayChain<B, OH>
+impl<B, OH> SelectRelayChainInner<B, OH>
 where
 	B: HeaderProviderProvider<PolkadotBlock>,
 	OH: OverseerHandleT,
 {
-	/// Create a new [`SelectRelayChain`] wrapping the given chain backend
+	/// Create a new [`SelectRelayChainInner`] wrapping the given chain backend
 	/// and a handle to the overseer.
 	pub fn new(backend: Arc<B>, overseer: OH, metrics: Metrics) -> Self {
-		SelectRelayChain { backend, overseer, metrics }
+		SelectRelayChainInner { backend, overseer, metrics }
 	}
 
 	fn block_header(&self, hash: Hash) -> Result<PolkadotHeader, ConsensusError> {
@@ -234,13 +225,13 @@ where
 	}
 }
 
-impl<B, OH> Clone for SelectRelayChain<B, OH>
+impl<B, OH> Clone for SelectRelayChainInner<B, OH>
 where
 	B: HeaderProviderProvider<PolkadotBlock> + Send + Sync,
 	OH: OverseerHandleT,
 {
 	fn clone(&self) -> Self {
-		SelectRelayChain {
+		SelectRelayChainInner {
 			backend: self.backend.clone(),
 			overseer: self.overseer.clone(),
 			metrics: self.metrics.clone(),
@@ -273,7 +264,7 @@ impl OverseerHandleT for Handle {
 	}
 }
 
-impl<B, OH> SelectRelayChain<B, OH>
+impl<B, OH> SelectRelayChainInner<B, OH>
 where
 	B: HeaderProviderProvider<PolkadotBlock>,
 	OH: OverseerHandleT,
@@ -317,7 +308,7 @@ where
 	///
 	/// It will also constrain the chain to only chains which are fully
 	/// approved, and chains which contain no disputes.
-	pub(crate) async fn finality_target_with_fallback(
+	pub(crate) async fn finality_target_with_longest_chain(
 		&self,
 		target_hash: Hash,
 		best_leaf: Option<Hash>,

--- a/node/service/src/tests.rs
+++ b/node/service/src/tests.rs
@@ -79,7 +79,7 @@ fn test_harness<T: Future<Output = VirtualOverseer>>(
 
 	let (finality_target_tx, finality_target_rx) = oneshot::channel::<Option<Hash>>();
 
-	let select_relay_chain = SelectRelayChain::<TestChainStorage, TestSubsystemSender>::new(
+	let select_relay_chain = SelectRelayChainInner::<TestChainStorage, TestSubsystemSender>::new(
 		Arc::new(case_vars.chain.clone()),
 		context.sender().clone(),
 		Default::default(),

--- a/node/subsystem-test-helpers/src/lib.rs
+++ b/node/subsystem-test-helpers/src/lib.rs
@@ -19,8 +19,8 @@
 #![warn(missing_docs)]
 
 use polkadot_node_subsystem::{
-	messages::AllMessages, overseer, FromOverseer, OverseerConnector, OverseerSignal,
-	SpawnedSubsystem, SubsystemContext, SubsystemError, SubsystemResult,
+	messages::AllMessages, overseer, FromOverseer, OverseerSignal, SpawnedSubsystem,
+	SubsystemContext, SubsystemError, SubsystemResult,
 };
 use polkadot_node_subsystem_util::TimeoutExt;
 
@@ -372,7 +372,9 @@ mod tests {
 	use super::*;
 	use futures::executor::block_on;
 	use polkadot_node_subsystem::messages::CollatorProtocolMessage;
-	use polkadot_overseer::{AllSubsystems, Handle, HeadSupportsParachains, Overseer};
+	use polkadot_overseer::{
+		AllSubsystems, Handle, HeadSupportsParachains, Overseer, OverseerConnector,
+	};
 	use polkadot_primitives::v1::Hash;
 
 	struct AlwaysSupportsParachains;

--- a/node/subsystem-test-helpers/src/lib.rs
+++ b/node/subsystem-test-helpers/src/lib.rs
@@ -19,8 +19,8 @@
 #![warn(missing_docs)]
 
 use polkadot_node_subsystem::{
-	messages::AllMessages, overseer, FromOverseer, OverseerSignal, SpawnedSubsystem,
-	SubsystemContext, SubsystemError, SubsystemResult,
+	messages::AllMessages, overseer, FromOverseer, OverseerConnector, OverseerSignal,
+	SpawnedSubsystem, SubsystemContext, SubsystemError, SubsystemResult,
 };
 use polkadot_node_subsystem_util::TimeoutExt;
 
@@ -394,6 +394,7 @@ mod tests {
 			None,
 			AlwaysSupportsParachains,
 			spawner.clone(),
+			OverseerConnector::default(),
 		)
 		.unwrap();
 		let mut handle = Handle(handle);

--- a/node/subsystem-test-helpers/src/lib.rs
+++ b/node/subsystem-test-helpers/src/lib.rs
@@ -396,7 +396,7 @@ mod tests {
 			spawner.clone(),
 		)
 		.unwrap();
-		let mut handle = Handle::Connected(handle);
+		let mut handle = Handle(handle);
 
 		spawner.spawn("overseer", overseer.run().then(|_| async { () }).boxed());
 

--- a/node/subsystem/src/lib.rs
+++ b/node/subsystem/src/lib.rs
@@ -24,7 +24,9 @@
 pub use jaeger::*;
 pub use polkadot_node_jaeger as jaeger;
 
-pub use polkadot_overseer::{self as overseer, ActiveLeavesUpdate, DummySubsystem, OverseerSignal, OverseerConnector};
+pub use polkadot_overseer::{
+	self as overseer, ActiveLeavesUpdate, DummySubsystem, OverseerConnector, OverseerSignal,
+};
 
 pub use polkadot_node_subsystem_types::{
 	errors::{self, *},

--- a/node/subsystem/src/lib.rs
+++ b/node/subsystem/src/lib.rs
@@ -24,7 +24,7 @@
 pub use jaeger::*;
 pub use polkadot_node_jaeger as jaeger;
 
-pub use polkadot_overseer::{self as overseer, ActiveLeavesUpdate, DummySubsystem, OverseerSignal};
+pub use polkadot_overseer::{self as overseer, ActiveLeavesUpdate, DummySubsystem, OverseerSignal, OverseerConnector};
 
 pub use polkadot_node_subsystem_types::{
 	errors::{self, *},

--- a/node/subsystem/src/lib.rs
+++ b/node/subsystem/src/lib.rs
@@ -25,7 +25,7 @@ pub use jaeger::*;
 pub use polkadot_node_jaeger as jaeger;
 
 pub use polkadot_overseer::{
-	self as overseer, ActiveLeavesUpdate, DummySubsystem, OverseerConnector, OverseerSignal,
+	self as overseer, dummy::DummySubsystem, ActiveLeavesUpdate, OverseerConnector, OverseerSignal,
 };
 
 pub use polkadot_node_subsystem_types::{


### PR DESCRIPTION
Reduces #3803 to the essential change-set to simplify review

Closes https://github.com/paritytech/polkadot/issues/3777

Renames:

* `RelayChainSelectionWithFallback` -> `RelayChainSelection`
* `RelayChainSelection` -> `RelayChainSelectionInner`

Adds:

* `OverseerConnector` usage
* `Basics`

Removes:

* `Overseer` `Connected`/`Disconnected` state handling and uses a `bool` `is_relay_chain` instead