### PR TITLE
Remove logging from the check-dependent-* job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -285,7 +285,6 @@ build-adder-collator:
         --polkadot
         "$DEPENDENT_REPO"
         "$GITHUB_PR_TOKEN"
-    - cd "$DEPENDENT_REPO" && git rev-parse --abbrev-ref HEAD
 
 check-dependent-cumulus:
   <<: *check-dependent-project


### PR DESCRIPTION
such command belongs to the script rather than the job