### PR TITLE
Add `matches_prefix` function to `MultiLocation` and `Junctions`

### DIFF
--- a/xcm/src/v0/multi_location.rs
+++ b/xcm/src/v0/multi_location.rs
@@ -367,6 +367,31 @@ impl MultiLocation {
 		return self.at(prefix.len())
 	}
 
+	/// Returns whether `self` begins with or is equal to `prefix`.
+	///
+	/// # Example
+	/// ```rust
+	/// # use xcm::v0::{Junction::*, MultiLocation::*};
+	/// # fn main() {
+	/// let m = X4(Parent, PalletInstance(3), OnlyChild, OnlyChild);
+	/// assert!(m.matches_prefix(&X2(Parent, PalletInstance(3))));
+	/// assert!(m.matches_prefix(&m));
+	/// assert!(!m.matches_prefix(&X2(Parent, GeneralIndex(99))));
+	/// assert!(!m.matches_prefix(&X1(PalletInstance(3))));
+	/// # }
+	/// ```
+	pub fn matches_prefix(&self, prefix: &MultiLocation) -> bool {
+		if self.len() < prefix.len() {
+			return false
+		}
+		for i in 0..prefix.len() {
+			if prefix.at(i) != self.at(i) {
+				return false
+			}
+		}
+		true
+	}
+
 	/// Mutates `self`, suffixing it with `new`. Returns `Err` in case of overflow.
 	pub fn push(&mut self, new: Junction) -> result::Result<(), ()> {
 		let mut n = MultiLocation::Null;


### PR DESCRIPTION
What it says on the tin :wink: 

Motivated by https://github.com/paritytech/cumulus/pull/936#discussion_r796234771

Key motivation: `match_and_split` only allows a single `Junction` after the prefix but it can be useful to be able to just check for a prefix and ignore what comes after.

Possible extension: We could introduce a corresponding `match_and_split_tail` (or similar, just a naming suggestion) to allow splitting off arbitrary suffixes.