### PR TITLE
Update GHA to s3krit/matrix-message-action@v0.0.3 + doc

### DIFF
--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -8,7 +8,8 @@ jobs:
   check-labels:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout sources
+        uses: actions/checkout@v2
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/extrinsic-ordering-check-from-bin.yml
+++ b/.github/workflows/extrinsic-ordering-check-from-bin.yml
@@ -27,7 +27,8 @@ jobs:
       REF_URL: ${{github.event.inputs.reference_url}}
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout sources
+        uses: actions/checkout@v2
 
       - name: Fetch binary
         run: |

--- a/.github/workflows/publish-docker-release.yml
+++ b/.github/workflows/publish-docker-release.yml
@@ -9,7 +9,8 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout sources
+        uses: actions/checkout@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Cache Docker layers

--- a/.github/workflows/publish-draft-release.yml
+++ b/.github/workflows/publish-draft-release.yml
@@ -26,7 +26,8 @@ jobs:
       matrix:
         runtime: ["polkadot", "kusama", "westend"]
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout sources
+        uses: actions/checkout@v2
       - name: Cache target dir
         uses: actions/cache@v2
         with:
@@ -64,7 +65,8 @@ jobs:
       release_url: ${{ steps.create-release.outputs.html_url }}
       asset_upload_url: ${{ steps.create-release.outputs.upload_url }}
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout sources
+        uses: actions/checkout@v2
         with:
           fetch-depth: 0
           path: polkadot
@@ -100,8 +102,10 @@ jobs:
       matrix:
         runtime: ["polkadot", "kusama", "westend"]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - name: Checkout sources
+        uses: actions/checkout@v2
+      - name: Download artifacts
+        uses: actions/download-artifact@v2
       - name: Set up Ruby 2.7
         uses: actions/setup-ruby@v1
         with:
@@ -128,7 +132,7 @@ jobs:
     needs: publish-draft-release
     steps:
       - name: Internal polkadot channel
-        uses: s3krit/matrix-message-action@v0.0.2
+        uses: s3krit/matrix-message-action@v0.0.3
         with:
           room_id: ${{ secrets.INTERNAL_POLKADOT_MATRIX_ROOM_ID }}
           access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}

--- a/.github/workflows/release-bot.yml
+++ b/.github/workflows/release-bot.yml
@@ -15,7 +15,8 @@ jobs:
         - '!NTogofoetwjbTwOoPi:matrix.parity.io' # Internal release-notes channel
     runs-on: ubuntu-latest
     steps:
-      - uses: s3krit/matrix-message-action@v0.0.3
+      - name: Send Matrix message
+        uses: s3krit/matrix-message-action@v0.0.3
         with:
           room_id: ${{ matrix.channel }} # heh
           access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -7,7 +7,8 @@ jobs:
   tag_rc:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout sources
+        uses: actions/checkout@v2
         with:
           fetch-depth: 0
       - id: compute_tag
@@ -48,7 +49,8 @@ jobs:
           VERSION: ${{ steps.compute_tag.outputs.version }}
         with:
           filename: .github/ISSUE_TEMPLATE/release.md
-      - uses: s3krit/matrix-message-action@v0.0.2
+      - name: Send Matrix message
+        uses: s3krit/matrix-message-action@v0.0.3
         if: steps.create-issue.outputs.url != ''
         with:
           room_id: ${{ secrets.INTERNAL_POLKADOT_MATRIX_ROOM_ID }}


### PR DESCRIPTION
This PR mainly bumps the GHA from @s3krit to the latest version.

It also adds names to some tasks. That makes the YML slightly more verbose but makes it easier to check for the list of GHA in use and spot those requiring a bump with:
```
 find .github/workflows -name "*.yml" | xargs -I{} grep "uses" {} | sort | uniq
```
