### PR TITLE
Bump pwasm-utils to 0.18.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7572,9 +7572,9 @@ dependencies = [
 
 [[package]]
 name = "pwasm-utils"
-version = "0.18.0"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0e517f47d9964362883182404b68d0b6949382c0baa40aa5ffca94f5f1e3481"
+checksum = "880b3384fb00b8f6ecccd5d358b93bd2201900ae3daad213791d1864f6441f5c"
 dependencies = [
  "byteorder",
  "log",
@@ -11122,7 +11122,7 @@ version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f559b464de2e2bdabcac6a210d12e9b5a5973c251e102c44c585c71d51bd78e"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "rand 0.8.4",
  "static_assertions",
 ]


### PR DESCRIPTION
Mainly to incorporate this change https://github.com/paritytech/wasm-utils/pull/170 which affect the deterministic stack limit injection performance.

https://github.com/paritytech/polkadot/blob/a2244b66a8e2cc87a2bafca1c8a48306c77d231d/node/core/pvf/src/executor_intf.rs#L66

