### PR TITLE
chore: fix copy&paste and tidy comments

### DIFF
--- a/runtime/parachains/src/configuration.rs
+++ b/runtime/parachains/src/configuration.rs
@@ -1092,12 +1092,12 @@ pub struct SessionChangeOutcome<BlockNumber> {
 }
 
 impl<T: Config> Pallet<T> {
-	/// Called by the initializer to initialize the configuration module.
+	/// Called by the initializer to initialize the configuration pallet.
 	pub(crate) fn initializer_initialize(_now: T::BlockNumber) -> Weight {
 		0
 	}
 
-	/// Called by the initializer to finalize the configuration module.
+	/// Called by the initializer to finalize the configuration pallet.
 	pub(crate) fn initializer_finalize() {}
 
 	/// Called by the initializer to note that a new session has started.
@@ -1146,7 +1146,7 @@ impl<T: Config> Pallet<T> {
 	}
 
 	/// Forcibly set the active config. This should be used with extreme care, and typically
-	/// only when enabling parachains runtime modules for the first time on a chain which has
+	/// only when enabling parachains runtime pallets for the first time on a chain which has
 	/// been running without them.
 	pub fn force_set_active_config(config: HostConfiguration<T::BlockNumber>) {
 		<Self as Store>::ActiveConfig::set(config);

--- a/runtime/parachains/src/disputes.rs
+++ b/runtime/parachains/src/disputes.rs
@@ -134,10 +134,10 @@ pub trait DisputesHandler<BlockNumber> {
 	/// Whether the given candidate concluded invalid in a dispute with supermajority.
 	fn concluded_invalid(session: SessionIndex, candidate_hash: CandidateHash) -> bool;
 
-	/// Called by the initializer to initialize the configuration module.
+	/// Called by the initializer to initialize the disputes pallet.
 	fn initializer_initialize(now: BlockNumber) -> Weight;
 
-	/// Called by the initializer to finalize the configuration module.
+	/// Called by the initializer to finalize the disputes pallet.
 	fn initializer_finalize();
 
 	/// Called by the initializer to note that a new session has started.
@@ -678,10 +678,10 @@ impl<T: Config> Pallet<T> {
 		weight
 	}
 
-	/// Called by the initializer to finalize the disputes module.
+	/// Called by the initializer to finalize the disputes pallet.
 	pub(crate) fn initializer_finalize() {}
 
-	/// Called by the initializer to note a new session in the disputes module.
+	/// Called by the initializer to note a new session in the disputes pallet.
 	pub(crate) fn initializer_on_new_session(
 		notification: &SessionChangeNotification<T::BlockNumber>,
 	) {
@@ -704,7 +704,7 @@ impl<T: Config> Pallet<T> {
 				// This should be small, as disputes are rare, so `None` is fine.
 				<Disputes<T>>::remove_prefix(to_prune, None);
 
-				// This is larger, and will be extracted to the `shared` module for more proper pruning.
+				// This is larger, and will be extracted to the `shared` pallet for more proper pruning.
 				// TODO: https://github.com/paritytech/polkadot/issues/3469
 				<Included<T>>::remove_prefix(to_prune, None);
 				SpamSlots::<T>::remove(to_prune);

--- a/runtime/parachains/src/paras.rs
+++ b/runtime/parachains/src/paras.rs
@@ -997,13 +997,13 @@ const INVALID_TX_BAD_SUBJECT: u8 = 2;
 const INVALID_TX_DOUBLE_VOTE: u8 = 3;
 
 impl<T: Config> Pallet<T> {
-	/// Called by the initializer to initialize the configuration pallet.
+	/// Called by the initializer to initialize the paras pallet.
 	pub(crate) fn initializer_initialize(now: T::BlockNumber) -> Weight {
 		let weight = Self::prune_old_code(now);
 		weight + Self::process_scheduled_upgrade_changes(now)
 	}
 
-	/// Called by the initializer to finalize the configuration pallet.
+	/// Called by the initializer to finalize the paras pallet.
 	pub(crate) fn initializer_finalize(now: T::BlockNumber) {
 		Self::process_scheduled_upgrade_cooldowns(now);
 	}
@@ -1465,7 +1465,7 @@ impl<T: Config> Pallet<T> {
 	/// does not guarantee that the parachain will eventually be onboarded. This can happen in case
 	/// the PVF does not pass PVF pre-checking.
 	///
-	/// The Para ID should be not activated in this module. The validation code supplied in
+	/// The Para ID should be not activated in this pallet. The validation code supplied in
 	/// `genesis_data` should not be empty. If those conditions are not met, then the para cannot
 	/// be onboarded.
 	pub(crate) fn schedule_para_initialize(

--- a/runtime/parachains/src/scheduler.rs
+++ b/runtime/parachains/src/scheduler.rs
@@ -220,12 +220,12 @@ pub mod pallet {
 }
 
 impl<T: Config> Pallet<T> {
-	/// Called by the initializer to initialize the scheduler module.
+	/// Called by the initializer to initialize the scheduler pallet.
 	pub(crate) fn initializer_initialize(_now: T::BlockNumber) -> Weight {
 		0
 	}
 
-	/// Called by the initializer to finalize the scheduler module.
+	/// Called by the initializer to finalize the scheduler pallet.
 	pub(crate) fn initializer_finalize() {}
 
 	/// Called by the initializer to note that a new session has started.
@@ -818,7 +818,7 @@ mod tests {
 			Paras::initializer_initialize(b + 1);
 			Scheduler::initializer_initialize(b + 1);
 
-			// In the real runt;me this is expected to be called by the `InclusionInherent` module.
+			// In the real runtime this is expected to be called by the `InclusionInherent` pallet.
 			Scheduler::clear();
 			Scheduler::schedule(Vec::new(), b + 1);
 		}


### PR DESCRIPTION
As was brought up in [here][og], we have some copy&paste comments. I
fixed them and also took liberty of fixing some other places.
Specifically, those that say "module" instead of contemporary "pallet".

[og]:
https://github.com/paritytech/polkadot/pull/4603#discussion_r776971291