### PR TITLE
introduce trusted teleporter Encointer for Rococo and Westend

### DIFF
--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -671,6 +671,7 @@ parameter_types! {
 	pub const RococoForTrack: (MultiAssetFilter, MultiLocation) = (Rococo::get(), Parachain(120).into());
 	pub const RococoForStatemine: (MultiAssetFilter, MultiLocation) = (Rococo::get(), Parachain(1000).into());
 	pub const RococoForCanvas: (MultiAssetFilter, MultiLocation) = (Rococo::get(), Parachain(1002).into());
+	pub const RococoForEncointer: (MultiAssetFilter, MultiLocation) = (Rococo::get(), Parachain(1003).into());
 	pub const MaxInstructions: u32 = 100;
 }
 pub type TrustedTeleporters = (
@@ -679,6 +680,7 @@ pub type TrustedTeleporters = (
 	xcm_builder::Case<RococoForTrack>,
 	xcm_builder::Case<RococoForStatemine>,
 	xcm_builder::Case<RococoForCanvas>,
+	xcm_builder::Case<RococoForEncointer>,
 );
 
 parameter_types! {
@@ -689,6 +691,7 @@ parameter_types! {
 			Parachain(120).into(),
 			Parachain(1000).into(),
 			Parachain(1002).into(),
+			Parachain(1003).into(),
 		];
 }
 

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -990,11 +990,15 @@ pub type XcmRouter = (
 
 parameter_types! {
 	pub const Westmint: MultiLocation = Parachain(1000).into();
+	pub const Encointer: MultiLocation = Parachain(1001).into();
 	pub const WestendForWestmint: (MultiAssetFilter, MultiLocation) =
 		(Wild(AllOf { fun: WildFungible, id: Concrete(WndLocation::get()) }), Westmint::get());
+	pub const WestendForEncointer: (MultiAssetFilter, MultiLocation) =
+		(Wild(AllOf { fun: WildFungible, id: Concrete(WndLocation::get()) }), Encointer::get());
 	pub const MaxInstructions: u32 = 100;
 }
-pub type TrustedTeleporters = (xcm_builder::Case<WestendForWestmint>,);
+pub type TrustedTeleporters =
+	(xcm_builder::Case<WestendForWestmint>, xcm_builder::Case<WestendForEncointer>);
 
 /// The barriers one of which must be passed for an XCM message to be executed.
 pub type Barrier = (


### PR DESCRIPTION
After discussion with @gavofyork, we have adjusted our common good parachain governance model. As desired for common good, there will be no root origin on the parachain and with this PR we'd like to be included in the trusted teleport set.

We believe this is in line with Kusama council's decision to accept Encointer as a common good:
Discussion: https://kusama.polkassembly.io/post/610
Executed signalling motion:  https://kusama.polkassembly.io/motion/357

As discussed with @joepetrowski, we'd test teleport on rococo first and wait for this PR to enter a release before testing teleport and set_code on westmint 

@joepetrowski may I ask for your review? Should this work?