### PR TITLE
bump finality safety net depth to 500 blocks

### DIFF
--- a/node/service/src/relay_chain_selection.rs
+++ b/node/service/src/relay_chain_selection.rs
@@ -53,7 +53,7 @@ use std::sync::Arc;
 /// or disputes.
 ///
 /// This is a safety net that should be removed at some point in the future.
-const MAX_FINALITY_LAG: polkadot_primitives::v1::BlockNumber = 50;
+const MAX_FINALITY_LAG: polkadot_primitives::v1::BlockNumber = 500;
 
 const LOG_TARGET: &str = "parachain::chain-selection";
 


### PR DESCRIPTION
This will give us more time to diagnose a problem and the safety net will be eventually removed anyway.