### PR TITLE
Do not compile `wasm_api` module when not needed.

### DIFF
--- a/parachain/src/lib.rs
+++ b/parachain/src/lib.rs
@@ -47,6 +47,7 @@
 
 pub mod primitives;
 
+#[cfg(all(not(feature = "std"), feature = "wasm-api"))]
 mod wasm_api;
 
 #[cfg(all(not(feature = "std"), feature = "wasm-api"))]


### PR DESCRIPTION
This otherwise generates some warnings which leads to errors in CI:
https://gitlab.parity.io/parity/cumulus/-/jobs/1141589