### PR TITLE
Remove incorrect proof about Jemalloc

### DIFF
--- a/node/overseer/src/lib.rs
+++ b/node/overseer/src/lib.rs
@@ -539,7 +539,7 @@ where
 			Err(_) => {
 				tracing::debug!(
 					target: LOG_TARGET,
-					"Jemalloc not set as allocator, so memory allocations will not be tracked",
+					"Memory allocation tracking is not supported by the allocator.",
 				);
 
 				Box::new(|_| {})

--- a/node/overseer/src/lib.rs
+++ b/node/overseer/src/lib.rs
@@ -518,18 +518,26 @@ where
 	}
 	let subsystem_meters = overseer.map_subsystems(ExtractNameAndMeters);
 
-	let memory_stats =
-		MemoryAllocationTracker::new().expect("Jemalloc is the default allocator. qed");
-
-	let metronome = Metronome::new(std::time::Duration::from_millis(950)).for_each(move |_| {
-		match memory_stats.snapshot() {
+	let collect_memory_stats: Box<dyn Fn(&OverseerMetrics) + Send> = match MemoryAllocationTracker::new() {
+		Ok(memory_stats) => Box::new(move |metrics: &OverseerMetrics| match memory_stats.snapshot() {
 			Ok(memory_stats_snapshot) => {
 				tracing::trace!(target: LOG_TARGET, "memory_stats: {:?}", &memory_stats_snapshot);
-				metronome_metrics.memory_stats_snapshot(memory_stats_snapshot);
+				metrics.memory_stats_snapshot(memory_stats_snapshot);
 			},
-
 			Err(e) => tracing::debug!(target: LOG_TARGET, "Failed to obtain memory stats: {:?}", e),
-		}
+		}),
+		Err(_) => {
+			tracing::debug!(
+				target: LOG_TARGET,
+				"Jemalloc not set as allocator, so memory allocations will not be tracked",
+			);
+
+			Box::new(|_| {})
+		},
+	};
+
+	let metronome = Metronome::new(std::time::Duration::from_millis(950)).for_each(move |_| {
+		collect_memory_stats(&metronome_metrics);
 
 		// We combine the amount of messages from subsystems to the overseer
 		// as well as the amount of messages from external sources to the overseer


### PR DESCRIPTION
The truth is that Jemalloc is not always the default allocator. This is
only true for the polkadot binary.