### PR TITLE
Fix Provisioner dispute metrics naming

### DIFF
--- a/node/core/provisioner/src/metrics.rs
+++ b/node/core/provisioner/src/metrics.rs
@@ -23,11 +23,11 @@ struct MetricsInner {
 	request_inherent_data: prometheus::Histogram,
 	provisionable_data: prometheus::Histogram,
 
-	/// The `dispute_*` metrics track how many disputes/votes the runtime will have to process. It will count
+	/// The following metrics track how many disputes/votes the runtime will have to process. These will count
 	/// all recent statements meaning every dispute from last sessions: 10 min on Rococo, 60 min on Kusama and
 	/// 4 hours on Polkadot. The metrics are updated only when the node authors a block, so values vary across nodes.
-	dispute_statement_sets: prometheus::Counter<prometheus::U64>,
-	dispute_statements: prometheus::CounterVec<prometheus::U64>,
+	inherent_data_dispute_statement_sets: prometheus::Counter<prometheus::U64>,
+	inherent_data_dispute_statements: prometheus::CounterVec<prometheus::U64>,
 }
 
 /// Provisioner metrics.
@@ -61,7 +61,7 @@ impl Metrics {
 	pub(crate) fn inc_valid_statements_by(&self, votes: usize) {
 		if let Some(metrics) = &self.0 {
 			metrics
-				.dispute_statements
+				.inherent_data_dispute_statements
 				.with_label_values(&["valid"])
 				.inc_by(votes.try_into().unwrap_or(0));
 		}
@@ -70,7 +70,7 @@ impl Metrics {
 	pub(crate) fn inc_invalid_statements_by(&self, votes: usize) {
 		if let Some(metrics) = &self.0 {
 			metrics
-				.dispute_statements
+				.inherent_data_dispute_statements
 				.with_label_values(&["invalid"])
 				.inc_by(votes.try_into().unwrap_or(0));
 		}
@@ -78,7 +78,9 @@ impl Metrics {
 
 	pub(crate) fn inc_dispute_statement_sets_by(&self, disputes: usize) {
 		if let Some(metrics) = &self.0 {
-			metrics.dispute_statement_sets.inc_by(disputes.try_into().unwrap_or(0));
+			metrics
+				.inherent_data_dispute_statement_sets
+				.inc_by(disputes.try_into().unwrap_or(0));
 		}
 	}
 }
@@ -110,19 +112,19 @@ impl metrics::Metrics for Metrics {
 				))?,
 				registry,
 			)?,
-			dispute_statements: prometheus::register(
+			inherent_data_dispute_statements: prometheus::register(
 				prometheus::CounterVec::new(
 					prometheus::Opts::new(
-						"parachain_create_inherent_dispute_statements",
+						"parachain_inherent_data_dispute_statements",
 						"Number of dispute statements passed to `create_inherent()`.",
 					),
 					&["validity"],
 				)?,
 				&registry,
 			)?,
-			dispute_statement_sets: prometheus::register(
+			inherent_data_dispute_statement_sets: prometheus::register(
 				prometheus::Counter::new(
-					"parachain_create_inherent_dispute_statement_sets",
+					"parachain_inherent_data_dispute_statement_sets",
 					"Number of dispute statements sets passed to `create_inherent()`.",
 				)?,
 				registry,

--- a/node/core/provisioner/src/metrics.rs
+++ b/node/core/provisioner/src/metrics.rs
@@ -23,11 +23,11 @@ struct MetricsInner {
 	request_inherent_data: prometheus::Histogram,
 	provisionable_data: prometheus::Histogram,
 
-	/// The `dispute_statement_*` metrics track how many disputes/votes the runtime will have to process. It will count
+	/// The `dispute_*` metrics track how many disputes/votes the runtime will have to process. It will count
 	/// all recent statements meaning every dispute from last sessions: 10 min on Rococo, 60 min on Kusama and
 	/// 4 hours on Polkadot. The metrics are updated only when the node authors a block, so values vary across nodes.
-	dispute_statement_sets_requested: prometheus::Counter<prometheus::U64>,
-	dispute_statements_requested: prometheus::CounterVec<prometheus::U64>,
+	dispute_statement_sets: prometheus::Counter<prometheus::U64>,
+	dispute_statements: prometheus::CounterVec<prometheus::U64>,
 }
 
 /// Provisioner metrics.
@@ -61,7 +61,7 @@ impl Metrics {
 	pub(crate) fn inc_valid_statements_by(&self, votes: usize) {
 		if let Some(metrics) = &self.0 {
 			metrics
-				.dispute_statements_requested
+				.dispute_statements
 				.with_label_values(&["valid"])
 				.inc_by(votes.try_into().unwrap_or(0));
 		}
@@ -70,7 +70,7 @@ impl Metrics {
 	pub(crate) fn inc_invalid_statements_by(&self, votes: usize) {
 		if let Some(metrics) = &self.0 {
 			metrics
-				.dispute_statements_requested
+				.dispute_statements
 				.with_label_values(&["invalid"])
 				.inc_by(votes.try_into().unwrap_or(0));
 		}
@@ -78,9 +78,7 @@ impl Metrics {
 
 	pub(crate) fn inc_dispute_statement_sets_by(&self, disputes: usize) {
 		if let Some(metrics) = &self.0 {
-			metrics
-				.dispute_statement_sets_requested
-				.inc_by(disputes.try_into().unwrap_or(0));
+			metrics.dispute_statement_sets.inc_by(disputes.try_into().unwrap_or(0));
 		}
 	}
 }
@@ -112,20 +110,20 @@ impl metrics::Metrics for Metrics {
 				))?,
 				registry,
 			)?,
-			dispute_statements_requested: prometheus::register(
+			dispute_statements: prometheus::register(
 				prometheus::CounterVec::new(
 					prometheus::Opts::new(
-						"parachain_inherent_dispute_statements_requested",
-						"Number of inherent dispute statements requested.",
+						"parachain_create_inherent_dispute_statements",
+						"Number of dispute statements passed to `create_inherent()`.",
 					),
 					&["validity"],
 				)?,
 				&registry,
 			)?,
-			dispute_statement_sets_requested: prometheus::register(
+			dispute_statement_sets: prometheus::register(
 				prometheus::Counter::new(
-					"parachain_inherent_dispute_statement_sets_requested",
-					"Number of inherent DisputeStatementSets requested.",
+					"parachain_create_inherent_dispute_statement_sets",
+					"Number of dispute statements sets passed to `create_inherent()`.",
 				)?,
 				registry,
 			)?,


### PR DESCRIPTION
skip check-dependent-cumulus
