### PR TITLE
Enable BEEFY explicitly

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -103,7 +103,7 @@ pub struct RunCmd {
 
 	/// Disable BEEFY gadget.
 	#[structopt(long)]
-	pub no_beefy: bool,
+	pub beefy: bool,
 
 	/// Add the destination address to the jaeger agent.
 	///

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -101,7 +101,7 @@ pub struct RunCmd {
 	#[structopt(long = "grandpa-pause", number_of_values(2))]
 	pub grandpa_pause: Vec<u32>,
 
-	/// Disable BEEFY gadget.
+	/// Enable the BEEFY gadget (only on Rococo or Wococo for now).
 	#[structopt(long)]
 	pub beefy: bool,
 

--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -254,7 +254,7 @@ fn run_node_inner(cli: Cli, overseer_gen: impl service::OverseerGen) -> Result<(
 				config,
 				service::IsCollator::No,
 				grandpa_pause,
-				cli.run.no_beefy,
+				cli.run.beefy,
 				jaeger_agent,
 				None,
 				overseer_gen,

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -669,7 +669,7 @@ pub fn new_full<RuntimeApi, ExecutorDispatch, OverseerGenerator>(
 	mut config: Configuration,
 	is_collator: IsCollator,
 	grandpa_pause: Option<(u32, u32)>,
-	disable_beefy: bool,
+	enable_beefy: bool,
 	jaeger_agent: Option<std::net::SocketAddr>,
 	telemetry_worker_handle: Option<TelemetryWorkerHandle>,
 	program_path: Option<std::path::PathBuf>,
@@ -1053,7 +1053,7 @@ where
 		if role.is_authority() { Some(keystore_container.sync_keystore()) } else { None };
 
 	// We currently only run the BEEFY gadget on the Rococo and Wococo testnets.
-	if !disable_beefy && (chain_spec.is_rococo() || chain_spec.is_wococo()) {
+	if enable_beefy && (chain_spec.is_rococo() || chain_spec.is_wococo()) {
 		let beefy_params = beefy_gadget::BeefyParams {
 			client: client.clone(),
 			backend: backend.clone(),
@@ -1211,7 +1211,7 @@ pub fn build_full(
 	config: Configuration,
 	is_collator: IsCollator,
 	grandpa_pause: Option<(u32, u32)>,
-	disable_beefy: bool,
+	enable_beefy: bool,
 	jaeger_agent: Option<std::net::SocketAddr>,
 	telemetry_worker_handle: Option<TelemetryWorkerHandle>,
 	overseer_gen: impl OverseerGen,
@@ -1222,7 +1222,7 @@ pub fn build_full(
 			config,
 			is_collator,
 			grandpa_pause,
-			disable_beefy,
+			enable_beefy,
 			jaeger_agent,
 			telemetry_worker_handle,
 			None,
@@ -1237,7 +1237,7 @@ pub fn build_full(
 			config,
 			is_collator,
 			grandpa_pause,
-			disable_beefy,
+			enable_beefy,
 			jaeger_agent,
 			telemetry_worker_handle,
 			None,
@@ -1252,7 +1252,7 @@ pub fn build_full(
 			config,
 			is_collator,
 			grandpa_pause,
-			disable_beefy,
+			enable_beefy,
 			jaeger_agent,
 			telemetry_worker_handle,
 			None,
@@ -1267,7 +1267,7 @@ pub fn build_full(
 			config,
 			is_collator,
 			grandpa_pause,
-			disable_beefy,
+			enable_beefy,
 			jaeger_agent,
 			telemetry_worker_handle,
 			None,


### PR DESCRIPTION
Change the CLI command from `--no-beefy` to `--beefy` which means that BEEFY needs to be explicitly enabled. Since BEEFY is still in development I believe that this will be less error-prone on Rococo.