### PR TITLE
Remove unoccupied bit check

### DIFF
--- a/runtime/parachains/src/inclusion.rs
+++ b/runtime/parachains/src/inclusion.rs
@@ -170,8 +170,6 @@ pub mod pallet {
 		NewCodeTooLarge,
 		/// Candidate not in parent context.
 		CandidateNotInParentContext,
-		/// The bitfield contains a bit relating to an unassigned availability core.
-		UnoccupiedBitInBitfield,
 		/// Invalid group index in core assignment.
 		InvalidGroupIndex,
 		/// Insufficient (non-majority) backing.
@@ -297,12 +295,6 @@ impl<T: Config> Pallet<T> {
 				ensure!(
 					(unchecked_bitfield.unchecked_validator_index().0 as usize) < validators.len(),
 					Error::<T>::ValidatorIndexOutOfBounds,
-				);
-
-				ensure!(
-					occupied_bitmask.clone() & unchecked_bitfield.unchecked_payload().0.clone() ==
-						unchecked_bitfield.unchecked_payload().0,
-					Error::<T>::UnoccupiedBitInBitfield,
 				);
 
 				let validator_public =

--- a/runtime/parachains/src/inclusion.rs
+++ b/runtime/parachains/src/inclusion.rs
@@ -263,14 +263,6 @@ impl<T: Config> Pallet<T> {
 		// 3. each bitfield has exactly `expected_bits`
 		// 4. signature is valid.
 		let signed_bitfields = {
-			let occupied_bitmask: BitVec<BitOrderLsb0, u8> = assigned_paras_record
-				.iter()
-				.map(|p| {
-					p.as_ref()
-						.map_or(false, |(_id, pending_availability)| pending_availability.is_some())
-				})
-				.collect();
-
 			let mut last_index = None;
 
 			let signing_context = SigningContext {

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -105,7 +105,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("rococo"),
 	impl_name: create_runtime_str!("parity-rococo-v1.8"),
 	authoring_version: 0,
-	spec_version: 9105,
+	spec_version: 9106,
 	impl_version: 0,
 	#[cfg(not(feature = "disable-runtime-api"))]
 	apis: RUNTIME_API_VERSIONS,


### PR DESCRIPTION
A previous PR removed an `expect` afterwards, but not the check itself.