### PR TITLE
paras: `initialize_para_now` and `ParachainsCache`

### DIFF
--- a/runtime/parachains/src/hrmp/benchmarking.rs
+++ b/runtime/parachains/src/hrmp/benchmarking.rs
@@ -17,7 +17,7 @@
 use crate::{
 	configuration::Pallet as Configuration,
 	hrmp::{Pallet as Hrmp, *},
-	paras::Pallet as Paras,
+	paras::{Pallet as Paras, ParachainsCache},
 	shared::Pallet as Shared,
 };
 use frame_support::{assert_ok, traits::Currency};
@@ -26,14 +26,16 @@ type BalanceOf<T> =
 	<<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
 
 fn register_parachain_with_balance<T: Config>(id: ParaId, balance: BalanceOf<T>) {
-	assert_ok!(Paras::<T>::initialize_para_now(
+	let mut parachains = ParachainsCache::new();
+	Paras::<T>::initialize_para_now(
+		&mut parachains,
 		id,
-		crate::paras::ParaGenesisArgs {
+		&crate::paras::ParaGenesisArgs {
 			parachain: true,
 			genesis_head: vec![1].into(),
 			validation_code: vec![1].into(),
 		},
-	));
+	);
 	T::Currency::make_free_balance_be(&id.into_account(), balance);
 }
 

--- a/runtime/parachains/src/paras/tests.rs
+++ b/runtime/parachains/src/paras/tests.rs
@@ -1020,6 +1020,7 @@ fn pvf_check_coalescing_onboarding_and_upgrade() {
 
 	let a = ParaId::from(111);
 	let b = ParaId::from(222);
+	let existing_code: ValidationCode = vec![1, 2, 3].into();
 	let validation_code: ValidationCode = vec![3, 2, 1].into();
 
 	let paras = vec![(
@@ -1027,7 +1028,7 @@ fn pvf_check_coalescing_onboarding_and_upgrade() {
 		ParaGenesisArgs {
 			parachain: true,
 			genesis_head: Default::default(),
-			validation_code: ValidationCode(vec![]), // valid since in genesis
+			validation_code: existing_code,
 		},
 	)];
 
@@ -1159,6 +1160,7 @@ fn pvf_check_onboarding_reject_on_expiry() {
 #[test]
 fn pvf_check_upgrade_reject() {
 	let a = ParaId::from(111);
+	let old_code: ValidationCode = vec![1, 2, 3].into();
 	let new_code: ValidationCode = vec![3, 2, 1].into();
 
 	let paras = vec![(
@@ -1166,7 +1168,7 @@ fn pvf_check_upgrade_reject() {
 		ParaGenesisArgs {
 			parachain: false,
 			genesis_head: Default::default(),
-			validation_code: ValidationCode(vec![]), // valid since in genesis
+			validation_code: old_code,
 		},
 	)];
 


### PR DESCRIPTION
This commit adds a new primitive called `ParachainsCache` to manipulate
the `Parachains` storage entry in a more convenient way.

Then, on top of that, this commit changes the logic of
`initialize_para_now` so that it is identical to what is used for
initialization of onboarding.