### PR TITLE
Fix `pallet_xcm::execute`

### DIFF
--- a/xcm/pallet-xcm/src/lib.rs
+++ b/xcm/pallet-xcm/src/lib.rs
@@ -572,7 +572,7 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			message: Box<VersionedXcm<<T as SysConfig>::Call>>,
 			max_weight: Weight,
-		) -> DispatchResult {
+		) -> DispatchResultWithPostInfo {
 			let origin_location = T::ExecuteXcmOrigin::ensure_origin(origin)?;
 			let message = (*message).try_into().map_err(|()| Error::<T>::BadVersion)?;
 			let value = (origin_location, message);
@@ -584,8 +584,9 @@ pub mod pallet {
 				max_weight,
 				max_weight,
 			);
+			let result = Ok(Some(outcome.weight_used().saturating_add(100_000_000)).into());
 			Self::deposit_event(Event::Attempted(outcome));
-			Ok(())
+			result
 		}
 
 		/// Extoll that a particular destination can be communicated with through a particular

--- a/xcm/pallet-xcm/src/lib.rs
+++ b/xcm/pallet-xcm/src/lib.rs
@@ -578,7 +578,12 @@ pub mod pallet {
 			let value = (origin_location, message);
 			ensure!(T::XcmExecuteFilter::contains(&value), Error::<T>::Filtered);
 			let (origin_location, message) = value;
-			let outcome = T::XcmExecutor::execute_xcm(origin_location, message, max_weight);
+			let outcome = T::XcmExecutor::execute_xcm_in_credit(
+				origin_location,
+				message,
+				max_weight,
+				max_weight,
+			);
 			Self::deposit_event(Event::Attempted(outcome));
 			Ok(())
 		}


### PR DESCRIPTION
The `max_weight` argument is listed in the weight annotation and therefore the weight is already paid by including the extrinsic due to weight fee collection. Therefore we should credit it here.

We should also use weight correction here. I only use it in case we actually do the xcm execution. One could also use it in case we error out before reaching this point. This would add more complexity to the function. Not sure if worth.

I would need to add some additional tests if we consider merging this. Just wanted to make sure that my assumptions about this functions are correct before investing more work.