### PR TITLE
Add `starts_with` function to `MultiLocation` and `Junctions`

### DIFF
--- a/xcm/src/v0/multi_location.rs
+++ b/xcm/src/v0/multi_location.rs
@@ -356,13 +356,8 @@ impl MultiLocation {
 	/// # }
 	/// ```
 	pub fn match_and_split(&self, prefix: &MultiLocation) -> Option<&Junction> {
-		if prefix.len() + 1 != self.len() {
+		if prefix.len() + 1 != self.len() || !self.starts_with(prefix) {
 			return None
-		}
-		for i in 0..prefix.len() {
-			if prefix.at(i) != self.at(i) {
-				return None
-			}
 		}
 		return self.at(prefix.len())
 	}

--- a/xcm/src/v1/multilocation.rs
+++ b/xcm/src/v1/multilocation.rs
@@ -834,13 +834,8 @@ impl Junctions {
 	/// # }
 	/// ```
 	pub fn match_and_split(&self, prefix: &Junctions) -> Option<&Junction> {
-		if prefix.len() + 1 != self.len() {
+		if prefix.len() + 1 != self.len() || !self.starts_with(prefix) {
 			return None
-		}
-		for i in 0..prefix.len() {
-			if prefix.at(i) != self.at(i) {
-				return None
-			}
 		}
 		self.at(prefix.len())
 	}


### PR DESCRIPTION
What it says on the tin :wink: 

Motivated by https://github.com/paritytech/cumulus/pull/936#discussion_r796234771

Key motivation: `match_and_split` only allows a single `Junction` after the prefix but it can be useful to be able to just check for a prefix and ignore what comes after.

Possible extension: We could introduce a corresponding `match_and_split_tail` (or similar, just a naming suggestion) to allow splitting off arbitrary suffixes.

supersedes #4827 