### PR TITLE
allow overseer to be enabled anyways

### DIFF
--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -665,6 +665,10 @@ where
 ///
 /// This is an advanced feature and not recommended for general use. Generally, `build_full` is
 /// a better choice.
+///
+/// `overseer_enable_anyways` always enables the overseer, based on the provided `OverseerGenerator`,
+/// regardless of the role the node has. The relay chain selection (longest or disputes-aware) is
+/// still determined based on the role of the node. Likewise for authority discovery.
 #[cfg(feature = "full-node")]
 pub fn new_full<RuntimeApi, ExecutorDispatch, OverseerGenerator>(
 	mut config: Configuration,
@@ -674,6 +678,7 @@ pub fn new_full<RuntimeApi, ExecutorDispatch, OverseerGenerator>(
 	jaeger_agent: Option<std::net::SocketAddr>,
 	telemetry_worker_handle: Option<TelemetryWorkerHandle>,
 	program_path: Option<std::path::PathBuf>,
+	overseer_enable_anyways: bool,
 	overseer_gen: OverseerGenerator,
 ) -> Result<NewFull<Arc<FullClient<RuntimeApi, ExecutorDispatch>>>, Error>
 where
@@ -909,14 +914,14 @@ where
 	let active_leaves =
 		futures::executor::block_on(active_leaves(select_chain.as_longest_chain(), &*client))?;
 
-	let authority_discovery_service = if auth_or_collator {
+	let authority_discovery_service = if auth_or_collator || overseer_enable_anyways {
 		use futures::StreamExt;
 		use sc_network::Event;
 
 		let authority_discovery_role = if role.is_authority() {
 			sc_authority_discovery::Role::PublishAndDiscover(keystore_container.keystore())
 		} else {
-			// don't publish our addresses when we're only a collator
+			// don't publish our addresses when we're not an authority (collator, cumulus, ..)
 			sc_authority_discovery::Role::Discover
 		};
 		let dht_event_stream =
@@ -1275,6 +1280,7 @@ pub fn build_full(
 			jaeger_agent,
 			telemetry_worker_handle,
 			None,
+			false,
 			overseer_gen,
 		)
 		.map(|full| full.with_client(Client::Rococo))
@@ -1290,6 +1296,7 @@ pub fn build_full(
 			jaeger_agent,
 			telemetry_worker_handle,
 			None,
+			false,
 			overseer_gen,
 		)
 		.map(|full| full.with_client(Client::Kusama))
@@ -1305,6 +1312,7 @@ pub fn build_full(
 			jaeger_agent,
 			telemetry_worker_handle,
 			None,
+			false,
 			overseer_gen,
 		)
 		.map(|full| full.with_client(Client::Westend))
@@ -1320,6 +1328,7 @@ pub fn build_full(
 			jaeger_agent,
 			telemetry_worker_handle,
 			None,
+			false,
 			overseer_gen,
 		)
 		.map(|full| full.with_client(Client::Polkadot))

--- a/node/test/service/src/lib.rs
+++ b/node/test/service/src/lib.rs
@@ -95,6 +95,7 @@ pub fn new_full(
 		None,
 		None,
 		worker_program_path,
+		false,
 		polkadot_service::RealOverseerGen,
 	)
 }


### PR DESCRIPTION
Ref #4763

CC @bkchr 

If this deviates from your expectation of behavior, then let's schedule a talk.

Assumption here was, we are not running disputes coordinator and as such we want to follow the longest chain as relay chain selection algorithm would do. A keystore most be present for the overseer to launch.