### PR TITLE
Tidy up XCM errors in preparation for v2.

### DIFF
--- a/scripts/gitlab/lingua.dic
+++ b/scripts/gitlab/lingua.dic
@@ -304,3 +304,4 @@ yml
 decrement
 DM
 ParaId
+functor

--- a/xcm/pallet-xcm/src/lib.rs
+++ b/xcm/pallet-xcm/src/lib.rs
@@ -1098,6 +1098,7 @@ pub mod pallet {
 			Ok(())
 		}
 	}
+	
 	impl<T: Config> DropAssets for Pallet<T> {
 		fn drop_assets(origin: &MultiLocation, assets: Assets) -> Weight {
 			if assets.is_empty() {

--- a/xcm/pallet-xcm/src/lib.rs
+++ b/xcm/pallet-xcm/src/lib.rs
@@ -1098,7 +1098,7 @@ pub mod pallet {
 			Ok(())
 		}
 	}
-	
+
 	impl<T: Config> DropAssets for Pallet<T> {
 		fn drop_assets(origin: &MultiLocation, assets: Assets) -> Weight {
 			if assets.is_empty() {

--- a/xcm/pallet-xcm/src/tests.rs
+++ b/xcm/pallet-xcm/src/tests.rs
@@ -74,7 +74,7 @@ fn report_outcome_notify_works() {
 			Parachain(PARA_ID).into(),
 			Xcm(vec![QueryResponse {
 				query_id: 0,
-				response: Response::ExecutionResult(Ok(())),
+				response: Response::ExecutionResult(None),
 				max_weight: 1_000_000,
 			}]),
 			1_000_000_000,
@@ -86,7 +86,7 @@ fn report_outcome_notify_works() {
 				Event::TestNotifier(pallet_test_notifier::Event::ResponseReceived(
 					Parachain(PARA_ID).into(),
 					0,
-					Response::ExecutionResult(Ok(())),
+					Response::ExecutionResult(None),
 				)),
 				Event::XcmPallet(crate::Event::Notified(0, 4, 2)),
 			]
@@ -128,7 +128,7 @@ fn report_outcome_works() {
 			Parachain(PARA_ID).into(),
 			Xcm(vec![QueryResponse {
 				query_id: 0,
-				response: Response::ExecutionResult(Ok(())),
+				response: Response::ExecutionResult(None),
 				max_weight: 0,
 			}]),
 			1_000_000_000,
@@ -136,10 +136,10 @@ fn report_outcome_works() {
 		assert_eq!(r, Outcome::Complete(1_000));
 		assert_eq!(
 			last_event(),
-			Event::XcmPallet(crate::Event::ResponseReady(0, Response::ExecutionResult(Ok(())),))
+			Event::XcmPallet(crate::Event::ResponseReady(0, Response::ExecutionResult(None),))
 		);
 
-		let response = Some((Response::ExecutionResult(Ok(())), 1));
+		let response = Some((Response::ExecutionResult(None), 1));
 		assert_eq!(XcmPallet::take_response(0), response);
 	});
 }

--- a/xcm/src/v2/mod.rs
+++ b/xcm/src/v2/mod.rs
@@ -152,7 +152,7 @@ pub enum Response {
 	/// Some assets.
 	Assets(MultiAssets),
 	/// The outcome of an XCM instruction.
-	ExecutionResult(result::Result<(), (u32, Error)>),
+	ExecutionResult(Option<(u32, Error)>),
 	/// An XCM version.
 	Version(super::Version),
 }

--- a/xcm/src/v2/traits.rs
+++ b/xcm/src/v2/traits.rs
@@ -28,49 +28,49 @@ pub enum Error {
 	// XCM specification.
 	
 	/// An arithmetic overflow happened.
-	Overflow = 0,
+	#[codec(index = 0)] Overflow,
 	/// The instruction is intentionally unsupported.
-	Unimplemented = 1,
+	#[codec(index = 1)] Unimplemented,
 	/// Origin Register does not contain a value value for a reserve transfer notification.
-	UntrustedReserveLocation = 2,
+	#[codec(index = 2)] UntrustedReserveLocation,
 	/// Origin Register does not contain a value value for a teleport notification.
-	UntrustedTeleportLocation = 3,
+	#[codec(index = 3)] UntrustedTeleportLocation,
 	/// `MultiLocation` value too large to descend further.
-	MultiLocationFull = 4,
+	#[codec(index = 4)] MultiLocationFull,
 	/// `MultiLocation` value ascend more parents than known ancestors of local location.
-	MultiLocationNotInvertible = 5,
+	#[codec(index = 5)] MultiLocationNotInvertible,
 	/// The Origin Register does not contain a valid value for instruction.
-	BadOrigin = 6,
+	#[codec(index = 6)] BadOrigin,
 	/// The location parameter is not a valid value for the instruction.
-	InvalidLocation = 7,
+	#[codec(index = 7)] InvalidLocation,
 	/// The given asset is not handled.
-	AssetNotFound = 8,
+	#[codec(index = 8)] AssetNotFound,
 	/// An asset transaction (like withdraw or deposit) failed (typically due to type conversions).
-	FailedToTransactAsset(#[codec(skip)] &'static str) = 9,
+	#[codec(index = 9)] FailedToTransactAsset(#[codec(skip)] &'static str),
 	/// An asset cannot be withdrawn, potentially due to lack of ownership, availability or rights.
-	NotWithdrawable = 10,
+	#[codec(index = 10)] NotWithdrawable,
 	/// An asset cannot be deposited under the ownership of a particular location.
-	LocationCannotHold = 11,
+	#[codec(index = 11)] LocationCannotHold,
 	/// Attempt to send a message greater than the maximum supported by the transport protocol.
-	ExceedsMaxMessageSize = 12,
+	#[codec(index = 12)] ExceedsMaxMessageSize,
 	/// The given message cannot be translated into a format supported by the destination.
-	DestinationUnsupported = 13,
+	#[codec(index = 13)] DestinationUnsupported,
 	/// Destination is routable, but there is some issue with the transport mechanism.
-	Transport(#[codec(skip)] &'static str) = 14,
+	#[codec(index = 14)] Transport(#[codec(skip)] &'static str),
 	/// Destination is known to be unroutable.
-	Unroutable = 15,
+	#[codec(index = 15)] Unroutable,
 	/// Used by `ClaimAsset` when the given claim could not be recognized/found.
-	UnknownClaim = 16,
+	#[codec(index = 16)] UnknownClaim,
 	/// Used by `Transact` when the functor cannot be decoded.
-	FailedToDecode = 17,
+	#[codec(index = 17)] FailedToDecode,
 	/// Used by `Transact` to indicate that the given weight limit could be breached by the functor.
-	TooMuchWeightRequired = 18,
+	#[codec(index = 18)] TooMuchWeightRequired,
 	/// Used by `BuyExecution` when the Holding Register does not contain payable fees.
-	NotHoldingFees = 19,
+	#[codec(index = 19)] NotHoldingFees,
 	/// Used by `BuyExecution` when the fees declared to purchase weight are insufficient.
-	TooExpensive = 20,
+	#[codec(index = 20)] TooExpensive,
 	/// Used by the `Trap` instruction to force an error intentionally. Its code is included.
-	Trap(u64) = 21,
+	#[codec(index = 21)] Trap(u64),
 
 	// Errors that happen prior to instructions being executed. These fall outside of the XCM spec.
 	

--- a/xcm/src/v2/traits.rs
+++ b/xcm/src/v2/traits.rs
@@ -40,17 +40,17 @@ pub enum Error {
 	/// `MultiLocation` value ascend more parents than known ancestors of local location.
 	MultiLocationNotInvertible = 5,
 	/// The Origin Register does not contain a valid value for instruction.
-	BadOrigin = 7,
+	BadOrigin = 6,
 	/// The location parameter is not a valid value for the instruction.
-	InvalidLocation = 16,
+	InvalidLocation = 7,
 	/// The given asset is not handled.
-	AssetNotFound = 11,
+	AssetNotFound = 8,
 	/// An asset transaction (like withdraw or deposit) failed (typically due to type conversions).
-	FailedToTransactAsset(#[codec(skip)] &'static str) = 8,
+	FailedToTransactAsset(#[codec(skip)] &'static str) = 9,
 	/// An asset cannot be withdrawn, potentially due to lack of ownership, availability or rights.
-	NotWithdrawable = 9,
+	NotWithdrawable = 10,
 	/// An asset cannot be deposited under the ownership of a particular location.
-	LocationCannotHold = 10,
+	LocationCannotHold = 11,
 	/// Attempt to send a message greater than the maximum supported by the transport protocol.
 	ExceedsMaxMessageSize = 12,
 	/// The given message cannot be translated into a format supported by the destination.
@@ -60,17 +60,17 @@ pub enum Error {
 	/// Destination is known to be unroutable.
 	Unroutable = 15,
 	/// Used by `ClaimAsset` when the given claim could not be recognized/found.
-	UnknownClaim = 17,
+	UnknownClaim = 16,
 	/// Used by `Transact` when the functor cannot be decoded.
-	FailedToDecode = 18,
+	FailedToDecode = 17,
 	/// Used by `Transact` to indicate that the given weight limit could be breached by the functor.
-	TooMuchWeightRequired = 19,
+	TooMuchWeightRequired = 18,
 	/// Used by `BuyExecution` when the Holding Register does not contain payable fees.
-	NotHoldingFees = 20,
+	NotHoldingFees = 19,
 	/// Used by `BuyExecution` when the fees declared to purchase weight are insufficient.
-	TooExpensive = 21,
+	TooExpensive = 20,
 	/// Used by the `Trap` instruction to force an error intentionally. Its code is included.
-	Trap(u64) = 22,
+	Trap(u64) = 21,
 
 	// Errors that happen prior to instructions being executed. These fall outside of the XCM spec.
 	

--- a/xcm/src/v2/traits.rs
+++ b/xcm/src/v2/traits.rs
@@ -26,60 +26,80 @@ use super::*;
 pub enum Error {
 	// Errors that happen due to instructions being executed. These alone are defined in the
 	// XCM specification.
-	
 	/// An arithmetic overflow happened.
-	#[codec(index = 0)] Overflow,
+	#[codec(index = 0)]
+	Overflow,
 	/// The instruction is intentionally unsupported.
-	#[codec(index = 1)] Unimplemented,
+	#[codec(index = 1)]
+	Unimplemented,
 	/// Origin Register does not contain a value value for a reserve transfer notification.
-	#[codec(index = 2)] UntrustedReserveLocation,
+	#[codec(index = 2)]
+	UntrustedReserveLocation,
 	/// Origin Register does not contain a value value for a teleport notification.
-	#[codec(index = 3)] UntrustedTeleportLocation,
+	#[codec(index = 3)]
+	UntrustedTeleportLocation,
 	/// `MultiLocation` value too large to descend further.
-	#[codec(index = 4)] MultiLocationFull,
+	#[codec(index = 4)]
+	MultiLocationFull,
 	/// `MultiLocation` value ascend more parents than known ancestors of local location.
-	#[codec(index = 5)] MultiLocationNotInvertible,
+	#[codec(index = 5)]
+	MultiLocationNotInvertible,
 	/// The Origin Register does not contain a valid value for instruction.
-	#[codec(index = 6)] BadOrigin,
+	#[codec(index = 6)]
+	BadOrigin,
 	/// The location parameter is not a valid value for the instruction.
-	#[codec(index = 7)] InvalidLocation,
+	#[codec(index = 7)]
+	InvalidLocation,
 	/// The given asset is not handled.
-	#[codec(index = 8)] AssetNotFound,
+	#[codec(index = 8)]
+	AssetNotFound,
 	/// An asset transaction (like withdraw or deposit) failed (typically due to type conversions).
-	#[codec(index = 9)] FailedToTransactAsset(#[codec(skip)] &'static str),
+	#[codec(index = 9)]
+	FailedToTransactAsset(#[codec(skip)] &'static str),
 	/// An asset cannot be withdrawn, potentially due to lack of ownership, availability or rights.
-	#[codec(index = 10)] NotWithdrawable,
+	#[codec(index = 10)]
+	NotWithdrawable,
 	/// An asset cannot be deposited under the ownership of a particular location.
-	#[codec(index = 11)] LocationCannotHold,
+	#[codec(index = 11)]
+	LocationCannotHold,
 	/// Attempt to send a message greater than the maximum supported by the transport protocol.
-	#[codec(index = 12)] ExceedsMaxMessageSize,
+	#[codec(index = 12)]
+	ExceedsMaxMessageSize,
 	/// The given message cannot be translated into a format supported by the destination.
-	#[codec(index = 13)] DestinationUnsupported,
+	#[codec(index = 13)]
+	DestinationUnsupported,
 	/// Destination is routable, but there is some issue with the transport mechanism.
-	#[codec(index = 14)] Transport(#[codec(skip)] &'static str),
+	#[codec(index = 14)]
+	Transport(#[codec(skip)] &'static str),
 	/// Destination is known to be unroutable.
-	#[codec(index = 15)] Unroutable,
+	#[codec(index = 15)]
+	Unroutable,
 	/// Used by `ClaimAsset` when the given claim could not be recognized/found.
-	#[codec(index = 16)] UnknownClaim,
+	#[codec(index = 16)]
+	UnknownClaim,
 	/// Used by `Transact` when the functor cannot be decoded.
-	#[codec(index = 17)] FailedToDecode,
+	#[codec(index = 17)]
+	FailedToDecode,
 	/// Used by `Transact` to indicate that the given weight limit could be breached by the functor.
-	#[codec(index = 18)] TooMuchWeightRequired,
+	#[codec(index = 18)]
+	TooMuchWeightRequired,
 	/// Used by `BuyExecution` when the Holding Register does not contain payable fees.
-	#[codec(index = 19)] NotHoldingFees,
+	#[codec(index = 19)]
+	NotHoldingFees,
 	/// Used by `BuyExecution` when the fees declared to purchase weight are insufficient.
-	#[codec(index = 20)] TooExpensive,
+	#[codec(index = 20)]
+	TooExpensive,
 	/// Used by the `Trap` instruction to force an error intentionally. Its code is included.
-	#[codec(index = 21)] Trap(u64),
+	#[codec(index = 21)]
+	Trap(u64),
 
 	// Errors that happen prior to instructions being executed. These fall outside of the XCM spec.
-	
 	/// XCM version not able to be handled.
 	UnhandledXcmVersion,
 	/// Execution of the XCM would potentially result in a greater weight used than weight limit.
 	WeightLimitReached(Weight),
 	/// The XCM did not pass the barrier condition for execution.
-	/// 
+	///
 	/// The barrier condition differs on different chains and in different circumstances, but
 	/// generally it means that the conditions surrounding the message were not such that the chain
 	/// considers the message worth spending time executing. Since most chains lift the barrier to

--- a/xcm/xcm-executor/integration-tests/src/lib.rs
+++ b/xcm/xcm-executor/integration-tests/src/lib.rs
@@ -117,7 +117,7 @@ fn query_response_fires() {
 
 	let mut block_builder = client.init_polkadot_block_builder();
 
-	let response = Response::ExecutionResult(Ok(()));
+	let response = Response::ExecutionResult(None);
 	let max_weight = 1_000_000;
 	let msg = Xcm(vec![QueryResponse { query_id, response, max_weight }]);
 	let msg = Box::new(VersionedXcm::from(msg));
@@ -148,13 +148,13 @@ fn query_response_fires() {
 				r.event,
 				polkadot_test_runtime::Event::Xcm(pallet_xcm::Event::ResponseReady(
 					q,
-					Response::ExecutionResult(Ok(())),
+					Response::ExecutionResult(None),
 				)) if q == query_id,
 			)));
 			assert_eq!(
 				polkadot_test_runtime::Xcm::query(query_id),
 				Some(QueryStatus::Ready {
-					response: VersionedResponse::V2(Response::ExecutionResult(Ok(()))),
+					response: VersionedResponse::V2(Response::ExecutionResult(None)),
 					at: 2u32.into()
 				}),
 			)
@@ -206,7 +206,7 @@ fn query_response_elicits_handler() {
 
 	let mut block_builder = client.init_polkadot_block_builder();
 
-	let response = Response::ExecutionResult(Ok(()));
+	let response = Response::ExecutionResult(None);
 	let max_weight = 1_000_000;
 	let msg = Xcm(vec![QueryResponse { query_id, response, max_weight }]);
 
@@ -237,7 +237,7 @@ fn query_response_elicits_handler() {
 				TestNotifier(ResponseReceived(
 					MultiLocation { parents: 0, interior: X1(Junction::AccountId32 { .. }) },
 					q,
-					Response::ExecutionResult(Ok(())),
+					Response::ExecutionResult(None),
 				)) if q == query_id,
 			)));
 		});

--- a/xcm/xcm-executor/src/lib.rs
+++ b/xcm/xcm-executor/src/lib.rs
@@ -345,10 +345,7 @@ impl<Config: config::Config> XcmExecutor<Config> {
 			ReportError { query_id, dest, max_response_weight: max_weight } => {
 				// Report the given result by sending a QueryResponse XCM to a previously given outcome
 				// destination if one was registered.
-				let response = Response::ExecutionResult(match self.error {
-					None => Ok(()),
-					Some(e) => Err(e),
-				});
+				let response = Response::ExecutionResult(self.error);
 				let message = QueryResponse { query_id, response, max_weight };
 				Config::XcmSender::send_xcm(dest, Xcm(vec![message]))?;
 				Ok(())


### PR DESCRIPTION
Just alter some of the error codes to keep things tidy. This should go in before any release that contains XCM v2.

cc @s3krit 