### PR TITLE
Add miss features

### DIFF
--- a/runtime/parachains/Cargo.toml
+++ b/runtime/parachains/Cargo.toml
@@ -72,6 +72,7 @@ std = [
 	"sp-session/std",
 	"sp-staking/std",
 	"pallet-authorship/std",
+	"pallet-babe/std",
 	"pallet-balances/std",
 	"pallet-session/std",
 	"pallet-staking/std",


### PR DESCRIPTION
The bug is caused by here:
https://github.com/paritytech/polkadot/pull/4028/files#diff-0b61a7e811906a9cfbc25e12b3ff3828ea79365e7adf40c892f3ff4025a81ff2R30

add `pallet-babe/std`. 

Please merge the PR into the `release-v0.9.13` branch. Thanks a lot.
