### PR TITLE
Use Length Summation for Slot Winners

### DIFF
--- a/runtime/common/slot_range_helper/src/lib.rs
+++ b/runtime/common/slot_range_helper/src/lib.rs
@@ -147,11 +147,22 @@ macro_rules! generate_slot_range_len {
 	) => {
 		/// Return the length of occupying a `SlotRange`.
 		///
-		/// Example:`SlotRange::OneTwo.len() == 2`
+		/// Example: `SlotRange::OneTwo.len() == 2`
 		pub fn len(&self) -> usize {
 			match self {
 				// len (0, 2) = 2 - 0 + 1 = 3
 				$( SlotRange::$parsed => { ( $t2 - $t1 + 1) } )*
+			}
+		}
+
+		/// Return the "length summation" of occupying a `SlotRange`.
+		///
+		/// Example: `SlotRange::OneTwo.len() == 5`
+		pub fn len_sum(&self) -> usize {
+			match self {
+				$( SlotRange::$parsed => {
+					($t1 + 1 ..= $t2 + 1).sum()
+				} )*
 			}
 		}
 	};
@@ -254,6 +265,10 @@ mod tests {
 		assert_eq!(SlotRange::TwoTwo.len(), 1);
 		assert_eq!(SlotRange::OneTwo.len(), 2);
 		assert_eq!(SlotRange::ZeroThree.len(), 4);
+		assert_eq!(SlotRange::ZeroZero.len_sum(), 1);
+		assert_eq!(SlotRange::ZeroTwo.len_sum(), 6);
+		assert_eq!(SlotRange::OneTwo.len_sum(), 5);
+		assert_eq!(SlotRange::TwoThree.len_sum(), 7);
 		assert!(SlotRange::ZeroOne.intersects(SlotRange::OneThree));
 		assert!(!SlotRange::ZeroOne.intersects(SlotRange::TwoThree));
 		assert_eq!(SlotRange::ZeroZero.as_pair(), (0, 0));
@@ -279,6 +294,10 @@ mod tests {
 		assert_eq!(SlotRange::OneTwo.len(), 2);
 		assert_eq!(SlotRange::ZeroThree.len(), 4);
 		assert_eq!(SlotRange::ZeroSeven.len(), 8);
+		assert_eq!(SlotRange::ZeroZero.len_sum(), 1);
+		assert_eq!(SlotRange::ZeroTwo.len_sum(), 6);
+		assert_eq!(SlotRange::OneTwo.len_sum(), 5);
+		assert_eq!(SlotRange::ThreeSeven.len_sum(), 30);
 		assert!(SlotRange::ZeroOne.intersects(SlotRange::OneThree));
 		assert!(!SlotRange::ZeroOne.intersects(SlotRange::TwoThree));
 		assert!(SlotRange::FiveSix.intersects(SlotRange::SixSeven));

--- a/runtime/common/src/auctions.rs
+++ b/runtime/common/src/auctions.rs
@@ -606,7 +606,7 @@ impl<T: Config> Pallet<T> {
 			let best_bid = |range: SlotRange| {
 				winning[range as u8 as usize]
 					.as_ref()
-					.map(|(_, _, amount)| *amount * (range.len() as u32).into())
+					.map(|(_, _, amount)| *amount * (range.len_sum() as u32).into())
 			};
 			for i in 0..SlotRange::LEASE_PERIODS_PER_SLOT {
 				let r = SlotRange::new_bounded(0, 0, i as u32).expect("`i < LPPS`; qed");

--- a/runtime/common/src/integration_tests.rs
+++ b/runtime/common/src/integration_tests.rs
@@ -612,8 +612,14 @@ fn competing_slots() {
 		run_to_block(160);
 
 		// Appropriate Paras should have won slots
-		// 900 + 4500 + 2x 8100 = 21,600
-		// 900 + 4500 + 7200 + 9000 = 21,600
+		//
+		// Unweighted:
+		// 900 + 4500 + 2x 8100 = 21,600 ("tie")
+		// 900 + 4500 + 7200 + 9000 = 21,600 ("tie")
+		//
+		// Length Weighted:
+		// 900 * 1 + 4500 * 2 + 8100 * (3 + 4) = 66,600
+		// 900 * 1 + 4500 * 2 + 7200 * 4 + 9000 * 4 = 67,500 ("winner")
 		assert_eq!(
 			slots::Leases::<Test>::get(para_id),
 			// -- 1 --- 2 --- 3 ---------- 4 ------
@@ -624,11 +630,15 @@ fn competing_slots() {
 			// -- 1 --- 2 --- 3 --- 4 ---------- 5 -------
 			vec![None, None, None, None, Some((50, 4500))],
 		);
-		// TODO: Is this right?
 		assert_eq!(
-			slots::Leases::<Test>::get(para_id + 8),
-			// -- 1 --- 2 --- 3 --- 4 --- 5 ---------- 6 --------------- 7 -------
-			vec![None, None, None, None, None, Some((90, 8100)), Some((90, 8100))],
+			slots::Leases::<Test>::get(para_id + 7),
+			// -- 1 --- 2 --- 3 --- 4 --- 5 ---------- 6 -------
+			vec![None, None, None, None, None, Some((80, 7200))],
+		);
+		assert_eq!(
+			slots::Leases::<Test>::get(para_id + 9),
+			// -- 1 --- 2 --- 3 --- 4 --- 5 --- 6 ------------7--------
+			vec![None, None, None, None, None, None, Some((100, 9000))],
 		);
 	});
 }


### PR DESCRIPTION
Rather than calculating slot winners with simply the sum of bids for each lease period, we use a weighted sum, where each bid counts for the lease periods before it too, taking into account the total time tokens are locked for, rather than just how much are locked.

So...

Before:

```
1 + 2 + 3 + 4 = 10
```

After:

```
1 * 1 + 2 * 2 + 3 * 3 + 4 * 4 = 30
```

Thus a single bid for lease period 8 for 10 UNITS will be worth 80.

A bid for lease periods 7 and 8 for 10 UNITS will be worth 150.

etc...

This may have impact in some fringe scenarios as shown in the change in test in this PR.