### PR TITLE
remove duplicate Deposit from OnUnbalanced implementation

### DIFF
--- a/runtime/common/src/impls.rs
+++ b/runtime/common/src/impls.rs
@@ -29,16 +29,10 @@ where
 	<R as frame_system::Config>::Event: From<pallet_balances::Event<R>>,
 {
 	fn on_nonzero_unbalanced(amount: NegativeImbalance<R>) {
-		let numeric_amount = amount.peek();
-		let author = <pallet_authorship::Pallet<R>>::author();
 		<pallet_balances::Pallet<R>>::resolve_creating(
 			&<pallet_authorship::Pallet<R>>::author(),
 			amount,
 		);
-		<frame_system::Pallet<R>>::deposit_event(pallet_balances::Event::Deposit(
-			author,
-			numeric_amount,
-		));
 	}
 }
 


### PR DESCRIPTION
Due to https://github.com/paritytech/substrate/pull/9425 there is already a deposit event created for the block author rewards.