### PR TITLE
Add tests to ensure session is set correctly in `OnChainScrapingVotes`

### DIFF
--- a/runtime/parachains/src/disputes.rs
+++ b/runtime/parachains/src/disputes.rs
@@ -1313,7 +1313,9 @@ fn check_signature(
 	}
 }
 
+
 #[cfg(test)]
+#[allow(unused_import)]
 pub(crate) use self::tests::run_to_block;
 
 #[cfg(test)]

--- a/runtime/parachains/src/disputes.rs
+++ b/runtime/parachains/src/disputes.rs
@@ -1313,9 +1313,8 @@ fn check_signature(
 	}
 }
 
-
 #[cfg(test)]
-#[allow(unused_import)]
+#[allow(unused_imports)]
 pub(crate) use self::tests::run_to_block;
 
 #[cfg(test)]

--- a/runtime/parachains/src/disputes.rs
+++ b/runtime/parachains/src/disputes.rs
@@ -1314,6 +1314,9 @@ fn check_signature(
 }
 
 #[cfg(test)]
+pub(crate) use self::tests::run_to_block;
+
+#[cfg(test)]
 mod tests {
 	use super::*;
 	use crate::{
@@ -1363,7 +1366,7 @@ mod tests {
 
 	// Run to specific block, while calling disputes pallet hooks manually, because disputes is not
 	// integrated in initializer yet.
-	fn run_to_block<'a>(
+	pub(crate) fn run_to_block<'a>(
 		to: BlockNumber,
 		new_session: impl Fn(BlockNumber) -> Option<NewSession<'a>>,
 	) {

--- a/runtime/parachains/src/paras_inherent/tests.rs
+++ b/runtime/parachains/src/paras_inherent/tests.rs
@@ -127,6 +127,12 @@ mod enter {
 				Pallet::<Test>::on_chain_votes().unwrap().backing_validators_per_candidate.len(),
 				2
 			);
+
+			assert_eq!(
+				// The session of the on chain votes should equal the current session, which is 2
+				Pallet::<Test>::on_chain_votes().unwrap().session,
+				2
+			);
 		});
 	}
 
@@ -194,6 +200,12 @@ mod enter {
 				Pallet::<Test>::on_chain_votes().unwrap().backing_validators_per_candidate.len(),
 				0
 			);
+
+			assert_eq!(
+				// The session of the on chain votes should equal the current session, which is 2
+				Pallet::<Test>::on_chain_votes().unwrap().session,
+				2
+			);
 		});
 	}
 
@@ -258,6 +270,12 @@ mod enter {
 				Pallet::<Test>::on_chain_votes().unwrap().backing_validators_per_candidate.len(),
 				0
 			);
+
+			assert_eq!(
+				// The session of the on chain votes should equal the current session, which is 2
+				Pallet::<Test>::on_chain_votes().unwrap().session,
+				2
+			);
 		});
 	}
 
@@ -300,6 +318,9 @@ mod enter {
 				frame_system::RawOrigin::None.into(),
 				expected_para_inherent_data,
 			), Err(e) => { dbg!(e) });
+
+			// The block was not included, as such, `on_chain_votes` _must_ return `None`.
+			assert_eq!(Pallet::<Test>::on_chain_votes(), None,);
 		});
 	}
 
@@ -377,6 +398,12 @@ mod enter {
 				Pallet::<Test>::on_chain_votes().unwrap().backing_validators_per_candidate.len(),
 				0,
 			);
+
+			assert_eq!(
+				// The session of the on chain votes should equal the current session, which is 2
+				Pallet::<Test>::on_chain_votes().unwrap().session,
+				2
+			);
 		});
 	}
 
@@ -425,12 +452,8 @@ mod enter {
 				dbg!(e)
 			});
 
-			assert_eq!(
-				// The length of this vec is equal to the number of candidates, so we know
-				// all of our candidates got filtered out
-				Pallet::<Test>::on_chain_votes(),
-				None,
-			);
+			// The block was not included, as such, `on_chain_votes` _must_ return `None`.
+			assert_eq!(Pallet::<Test>::on_chain_votes(), None,);
 		});
 	}
 
@@ -513,6 +536,12 @@ mod enter {
 				// all of our candidates got filtered out
 				Pallet::<Test>::on_chain_votes().unwrap().backing_validators_per_candidate.len(),
 				0,
+			);
+
+			assert_eq!(
+				// The session of the on chain votes should equal the current session, which is 2
+				Pallet::<Test>::on_chain_votes().unwrap().session,
+				2
 			);
 		});
 	}
@@ -674,6 +703,12 @@ mod enter {
 				Pallet::<Test>::on_chain_votes().unwrap().backing_validators_per_candidate.len(),
 				1
 			);
+
+			assert_eq!(
+				// The session of the on chain votes should equal the current session, which is 2
+				Pallet::<Test>::on_chain_votes().unwrap().session,
+				2
+			);
 		});
 	}
 
@@ -717,6 +752,7 @@ mod enter {
 				expected_para_inherent_data,
 			), Err(e) => { dbg!(e) });
 
+			// The block was not included, as such, `on_chain_votes` _must_ return `None`.
 			assert_matches!(Pallet::<Test>::on_chain_votes(), None);
 		});
 	}

--- a/runtime/parachains/src/paras_inherent/tests.rs
+++ b/runtime/parachains/src/paras_inherent/tests.rs
@@ -138,21 +138,9 @@ mod enter {
 
 	#[test]
 	fn test_session_is_tracked_in_on_chain_scraping() {
-		use crate::{
-			configuration::HostConfiguration,
-			disputes::{run_to_block, DisputesHandler},
-			mock::{
-				new_test_ext, AccountId, AllPalletsWithSystem, Initializer, MockGenesisConfig,
-				System, Test, PUNISH_VALIDATORS_AGAINST, PUNISH_VALIDATORS_FOR,
-				PUNISH_VALIDATORS_INCONCLUSIVE, REWARD_VALIDATORS,
-			},
-		};
-		use frame_support::{
-			assert_err, assert_noop, assert_ok,
-			traits::{OnFinalize, OnInitialize},
-		};
+		use crate::disputes::run_to_block;
 		use primitives::v1::{
-			BlockNumber, DisputeStatement, DisputeStatementSet, ExplicitDisputeStatement,
+			DisputeStatement, DisputeStatementSet, ExplicitDisputeStatement,
 			InvalidDisputeStatementKind, ValidDisputeStatementKind,
 		};
 		use sp_core::{crypto::CryptoType, Pair};

--- a/runtime/parachains/src/paras_inherent/tests.rs
+++ b/runtime/parachains/src/paras_inherent/tests.rs
@@ -142,20 +142,22 @@ mod enter {
 			configuration::HostConfiguration,
 			disputes::{run_to_block, DisputesHandler},
 			mock::{
-				new_test_ext, AccountId, AllPalletsWithSystem, Initializer, MockGenesisConfig, System,
-				Test, PUNISH_VALIDATORS_AGAINST, PUNISH_VALIDATORS_FOR, PUNISH_VALIDATORS_INCONCLUSIVE,
-				REWARD_VALIDATORS,
+				new_test_ext, AccountId, AllPalletsWithSystem, Initializer, MockGenesisConfig,
+				System, Test, PUNISH_VALIDATORS_AGAINST, PUNISH_VALIDATORS_FOR,
+				PUNISH_VALIDATORS_INCONCLUSIVE, REWARD_VALIDATORS,
 			},
 		};
 		use frame_support::{
 			assert_err, assert_noop, assert_ok,
 			traits::{OnFinalize, OnInitialize},
 		};
-		use primitives::v1::{ExplicitDisputeStatement, ValidDisputeStatementKind, InvalidDisputeStatementKind, BlockNumber, DisputeStatement, DisputeStatementSet};
+		use primitives::v1::{
+			BlockNumber, DisputeStatement, DisputeStatementSet, ExplicitDisputeStatement,
+			InvalidDisputeStatementKind, ValidDisputeStatementKind,
+		};
 		use sp_core::{crypto::CryptoType, Pair};
 
-		new_test_ext(Default::default())
-		.execute_with(|| {
+		new_test_ext(Default::default()).execute_with(|| {
 			let v0 = <ValidatorId as CryptoType>::Pair::generate().0;
 			let v1 = <ValidatorId as CryptoType>::Pair::generate().0;
 
@@ -171,50 +173,48 @@ mod enter {
 
 			let generate_votes = |session: u32, candidate_hash: CandidateHash| {
 				// v0 votes for 3
-				vec![
-					DisputeStatementSet {
-						candidate_hash: candidate_hash.clone(),
-						session,
-						statements: vec![
-							(
-								DisputeStatement::Invalid(InvalidDisputeStatementKind::Explicit),
-								ValidatorIndex(0),
-								v0.sign(
-									&ExplicitDisputeStatement {
-										valid: false,
-										candidate_hash: candidate_hash.clone(),
-										session,
-									}
-									.signing_payload(),
-								),
+				vec![DisputeStatementSet {
+					candidate_hash: candidate_hash.clone(),
+					session,
+					statements: vec![
+						(
+							DisputeStatement::Invalid(InvalidDisputeStatementKind::Explicit),
+							ValidatorIndex(0),
+							v0.sign(
+								&ExplicitDisputeStatement {
+									valid: false,
+									candidate_hash: candidate_hash.clone(),
+									session,
+								}
+								.signing_payload(),
 							),
-							(
-								DisputeStatement::Invalid(InvalidDisputeStatementKind::Explicit),
-								ValidatorIndex(1),
-								v1.sign(
-									&ExplicitDisputeStatement {
-										valid: false,
-										candidate_hash: candidate_hash.clone(),
-										session,
-									}
-									.signing_payload(),
-								),
+						),
+						(
+							DisputeStatement::Invalid(InvalidDisputeStatementKind::Explicit),
+							ValidatorIndex(1),
+							v1.sign(
+								&ExplicitDisputeStatement {
+									valid: false,
+									candidate_hash: candidate_hash.clone(),
+									session,
+								}
+								.signing_payload(),
 							),
-							(
-								DisputeStatement::Valid(ValidDisputeStatementKind::Explicit),
-								ValidatorIndex(1),
-								v1.sign(
-									&ExplicitDisputeStatement {
-										valid: true,
-										candidate_hash: candidate_hash.clone(),
-										session,
-									}
-									.signing_payload(),
-								),
+						),
+						(
+							DisputeStatement::Valid(ValidDisputeStatementKind::Explicit),
+							ValidatorIndex(1),
+							v1.sign(
+								&ExplicitDisputeStatement {
+									valid: true,
+									candidate_hash: candidate_hash.clone(),
+									session,
+								}
+								.signing_payload(),
 							),
-						],
-					}
-				]
+						),
+					],
+				}]
 				.into_iter()
 				.map(CheckedDisputeStatementSet::unchecked_from_unchecked)
 				.collect::<Vec<CheckedDisputeStatementSet>>()


### PR DESCRIPTION
Add assertions to runtime tests in order to ensure that session in `OnChainScrapingVotes` matches the expected session.

Addition to #4810 