### PR TITLE
chore: ci list files that spellcheck finds

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -242,7 +242,7 @@ spellcheck:
     - cargo spellcheck --version
     # compare with the commit parent to the PR, given it's from a default branch
     - git fetch origin +${CI_DEFAULT_BRANCH}:${CI_DEFAULT_BRANCH}
-    - cargo spellcheck list-files -vvv $(git diff --name-only --diff-filter=AM --merge-base master HEAD)
+    - cargo spellcheck list-files -vvv $(git diff --name-only --diff-filter=AM --merge-base ${CI_DEFAULT_BRANCH})
     - time cargo spellcheck check -vvv --cfg=scripts/gitlab/spellcheck.toml --checkers hunspell --code 1
         $(git diff --diff-filter=AM --name-only $(git merge-base ${CI_COMMIT_SHA} ${CI_DEFAULT_BRANCH})) ${CI_COMMIT_SHA}
   allow_failure:                   true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -242,9 +242,9 @@ spellcheck:
     - cargo spellcheck --version
     # compare with the commit parent to the PR, given it's from a default branch
     - git fetch origin +${CI_DEFAULT_BRANCH}:${CI_DEFAULT_BRANCH}
-    - cargo spellcheck list-files -vvv $(git diff --name-only --diff-filter=AM --merge-base ${CI_DEFAULT_BRANCH})
+    - cargo spellcheck list-files -vvv $(git diff --diff-filter=AM --name-only $(git merge-base ${CI_COMMIT_SHA} ${CI_DEFAULT_BRANCH}))
     - time cargo spellcheck check -vvv --cfg=scripts/gitlab/spellcheck.toml --checkers hunspell --code 1
-        $(git diff --diff-filter=AM --name-only $(git merge-base ${CI_COMMIT_SHA} ${CI_DEFAULT_BRANCH})) ${CI_COMMIT_SHA}
+        $(git diff --diff-filter=AM --name-only $(git merge-base ${CI_COMMIT_SHA} ${CI_DEFAULT_BRANCH}))
   allow_failure:                   true
 
 build-adder-collator:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -242,8 +242,9 @@ spellcheck:
     - cargo spellcheck --version
     # compare with the commit parent to the PR, given it's from a default branch
     - git fetch origin +${CI_DEFAULT_BRANCH}:${CI_DEFAULT_BRANCH}
+    - cargo spellcheck list-files -vvv $(git diff --name-only --diff-filter=AM --merge-base master HEAD)
     - time cargo spellcheck check -vvv --cfg=scripts/gitlab/spellcheck.toml --checkers hunspell --code 1
-        -r $(git diff --name-only ${CI_COMMIT_SHA} $(git merge-base ${CI_COMMIT_SHA} ${CI_DEFAULT_BRANCH}))
+        $(git diff --diff-filter=AM --name-only $(git merge-base ${CI_COMMIT_SHA} ${CI_DEFAULT_BRANCH})) ${CI_COMMIT_SHA}
   allow_failure:                   true
 
 build-adder-collator:


### PR DESCRIPTION
Remove `-r` flag for accidental inclusion of things we don't really want to check. The provided file list does not require any extension.