### PR TITLE
rococo-runtime: Switch to latest `construct_runtime!` syntax

### DIFF
--- a/node/service/src/chain_spec.rs
+++ b/node/service/src/chain_spec.rs
@@ -366,7 +366,7 @@ fn polkadot_staging_testnet_config_genesis(wasm_binary: &[u8]) -> polkadot::Gene
 			config: default_parachains_host_configuration(),
 		},
 		paras: Default::default(),
-		xcm_pallet: polkadot::XcmPalletConfig { safe_xcm_version: Some(2) },
+		xcm_pallet: Default::default(),
 	}
 }
 
@@ -550,7 +550,7 @@ fn westend_staging_testnet_config_genesis(wasm_binary: &[u8]) -> westend::Genesi
 		registrar: westend_runtime::RegistrarConfig {
 			next_free_para_id: polkadot_primitives::v1::LOWEST_PUBLIC_ID,
 		},
-		xcm_pallet: westend_runtime::XcmPalletConfig { safe_xcm_version: Some(2) },
+		xcm_pallet: Default::default(),
 	}
 }
 
@@ -746,7 +746,7 @@ fn kusama_staging_testnet_config_genesis(wasm_binary: &[u8]) -> kusama::GenesisC
 		},
 		gilt: Default::default(),
 		paras: Default::default(),
-		xcm_pallet: kusama::XcmPalletConfig { safe_xcm_version: Some(2) },
+		xcm_pallet: Default::default(),
 	}
 }
 
@@ -1043,7 +1043,8 @@ fn rococo_staging_testnet_config_genesis(wasm_binary: &[u8]) -> rococo_runtime::
 		registrar: rococo_runtime::RegistrarConfig {
 			next_free_para_id: polkadot_primitives::v1::LOWEST_PUBLIC_ID,
 		},
-		xcm_pallet: rococo_runtime::XcmPalletConfig { safe_xcm_version: Some(2) },
+		xcm_pallet: Default::default(),
+		transaction_payment: Default::default(),
 		// bridge_rococo_grandpa: rococo_runtime::BridgeRococoGrandpaConfig {
 		// 	owner: Some(endowed_accounts[0].clone()),
 		// 	..Default::default()
@@ -1311,7 +1312,7 @@ pub fn polkadot_testnet_genesis(
 			config: default_parachains_host_configuration(),
 		},
 		paras: Default::default(),
-		xcm_pallet: polkadot::XcmPalletConfig { safe_xcm_version: Some(2) },
+		xcm_pallet: Default::default(),
 	}
 }
 
@@ -1398,7 +1399,7 @@ pub fn kusama_testnet_genesis(
 		},
 		gilt: Default::default(),
 		paras: Default::default(),
-		xcm_pallet: kusama::XcmPalletConfig { safe_xcm_version: Some(2) },
+		xcm_pallet: Default::default(),
 	}
 }
 
@@ -1478,7 +1479,7 @@ pub fn westend_testnet_genesis(
 		registrar: westend_runtime::RegistrarConfig {
 			next_free_para_id: polkadot_primitives::v1::LOWEST_PUBLIC_ID,
 		},
-		xcm_pallet: westend_runtime::XcmPalletConfig { safe_xcm_version: Some(2) },
+		xcm_pallet: Default::default(),
 	}
 }
 
@@ -1552,7 +1553,8 @@ pub fn rococo_testnet_genesis(
 		registrar: rococo_runtime::RegistrarConfig {
 			next_free_para_id: polkadot_primitives::v1::LOWEST_PUBLIC_ID,
 		},
-		xcm_pallet: rococo_runtime::XcmPalletConfig { safe_xcm_version: Some(2) },
+		xcm_pallet: Default::default(),
+		transaction_payment: Default::default(),
 		// bridge_rococo_grandpa: rococo_runtime::BridgeRococoGrandpaConfig {
 		// 	owner: Some(root_key.clone()),
 		// 	..Default::default()

--- a/runtime/common/src/integration_tests.rs
+++ b/runtime/common/src/integration_tests.rs
@@ -32,7 +32,7 @@ use frame_system::EnsureRoot;
 use primitives::v1::{
 	BlockNumber, HeadData, Header, Id as ParaId, ValidationCode, LOWEST_PUBLIC_ID,
 };
-use runtime_parachains::{configuration, paras, shared, Origin as ParaOrigin, ParaLifecycle};
+use runtime_parachains::{configuration, paras, shared, Origin as ParaOrigin, ParaLifecycle, origin};
 use sp_core::{crypto::KeyTypeId, H256};
 use sp_io::TestExternalities;
 use sp_keystore::{testing::KeyStore, KeystoreExt};
@@ -59,8 +59,9 @@ frame_support::construct_runtime!(
 
 		// Parachains Runtime
 		Configuration: configuration::{Pallet, Call, Storage, Config<T>},
-		Paras: paras::{Pallet, Origin, Call, Storage, Event, Config},
+		Paras: paras::{Pallet, Call, Storage, Event, Config},
 		ParasShared: shared::{Pallet, Call, Storage},
+		ParachainsOrigin: origin::{Pallet, Origin},
 
 		// Para Onboarding Pallets
 		Registrar: paras_registrar::{Pallet, Call, Storage, Event<T>},
@@ -164,8 +165,9 @@ impl configuration::Config for Test {
 
 impl shared::Config for Test {}
 
+impl origin::Config for Test {}
+
 impl paras::Config for Test {
-	type Origin = Origin;
 	type Event = Event;
 	type WeightInfo = paras::TestWeightInfo;
 }

--- a/runtime/common/src/integration_tests.rs
+++ b/runtime/common/src/integration_tests.rs
@@ -32,7 +32,9 @@ use frame_system::EnsureRoot;
 use primitives::v1::{
 	BlockNumber, HeadData, Header, Id as ParaId, ValidationCode, LOWEST_PUBLIC_ID,
 };
-use runtime_parachains::{configuration, paras, shared, Origin as ParaOrigin, ParaLifecycle, origin};
+use runtime_parachains::{
+	configuration, origin, paras, shared, Origin as ParaOrigin, ParaLifecycle,
+};
 use sp_core::{crypto::KeyTypeId, H256};
 use sp_io::TestExternalities;
 use sp_keystore::{testing::KeyStore, KeystoreExt};

--- a/runtime/common/src/paras_registrar.rs
+++ b/runtime/common/src/paras_registrar.rs
@@ -575,7 +575,7 @@ mod tests {
 	use frame_system::limits;
 	use pallet_balances::Error as BalancesError;
 	use primitives::v1::{Balance, BlockNumber, Header};
-	use runtime_parachains::{configuration, shared};
+	use runtime_parachains::{configuration, origin, shared};
 	use sp_core::H256;
 	use sp_io::TestExternalities;
 	use sp_runtime::{
@@ -595,9 +595,10 @@ mod tests {
 			System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 			Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
 			Configuration: configuration::{Pallet, Call, Storage, Config<T>},
-			Parachains: paras::{Pallet, Origin, Call, Storage, Config, Event},
+			Parachains: paras::{Pallet, Call, Storage, Config, Event},
 			ParasShared: shared::{Pallet, Call, Storage},
 			Registrar: paras_registrar::{Pallet, Call, Storage, Event<T>},
+			ParachainsOrigin: origin::{Pallet, Origin},
 		}
 	);
 
@@ -654,8 +655,9 @@ mod tests {
 
 	impl shared::Config for Test {}
 
+	impl origin::Config for Test {}
+
 	impl paras::Config for Test {
-		type Origin = Origin;
 		type Event = Event;
 		type WeightInfo = paras::TestWeightInfo;
 	}

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -1177,7 +1177,6 @@ impl parachains_inclusion::Config for Runtime {
 }
 
 impl parachains_paras::Config for Runtime {
-	type Origin = Origin;
 	type Event = Event;
 	type WeightInfo = weights::runtime_parachains_paras::WeightInfo<Runtime>;
 }

--- a/runtime/parachains/src/disputes.rs
+++ b/runtime/parachains/src/disputes.rs
@@ -41,8 +41,6 @@ use sp_std::{collections::btree_set::BTreeSet, prelude::*};
 #[cfg(feature = "runtime-benchmarks")]
 mod benchmarking;
 
-pub use crate::Origin as ParachainOrigin;
-
 /// Whether the dispute is local or remote.
 #[derive(Encode, Decode, Clone, PartialEq, Eq, RuntimeDebug, TypeInfo)]
 pub enum DisputeLocation {
@@ -344,9 +342,6 @@ pub mod pallet {
 		/// A dispute where there are only votes on one side.
 		SingleSidedDispute,
 	}
-
-	#[pallet::origin]
-	pub type Origin = ParachainOrigin;
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {

--- a/runtime/parachains/src/mock.rs
+++ b/runtime/parachains/src/mock.rs
@@ -17,8 +17,8 @@
 //! Mocks for all the traits.
 
 use crate::{
-	configuration, disputes, dmp, hrmp, inclusion, initializer, paras, paras_inherent, scheduler,
-	session_info, shared,
+	configuration, disputes, dmp, hrmp, inclusion, initializer, origin, paras, paras_inherent,
+	scheduler, session_info, shared,
 	ump::{self, MessageId, UmpSink},
 	ParaId,
 };
@@ -51,21 +51,22 @@ frame_support::construct_runtime!(
 		NodeBlock = Block,
 		UncheckedExtrinsic = UncheckedExtrinsic,
 	{
-		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
-		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
-		Paras: paras::{Pallet, Origin, Call, Storage, Event, Config},
-		Configuration: configuration::{Pallet, Call, Storage, Config<T>},
-		ParasShared: shared::{Pallet, Call, Storage},
-		ParaInclusion: inclusion::{Pallet, Call, Storage, Event<T>},
-		ParaInherent: paras_inherent::{Pallet, Call, Storage},
-		Scheduler: scheduler::{Pallet, Storage},
-		Initializer: initializer::{Pallet, Call, Storage},
-		Dmp: dmp::{Pallet, Call, Storage},
-		Ump: ump::{Pallet, Call, Storage, Event},
-		Hrmp: hrmp::{Pallet, Call, Storage, Event<T>},
-		SessionInfo: session_info::{Pallet, Storage},
-		Disputes: disputes::{Pallet, Storage, Event<T>},
-		Babe: pallet_babe::{Pallet, Call, Storage, Config, ValidateUnsigned},
+		System: frame_system,
+		Balances: pallet_balances,
+		Paras: paras,
+		Configuration: configuration,
+		ParasShared: shared,
+		ParaInclusion: inclusion,
+		ParaInherent: paras_inherent,
+		Scheduler: scheduler,
+		Initializer: initializer,
+		Dmp: dmp,
+		Ump: ump,
+		Hrmp: hrmp,
+		ParachainsOrigin: origin,
+		SessionInfo: session_info,
+		Disputes: disputes,
+		Babe: pallet_babe,
 	}
 );
 
@@ -177,8 +178,9 @@ impl crate::configuration::Config for Test {
 
 impl crate::shared::Config for Test {}
 
+impl origin::Config for Test {}
+
 impl crate::paras::Config for Test {
-	type Origin = Origin;
 	type Event = Event;
 	type WeightInfo = crate::paras::TestWeightInfo;
 }

--- a/runtime/parachains/src/paras.rs
+++ b/runtime/parachains/src/paras.rs
@@ -34,7 +34,7 @@ use primitives::v1::{
 use scale_info::TypeInfo;
 use sp_core::RuntimeDebug;
 use sp_runtime::{traits::One, DispatchResult, SaturatedConversion};
-use sp_std::{prelude::*, result};
+use sp_std::prelude::*;
 
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
@@ -307,11 +307,6 @@ pub mod pallet {
 
 	#[pallet::config]
 	pub trait Config: frame_system::Config + configuration::Config + shared::Config {
-		/// The outer origin type.
-		type Origin: From<Origin>
-			+ From<<Self as frame_system::Config>::Origin>
-			+ Into<result::Result<Origin, <Self as Config>::Origin>>;
-
 		type Event: From<Event> + IsType<<Self as frame_system::Config>::Event>;
 
 		/// Weight information for extrinsics in this pallet.
@@ -517,9 +512,6 @@ pub mod pallet {
 			}
 		}
 	}
-
-	#[pallet::origin]
-	pub type Origin = ParachainOrigin;
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -1170,7 +1170,6 @@ impl parachains_inclusion::Config for Runtime {
 }
 
 impl parachains_paras::Config for Runtime {
-	type Origin = Origin;
 	type Event = Event;
 	type WeightInfo = weights::runtime_parachains_paras::WeightInfo<Runtime>;
 }

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -202,54 +202,54 @@ construct_runtime! {
 		NodeBlock = primitives::v1::Block,
 		UncheckedExtrinsic = UncheckedExtrinsic
 	{
-		System: frame_system::{Pallet, Call, Storage, Config, Event<T>},
+		System: frame_system,
 
 		// Must be before session.
-		Babe: pallet_babe::{Pallet, Call, Storage, Config, ValidateUnsigned},
+		Babe: pallet_babe,
 
-		Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent},
-		Indices: pallet_indices::{Pallet, Call, Storage, Config<T>, Event<T>},
-		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
-		TransactionPayment: pallet_transaction_payment::{Pallet, Storage},
+		Timestamp: pallet_timestamp,
+		Indices: pallet_indices,
+		Balances: pallet_balances,
+		TransactionPayment: pallet_transaction_payment,
 
 		// Consensus support.
-		Authorship: pallet_authorship::{Pallet, Call, Storage},
-		Offences: pallet_offences::{Pallet, Storage, Event},
-		Historical: session_historical::{Pallet},
-		Session: pallet_session::{Pallet, Call, Storage, Event, Config<T>},
-		Grandpa: pallet_grandpa::{Pallet, Call, Storage, Config, Event, ValidateUnsigned},
-		ImOnline: pallet_im_online::{Pallet, Call, Storage, Event<T>, ValidateUnsigned, Config<T>},
-		AuthorityDiscovery: pallet_authority_discovery::{Pallet, Config},
+		Authorship: pallet_authorship,
+		Offences: pallet_offences,
+		Historical: session_historical,
+		Session: pallet_session,
+		Grandpa: pallet_grandpa,
+		ImOnline: pallet_im_online,
+		AuthorityDiscovery: pallet_authority_discovery,
 
 		// Parachains modules.
-		ParachainsOrigin: parachains_origin::{Pallet, Origin},
-		Configuration: parachains_configuration::{Pallet, Call, Storage, Config<T>},
-		ParasShared: parachains_shared::{Pallet, Call, Storage},
-		ParaInclusion: parachains_inclusion::{Pallet, Call, Storage, Event<T>},
-		ParaInherent: parachains_paras_inherent::{Pallet, Call, Storage, Inherent},
-		ParaScheduler: parachains_scheduler::{Pallet, Storage},
-		Paras: parachains_paras::{Pallet, Call, Storage, Event, Config},
-		Initializer: parachains_initializer::{Pallet, Call, Storage},
-		Dmp: parachains_dmp::{Pallet, Call, Storage},
-		Ump: parachains_ump::{Pallet, Call, Storage, Event},
-		Hrmp: parachains_hrmp::{Pallet, Call, Storage, Event<T>, Config},
-		ParaSessionInfo: parachains_session_info::{Pallet, Storage},
-		ParasDisputes: parachains_disputes::{Pallet, Call, Storage, Event<T>},
+		ParachainsOrigin: parachains_origin,
+		Configuration: parachains_configuration,
+		ParasShared: parachains_shared,
+		ParaInclusion: parachains_inclusion,
+		ParaInherent: parachains_paras_inherent,
+		ParaScheduler: parachains_scheduler,
+		Paras: parachains_paras,
+		Initializer: parachains_initializer,
+		Dmp: parachains_dmp,
+		Ump: parachains_ump,
+		Hrmp: parachains_hrmp,
+		ParaSessionInfo: parachains_session_info,
+		ParasDisputes: parachains_disputes,
 
 		// Parachain Onboarding Pallets
-		Registrar: paras_registrar::{Pallet, Call, Storage, Event<T>, Config},
-		Auctions: auctions::{Pallet, Call, Storage, Event<T>},
-		Crowdloan: crowdloan::{Pallet, Call, Storage, Event<T>},
-		Slots: slots::{Pallet, Call, Storage, Event<T>},
-		ParasSudoWrapper: paras_sudo_wrapper::{Pallet, Call},
+		Registrar: paras_registrar,
+		Auctions: auctions,
+		Crowdloan: crowdloan,
+		Slots: slots,
+		ParasSudoWrapper: paras_sudo_wrapper,
 
 		// Sudo
-		Sudo: pallet_sudo::{Pallet, Call, Storage, Event<T>, Config<T>},
+		Sudo: pallet_sudo,
 
 		// Bridges support.
-		Mmr: pallet_mmr::{Pallet, Storage},
-		Beefy: pallet_beefy::{Pallet, Config<T>, Storage},
-		MmrLeaf: pallet_beefy_mmr::{Pallet, Storage},
+		Mmr: pallet_mmr,
+		Beefy: pallet_beefy,
+		MmrLeaf: pallet_beefy_mmr,
 
 		// It might seem strange that we add both sides of the bridge to the same runtime. We do this because this
 		// runtime as shared by both the Rococo and Wococo chains. When running as Rococo we only use
@@ -258,7 +258,7 @@ construct_runtime! {
 		// BridgeWococoGrandpa: pallet_bridge_grandpa::<Instance1>::{Pallet, Call, Storage, Config<T>} = 41,
 
 		// Validator Manager pallet.
-		ValidatorManager: validator_manager::{Pallet, Call, Storage, Event<T>},
+		ValidatorManager: validator_manager,
 
 		// Bridge messages support. The same story as with the bridge grandpa pallet above ^^^ - when we're
 		// running as Rococo we only use `BridgeWococoMessages`/`BridgeWococoMessagesDispatch`, and vice versa.
@@ -268,15 +268,15 @@ construct_runtime! {
 		// BridgeWococoMessagesDispatch: pallet_bridge_dispatch::<Instance1>::{Pallet, Event<T>} = 46,
 
 		// A "council"
-		Collective: pallet_collective::{Pallet, Call, Storage, Origin<T>, Event<T>, Config<T>} = 80,
-		Membership: pallet_membership::{Pallet, Call, Storage, Event<T>, Config<T>} = 81,
+		Collective: pallet_collective = 80,
+		Membership: pallet_membership = 81,
 
-		Utility: pallet_utility::{Pallet, Call, Event} = 90,
-		Proxy: pallet_proxy::{Pallet, Call, Storage, Event<T>} = 91,
-		Multisig: pallet_multisig::{Pallet, Call, Storage, Event<T>},
+		Utility: pallet_utility = 90,
+		Proxy: pallet_proxy = 91,
+		Multisig: pallet_multisig,
 
 		// Pallet for sending XCM.
-		XcmPallet: pallet_xcm::{Pallet, Call, Storage, Event<T>, Origin, Config} = 99,
+		XcmPallet: pallet_xcm = 99,
 
 	}
 }
@@ -614,7 +614,6 @@ impl parachains_inclusion::Config for Runtime {
 }
 
 impl parachains_paras::Config for Runtime {
-	type Origin = Origin;
 	type Event = Event;
 	type WeightInfo = weights::runtime_parachains_paras::WeightInfo<Runtime>;
 }

--- a/runtime/rococo/src/validator_manager.rs
+++ b/runtime/rococo/src/validator_manager.rs
@@ -16,84 +16,87 @@
 
 //! A pallet for managing validators on Rococo.
 
-use frame_support::{decl_error, decl_event, decl_module, decl_storage, traits::EnsureOrigin};
 use sp_staking::SessionIndex;
 use sp_std::vec::Vec;
 
+pub use pallet::*;
+
 type Session<T> = pallet_session::Pallet<T>;
 
-/// Configuration for the parachain proposer.
-pub trait Config: pallet_session::Config {
-	/// The overreaching event type.
-	type Event: From<Event<Self>> + Into<<Self as frame_system::Config>::Event>;
+#[frame_support::pallet]
+pub mod pallet {
+	use super::*;
+	use frame_support::{dispatch::DispatchResult, pallet_prelude::*, traits::EnsureOrigin};
+	use frame_system::pallet_prelude::*;
 
-	/// Privileged origin that can add or remove validators.
-	type PrivilegedOrigin: EnsureOrigin<<Self as frame_system::Config>::Origin>;
-}
+	#[pallet::pallet]
+	pub struct Pallet<T>(_);
 
-decl_event! {
-	pub enum Event<T> where ValidatorId = <T as pallet_session::Config>::ValidatorId {
+	/// Configuration for the parachain proposer.
+	#[pallet::config]
+	pub trait Config: frame_system::Config + pallet_session::Config {
+		/// The overreaching event type.
+		type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
+
+		/// Privileged origin that can add or remove validators.
+		type PrivilegedOrigin: EnsureOrigin<<Self as frame_system::Config>::Origin>;
+	}
+
+	#[pallet::event]
+	#[pallet::generate_deposit(pub(super) fn deposit_event)]
+	pub enum Event<T: Config> {
 		/// New validators were added to the set.
-		ValidatorsRegistered(Vec<ValidatorId>),
+		ValidatorsRegistered(Vec<T::ValidatorId>),
 		/// Validators were removed from the set.
-		ValidatorsDeregistered(Vec<ValidatorId>),
+		ValidatorsDeregistered(Vec<T::ValidatorId>),
 	}
-}
 
-decl_error! {
-	pub enum Error for Module<T: Config> {}
-}
+	/// Validators that should be retired, because their Parachain was deregistered.
+	#[pallet::storage]
+	pub(crate) type ValidatorsToRetire<T: Config> =
+		StorageValue<_, Vec<T::ValidatorId>, ValueQuery>;
 
-decl_storage! {
-	trait Store for Module<T: Config> as ParachainProposer {
-		/// Validators that should be retired, because their Parachain was deregistered.
-		ValidatorsToRetire: Vec<T::ValidatorId>;
-		/// Validators that should be added.
-		ValidatorsToAdd: Vec<T::ValidatorId>;
-	}
-}
+	/// Validators that should be added.
+	#[pallet::storage]
+	pub(crate) type ValidatorsToAdd<T: Config> = StorageValue<_, Vec<T::ValidatorId>, ValueQuery>;
 
-decl_module! {
-	pub struct Module<T: Config> for enum Call where origin: <T as frame_system::Config>::Origin {
-		type Error = Error<T>;
-
-		fn deposit_event() = default;
-
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
 		/// Add new validators to the set.
 		///
 		/// The new validators will be active from current session + 2.
-		#[weight = 100_000]
-		fn register_validators(
-			origin,
+		#[pallet::weight(100_000)]
+		pub fn register_validators(
+			origin: OriginFor<T>,
 			validators: Vec<T::ValidatorId>,
-		) {
+		) -> DispatchResult {
 			T::PrivilegedOrigin::ensure_origin(origin)?;
 
 			validators.clone().into_iter().for_each(|v| ValidatorsToAdd::<T>::append(v));
 
-			Self::deposit_event(RawEvent::ValidatorsRegistered(validators));
+			Self::deposit_event(Event::ValidatorsRegistered(validators));
+			Ok(())
 		}
 
 		/// Remove validators from the set.
 		///
 		/// The removed validators will be deactivated from current session + 2.
-		#[weight = 100_000]
-		fn deregister_validators(
-			origin,
+		#[pallet::weight(100_000)]
+		pub fn deregister_validators(
+			origin: OriginFor<T>,
 			validators: Vec<T::ValidatorId>,
-		) {
+		) -> DispatchResult {
 			T::PrivilegedOrigin::ensure_origin(origin)?;
 
 			validators.clone().into_iter().for_each(|v| ValidatorsToRetire::<T>::append(v));
 
-			Self::deposit_event(RawEvent::ValidatorsDeregistered(validators));
+			Self::deposit_event(Event::ValidatorsDeregistered(validators));
+			Ok(())
 		}
 	}
 }
 
-impl<T: Config> Module<T> {}
-
-impl<T: Config> pallet_session::SessionManager<T::ValidatorId> for Module<T> {
+impl<T: Config> pallet_session::SessionManager<T::ValidatorId> for Pallet<T> {
 	fn new_session(new_index: SessionIndex) -> Option<Vec<T::ValidatorId>> {
 		if new_index <= 1 {
 			return None
@@ -121,7 +124,7 @@ impl<T: Config> pallet_session::SessionManager<T::ValidatorId> for Module<T> {
 	fn start_session(_start_index: SessionIndex) {}
 }
 
-impl<T: Config> pallet_session::historical::SessionManager<T::ValidatorId, ()> for Module<T> {
+impl<T: Config> pallet_session::historical::SessionManager<T::ValidatorId, ()> for Pallet<T> {
 	fn new_session(new_index: SessionIndex) -> Option<Vec<(T::ValidatorId, ())>> {
 		<Self as pallet_session::SessionManager<_>>::new_session(new_index)
 			.map(|r| r.into_iter().map(|v| (v, Default::default())).collect())

--- a/runtime/test-runtime/src/lib.rs
+++ b/runtime/test-runtime/src/lib.rs
@@ -27,7 +27,7 @@ use sp_std::{collections::btree_map::BTreeMap, prelude::*};
 use polkadot_runtime_parachains::{
 	configuration as parachains_configuration, disputes as parachains_disputes,
 	dmp as parachains_dmp, hrmp as parachains_hrmp, inclusion as parachains_inclusion,
-	initializer as parachains_initializer, paras as parachains_paras,
+	initializer as parachains_initializer, origin as parachains_origin, paras as parachains_paras,
 	paras_inherent as parachains_paras_inherent, runtime_api_impl::v1 as runtime_impl,
 	scheduler as parachains_scheduler, session_info as parachains_session_info,
 	shared as parachains_shared, ump as parachains_ump,
@@ -489,7 +489,6 @@ impl parachains_initializer::Config for Runtime {
 impl parachains_session_info::Config for Runtime {}
 
 impl parachains_paras::Config for Runtime {
-	type Origin = Origin;
 	type Event = Event;
 	type WeightInfo = parachains_paras::TestWeightInfo;
 }
@@ -543,6 +542,8 @@ impl parachains_hrmp::Config for Runtime {
 impl parachains_scheduler::Config for Runtime {}
 
 impl paras_sudo_wrapper::Config for Runtime {}
+
+impl parachains_origin::Config for Runtime {}
 
 impl pallet_test_notifier::Config for Runtime {
 	type Event = Event;
@@ -667,10 +668,11 @@ construct_runtime! {
 		ParaInclusion: parachains_inclusion::{Pallet, Call, Storage, Event<T>},
 		ParaInherent: parachains_paras_inherent::{Pallet, Call, Storage, Inherent},
 		Initializer: parachains_initializer::{Pallet, Call, Storage},
-		Paras: parachains_paras::{Pallet, Call, Storage, Origin, Event},
+		Paras: parachains_paras::{Pallet, Call, Storage, Event},
 		ParasShared: parachains_shared::{Pallet, Call, Storage},
 		Scheduler: parachains_scheduler::{Pallet, Storage},
 		ParasSudoWrapper: paras_sudo_wrapper::{Pallet, Call},
+		ParasOrigin: parachains_origin::{Pallet, Origin},
 		ParaSessionInfo: parachains_session_info::{Pallet, Storage},
 		Hrmp: parachains_hrmp::{Pallet, Call, Storage, Event<T>},
 		Ump: parachains_ump::{Pallet, Call, Storage, Event},

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -824,7 +824,6 @@ impl parachains_inclusion::Config for Runtime {
 }
 
 impl parachains_paras::Config for Runtime {
-	type Origin = Origin;
 	type Event = Event;
 	type WeightInfo = weights::runtime_parachains_paras::WeightInfo<Runtime>;
 }


### PR DESCRIPTION
Besides that it fixes pallet macro errors in other crates that popped up
because of this switch.