### PR TITLE
fix: chain sel + av-store error handling

### DIFF
--- a/node/core/av-store/src/lib.rs
+++ b/node/core/av-store/src/lib.rs
@@ -366,6 +366,9 @@ pub enum Error {
 }
 
 impl Error {
+	/// Determine if the error is irrecoverable
+	/// or notifying the user via means of logging
+	/// is sufficient.
 	fn is_fatal(&self) -> bool {
 		match self {
 			Self::Io(_) => true,

--- a/node/core/chain-selection/src/lib.rs
+++ b/node/core/chain-selection/src/lib.rs
@@ -458,7 +458,7 @@ async fn fetch_finalized(
 				target: LOG_TARGET,
 				number,
 				?err,
-				"Fetching finzalied block number failed"
+				"Fetching finalized block number failed"
 			);
 			Ok(None)
 		},


### PR DESCRIPTION
Currently IO errors were silently ignored, which was triggered by an excessive number of siblings.

Changes in this PR:

* degraded non-fatal errors to `Some(val)` where possible and print warnings
* remove incorrect `if let Err(_)` condition which included an oversight of the past and should be `Subsystem(Generated(Context))`