### PR TITLE
Allow two Parachains to swap

### DIFF
--- a/runtime/common/src/paras_registrar.rs
+++ b/runtime/common/src/paras_registrar.rs
@@ -275,7 +275,7 @@ pub mod pallet {
 				if let Some(other_lifecycle) = paras::Pallet::<T>::lifecycle(other) {
 					if let Some(id_lifecycle) = paras::Pallet::<T>::lifecycle(id) {
 						// identify which is a parachain and which is a parathread
-						if id_lifecycle.is_parachain() && other_lifecycle.is_parathread() {
+						if id_lifecycle == ParaLifecycle::Parachain && other_lifecycle == ParaLifecycle::Parathread {
 							// We check that both paras are in an appropriate lifecycle for a swap,
 							// so these should never fail.
 							let res1 = runtime_parachains::schedule_parachain_downgrade::<T>(id);
@@ -283,13 +283,18 @@ pub mod pallet {
 							let res2 = runtime_parachains::schedule_parathread_upgrade::<T>(other);
 							debug_assert!(res2.is_ok());
 							T::OnSwap::on_swap(id, other);
-						} else if id_lifecycle.is_parathread() && other_lifecycle.is_parachain() {
+						} else if id_lifecycle == ParaLifecycle::Parathread && other_lifecycle == ParaLifecycle::Parachain {
 							// We check that both paras are in an appropriate lifecycle for a swap,
 							// so these should never fail.
 							let res1 = runtime_parachains::schedule_parachain_downgrade::<T>(other);
 							debug_assert!(res1.is_ok());
 							let res2 = runtime_parachains::schedule_parathread_upgrade::<T>(id);
 							debug_assert!(res2.is_ok());
+							T::OnSwap::on_swap(id, other);
+						} else if id_lifecycle == ParaLifecycle::Parachain && other_lifecycle == ParaLifecycle::Parachain {
+							// If both chains are currently parachains, there is nothing funny we
+							// need to do for their lifecycle management, just swap the underlying
+							// data.
 							T::OnSwap::on_swap(id, other);
 						}
 

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -138,11 +138,11 @@ pub fn native_version() -> NativeVersion {
 	NativeVersion { runtime_version: VERSION, can_author_with: Default::default() }
 }
 
-/// Don't allow swaps until parathread story is more mature.
+/// We currently allow all calls.
 pub struct BaseFilter;
 impl Contains<Call> for BaseFilter {
 	fn contains(c: &Call) -> bool {
-		!matches!(c, Call::Registrar(paras_registrar::Call::swap { .. }))
+		true
 	}
 }
 


### PR DESCRIPTION
This PR polishes the `swap` function available in the `paras_registrar`.

Specifically, we add the ability for two parachains to swap their slots, in addition to allowing a parachain and a parathread to swap.

Additional tests were added to verify this functionality, and it will been enabled in Kusama and Polkadot.