### PR TITLE
lower debug level for testnet build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,7 +121,7 @@ lto = true
 
 [profile.testnet]
 inherits = "release"
-debug = true # debug symbols are useful for profilers
+debug = 1 # debug symbols are useful for profilers
 debug-assertions = true
 overflow-checks = true
 


### PR DESCRIPTION
From https://fasterthanli.me/articles/why-is-my-rust-build-so-slow:
> In Cargo.toml, debug = true actually means debug = 2, and it's usually overkill, unless you're doing the sort of debugging where you need to be able to inspect the value of local variables for example. If all you're after is a stack trace, debug = 1 is good enough.

debug = 1 reduced the binary size to "only" 1GB compared to 1.7GB with debug = true :sweat_smile: 