### PR TITLE
add polkadot-simnet runner

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -576,4 +576,4 @@ simnet-tests:
   allow_failure:                   true
   retry: 2
   tags:
-    - parity-simnet
+    - polkadot-simnet


### PR DESCRIPTION
I added a new simnet runner, exclusively for polkadot  gitlab project 
Nothing changed for polkadot ci, except the simnet runner it's using with different tag now

pipeline is green: https://gitlab.parity.io/parity/polkadot/-/pipelines/160138

here is merge request in simnet: https://gitlab.parity.io/parity/simnet/-/merge_requests/133/diffs#82f28be153ada9b14aa5ebeadfdd19417f2efa98
