### PR TITLE
make xcm_config public

### DIFF
--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -101,7 +101,7 @@ mod weights;
 mod bag_thresholds;
 
 // XCM configurations.
-mod xcm_config;
+pub mod xcm_config;
 
 #[cfg(test)]
 mod tests;

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -102,7 +102,7 @@ mod weights;
 
 mod bag_thresholds;
 
-mod xcm_config;
+pub mod xcm_config;
 
 // Make the WASM binary available.
 #[cfg(feature = "std")]

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -89,7 +89,7 @@ use frame_support::traits::{InstanceFilter, OnRuntimeUpgrade};
 mod bridge_messages;
 mod validator_manager;
 mod weights;
-mod xcm_config;
+pub mod xcm_config;
 
 // Make the WASM binary available.
 #[cfg(feature = "std")]

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -97,7 +97,7 @@ mod weights;
 mod bag_thresholds;
 
 // XCM configurations.
-mod xcm_config;
+pub mod xcm_config;
 
 #[cfg(test)]
 mod tests;


### PR DESCRIPTION
@KiChjang acala use xcm-emulator which mock real runtime, so previous it use `kusama_runtime::XcmConfig`. as https://github.com/paritytech/polkadot/pull/4644 changed, we need make `xcm_config` public, otherwise there're error like: **module `xcm_config` is private**.

https://github.com/AcalaNetwork/Acala/blob/9dfa889afea18b4dbff49f3e7fef3e26064fcb91/runtime/integration-tests/src/relaychain/kusama_test_net.rs#L31-L34

```
decl_test_relay_chain! {
	pub struct KusamaNet {
		Runtime = kusama_runtime::Runtime,
		XcmConfig = kusama_runtime::XcmConfig, // 🔥
		new_ext = kusama_ext(),
	}
}
```

the [xcm-simulator](https://github.com/paritytech/polkadot/blob/master/xcm/xcm-simulator/example/src/lib.rs#L48) in polkadot code base don't have this problem because it use mock XcmConfig. but parachain integration test need use real instead mock XcmConfig.

another question, should we move other xcm related config, such as `cumulus_pallet_xcm::Config`,`cumulus_pallet_xcmp_queue::Config`, `cumulus_pallet_dmp_queue::Config` to xcm_config? or just leave it alone?