### PR TITLE
Do not log PVF prunning every hour

### DIFF
--- a/node/core/pvf/src/host.rs
+++ b/node/core/pvf/src/host.rs
@@ -646,7 +646,7 @@ async fn handle_cleanup_pulse(
 	artifact_ttl: Duration,
 ) -> Result<(), Fatal> {
 	let to_remove = artifacts.prune(artifact_ttl);
-	tracing::info!(
+	tracing::debug!(
 		target: LOG_TARGET,
 		"PVF pruning: {} artifacts reached their end of life",
 		to_remove.len(),


### PR DESCRIPTION
This lowers the level of the PVF pruning.

Closes https://github.com/paritytech/polkadot/issues/4361