### PR TITLE
Fix Migrations for the upcoming release

### DIFF
--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -1634,7 +1634,7 @@ pub type Executive = frame_executive::Executive<
 	frame_system::ChainContext<Runtime>,
 	Runtime,
 	AllPalletsWithSystem,
-	(SessionHistoricalPalletPrefixMigration, SchedulerMigrationV3),
+	(SchedulerMigrationV3, RefundNickPalletDeposit),
 >;
 /// The payload being signed in the transactions.
 pub type SignedPayload = generic::SignedPayload<Call, SignedExtra>;
@@ -3041,8 +3041,9 @@ impl OnRuntimeUpgrade for RefundNickPalletDeposit {
 	}
 
 	#[cfg(feature = "try-runtime")]
-	fn pre_migrate() -> Result<(), &'static str> {
-		Self::execute(true)
+	fn pre_upgrade() -> Result<(), &'static str> {
+		let _ = Self::execute(true);
+		Ok(())
 	}
 }
 

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -1582,12 +1582,7 @@ pub type Executive = frame_executive::Executive<
 	frame_system::ChainContext<Runtime>,
 	Runtime,
 	AllPalletsWithSystem,
-	(
-		StakingBagsListMigrationV8,
-		SessionHistoricalPalletPrefixMigration,
-		SchedulerMigrationV3,
-		FixCouncilDepositMigration,
-	),
+	(SchedulerMigrationV3, FixCouncilDepositMigration),
 >;
 /// The payload being signed in transactions.
 pub type SignedPayload = generic::SignedPayload<Call, SignedExtra>;
@@ -1781,7 +1776,8 @@ impl OnRuntimeUpgrade for FixCouncilDepositMigration {
 
 	#[cfg(feature = "try-runtime")]
 	fn pre_upgrade() -> Result<(), &'static str> {
-		Self::execute(true)
+		let _ = Self::execute(true);
+		Ok(())
 	}
 }
 


### PR DESCRIPTION
- Removes the buggy migration that is no longer needed. 
- I actually forgot to include the migration for the nicks pallet fix into `Executive` 🤦 
- made this to remember a cleanup: https://github.com/paritytech/polkadot/issues/4691