### PR TITLE
Add Statemine as parachain 1000 to rococo trusted teleporters

### DIFF
--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -666,7 +666,6 @@ parameter_types! {
 	pub const RococoForTrick: (MultiAssetFilter, MultiLocation) = (Rococo::get(), Parachain(110).into());
 	pub const RococoForTrack: (MultiAssetFilter, MultiLocation) = (Rococo::get(), Parachain(120).into());
 	pub const RococoForStatemine: (MultiAssetFilter, MultiLocation) = (Rococo::get(), Parachain(1000).into());
-	pub const RococoForRockmine: (MultiAssetFilter, MultiLocation) = (Rococo::get(), Parachain(1001).into());
 	pub const RococoForCanvas: (MultiAssetFilter, MultiLocation) = (Rococo::get(), Parachain(1002).into());
 	pub const MaxInstructions: u32 = 100;
 }
@@ -675,7 +674,6 @@ pub type TrustedTeleporters = (
 	xcm_builder::Case<RococoForTrick>,
 	xcm_builder::Case<RococoForTrack>,
 	xcm_builder::Case<RococoForStatemine>,
-	xcm_builder::Case<RococoForRockmine>,
 	xcm_builder::Case<RococoForCanvas>,
 );
 
@@ -686,7 +684,6 @@ parameter_types! {
 			Parachain(110).into(),
 			Parachain(120).into(),
 			Parachain(1000).into(),
-			Parachain(1001).into(),
 			Parachain(1002).into(),
 		];
 }

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -665,6 +665,7 @@ parameter_types! {
 	pub const RococoForTick: (MultiAssetFilter, MultiLocation) = (Rococo::get(), Parachain(100).into());
 	pub const RococoForTrick: (MultiAssetFilter, MultiLocation) = (Rococo::get(), Parachain(110).into());
 	pub const RococoForTrack: (MultiAssetFilter, MultiLocation) = (Rococo::get(), Parachain(120).into());
+	pub const RococoForStatemine: (MultiAssetFilter, MultiLocation) = (Rococo::get(), Parachain(1000).into());
 	pub const RococoForRockmine: (MultiAssetFilter, MultiLocation) = (Rococo::get(), Parachain(1001).into());
 	pub const RococoForCanvas: (MultiAssetFilter, MultiLocation) = (Rococo::get(), Parachain(1002).into());
 	pub const MaxInstructions: u32 = 100;
@@ -673,6 +674,7 @@ pub type TrustedTeleporters = (
 	xcm_builder::Case<RococoForTick>,
 	xcm_builder::Case<RococoForTrick>,
 	xcm_builder::Case<RococoForTrack>,
+	xcm_builder::Case<RococoForStatemine>,
 	xcm_builder::Case<RococoForRockmine>,
 	xcm_builder::Case<RococoForCanvas>,
 );
@@ -683,6 +685,7 @@ parameter_types! {
 			Parachain(100).into(),
 			Parachain(110).into(),
 			Parachain(120).into(),
+			Parachain(1000).into(),
 			Parachain(1001).into(),
 			Parachain(1002).into(),
 		];


### PR DESCRIPTION
Fixing a weird historical thing where Statemint-like chains are at id 1001 on Rococo (and thus you cannot teleport funds to Statemint if it is registered at id 1000).
We can remove 1001 later if we want.