### PR TITLE
Re-enable metadata compare CI check

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -113,13 +113,13 @@ default:
       file:                        false
     GITHUB_TOKEN:
       vault:                       cicd/gitlab/$CI_PROJECT_PATH/GITHUB_TOKEN@kv
-      file:                        false    
+      file:                        false
     MATRIX_ACCESS_TOKEN:
       vault:                       cicd/gitlab/$CI_PROJECT_PATH/MATRIX_ACCESS_TOKEN@kv
       file:                        false
     MATRIX_ROOM_ID:
       vault:                       cicd/gitlab/$CI_PROJECT_PATH/MATRIX_ROOM_ID@kv
-      file:                        false   
+      file:                        false
     PARITYPR_USER:
       vault:                       cicd/gitlab/$CI_PROJECT_PATH/PARITYPR_USER@kv
       file:                        false
@@ -268,6 +268,22 @@ build-adder-collator:
     - cp -r scripts/docker/* ./artifacts
 
 #### stage:                        build
+
+check-transaction-versions:
+  image:                           node:15
+  stage:                           build
+  <<:                              *rules-test
+  <<:                              *docker-env
+  <<:                              *vault-secrets
+  needs:
+    - job:                         test-build-linux-stable
+      artifacts:                   true
+  before_script:
+    - apt-get -y update; apt-get -y install jq lsof
+    - npm install --ignore-scripts -g @polkadot/metadata-cmp
+    - git fetch origin release
+  script:
+    - scripts/gitlab/check_extrinsics_ordering.sh
 
 generate-impl-guide:
   stage:                           build


### PR DESCRIPTION
Adds removed CI check in https://github.com/paritytech/polkadot/pull/3336/commits/f512c860b1fcd906575f13479177c95c0b0cfb29

Possible after https://github.com/polkadot-js/tools/releases/tag/v0.46.1

Closes https://github.com/paritytech/polkadot/issues/3854