### PR TITLE
paras_inherent: reject only candidates with concluded disputes

### DIFF
--- a/runtime/parachains/src/paras_inherent.rs
+++ b/runtime/parachains/src/paras_inherent.rs
@@ -66,8 +66,6 @@ pub mod pallet {
 		/// The hash of the submitted parent header doesn't correspond to the saved block hash of
 		/// the parent.
 		InvalidParentHeader,
-		/// Potentially invalid candidate.
-		CandidateCouldBeInvalid,
 		/// Disputed candidate that was concluded invalid.
 		CandidateConcludedInvalid,
 	}

--- a/runtime/parachains/src/paras_inherent.rs
+++ b/runtime/parachains/src/paras_inherent.rs
@@ -68,6 +68,8 @@ pub mod pallet {
 		InvalidParentHeader,
 		/// Potentially invalid candidate.
 		CandidateCouldBeInvalid,
+		/// Disputed candidate that was concluded invalid.
+		CandidateConcludedInvalid,
 	}
 
 	/// Whether the paras inherent was included within this block.
@@ -238,14 +240,14 @@ pub mod pallet {
 			let backed_candidates = limit_backed_candidates::<T>(backed_candidates);
 			let backed_candidates_len = backed_candidates.len() as Weight;
 
-			// Refuse to back any candidates that are disputed or invalid.
+			// Refuse to back any candidates that were disputed and are concluded invalid.
 			for candidate in &backed_candidates {
 				ensure!(
-					!T::DisputesHandler::could_be_invalid(
+					!T::DisputesHandler::concluded_invalid(
 						current_session,
 						candidate.candidate.hash(),
 					),
-					Error::<T>::CandidateCouldBeInvalid,
+					Error::<T>::CandidateConcludedInvalid,
 				);
 			}
 


### PR DESCRIPTION
Triggers `Error::<T>::CandidateConcludedInvalid` (formerly `Error::<T>::CandidateCouldBeInvalid`) only if the dispute already has an AGAINST_SUPERMAJORITY. In other cases the dispute (and reverting) can still be handled later when needed.