### PR TITLE
req/resp: use IfDisconnected::ImmediateError

### DIFF
--- a/node/network/availability-distribution/src/pov_requester/mod.rs
+++ b/node/network/availability-distribution/src/pov_requester/mod.rs
@@ -67,7 +67,7 @@ where
 		// We are supposed to be connected to validators of our group via `PeerSet`,
 		// but at session boundaries that is kind of racy, in case a connection takes
 		// longer to get established, so we try to connect in any case.
-		IfDisconnected::TryConnect,
+		IfDisconnected::ImmediateError,
 	))
 	.await;
 

--- a/node/network/availability-distribution/src/pov_requester/mod.rs
+++ b/node/network/availability-distribution/src/pov_requester/mod.rs
@@ -64,9 +64,6 @@ where
 
 	ctx.send_message(NetworkBridgeMessage::SendRequests(
 		vec![full_req],
-		// We are supposed to be connected to validators of our group via `PeerSet`,
-		// but at session boundaries that is kind of racy, in case a connection takes
-		// longer to get established, so we try to connect in any case.
 		IfDisconnected::ImmediateError,
 	))
 	.await;

--- a/node/network/availability-distribution/src/requester/fetch_task/mod.rs
+++ b/node/network/availability-distribution/src/requester/fetch_task/mod.rs
@@ -327,7 +327,7 @@ impl RunningTask {
 
 		self.sender
 			.send(FromFetchTask::Message(AllMessages::NetworkBridge(
-				NetworkBridgeMessage::SendRequests(vec![requests], IfDisconnected::TryConnect),
+				NetworkBridgeMessage::SendRequests(vec![requests], IfDisconnected::ImmediateError),
 			)))
 			.await
 			.map_err(|_| TaskError::ShuttingDown)?;

--- a/node/network/availability-distribution/src/requester/fetch_task/tests.rs
+++ b/node/network/availability-distribution/src/requester/fetch_task/tests.rs
@@ -230,7 +230,7 @@ impl TestRun {
 		match msg {
 			AllMessages::NetworkBridge(NetworkBridgeMessage::SendRequests(
 				reqs,
-				IfDisconnected::TryConnect,
+				IfDisconnected::ImmediateError,
 			)) => {
 				let mut valid_responses = 0;
 				for req in reqs {

--- a/node/network/availability-distribution/src/tests/state.rs
+++ b/node/network/availability-distribution/src/tests/state.rs
@@ -215,7 +215,7 @@ impl TestState {
 			match msg {
 				AllMessages::NetworkBridge(NetworkBridgeMessage::SendRequests(
 					reqs,
-					IfDisconnected::TryConnect,
+					IfDisconnected::ImmediateError,
 				)) => {
 					for req in reqs {
 						// Forward requests:

--- a/node/network/availability-recovery/src/lib.rs
+++ b/node/network/availability-recovery/src/lib.rs
@@ -201,7 +201,7 @@ impl RequestFromBackers {
 				.send_message(
 					NetworkBridgeMessage::SendRequests(
 						vec![Requests::AvailableDataFetching(req)],
-						IfDisconnected::TryConnect,
+						IfDisconnected::ImmediateError,
 					)
 					.into(),
 				)
@@ -345,7 +345,7 @@ impl RequestChunksFromValidators {
 
 		sender
 			.send_message(
-				NetworkBridgeMessage::SendRequests(requests, IfDisconnected::TryConnect).into(),
+				NetworkBridgeMessage::SendRequests(requests, IfDisconnected::ImmediateError).into(),
 			)
 			.await;
 	}

--- a/node/network/availability-recovery/src/tests.rs
+++ b/node/network/availability-recovery/src/tests.rs
@@ -275,7 +275,7 @@ impl TestState {
 				AllMessages::NetworkBridge(
 					NetworkBridgeMessage::SendRequests(
 						requests,
-						IfDisconnected::TryConnect,
+						IfDisconnected::ImmediateError,
 					)
 				) => {
 					for req in requests {
@@ -324,7 +324,7 @@ impl TestState {
 				AllMessages::NetworkBridge(
 					NetworkBridgeMessage::SendRequests(
 						mut requests,
-						IfDisconnected::TryConnect,
+						IfDisconnected::ImmediateError,
 					)
 				) => {
 					assert_eq!(requests.len(), 1);

--- a/node/network/dispute-distribution/src/sender/send_task.rs
+++ b/node/network/dispute-distribution/src/sender/send_task.rs
@@ -306,7 +306,6 @@ async fn send_requests<Context: SubsystemContext>(
 
 	let msg = NetworkBridgeMessage::SendRequests(
 		reqs,
-		// We should be connected, but the hell - if not, try!
 		IfDisconnected::ImmediateError,
 	);
 	ctx.send_message(AllMessages::NetworkBridge(msg)).await;

--- a/node/network/dispute-distribution/src/sender/send_task.rs
+++ b/node/network/dispute-distribution/src/sender/send_task.rs
@@ -304,10 +304,7 @@ async fn send_requests<Context: SubsystemContext>(
 		statuses.insert(receiver, DeliveryStatus::Pending(remote_handle));
 	}
 
-	let msg = NetworkBridgeMessage::SendRequests(
-		reqs,
-		IfDisconnected::ImmediateError,
-	);
+	let msg = NetworkBridgeMessage::SendRequests(reqs, IfDisconnected::ImmediateError);
 	ctx.send_message(AllMessages::NetworkBridge(msg)).await;
 	Ok(statuses)
 }

--- a/node/network/dispute-distribution/src/sender/send_task.rs
+++ b/node/network/dispute-distribution/src/sender/send_task.rs
@@ -307,7 +307,7 @@ async fn send_requests<Context: SubsystemContext>(
 	let msg = NetworkBridgeMessage::SendRequests(
 		reqs,
 		// We should be connected, but the hell - if not, try!
-		IfDisconnected::TryConnect,
+		IfDisconnected::ImmediateError,
 	);
 	ctx.send_message(AllMessages::NetworkBridge(msg)).await;
 	Ok(statuses)

--- a/node/network/dispute-distribution/src/tests/mod.rs
+++ b/node/network/dispute-distribution/src/tests/mod.rs
@@ -663,7 +663,7 @@ async fn check_sent_requests(
 	assert_matches!(
 		handle.recv().await,
 		AllMessages::NetworkBridge(
-			NetworkBridgeMessage::SendRequests(reqs, IfDisconnected::TryConnect)
+			NetworkBridgeMessage::SendRequests(reqs, IfDisconnected::ImmediateError)
 		) => {
 			let reqs: Vec<_> = reqs.into_iter().map(|r|
 				assert_matches!(


### PR DESCRIPTION
As discussed, we should attempt to preconnect to every validator and trying to connect if disconnected in req/resp will only waste time.

- [x] Update the comments.

> // We are supposed to be connected to validators of our group via `PeerSet`, 
> // but at session boundaries that is kind of racy, in case a connection takes
> // longer to get established, so we try to connect in any case.

we are supposed to be preconnected to the next session authorities as well, so it shouldn't be racy at session boundaries