### PR TITLE
Update CI image to use the latest rustc

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,7 +15,7 @@ stages:
   - publish
   - deploy
 
-image:                             paritytech/ci-linux:staging
+image:                             paritytech/ci-linux:production
 
 workflow:
   rules:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,7 +15,7 @@ stages:
   - publish
   - deploy
 
-image:                             paritytech/ci-linux:production
+image:                             paritytech/ci-linux:staging
 
 workflow:
   rules:

--- a/node/overseer/overseer-gen/proc-macro/src/impl_channels_out.rs
+++ b/node/overseer/overseer-gen/proc-macro/src/impl_channels_out.rs
@@ -56,6 +56,7 @@ pub(crate) fn impl_channels_out_struct(info: &OverseerInfo) -> Result<proc_macro
 			)*
 		}
 
+		#[allow(unreachable_code)] // when no defined messages in enum
 		impl ChannelsOut {
 			/// Send a message via a bounded channel.
 			pub async fn send_and_log_error(


### PR DESCRIPTION
I've created this pr to check whether CI pipeline can use CI image with updated rustc (version 1.56.1)

(Companion to https://github.com/paritytech/substrate/pull/10142 )