### PR TITLE
Ensure all parachain configuration extrinsics are operational

### DIFF
--- a/runtime/parachains/src/configuration.rs
+++ b/runtime/parachains/src/configuration.rs
@@ -333,7 +333,10 @@ pub mod pallet {
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
 		/// Set the validation upgrade frequency.
-		#[pallet::weight(T::WeightInfo::set_config_with_block_number())]
+		#[pallet::weight((
+			T::WeightInfo::set_config_with_block_number(),
+			DispatchClass::Operational,
+		))]
 		pub fn set_validation_upgrade_frequency(
 			origin: OriginFor<T>,
 			new: T::BlockNumber,
@@ -346,7 +349,10 @@ pub mod pallet {
 		}
 
 		/// Set the validation upgrade delay.
-		#[pallet::weight(T::WeightInfo::set_config_with_block_number())]
+		#[pallet::weight((
+			T::WeightInfo::set_config_with_block_number(),
+			DispatchClass::Operational,
+		))]
 		pub fn set_validation_upgrade_delay(
 			origin: OriginFor<T>,
 			new: T::BlockNumber,
@@ -359,7 +365,10 @@ pub mod pallet {
 		}
 
 		/// Set the acceptance period for an included candidate.
-		#[pallet::weight(T::WeightInfo::set_config_with_block_number())]
+		#[pallet::weight((
+			T::WeightInfo::set_config_with_block_number(),
+			DispatchClass::Operational,
+		))]
 		pub fn set_code_retention_period(
 			origin: OriginFor<T>,
 			new: T::BlockNumber,
@@ -372,7 +381,10 @@ pub mod pallet {
 		}
 
 		/// Set the max validation code size for incoming upgrades.
-		#[pallet::weight(T::WeightInfo::set_config_with_u32())]
+		#[pallet::weight((
+			T::WeightInfo::set_config_with_u32(),
+			DispatchClass::Operational,
+		))]
 		pub fn set_max_code_size(origin: OriginFor<T>, new: u32) -> DispatchResult {
 			ensure_root(origin)?;
 			ensure!(new <= MAX_CODE_SIZE, Error::<T>::InvalidNewValue);
@@ -383,7 +395,10 @@ pub mod pallet {
 		}
 
 		/// Set the max POV block size for incoming upgrades.
-		#[pallet::weight(T::WeightInfo::set_config_with_u32())]
+		#[pallet::weight((
+			T::WeightInfo::set_config_with_u32(),
+			DispatchClass::Operational,
+		))]
 		pub fn set_max_pov_size(origin: OriginFor<T>, new: u32) -> DispatchResult {
 			ensure_root(origin)?;
 			ensure!(new <= MAX_POV_SIZE, Error::<T>::InvalidNewValue);
@@ -394,7 +409,10 @@ pub mod pallet {
 		}
 
 		/// Set the max head data size for paras.
-		#[pallet::weight(T::WeightInfo::set_config_with_u32())]
+		#[pallet::weight((
+			T::WeightInfo::set_config_with_u32(),
+			DispatchClass::Operational,
+		))]
 		pub fn set_max_head_data_size(origin: OriginFor<T>, new: u32) -> DispatchResult {
 			ensure_root(origin)?;
 			ensure!(new <= MAX_HEAD_DATA_SIZE, Error::<T>::InvalidNewValue);
@@ -405,7 +423,10 @@ pub mod pallet {
 		}
 
 		/// Set the number of parathread execution cores.
-		#[pallet::weight(T::WeightInfo::set_config_with_u32())]
+		#[pallet::weight((
+			T::WeightInfo::set_config_with_u32(),
+			DispatchClass::Operational,
+		))]
 		pub fn set_parathread_cores(origin: OriginFor<T>, new: u32) -> DispatchResult {
 			ensure_root(origin)?;
 			Self::update_config_member(|config| {
@@ -415,7 +436,10 @@ pub mod pallet {
 		}
 
 		/// Set the number of retries for a particular parathread.
-		#[pallet::weight(T::WeightInfo::set_config_with_u32())]
+		#[pallet::weight((
+			T::WeightInfo::set_config_with_u32(),
+			DispatchClass::Operational,
+		))]
 		pub fn set_parathread_retries(origin: OriginFor<T>, new: u32) -> DispatchResult {
 			ensure_root(origin)?;
 			Self::update_config_member(|config| {
@@ -425,7 +449,10 @@ pub mod pallet {
 		}
 
 		/// Set the parachain validator-group rotation frequency
-		#[pallet::weight(T::WeightInfo::set_config_with_block_number())]
+		#[pallet::weight((
+			T::WeightInfo::set_config_with_block_number(),
+			DispatchClass::Operational,
+		))]
 		pub fn set_group_rotation_frequency(
 			origin: OriginFor<T>,
 			new: T::BlockNumber,
@@ -441,7 +468,10 @@ pub mod pallet {
 		}
 
 		/// Set the availability period for parachains.
-		#[pallet::weight(T::WeightInfo::set_config_with_block_number())]
+		#[pallet::weight((
+			T::WeightInfo::set_config_with_block_number(),
+			DispatchClass::Operational,
+		))]
 		pub fn set_chain_availability_period(
 			origin: OriginFor<T>,
 			new: T::BlockNumber,
@@ -457,7 +487,10 @@ pub mod pallet {
 		}
 
 		/// Set the availability period for parathreads.
-		#[pallet::weight(T::WeightInfo::set_config_with_block_number())]
+		#[pallet::weight((
+			T::WeightInfo::set_config_with_block_number(),
+			DispatchClass::Operational,
+		))]
 		pub fn set_thread_availability_period(
 			origin: OriginFor<T>,
 			new: T::BlockNumber,
@@ -473,7 +506,10 @@ pub mod pallet {
 		}
 
 		/// Set the scheduling lookahead, in expected number of blocks at peak throughput.
-		#[pallet::weight(T::WeightInfo::set_config_with_u32())]
+		#[pallet::weight((
+			T::WeightInfo::set_config_with_u32(),
+			DispatchClass::Operational,
+		))]
 		pub fn set_scheduling_lookahead(origin: OriginFor<T>, new: u32) -> DispatchResult {
 			ensure_root(origin)?;
 			Self::update_config_member(|config| {
@@ -483,7 +519,10 @@ pub mod pallet {
 		}
 
 		/// Set the maximum number of validators to assign to any core.
-		#[pallet::weight(T::WeightInfo::set_config_with_option_u32())]
+		#[pallet::weight((
+			T::WeightInfo::set_config_with_option_u32(),
+			DispatchClass::Operational,
+		))]
 		pub fn set_max_validators_per_core(
 			origin: OriginFor<T>,
 			new: Option<u32>,
@@ -496,7 +535,10 @@ pub mod pallet {
 		}
 
 		/// Set the maximum number of validators to use in parachain consensus.
-		#[pallet::weight(T::WeightInfo::set_config_with_option_u32())]
+		#[pallet::weight((
+			T::WeightInfo::set_config_with_option_u32(),
+			DispatchClass::Operational,
+		))]
 		pub fn set_max_validators(origin: OriginFor<T>, new: Option<u32>) -> DispatchResult {
 			ensure_root(origin)?;
 			Self::update_config_member(|config| {
@@ -506,7 +548,10 @@ pub mod pallet {
 		}
 
 		/// Set the dispute period, in number of sessions to keep for disputes.
-		#[pallet::weight(T::WeightInfo::set_config_with_u32())]
+		#[pallet::weight((
+			T::WeightInfo::set_config_with_u32(),
+			DispatchClass::Operational,
+		))]
 		pub fn set_dispute_period(origin: OriginFor<T>, new: SessionIndex) -> DispatchResult {
 			ensure_root(origin)?;
 			Self::update_config_member(|config| {
@@ -516,7 +561,10 @@ pub mod pallet {
 		}
 
 		/// Set the dispute post conclusion acceptance period.
-		#[pallet::weight(T::WeightInfo::set_config_with_block_number())]
+		#[pallet::weight((
+			T::WeightInfo::set_config_with_block_number(),
+			DispatchClass::Operational,
+		))]
 		pub fn set_dispute_post_conclusion_acceptance_period(
 			origin: OriginFor<T>,
 			new: T::BlockNumber,
@@ -530,7 +578,10 @@ pub mod pallet {
 		}
 
 		/// Set the maximum number of dispute spam slots.
-		#[pallet::weight(T::WeightInfo::set_config_with_u32())]
+		#[pallet::weight((
+			T::WeightInfo::set_config_with_u32(),
+			DispatchClass::Operational,
+		))]
 		pub fn set_dispute_max_spam_slots(origin: OriginFor<T>, new: u32) -> DispatchResult {
 			ensure_root(origin)?;
 			Self::update_config_member(|config| {
@@ -540,7 +591,10 @@ pub mod pallet {
 		}
 
 		/// Set the dispute conclusion by time out period.
-		#[pallet::weight(T::WeightInfo::set_config_with_block_number())]
+		#[pallet::weight((
+			T::WeightInfo::set_config_with_block_number(),
+			DispatchClass::Operational,
+		))]
 		pub fn set_dispute_conclusion_by_time_out_period(
 			origin: OriginFor<T>,
 			new: T::BlockNumber,
@@ -554,7 +608,10 @@ pub mod pallet {
 
 		/// Set the no show slots, in number of number of consensus slots.
 		/// Must be at least 1.
-		#[pallet::weight(T::WeightInfo::set_config_with_u32())]
+		#[pallet::weight((
+			T::WeightInfo::set_config_with_u32(),
+			DispatchClass::Operational,
+		))]
 		pub fn set_no_show_slots(origin: OriginFor<T>, new: u32) -> DispatchResult {
 			ensure_root(origin)?;
 
@@ -567,7 +624,10 @@ pub mod pallet {
 		}
 
 		/// Set the total number of delay tranches.
-		#[pallet::weight(T::WeightInfo::set_config_with_u32())]
+		#[pallet::weight((
+			T::WeightInfo::set_config_with_u32(),
+			DispatchClass::Operational,
+		))]
 		pub fn set_n_delay_tranches(origin: OriginFor<T>, new: u32) -> DispatchResult {
 			ensure_root(origin)?;
 			Self::update_config_member(|config| {
@@ -577,7 +637,10 @@ pub mod pallet {
 		}
 
 		/// Set the zeroth delay tranche width.
-		#[pallet::weight(T::WeightInfo::set_config_with_u32())]
+		#[pallet::weight((
+			T::WeightInfo::set_config_with_u32(),
+			DispatchClass::Operational,
+		))]
 		pub fn set_zeroth_delay_tranche_width(origin: OriginFor<T>, new: u32) -> DispatchResult {
 			ensure_root(origin)?;
 			Self::update_config_member(|config| {
@@ -587,7 +650,10 @@ pub mod pallet {
 		}
 
 		/// Set the number of validators needed to approve a block.
-		#[pallet::weight(T::WeightInfo::set_config_with_u32())]
+		#[pallet::weight((
+			T::WeightInfo::set_config_with_u32(),
+			DispatchClass::Operational,
+		))]
 		pub fn set_needed_approvals(origin: OriginFor<T>, new: u32) -> DispatchResult {
 			ensure_root(origin)?;
 			Self::update_config_member(|config| {
@@ -597,7 +663,10 @@ pub mod pallet {
 		}
 
 		/// Set the number of samples to do of the `RelayVRFModulo` approval assignment criterion.
-		#[pallet::weight(T::WeightInfo::set_config_with_u32())]
+		#[pallet::weight((
+			T::WeightInfo::set_config_with_u32(),
+			DispatchClass::Operational,
+		))]
 		pub fn set_relay_vrf_modulo_samples(origin: OriginFor<T>, new: u32) -> DispatchResult {
 			ensure_root(origin)?;
 			Self::update_config_member(|config| {
@@ -607,7 +676,10 @@ pub mod pallet {
 		}
 
 		/// Sets the maximum items that can present in a upward dispatch queue at once.
-		#[pallet::weight(T::WeightInfo::set_config_with_u32())]
+		#[pallet::weight((
+			T::WeightInfo::set_config_with_u32(),
+			DispatchClass::Operational,
+		))]
 		pub fn set_max_upward_queue_count(origin: OriginFor<T>, new: u32) -> DispatchResult {
 			ensure_root(origin)?;
 			Self::update_config_member(|config| {
@@ -617,7 +689,10 @@ pub mod pallet {
 		}
 
 		/// Sets the maximum total size of items that can present in a upward dispatch queue at once.
-		#[pallet::weight(T::WeightInfo::set_config_with_u32())]
+		#[pallet::weight((
+			T::WeightInfo::set_config_with_u32(),
+			DispatchClass::Operational,
+		))]
 		pub fn set_max_upward_queue_size(origin: OriginFor<T>, new: u32) -> DispatchResult {
 			ensure_root(origin)?;
 			Self::update_config_member(|config| {
@@ -627,7 +702,10 @@ pub mod pallet {
 		}
 
 		/// Set the critical downward message size.
-		#[pallet::weight(T::WeightInfo::set_config_with_u32())]
+		#[pallet::weight((
+			T::WeightInfo::set_config_with_u32(),
+			DispatchClass::Operational,
+		))]
 		pub fn set_max_downward_message_size(origin: OriginFor<T>, new: u32) -> DispatchResult {
 			ensure_root(origin)?;
 			Self::update_config_member(|config| {
@@ -637,7 +715,10 @@ pub mod pallet {
 		}
 
 		/// Sets the soft limit for the phase of dispatching dispatchable upward messages.
-		#[pallet::weight(T::WeightInfo::set_config_with_weight())]
+		#[pallet::weight((
+			T::WeightInfo::set_config_with_weight(),
+			DispatchClass::Operational,
+		))]
 		pub fn set_ump_service_total_weight(origin: OriginFor<T>, new: Weight) -> DispatchResult {
 			ensure_root(origin)?;
 			Self::update_config_member(|config| {
@@ -647,7 +728,10 @@ pub mod pallet {
 		}
 
 		/// Sets the maximum size of an upward message that can be sent by a candidate.
-		#[pallet::weight(T::WeightInfo::set_config_with_u32())]
+		#[pallet::weight((
+			T::WeightInfo::set_config_with_u32(),
+			DispatchClass::Operational,
+		))]
 		pub fn set_max_upward_message_size(origin: OriginFor<T>, new: u32) -> DispatchResult {
 			ensure_root(origin)?;
 			Self::update_config_member(|config| {
@@ -657,7 +741,10 @@ pub mod pallet {
 		}
 
 		/// Sets the maximum number of messages that a candidate can contain.
-		#[pallet::weight(T::WeightInfo::set_config_with_u32())]
+		#[pallet::weight((
+			T::WeightInfo::set_config_with_u32(),
+			DispatchClass::Operational,
+		))]
 		pub fn set_max_upward_message_num_per_candidate(
 			origin: OriginFor<T>,
 			new: u32,
@@ -670,7 +757,10 @@ pub mod pallet {
 		}
 
 		/// Sets the number of sessions after which an HRMP open channel request expires.
-		#[pallet::weight(T::WeightInfo::set_hrmp_open_request_ttl())]
+		#[pallet::weight((
+			T::WeightInfo::set_hrmp_open_request_ttl(),
+			DispatchClass::Operational,
+		))]
 		// Deprecated, but is not marked as such, because that would trigger warnings coming from
 		// the macro.
 		pub fn set_hrmp_open_request_ttl(_origin: OriginFor<T>, _new: u32) -> DispatchResult {
@@ -678,7 +768,10 @@ pub mod pallet {
 		}
 
 		/// Sets the amount of funds that the sender should provide for opening an HRMP channel.
-		#[pallet::weight(T::WeightInfo::set_config_with_balance())]
+		#[pallet::weight((
+			T::WeightInfo::set_config_with_balance(),
+			DispatchClass::Operational,
+		))]
 		pub fn set_hrmp_sender_deposit(origin: OriginFor<T>, new: Balance) -> DispatchResult {
 			ensure_root(origin)?;
 			Self::update_config_member(|config| {
@@ -689,7 +782,10 @@ pub mod pallet {
 
 		/// Sets the amount of funds that the recipient should provide for accepting opening an HRMP
 		/// channel.
-		#[pallet::weight(T::WeightInfo::set_config_with_balance())]
+		#[pallet::weight((
+			T::WeightInfo::set_config_with_balance(),
+			DispatchClass::Operational,
+		))]
 		pub fn set_hrmp_recipient_deposit(origin: OriginFor<T>, new: Balance) -> DispatchResult {
 			ensure_root(origin)?;
 			Self::update_config_member(|config| {
@@ -699,7 +795,10 @@ pub mod pallet {
 		}
 
 		/// Sets the maximum number of messages allowed in an HRMP channel at once.
-		#[pallet::weight(T::WeightInfo::set_config_with_u32())]
+		#[pallet::weight((
+			T::WeightInfo::set_config_with_u32(),
+			DispatchClass::Operational,
+		))]
 		pub fn set_hrmp_channel_max_capacity(origin: OriginFor<T>, new: u32) -> DispatchResult {
 			ensure_root(origin)?;
 			Self::update_config_member(|config| {
@@ -709,7 +808,10 @@ pub mod pallet {
 		}
 
 		/// Sets the maximum total size of messages in bytes allowed in an HRMP channel at once.
-		#[pallet::weight(T::WeightInfo::set_config_with_u32())]
+		#[pallet::weight((
+			T::WeightInfo::set_config_with_u32(),
+			DispatchClass::Operational,
+		))]
 		pub fn set_hrmp_channel_max_total_size(origin: OriginFor<T>, new: u32) -> DispatchResult {
 			ensure_root(origin)?;
 			Self::update_config_member(|config| {
@@ -719,7 +821,10 @@ pub mod pallet {
 		}
 
 		/// Sets the maximum number of inbound HRMP channels a parachain is allowed to accept.
-		#[pallet::weight(T::WeightInfo::set_config_with_u32())]
+		#[pallet::weight((
+			T::WeightInfo::set_config_with_u32(),
+			DispatchClass::Operational,
+		))]
 		pub fn set_hrmp_max_parachain_inbound_channels(
 			origin: OriginFor<T>,
 			new: u32,
@@ -732,7 +837,10 @@ pub mod pallet {
 		}
 
 		/// Sets the maximum number of inbound HRMP channels a parathread is allowed to accept.
-		#[pallet::weight(T::WeightInfo::set_config_with_u32())]
+		#[pallet::weight((
+			T::WeightInfo::set_config_with_u32(),
+			DispatchClass::Operational,
+		))]
 		pub fn set_hrmp_max_parathread_inbound_channels(
 			origin: OriginFor<T>,
 			new: u32,
@@ -745,7 +853,10 @@ pub mod pallet {
 		}
 
 		/// Sets the maximum size of a message that could ever be put into an HRMP channel.
-		#[pallet::weight(T::WeightInfo::set_config_with_u32())]
+		#[pallet::weight((
+			T::WeightInfo::set_config_with_u32(),
+			DispatchClass::Operational,
+		))]
 		pub fn set_hrmp_channel_max_message_size(origin: OriginFor<T>, new: u32) -> DispatchResult {
 			ensure_root(origin)?;
 			Self::update_config_member(|config| {
@@ -755,7 +866,10 @@ pub mod pallet {
 		}
 
 		/// Sets the maximum number of outbound HRMP channels a parachain is allowed to open.
-		#[pallet::weight(T::WeightInfo::set_config_with_u32())]
+		#[pallet::weight((
+			T::WeightInfo::set_config_with_u32(),
+			DispatchClass::Operational,
+		))]
 		pub fn set_hrmp_max_parachain_outbound_channels(
 			origin: OriginFor<T>,
 			new: u32,
@@ -768,7 +882,10 @@ pub mod pallet {
 		}
 
 		/// Sets the maximum number of outbound HRMP channels a parathread is allowed to open.
-		#[pallet::weight(T::WeightInfo::set_config_with_u32())]
+		#[pallet::weight((
+			T::WeightInfo::set_config_with_u32(),
+			DispatchClass::Operational,
+		))]
 		pub fn set_hrmp_max_parathread_outbound_channels(
 			origin: OriginFor<T>,
 			new: u32,
@@ -781,7 +898,10 @@ pub mod pallet {
 		}
 
 		/// Sets the maximum number of outbound HRMP messages can be sent by a candidate.
-		#[pallet::weight(T::WeightInfo::set_config_with_u32())]
+		#[pallet::weight((
+			T::WeightInfo::set_config_with_u32(),
+			DispatchClass::Operational,
+		))]
 		pub fn set_hrmp_max_message_num_per_candidate(
 			origin: OriginFor<T>,
 			new: u32,
@@ -794,7 +914,10 @@ pub mod pallet {
 		}
 
 		/// Sets the maximum amount of weight any individual upward message may consume.
-		#[pallet::weight(T::WeightInfo::set_config_with_weight())]
+		#[pallet::weight((
+			T::WeightInfo::set_config_with_weight(),
+			DispatchClass::Operational,
+		))]
 		pub fn set_ump_max_individual_weight(origin: OriginFor<T>, new: Weight) -> DispatchResult {
 			ensure_root(origin)?;
 			Self::update_config_member(|config| {


### PR DESCRIPTION
Re-add `DispatchClass::Operational` to all extrinsic weights in `parachain_runtime::configuration`. They were erroneously removed when benchmarks for the configuration pallet was introduced in #3862.