### PR TITLE
allow SetAppendix(Xcm(vec])) xcm message to pass barrier check

### DIFF
--- a/xcm/xcm-builder/src/barriers.rs
+++ b/xcm/xcm-builder/src/barriers.rs
@@ -65,7 +65,13 @@ impl<T: Contains<MultiLocation>> ShouldExecute for AllowTopLevelPaidExecutionFro
 		);
 		ensure!(T::contains(origin), ());
 		let mut iter = message.0.iter_mut();
-		let i = iter.next().ok_or(())?;
+		let mut i = iter.next().ok_or(())?;
+		match i {
+			SetAppendix(Xcm(ref instrs)) if matches!(&instrs[..], &[ReportError { .. }]) => {
+				i = iter.next().ok_or(())?;
+			},
+			_ => (),
+		}
 		match i {
 			ReceiveTeleportedAsset(..) |
 			WithdrawAsset(..) |


### PR DESCRIPTION
Signed-off-by: Cheng JIANG <alex_cj96@foxmail.com>

With more and more usage of xcm.Transact, we really need the error reporting feature. However it's not possible with current kusama runtime because this kind of message cannot pass barrier check. This really cause troubles for parachain teams to test and use this feature

close: #4139