### PR TITLE
configuration: Consistency checks for PVF pre-checking

### DIFF
--- a/node/service/src/chain_spec.rs
+++ b/node/service/src/chain_spec.rs
@@ -210,6 +210,7 @@ fn default_parachains_host_configuration(
 		needed_approvals: 2,
 		relay_vrf_modulo_samples: 2,
 		zeroth_delay_tranche_width: 0,
+		minimum_validation_upgrade_delay: 5,
 		..Default::default()
 	}
 }

--- a/node/test/service/src/chain_spec.rs
+++ b/node/test/service/src/chain_spec.rs
@@ -171,6 +171,7 @@ fn polkadot_testnet_genesis(
 				chain_availability_period: 4,
 				thread_availability_period: 4,
 				no_show_slots: 10,
+				minimum_validation_upgrade_delay: 5,
 				..Default::default()
 			},
 		},

--- a/runtime/parachains/src/paras.rs
+++ b/runtime/parachains/src/paras.rs
@@ -2453,7 +2453,11 @@ mod tests {
 					code_retention_period,
 					validation_upgrade_delay,
 					pvf_checking_enabled: false,
-					minimum_validation_upgrade_delay: 0,
+					minimum_validation_upgrade_delay: 2,
+					// Those are not relevant to this test. However, HostConfiguration is still a
+					// subject for the consistency check.
+					chain_availability_period: 1,
+					thread_availability_period: 1,
 					..Default::default()
 				},
 				..Default::default()

--- a/runtime/parachains/src/scheduler.rs
+++ b/runtime/parachains/src/scheduler.rs
@@ -850,6 +850,10 @@ mod tests {
 			scheduling_lookahead: 2,
 			parathread_retries: 1,
 			pvf_checking_enabled: false,
+			// This field does not affect anything that scheduler does. However, `HostConfiguration`
+			// is still a subject to consistency test. It requires that `minimum_validation_upgrade_delay`
+			// is greater than `chain_availability_period` and `thread_availability_period`.
+			minimum_validation_upgrade_delay: 6,
 			..Default::default()
 		}
 	}


### PR DESCRIPTION
As was suggested by Alexander Popiak [here][comment], this commit
checks the consistency of the configuration.

[comment]:
https://github.com/paritytech/polkadot/pull/4420#discussion_r764796519