### PR TITLE
Remove `Default` bound on `AccountId` types under the xcm directory

### DIFF
--- a/bridges/bin/rialto-parachain/runtime/src/lib.rs
+++ b/bridges/bin/rialto-parachain/runtime/src/lib.rs
@@ -30,7 +30,7 @@ use sp_api::impl_runtime_apis;
 use sp_core::{crypto::KeyTypeId, OpaqueMetadata};
 use sp_runtime::{
 	create_runtime_str, generic, impl_opaque_keys,
-	traits::{AccountIdConversion, AccountIdLookup, Block as BlockT},
+	traits::{AccountIdLookup, Block as BlockT},
 	transaction_validity::{TransactionSource, TransactionValidity},
 	ApplyExtrinsicResult,
 };
@@ -48,7 +48,7 @@ pub use frame_support::{
 		constants::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight, WEIGHT_PER_SECOND},
 		DispatchClass, IdentityFee, Weight,
 	},
-	PalletId, StorageValue,
+	StorageValue,
 };
 pub use frame_system::Call as SystemCall;
 pub use pallet_balances::Call as BalancesCall;
@@ -70,7 +70,7 @@ use xcm::latest::prelude::*;
 use xcm_builder::{
 	AccountId32Aliases, AllowTopLevelPaidExecutionFrom, AllowUnpaidExecutionFrom, CurrencyAdapter,
 	EnsureXcmOrigin, FixedWeightBounds, IsConcrete, LocationInverter, NativeAsset,
-	ParentAsSuperuser, ParentIs, RelayChainAsNative, SiblingParachainAsNative,
+	ParentAsSuperuser, ParentIsPreset, RelayChainAsNative, SiblingParachainAsNative,
 	SiblingParachainConvertsVia, SignedAccountId32AsNative, SignedToAccountId32,
 	SovereignSignedViaLocation, TakeWeightCredit, UsingComponents,
 };
@@ -288,7 +288,6 @@ parameter_types! {
 	pub const RelayNetwork: NetworkId = NetworkId::Polkadot;
 	pub RelayOrigin: Origin = cumulus_pallet_xcm::Origin::Relay.into();
 	pub Ancestry: MultiLocation = Parachain(ParachainInfo::parachain_id().into()).into();
-	pub ParentAccount: AccountId = PalletId(*b"b-rialto").into_account();
 }
 
 /// Type for specifying how a `MultiLocation` can be converted into an `AccountId`. This is used
@@ -296,7 +295,7 @@ parameter_types! {
 /// `Transact` in order to determine the dispatch Origin.
 pub type LocationToAccountId = (
 	// The parent (Relay-chain) origin converts to the parent `AccountId`.
-	ParentIs<ParentAccount, AccountId>,
+	ParentIsPreset<AccountId>,
 	// Sibling parachain origins convert to AccountId via the `ParaId::into`.
 	SiblingParachainConvertsVia<Sibling, AccountId>,
 	// Straight up local `AccountId32` origins just alias directly to `AccountId`.

--- a/bridges/bin/rialto-parachain/runtime/src/lib.rs
+++ b/bridges/bin/rialto-parachain/runtime/src/lib.rs
@@ -30,7 +30,7 @@ use sp_api::impl_runtime_apis;
 use sp_core::{crypto::KeyTypeId, OpaqueMetadata};
 use sp_runtime::{
 	create_runtime_str, generic, impl_opaque_keys,
-	traits::{AccountIdLookup, Block as BlockT},
+	traits::{AccountIdConversion, AccountIdLookup, Block as BlockT},
 	transaction_validity::{TransactionSource, TransactionValidity},
 	ApplyExtrinsicResult,
 };
@@ -48,7 +48,7 @@ pub use frame_support::{
 		constants::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight, WEIGHT_PER_SECOND},
 		DispatchClass, IdentityFee, Weight,
 	},
-	StorageValue,
+	PalletId, StorageValue,
 };
 pub use frame_system::Call as SystemCall;
 pub use pallet_balances::Call as BalancesCall;
@@ -288,7 +288,7 @@ parameter_types! {
 	pub const RelayNetwork: NetworkId = NetworkId::Polkadot;
 	pub RelayOrigin: Origin = cumulus_pallet_xcm::Origin::Relay.into();
 	pub Ancestry: MultiLocation = Parachain(ParachainInfo::parachain_id().into()).into();
-	pub CheckingAccount: AccountId = AccountId::from([0; 32]);
+	pub ParentAccount: AccountId = PalletId(*b"rialto").into_account();
 }
 
 /// Type for specifying how a `MultiLocation` can be converted into an `AccountId`. This is used
@@ -296,7 +296,7 @@ parameter_types! {
 /// `Transact` in order to determine the dispatch Origin.
 pub type LocationToAccountId = (
 	// The parent (Relay-chain) origin converts to the checking `AccountId`.
-	ParentIs<CheckingAccount, AccountId>,
+	ParentIs<ParentAccount, AccountId>,
 	// Sibling parachain origins convert to AccountId via the `ParaId::into`.
 	SiblingParachainConvertsVia<Sibling, AccountId>,
 	// Straight up local `AccountId32` origins just alias directly to `AccountId`.

--- a/bridges/bin/rialto-parachain/runtime/src/lib.rs
+++ b/bridges/bin/rialto-parachain/runtime/src/lib.rs
@@ -288,14 +288,14 @@ parameter_types! {
 	pub const RelayNetwork: NetworkId = NetworkId::Polkadot;
 	pub RelayOrigin: Origin = cumulus_pallet_xcm::Origin::Relay.into();
 	pub Ancestry: MultiLocation = Parachain(ParachainInfo::parachain_id().into()).into();
-	pub ParentAccount: AccountId = PalletId(*b"rialto").into_account();
+	pub ParentAccount: AccountId = PalletId(*b"b-rialto").into_account();
 }
 
 /// Type for specifying how a `MultiLocation` can be converted into an `AccountId`. This is used
 /// when determining ownership of accounts for asset transacting and when attempting to use XCM
 /// `Transact` in order to determine the dispatch Origin.
 pub type LocationToAccountId = (
-	// The parent (Relay-chain) origin converts to the checking `AccountId`.
+	// The parent (Relay-chain) origin converts to the parent `AccountId`.
 	ParentIs<ParentAccount, AccountId>,
 	// Sibling parachain origins convert to AccountId via the `ParaId::into`.
 	SiblingParachainConvertsVia<Sibling, AccountId>,

--- a/bridges/bin/rialto-parachain/runtime/src/lib.rs
+++ b/bridges/bin/rialto-parachain/runtime/src/lib.rs
@@ -70,7 +70,7 @@ use xcm::latest::prelude::*;
 use xcm_builder::{
 	AccountId32Aliases, AllowTopLevelPaidExecutionFrom, AllowUnpaidExecutionFrom, CurrencyAdapter,
 	EnsureXcmOrigin, FixedWeightBounds, IsConcrete, LocationInverter, NativeAsset,
-	ParentAsSuperuser, ParentIsDefault, RelayChainAsNative, SiblingParachainAsNative,
+	ParentAsSuperuser, ParentIsAllZeroes, RelayChainAsNative, SiblingParachainAsNative,
 	SiblingParachainConvertsVia, SignedAccountId32AsNative, SignedToAccountId32,
 	SovereignSignedViaLocation, TakeWeightCredit, UsingComponents,
 };
@@ -295,7 +295,7 @@ parameter_types! {
 /// `Transact` in order to determine the dispatch Origin.
 pub type LocationToAccountId = (
 	// The parent (Relay-chain) origin converts to the default `AccountId`.
-	ParentIsDefault<AccountId>,
+	ParentIsAllZeroes<AccountId>,
 	// Sibling parachain origins convert to AccountId via the `ParaId::into`.
 	SiblingParachainConvertsVia<Sibling, AccountId>,
 	// Straight up local `AccountId32` origins just alias directly to `AccountId`.

--- a/bridges/bin/rialto-parachain/runtime/src/lib.rs
+++ b/bridges/bin/rialto-parachain/runtime/src/lib.rs
@@ -70,7 +70,7 @@ use xcm::latest::prelude::*;
 use xcm_builder::{
 	AccountId32Aliases, AllowTopLevelPaidExecutionFrom, AllowUnpaidExecutionFrom, CurrencyAdapter,
 	EnsureXcmOrigin, FixedWeightBounds, IsConcrete, LocationInverter, NativeAsset,
-	ParentAsSuperuser, ParentIsAllZeroes, RelayChainAsNative, SiblingParachainAsNative,
+	ParentAsSuperuser, ParentIs, RelayChainAsNative, SiblingParachainAsNative,
 	SiblingParachainConvertsVia, SignedAccountId32AsNative, SignedToAccountId32,
 	SovereignSignedViaLocation, TakeWeightCredit, UsingComponents,
 };
@@ -288,14 +288,15 @@ parameter_types! {
 	pub const RelayNetwork: NetworkId = NetworkId::Polkadot;
 	pub RelayOrigin: Origin = cumulus_pallet_xcm::Origin::Relay.into();
 	pub Ancestry: MultiLocation = Parachain(ParachainInfo::parachain_id().into()).into();
+	pub CheckingAccount: AccountId = AccountId::from([0; 32]);
 }
 
 /// Type for specifying how a `MultiLocation` can be converted into an `AccountId`. This is used
 /// when determining ownership of accounts for asset transacting and when attempting to use XCM
 /// `Transact` in order to determine the dispatch Origin.
 pub type LocationToAccountId = (
-	// The parent (Relay-chain) origin converts to the default `AccountId`.
-	ParentIsAllZeroes<AccountId>,
+	// The parent (Relay-chain) origin converts to the checking `AccountId`.
+	ParentIs<CheckingAccount, AccountId>,
 	// Sibling parachain origins convert to AccountId via the `ParaId::into`.
 	SiblingParachainConvertsVia<Sibling, AccountId>,
 	// Straight up local `AccountId32` origins just alias directly to `AccountId`.

--- a/xcm/xcm-builder/src/currency_adapter.rs
+++ b/xcm/xcm-builder/src/currency_adapter.rs
@@ -54,7 +54,7 @@ impl From<Error> for XcmError {
 /// ```
 /// use frame_support::parameter_types;
 /// use xcm::latest::prelude::*;
-/// use xcm_builder::{ParentIsDefault, CurrencyAdapter, IsConcrete};
+/// use xcm_builder::{ParentIsAllZeroes, CurrencyAdapter, IsConcrete};
 ///
 /// /// Our chain's account id.
 /// type AccountId = sp_runtime::AccountId32;
@@ -67,7 +67,7 @@ impl From<Error> for XcmError {
 ///
 /// /// Some items that implement `Convert<MultiLocation, AccountId>`. Can be more, but for now we just assume we accept
 /// /// messages from the parent (relay chain).
-/// pub type LocationConvertor = (ParentIsDefault<RelayChain>);
+/// pub type LocationConvertor = (ParentIsAllZeroes<RelayChain>);
 ///
 /// /// Final currency adapter. This can be used in `xcm::Config` to specify how asset related transactions happen.
 /// pub type AssetTransactor = CurrencyAdapter<

--- a/xcm/xcm-builder/src/currency_adapter.rs
+++ b/xcm/xcm-builder/src/currency_adapter.rs
@@ -52,7 +52,9 @@ impl From<Error> for XcmError {
 ///
 /// # Example
 /// ```
+/// use parity_scale_codec::Decode;
 /// use frame_support::parameter_types;
+/// use sp_runtime::traits::TrailingZeroInput;
 /// use xcm::latest::prelude::*;
 /// use xcm_builder::{ParentIsAllZeroes, CurrencyAdapter, IsConcrete};
 ///
@@ -62,7 +64,8 @@ impl From<Error> for XcmError {
 /// /// Our relay chain's location.
 /// parameter_types! {
 ///     pub RelayChain: MultiLocation = Parent.into();
-///     pub CheckingAccount: AccountId = Default::default();
+///     pub CheckingAccount: AccountId =
+///         AccountId::decode(&mut TrailingZeroInput::zeroes()).unwrap();
 /// }
 ///
 /// /// Some items that implement `Convert<MultiLocation, AccountId>`. Can be more, but for now we just assume we accept

--- a/xcm/xcm-builder/src/currency_adapter.rs
+++ b/xcm/xcm-builder/src/currency_adapter.rs
@@ -64,8 +64,7 @@ impl From<Error> for XcmError {
 /// /// Our relay chain's location.
 /// parameter_types! {
 ///     pub RelayChain: MultiLocation = Parent.into();
-///     pub CheckingAccount: AccountId =
-///         AccountId::decode(&mut TrailingZeroInput::zeroes()).unwrap();
+///     pub CheckingAccount: AccountId = PalletId(*b"checking").into_account();
 ///     pub ParentAccount: AccountId = PalletId(*b"testacct").into_account();
 /// }
 ///

--- a/xcm/xcm-builder/src/currency_adapter.rs
+++ b/xcm/xcm-builder/src/currency_adapter.rs
@@ -56,7 +56,7 @@ impl From<Error> for XcmError {
 /// use frame_support::{parameter_types, PalletId};
 /// use sp_runtime::traits::{AccountIdConversion, TrailingZeroInput};
 /// use xcm::latest::prelude::*;
-/// use xcm_builder::{ParentIs, CurrencyAdapter, IsConcrete};
+/// use xcm_builder::{ParentIsPreset, CurrencyAdapter, IsConcrete};
 ///
 /// /// Our chain's account id.
 /// type AccountId = sp_runtime::AccountId32;
@@ -65,12 +65,11 @@ impl From<Error> for XcmError {
 /// parameter_types! {
 ///     pub RelayChain: MultiLocation = Parent.into();
 ///     pub CheckingAccount: AccountId = PalletId(*b"checking").into_account();
-///     pub ParentAccount: AccountId = PalletId(*b"testacct").into_account();
 /// }
 ///
 /// /// Some items that implement `Convert<MultiLocation, AccountId>`. Can be more, but for now we just assume we accept
 /// /// messages from the parent (relay chain).
-/// pub type LocationConvertor = (ParentIs<ParentAccount, AccountId>);
+/// pub type LocationConverter = (ParentIsPreset<AccountId>);
 ///
 /// /// Final currency adapter. This can be used in `xcm::Config` to specify how asset related transactions happen.
 /// pub type AssetTransactor = CurrencyAdapter<
@@ -78,8 +77,8 @@ impl From<Error> for XcmError {
 ///     u128,
 ///     // The matcher: use the currency when the asset is a concrete asset in our relay chain.
 ///     IsConcrete<RelayChain>,
-///     // The local convertor: default account of the parent relay chain.
-///     LocationConvertor,
+///     // The local converter: default account of the parent relay chain.
+///     LocationConverter,
 ///     // Our chain's account ID type.
 ///     AccountId,
 ///     // The checking account. Can be any deterministic inaccessible account.

--- a/xcm/xcm-builder/src/currency_adapter.rs
+++ b/xcm/xcm-builder/src/currency_adapter.rs
@@ -66,7 +66,7 @@ impl From<Error> for XcmError {
 ///     pub RelayChain: MultiLocation = Parent.into();
 ///     pub CheckingAccount: AccountId =
 ///         AccountId::decode(&mut TrailingZeroInput::zeroes()).unwrap();
-///     pub ParentAccount: AccountId = PalletId(*b"relay-chain").into_account();
+///     pub ParentAccount: AccountId = PalletId(*b"testacct").into_account();
 /// }
 ///
 /// /// Some items that implement `Convert<MultiLocation, AccountId>`. Can be more, but for now we just assume we accept

--- a/xcm/xcm-builder/src/currency_adapter.rs
+++ b/xcm/xcm-builder/src/currency_adapter.rs
@@ -53,8 +53,8 @@ impl From<Error> for XcmError {
 /// # Example
 /// ```
 /// use parity_scale_codec::Decode;
-/// use frame_support::parameter_types;
-/// use sp_runtime::traits::TrailingZeroInput;
+/// use frame_support::{parameter_types, PalletId};
+/// use sp_runtime::traits::{AccountIdConversion, TrailingZeroInput};
 /// use xcm::latest::prelude::*;
 /// use xcm_builder::{ParentIs, CurrencyAdapter, IsConcrete};
 ///
@@ -66,11 +66,12 @@ impl From<Error> for XcmError {
 ///     pub RelayChain: MultiLocation = Parent.into();
 ///     pub CheckingAccount: AccountId =
 ///         AccountId::decode(&mut TrailingZeroInput::zeroes()).unwrap();
+///     pub ParentAccount: AccountId = PalletId(*b"relay-chain").into_account();
 /// }
 ///
 /// /// Some items that implement `Convert<MultiLocation, AccountId>`. Can be more, but for now we just assume we accept
 /// /// messages from the parent (relay chain).
-/// pub type LocationConvertor = (ParentIs<AccountId, CheckingAccount>);
+/// pub type LocationConvertor = (ParentIs<ParentAccount, AccountId>);
 ///
 /// /// Final currency adapter. This can be used in `xcm::Config` to specify how asset related transactions happen.
 /// pub type AssetTransactor = CurrencyAdapter<

--- a/xcm/xcm-builder/src/currency_adapter.rs
+++ b/xcm/xcm-builder/src/currency_adapter.rs
@@ -56,7 +56,7 @@ impl From<Error> for XcmError {
 /// use frame_support::parameter_types;
 /// use sp_runtime::traits::TrailingZeroInput;
 /// use xcm::latest::prelude::*;
-/// use xcm_builder::{ParentIsAllZeroes, CurrencyAdapter, IsConcrete};
+/// use xcm_builder::{ParentIs, CurrencyAdapter, IsConcrete};
 ///
 /// /// Our chain's account id.
 /// type AccountId = sp_runtime::AccountId32;
@@ -70,7 +70,7 @@ impl From<Error> for XcmError {
 ///
 /// /// Some items that implement `Convert<MultiLocation, AccountId>`. Can be more, but for now we just assume we accept
 /// /// messages from the parent (relay chain).
-/// pub type LocationConvertor = (ParentIsAllZeroes<RelayChain>);
+/// pub type LocationConvertor = (ParentIs<AccountId, CheckingAccount>);
 ///
 /// /// Final currency adapter. This can be used in `xcm::Config` to specify how asset related transactions happen.
 /// pub type AssetTransactor = CurrencyAdapter<

--- a/xcm/xcm-builder/src/lib.rs
+++ b/xcm/xcm-builder/src/lib.rs
@@ -31,7 +31,7 @@ pub mod test_utils;
 mod location_conversion;
 pub use location_conversion::{
 	Account32Hash, AccountId32Aliases, AccountKey20Aliases, ChildParachainConvertsVia,
-	LocationInverter, ParentIs, SiblingParachainConvertsVia,
+	LocationInverter, ParentIsPreset, SiblingParachainConvertsVia,
 };
 
 mod origin_conversion;

--- a/xcm/xcm-builder/src/lib.rs
+++ b/xcm/xcm-builder/src/lib.rs
@@ -31,7 +31,7 @@ pub mod test_utils;
 mod location_conversion;
 pub use location_conversion::{
 	Account32Hash, AccountId32Aliases, AccountKey20Aliases, ChildParachainConvertsVia,
-	LocationInverter, ParentIsAllZeroes, SiblingParachainConvertsVia,
+	LocationInverter, ParentIs, SiblingParachainConvertsVia,
 };
 
 mod origin_conversion;

--- a/xcm/xcm-builder/src/lib.rs
+++ b/xcm/xcm-builder/src/lib.rs
@@ -31,7 +31,7 @@ pub mod test_utils;
 mod location_conversion;
 pub use location_conversion::{
 	Account32Hash, AccountId32Aliases, AccountKey20Aliases, ChildParachainConvertsVia,
-	LocationInverter, ParentIsDefault, SiblingParachainConvertsVia,
+	LocationInverter, ParentIsAllZeroes, SiblingParachainConvertsVia,
 };
 
 mod origin_conversion;

--- a/xcm/xcm-builder/src/location_conversion.rs
+++ b/xcm/xcm-builder/src/location_conversion.rs
@@ -15,9 +15,9 @@
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
 use frame_support::traits::Get;
-use parity_scale_codec::Encode;
+use parity_scale_codec::{Decode, Encode};
 use sp_io::hashing::blake2_256;
-use sp_runtime::traits::AccountIdConversion;
+use sp_runtime::traits::{AccountIdConversion, TrailingZeroInput};
 use sp_std::{borrow::Borrow, marker::PhantomData};
 use xcm::latest::{Junction::*, Junctions::*, MultiLocation, NetworkId, Parent};
 use xcm_executor::traits::{Convert, InvertLocation};
@@ -36,21 +36,26 @@ impl<Network: Get<NetworkId>, AccountId: From<[u8; 32]> + Into<[u8; 32]> + Clone
 }
 
 /// A [`MultiLocation`] consisting of a single `Parent` [`Junction`] will be converted to the
-/// `AccountId` specified in `A`.
-pub struct ParentIs<A: Get<AccountId>, AccountId>(PhantomData<(AccountId, A)>);
-impl<AccountId: Eq + Clone, A: Get<AccountId>> Convert<MultiLocation, AccountId>
-	for ParentIs<A, AccountId>
+/// parent `AccountId`.
+pub struct ParentIsPreset<AccountId>(PhantomData<AccountId>);
+impl<AccountId: Decode + Eq + Clone> Convert<MultiLocation, AccountId>
+	for ParentIsPreset<AccountId>
 {
 	fn convert_ref(location: impl Borrow<MultiLocation>) -> Result<AccountId, ()> {
 		if location.borrow().contains_parents_only(1) {
-			Ok(A::get())
+			Ok(b"Parent"
+				.using_encoded(|b| AccountId::decode(&mut TrailingZeroInput::new(b)))
+				.expect("infinite length input; no invalid inputs for type; qed"))
 		} else {
 			Err(())
 		}
 	}
 
 	fn reverse_ref(who: impl Borrow<AccountId>) -> Result<MultiLocation, ()> {
-		if who.borrow() == &A::get() {
+		let parent_account = b"Parent"
+			.using_encoded(|b| AccountId::decode(&mut TrailingZeroInput::new(b)))
+			.expect("infinite length input; no invalid inputs for type; qed");
+		if who.borrow() == &parent_account {
 			Ok(Parent.into())
 		} else {
 			Err(())

--- a/xcm/xcm-builder/src/location_conversion.rs
+++ b/xcm/xcm-builder/src/location_conversion.rs
@@ -15,9 +15,9 @@
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
 use frame_support::traits::Get;
-use parity_scale_codec::{Decode, Encode};
+use parity_scale_codec::Encode;
 use sp_io::hashing::blake2_256;
-use sp_runtime::traits::{AccountIdConversion, TrailingZeroInput};
+use sp_runtime::traits::AccountIdConversion;
 use sp_std::{borrow::Borrow, marker::PhantomData};
 use xcm::latest::{Junction::*, Junctions::*, MultiLocation, NetworkId, Parent};
 use xcm_executor::traits::{Convert, InvertLocation};
@@ -35,26 +35,22 @@ impl<Network: Get<NetworkId>, AccountId: From<[u8; 32]> + Into<[u8; 32]> + Clone
 	}
 }
 
-/// A [`MultiLocation`] consisting of a single `Parent` [`Junction`] will be converted to all zeros
-/// for `AccountId`.
-pub struct ParentIsAllZeroes<AccountId>(PhantomData<AccountId>);
-impl<AccountId: Decode + Eq + Clone> Convert<MultiLocation, AccountId>
-	for ParentIsAllZeroes<AccountId>
+/// A [`MultiLocation`] consisting of a single `Parent` [`Junction`] will be converted to the
+/// `AccountId` specified in `A`.
+pub struct ParentIs<A: Get<AccountId>, AccountId>(PhantomData<(AccountId, A)>);
+impl<AccountId: Eq + Clone, A: Get<AccountId>> Convert<MultiLocation, AccountId>
+	for ParentIs<A, AccountId>
 {
 	fn convert_ref(location: impl Borrow<MultiLocation>) -> Result<AccountId, ()> {
 		if location.borrow().contains_parents_only(1) {
-			Ok(AccountId::decode(&mut TrailingZeroInput::zeroes())
-				.expect("infinite length input; no invalid inputs for type; qed"))
+			Ok(A::get())
 		} else {
 			Err(())
 		}
 	}
 
 	fn reverse_ref(who: impl Borrow<AccountId>) -> Result<MultiLocation, ()> {
-		if who.borrow() ==
-			&AccountId::decode(&mut TrailingZeroInput::zeroes())
-				.expect("inifinite length input; no invalid inputs for type; qed")
-		{
+		if who.borrow() == &A::get() {
 			Ok(Parent.into())
 		} else {
 			Err(())

--- a/xcm/xcm-builder/src/location_conversion.rs
+++ b/xcm/xcm-builder/src/location_conversion.rs
@@ -15,9 +15,9 @@
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
 use frame_support::traits::Get;
-use parity_scale_codec::Encode;
+use parity_scale_codec::{Decode, Encode};
 use sp_io::hashing::blake2_256;
-use sp_runtime::traits::AccountIdConversion;
+use sp_runtime::traits::{AccountIdConversion, TrailingZeroInput};
 use sp_std::{borrow::Borrow, marker::PhantomData};
 use xcm::latest::{Junction::*, Junctions::*, MultiLocation, NetworkId, Parent};
 use xcm_executor::traits::{Convert, InvertLocation};
@@ -35,22 +35,26 @@ impl<Network: Get<NetworkId>, AccountId: From<[u8; 32]> + Into<[u8; 32]> + Clone
 	}
 }
 
-/// A [`MultiLocation`] consisting of a single `Parent` [`Junction`] will be converted to the
-/// default value of `AccountId` (e.g. all zeros for `AccountId32`).
-pub struct ParentIsDefault<AccountId>(PhantomData<AccountId>);
-impl<AccountId: Default + Eq + Clone> Convert<MultiLocation, AccountId>
-	for ParentIsDefault<AccountId>
+/// A [`MultiLocation`] consisting of a single `Parent` [`Junction`] will be converted to all zeros
+/// for `AccountId`.
+pub struct ParentIsAllZeroes<AccountId>(PhantomData<AccountId>);
+impl<AccountId: Decode + Eq + Clone> Convert<MultiLocation, AccountId>
+	for ParentIsAllZeroes<AccountId>
 {
 	fn convert_ref(location: impl Borrow<MultiLocation>) -> Result<AccountId, ()> {
 		if location.borrow().contains_parents_only(1) {
-			Ok(AccountId::default())
+			Ok(AccountId::decode(&mut TrailingZeroInput::zeroes())
+				.expect("infinite length input; no invalid inputs for type; qed"))
 		} else {
 			Err(())
 		}
 	}
 
 	fn reverse_ref(who: impl Borrow<AccountId>) -> Result<MultiLocation, ()> {
-		if who.borrow() == &AccountId::default() {
+		if who.borrow() ==
+			&AccountId::decode(&mut TrailingZeroInput::zeroes())
+				.expect("inifinite length input; no invalid inputs for type; qed")
+		{
 			Ok(Parent.into())
 		} else {
 			Err(())

--- a/xcm/xcm-simulator/example/src/parachain.rs
+++ b/xcm/xcm-simulator/example/src/parachain.rs
@@ -106,7 +106,7 @@ parameter_types! {
 	pub const KsmLocation: MultiLocation = MultiLocation::parent();
 	pub const RelayNetwork: NetworkId = NetworkId::Kusama;
 	pub Ancestry: MultiLocation = Parachain(MsgQueue::parachain_id().into()).into();
-	pub ParentAccount: AccountId = PalletId(*b"xcm-simulator").into_account();
+	pub ParentAccount: AccountId = PalletId(*b"simulate").into_account();
 }
 
 pub type LocationToAccountId = (

--- a/xcm/xcm-simulator/example/src/parachain.rs
+++ b/xcm/xcm-simulator/example/src/parachain.rs
@@ -21,11 +21,12 @@ use frame_support::{
 	construct_runtime, parameter_types,
 	traits::{Everything, Nothing},
 	weights::{constants::WEIGHT_PER_SECOND, Weight},
+	PalletId,
 };
 use sp_core::H256;
 use sp_runtime::{
 	testing::Header,
-	traits::{Hash, IdentityLookup},
+	traits::{AccountIdConversion, Hash, IdentityLookup},
 	AccountId32,
 };
 use sp_std::{convert::TryFrom, prelude::*};
@@ -105,11 +106,11 @@ parameter_types! {
 	pub const KsmLocation: MultiLocation = MultiLocation::parent();
 	pub const RelayNetwork: NetworkId = NetworkId::Kusama;
 	pub Ancestry: MultiLocation = Parachain(MsgQueue::parachain_id().into()).into();
-	pub CheckingAccount: AccountId = AccountId::from([0; 32]);
+	pub ParentAccount: AccountId = PalletId(*b"xcm-simulator-relay-chain").into_account();
 }
 
 pub type LocationToAccountId = (
-	ParentIs<CheckingAccount, AccountId>,
+	ParentIs<ParentAccount, AccountId>,
 	SiblingParachainConvertsVia<Sibling, AccountId>,
 	AccountId32Aliases<RelayNetwork, AccountId>,
 );

--- a/xcm/xcm-simulator/example/src/parachain.rs
+++ b/xcm/xcm-simulator/example/src/parachain.rs
@@ -39,7 +39,7 @@ use xcm::{latest::prelude::*, VersionedXcm};
 use xcm_builder::{
 	AccountId32Aliases, AllowUnpaidExecutionFrom, CurrencyAdapter as XcmCurrencyAdapter,
 	EnsureXcmOrigin, FixedRateOfFungible, FixedWeightBounds, IsConcrete, LocationInverter,
-	NativeAsset, ParentIsAllZeroes, SiblingParachainConvertsVia, SignedAccountId32AsNative,
+	NativeAsset, ParentIs, SiblingParachainConvertsVia, SignedAccountId32AsNative,
 	SignedToAccountId32, SovereignSignedViaLocation,
 };
 use xcm_executor::{Config, XcmExecutor};
@@ -105,10 +105,11 @@ parameter_types! {
 	pub const KsmLocation: MultiLocation = MultiLocation::parent();
 	pub const RelayNetwork: NetworkId = NetworkId::Kusama;
 	pub Ancestry: MultiLocation = Parachain(MsgQueue::parachain_id().into()).into();
+	pub CheckingAccount: AccountId = AccountId::from([0; 32]);
 }
 
 pub type LocationToAccountId = (
-	ParentIsAllZeroes<AccountId>,
+	ParentIs<CheckingAccount, AccountId>,
 	SiblingParachainConvertsVia<Sibling, AccountId>,
 	AccountId32Aliases<RelayNetwork, AccountId>,
 );

--- a/xcm/xcm-simulator/example/src/parachain.rs
+++ b/xcm/xcm-simulator/example/src/parachain.rs
@@ -39,7 +39,7 @@ use xcm::{latest::prelude::*, VersionedXcm};
 use xcm_builder::{
 	AccountId32Aliases, AllowUnpaidExecutionFrom, CurrencyAdapter as XcmCurrencyAdapter,
 	EnsureXcmOrigin, FixedRateOfFungible, FixedWeightBounds, IsConcrete, LocationInverter,
-	NativeAsset, ParentIsDefault, SiblingParachainConvertsVia, SignedAccountId32AsNative,
+	NativeAsset, ParentIsAllZeroes, SiblingParachainConvertsVia, SignedAccountId32AsNative,
 	SignedToAccountId32, SovereignSignedViaLocation,
 };
 use xcm_executor::{Config, XcmExecutor};
@@ -108,7 +108,7 @@ parameter_types! {
 }
 
 pub type LocationToAccountId = (
-	ParentIsDefault<AccountId>,
+	ParentIsAllZeroes<AccountId>,
 	SiblingParachainConvertsVia<Sibling, AccountId>,
 	AccountId32Aliases<RelayNetwork, AccountId>,
 );

--- a/xcm/xcm-simulator/example/src/parachain.rs
+++ b/xcm/xcm-simulator/example/src/parachain.rs
@@ -21,12 +21,11 @@ use frame_support::{
 	construct_runtime, parameter_types,
 	traits::{Everything, Nothing},
 	weights::{constants::WEIGHT_PER_SECOND, Weight},
-	PalletId,
 };
 use sp_core::H256;
 use sp_runtime::{
 	testing::Header,
-	traits::{AccountIdConversion, Hash, IdentityLookup},
+	traits::{Hash, IdentityLookup},
 	AccountId32,
 };
 use sp_std::{convert::TryFrom, prelude::*};
@@ -40,7 +39,7 @@ use xcm::{latest::prelude::*, VersionedXcm};
 use xcm_builder::{
 	AccountId32Aliases, AllowUnpaidExecutionFrom, CurrencyAdapter as XcmCurrencyAdapter,
 	EnsureXcmOrigin, FixedRateOfFungible, FixedWeightBounds, IsConcrete, LocationInverter,
-	NativeAsset, ParentIs, SiblingParachainConvertsVia, SignedAccountId32AsNative,
+	NativeAsset, ParentIsPreset, SiblingParachainConvertsVia, SignedAccountId32AsNative,
 	SignedToAccountId32, SovereignSignedViaLocation,
 };
 use xcm_executor::{Config, XcmExecutor};
@@ -106,11 +105,10 @@ parameter_types! {
 	pub const KsmLocation: MultiLocation = MultiLocation::parent();
 	pub const RelayNetwork: NetworkId = NetworkId::Kusama;
 	pub Ancestry: MultiLocation = Parachain(MsgQueue::parachain_id().into()).into();
-	pub ParentAccount: AccountId = PalletId(*b"simulate").into_account();
 }
 
 pub type LocationToAccountId = (
-	ParentIs<ParentAccount, AccountId>,
+	ParentIsPreset<AccountId>,
 	SiblingParachainConvertsVia<Sibling, AccountId>,
 	AccountId32Aliases<RelayNetwork, AccountId>,
 );

--- a/xcm/xcm-simulator/example/src/parachain.rs
+++ b/xcm/xcm-simulator/example/src/parachain.rs
@@ -106,7 +106,7 @@ parameter_types! {
 	pub const KsmLocation: MultiLocation = MultiLocation::parent();
 	pub const RelayNetwork: NetworkId = NetworkId::Kusama;
 	pub Ancestry: MultiLocation = Parachain(MsgQueue::parachain_id().into()).into();
-	pub ParentAccount: AccountId = PalletId(*b"xcm-simulator-relay-chain").into_account();
+	pub ParentAccount: AccountId = PalletId(*b"xcm-simulator").into_account();
 }
 
 pub type LocationToAccountId = (

--- a/xcm/xcm-simulator/fuzzer/src/parachain.rs
+++ b/xcm/xcm-simulator/fuzzer/src/parachain.rs
@@ -106,7 +106,7 @@ parameter_types! {
 	pub const KsmLocation: MultiLocation = MultiLocation::parent();
 	pub const RelayNetwork: NetworkId = NetworkId::Kusama;
 	pub Ancestry: MultiLocation = Parachain(MsgQueue::parachain_id().into()).into();
-	pub ParentAccount: AccountId = PalletId(*b"xcm-simulator-fuzzer-relay-chain").into_account();
+	pub ParentAccount: AccountId = PalletId(*b"fuzzer").into_account();
 }
 
 pub type LocationToAccountId = (

--- a/xcm/xcm-simulator/fuzzer/src/parachain.rs
+++ b/xcm/xcm-simulator/fuzzer/src/parachain.rs
@@ -21,12 +21,11 @@ use frame_support::{
 	construct_runtime, parameter_types,
 	traits::{Everything, Nothing},
 	weights::{constants::WEIGHT_PER_SECOND, Weight},
-	PalletId,
 };
 use sp_core::H256;
 use sp_runtime::{
 	testing::Header,
-	traits::{AccountIdConversion, Hash, IdentityLookup},
+	traits::{Hash, IdentityLookup},
 	AccountId32,
 };
 use sp_std::{convert::TryFrom, prelude::*};
@@ -40,7 +39,7 @@ use xcm::{latest::prelude::*, VersionedXcm};
 use xcm_builder::{
 	AccountId32Aliases, AllowUnpaidExecutionFrom, CurrencyAdapter as XcmCurrencyAdapter,
 	EnsureXcmOrigin, FixedRateOfFungible, FixedWeightBounds, IsConcrete, LocationInverter,
-	NativeAsset, ParentIs, SiblingParachainConvertsVia, SignedAccountId32AsNative,
+	NativeAsset, ParentIsPreset, SiblingParachainConvertsVia, SignedAccountId32AsNative,
 	SignedToAccountId32, SovereignSignedViaLocation,
 };
 use xcm_executor::{Config, XcmExecutor};
@@ -106,11 +105,10 @@ parameter_types! {
 	pub const KsmLocation: MultiLocation = MultiLocation::parent();
 	pub const RelayNetwork: NetworkId = NetworkId::Kusama;
 	pub Ancestry: MultiLocation = Parachain(MsgQueue::parachain_id().into()).into();
-	pub ParentAccount: AccountId = PalletId(*b"x-fuzzer").into_account();
 }
 
 pub type LocationToAccountId = (
-	ParentIs<ParentAccount, AccountId>,
+	ParentIsPreset<AccountId>,
 	SiblingParachainConvertsVia<Sibling, AccountId>,
 	AccountId32Aliases<RelayNetwork, AccountId>,
 );

--- a/xcm/xcm-simulator/fuzzer/src/parachain.rs
+++ b/xcm/xcm-simulator/fuzzer/src/parachain.rs
@@ -106,7 +106,7 @@ parameter_types! {
 	pub const KsmLocation: MultiLocation = MultiLocation::parent();
 	pub const RelayNetwork: NetworkId = NetworkId::Kusama;
 	pub Ancestry: MultiLocation = Parachain(MsgQueue::parachain_id().into()).into();
-	pub ParentAccount: AccountId = PalletId(*b"fuzzer").into_account();
+	pub ParentAccount: AccountId = PalletId(*b"x-fuzzer").into_account();
 }
 
 pub type LocationToAccountId = (

--- a/xcm/xcm-simulator/fuzzer/src/parachain.rs
+++ b/xcm/xcm-simulator/fuzzer/src/parachain.rs
@@ -39,7 +39,7 @@ use xcm::{latest::prelude::*, VersionedXcm};
 use xcm_builder::{
 	AccountId32Aliases, AllowUnpaidExecutionFrom, CurrencyAdapter as XcmCurrencyAdapter,
 	EnsureXcmOrigin, FixedRateOfFungible, FixedWeightBounds, IsConcrete, LocationInverter,
-	NativeAsset, ParentIsAllZeroes, SiblingParachainConvertsVia, SignedAccountId32AsNative,
+	NativeAsset, ParentIs, SiblingParachainConvertsVia, SignedAccountId32AsNative,
 	SignedToAccountId32, SovereignSignedViaLocation,
 };
 use xcm_executor::{Config, XcmExecutor};
@@ -105,10 +105,11 @@ parameter_types! {
 	pub const KsmLocation: MultiLocation = MultiLocation::parent();
 	pub const RelayNetwork: NetworkId = NetworkId::Kusama;
 	pub Ancestry: MultiLocation = Parachain(MsgQueue::parachain_id().into()).into();
+	pub CheckingAccount: AccountId = AccountId::from([0; 32]);
 }
 
 pub type LocationToAccountId = (
-	ParentIsAllZeroes<AccountId>,
+	ParentIs<CheckingAccount, AccountId>,
 	SiblingParachainConvertsVia<Sibling, AccountId>,
 	AccountId32Aliases<RelayNetwork, AccountId>,
 );

--- a/xcm/xcm-simulator/fuzzer/src/parachain.rs
+++ b/xcm/xcm-simulator/fuzzer/src/parachain.rs
@@ -39,7 +39,7 @@ use xcm::{latest::prelude::*, VersionedXcm};
 use xcm_builder::{
 	AccountId32Aliases, AllowUnpaidExecutionFrom, CurrencyAdapter as XcmCurrencyAdapter,
 	EnsureXcmOrigin, FixedRateOfFungible, FixedWeightBounds, IsConcrete, LocationInverter,
-	NativeAsset, ParentIsDefault, SiblingParachainConvertsVia, SignedAccountId32AsNative,
+	NativeAsset, ParentIsAllZeroes, SiblingParachainConvertsVia, SignedAccountId32AsNative,
 	SignedToAccountId32, SovereignSignedViaLocation,
 };
 use xcm_executor::{Config, XcmExecutor};
@@ -108,7 +108,7 @@ parameter_types! {
 }
 
 pub type LocationToAccountId = (
-	ParentIsDefault<AccountId>,
+	ParentIsAllZeroes<AccountId>,
 	SiblingParachainConvertsVia<Sibling, AccountId>,
 	AccountId32Aliases<RelayNetwork, AccountId>,
 );

--- a/xcm/xcm-simulator/fuzzer/src/parachain.rs
+++ b/xcm/xcm-simulator/fuzzer/src/parachain.rs
@@ -21,11 +21,12 @@ use frame_support::{
 	construct_runtime, parameter_types,
 	traits::{Everything, Nothing},
 	weights::{constants::WEIGHT_PER_SECOND, Weight},
+	PalletId,
 };
 use sp_core::H256;
 use sp_runtime::{
 	testing::Header,
-	traits::{Hash, IdentityLookup},
+	traits::{AccountIdConversion, Hash, IdentityLookup},
 	AccountId32,
 };
 use sp_std::{convert::TryFrom, prelude::*};
@@ -105,11 +106,11 @@ parameter_types! {
 	pub const KsmLocation: MultiLocation = MultiLocation::parent();
 	pub const RelayNetwork: NetworkId = NetworkId::Kusama;
 	pub Ancestry: MultiLocation = Parachain(MsgQueue::parachain_id().into()).into();
-	pub CheckingAccount: AccountId = AccountId::from([0; 32]);
+	pub ParentAccount: AccountId = PalletId(*b"xcm-simulator-fuzzer-relay-chain").into_account();
 }
 
 pub type LocationToAccountId = (
-	ParentIs<CheckingAccount, AccountId>,
+	ParentIs<ParentAccount, AccountId>,
 	SiblingParachainConvertsVia<Sibling, AccountId>,
 	AccountId32Aliases<RelayNetwork, AccountId>,
 );


### PR DESCRIPTION
Fixes #4687.

cumulus companion: paritytech/cumulus#901