### PR TITLE
derive Copy and Clone for Upgrade signals (#4637)

### DIFF
--- a/primitives/src/v1/mod.rs
+++ b/primitives/src/v1/mod.rs
@@ -1064,7 +1064,7 @@ pub struct AbridgedHrmpChannel {
 }
 
 /// A possible upgrade restriction that prevents a parachain from performing an upgrade.
-#[derive(Encode, Decode, PartialEq, RuntimeDebug, TypeInfo)]
+#[derive(Copy, Clone, Encode, Decode, PartialEq, RuntimeDebug, TypeInfo)]
 pub enum UpgradeRestriction {
 	/// There is an upgrade restriction and there are no details about its specifics nor how long
 	/// it could last.
@@ -1077,7 +1077,7 @@ pub enum UpgradeRestriction {
 ///
 /// This data type appears in the last step of the upgrade process. After the parachain observes it
 /// and reacts to it the upgrade process concludes.
-#[derive(Encode, Decode, PartialEq, RuntimeDebug, TypeInfo)]
+#[derive(Copy, Clone, Encode, Decode, PartialEq, RuntimeDebug, TypeInfo)]
 pub enum UpgradeGoAhead {
 	/// Abort the upgrade process. There is something wrong with the validation code previously
 	/// submitted by the parachain. This variant can also be used to prevent upgrades by the governance


### PR DESCRIPTION
This is resubmission of https://github.com/paritytech/polkadot/pull/4637 which was accidentially merged into the previous PR in the stack rather than in master. I opted in for resubmission because otherwise those two PRs would be squashed as a single commit on master, which is not ideal.
