### PR TITLE
Pallet-Xcm compile for runtime-benchmarks

### DIFF
--- a/xcm/pallet-xcm/Cargo.toml
+++ b/xcm/pallet-xcm/Cargo.toml
@@ -39,4 +39,8 @@ std = [
 	"frame-system/std",
 	"xcm/std",
 ]
-runtime-benchmarks = []
+runtime-benchmarks = [
+	"frame-support/runtime-benchmarks",
+	"frame-system/runtime-benchmarks",
+	"xcm-builder/runtime-benchmarks",
+]


### PR DESCRIPTION
Currently `cargo test --features runtime-benchmarks` does not compile for pallet-xcm

Nvm: A lot of pallets don't individually compile with runtime-benchmarks. Only runtimes really need to