### PR TITLE
Use derive macro to generate XcmWeightInfo trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11854,6 +11854,7 @@ dependencies = [
 name = "xcm-procedural"
 version = "0.1.0"
 dependencies = [
+ "Inflector",
  "proc-macro2",
  "quote",
  "syn",

--- a/xcm/procedural/Cargo.toml
+++ b/xcm/procedural/Cargo.toml
@@ -11,3 +11,4 @@ proc-macro = true
 proc-macro2 = "1.0.34"
 quote = "1.0.10"
 syn = "1.0.83"
+Inflector = "0.11.4"

--- a/xcm/procedural/src/lib.rs
+++ b/xcm/procedural/src/lib.rs
@@ -20,6 +20,7 @@ use proc_macro::TokenStream;
 
 mod v0;
 mod v1;
+mod weight_info;
 
 #[proc_macro]
 pub fn impl_conversion_functions_for_multilocation_v0(input: TokenStream) -> TokenStream {
@@ -33,4 +34,9 @@ pub fn impl_conversion_functions_for_multilocation_v1(input: TokenStream) -> Tok
 	v1::multilocation::generate_conversion_functions(input)
 		.unwrap_or_else(syn::Error::into_compile_error)
 		.into()
+}
+
+#[proc_macro_derive(XcmWeightInfoTrait)]
+pub fn derive_xcm_weight_info(item: TokenStream) -> TokenStream {
+	weight_info::derive(item)
 }

--- a/xcm/procedural/src/weight_info.rs
+++ b/xcm/procedural/src/weight_info.rs
@@ -49,9 +49,6 @@ pub fn derive(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
 			});
 
 			let res = quote::quote! {
-				/// Local weight type; execution time in picoseconds.
-				pub type Weight = u64;
-
 				pub trait XcmWeightInfo #generics {
 					#(#methods)*
 				}

--- a/xcm/procedural/src/weight_info.rs
+++ b/xcm/procedural/src/weight_info.rs
@@ -1,0 +1,70 @@
+// Copyright 2021 Parity Technologies (UK) Ltd.
+// This file is part of Polkadot.
+
+// Polkadot is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Polkadot is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
+
+use inflector::Inflector;
+use quote::format_ident;
+
+pub fn derive(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
+	let input: syn::DeriveInput = match syn::parse(item) {
+		Ok(input) => input,
+		Err(e) => return e.into_compile_error().into(),
+	};
+
+	let syn::DeriveInput { generics, data, .. } = input;
+
+	match data {
+		syn::Data::Enum(syn::DataEnum { variants, .. }) => {
+			let methods = variants.into_iter().map(|syn::Variant { ident, fields, .. }| {
+				let snake_cased_ident = format_ident!("{}", ident.to_string().to_snake_case());
+				let ref_fields =
+					fields.into_iter().enumerate().map(|(idx, syn::Field { ident, ty, .. })| {
+						let field_name = ident.unwrap_or_else(|| format_ident!("_{}", idx));
+						let field_ty = match ty {
+							syn::Type::Reference(r) => {
+								// If the type is already a reference, do nothing
+								quote::quote!(#r)
+							},
+							t => {
+								// Otherwise, make it a reference
+								quote::quote!(&#t)
+							},
+						};
+
+						quote::quote!(#field_name: #field_ty,)
+					});
+				quote::quote!(fn #snake_cased_ident( #(#ref_fields)* ) -> Weight;)
+			});
+
+			let res = quote::quote! {
+				/// Local weight type; execution time in picoseconds.
+				pub type Weight = u64;
+
+				pub trait XcmWeightInfo #generics {
+					#(#methods)*
+				}
+			};
+			res.into()
+		},
+		syn::Data::Struct(syn::DataStruct { struct_token, .. }) => {
+			let msg = "structs are not supported by 'derive(XcmWeightInfo)'";
+			syn::Error::new(struct_token.span, msg).into_compile_error().into()
+		},
+		syn::Data::Union(syn::DataUnion { union_token, .. }) => {
+			let msg = "unions are not supported by 'derive(XcmWeightInfo)'";
+			syn::Error::new(union_token.span, msg).into_compile_error().into()
+		},
+	}
+}

--- a/xcm/src/v2/mod.rs
+++ b/xcm/src/v2/mod.rs
@@ -222,6 +222,9 @@ impl From<WeightLimit> for Option<u64> {
 	}
 }
 
+/// Local weight type; execution time in picoseconds.
+pub type Weight = u64;
+
 /// Cross-Consensus Message: A message from one consensus system to another.
 ///
 /// Consensus systems that may send and receive messages include blockchains and smart contracts.

--- a/xcm/src/v2/mod.rs
+++ b/xcm/src/v2/mod.rs
@@ -64,9 +64,7 @@ use scale_info::TypeInfo;
 
 mod traits;
 
-pub use traits::{
-	Error, ExecuteXcm, Outcome, Result, SendError, SendResult, SendXcm, Weight, XcmWeightInfo,
-};
+pub use traits::{Error, ExecuteXcm, Outcome, Result, SendError, SendResult, SendXcm};
 // These parts of XCM v1 have been unchanged in XCM v2, and are re-imported here.
 pub use super::v1::{
 	Ancestor, AncestorThen, AssetId, AssetInstance, BodyId, BodyPart, Fungibility,
@@ -232,7 +230,7 @@ impl From<WeightLimit> for Option<u64> {
 ///
 /// This is the inner XCM format and is version-sensitive. Messages are typically passed using the outer
 /// XCM format, known as `VersionedXcm`.
-#[derive(Derivative, Encode, Decode, TypeInfo)]
+#[derive(Derivative, Encode, Decode, TypeInfo, xcm_procedural::XcmWeightInfoTrait)]
 #[derivative(Clone(bound = ""), Eq(bound = ""), PartialEq(bound = ""), Debug(bound = ""))]
 #[codec(encode_bound())]
 #[codec(decode_bound())]

--- a/xcm/src/v2/traits.rs
+++ b/xcm/src/v2/traits.rs
@@ -123,9 +123,6 @@ impl From<SendError> for Error {
 
 pub type Result = result::Result<(), Error>;
 
-/// Local weight type; execution time in picoseconds.
-pub type Weight = u64;
-
 /// Outcome of an XCM execution.
 #[derive(Clone, Encode, Decode, Eq, PartialEq, Debug, TypeInfo)]
 pub enum Outcome {
@@ -318,63 +315,4 @@ impl SendXcm for Tuple {
 		)* );
 		Err(SendError::CannotReachDestination(destination.into(), message))
 	}
-}
-
-/// The info needed to weight an XCM.
-// TODO: Automate Generation
-pub trait XcmWeightInfo<Call> {
-	fn withdraw_asset(assets: &MultiAssets) -> Weight;
-	fn reserve_asset_deposited(assets: &MultiAssets) -> Weight;
-	fn receive_teleported_asset(assets: &MultiAssets) -> Weight;
-	fn query_response(query_id: &u64, response: &Response, max_weight: &u64) -> Weight;
-	fn transfer_asset(assets: &MultiAssets, beneficiary: &MultiLocation) -> Weight;
-	fn transfer_reserve_asset(assets: &MultiAssets, dest: &MultiLocation, xcm: &Xcm<()>) -> Weight;
-	fn transact(
-		origin_type: &OriginKind,
-		require_weight_at_most: &u64,
-		call: &DoubleEncoded<Call>,
-	) -> Weight;
-	fn hrmp_new_channel_open_request(
-		sender: &u32,
-		max_message_size: &u32,
-		max_capacity: &u32,
-	) -> Weight;
-	fn hrmp_channel_accepted(recipient: &u32) -> Weight;
-	fn hrmp_channel_closing(initiator: &u32, sender: &u32, recipient: &u32) -> Weight;
-	fn clear_origin() -> Weight;
-	fn descend_origin(who: &InteriorMultiLocation) -> Weight;
-	fn report_error(query_id: &QueryId, dest: &MultiLocation, max_response_weight: &u64) -> Weight;
-	fn deposit_asset(
-		assets: &MultiAssetFilter,
-		max_assets: &u32,
-		beneficiary: &MultiLocation,
-	) -> Weight;
-	fn deposit_reserve_asset(
-		assets: &MultiAssetFilter,
-		max_assets: &u32,
-		dest: &MultiLocation,
-		xcm: &Xcm<()>,
-	) -> Weight;
-	fn exchange_asset(give: &MultiAssetFilter, receive: &MultiAssets) -> Weight;
-	fn initiate_reserve_withdraw(
-		assets: &MultiAssetFilter,
-		reserve: &MultiLocation,
-		xcm: &Xcm<()>,
-	) -> Weight;
-	fn initiate_teleport(assets: &MultiAssetFilter, dest: &MultiLocation, xcm: &Xcm<()>) -> Weight;
-	fn query_holding(
-		query_id: &u64,
-		dest: &MultiLocation,
-		assets: &MultiAssetFilter,
-		max_response_weight: &u64,
-	) -> Weight;
-	fn buy_execution(fees: &MultiAsset, weight_limit: &WeightLimit) -> Weight;
-	fn refund_surplus() -> Weight;
-	fn set_error_handler(xcm: &Xcm<Call>) -> Weight;
-	fn set_appendix(xcm: &Xcm<Call>) -> Weight;
-	fn clear_error() -> Weight;
-	fn claim_asset(assets: &MultiAssets, ticket: &MultiLocation) -> Weight;
-	fn trap(code: &u64) -> Weight;
-	fn subscribe_version(query_id: &QueryId, max_response_weight: &u64) -> Weight;
-	fn unsubscribe_version() -> Weight;
 }


### PR DESCRIPTION
Per title.

One thing to note is that the derive macro is named `XcmWeightInfoTrait`, as it generates code for a *trait*, and not the *implementation of a trait* as is common with most derive macros. Such a naming scheme would allow us to then create a `XcmWeightInfo` derive macro in the future that would properly generate the implementation of `XcmWeightInfo`, if the need arises.