### PR TITLE
[zombienet] Increment `within` time for dispute tests

### DIFF
--- a/node/malus/integrationtests/0001-dispute-valid-block.feature
+++ b/node/malus/integrationtests/0001-dispute-valid-block.feature
@@ -17,13 +17,13 @@ bob: reports peers count is at least 2
 charlie: reports block height is at least 2
 charlie: reports peers count is at least 2
 alice: reports parachain_candidate_disputes_total is at least 1 within 250 seconds
-bob: reports parachain_candidate_disputes_total is at least 1 within 45 seconds
-charlie: reports parachain_candidate_disputes_total is at least 1 within 45 seconds
-alice: reports parachain_candidate_dispute_votes{validity="valid"} is at least 1 within 45 seconds
-bob: reports parachain_candidate_dispute_votes{validity="valid"} is at least 2 within 45 seconds
-charlie: reports parachain_candidate_dispute_votes{validity="valid"} is at least 2 within 45 seconds
-alice: reports parachain_candidate_dispute_concluded{validity="valid"} is at least 1 within 45 seconds
-alice: reports parachain_candidate_dispute_concluded{validity="invalid"} is 0 within 45 seconds
-bob: reports parachain_candidate_dispute_concluded{validity="valid"} is at least 1 within 45 seconds
-charlie: reports parachain_candidate_dispute_concluded{validity="valid"} is at least 1 within 45 seconds
-charlie: reports parachain_candidate_dispute_concluded{validity="valid"} is at least 1 within 45 seconds
+bob: reports parachain_candidate_disputes_total is at least 1 within 90 seconds
+charlie: reports parachain_candidate_disputes_total is at least 1 within 90 seconds
+alice: reports parachain_candidate_dispute_votes{validity="valid"} is at least 1 within 90 seconds
+bob: reports parachain_candidate_dispute_votes{validity="valid"} is at least 2 within 90 seconds
+charlie: reports parachain_candidate_dispute_votes{validity="valid"} is at least 2 within 90 seconds
+alice: reports parachain_candidate_dispute_concluded{validity="valid"} is at least 1 within 90 seconds
+alice: reports parachain_candidate_dispute_concluded{validity="invalid"} is 0 within 90 seconds
+bob: reports parachain_candidate_dispute_concluded{validity="valid"} is at least 1 within 90 seconds
+charlie: reports parachain_candidate_dispute_concluded{validity="valid"} is at least 1 within 90 seconds
+charlie: reports parachain_candidate_dispute_concluded{validity="valid"} is at least 1 within 90 seconds


### PR DESCRIPTION
Increment the timeout to get the desired metrics to 90s.