### PR TITLE
Add doc about runtime version bump

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -17,7 +17,8 @@ candidate branch.
 
 - [ ] Verify [`spec_version`](#spec-version) has been incremented since the
     last release for any native runtimes from any existing use on public
-    (non-private/test) networks.
+    (non-private/test) networks. If the runtime was published (release or pre-release), either
+    the `spec_version` or `impl` must be bumped.
 - [ ] Verify previously [completed migrations](#old-migrations-removed) are
     removed for any public (non-private/test) networks.
 - [ ] Verify pallet and [extrinsic ordering](#extrinsic-ordering) has stayed


### PR DESCRIPTION
Some doc to avoid releasing a **new** runtime using the same `core_version` as another previously (pre)released one.

skip check-dependent-cumulus