### PR TITLE
Re-configure offchain repeat frequency for elections

### DIFF
--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -357,8 +357,8 @@ parameter_types! {
 	pub SignedRewardBase: Balance =  UNITS / 10;
 	pub SolutionImprovementThreshold: Perbill = Perbill::from_rational(5u32, 10_000);
 
-	// miner configs
-	pub OffchainRepeat: BlockNumber = 5;
+	// 1 hour session, 15 minutes unsigned phase, 8 offchain executions.
+	pub OffchainRepeat: BlockNumber = UnsignedPhase::get() / 8;
 
 	/// Whilst `UseNominatorsAndUpdateBagsList` or `UseNominatorsMap` is in use, this can still be a
 	/// very large value. Once the `BagsList` is in full motion, staking might open its door to many

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -381,8 +381,8 @@ parameter_types! {
 	pub SignedRewardBase: Balance = 1 * UNITS;
 	pub SolutionImprovementThreshold: Perbill = Perbill::from_rational(5u32, 10_000);
 
-	// miner configs
-	pub OffchainRepeat: BlockNumber = 5;
+	// 4 hour session, 1 hour unsigned phase, 32 offchain executions.
+	pub OffchainRepeat: BlockNumber = UnsignedPhase::get() / 32;
 
 	/// Whilst `UseNominatorsAndUpdateBagsList` or `UseNominatorsMap` is in use, this can still be a
 	/// very large value. Once the `BagsList` is in full motion, staking might open its door to many

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -343,8 +343,8 @@ parameter_types! {
 	pub SignedRewardBase: Balance = 1 * UNITS;
 	pub SolutionImprovementThreshold: Perbill = Perbill::from_rational(5u32, 10_000);
 
-	// miner configs
-	pub OffchainRepeat: BlockNumber = 5;
+	// 1 hour session, 15 minutes unsigned phase, 4 offchain executions.
+	pub OffchainRepeat: BlockNumber = UnsignedPhase::get() / 4;
 
 	/// Whilst `UseNominatorsAndUpdateBagsList` or `UseNominatorsMap` is in use, this can still be a
 	/// very large value. Once the `BagsList` is in full motion, staking might open its door to many


### PR DESCRIPTION
This minor PR re-configures the offchain worker repeat frequency in all chains. Two main reasons to do this: 

1. The staking-miner has been working well for all of them, and the offchain worker solutions are merely a backup. 

2. I looked at the logs, and almost always the staking-miner solutions are better than that of the offchain worker. This means that the offchain workers never manage to submit or cache a solution, which means that they will mine a new solution (CPU intense task) every 5 blocks. This PR relaxes this a little bit, allowing for less CPU usage. I configured the new numbers in a way that in westend we get 4 OCW runs, in Kusama 8, and in Polkadot 32. For all networks, this is better than the previous config, which was "run once every 5 blocks, aka half a minute". 

Marking as audit, but it is pretty insubstantial IMO. 