### PR TITLE
Increment the retired metric instead of spawned

### DIFF
--- a/node/core/pvf/src/metrics.rs
+++ b/node/core/pvf/src/metrics.rs
@@ -208,7 +208,7 @@ impl<'a> WorkerRelatedMetrics<'a> {
 	/// When the worker was killed or died.
 	pub(crate) fn on_retired(&self) {
 		if let Some(metrics) = &self.metrics.0 {
-			metrics.worker_spawned.with_label_values(&[self.flavor.as_label()]).inc();
+			metrics.worker_retired.with_label_values(&[self.flavor.as_label()]).inc();
 		}
 	}
 }


### PR DESCRIPTION
Set to 0.9.13 in order to help diagnose the burn-in