### PR TITLE
assure disputes are checked too

### DIFF
--- a/scripts/gitlab/test_linux_stable.sh
+++ b/scripts/gitlab/test_linux_stable.sh
@@ -4,4 +4,6 @@ set -e
 #shellcheck source=../common/lib.sh
 source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/../common/lib.sh"
 
+time cargo t --features=disputes -p polkadot-node-core-dispute-coordinator
+
 time cargo test --workspace --release --verbose --locked --features=runtime-benchmarks


### PR DESCRIPTION
Currently the disputes feature is disabled in CI, but that's our focus of work now.

This adds an extra command to verify the `"disputes"` enabled `disputes-coordinator` is functional.