### PR TITLE
Fix use of weight limit errors

### DIFF
--- a/xcm/src/v0/traits.rs
+++ b/xcm/src/v0/traits.rs
@@ -56,12 +56,12 @@ pub enum Error {
 	/// An asset wildcard was passed where it was not expected (e.g. as the asset to withdraw in a
 	/// `WithdrawAsset` XCM).
 	Wildcard,
-	/// The case where an XCM message has specified a optional weight limit and the weight required for
-	/// processing is too great.
+	/// The case where an XCM message has specified a weight limit on an interior call and this
+	/// limit is too low.
 	///
 	/// Used by:
 	/// - `Transact`
-	TooMuchWeightRequired,
+	MaxWeightInvalid,
 	/// The fees specified by the XCM message were not found in the holding account.
 	///
 	/// Used by:

--- a/xcm/src/v1/traits.rs
+++ b/xcm/src/v1/traits.rs
@@ -57,12 +57,12 @@ pub enum Error {
 	/// An asset wildcard was passed where it was not expected (e.g. as the asset to withdraw in a
 	/// `WithdrawAsset` XCM).
 	Wildcard,
-	/// The case where an XCM message has specified a optional weight limit and the weight required for
-	/// processing is too great.
+	/// The case where an XCM message has specified a weight limit on an interior call and this
+	/// limit is too low.
 	///
 	/// Used by:
 	/// - `Transact`
-	TooMuchWeightRequired,
+	MaxWeightInvalid,
 	/// The fees specified by the XCM message were not found in the holding register.
 	///
 	/// Used by:

--- a/xcm/src/v2/traits.rs
+++ b/xcm/src/v2/traits.rs
@@ -82,7 +82,7 @@ pub enum Error {
 	FailedToDecode,
 	/// Used by `Transact` to indicate that the given weight limit could be breached by the functor.
 	#[codec(index = 18)]
-	TooMuchWeightRequired,
+	MaxWeightInvalid,
 	/// Used by `BuyExecution` when the Holding Register does not contain payable fees.
 	#[codec(index = 19)]
 	NotHoldingFees,

--- a/xcm/xcm-builder/src/tests.rs
+++ b/xcm/xcm-builder/src/tests.rs
@@ -598,7 +598,7 @@ fn transacting_should_respect_max_weight_requirement() {
 	}]);
 	let weight_limit = 60;
 	let r = XcmExecutor::<TestConfig>::execute_xcm(Parent, message, weight_limit);
-	assert_eq!(r, Outcome::Incomplete(50, XcmError::TooMuchWeightRequired));
+	assert_eq!(r, Outcome::Incomplete(50, XcmError::MaxWeightInvalid));
 }
 
 #[test]

--- a/xcm/xcm-executor/src/lib.rs
+++ b/xcm/xcm-executor/src/lib.rs
@@ -344,7 +344,7 @@ impl<Config: config::Config> XcmExecutor<Config> {
 				let dispatch_origin = Config::OriginConverter::convert_origin(origin, origin_type)
 					.map_err(|_| XcmError::BadOrigin)?;
 				let weight = message_call.get_dispatch_info().weight;
-				ensure!(weight <= require_weight_at_most, XcmError::TooMuchWeightRequired);
+				ensure!(weight <= require_weight_at_most, XcmError::MaxWeightInvalid);
 				let actual_weight = match message_call.dispatch(dispatch_origin) {
 					Ok(post_info) => post_info.actual_weight,
 					Err(error_and_info) => {


### PR DESCRIPTION
The weight limit error `TooMuchWeightRequired` (used by `Transact` to indicate an invalid upper limit for the dispatchable call) was being incorrectly used in the place of `WeightLimitReached`.

This PR fixes that usage and renames the offending error into something more obvious.

Cumulus companion: https://github.com/paritytech/cumulus/pull/791