### PR TITLE
prefer code upgrades in inherent filtering

### DIFF
--- a/runtime/parachains/src/paras_inherent.rs
+++ b/runtime/parachains/src/paras_inherent.rs
@@ -706,8 +706,6 @@ fn random_sel<X, F: Fn(&X) -> Weight>(
 
 		// preferred indices originate from outside
 		if let Some(item) = selectables.get(preferred_idx) {
-			weight_acc += weight_fn(item);
-
 			let updated = weight_acc + weight_fn(item);
 			if updated > weight_limit {
 				continue

--- a/runtime/parachains/src/paras_inherent.rs
+++ b/runtime/parachains/src/paras_inherent.rs
@@ -969,6 +969,10 @@ fn sanitize_backed_candidates<T: crate::inclusion::Config, F: Fn(CandidateHash) 
 	backed_candidates
 }
 
+/// Derive entropy from babe provided per block randomness.
+///
+/// In the odd case none is available, uses the `parent_hash` and
+/// a const value, while emitting a warning.
 fn compute_entropy<T: Config>(parent_hash: T::Hash) -> [u8; 32] {
 	const CANDIDATE_SEED_SUBJECT: [u8; 32] = *b"candidate-seed-selection-subject";
 	let vrf_random = CurrentBlockRandomness::<T>::random(&CANDIDATE_SEED_SUBJECT[..]).0;

--- a/runtime/parachains/src/paras_inherent.rs
+++ b/runtime/parachains/src/paras_inherent.rs
@@ -672,7 +672,7 @@ where
 	DisputedBitfield::from(bitvec)
 }
 
-/// Select a random subset
+/// Select a random subset, with preference for certain indices.
 ///
 /// Adds random items to the set until all candidates
 /// are tried or the remaining weight is depleted.
@@ -789,7 +789,7 @@ fn apply_weight_limit<T: Config + inclusion::Config>(
 			random_sel::<BackedCandidate<<T as frame_system::Config>::Hash>, _>(
 				rng,
 				candidates.clone(),
-				vec![],
+				preferred_indices,
 				|c| backed_candidate_weight::<T>(c),
 				remaining_weight,
 			);

--- a/runtime/parachains/src/paras_inherent.rs
+++ b/runtime/parachains/src/paras_inherent.rs
@@ -682,28 +682,28 @@ where
 fn random_sel<X, F: Fn(&X) -> Weight>(
 	rng: &mut rand_chacha::ChaChaRng,
 	selectables: Vec<X>,
-	mut prefered_indices: Vec<usize>,
+	mut preferred_indices: Vec<usize>,
 	weight_fn: F,
 	weight_limit: Weight,
 ) -> (Weight, Vec<usize>) {
 	if selectables.is_empty() {
 		return (0 as Weight, Vec::new())
 	}
-	// all indices that are not part of the prefered set
+	// all indices that are not part of the preferred set
 	let mut indices = (0..selectables.len())
 		.into_iter()
-		.filter(|idx| !prefered_indices.contains(idx))
+		.filter(|idx| !preferred_indices.contains(idx))
 		.collect::<Vec<_>>();
 	let mut picked_indices = Vec::with_capacity(selectables.len().saturating_sub(1));
 
 	let mut weight_acc = 0 as Weight;
 
-	// also shuffle the prefered ones
-	rng.shuffle(&mut prefered_indices);
-	for prefered_idx in prefered_indices {
+	// also shuffle the preferred ones
+	rng.shuffle(&mut preferred_indices);
+	for preferred_idx in preferred_indices {
 
-		// prefered indices originate from outside
-		if let Some(item) = selectables.get(prefered_idx) {
+		// preferred indices originate from outside
+		if let Some(item) = selectables.get(preferred_idx) {
 			weight_acc += weight_fn(item);
 
 			let updated = weight_acc + weight_fn(item);
@@ -711,7 +711,7 @@ fn random_sel<X, F: Fn(&X) -> Weight>(
 				continue
 			}
 			weight_acc = updated;
-			picked_indices.push(prefered_idx);
+			picked_indices.push(preferred_idx);
 		}
 	}
 

--- a/runtime/parachains/src/paras_inherent.rs
+++ b/runtime/parachains/src/paras_inherent.rs
@@ -769,7 +769,7 @@ fn apply_weight_limit<T: Config + inclusion::Config>(
 
 	// Prefer code upgrades, they tend to be large and hence stand no chance to be picked
 	// late while maintaining the weight bounds
-	let preferd_indices = candidates
+	let preferred_indices = candidates
 		.iter()
 		.enumerate()
 		.filter_map(|(idx, &candidate)| {

--- a/runtime/parachains/src/paras_inherent.rs
+++ b/runtime/parachains/src/paras_inherent.rs
@@ -698,9 +698,11 @@ fn random_sel<X, F: Fn(&X) -> Weight>(
 
 	let mut weight_acc = 0 as Weight;
 
-	// also shuffle the preferred ones
-	rng.shuffle(&mut preferred_indices);
-	for preferred_idx in preferred_indices {
+	while !preferred_indices.is_empty() {
+		// randomly pick an index from the preferred set
+		let pick = rng.gen_range(0..preferred_indices.len());
+		// remove the index from the available set of preferred indices
+		let preferred_idx = preferred_indices.swap_remove(pick);
 
 		// preferred indices originate from outside
 		if let Some(item) = selectables.get(preferred_idx) {

--- a/runtime/parachains/src/paras_inherent.rs
+++ b/runtime/parachains/src/paras_inherent.rs
@@ -772,13 +772,8 @@ fn apply_weight_limit<T: Config + inclusion::Config>(
 	let preferred_indices = candidates
 		.iter()
 		.enumerate()
-		.filter_map(|(idx, &candidate)| {
-			candidate
-				.candidate
-				.commitments
-				.new_validation_code
-				.as_ref()
-				.map(move |_code| idx)
+		.filter_map(|(idx, candidate)| {
+			candidate.candidate.commitments.new_validation_code.as_ref().map(|_code| idx)
 		})
 		.collect::<Vec<usize>>();
 

--- a/runtime/parachains/src/paras_inherent.rs
+++ b/runtime/parachains/src/paras_inherent.rs
@@ -722,11 +722,12 @@ fn random_sel<X, F: Fn(&X) -> Weight>(
 		let idx = indices.swap_remove(pick);
 
 		let item = &selectables[idx];
-		weight_acc += weight_fn(item);
+		let updated = weight_acc + weight_fn(item);
 
-		if weight_acc > weight_limit {
-			break
+		if updated > weight_limit {
+			continue
 		}
+		weight_acc = updated;
 
 		picked_indices.push(idx);
 	}


### PR DESCRIPTION
Closes #4330 

Also closes an issue that would stop processing additional backed candidates in case we had two code upgrades in a block where the second would cause an overweight condition.

skip check-dependent-cumulus