### PR TITLE
Update reward_points.rs

### DIFF
--- a/runtime/parachains/src/reward_points.rs
+++ b/runtime/parachains/src/reward_points.rs
@@ -26,7 +26,7 @@ use pallet_staking::SessionInterface;
 use primitives::v1::ValidatorIndex;
 
 /// The amount of era points given by backing a candidate that is included.
-pub const BACKING_POINTS: u32 = 20;
+pub const BACKING_POINTS: u32 = 100;
 
 /// Rewards validators for participating in parachains with era points in pallet-staking.
 pub struct RewardValidatorsWithEraPoints<C>(sp_std::marker::PhantomData<C>);


### PR DESCRIPTION
Between era 2800 and 2883 my node had 17 eras that earned 100 points or less per Era.

About 20% of the entire 84 Eras my node and my nominators have earned 0.386 KSM.

Just to be clear, my node has enough resources and it is set up properly.
Avg era 1597 points
Avg reward = 0.54 KSM
Max era 9860 points

Could we get the weight adjusted for Block production from 20 points per block to 100 points per block?

I understand that we want to award people that run their nodes with proper configuration and with enough resources.

But it is not my fault that the algorithm didn't pick my Validator for Parachain Validating even once during 6 sessions for total of 106 Session with no Parachain Validator slot.