### PR TITLE
Fix path of the polkadot sha256

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -201,7 +201,10 @@ test-build-linux-stable:
     - mkdir -p ./artifacts
     - VERSION="${CI_COMMIT_REF_NAME}" # will be tag or branch name
     - mv ./target/release/polkadot ./artifacts/.
-    - sha256sum ./artifacts/polkadot | tee ./artifacts/polkadot.sha256
+    - pushd artifacts
+    - sha256sum polkadot | tee polkadot.sha256
+    - shasum -c polkadot.sha256
+    - popd
     - EXTRATAG="$(./artifacts/polkadot --version |
         sed -n -r 's/^polkadot ([0-9.]+.*-[0-9a-f]{7,13})-.*$/\1/p')"
     - EXTRATAG="${CI_COMMIT_REF_NAME}-${EXTRATAG}-$(cut -c 1-8 ./artifacts/polkadot.sha256)"


### PR DESCRIPTION
The build script for Polkadot creates a sha256 similar to:
```
91ac4f668e84c05c98542734c37eee21f74de1e9f35982186e87343bcbc7897d  ./artifacts/polkadot
```

That makes it inconvenient for users who probably do not have this `artifacts` sub-folder and cannot check the sha56 using a simple:
```
shasum -c polkadot.sha256
```
without modifying the checksum file.

This PR fixes that, allowing users to download the binary and the sha256 and immediately check the binary without extra trickery.