### PR TITLE
chore: fmt should print version

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -158,6 +158,7 @@ cargo-fmt:
   <<:                              *docker-env
   <<:                              *rules-test
   script:
+    - cargo +nightly --version
     - cargo +nightly fmt --all -- --check
   allow_failure:                   true
 


### PR DESCRIPTION
Because it's just too aggravating having to fetch the container every time to
find out the version of cargo +nightly fmt.