### PR TITLE
Announce only on releases

### DIFF
--- a/.github/workflows/release-bot.yml
+++ b/.github/workflows/release-bot.yml
@@ -2,7 +2,7 @@ name: Send new release notification to matrix channels
 on:
   release:
     types:
-      - published
+      - released
 jobs:
   ping_matrix:
     strategy:


### PR DESCRIPTION
Draft for now as I think we should be able to listen to `pubished` but announce on **some** channels only on releases.