### PR TITLE
(testing graphite) Fix warn by remove unused var

### DIFF
--- a/runtime/parachains/src/inclusion.rs
+++ b/runtime/parachains/src/inclusion.rs
@@ -950,7 +950,6 @@ impl<T: Config> CandidateCheckContext<T> {
 		backed_candidate: &BackedCandidate<<T as frame_system::Config>::Hash>,
 	) -> Result<(), Error<T>> {
 		let para_id = backed_candidate.descriptor().para_id;
-		let now = self.now;
 
 		// we require that the candidate is in the context of the parent block.
 		ensure!(


### PR DESCRIPTION
This PR just fixes an existing warning introduced by https://github.com/paritytech/polkadot/pull/4349

