### PR TITLE
add missing feature

### DIFF
--- a/xcm/pallet-xcm/Cargo.toml
+++ b/xcm/pallet-xcm/Cargo.toml
@@ -38,5 +38,6 @@ std = [
 	"frame-support/std",
 	"frame-system/std",
 	"xcm/std",
+	"xcm-executor/std",
 ]
 runtime-benchmarks = []


### PR DESCRIPTION
This is causing building error in Acala.

The workaround is make `xcm-executor` our dependencies and explicitly add `xcm-executor/std` despite that it is only used in our test.

```
error: cannot find macro `vec` in this scope
   --> /Users/xiliangchen/.cargo/git/checkouts/polkadot-9da13ac14bbabc7b/5feed98/xcm/xcm-executor/src/lib.rs:163:23
    |
163 |             error_handler: Xcm(vec![]),
    |                                ^^^
    |
    = note: consider importing one of these items:
            parity_scale_codec::alloc::vec
            sp_std::vec
```

skip check-dependent-cumulus