### PR TITLE
feat(cicd): expire artifacts after 7 days

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,7 +40,7 @@ default:
   artifacts:
     name:                          "${CI_JOB_NAME}_${CI_COMMIT_REF_NAME}"
     when:                          on_success
-    expire_in:                     28 days
+    expire_in:                     7 days
     paths:
       - ./artifacts/
 


### PR DESCRIPTION
We received several alerts about disk space in gitlab server.
Even if we have 1TiB allocated, disk space is consumed very fast.
We need to address this problem by expiring artifacts after 7 days.