### PR TITLE
Pin changelogerator to the latest compatible version for the current flow

### DIFF
--- a/.github/workflows/publish-draft-release.yml
+++ b/.github/workflows/publish-draft-release.yml
@@ -82,7 +82,7 @@ jobs:
           RUSTC_NIGHTLY: ${{ needs.get-rust-versions.outputs.rustc-nightly }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gem install changelogerator git toml
+          gem install changelogerator:0.0.16 git toml
           ruby $GITHUB_WORKSPACE/polkadot/scripts/github/generate_release_text.rb | tee release_text.md
       - name: Create draft release
         id: create-release


### PR DESCRIPTION
The release note generation flow as it is today supports only up to changelogerator 0.0.16.
This PR pins changelogetor to this latest version.
Newer versions will require deeper modifications of the workflow as we have it now in cumulus.

skip check-dependent-cumulus 