### PR TITLE
refactor runtime cache for SessionInfo

### DIFF
--- a/node/core/runtime-api/src/cache.rs
+++ b/node/core/runtime-api/src/cache.rs
@@ -102,7 +102,7 @@ pub(crate) struct RequestResultCache {
 	candidate_pending_availability:
 		MemoryLruCache<(Hash, ParaId), ResidentSizeOf<Option<CommittedCandidateReceipt>>>,
 	candidate_events: MemoryLruCache<Hash, ResidentSizeOf<Vec<CandidateEvent>>>,
-	session_info: MemoryLruCache<SessionIndex, ResidentSizeOf<Option<SessionInfo>>>,
+	session_info: MemoryLruCache<SessionIndex, ResidentSizeOf<SessionInfo>>,
 	dmq_contents:
 		MemoryLruCache<(Hash, ParaId), ResidentSizeOf<Vec<InboundDownwardMessage<BlockNumber>>>>,
 	inbound_hrmp_channels_contents: MemoryLruCache<
@@ -309,18 +309,12 @@ impl RequestResultCache {
 		self.candidate_events.insert(relay_parent, ResidentSizeOf(events));
 	}
 
-	pub(crate) fn session_info(
-		&mut self,
-		key: (Hash, SessionIndex),
-	) -> Option<&Option<SessionInfo>> {
-		self.session_info.get(&key.1).map(|v| &v.0)
+	pub(crate) fn session_info(&mut self, key: SessionIndex) -> Option<&SessionInfo> {
+		self.session_info.get(&key).map(|v| &v.0)
 	}
 
-	pub(crate) fn cache_session_info(&mut self, key: SessionIndex, value: Option<SessionInfo>) {
-		// only cache Some(SessionInfo)
-		if value.is_some() {
-			self.session_info.insert(key, ResidentSizeOf(value));
-		}
+	pub(crate) fn cache_session_info(&mut self, key: SessionIndex, value: SessionInfo) {
+		self.session_info.insert(key, ResidentSizeOf(value));
 	}
 
 	pub(crate) fn dmq_contents(


### PR DESCRIPTION
The query invocation doesn't use the macro, but it's more explicit now.

Addresses https://github.com/paritytech/polkadot/pull/4706#discussion_r785179443.