### PR TITLE
introduce Dummy trait for benches

### DIFF
--- a/parachain/src/primitives.rs
+++ b/parachain/src/primitives.rs
@@ -41,19 +41,9 @@ pub use polkadot_core_primitives::BlockNumber as RelayChainBlockNumber;
 
 /// Parachain head data included in the chain.
 #[derive(
-	PartialEq,
-	Eq,
-	Clone,
-	PartialOrd,
-	Ord,
-	Encode,
-	Decode,
-	RuntimeDebug,
-	derive_more::From,
-	TypeInfo,
-	Default,
+	PartialEq, Eq, Clone, PartialOrd, Ord, Encode, Decode, RuntimeDebug, derive_more::From, TypeInfo,
 )]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize, Hash, MallocSizeOf))]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize, Hash, Default, MallocSizeOf))]
 pub struct HeadData(#[cfg_attr(feature = "std", serde(with = "bytes"))] pub Vec<u8>);
 
 impl HeadData {
@@ -64,10 +54,8 @@ impl HeadData {
 }
 
 /// Parachain validation code.
-#[derive(
-	Default, PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug, derive_more::From, TypeInfo,
-)]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize, Hash, MallocSizeOf))]
+#[derive(PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug, derive_more::From, TypeInfo)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize, Hash, Default, MallocSizeOf))]
 pub struct ValidationCode(#[cfg_attr(feature = "std", serde(with = "bytes"))] pub Vec<u8>);
 
 impl ValidationCode {
@@ -82,8 +70,8 @@ impl ValidationCode {
 /// This type is produced by [`ValidationCode::hash`].
 ///
 /// This type makes it easy to enforce that a hash is a validation code hash on the type level.
-#[derive(Clone, Copy, Encode, Decode, Default, Hash, Eq, PartialEq, PartialOrd, Ord, TypeInfo)]
-#[cfg_attr(feature = "std", derive(MallocSizeOf))]
+#[derive(Clone, Copy, Encode, Decode, Hash, Eq, PartialEq, PartialOrd, Ord, TypeInfo)]
+#[cfg_attr(feature = "std", derive(Default, MallocSizeOf))]
 pub struct ValidationCodeHash(Hash);
 
 impl sp_std::fmt::Display for ValidationCodeHash {

--- a/primitives/src/v1/mod.rs
+++ b/primitives/src/v1/mod.rs
@@ -327,8 +327,8 @@ fn check_collator_signature<H: AsRef<[u8]>>(
 }
 
 /// A unique descriptor of the candidate receipt.
-#[derive(PartialEq, Eq, Clone, Encode, Decode, TypeInfo, Default)]
-#[cfg_attr(feature = "std", derive(Debug, Hash, MallocSizeOf))]
+#[derive(PartialEq, Eq, Clone, Encode, Decode, TypeInfo)]
+#[cfg_attr(feature = "std", derive(Debug, Hash, Default, MallocSizeOf))]
 pub struct CandidateDescriptor<H = Hash> {
 	/// The ID of the para this is a candidate for.
 	pub para_id: Id,

--- a/roadmap/implementers-guide/src/types/candidate.md
+++ b/roadmap/implementers-guide/src/types/candidate.md
@@ -139,7 +139,7 @@ The execution and validation of parachain or parathread candidates produces a nu
 ```rust
 /// Commitments made in a `CandidateReceipt`. Many of these are outputs of validation.
 #[derive(PartialEq, Eq, Clone, Encode, Decode)]
-#[cfg_attr(feature = "std", derive(Debug, Default))]
+#[cfg_attr(feature = "std", derive(Debug))]
 struct CandidateCommitments {
 	/// Messages directed to other paras routed via the relay chain.
 	horizontal_messages: Vec<OutboundHrmpMessage>,


### PR DESCRIPTION
During the benchmarks PR some defaults were made unconditional, which enables them in production and allows for some serious footguns. This has been there for a while and is used in quite a few unit tests, besides the runtime benchmarking.

This is the first step to replace the `Default::default()` instances with `Dummy::dummy()`.

Since this is spread out over the codebase, we might want to introduce `derive(Dummy)`.

@zeke could you double check the failing tests, I am not entirely sure how this change could affect this

Blocks https://github.com/paritytech/substrate/pull/10403