### PR TITLE
runtime-api: Fix runtime version checking

### DIFF
--- a/node/core/runtime-api/src/lib.rs
+++ b/node/core/runtime-api/src/lib.rs
@@ -344,42 +344,30 @@ where
 {
 	let _timer = metrics.time_make_runtime_api_request();
 
-	// The version of the `ParachainHost` runtime API that we are absolutely sure is deployed widely
-	// on all supported networks: Rococo, Kusama, Polkadot and perhaps others like Versi.
-	//
-	// This version is used for eliding unnecessary runtime API calls. It is safer to keep the lower
-	// version.
-	const WIDELY_DEPLOYED_API_VERSION: u32 = 1;
-
 	macro_rules! query {
 		($req_variant:ident, $api_name:ident ($($param:expr),*), ver = $version:literal, $sender:expr) => {{
 			let sender = $sender;
 			let api = client.runtime_api();
 
-			let runtime_version = if $version > WIDELY_DEPLOYED_API_VERSION {
-				use sp_api::ApiExt;
-				api.api_version::<dyn ParachainHost<Block>>(&BlockId::Hash(relay_parent))
-					.unwrap_or_else(|e| {
-						tracing::warn!(
-							target: LOG_TARGET,
-							"cannot query the runtime API version: {}",
-							e,
-						);
-						Some(WIDELY_DEPLOYED_API_VERSION)
-					})
-					.unwrap_or_else(|| {
-						tracing::warn!(
-							target: LOG_TARGET,
-							"no runtime version is reported"
-						);
-						WIDELY_DEPLOYED_API_VERSION
-					})
-			} else {
-				// The required version is less or equal to the widely deployed runtime API version.
-				WIDELY_DEPLOYED_API_VERSION
-			};
+			use sp_api::ApiExt;
+			let runtime_version = api.api_version::<dyn ParachainHost<Block>>(&BlockId::Hash(relay_parent))
+				.unwrap_or_else(|e| {
+					tracing::warn!(
+						target: LOG_TARGET,
+						"cannot query the runtime API version: {}",
+						e,
+					);
+					Some(0)
+				})
+				.unwrap_or_else(|| {
+					tracing::warn!(
+						target: LOG_TARGET,
+						"no runtime version is reported"
+					);
+					0
+				});
 
-			let res = if runtime_version <= $version {
+			let res = if runtime_version >= $version {
 				api.$api_name(&BlockId::Hash(relay_parent) $(, $param.clone() )*)
 					.map_err(|e| RuntimeApiError::Execution {
 						runtime_api_name: stringify!($api_name),


### PR DESCRIPTION
The runtime version check `runtime_version <= version` was wrong, it
needs to be `>=`. Besides that the `WIDELY_DEPLOYED_API_VERSION` is
removed. The runtime version is already cached, aka we don't always call
into the runtime when requesting the runtime version. So, there is no
need to "optimize" this.