### PR TITLE
Remove sort_unstable_by

### DIFF
--- a/runtime/parachains/src/paras_inherent.rs
+++ b/runtime/parachains/src/paras_inherent.rs
@@ -957,7 +957,7 @@ fn limit_disputes<T: Config>(
 		// Sort the dispute statements according to the following prioritization:
 		//  1. Prioritize local disputes over remote disputes.
 		//  2. Prioritize older disputes over newer disputes.
-		disputes.sort_unstable_by(|a, b| {
+		disputes.sort_by(|a, b| {
 			let a_local_block = T::DisputesHandler::included_state(a.session, a.candidate_hash);
 			let b_local_block = T::DisputesHandler::included_state(b.session, b.candidate_hash);
 			match (a_local_block, b_local_block) {


### PR DESCRIPTION
This PR addresses a comment raised by @shawntabrizi regarding the unstable sort when a particular item may not be unique in the comparison of disputes.