### PR TITLE
improved approval-voting logging

### DIFF
--- a/node/core/approval-voting/src/lib.rs
+++ b/node/core/approval-voting/src/lib.rs
@@ -1326,9 +1326,8 @@ async fn handle_approved_ancestor(
 									let next_wakeup =
 										wakeups.wakeup_for(block_hash, candidate_hash);
 
-									let approved = triggered && {
-										a_entry.local_statements().1.is_some()
-									};
+									let approved =
+										triggered && { a_entry.local_statements().1.is_some() };
 
 									tracing::debug!(
 										target: LOG_TARGET,


### PR DESCRIPTION
When a candidate goes unapproved for a long time we now log not only whether we've triggered our assignment (begun approval work) but also whether we've cast an approval vote (finished approval work).