### PR TITLE
ci: cache seed in fuzzer job

### DIFF
--- a/.github/workflows/honggfuzz.yml
+++ b/.github/workflows/honggfuzz.yml
@@ -14,7 +14,7 @@ jobs:
           fetch-depth: 1
 
       - name: Cache Seed
-        id: cache-seed
+        id: cache-seed-round-trip
         uses: actions/cache@v2
         with:
           path: erasure-coding/fuzzer/hfuzz_workspace
@@ -60,7 +60,7 @@ jobs:
           fetch-depth: 1
 
       - name: Cache Seed
-        id: cache-seed
+        id: cache-seed-reconstruct
         uses: actions/cache@v2
         with:
           path: erasure-coding/fuzzer/hfuzz_workspace

--- a/.github/workflows/honggfuzz.yml
+++ b/.github/workflows/honggfuzz.yml
@@ -13,6 +13,13 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Cache Seed
+        id: cache-seed
+        uses: actions/cache@v2
+        with:
+          path: erasure-coding/fuzzer/hfuzz_workspace
+          key: ${{ runner.os }}-erasure-coding
+
       - name: Install minimal stable Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -51,6 +58,13 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 1
+
+      - name: Cache Seed
+        id: cache-seed
+        uses: actions/cache@v2
+        with:
+          path: erasure-coding/fuzzer/hfuzz_workspace
+          key: ${{ runner.os }}-erasure-coding
 
       - name: Install minimal stable Rust
         uses: actions-rs/toolchain@v1


### PR DESCRIPTION
Addresses https://github.com/paritytech/ci_cd/issues/206.

We could add seed minimization before caching it, but it's not currently exposed by `cargo hfuzz`: https://github.com/rust-fuzz/honggfuzz-rs/issues/26.