### PR TITLE
Update docs on `validation_upgrade_frequency`

### DIFF
--- a/primitives/src/v1/mod.rs
+++ b/primitives/src/v1/mod.rs
@@ -1095,7 +1095,7 @@ pub struct AbridgedHostConfiguration {
 	///
 	/// This parameter affects the upper bound of size of `CandidateCommitments`.
 	pub hrmp_max_message_num_per_candidate: u32,
-	/// The minimum frequency at which parachains can update their validation code.
+	/// The minimum period, in blocks, between which parachains can update their validation code.
 	pub validation_upgrade_frequency: BlockNumber,
 	/// The delay, in blocks, before a validation upgrade is applied.
 	pub validation_upgrade_delay: BlockNumber,

--- a/roadmap/implementers-guide/src/types/runtime.md
+++ b/roadmap/implementers-guide/src/types/runtime.md
@@ -8,7 +8,7 @@ The internal-to-runtime configuration of the parachain host. This is expected to
 
 ```rust
 struct HostConfiguration {
-	/// The minimum frequency at which parachains can update their validation code.
+	/// The minimum period, in blocks, between which parachains can update their validation code.
 	pub validation_upgrade_frequency: BlockNumber,
 	/// The delay, in blocks, before a validation upgrade is applied.
 	pub validation_upgrade_delay: BlockNumber,

--- a/runtime/parachains/src/configuration.rs
+++ b/runtime/parachains/src/configuration.rs
@@ -72,7 +72,7 @@ pub struct HostConfiguration<BlockNumber> {
 	///
 	/// This parameter affects the upper bound of size of `CandidateCommitments`.
 	pub hrmp_max_message_num_per_candidate: u32,
-	/// The minimum frequency at which parachains can update their validation code.
+	/// The minimum period, in blocks, between which parachains can update their validation code.
 	pub validation_upgrade_frequency: BlockNumber,
 	/// The delay, in blocks, before a validation upgrade is applied.
 	pub validation_upgrade_delay: BlockNumber,


### PR DESCRIPTION
Frequency is the inverse of time, so this variable is actually the _maximum_ frequency of or _minimum_ time period between upgrades.

Would consider renaming the variable to `validation_upgrade_period`.