### PR TITLE
Fix path of the polkadot_injected docker image

### DIFF
--- a/.github/workflows/publish-docker-release.yml
+++ b/.github/workflows/publish-docker-release.yml
@@ -30,7 +30,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          file: scripts/docker/polkadot_injected_release.Dockerfile
+          file: scripts/dockerfiles/polkadot_injected_release.Dockerfile
           tags: |
             parity/polkadot:latest
             parity/polkadot:${{ github.event.release.tag_name }}


### PR DESCRIPTION
`scripts/docker`-> `scripts/dockerfiles`

This PR fixes the issues we see [here](https://github.com/paritytech/polkadot/actions/workflows/publish-docker-release.yml)