### PR TITLE
Fix parachain runtime upgrades on local networks

### DIFF
--- a/runtime/parachains/src/paras.rs
+++ b/runtime/parachains/src/paras.rs
@@ -979,7 +979,7 @@ impl<T: Config> Pallet<T> {
 
 				// If the expected upgrade block is in the past, we need
 				// to move this up to the current block. Aka when a parachain block
-				// will be enacted that was build on this or any descendent block the
+				// will be enacted that was built on this or any descendent block the
 				// runtime upgrade should be enacted.
 				let expected_at = if expected_at <= now { now } else { expected_at };
 


### PR DESCRIPTION
On local networks we often use runtime upgrade delays for parachains of
1 block. However, with the new go-ahead signal, this is broken. The
problem is that when we enact a block in relay chain block N, the
upgrade block X will already be
in the past and the go-ahead signal will be set in the next relay chain
block N + 1. However, the next parachain block that is build and enacted
on N, will not have seen the go-ahead signal, but it is required to
enact the runtime upgrade. The solution to this problem is to directly
set the go-ahead signal when we schedule a runtime upgrade and the
expected block is in the past.