### PR TITLE
Use BlockImport and not BlockImportNotification to determine active leaves.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6677,6 +6677,7 @@ name = "polkadot-overseer"
 version = "0.9.13"
 dependencies = [
  "assert_matches",
+ "async-trait",
  "femme",
  "futures 0.3.19",
  "futures-timer",
@@ -6692,7 +6693,9 @@ dependencies = [
  "polkadot-primitives",
  "polkadot-primitives-test-helpers",
  "sc-client-api",
+ "sc-consensus",
  "sp-api",
+ "sp-consensus",
  "sp-core",
  "tracing",
 ]

--- a/node/overseer/Cargo.toml
+++ b/node/overseer/Cargo.toml
@@ -19,6 +19,9 @@ polkadot-overseer-gen = { path = "./overseer-gen" }
 tracing = "0.1.29"
 lru = "0.7"
 parity-util-mem = { version = ">= 0.10.1", default-features = false }
+sc-consensus = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-consensus = { git = "https://github.com/paritytech/substrate", branch = "master" }
+async-trait = "0.1.50"
 
 [dev-dependencies]
 metered-channel = { path = "../metered-channel" }

--- a/node/overseer/src/lib.rs
+++ b/node/overseer/src/lib.rs
@@ -278,6 +278,11 @@ pub struct OverseerBlockImport<I> {
 	handle: Handle,
 }
 
+/// Create a new [`OverseerBlockImport`] with given inner implementation and handle.
+pub fn block_import<I>(inner: I, handle: Handle) -> OverseerBlockImport<I> {
+	OverseerBlockImport { inner, handle }
+}
+
 #[async_trait::async_trait]
 impl<I: BlockImport<Block> + Send> BlockImport<Block> for OverseerBlockImport<I> {
 	type Error = I::Error;

--- a/node/overseer/src/lib.rs
+++ b/node/overseer/src/lib.rs
@@ -75,10 +75,8 @@ use polkadot_primitives::{
 	v1::{Block, BlockId, BlockNumber, Hash},
 	v2::ParachainHost,
 };
+use sc_consensus::block_import::{BlockCheckParams, BlockImport, BlockImportParams, ImportResult};
 use sp_api::{ApiExt, ProvideRuntimeApi};
-use sc_consensus::block_import::{
-	BlockCheckParams, BlockImport, BlockImportParams, ImportResult,
-};
 use sp_consensus::CacheKeyId;
 
 use polkadot_node_network_protocol::v1 as protocol_v1;
@@ -329,7 +327,10 @@ impl<I: BlockImport<Block> + Send> BlockImport<Block> for OverseerBlockImport<I>
 
 /// Glues together the [`Overseer`] and `BlockchainEvents` by forwarding
 /// finality notifications into the [`OverseerHandle`].
-pub async fn forward_finality_events<P: BlockchainEvents<Block>>(client: Arc<P>, mut handle: Handle) {
+pub async fn forward_finality_events<P: BlockchainEvents<Block>>(
+	client: Arc<P>,
+	mut handle: Handle,
+) {
 	let mut finality = client.finality_notification_stream();
 
 	while let Some(f) = finality.next().await {

--- a/node/overseer/src/lib.rs
+++ b/node/overseer/src/lib.rs
@@ -328,12 +328,22 @@ impl<I: BlockImport<Block> + Send> BlockImport<Block> for OverseerBlockImport<I>
 }
 
 /// Glues together the [`Overseer`] and `BlockchainEvents` by forwarding
-/// import and finality notifications into the [`OverseerHandle`].
+/// finality notifications into the [`OverseerHandle`].
 pub async fn forward_finality_events<P: BlockchainEvents<Block>>(client: Arc<P>, mut handle: Handle) {
 	let mut finality = client.finality_notification_stream();
 
 	while let Some(f) = finality.next().await {
 		handle.block_finalized(f.into()).await;
+	}
+}
+
+/// Glues together the [`Overseer`] and `BlockchainEvents` by forwarding
+/// import notifications into the [`OverseerHandle`].
+pub async fn forward_import_events<P: BlockchainEvents<Block>>(client: Arc<P>, mut handle: Handle) {
+	let mut import = client.import_notification_stream();
+
+	while let Some(f) = import.next().await {
+		handle.block_imported(f.into()).await;
 	}
 }
 

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -414,7 +414,7 @@ fn new_partial<RuntimeApi, ExecutorDispatch, ChainSelection>(
 						Block,
 						FullClient<RuntimeApi, ExecutorDispatch>,
 						FullGrandpaBlockImport<RuntimeApi, ExecutorDispatch, ChainSelection>,
-					>
+					>,
 				>,
 				grandpa::LinkHalf<Block, FullClient<RuntimeApi, ExecutorDispatch>, ChainSelection>,
 				babe::BabeLink<Block>,
@@ -1004,7 +1004,8 @@ where
 				Box::pin(async move {
 					use futures::{pin_mut, select, FutureExt};
 
-					let forward = polkadot_overseer::forward_finality_events(overseer_client, handle);
+					let forward =
+						polkadot_overseer::forward_finality_events(overseer_client, handle);
 
 					let forward = forward.fuse();
 					let overseer_fut = overseer.run().fuse();

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -464,6 +464,7 @@ where
 	let babe_config = babe::Config::get(&*client)?;
 	let (block_import, babe_link) =
 		babe::block_import(babe_config.clone(), grandpa_block_import, client.clone())?;
+	let block_import = polkadot_overseer::block_import(block_import, overseer_handle);
 
 	let slot_duration = babe_link.config().slot_duration();
 	let import_queue = babe::import_queue(
@@ -488,8 +489,6 @@ where
 		consensus_common::CanAuthorWithNativeVersion::new(client.executor().clone()),
 		telemetry.as_ref().map(|x| x.handle()),
 	)?;
-
-	let block_import = polkadot_overseer::block_import(block_import, overseer_handle);
 
 	let (beefy_commitment_link, beefy_commitment_stream) =
 		beefy_gadget::notification::BeefySignedCommitmentStream::<Block>::channel();


### PR DESCRIPTION
Block import notifications were too flaky, esp. when concerning small forks of the type that occurs when reverting. With this PR we now aggressively consider every single block the node imports successfully (even the millions during initial sync) an active leaf, at least temporarily.