### PR TITLE
XCM v3: Introduce querier field into `QueryReponse`

### DIFF
--- a/runtime/test-runtime/src/lib.rs
+++ b/runtime/test-runtime/src/lib.rs
@@ -608,6 +608,7 @@ pub mod pallet_test_notifier {
 			let qid = pallet_xcm::Pallet::<T>::new_query(
 				Junction::AccountId32 { network: Any, id }.into(),
 				100u32.into(),
+				Here,
 			);
 			Self::deposit_event(Event::<T>::QueryPrepared(qid));
 			Ok(())
@@ -625,6 +626,7 @@ pub mod pallet_test_notifier {
 				Junction::AccountId32 { network: Any, id }.into(),
 				<T as Config>::Call::from(call),
 				100u32.into(),
+				Here,
 			);
 			Self::deposit_event(Event::<T>::NotifyQueryPrepared(qid));
 			Ok(())

--- a/scripts/gitlab/lingua.dic
+++ b/scripts/gitlab/lingua.dic
@@ -215,6 +215,7 @@ proxy/G
 proxying
 PRs
 PVF/S
+querier
 README/MS
 redhat/M
 register/CD

--- a/xcm/pallet-xcm-benchmarks/src/generic/benchmarking.rs
+++ b/xcm/pallet-xcm-benchmarks/src/generic/benchmarking.rs
@@ -96,7 +96,8 @@ benchmarks! {
 		let mut executor = new_executor::<T>(Default::default());
 		let (query_id, response) = T::worst_case_response();
 		let max_weight = u64::MAX;
-		let instruction = Instruction::QueryResponse { query_id, response, max_weight };
+		let querier: Option<MultiLocation> = Some(Here.into());
+		let instruction = Instruction::QueryResponse { query_id, response, max_weight, querier };
 		let xcm = Xcm(vec![instruction]);
 	}: {
 		executor.execute(xcm)?;

--- a/xcm/pallet-xcm-benchmarks/src/mock.rs
+++ b/xcm/pallet-xcm-benchmarks/src/mock.rs
@@ -27,10 +27,16 @@ impl xcm::opaque::latest::SendXcm for DevNull {
 }
 
 impl xcm_executor::traits::OnResponse for DevNull {
-	fn expecting_response(_: &MultiLocation, _: u64) -> bool {
+	fn expecting_response(_: &MultiLocation, _: u64, _: Option<&MultiLocation>) -> bool {
 		false
 	}
-	fn on_response(_: &MultiLocation, _: u64, _: Response, _: Weight) -> Weight {
+	fn on_response(
+		_: &MultiLocation,
+		_: u64,
+		_: Option<&MultiLocation>,
+		_: Response,
+		_: Weight,
+	) -> Weight {
 		0
 	}
 }

--- a/xcm/pallet-xcm/src/lib.rs
+++ b/xcm/pallet-xcm/src/lib.rs
@@ -225,8 +225,8 @@ pub mod pallet {
 		///
 		/// \[ origin location, id \]
 		InvalidQuerierVersion(MultiLocation, QueryId),
-		/// Expected query response has been received but the origin location of the response does
-		/// not match that expected. The query remains registered for a later, valid, response to
+		/// Expected query response has been received but the querier location of the response does
+		/// not match the expected. The query remains registered for a later, valid, response to
 		/// be received and acted upon.
 		///
 		/// \[ origin location, id, expected querier, maybe actual querier \]

--- a/xcm/pallet-xcm/src/lib.rs
+++ b/xcm/pallet-xcm/src/lib.rs
@@ -215,6 +215,22 @@ pub mod pallet {
 		///
 		/// \[ location, query ID \]
 		NotifyTargetMigrationFail(VersionedMultiLocation, QueryId),
+		/// Expected query response has been received but the expected querier location placed in
+		/// storage by this runtime previously cannot be decoded. The query remains registered.
+		///
+		/// This is unexpected (since a location placed in storage in a previously executing
+		/// runtime should be readable prior to query timeout) and dangerous since the possibly
+		/// valid response will be dropped. Manual governance intervention is probably going to be
+		/// needed.
+		///
+		/// \[ origin location, id \]
+		InvalidQuerierVersion(MultiLocation, QueryId),
+		/// Expected query response has been received but the origin location of the response does
+		/// not match that expected. The query remains registered for a later, valid, response to
+		/// be received and acted upon.
+		///
+		/// \[ origin location, id, expected querier, maybe actual querier \]
+		InvalidQuerier(MultiLocation, QueryId, MultiLocation, Option<MultiLocation>),
 	}
 
 	#[pallet::origin]
@@ -269,7 +285,12 @@ pub mod pallet {
 	pub enum QueryStatus<BlockNumber> {
 		/// The query was sent but no response has yet been received.
 		Pending {
+			/// The `QueryResponse` XCM must have this origin to be considered a reply for this
+			/// query.
 			responder: VersionedMultiLocation,
+			/// The `QueryResponse` XCM must have this value as the `querier` field to be
+			/// considered a reply for this query. If `None` then the querier is ignored.
+			maybe_match_querier: Option<VersionedMultiLocation>,
 			maybe_notify: Option<(u8, u8)>,
 			timeout: BlockNumber,
 		},
@@ -446,6 +467,75 @@ pub mod pallet {
 			// block, which should be good enough)...
 			CurrentMigration::<T>::put(VersionMigrationStage::default());
 			T::DbWeight::get().write
+		}
+	}
+
+	pub mod migrations {
+		use super::*;
+		use frame_support::traits::{PalletInfoAccess, StorageVersion};
+
+		#[derive(Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug, TypeInfo)]
+		enum QueryStatusV0<BlockNumber> {
+			Pending {
+				responder: VersionedMultiLocation,
+				maybe_notify: Option<(u8, u8)>,
+				timeout: BlockNumber,
+			},
+			VersionNotifier { origin: VersionedMultiLocation, is_active: bool },
+			Ready { response: VersionedResponse, at: BlockNumber },
+		}
+		impl<B> From<QueryStatusV0<B>> for QueryStatus<B> {
+			fn from(old: QueryStatusV0<B>) -> Self {
+				use QueryStatusV0::*;
+				match old {
+					Pending { responder, maybe_notify, timeout }
+					=> QueryStatus::Pending {
+						responder,
+						maybe_notify,
+						timeout,
+						maybe_match_querier: Some(MultiLocation::here().into()),
+					},
+					VersionNotifier { origin, is_active }
+					=> QueryStatus::VersionNotifier { origin, is_active },
+					Ready { response, at }
+					=> QueryStatus::Ready { response, at },
+				}
+			}
+		}
+
+		pub fn migrate_to_v1<T: Config, P: GetStorageVersion + PalletInfoAccess>(
+		) -> frame_support::weights::Weight {
+			let on_chain_storage_version = <P as GetStorageVersion>::on_chain_storage_version();
+			log::info!(
+				target: "runtime::xcm",
+				"Running migration storage v1 for xcm with storage version {:?}",
+				on_chain_storage_version,
+			);
+
+			if on_chain_storage_version < 1 {
+				let mut count = 0;
+				Queries::<T>::translate::<QueryStatusV0<T::BlockNumber>, _>(
+					|_key, value| {
+						count += 1;
+						Some(value.into())
+					},
+				);
+				StorageVersion::new(1).put::<P>();
+				log::info!(
+					target: "runtime::xcm",
+					"Running migration storage v1 for xcm with storage version {:?} was complete",
+					on_chain_storage_version,
+				);
+				// calculate and return migration weights
+				T::DbWeight::get().reads_writes(count as Weight + 1, count as Weight + 1)
+			} else {
+				log::warn!(
+					target: "runtime::xcm",
+					"Attempted to apply migration to v1 but failed because storage version is {:?}",
+					on_chain_storage_version,
+				);
+				T::DbWeight::get().reads(1)
+			}
 		}
 	}
 
@@ -952,7 +1042,7 @@ pub mod pallet {
 						},
 					};
 					let response = Response::Version(xcm_version);
-					let message = Xcm(vec![QueryResponse { query_id, response, max_weight }]);
+					let message = Xcm(vec![QueryResponse { query_id, response, max_weight, querier: None }]);
 					let event = match T::XcmRouter::send_xcm(new_key.clone(), message) {
 						Ok(()) => {
 							let value = (query_id, max_weight, xcm_version);
@@ -999,7 +1089,7 @@ pub mod pallet {
 							// Need to notify target.
 							let response = Response::Version(xcm_version);
 							let message =
-								Xcm(vec![QueryResponse { query_id, response, max_weight }]);
+								Xcm(vec![QueryResponse { query_id, response, max_weight, querier: None }]);
 							let event = match T::XcmRouter::send_xcm(new_key.clone(), message) {
 								Ok(()) => {
 									VersionNotifyTargets::<T>::insert(
@@ -1076,10 +1166,12 @@ pub mod pallet {
 			AccountIdConversion::<T::AccountId>::into_account(&ID)
 		}
 
+		/// Create a new expectation of a query response with the querier being here.
 		fn do_new_query(
 			responder: impl Into<MultiLocation>,
 			maybe_notify: Option<(u8, u8)>,
 			timeout: T::BlockNumber,
+			match_querier: impl Into<MultiLocation>,
 		) -> u64 {
 			QueryCounter::<T>::mutate(|q| {
 				let r = *q;
@@ -1088,6 +1180,7 @@ pub mod pallet {
 					r,
 					QueryStatus::Pending {
 						responder: responder.into().into(),
+						maybe_match_querier: Some(match_querier.into().into()),
 						maybe_notify,
 						timeout,
 					},
@@ -1106,6 +1199,8 @@ pub mod pallet {
 		///
 		/// `report_outcome` may return an error if the `responder` is not invertible.
 		///
+		/// It is assumed that the querier of the response will be `Here`.
+		///
 		/// To check the status of the query, use `fn query()` passing the resultant `QueryId`
 		/// value.
 		pub fn report_outcome(
@@ -1116,7 +1211,7 @@ pub mod pallet {
 			let responder = responder.into();
 			let destination = T::LocationInverter::invert_location(&responder)
 				.map_err(|()| XcmError::MultiLocationNotInvertible)?;
-			let query_id = Self::new_query(responder, timeout);
+			let query_id = Self::new_query(responder, timeout, Here);
 			let response_info = QueryResponseInfo { destination, query_id, max_weight: 0 };
 			let report_error = Xcm(vec![ReportError(response_info)]);
 			message.0.insert(0, SetAppendix(report_error));
@@ -1138,6 +1233,8 @@ pub mod pallet {
 		///
 		/// `report_outcome_notify` may return an error if the `responder` is not invertible.
 		///
+		/// It is assumed that the querier of the response will be `Here`.
+		///
 		/// NOTE: `notify` gets called as part of handling an incoming message, so it should be
 		/// lightweight. Its weight is estimated during this function and stored ready for
 		/// weighing `ReportOutcome` on the way back. If it turns out to be heavier once it returns
@@ -1154,7 +1251,7 @@ pub mod pallet {
 				.map_err(|()| XcmError::MultiLocationNotInvertible)?;
 			let notify: <T as Config>::Call = notify.into();
 			let max_weight = notify.get_dispatch_info().weight;
-			let query_id = Self::new_notify_query(responder, notify, timeout);
+			let query_id = Self::new_notify_query(responder, notify, timeout, Here);
 			let response_info = QueryResponseInfo { destination, query_id, max_weight };
 			let report_error = Xcm(vec![ReportError(response_info)]);
 			message.0.insert(0, SetAppendix(report_error));
@@ -1162,8 +1259,8 @@ pub mod pallet {
 		}
 
 		/// Attempt to create a new query ID and register it as a query that is yet to respond.
-		pub fn new_query(responder: impl Into<MultiLocation>, timeout: T::BlockNumber) -> u64 {
-			Self::do_new_query(responder, None, timeout)
+		pub fn new_query(responder: impl Into<MultiLocation>, timeout: T::BlockNumber, match_querier: impl Into<MultiLocation>) -> u64 {
+			Self::do_new_query(responder, None, timeout, match_querier)
 		}
 
 		/// Attempt to create a new query ID and register it as a query that is yet to respond, and
@@ -1172,12 +1269,13 @@ pub mod pallet {
 			responder: impl Into<MultiLocation>,
 			notify: impl Into<<T as Config>::Call>,
 			timeout: T::BlockNumber,
+			match_querier: impl Into<MultiLocation>,
 		) -> u64 {
 			let notify =
 				notify.into().using_encoded(|mut bytes| Decode::decode(&mut bytes)).expect(
 					"decode input is output of Call encode; Call guaranteed to have two enums; qed",
 				);
-			Self::do_new_query(responder, Some(notify), timeout)
+			Self::do_new_query(responder, Some(notify), timeout, match_querier)
 		}
 
 		/// Attempt to remove and return the response of query with ID `query_id`.
@@ -1252,7 +1350,7 @@ pub mod pallet {
 
 			let xcm_version = T::AdvertisedXcmVersion::get();
 			let response = Response::Version(xcm_version);
-			let instruction = QueryResponse { query_id, response, max_weight };
+			let instruction = QueryResponse { query_id, response, max_weight, querier: None };
 			T::XcmRouter::send_xcm(dest.clone(), Xcm(vec![instruction]))?;
 
 			let value = (query_id, max_weight, xcm_version);
@@ -1315,10 +1413,14 @@ pub mod pallet {
 	}
 
 	impl<T: Config> OnResponse for Pallet<T> {
-		fn expecting_response(origin: &MultiLocation, query_id: QueryId) -> bool {
+		fn expecting_response(origin: &MultiLocation, query_id: QueryId, querier: &Option<MultiLocation>) -> bool {
 			match Queries::<T>::get(query_id) {
-				Some(QueryStatus::Pending { responder, .. }) =>
-					MultiLocation::try_from(responder).map_or(false, |r| origin == &r),
+				Some(QueryStatus::Pending { responder, maybe_match_querier, .. }) =>
+					MultiLocation::try_from(responder).map_or(false, |r| origin == &r) &&
+					maybe_match_querier.map_or(true, |match_querier|
+						MultiLocation::try_from(match_querier)
+						.map_or(false, |match_querier| querier.as_ref().map_or(false, |q| q == &match_querier))
+					),
 				Some(QueryStatus::VersionNotifier { origin: r, .. }) =>
 					MultiLocation::try_from(r).map_or(false, |r| origin == &r),
 				_ => false,
@@ -1328,6 +1430,7 @@ pub mod pallet {
 		fn on_response(
 			origin: &MultiLocation,
 			query_id: QueryId,
+			querier: &Option<MultiLocation>,
 			response: Response,
 			max_weight: Weight,
 		) -> Weight {
@@ -1375,7 +1478,28 @@ pub mod pallet {
 					Self::deposit_event(Event::SupportedVersionChanged(origin, v));
 					0
 				},
-				(response, Some(QueryStatus::Pending { responder, maybe_notify, .. })) => {
+				(response, Some(QueryStatus::Pending { responder, maybe_notify, maybe_match_querier, .. })) => {
+					if let Some(match_querier) = maybe_match_querier {
+						let match_querier = match MultiLocation::try_from(match_querier) {
+							Ok(mq) => mq,
+							Err(_) => {
+								Self::deposit_event(Event::InvalidQuerierVersion(
+									origin.clone(),
+									query_id,
+								));
+								return 0
+							}
+						};
+						if querier.as_ref().map_or(false, |q| q != &match_querier) {
+							Self::deposit_event(Event::InvalidQuerier(
+								origin.clone(),
+								query_id,
+								match_querier,
+								querier.clone(),
+							));
+							return 0
+						}
+					}
 					let responder = match MultiLocation::try_from(responder) {
 						Ok(r) => r,
 						Err(_) => {

--- a/xcm/pallet-xcm/src/lib.rs
+++ b/xcm/pallet-xcm/src/lib.rs
@@ -1511,7 +1511,7 @@ pub mod pallet {
 								return 0
 							},
 						};
-						if querier.map_or(false, |q| q != &match_querier) {
+						if querier.map_or(true, |q| q != &match_querier) {
 							Self::deposit_event(Event::InvalidQuerier(
 								origin.clone(),
 								query_id,

--- a/xcm/pallet-xcm/src/mock.rs
+++ b/xcm/pallet-xcm/src/mock.rs
@@ -82,6 +82,7 @@ pub mod pallet_test_notifier {
 			let qid = crate::Pallet::<T>::new_query(
 				Junction::AccountId32 { network: Any, id }.into(),
 				100u32.into(),
+				Here,
 			);
 			Self::deposit_event(Event::<T>::QueryPrepared(qid));
 			Ok(())
@@ -99,6 +100,7 @@ pub mod pallet_test_notifier {
 				Junction::AccountId32 { network: Any, id }.into(),
 				<T as Config>::Call::from(call),
 				100u32.into(),
+				Here,
 			);
 			Self::deposit_event(Event::<T>::NotifyQueryPrepared(qid));
 			Ok(())

--- a/xcm/pallet-xcm/src/mock.rs
+++ b/xcm/pallet-xcm/src/mock.rs
@@ -74,7 +74,7 @@ pub mod pallet_test_notifier {
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
 		#[pallet::weight(1_000_000)]
-		pub fn prepare_new_query(origin: OriginFor<T>) -> DispatchResult {
+		pub fn prepare_new_query(origin: OriginFor<T>, querier: MultiLocation) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 			let id = who
 				.using_encoded(|mut d| <[u8; 32]>::decode(&mut d))
@@ -82,14 +82,17 @@ pub mod pallet_test_notifier {
 			let qid = crate::Pallet::<T>::new_query(
 				Junction::AccountId32 { network: Any, id }.into(),
 				100u32.into(),
-				Here,
+				querier,
 			);
 			Self::deposit_event(Event::<T>::QueryPrepared(qid));
 			Ok(())
 		}
 
 		#[pallet::weight(1_000_000)]
-		pub fn prepare_new_notify_query(origin: OriginFor<T>) -> DispatchResult {
+		pub fn prepare_new_notify_query(
+			origin: OriginFor<T>,
+			querier: MultiLocation,
+		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 			let id = who
 				.using_encoded(|mut d| <[u8; 32]>::decode(&mut d))
@@ -100,7 +103,7 @@ pub mod pallet_test_notifier {
 				Junction::AccountId32 { network: Any, id }.into(),
 				<T as Config>::Call::from(call),
 				100u32.into(),
-				Here,
+				querier,
 			);
 			Self::deposit_event(Event::<T>::NotifyQueryPrepared(qid));
 			Ok(())

--- a/xcm/pallet-xcm/src/tests.rs
+++ b/xcm/pallet-xcm/src/tests.rs
@@ -63,10 +63,12 @@ fn report_outcome_notify_works() {
 				TransferAsset { assets: (Here, SEND_AMOUNT).into(), beneficiary: sender.clone() },
 			])
 		);
+		let querier: MultiLocation = Here.into();
 		let status = QueryStatus::Pending {
 			responder: MultiLocation::from(Parachain(PARA_ID)).into(),
 			maybe_notify: Some((4, 2)),
 			timeout: 100,
+			maybe_match_querier: Some(querier.clone().into()),
 		};
 		assert_eq!(crate::Queries::<Test>::iter().collect::<Vec<_>>(), vec![(0, status)]);
 
@@ -76,6 +78,7 @@ fn report_outcome_notify_works() {
 				query_id: 0,
 				response: Response::ExecutionResult(None),
 				max_weight: 1_000_000,
+				querier: Some(querier),
 			}]),
 			1_000_000_000,
 		);
@@ -117,10 +120,12 @@ fn report_outcome_works() {
 				TransferAsset { assets: (Here, SEND_AMOUNT).into(), beneficiary: sender.clone() },
 			])
 		);
+		let querier: MultiLocation = Here.into();
 		let status = QueryStatus::Pending {
 			responder: MultiLocation::from(Parachain(PARA_ID)).into(),
 			maybe_notify: None,
 			timeout: 100,
+			maybe_match_querier: Some(querier.clone().into()),
 		};
 		assert_eq!(crate::Queries::<Test>::iter().collect::<Vec<_>>(), vec![(0, status)]);
 
@@ -130,6 +135,7 @@ fn report_outcome_works() {
 				query_id: 0,
 				response: Response::ExecutionResult(None),
 				max_weight: 0,
+				querier: Some(querier),
 			}]),
 			1_000_000_000,
 		);
@@ -617,7 +623,12 @@ fn basic_subscription_works() {
 		let weight = BaseXcmWeight::get();
 		let mut message = Xcm::<()>(vec![
 			// Remote supports XCM v1
-			QueryResponse { query_id: 0, max_weight: 0, response: Response::Version(1) },
+			QueryResponse {
+				query_id: 0,
+				max_weight: 0,
+				response: Response::Version(1),
+				querier: None,
+			},
 		]);
 		assert_ok!(AllowKnownQueryResponses::<XcmPallet>::should_execute(
 			&remote,
@@ -722,7 +733,12 @@ fn subscription_side_works() {
 		let r = XcmExecutor::<XcmConfig>::execute_xcm(remote.clone(), message, weight);
 		assert_eq!(r, Outcome::Complete(weight));
 
-		let instr = QueryResponse { query_id: 0, max_weight: 0, response: Response::Version(1) };
+		let instr = QueryResponse {
+			query_id: 0,
+			max_weight: 0,
+			response: Response::Version(1),
+			querier: None,
+		};
 		assert_eq!(take_sent_xcm(), vec![(remote.clone(), Xcm(vec![instr]))]);
 
 		// A runtime upgrade which doesn't alter the version sends no notifications.
@@ -736,7 +752,12 @@ fn subscription_side_works() {
 		// A runtime upgrade which alters the version does send notifications.
 		XcmPallet::on_runtime_upgrade();
 		XcmPallet::on_initialize(2);
-		let instr = QueryResponse { query_id: 0, max_weight: 0, response: Response::Version(2) };
+		let instr = QueryResponse {
+			query_id: 0,
+			max_weight: 0,
+			response: Response::Version(2),
+			querier: None,
+		};
 		assert_eq!(take_sent_xcm(), vec![(remote.clone(), Xcm(vec![instr]))]);
 	});
 }
@@ -762,9 +783,24 @@ fn subscription_side_upgrades_work_with_notify() {
 		XcmPallet::on_runtime_upgrade();
 		XcmPallet::on_initialize(1);
 
-		let instr0 = QueryResponse { query_id: 69, max_weight: 0, response: Response::Version(2) };
-		let instr1 = QueryResponse { query_id: 70, max_weight: 0, response: Response::Version(2) };
-		let instr2 = QueryResponse { query_id: 71, max_weight: 0, response: Response::Version(2) };
+		let instr0 = QueryResponse {
+			query_id: 69,
+			max_weight: 0,
+			response: Response::Version(2),
+			querier: None,
+		};
+		let instr1 = QueryResponse {
+			query_id: 70,
+			max_weight: 0,
+			response: Response::Version(2),
+			querier: None,
+		};
+		let instr2 = QueryResponse {
+			query_id: 71,
+			max_weight: 0,
+			response: Response::Version(2),
+			querier: None,
+		};
 		let mut sent = take_sent_xcm();
 		sent.sort_by_key(|k| match (k.1).0[0] {
 			QueryResponse { query_id: q, .. } => q,
@@ -836,7 +872,12 @@ fn subscriber_side_subscription_works() {
 		let weight = BaseXcmWeight::get();
 		let message = Xcm(vec![
 			// Remote supports XCM v1
-			QueryResponse { query_id: 0, max_weight: 0, response: Response::Version(1) },
+			QueryResponse {
+				query_id: 0,
+				max_weight: 0,
+				response: Response::Version(1),
+				querier: None,
+			},
 		]);
 		let r = XcmExecutor::<XcmConfig>::execute_xcm(remote.clone(), message, weight);
 		assert_eq!(r, Outcome::Complete(weight));
@@ -848,7 +889,12 @@ fn subscriber_side_subscription_works() {
 
 		let message = Xcm(vec![
 			// Remote upgraded to XCM v2
-			QueryResponse { query_id: 0, max_weight: 0, response: Response::Version(2) },
+			QueryResponse {
+				query_id: 0,
+				max_weight: 0,
+				response: Response::Version(2),
+				querier: None,
+			},
 		]);
 		let r = XcmExecutor::<XcmConfig>::execute_xcm(remote.clone(), message, weight);
 		assert_eq!(r, Outcome::Complete(weight));
@@ -903,7 +949,12 @@ fn auto_subscription_works() {
 		let weight = BaseXcmWeight::get();
 		let message = Xcm(vec![
 			// Remote supports XCM v2
-			QueryResponse { query_id: 0, max_weight: 0, response: Response::Version(2) },
+			QueryResponse {
+				query_id: 0,
+				max_weight: 0,
+				response: Response::Version(2),
+				querier: None,
+			},
 		]);
 		let r = XcmExecutor::<XcmConfig>::execute_xcm(remote0.clone(), message, weight);
 		assert_eq!(r, Outcome::Complete(weight));
@@ -928,7 +979,12 @@ fn auto_subscription_works() {
 		let weight = BaseXcmWeight::get();
 		let message = Xcm(vec![
 			// Remote supports XCM v1
-			QueryResponse { query_id: 1, max_weight: 0, response: Response::Version(1) },
+			QueryResponse {
+				query_id: 1,
+				max_weight: 0,
+				response: Response::Version(1),
+				querier: None,
+			},
 		]);
 		let r = XcmExecutor::<XcmConfig>::execute_xcm(remote1.clone(), message, weight);
 		assert_eq!(r, Outcome::Complete(weight));
@@ -967,9 +1023,24 @@ fn subscription_side_upgrades_work_with_multistage_notify() {
 		}
 		assert_eq!(counter, 4);
 
-		let instr0 = QueryResponse { query_id: 69, max_weight: 0, response: Response::Version(2) };
-		let instr1 = QueryResponse { query_id: 70, max_weight: 0, response: Response::Version(2) };
-		let instr2 = QueryResponse { query_id: 71, max_weight: 0, response: Response::Version(2) };
+		let instr0 = QueryResponse {
+			query_id: 69,
+			max_weight: 0,
+			response: Response::Version(2),
+			querier: None,
+		};
+		let instr1 = QueryResponse {
+			query_id: 70,
+			max_weight: 0,
+			response: Response::Version(2),
+			querier: None,
+		};
+		let instr2 = QueryResponse {
+			query_id: 71,
+			max_weight: 0,
+			response: Response::Version(2),
+			querier: None,
+		};
 		let mut sent = take_sent_xcm();
 		sent.sort_by_key(|k| match (k.1).0[0] {
 			QueryResponse { query_id: q, .. } => q,

--- a/xcm/src/v1/multilocation.rs
+++ b/xcm/src/v1/multilocation.rs
@@ -324,6 +324,17 @@ impl MultiLocation {
 		Ok(())
 	}
 
+	/// Consume `self` and return the value representing the same location from the point of view
+	/// of `target`. The context of `self` is provided as `ancestry`.
+	///
+	/// Returns an `Err` with the unmodified `self` in the case of error.
+	pub fn reanchored(mut self, target: &MultiLocation, ancestry: &MultiLocation) -> Result<Self, Self> {
+		match self.reanchor(target, ancestry) {
+			Ok(()) => Ok(self),
+			Err(()) => Err(self),
+		}
+	}
+
 	/// Mutate `self` so that it represents the same location from the point of view of `target`.
 	/// The context of `self` is provided as `ancestry`.
 	///

--- a/xcm/src/v1/multilocation.rs
+++ b/xcm/src/v1/multilocation.rs
@@ -328,7 +328,11 @@ impl MultiLocation {
 	/// of `target`. The context of `self` is provided as `ancestry`.
 	///
 	/// Returns an `Err` with the unmodified `self` in the case of error.
-	pub fn reanchored(mut self, target: &MultiLocation, ancestry: &MultiLocation) -> Result<Self, Self> {
+	pub fn reanchored(
+		mut self,
+		target: &MultiLocation,
+		ancestry: &MultiLocation,
+	) -> Result<Self, Self> {
 		match self.reanchor(target, ancestry) {
 			Ok(()) => Ok(self),
 			Err(()) => Err(self),

--- a/xcm/src/v2/mod.rs
+++ b/xcm/src/v2/mod.rs
@@ -932,7 +932,7 @@ impl<Call> TryFrom<NewInstruction<Call>> for Instruction<Call> {
 			WithdrawAsset(assets) => Self::WithdrawAsset(assets),
 			ReserveAssetDeposited(assets) => Self::ReserveAssetDeposited(assets),
 			ReceiveTeleportedAsset(assets) => Self::ReceiveTeleportedAsset(assets),
-			QueryResponse { query_id, response, max_weight } =>
+			QueryResponse { query_id, response, max_weight, .. } =>
 				Self::QueryResponse { query_id, response: response.try_into()?, max_weight },
 			TransferAsset { assets, beneficiary } => Self::TransferAsset { assets, beneficiary },
 			TransferReserveAsset { assets, dest, xcm } =>

--- a/xcm/src/v3/mod.rs
+++ b/xcm/src/v3/mod.rs
@@ -265,8 +265,15 @@ pub enum Instruction<Call> {
 	/// - `query_id`: The identifier of the query that resulted in this message being sent.
 	/// - `response`: The message content.
 	/// - `max_weight`: The maximum weight that handling this response should take.
+	/// - `querier`: The location responsible for the initiation of the response, if there is one.
+	///   In general this will tend to be the same location as the receiver of this message.
+	///   NOTE: As usual, this is interpreted from the perspective of the receiving consensus
+	///   system.
 	///
-	/// Safety: No concerns.
+	/// Safety: Since this is information only, there are no immediate concerns. However, it should
+	/// be remembered that even if the Origin behaves reasonably, it can always be asked to make
+	/// a response to a third-party chain who may or may not be expecting the response. Therefore
+	/// the `querier` should be checked to match the expected value.
 	///
 	/// Kind: *Information*.
 	///
@@ -277,6 +284,7 @@ pub enum Instruction<Call> {
 		response: Response,
 		#[codec(compact)]
 		max_weight: Weight,
+		querier: Option<MultiLocation>,
 	},
 
 	/// Withdraw asset(s) (`assets`) from the ownership of `origin` and place equivalent assets
@@ -731,8 +739,8 @@ impl<Call> Instruction<Call> {
 			WithdrawAsset(assets) => WithdrawAsset(assets),
 			ReserveAssetDeposited(assets) => ReserveAssetDeposited(assets),
 			ReceiveTeleportedAsset(assets) => ReceiveTeleportedAsset(assets),
-			QueryResponse { query_id, response, max_weight } =>
-				QueryResponse { query_id, response, max_weight },
+			QueryResponse { query_id, response, max_weight, querier } =>
+				QueryResponse { query_id, response, max_weight, querier },
 			TransferAsset { assets, beneficiary } => TransferAsset { assets, beneficiary },
 			TransferReserveAsset { assets, dest, xcm } =>
 				TransferReserveAsset { assets, dest, xcm },
@@ -785,7 +793,7 @@ impl<Call, W: XcmWeightInfo<Call>> GetWeight<W> for Instruction<Call> {
 			WithdrawAsset(assets) => W::withdraw_asset(assets),
 			ReserveAssetDeposited(assets) => W::reserve_asset_deposited(assets),
 			ReceiveTeleportedAsset(assets) => W::receive_teleported_asset(assets),
-			QueryResponse { query_id, response, max_weight } =>
+			QueryResponse { query_id, response, max_weight, .. } =>
 				W::query_response(query_id, response, max_weight),
 			TransferAsset { assets, beneficiary } => W::transfer_asset(assets, beneficiary),
 			TransferReserveAsset { assets, dest, xcm } =>
@@ -874,7 +882,7 @@ impl<Call> TryFrom<OldInstruction<Call>> for Instruction<Call> {
 			ReserveAssetDeposited(assets) => Self::ReserveAssetDeposited(assets),
 			ReceiveTeleportedAsset(assets) => Self::ReceiveTeleportedAsset(assets),
 			QueryResponse { query_id, response, max_weight } =>
-				Self::QueryResponse { query_id, response: response.try_into()?, max_weight },
+				Self::QueryResponse { query_id, response: response.try_into()?, max_weight, querier: None },
 			TransferAsset { assets, beneficiary } => Self::TransferAsset { assets, beneficiary },
 			TransferReserveAsset { assets, dest, xcm } =>
 				Self::TransferReserveAsset { assets, dest, xcm: xcm.try_into()? },

--- a/xcm/src/v3/mod.rs
+++ b/xcm/src/v3/mod.rs
@@ -881,8 +881,12 @@ impl<Call> TryFrom<OldInstruction<Call>> for Instruction<Call> {
 			WithdrawAsset(assets) => Self::WithdrawAsset(assets),
 			ReserveAssetDeposited(assets) => Self::ReserveAssetDeposited(assets),
 			ReceiveTeleportedAsset(assets) => Self::ReceiveTeleportedAsset(assets),
-			QueryResponse { query_id, response, max_weight } =>
-				Self::QueryResponse { query_id, response: response.try_into()?, max_weight, querier: None },
+			QueryResponse { query_id, response, max_weight } => Self::QueryResponse {
+				query_id,
+				response: response.try_into()?,
+				max_weight,
+				querier: None,
+			},
 			TransferAsset { assets, beneficiary } => Self::TransferAsset { assets, beneficiary },
 			TransferReserveAsset { assets, dest, xcm } =>
 				Self::TransferReserveAsset { assets, dest, xcm: xcm.try_into()? },

--- a/xcm/src/v3/traits.rs
+++ b/xcm/src/v3/traits.rs
@@ -108,6 +108,9 @@ pub enum Error {
 	/// The given operation would lead to an overflow of the Holding Register.
 	#[codec(index = 26)]
 	HoldingWouldOverflow,
+	/// `MultiLocation` value failed to be reanchored.
+	#[codec(index = 27)]
+	ReanchorFailed,
 
 	// Errors that happen prior to instructions being executed. These fall outside of the XCM spec.
 	/// XCM version not able to be handled.

--- a/xcm/xcm-builder/src/barriers.rs
+++ b/xcm/xcm-builder/src/barriers.rs
@@ -138,8 +138,8 @@ impl<ResponseHandler: OnResponse> ShouldExecute for AllowKnownQueryResponses<Res
 			origin, message, _max_weight, _weight_credit,
 		);
 		match message.0.first() {
-			Some(QueryResponse { query_id, .. })
-				if ResponseHandler::expecting_response(origin, *query_id) =>
+			Some(QueryResponse { query_id, querier, .. })
+				if ResponseHandler::expecting_response(origin, *query_id, querier.as_ref()) =>
 				Ok(()),
 			_ => Err(()),
 		}

--- a/xcm/xcm-builder/src/mock.rs
+++ b/xcm/xcm-builder/src/mock.rs
@@ -216,7 +216,11 @@ thread_local! {
 }
 pub struct TestResponseHandler;
 impl OnResponse for TestResponseHandler {
-	fn expecting_response(origin: &MultiLocation, query_id: u64) -> bool {
+	fn expecting_response(
+		origin: &MultiLocation,
+		query_id: u64,
+		_querier: Option<&MultiLocation>,
+	) -> bool {
 		QUERIES.with(|q| match q.borrow().get(&query_id) {
 			Some(ResponseSlot::Expecting(ref l)) => l == origin,
 			_ => false,
@@ -225,6 +229,7 @@ impl OnResponse for TestResponseHandler {
 	fn on_response(
 		_origin: &MultiLocation,
 		query_id: u64,
+		_querier: Option<&MultiLocation>,
 		response: xcm::latest::Response,
 		_max_weight: Weight,
 	) -> Weight {

--- a/xcm/xcm-builder/src/tests.rs
+++ b/xcm/xcm-builder/src/tests.rs
@@ -646,6 +646,7 @@ fn prepaid_result_of_query_should_get_free_execution() {
 		query_id,
 		response: the_response.clone(),
 		max_weight: 10,
+		querier: Some(Here.into().into()),
 	}]);
 	let weight_limit = 10;
 
@@ -735,6 +736,7 @@ fn pallet_query_should_work() {
 				query_id: 1,
 				max_weight: 50,
 				response: Response::PalletsInfo(vec![]),
+				querier: Some(Here.into()),
 			}]),
 		)]
 	);
@@ -774,6 +776,7 @@ fn pallet_query_with_results_should_work() {
 					minor: 42,
 					patch: 69,
 				},]),
+				querier: Some(Here.into()),
 			}]),
 		)]
 	);
@@ -806,6 +809,7 @@ fn report_successful_transact_status_should_work() {
 				response: Response::DispatchResult(MaybeErrorCode::Success),
 				query_id: 42,
 				max_weight: 5000,
+				querier: Some(Here.into()),
 			}])
 		)]
 	);
@@ -838,6 +842,7 @@ fn report_failed_transact_status_should_work() {
 				response: Response::DispatchResult(MaybeErrorCode::Error(vec![2])),
 				query_id: 42,
 				max_weight: 5000,
+				querier: Some(Here.into()),
 			}])
 		)]
 	);
@@ -871,6 +876,7 @@ fn clear_transact_status_should_work() {
 				response: Response::DispatchResult(MaybeErrorCode::Success),
 				query_id: 42,
 				max_weight: 5000,
+				querier: Some(Here.into()),
 			}])
 		)]
 	);

--- a/xcm/xcm-builder/tests/scenarios.rs
+++ b/xcm/xcm-builder/tests/scenarios.rs
@@ -142,6 +142,7 @@ fn report_holding_works() {
 					query_id: response_info.query_id,
 					response: Response::Assets(vec![].into()),
 					max_weight: response_info.max_weight,
+					querier: Some(Here.into().into()),
 				}]),
 			)]
 		);

--- a/xcm/xcm-executor/integration-tests/src/lib.rs
+++ b/xcm/xcm-executor/integration-tests/src/lib.rs
@@ -119,7 +119,8 @@ fn query_response_fires() {
 
 	let response = Response::ExecutionResult(None);
 	let max_weight = 1_000_000;
-	let msg = Xcm(vec![QueryResponse { query_id, response, max_weight }]);
+	let querier = Some(Here.into());
+	let msg = Xcm(vec![QueryResponse { query_id, response, max_weight, querier }]);
 	let msg = Box::new(VersionedXcm::from(msg));
 
 	let execute = construct_extrinsic(
@@ -208,7 +209,8 @@ fn query_response_elicits_handler() {
 
 	let response = Response::ExecutionResult(None);
 	let max_weight = 1_000_000;
-	let msg = Xcm(vec![QueryResponse { query_id, response, max_weight }]);
+	let querier = Some(Here.into());
+	let msg = Xcm(vec![QueryResponse { query_id, response, max_weight, querier }]);
 
 	let execute = construct_extrinsic(
 		&client,

--- a/xcm/xcm-executor/src/lib.rs
+++ b/xcm/xcm-executor/src/lib.rs
@@ -394,7 +394,13 @@ impl<Config: config::Config> XcmExecutor<Config> {
 			},
 			QueryResponse { query_id, response, max_weight, querier } => {
 				let origin = self.origin.as_ref().ok_or(XcmError::BadOrigin)?;
-				Config::ResponseHandler::on_response(origin, query_id, querier.as_ref(), response, max_weight);
+				Config::ResponseHandler::on_response(
+					origin,
+					query_id,
+					querier.as_ref(),
+					response,
+					max_weight,
+				);
 				Ok(())
 			},
 			DescendOrigin(who) => self
@@ -410,7 +416,11 @@ impl<Config: config::Config> XcmExecutor<Config> {
 			ReportError(response_info) => {
 				// Report the given result by sending a QueryResponse XCM to a previously given outcome
 				// destination if one was registered.
-				Self::respond(self.origin.clone(), Response::ExecutionResult(self.error), response_info)
+				Self::respond(
+					self.origin.clone(),
+					Response::ExecutionResult(self.error),
+					response_info,
+				)
 			},
 			DepositAsset { assets, beneficiary } => {
 				let deposited = self.holding.saturating_take(assets);
@@ -461,7 +471,7 @@ impl<Config: config::Config> XcmExecutor<Config> {
 				// from Holding.
 				let assets =
 					Self::reanchored(self.holding.min(&assets), &response_info.destination, None);
-					Self::respond(self.origin.clone(), Response::Assets(assets), response_info)
+				Self::respond(self.origin.clone(), Response::Assets(assets), response_info)
 			},
 			BuyExecution { fees, weight_limit } => {
 				// There is no need to buy any weight is `weight_limit` is `Unlimited` since it
@@ -567,13 +577,11 @@ impl<Config: config::Config> XcmExecutor<Config> {
 				ensure!(minor >= min_crate_minor, XcmError::VersionIncompatible);
 				Ok(())
 			},
-			ReportTransactStatus(response_info) => {
-				Self::respond(
-					self.origin.clone(),
-					Response::DispatchResult(self.transact_status.clone()),
-					response_info,
-				)
-			},
+			ReportTransactStatus(response_info) => Self::respond(
+				self.origin.clone(),
+				Response::DispatchResult(self.transact_status.clone()),
+				response_info,
+			),
 			ClearTransactStatus => {
 				self.transact_status = Default::default();
 				Ok(())
@@ -594,7 +602,7 @@ impl<Config: config::Config> XcmExecutor<Config> {
 			None => None,
 			Some(q) => Some(
 				q.reanchored(&destination, &Config::LocationInverter::ancestry())
-					.map_err(|_| XcmError::ReanchorFailed)?
+					.map_err(|_| XcmError::ReanchorFailed)?,
 			),
 		})
 	}

--- a/xcm/xcm-executor/src/lib.rs
+++ b/xcm/xcm-executor/src/lib.rs
@@ -392,9 +392,9 @@ impl<Config: config::Config> XcmExecutor<Config> {
 				self.total_surplus.saturating_accrue(surplus);
 				Ok(())
 			},
-			QueryResponse { query_id, response, max_weight } => {
+			QueryResponse { query_id, response, max_weight, querier } => {
 				let origin = self.origin.as_ref().ok_or(XcmError::BadOrigin)?;
-				Config::ResponseHandler::on_response(origin, query_id, response, max_weight);
+				Config::ResponseHandler::on_response(origin, query_id, &querier, response, max_weight);
 				Ok(())
 			},
 			DescendOrigin(who) => self
@@ -410,7 +410,7 @@ impl<Config: config::Config> XcmExecutor<Config> {
 			ReportError(response_info) => {
 				// Report the given result by sending a QueryResponse XCM to a previously given outcome
 				// destination if one was registered.
-				Self::respond(Response::ExecutionResult(self.error), response_info)
+				Self::respond(self.origin.clone(), Response::ExecutionResult(self.error), response_info)
 			},
 			DepositAsset { assets, beneficiary } => {
 				let deposited = self.holding.saturating_take(assets);
@@ -461,7 +461,7 @@ impl<Config: config::Config> XcmExecutor<Config> {
 				// from Holding.
 				let assets =
 					Self::reanchored(self.holding.min(&assets), &response_info.destination, None);
-				Self::respond(Response::Assets(assets), response_info)
+					Self::respond(self.origin.clone(), Response::Assets(assets), response_info)
 			},
 			BuyExecution { fees, weight_limit } => {
 				// There is no need to buy any weight is `weight_limit` is `Unlimited` since it
@@ -549,7 +549,8 @@ impl<Config: config::Config> XcmExecutor<Config> {
 					.collect::<Vec<_>>();
 				let QueryResponseInfo { destination, query_id, max_weight } = response_info;
 				let response = Response::PalletsInfo(pallets);
-				let instruction = QueryResponse { query_id, response, max_weight };
+				let querier = Self::to_querier(self.origin.clone(), &destination)?;
+				let instruction = QueryResponse { query_id, response, max_weight, querier };
 				let message = Xcm(vec![instruction]);
 				Config::XcmSender::send_xcm(destination, message).map_err(Into::into)
 			},
@@ -566,8 +567,13 @@ impl<Config: config::Config> XcmExecutor<Config> {
 				ensure!(minor >= min_crate_minor, XcmError::VersionIncompatible);
 				Ok(())
 			},
-			ReportTransactStatus(response_info) =>
-				Self::respond(Response::DispatchResult(self.transact_status.clone()), response_info),
+			ReportTransactStatus(response_info) => {
+				Self::respond(
+					self.origin.clone(),
+					Response::DispatchResult(self.transact_status.clone()),
+					response_info,
+				)
+			},
 			ClearTransactStatus => {
 				self.transact_status = Default::default();
 				Ok(())
@@ -579,10 +585,31 @@ impl<Config: config::Config> XcmExecutor<Config> {
 		}
 	}
 
+	/// Calculates what `local_querier` would be from the perspective of `destination`.
+	fn to_querier(
+		local_querier: Option<MultiLocation>,
+		destination: &MultiLocation,
+	) -> Result<Option<MultiLocation>, XcmError> {
+		Ok(match local_querier {
+			None => None,
+			Some(q) => Some(
+				q.reanchored(&destination, &Config::LocationInverter::ancestry())
+					.map_err(|_| XcmError::ReanchorFailed)?
+			),
+		})
+	}
+
 	/// Send a bare `QueryResponse` message containing `response` informed by the given `info`.
-	fn respond(response: Response, info: QueryResponseInfo) -> Result<(), XcmError> {
+	///
+	/// The `local_querier` argument is the querier (if any) specified from the *local* perspective.
+	fn respond(
+		local_querier: Option<MultiLocation>,
+		response: Response,
+		info: QueryResponseInfo,
+	) -> Result<(), XcmError> {
+		let querier = Self::to_querier(local_querier, &info.destination)?;
 		let QueryResponseInfo { destination, query_id, max_weight } = info;
-		let instruction = QueryResponse { query_id, response, max_weight };
+		let instruction = QueryResponse { query_id, response, max_weight, querier };
 		let message = Xcm(vec![instruction]);
 		Config::XcmSender::send_xcm(destination, message).map_err(Into::into)
 	}

--- a/xcm/xcm-executor/src/lib.rs
+++ b/xcm/xcm-executor/src/lib.rs
@@ -394,7 +394,7 @@ impl<Config: config::Config> XcmExecutor<Config> {
 			},
 			QueryResponse { query_id, response, max_weight, querier } => {
 				let origin = self.origin.as_ref().ok_or(XcmError::BadOrigin)?;
-				Config::ResponseHandler::on_response(origin, query_id, &querier, response, max_weight);
+				Config::ResponseHandler::on_response(origin, query_id, querier.as_ref(), response, max_weight);
 				Ok(())
 			},
 			DescendOrigin(who) => self

--- a/xcm/xcm-executor/src/traits/on_response.rs
+++ b/xcm/xcm-executor/src/traits/on_response.rs
@@ -21,25 +21,25 @@ use xcm::latest::{Error as XcmError, MultiLocation, QueryId, Response, Result as
 pub trait OnResponse {
 	/// Returns `true` if we are expecting a response from `origin` for query `query_id` that was
 	/// queried by `querier`.
-	fn expecting_response(origin: &MultiLocation, query_id: u64, querier: &Option<MultiLocation>) -> bool;
+	fn expecting_response(origin: &MultiLocation, query_id: u64, querier: Option<&MultiLocation>) -> bool;
 	/// Handler for receiving a `response` from `origin` relating to `query_id` initiated by
 	/// `querier`.
 	fn on_response(
 		origin: &MultiLocation,
 		query_id: u64,
-		querier: &Option<MultiLocation>,
+		querier: Option<&MultiLocation>,
 		response: Response,
 		max_weight: Weight,
 	) -> Weight;
 }
 impl OnResponse for () {
-	fn expecting_response(_origin: &MultiLocation, _query_id: u64, _querier: &Option<MultiLocation>) -> bool {
+	fn expecting_response(_origin: &MultiLocation, _query_id: u64, _querier: Option<&MultiLocation>) -> bool {
 		false
 	}
 	fn on_response(
 		_origin: &MultiLocation,
 		_query_id: u64,
-		_querier: &Option<MultiLocation>,
+		_querier: Option<&MultiLocation>,
 		_response: Response,
 		_max_weight: Weight,
 	) -> Weight {

--- a/xcm/xcm-executor/src/traits/on_response.rs
+++ b/xcm/xcm-executor/src/traits/on_response.rs
@@ -21,7 +21,11 @@ use xcm::latest::{Error as XcmError, MultiLocation, QueryId, Response, Result as
 pub trait OnResponse {
 	/// Returns `true` if we are expecting a response from `origin` for query `query_id` that was
 	/// queried by `querier`.
-	fn expecting_response(origin: &MultiLocation, query_id: u64, querier: Option<&MultiLocation>) -> bool;
+	fn expecting_response(
+		origin: &MultiLocation,
+		query_id: u64,
+		querier: Option<&MultiLocation>,
+	) -> bool;
 	/// Handler for receiving a `response` from `origin` relating to `query_id` initiated by
 	/// `querier`.
 	fn on_response(
@@ -33,7 +37,11 @@ pub trait OnResponse {
 	) -> Weight;
 }
 impl OnResponse for () {
-	fn expecting_response(_origin: &MultiLocation, _query_id: u64, _querier: Option<&MultiLocation>) -> bool {
+	fn expecting_response(
+		_origin: &MultiLocation,
+		_query_id: u64,
+		_querier: Option<&MultiLocation>,
+	) -> bool {
 		false
 	}
 	fn on_response(

--- a/xcm/xcm-executor/src/traits/on_response.rs
+++ b/xcm/xcm-executor/src/traits/on_response.rs
@@ -19,23 +19,27 @@ use xcm::latest::{Error as XcmError, MultiLocation, QueryId, Response, Result as
 
 /// Define what needs to be done upon receiving a query response.
 pub trait OnResponse {
-	/// Returns `true` if we are expecting a response from `origin` for query `query_id`.
-	fn expecting_response(origin: &MultiLocation, query_id: u64) -> bool;
-	/// Handler for receiving a `response` from `origin` relating to `query_id`.
+	/// Returns `true` if we are expecting a response from `origin` for query `query_id` that was
+	/// queried by `querier`.
+	fn expecting_response(origin: &MultiLocation, query_id: u64, querier: &Option<MultiLocation>) -> bool;
+	/// Handler for receiving a `response` from `origin` relating to `query_id` initiated by
+	/// `querier`.
 	fn on_response(
 		origin: &MultiLocation,
 		query_id: u64,
+		querier: &Option<MultiLocation>,
 		response: Response,
 		max_weight: Weight,
 	) -> Weight;
 }
 impl OnResponse for () {
-	fn expecting_response(_origin: &MultiLocation, _query_id: u64) -> bool {
+	fn expecting_response(_origin: &MultiLocation, _query_id: u64, _querier: &Option<MultiLocation>) -> bool {
 		false
 	}
 	fn on_response(
 		_origin: &MultiLocation,
 		_query_id: u64,
+		_querier: &Option<MultiLocation>,
 		_response: Response,
 		_max_weight: Weight,
 	) -> Weight {

--- a/xcm/xcm-simulator/example/src/lib.rs
+++ b/xcm/xcm-simulator/example/src/lib.rs
@@ -305,6 +305,7 @@ mod tests {
 					query_id: query_id_set,
 					response: Response::Assets(MultiAssets::new()),
 					max_weight: 1_000_000_000,
+					querier: Some(Here.into()),
 				}])],
 			);
 		});


### PR DESCRIPTION
Introduce an additional field into the `QueryResponse` XCM instruction `querier` indicating the original initiator which led to this response being sent (from the point of view of the receiver). Typically this will simply be `Here`, since the receiver of the response will be the one who originally made the query.

The XCM pallet's query response handler system now allows expected query responses to have have an expected initiator of the response. Generally this is set to `Here` when new queries are initiated.

Before any query response is executed using the XCM pallet's response-dispatch system, the `querier` field is matched against what is expected. If it differs, then the `ExpectedResponse` barrier doesn't pass and the response is ignored.
