### PR TITLE
revert +1 change to be on the safer side

### DIFF
--- a/node/primitives/src/lib.rs
+++ b/node/primitives/src/lib.rs
@@ -69,8 +69,7 @@ pub const POV_BOMB_LIMIT: usize = (MAX_POV_SIZE * 4u32) as usize;
 /// On Polkadot this is 1 day, and on Kusama it's 6 hours.
 ///
 /// Number of sessions we want to consider in disputes.
-/// + 1 for the child's session.
-pub const DISPUTE_WINDOW: SessionIndex = 6 + 1;
+pub const DISPUTE_WINDOW: SessionIndex = 6;
 
 /// The cumulative weight of a block in a fork-choice rule.
 pub type BlockWeight = u32;

--- a/node/subsystem-util/src/rolling_session_window.rs
+++ b/node/subsystem-util/src/rolling_session_window.rs
@@ -289,7 +289,7 @@ mod tests {
 	use polkadot_primitives::v1::Header;
 	use sp_core::testing::TaskExecutor;
 
-	const TEST_WINDOW_SIZE: SessionIndex = 6 + 1;
+	const TEST_WINDOW_SIZE: SessionIndex = 6;
 
 	fn dummy_session_info(index: SessionIndex) -> SessionInfo {
 		SessionInfo {


### PR DESCRIPTION
There was a concern raised after https://github.com/paritytech/polkadot/pull/3954#discussion_r718324887 that in https://github.com/paritytech/polkadot/blob/71a721eb9e634d2706cc4671c4fbd028c31814ea/node/subsystem-util/src/rolling_session_window.rs#L180 it would fail on startup because runtime doesn't store enough sessions. But that's actually not true, runtime stores `dispute_period + 1` session infos: https://github.com/paritytech/polkadot/blob/71a721eb9e634d2706cc4671c4fbd028c31814ea/runtime/parachains/src/session_info.rs#L108

Anyway, we revert it to be on the safer side.