### PR TITLE
Emma/optimize reanchor

### DIFF
--- a/xcm/src/v0/multi_location.rs
+++ b/xcm/src/v0/multi_location.rs
@@ -37,7 +37,7 @@ use parity_scale_codec::{self, Decode, Encode};
 /// between two locations, and cannot generally be used to refer to a location universally. It is comprised of a
 /// number of *junctions*, each morphing the previous location, either diving down into one of its internal locations,
 /// called a *sub-consensus*, or going up into its parent location. Correct `MultiLocation` values must have all
-/// `Parent` junctions as a prefix to all *sub-consensus* junctions.
+/// `Parent` junctions as a prefix to all *sub-consensus* junctions. // TODO encode this somewhere
 ///
 /// This specific `MultiLocation` implementation uses a Rust `enum` in order to make pattern matching easier.
 ///

--- a/xcm/src/v0/multi_location.rs
+++ b/xcm/src/v0/multi_location.rs
@@ -37,7 +37,7 @@ use parity_scale_codec::{self, Decode, Encode};
 /// between two locations, and cannot generally be used to refer to a location universally. It is comprised of a
 /// number of *junctions*, each morphing the previous location, either diving down into one of its internal locations,
 /// called a *sub-consensus*, or going up into its parent location. Correct `MultiLocation` values must have all
-/// `Parent` junctions as a prefix to all *sub-consensus* junctions. // TODO encode this somewhere
+/// `Parent` junctions as a prefix to all *sub-consensus* junctions.
 ///
 /// This specific `MultiLocation` implementation uses a Rust `enum` in order to make pattern matching easier.
 ///

--- a/xcm/src/v1/multilocation.rs
+++ b/xcm/src/v1/multilocation.rs
@@ -335,7 +335,7 @@ impl MultiLocation {
 			for i in 0..target.interior.len() {
 				if target.interior.at(i) != self.interior.at(i) {
 					first_different = Some(i);
-					break;
+					break
 				}
 			}
 
@@ -356,7 +356,9 @@ impl MultiLocation {
 		} else if target.parents > self.parents {
 			// Handle when the target has more parents so we have to go through ancestry
 			self.parents = target.len() as u8 - 1;
-			self.interior.push_front(ancestry.interior.first().unwrap_or(&Junction::OnlyChild).clone()).map_err(|_| ())?;
+			self.interior
+				.push_front(ancestry.interior.first().unwrap_or(&Junction::OnlyChild).clone())
+				.map_err(|_| ())?;
 		} else if target.parents < self.parents {
 			// Handle when the id has more parents so we must go all the way up the target path
 			self.parents = self.parents + target.interior().len() as u8;

--- a/xcm/src/v1/multilocation.rs
+++ b/xcm/src/v1/multilocation.rs
@@ -359,8 +359,6 @@ impl MultiLocation {
 			self.reanchor_on_same_branch(target);
 		} else {
 			let common_ancestor = max(target.parents, self.parents) as usize;
-			let parents = (common_ancestor - target.parents as usize + target.interior.len()) as u8;
-
 			for j in (self.parents as usize)..common_ancestor {
 				self.push_front_interior(
 					ancestry
@@ -371,7 +369,7 @@ impl MultiLocation {
 				)
 				.map_err(|_| ())?;
 			}
-			self.parents = parents;
+			self.parents = common_ancestor as u8 - target.parents + target.interior.len() as u8;
 		}
 
 		Ok(())
@@ -389,25 +387,6 @@ impl MultiLocation {
 		}
 		let parents = target.interior().len() as u8;
 		Ok(MultiLocation::new(parents, junctions))
-	}
-
-	/// Remove any unneeded parents/junctions in `self` based on the given context it will be
-	/// interpreted in.
-	pub fn simplify(&mut self, context: &Junctions) {
-		if context.len() < self.parents as usize {
-			// Not enough context
-			return
-		}
-		while self.parents > 0 {
-			let maybe = context.at(context.len() - (self.parents as usize));
-			match (self.interior.first(), maybe) {
-				(Some(i), Some(j)) if i == j => {
-					self.interior.take_first();
-					self.parents -= 1;
-				},
-				_ => break,
-			}
-		}
 	}
 }
 

--- a/xcm/src/v1/multilocation.rs
+++ b/xcm/src/v1/multilocation.rs
@@ -359,6 +359,7 @@ impl MultiLocation {
 			self.reanchor_on_same_branch(target);
 		} else {
 			let common_ancestor = max(target.parents, self.parents) as usize;
+			// Add junctions for the path from common ancestor to where `self` branches from `ancestry`
 			for j in (self.parents as usize)..common_ancestor {
 				self.push_front_interior(
 					ancestry

--- a/xcm/src/v1/multilocation.rs
+++ b/xcm/src/v1/multilocation.rs
@@ -895,12 +895,61 @@ mod tests {
 
 	#[test]
 	fn reanchor_works() {
+		// Test where the target is on the same branch as the current id.
 		let mut id: MultiLocation = (Parent, Parachain(1000), GeneralIndex(42)).into();
 		let ancestry = Parachain(2000).into();
 		let target = (Parent, Parachain(1000)).into();
 		let expected = GeneralIndex(42).into();
 		id.reanchor(&target, &ancestry).unwrap();
 		assert_eq!(id, expected);
+
+		// Test where the target is on a different branch than the current id.
+		let mut id: MultiLocation = (Parent, Parachain(1000), GeneralIndex(42)).into();
+		let ancestry = Parachain(2000).into();
+		let target = (Parent, Parachain(1000), Parachain(3000)).into();
+		let expected = (Parent, GeneralIndex(42)).into();
+		id.reanchor(&target, &ancestry).unwrap();
+		assert_eq!(id, expected);
+
+		// Test where target and id are on different branches, and target is deeper
+		let mut id: MultiLocation = (Parent, Parachain(1000), GeneralIndex(42)).into();
+		let ancestry = Parachain(2000).into();
+		let target = (Parent, Parachain(1000), Parachain(3000), Parachain(4000)).into();
+		let expected = (Parent, Parent, GeneralIndex(42)).into();
+		id.reanchor(&target, &ancestry).unwrap();
+		assert_eq!(id, expected);
+
+		// Test where target and id are on different branches, and id is deeper
+		let mut id: MultiLocation = (Parent, Parachain(1000), Parachain(4000), GeneralIndex(42)).into();
+		let ancestry = Parachain(2000).into();
+		let target = (Parent, Parachain(1000), Parachain(3000)).into();
+		let expected = (Parent, Parachain(4000), GeneralIndex(42)).into();
+		id.reanchor(&target, &ancestry).unwrap();
+		assert_eq!(id, expected);
+
+		// Test relying on ancestry
+		let mut id: MultiLocation = (Parent, Parachain(4000), GeneralIndex(42)).into();
+		let ancestry = Parachain(2000).into();
+		let target = (Parent, Parachain(1000), Parachain(3000)).into();
+		let expected = (Parent, Parent, Parachain(4000), GeneralIndex(42)).into();
+		id.reanchor(&target, &ancestry).unwrap();
+		assert_eq!(id, expected);
+
+		// What happens when you have bad inputs? no ancestor? the below failed a little bit nonsensically
+		// let mut id: MultiLocation = (Parachain(4000), GeneralIndex(42)).into();
+		// let ancestry = Parachain(2000).into();
+		// let target = (Parent, Parachain(1000), Parachain(3000)).into();
+		// let expected = (Parent, Parent, Parachain(4000), GeneralIndex(42)).into();
+		// id.reanchor(&target, &ancestry).unwrap();
+		// assert_eq!(id, expected);
+
+		// Test with repeated ancestor in Junctions
+		// let mut id: MultiLocation = (Parent, Parachain(2000), Parachain(4000), GeneralIndex(42)).into();
+		// let ancestry = Parachain(2000).into();
+		// let target = (Parent, Parachain(1000), Parachain(3000)).into();
+		// let expected = (Parent, Parent, Parachain(4000), GeneralIndex(42)).into();
+		// id.reanchor(&target, &ancestry).unwrap();
+		// assert_eq!(id, expected);
 	}
 
 	#[test]


### PR DESCRIPTION
This PR improves the algorithm for `reanchor` - see https://github.com/paritytech/polkadot/issues/4489 for more details.

Instead of finding the common ancestor, appending junctions, and simplifying, we instead handle the cases where `target` and `self` are not on the same path directly by adding parents and `ancestry` as a junction if needed, and then in the case of `target` and `self` on the same branch, walk down both paths until they split, return the number of parents as the number of remaining junctions to reach `target` and the remaining `Junctions` to reach `self` as the new path. I increased test coverage, too.