### PR TITLE
gossip-support: set last_session_index earlier

### DIFF
--- a/node/network/gossip-support/src/lib.rs
+++ b/node/network/gossip-support/src/lib.rs
@@ -234,8 +234,7 @@ where
 		&mut self,
 		ctx: &mut Context,
 		authorities: Vec<AuthorityDiscoveryId>,
-	)
-	where
+	) where
 		Context: SubsystemContext<Message = GossipSupportMessage>,
 		Context: overseer::SubsystemContext<Message = GossipSupportMessage>,
 	{

--- a/node/network/gossip-support/src/lib.rs
+++ b/node/network/gossip-support/src/lib.rs
@@ -219,7 +219,7 @@ where
 					authorities
 				};
 
-				self.issue_connection_request(ctx, other_authorities).await?;
+				self.issue_connection_request(ctx, other_authorities).await;
 
 				if is_new_session {
 					update_gossip_topology(ctx, our_index, all_authorities, relay_parent).await?;
@@ -234,7 +234,7 @@ where
 		&mut self,
 		ctx: &mut Context,
 		authorities: Vec<AuthorityDiscoveryId>,
-	) -> Result<(), util::Error>
+	)
 	where
 		Context: SubsystemContext<Message = GossipSupportMessage>,
 		Context: overseer::SubsystemContext<Message = GossipSupportMessage>,
@@ -295,8 +295,6 @@ where
 			self.last_failure = None;
 			self.failure_start = None;
 		};
-
-		Ok(())
 	}
 
 	fn handle_connect_disconnect(&mut self, ev: NetworkBridgeEvent<GossipSuppportNetworkMessage>) {

--- a/node/network/gossip-support/src/lib.rs
+++ b/node/network/gossip-support/src/lib.rs
@@ -208,6 +208,7 @@ where
 						%session_index,
 						"New session detected",
 					);
+					self.last_session_index = Some(session_index);
 				}
 
 				let all_authorities = determine_relevant_authorities(ctx, relay_parent).await?;
@@ -221,7 +222,6 @@ where
 				self.issue_connection_request(ctx, other_authorities).await?;
 
 				if is_new_session {
-					self.last_session_index = Some(session_index);
 					update_gossip_topology(ctx, our_index, all_authorities, relay_parent).await?;
 				}
 			}


### PR DESCRIPTION
This is causing some excessive logs from full-nodes with `parachain=debug` target which fail at `ensure_i_am_an_authority` check.