### PR TITLE
[ci] Create synth-wave docker image on tag

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -74,11 +74,21 @@ default:
     - sccache -s
 
 .test-refs:                        &test-refs
-  # these jobs run always*
+  # these jobs run on master and PR branches*
   rules:
+    - if: $CI_PIPELINE_SOURCE == "web"
     - if: $CI_PIPELINE_SOURCE == "schedule"
     - if: $CI_COMMIT_REF_NAME == "master"
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
+
+.common-refs:                      &common-refs
+  # these jobs run always*
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "web"
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+    - if: $CI_COMMIT_REF_NAME == "master"
+    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
+    - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
 
 .test-pr-refs:                     &test-pr-refs
   rules:
@@ -182,16 +192,12 @@ test-build-linux-stable:
   <<:                              *docker-env
   <<:                              *compiler-info
   <<:                              *collect-artifacts
+  <<:                              *common-refs
   variables:
     RUST_TOOLCHAIN: stable
     # Enable debug assertions since we are running optimized builds for testing
     # but still want to have debug assertions.
     RUSTFLAGS: "-Cdebug-assertions=y -Dwarnings"
-  rules:
-    - if: $CI_PIPELINE_SOURCE == "schedule"
-    - if: $CI_COMMIT_REF_NAME == "master"
-    - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
-    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
   script:
     - ./scripts/gitlab/test_linux_stable.sh
     # we're using the bin built here, instead of having a parallel `build-linux-release`
@@ -400,24 +406,18 @@ build-rustdoc:
   after_script:
     - buildah logout --all
 
-publish-polkadot-image:
+# This image is used in testnets
+# Release image is handled by the Github Action here:
+# .github/workflows/publish-docker-release.yml
+publish-polkadot-debug-image:
   stage:                           build
   <<:                              *build-push-image
+  <<:                              *common-refs
   variables:
     <<:                            *image-variables
     # scripts/dockerfiles/polkadot_injected_debug.Dockerfile
     DOCKERFILE:                    dockerfiles/polkadot_injected_debug.Dockerfile
     IMAGE_NAME:                    docker.io/paritypr/synth-wave
-  rules:
-    # Don't run on releases - this is handled by the Github Action here:
-    # .github/workflows/publish-docker-release.yml
-    - if: $CI_PIPELINE_SOURCE == "pipeline"
-      when: never
-    - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
-      when: never
-    - if: $CI_PIPELINE_SOURCE == "schedule"
-    - if: $CI_COMMIT_REF_NAME == "master"
-    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
   needs:
     - job:                         test-build-linux-stable
       artifacts:                   true


### PR DESCRIPTION
Added rule to `publish-polkadot-image` so it publishes synth-wave image on release. Also renamed it to `publish-polkadot-debug-image`

Closes https://github.com/paritytech/ci_cd/issues/328