### PR TITLE
CI: rename polkasync job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -592,11 +592,9 @@ publish-rustdoc:
 
 #### stage:                        deploy
 
-deploy-polkasync-kusama:
+deploy-parity-testnet:
   stage:                           deploy
   rules:
-    - if: $CI_COMMIT_REF_NAME == "rococo-v1"
-      when: never
     - if: $CI_PIPELINE_SOURCE == "schedule"
     - if: $CI_COMMIT_REF_NAME == "master"
   variables:


### PR DESCRIPTION
Rename the `deploy-polkasync-kusama` gitlab pipeline job to better reflect its current purpose : deploy the latest polkadot commit to internal parity testnets.