### PR TITLE
session-info: add dispute_period and random_seed

### DIFF
--- a/node/core/approval-voting/src/import.rs
+++ b/node/core/approval-voting/src/import.rs
@@ -686,6 +686,8 @@ pub(crate) mod tests {
 			no_show_slots: index as _,
 			needed_approvals: index as _,
 			active_validator_indices: Vec::new(),
+			dispute_period: 6,
+			random_seed: [0u8; 32],
 		}
 	}
 
@@ -1142,6 +1144,8 @@ pub(crate) mod tests {
 			n_delay_tranches: irrelevant,
 			no_show_slots: irrelevant,
 			active_validator_indices: Vec::new(),
+			dispute_period: 6,
+			random_seed: [0u8; 32],
 		};
 
 		let slot = Slot::from(10);

--- a/node/core/approval-voting/src/tests.rs
+++ b/node/core/approval-voting/src/tests.rs
@@ -753,6 +753,8 @@ fn session_info(keys: &[Sr25519Keyring]) -> SessionInfo {
 		n_delay_tranches: 50,
 		no_show_slots: 2,
 		active_validator_indices: vec![],
+		dispute_period: 6,
+		random_seed: [0u8; 32],
 	}
 }
 

--- a/node/core/dispute-coordinator/src/real/tests.rs
+++ b/node/core/dispute-coordinator/src/real/tests.rs
@@ -317,6 +317,8 @@ impl TestState {
 			no_show_slots: 1,
 			needed_approvals: 10,
 			active_validator_indices: Vec::new(),
+			dispute_period: 6,
+			random_seed: [0u8; 32],
 		}
 	}
 

--- a/node/core/runtime-api/src/tests.rs
+++ b/node/core/runtime-api/src/tests.rs
@@ -512,6 +512,8 @@ fn dummy_session_info() -> SessionInfo {
 		no_show_slots: 0u32,
 		needed_approvals: 1u32,
 		active_validator_indices: vec![],
+		dispute_period: 6,
+		random_seed: [0u8; 32],
 	}
 }
 #[test]

--- a/node/network/availability-distribution/src/tests/mock.rs
+++ b/node/network/availability-distribution/src/tests/mock.rs
@@ -65,6 +65,8 @@ pub fn make_session_info() -> SessionInfo {
 		no_show_slots: 0,
 		needed_approvals: 0,
 		active_validator_indices: Vec::new(),
+		dispute_period: 6,
+		random_seed: [0u8; 32],
 	}
 }
 

--- a/node/network/availability-recovery/src/tests.rs
+++ b/node/network/availability-recovery/src/tests.rs
@@ -221,6 +221,8 @@ impl TestState {
 					no_show_slots: 0,
 					needed_approvals: 0,
 					active_validator_indices: vec![],
+					dispute_period: 6,
+					random_seed: [0u8; 32],
 				}))).unwrap();
 			}
 		);

--- a/node/network/collator-protocol/src/collator_side/tests.rs
+++ b/node/network/collator-protocol/src/collator_side/tests.rs
@@ -114,6 +114,8 @@ impl Default for TestState {
 				no_show_slots: 0,
 				needed_approvals: 0,
 				active_validator_indices: vec![],
+				dispute_period: 6,
+				random_seed: [0u8; 32],
 			},
 			group_rotation_info,
 			validator_peer_id,

--- a/node/network/dispute-distribution/src/tests/mock.rs
+++ b/node/network/dispute-distribution/src/tests/mock.rs
@@ -90,6 +90,8 @@ pub static ref MOCK_SESSION_INFO: SessionInfo =
 		no_show_slots: 0,
 		needed_approvals: 0,
 		active_validator_indices: vec![],
+		dispute_period: 6,
+		random_seed: [0u8; 32],
 	};
 
 /// `SessionInfo` for the second session. (No more validators, but two more authorities.
@@ -110,6 +112,8 @@ pub static ref MOCK_NEXT_SESSION_INFO: SessionInfo =
 		no_show_slots: 0,
 		needed_approvals: 0,
 		active_validator_indices: vec![],
+		dispute_period: 6,
+		random_seed: [0u8; 32],
 	};
 }
 

--- a/node/network/statement-distribution/src/tests.rs
+++ b/node/network/statement-distribution/src/tests.rs
@@ -1852,5 +1852,7 @@ fn make_session_info(validators: Vec<Pair>, groups: Vec<Vec<u32>>) -> SessionInf
 		no_show_slots: 0,
 		needed_approvals: 0,
 		active_validator_indices: Vec::new(),
+		dispute_period: 6,
+		random_seed: [0u8; 32],
 	}
 }

--- a/node/subsystem-util/src/rolling_session_window.rs
+++ b/node/subsystem-util/src/rolling_session_window.rs
@@ -292,6 +292,8 @@ mod tests {
 			no_show_slots: index as _,
 			needed_approvals: index as _,
 			active_validator_indices: Vec::new(),
+			dispute_period: 6,
+			random_seed: [0u8; 32],
 		}
 	}
 

--- a/primitives/src/v2/mod.rs
+++ b/primitives/src/v2/mod.rs
@@ -34,6 +34,10 @@ pub struct SessionInfo {
 	/// All the validators actively participating in parachain consensus.
 	/// Indices are into the broader validator set.
 	pub active_validator_indices: Vec<v1::ValidatorIndex>,
+	/// A secure random seed for the session, gathered from BABE.
+	pub random_seed: [u8; 32],
+	/// The amount of sessions to keep for disputes.
+	pub dispute_period: v1::SessionIndex,
 
 	/****** Old fields ******/
 	/// Validators in canonical ordering.
@@ -87,6 +91,8 @@ impl From<v1::SessionInfo> for SessionInfo {
 		SessionInfo {
 			// new fields
 			active_validator_indices: Vec::new(),
+			random_seed: [0u8; 32],
+			dispute_period: 6,
 			// old fields
 			validators: old.validators,
 			discovery_keys: old.discovery_keys,

--- a/runtime/parachains/src/session_info.rs
+++ b/runtime/parachains/src/session_info.rs
@@ -118,6 +118,7 @@ impl<T: Config> Pallet<T> {
 		let needed_approvals = config.needed_approvals;
 
 		let new_session_index = notification.session_index;
+		let random_seed = notification.random_seed;
 		let old_earliest_stored_session = EarliestStoredSession::<T>::get();
 		let new_earliest_stored_session = new_session_index.saturating_sub(dispute_period);
 		let new_earliest_stored_session =
@@ -147,6 +148,8 @@ impl<T: Config> Pallet<T> {
 			no_show_slots,
 			needed_approvals,
 			active_validator_indices: active_set,
+			random_seed,
+			dispute_period,
 		};
 		Sessions::<T>::insert(&new_session_index, &new_session_info);
 	}


### PR DESCRIPTION
A follow up to #4545 to close #3227.

This will help with moving rolling session window from a constant to a runtime variable in the client side.