### PR TITLE
Update `bridge/` codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
-bridges/ @tomusdrw @svyatonik @acatangiu @antonio-dropulic
+bridges/ @tomusdrw @svyatonik @adoerr @acatangiu @antonio-dropulic
+ 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-bridges/ @tomusdrw @svyatonik @hcastano
+bridges/ @tomusdrw @svyatonik @acatangiu @antonio-dropulic


### PR DESCRIPTION
I'm no longer working on Bridges, so I'm removing myself from the `CODEOWNERS`. There
have also been two new joiners to the bridge team recently so I've added them as well
(cc @acatangiu and @antonio-dropulic).
