### PR TITLE
Increase preparation timeout

### DIFF
--- a/node/core/pvf/src/metrics.rs
+++ b/node/core/pvf/src/metrics.rs
@@ -152,8 +152,21 @@ impl metrics::Metrics for Metrics {
 				prometheus::Histogram::with_opts(
 					prometheus::HistogramOpts::new(
 						"pvf_preparation_time",
-						"Time spent in preparing PVF artifacts",
+						"Time spent in preparing PVF artifacts in seconds",
 					)
+					.buckets(vec![
+						// This is synchronized with COMPILATION_TIMEOUT=60s constant found in
+						// src/prepare/worker.rs
+						0.1,
+						0.5,
+						1.0,
+						10.0,
+						20.0,
+						30.0,
+						40.0,
+						50.0,
+						60.0,
+					]),
 				)?,
 				registry,
 			)?,

--- a/node/core/pvf/src/prepare/worker.rs
+++ b/node/core/pvf/src/prepare/worker.rs
@@ -37,6 +37,8 @@ use std::{sync::Arc, time::Duration};
 const NICENESS_BACKGROUND: i32 = 10;
 const NICENESS_FOREGROUND: i32 = 0;
 
+/// The time period after which the preparation worker is considered unresponsive and will be killed.
+// NOTE: If you change this make sure to fix the buckets of `pvf_preparation_time` metric.
 const COMPILATION_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// Spawns a new worker with the given program path that acts as the worker and the spawn timeout.

--- a/node/core/pvf/src/prepare/worker.rs
+++ b/node/core/pvf/src/prepare/worker.rs
@@ -37,7 +37,7 @@ use std::{sync::Arc, time::Duration};
 const NICENESS_BACKGROUND: i32 = 10;
 const NICENESS_FOREGROUND: i32 = 0;
 
-const COMPILATION_TIMEOUT: Duration = Duration::from_secs(10);
+const COMPILATION_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// Spawns a new worker with the given program path that acts as the worker and the spawn timeout.
 ///


### PR DESCRIPTION
Lately we've been observing preparation timeouts. Whereas in local testing, compilation of a hefty PVF should take <1s for multi-threaded compilation (and ≈3s for single-threaded), in the wild we were observing compilation speed of more like 5 seconds and more occasionally bumping into the 10s cutoff.

This timeout affects the maximum response time for backing and approvals work. However, it is amortized, and once compiled it will be cached for time the artifact is being used. 10s cutoff was chosen rather arbitrary. It is already more than backing, which has way less than 10s, so it will be missed anyway. Missing the deadline once in a while for approvals does not seem bad either. 

At the same time, increasing the timeout does not seem to be very bad at this moment. Exploiting JIT bombs does not seem to be likely. Doing so will require big investment and the effects of the attack are questionable. 

Priority is set to high, because we need to upgrade the nodes ASAP to minimize the time when nodes have different opinion on whether the code timed out or not.

