### PR TITLE
Update remote ext test default uri

### DIFF
--- a/utils/remote-ext-tests/bags-list/src/main.rs
+++ b/utils/remote-ext-tests/bags-list/src/main.rs
@@ -40,7 +40,7 @@ arg_enum! {
 
 #[derive(StructOpt)]
 struct Cli {
-	#[structopt(long, short, default_value = "wss://kusama-rpc.polkadot.io")]
+	#[structopt(long, short, default_value = "wss://kusama-rpc.polkadot.io:443")]
 	uri: String,
 	#[structopt(long, short, case_insensitive = true, possible_values = &Runtime::variants(), default_value = "kusama")]
 	runtime: Runtime,


### PR DESCRIPTION
This PR updates the default uri for `remote-ext-tests-bags-list` by adding the port number. This update is required to comply with the newer versons of `jsonrpsee` which do not add a default port number to the given uri for the ws client.