### PR TITLE
paras: fix placeholder weight

### DIFF
--- a/runtime/parachains/src/paras.rs
+++ b/runtime/parachains/src/paras.rs
@@ -765,7 +765,7 @@ pub mod pallet {
 
 		/// Includes a statement for a PVF pre-checking vote. Potentially, finalizes the vote and
 		/// enacts the results if that was the last vote before achieving the supermajority.
-		#[pallet::weight(0)]
+		#[pallet::weight(Weight::MAX)]
 		pub fn include_pvf_check_statement(
 			origin: OriginFor<T>,
 			stmt: PvfCheckStatement,


### PR DESCRIPTION
Setting zero as weight may be a source of problems.

The problem is, a rogue validator can shove a lot of duplicated votes
and thus fill a block with work that may well exceed the weight limit.