### PR TITLE
Move runtime to with_transaction in order to Rollback state changes

### DIFF
--- a/runtime/parachains/src/disputes.rs
+++ b/runtime/parachains/src/disputes.rs
@@ -1213,7 +1213,7 @@ mod tests {
 		REWARD_VALIDATORS,
 	};
 	use frame_support::{
-		assert_err, assert_noop, assert_ok,
+		assert_err, assert_noop, assert_ok, assert_storage_noop,
 		traits::{OnFinalize, OnInitialize},
 	};
 	use frame_system::InitKind;
@@ -2839,7 +2839,7 @@ mod tests {
 				],
 			}];
 
-			Pallet::<Test>::filter_multi_dispute_data(&mut statements);
+			assert_storage_noop!(Pallet::<Test>::filter_multi_dispute_data(&mut statements));
 
 			assert_eq!(
 				statements,
@@ -2921,7 +2921,7 @@ mod tests {
 				],
 			}];
 
-			Pallet::<Test>::filter_multi_dispute_data(&mut statements);
+			assert_storage_noop!(Pallet::<Test>::filter_multi_dispute_data(&mut statements));
 
 			assert!(statements.is_empty());
 		})
@@ -3062,7 +3062,7 @@ mod tests {
 			];
 
 			let old_statements = statements.clone();
-			Pallet::<Test>::filter_multi_dispute_data(&mut statements);
+			assert_storage_noop!(Pallet::<Test>::filter_multi_dispute_data(&mut statements));
 
 			assert_eq!(statements, old_statements);
 		})
@@ -3099,7 +3099,7 @@ mod tests {
 				)],
 			}];
 
-			Pallet::<Test>::filter_multi_dispute_data(&mut statements);
+			assert_storage_noop!(Pallet::<Test>::filter_multi_dispute_data(&mut statements));
 
 			assert!(statements.is_empty());
 		})
@@ -3191,7 +3191,7 @@ mod tests {
 				},
 			];
 
-			Pallet::<Test>::filter_multi_dispute_data(&mut statements);
+			assert_storage_noop!(Pallet::<Test>::filter_multi_dispute_data(&mut statements));
 
 			assert_eq!(
 				statements,
@@ -3281,7 +3281,7 @@ mod tests {
 				},
 			];
 
-			Pallet::<Test>::filter_multi_dispute_data(&mut statements);
+			assert_storage_noop!(Pallet::<Test>::filter_multi_dispute_data(&mut statements));
 
 			assert_eq!(
 				statements,
@@ -3336,7 +3336,7 @@ mod tests {
 				)],
 			}];
 
-			Pallet::<Test>::filter_multi_dispute_data(&mut statements);
+			assert_storage_noop!(Pallet::<Test>::filter_multi_dispute_data(&mut statements));
 
 			assert!(statements.is_empty());
 		})


### PR DESCRIPTION
Closes #4055 

The `filter_multi_disputes_data` function currently modifies internal state. However, this function should run on fresh state at every point and therefore it must be wrapped in a Rollback transaction.

This PR addresses this shortcoming.