### PR TITLE
New substrate.io site, no `homepage` fields in `Cargo.toml`

### DIFF
--- a/bridges/README.md
+++ b/bridges/README.md
@@ -39,7 +39,7 @@ cargo test --all
 ```
 
 If you need more information about setting up your development environment Substrate's
-[Getting Started](https://substrate.dev/docs/en/knowledgebase/getting-started/) page is a good
+[Getting Started](https://docs.substrate.io/v3/getting-started/installation) page is a good
 resource.
 
 ## High-Level Architecture

--- a/bridges/bin/millau/node/Cargo.toml
+++ b/bridges/bin/millau/node/Cargo.toml
@@ -5,7 +5,6 @@ version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 build = "build.rs"
-homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/parity-bridges-common/"
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 

--- a/bridges/bin/millau/runtime/Cargo.toml
+++ b/bridges/bin/millau/runtime/Cargo.toml
@@ -3,7 +3,6 @@ name = "millau-runtime"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
-homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/parity-bridges-common/"
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 

--- a/bridges/bin/rialto/node/Cargo.toml
+++ b/bridges/bin/rialto/node/Cargo.toml
@@ -5,7 +5,6 @@ version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 build = "build.rs"
-homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/parity-bridges-common/"
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 

--- a/bridges/bin/rialto/runtime/Cargo.toml
+++ b/bridges/bin/rialto/runtime/Cargo.toml
@@ -3,7 +3,6 @@ name = "rialto-runtime"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
-homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/parity-bridges-common/"
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 

--- a/bridges/bin/runtime-common/Cargo.toml
+++ b/bridges/bin/runtime-common/Cargo.toml
@@ -3,7 +3,6 @@ name = "bridge-runtime-common"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
-homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/parity-bridges-common/"
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 

--- a/roadmap/implementers-guide/src/glossary.md
+++ b/roadmap/implementers-guide/src/glossary.md
@@ -40,6 +40,6 @@ exactly one downward message queue.
 - VMP: (Vertical Message Passing) A family of mechanisms that are responsible for message exchange between the relay chain and parachains.
 - XCMP (Cross-Chain Message Passing) A type of horizontal message passing (i.e. between parachains) that allows secure message passing directly between parachains and has minimal resource requirements from the relay chain, thus highly scalable.
 
-Also of use is the [Substrate Glossary](https://substrate.dev/docs/en/knowledgebase/getting-started/glossary).
+Also of use is the [Substrate Glossary](https://docs.substrate.io/v3/getting-started/glossary).
 
 [0]: https://wiki.polkadot.network/docs/learn-consensus


### PR DESCRIPTION
- [x] All crates do not have a home page set, except bridges, this is removed for consistency.
- [x] Fix all Substrate  links to use https://substrate.io/ 
  - **Note: link to _specific_ docs include `v3` in the URL, for new versions of the docs we need to replace this manually**

Upstream https://github.com/paritytech/substrate/pull/10007