### PR TITLE
bridge: add all `PeerId`s of an `AuthorityId`  to the gossip topology

### DIFF
--- a/node/network/bridge/src/lib.rs
+++ b/node/network/bridge/src/lib.rs
@@ -57,7 +57,7 @@ mod validator_discovery;
 mod network;
 use network::{send_message, Network};
 
-use crate::network::get_peer_id_by_authority_id;
+use crate::network::get_addrs_by_authority_id;
 
 #[cfg(test)]
 mod tests;
@@ -586,12 +586,12 @@ where
 						let ads = &mut authority_discovery_service;
 						let mut gossip_peers = HashSet::with_capacity(our_neighbors.len());
 						for authority in our_neighbors {
-							let addr = get_peer_id_by_authority_id(
+							let addrs = get_addrs_by_authority_id(
 								ads,
-								authority.clone(),
+								authority,
 							).await;
 
-							if let Some(peer_id) = addr {
+							for (peer_id, _) in addrs {
 								gossip_peers.insert(peer_id);
 							}
 						}

--- a/node/network/bridge/src/network.rs
+++ b/node/network/bridge/src/network.rs
@@ -197,7 +197,7 @@ impl Network for Arc<NetworkService<Block, Hash>> {
 pub async fn get_addrs_by_authority_id<AD: AuthorityDiscovery>(
 	authority_discovery: &mut AD,
 	authority: AuthorityDiscoveryId,
-) -> impl Iterator<Item=(PeerId, Multiaddr)> {
+) -> impl Iterator<Item = (PeerId, Multiaddr)> {
 	// Note: `get_addresses_by_authority_id` searched in a cache, and it thus expected
 	// to be very quick.
 	authority_discovery


### PR DESCRIPTION
Fixes #4615 