### PR TITLE
configuration: validation_upgrade_delay consistency

### DIFF
--- a/runtime/parachains/src/inclusion/tests.rs
+++ b/runtime/parachains/src/inclusion/tests.rs
@@ -1307,7 +1307,7 @@ fn candidate_checks() {
 			{
 				let cfg = Configuration::config();
 				let expected_at = 10 + cfg.validation_upgrade_delay;
-				assert_eq!(expected_at, 10);
+				assert_eq!(expected_at, 12);
 				Paras::schedule_code_upgrade(chain_a, vec![1, 2, 3, 4].into(), expected_at, &cfg);
 			}
 


### PR DESCRIPTION
Closes #4248

Impose additional constraint on configuration consistency:
`validation_upgrade_delay` should not be less than or equal to 1.

See the original issue for more details.

TODO:

- [x] fix the default chainspec