### PR TITLE
update BaseXcmWeight to match Kusama

### DIFF
--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -625,7 +625,7 @@ type LocalOriginConverter = (
 );
 
 parameter_types! {
-	pub const BaseXcmWeight: Weight = 100_000;
+	pub const BaseXcmWeight: Weight = 1_000_000_000;
 }
 
 /// The XCM router. When we want to send an XCM message, we use this type. It amalgamates all of our

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -952,7 +952,7 @@ type LocalOriginConverter = (
 );
 
 parameter_types! {
-	pub const BaseXcmWeight: Weight = 10_000_000;
+	pub const BaseXcmWeight: Weight = 1_000_000_000;
 }
 
 /// The XCM router. When we want to send an XCM message, we use this type. It amalgamates all of our


### PR DESCRIPTION
Why they are different? This makes testing impossible because testing environment is not same as production environment (Kusama).

Code works on Westend / Rococo means nothing if it is going to work on Kusama.

There are no way to access those value from parachain runtime so we need to hardcode the number and this just makes everything harder for parachains with zero benefits.