### PR TITLE
feat: decrese the validity for biggest artifacts

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -353,7 +353,7 @@ build-rustdoc:
   artifacts:
     name:                          "${CI_JOB_NAME}_${CI_COMMIT_REF_NAME}-doc"
     when:                          on_success
-    expire_in:                     7 days
+    expire_in:                     1 days
     paths:
     - ./crate-docs/
   script:
@@ -430,6 +430,7 @@ publish-polkadot-image:
     reports:
       # this artifact is used in zombienet-tests job
       dotenv: ./artifacts/parachains.env
+    expire_in:                     1 days
 
 publish-adder-collator-image:
   # service image for Simnet


### PR DESCRIPTION
Some artifacts occupy too much space on our gitlab instance for example:
`-rw-r--r--   1 root root 392M Feb 22 11:08 2022-02-11-build-rustdoc_4797-doc.zip`
and
`  Job 1384377 (210.81 MiB): Deleting build-malus_4681.zip`

This PR helps with a lot with the storage maintenance. 
