### PR TITLE
add subxt as dependency in release checklist

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -35,6 +35,8 @@ candidate branch or started an additional release candidate branch (rc-2, rc-3, 
     networks.
 - [ ] Verify [Polkadot JS API](#polkadot-js) are up to date with the latest
     runtime changes.
+- [ ] Verify [SubXt](#substrate-subxt) is up to date with the latest
+    runtime changes.
 - [ ] Push runtime upgrade to Westend and verify network stability.
 
 ### All Releases
@@ -143,4 +145,9 @@ release-time. To initialise a benchmark run for each production runtime
 ### Polkadot JS
 
 Ensure that a release of [Polkadot JS API]() contains any new types or
+interfaces necessary to interact with the new runtime.
+
+### Substrate-SubXt
+
+Ensure that a release of [SubXt]() contains any new types or
 interfaces necessary to interact with the new runtime.


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

Forwarding some notes from @nud3l relevant for interBTC:

> Is there a way for us to ask that subxt is made a dependency to upgrade kusama? I think us and Phala are both requiring subxt to be compatible with the deployed version on kusama. If say, we had an update on kusama live that breaks our subxt dependency (the vault clients) it can have catastrophical consequences:

> - If don't upgrade subxt, our vault client will break. Vaults would not be able to redeem BTC to users. Users would then start to slash the vaults for their collateral at no fault of the vault.
> - If we don't upgrade the parachain and as a result the parachain would stop producing blocks, users could not slash vaults that steal BTC in time. They could only do so when the parachain comes online again.

> I would very much want to bring that to Parity's attention though as it could cause issues down the road if the release process would not consider at least the core dependencies developed by Parity.
