### PR TITLE
Update Benchmarks to Use Individual Tests

### DIFF
--- a/runtime/common/src/auctions.rs
+++ b/runtime/common/src/auctions.rs
@@ -1708,7 +1708,7 @@ mod benchmarking {
 	use frame_system::RawOrigin;
 	use sp_runtime::{traits::Bounded, SaturatedConversion};
 
-	use frame_benchmarking::{account, benchmarks, impl_benchmark_test_suite, whitelisted_caller};
+	use frame_benchmarking::{account, benchmarks, whitelisted_caller};
 
 	fn assert_last_event<T: Config>(generic_event: <T as Config>::Event) {
 		let events = frame_system::Pallet::<T>::events();
@@ -1883,11 +1883,11 @@ mod benchmarking {
 		verify {
 			assert!(AuctionInfo::<T>::get().is_none());
 		}
-	}
 
-	impl_benchmark_test_suite!(
-		Auctions,
-		crate::integration_tests::new_test_ext(),
-		crate::integration_tests::Test,
-	);
+		impl_benchmark_test_suite!(
+			Auctions,
+			crate::integration_tests::new_test_ext(),
+			crate::integration_tests::Test,
+		);
+	}
 }

--- a/runtime/common/src/claims.rs
+++ b/runtime/common/src/claims.rs
@@ -1589,13 +1589,8 @@ mod benchmarking {
 				assert!(super::Pallet::<T>::eth_recover(&signature, &data, extra).is_some());
 			}
 		}
-	}
 
-	#[cfg(test)]
-	mod tests {
-		use super::*;
-
-		frame_benchmarking::impl_benchmark_test_suite!(
+		impl_benchmark_test_suite!(
 			Pallet,
 			crate::claims::tests::new_test_ext(),
 			crate::claims::tests::Test,

--- a/runtime/common/src/crowdloan.rs
+++ b/runtime/common/src/crowdloan.rs
@@ -1857,7 +1857,7 @@ mod benchmarking {
 	use sp_runtime::traits::{Bounded, CheckedSub};
 	use sp_std::prelude::*;
 
-	use frame_benchmarking::{account, benchmarks, impl_benchmark_test_suite, whitelisted_caller};
+	use frame_benchmarking::{account, benchmarks, whitelisted_caller};
 
 	fn assert_last_event<T: Config>(generic_event: <T as Config>::Event) {
 		let events = frame_system::Pallet::<T>::events();
@@ -2105,11 +2105,11 @@ mod benchmarking {
 			assert_eq!(EndingsCount::<T>::get(), old_endings_count + 1);
 			assert_last_event::<T>(Event::<T>::HandleBidResult((n - 1).into(), Ok(())).into());
 		}
-	}
 
-	impl_benchmark_test_suite!(
-		Crowdloan,
-		crate::integration_tests::new_test_ext_with_offset(10),
-		crate::integration_tests::Test,
-	);
+		impl_benchmark_test_suite!(
+			Crowdloan,
+			crate::integration_tests::new_test_ext_with_offset(10),
+			crate::integration_tests::Test,
+		);
+	}
 }

--- a/runtime/common/src/paras_registrar.rs
+++ b/runtime/common/src/paras_registrar.rs
@@ -1048,7 +1048,7 @@ mod benchmarking {
 	use runtime_parachains::{paras, shared, Origin as ParaOrigin};
 	use sp_runtime::traits::Bounded;
 
-	use frame_benchmarking::{account, benchmarks, impl_benchmark_test_suite, whitelisted_caller};
+	use frame_benchmarking::{account, benchmarks, whitelisted_caller};
 
 	fn assert_last_event<T: Config>(generic_event: <T as Config>::Event) {
 		let events = frame_system::Pallet::<T>::events();
@@ -1160,11 +1160,11 @@ mod benchmarking {
 			assert_eq!(paras::Pallet::<T>::lifecycle(parachain), Some(ParaLifecycle::Parathread));
 			assert_eq!(paras::Pallet::<T>::lifecycle(parathread), Some(ParaLifecycle::Parachain));
 		}
-	}
 
-	impl_benchmark_test_suite!(
-		Registrar,
-		crate::integration_tests::new_test_ext(),
-		crate::integration_tests::Test,
-	);
+		impl_benchmark_test_suite!(
+			Registrar,
+			crate::integration_tests::new_test_ext(),
+			crate::integration_tests::Test,
+		);
+	}
 }

--- a/runtime/common/src/slots.rs
+++ b/runtime/common/src/slots.rs
@@ -975,7 +975,7 @@ mod benchmarking {
 	use frame_system::RawOrigin;
 	use sp_runtime::traits::Bounded;
 
-	use frame_benchmarking::{account, benchmarks, impl_benchmark_test_suite, whitelisted_caller};
+	use frame_benchmarking::{account, benchmarks, whitelisted_caller};
 
 	use crate::slots::Pallet as Slots;
 
@@ -1112,11 +1112,11 @@ mod benchmarking {
 			T::Registrar::execute_pending_transitions();
 			assert!(T::Registrar::is_parachain(para));
 		}
-	}
 
-	impl_benchmark_test_suite!(
-		Slots,
-		crate::integration_tests::new_test_ext(),
-		crate::integration_tests::Test,
-	);
+		impl_benchmark_test_suite!(
+			Slots,
+			crate::integration_tests::new_test_ext(),
+			crate::integration_tests::Test,
+		);
+	}
 }

--- a/runtime/parachains/src/configuration/benchmarking.rs
+++ b/runtime/parachains/src/configuration/benchmarking.rs
@@ -15,7 +15,7 @@
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
 use crate::configuration::*;
-use frame_benchmarking::{benchmarks, impl_benchmark_test_suite, BenchmarkError, BenchmarkResult};
+use frame_benchmarking::{benchmarks, BenchmarkError, BenchmarkResult};
 use frame_system::RawOrigin;
 use sp_runtime::traits::One;
 
@@ -35,10 +35,10 @@ benchmarks! {
 	}
 
 	set_config_with_balance {}: set_hrmp_sender_deposit(RawOrigin::Root, 100_000_000_000)
-}
 
-impl_benchmark_test_suite!(
-	Pallet,
-	crate::mock::new_test_ext(Default::default()),
-	crate::mock::Test
-);
+	impl_benchmark_test_suite!(
+		Pallet,
+		crate::mock::new_test_ext(Default::default()),
+		crate::mock::Test
+	);
+}

--- a/runtime/parachains/src/disputes/benchmarking.rs
+++ b/runtime/parachains/src/disputes/benchmarking.rs
@@ -16,7 +16,7 @@
 
 use super::*;
 
-use frame_benchmarking::{benchmarks, impl_benchmark_test_suite};
+use frame_benchmarking::benchmarks;
 use frame_system::RawOrigin;
 use sp_runtime::traits::One;
 
@@ -27,10 +27,10 @@ benchmarks! {
 	verify {
 		assert!(Frozen::<T>::get().is_none())
 	}
-}
 
-impl_benchmark_test_suite!(
-	Pallet,
-	crate::mock::new_test_ext(Default::default()),
-	crate::mock::Test
-);
+	impl_benchmark_test_suite!(
+		Pallet,
+		crate::mock::new_test_ext(Default::default()),
+		crate::mock::Test
+	);
+}

--- a/runtime/parachains/src/initializer/benchmarking.rs
+++ b/runtime/parachains/src/initializer/benchmarking.rs
@@ -15,7 +15,7 @@
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
 use super::*;
-use frame_benchmarking::{benchmarks, impl_benchmark_test_suite};
+use frame_benchmarking::benchmarks;
 use frame_system::{DigestItemOf, RawOrigin};
 use primitives::v1::ConsensusLog;
 
@@ -35,10 +35,10 @@ benchmarks! {
 			&<DigestItemOf<T>>::from(ConsensusLog::ForceApprove(d + 1)),
 		);
 	}
-}
 
-impl_benchmark_test_suite!(
-	Pallet,
-	crate::mock::new_test_ext(Default::default()),
-	crate::mock::Test
-);
+	impl_benchmark_test_suite!(
+		Pallet,
+		crate::mock::new_test_ext(Default::default()),
+		crate::mock::Test
+	);
+}

--- a/runtime/parachains/src/paras/benchmarking.rs
+++ b/runtime/parachains/src/paras/benchmarking.rs
@@ -16,7 +16,7 @@
 
 use super::*;
 use crate::{configuration::HostConfiguration, shared};
-use frame_benchmarking::{benchmarks, impl_benchmark_test_suite};
+use frame_benchmarking::benchmarks;
 use frame_system::RawOrigin;
 use primitives::v1::{HeadData, Id as ParaId, ValidationCode, MAX_CODE_SIZE, MAX_HEAD_DATA_SIZE};
 use sp_runtime::traits::{One, Saturating};
@@ -126,10 +126,10 @@ benchmarks! {
 		let next_session = crate::shared::Pallet::<T>::session_index().saturating_add(One::one());
 		assert_last_event::<T>(Event::ActionQueued(para_id, next_session).into());
 	}
-}
 
-impl_benchmark_test_suite!(
-	Pallet,
-	crate::mock::new_test_ext(Default::default()),
-	crate::mock::Test
-);
+	impl_benchmark_test_suite!(
+		Pallet,
+		crate::mock::new_test_ext(Default::default()),
+		crate::mock::Test
+	);
+}

--- a/xcm/pallet-xcm-benchmarks/src/fungible/benchmarking.rs
+++ b/xcm/pallet-xcm-benchmarks/src/fungible/benchmarking.rs
@@ -16,9 +16,7 @@
 
 use super::*;
 use crate::{account_and_location, new_executor, worst_case_holding, AssetTransactorOf, XcmCallOf};
-use frame_benchmarking::{
-	benchmarks_instance_pallet, impl_benchmark_test_suite, BenchmarkError, BenchmarkResult,
-};
+use frame_benchmarking::{benchmarks_instance_pallet, BenchmarkError, BenchmarkResult};
 use frame_support::{pallet_prelude::Get, traits::fungible::Inspect};
 use sp_runtime::traits::Zero;
 use sp_std::{convert::TryInto, prelude::*, vec};
@@ -210,10 +208,10 @@ benchmarks_instance_pallet! {
 			assert!(!T::TransactAsset::balance(&checked_account).is_zero());
 		}
 	}
-}
 
-impl_benchmark_test_suite!(
-	Pallet,
-	crate::fungible::mock::new_test_ext(),
-	crate::fungible::mock::Test
-);
+	impl_benchmark_test_suite!(
+		Pallet,
+		crate::fungible::mock::new_test_ext(),
+		crate::fungible::mock::Test
+	);
+}


### PR DESCRIPTION
Basically a companion to: https://github.com/paritytech/substrate/pull/9860

Gives a better output when running the benchmark tests.