### PR TITLE
Remove balancing iterations from OCW miners

### DIFF
--- a/runtime/common/src/elections.rs
+++ b/runtime/common/src/elections.rs
@@ -66,33 +66,6 @@ pub type OnOnChainAccuracy = sp_runtime::Perbill;
 pub type GenesisElectionOf<T> =
 	frame_election_provider_support::onchain::OnChainSequentialPhragmen<T>;
 
-/// Maximum number of iterations for balancing that will be executed in the embedded miner of
-/// pallet-election-provider-multi-phase.
-pub const MINER_MAX_ITERATIONS: u32 = 10;
-
-/// A source of random balance for the NPoS Solver, which is meant to be run by the off-chain worker
-/// election miner.
-pub struct OffchainRandomBalancing;
-impl frame_support::pallet_prelude::Get<Option<(usize, sp_npos_elections::ExtendedBalance)>>
-	for OffchainRandomBalancing
-{
-	fn get() -> Option<(usize, sp_npos_elections::ExtendedBalance)> {
-		use sp_runtime::{codec::Decode, traits::TrailingZeroInput};
-		let iters = match MINER_MAX_ITERATIONS {
-			0 => 0,
-			max @ _ => {
-				let seed = sp_io::offchain::random_seed();
-				let random = <u32>::decode(&mut TrailingZeroInput::new(&seed))
-					.expect("input is padded with zeroes; qed") %
-					max.saturating_add(1);
-				random as usize
-			},
-		};
-
-		Some((iters, 0))
-	}
-}
-
 /// Implementation of `frame_election_provider_support::SortedListProvider` that updates the
 /// bags-list but uses [`pallet_staking::Nominators`] for `iter`. This is meant to be a transitionary
 /// implementation for runtimes to "test" out the bags-list by keeping it up to date, but not yet

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -453,7 +453,7 @@ impl pallet_election_provider_multi_phase::Config for Runtime {
 	type Solver = frame_election_provider_support::SequentialPhragmen<
 		AccountId,
 		pallet_election_provider_multi_phase::SolutionAccuracyOf<Self>,
-		runtime_common::elections::OffchainRandomBalancing,
+		(),
 	>;
 	type BenchmarkingConfig = runtime_common::elections::BenchmarkConfig;
 	type ForceOrigin = EnsureOneOf<

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -410,11 +410,7 @@ parameter_types! {
 
 	// 1 hour session, 15 minutes unsigned phase, 8 offchain executions.
 	pub OffchainRepeat: BlockNumber = UnsignedPhase::get() / 8;
-
-	/// Whilst `UseNominatorsAndUpdateBagsList` or `UseNominatorsMap` is in use, this can still be a
-	/// very large value. Once the `BagsList` is in full motion, staking might open its door to many
-	/// more nominators, and this value should instead be what is a "safe" number (e.g. 22500).
-	pub const VoterSnapshotPerBlock: u32 = 22_500;
+	pub const VoterSnapshotPerBlock: u32 = 12_500;
 }
 
 sp_npos_elections::generate_solution_type!(

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -410,7 +410,11 @@ parameter_types! {
 
 	// 1 hour session, 15 minutes unsigned phase, 8 offchain executions.
 	pub OffchainRepeat: BlockNumber = UnsignedPhase::get() / 8;
-	pub const VoterSnapshotPerBlock: u32 = 12_500;
+
+	/// Whilst `UseNominatorsAndUpdateBagsList` or `UseNominatorsMap` is in use, this can still be a
+	/// very large value. Once the `BagsList` is in full motion, staking might open its door to many
+	/// more nominators, and this value should instead be what is a "safe" number (e.g. 22500).
+	pub const VoterSnapshotPerBlock: u32 = 22_500;
 }
 
 sp_npos_elections::generate_solution_type!(

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -450,10 +450,6 @@ parameter_types! {
 
 	// 4 hour session, 1 hour unsigned phase, 32 offchain executions.
 	pub OffchainRepeat: BlockNumber = UnsignedPhase::get() / 32;
-
-	/// Whilst `UseNominatorsAndUpdateBagsList` or `UseNominatorsMap` is in use, this can still be a
-	/// very large value. Once the `BagsList` is in full motion, staking might open its door to many
-	/// more nominators, and this value should instead be what is a "safe" number (e.g. 22500).
 	pub const VoterSnapshotPerBlock: u32 = 22_500;
 }
 

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -450,6 +450,10 @@ parameter_types! {
 
 	// 4 hour session, 1 hour unsigned phase, 32 offchain executions.
 	pub OffchainRepeat: BlockNumber = UnsignedPhase::get() / 32;
+
+	/// Whilst `UseNominatorsAndUpdateBagsList` or `UseNominatorsMap` is in use, this can still be a
+	/// very large value. Once the `BagsList` is in full motion, staking might open its door to many
+	/// more nominators, and this value should instead be what is a "safe" number (e.g. 22500).
 	pub const VoterSnapshotPerBlock: u32 = 22_500;
 }
 

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -493,7 +493,7 @@ impl pallet_election_provider_multi_phase::Config for Runtime {
 	type Solver = frame_election_provider_support::SequentialPhragmen<
 		AccountId,
 		pallet_election_provider_multi_phase::SolutionAccuracyOf<Self>,
-		runtime_common::elections::OffchainRandomBalancing,
+		(),
 	>;
 	type BenchmarkingConfig = runtime_common::elections::BenchmarkConfig;
 	type ForceOrigin = EnsureOneOf<

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -404,7 +404,7 @@ impl pallet_election_provider_multi_phase::Config for Runtime {
 	type Solver = frame_election_provider_support::SequentialPhragmen<
 		AccountId,
 		pallet_election_provider_multi_phase::SolutionAccuracyOf<Self>,
-		runtime_common::elections::OffchainRandomBalancing,
+		(),
 	>;
 	type BenchmarkingConfig = runtime_common::elections::BenchmarkConfig;
 	type ForceOrigin = EnsureRoot<AccountId>;

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -361,6 +361,10 @@ parameter_types! {
 
 	// 1 hour session, 15 minutes unsigned phase, 4 offchain executions.
 	pub OffchainRepeat: BlockNumber = UnsignedPhase::get() / 4;
+
+	/// Whilst `UseNominatorsAndUpdateBagsList` or `UseNominatorsMap` is in use, this can still be a
+	/// very large value. Once the `BagsList` is in full motion, staking might open its door to many
+	/// more nominators, and this value should instead be what is a "safe" number (e.g. 22500).
 	pub const VoterSnapshotPerBlock: u32 = 22_500;
 }
 

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -361,10 +361,6 @@ parameter_types! {
 
 	// 1 hour session, 15 minutes unsigned phase, 4 offchain executions.
 	pub OffchainRepeat: BlockNumber = UnsignedPhase::get() / 4;
-
-	/// Whilst `UseNominatorsAndUpdateBagsList` or `UseNominatorsMap` is in use, this can still be a
-	/// very large value. Once the `BagsList` is in full motion, staking might open its door to many
-	/// more nominators, and this value should instead be what is a "safe" number (e.g. 22500).
 	pub const VoterSnapshotPerBlock: u32 = 22_500;
 }
 

--- a/utils/staking-miner/src/dry_run.rs
+++ b/utils/staking-miner/src/dry_run.rs
@@ -115,20 +115,14 @@ macro_rules! dry_run_cmd_for { ($runtime:ident) => { paste::paste! {
 		signer: Signer,
 	) -> Result<(), Error<$crate::[<$runtime _runtime_exports>]::Runtime>> {
 		use $crate::[<$runtime _runtime_exports>]::*;
-		let mut ext = if config.force_snapshot {
-			let mut ext = crate::create_election_ext::<Runtime, Block>(
-				rpc.clone(),
-				config.at,
-				vec!["Staking".to_string(), "BagsList".to_string()],
-			).await?;
-			force_create_snapshot::<Runtime>(&mut ext)?;
-			ext
+		let pallets = if config.force_snapshot {
+			vec!["Staking".to_string(), "BagsList".to_string()]
 		} else {
-			crate::create_election_ext::<Runtime, Block>(
-				rpc.clone(),
-				config.at,
-				vec![],
-			).await?
+			Default::default()
+		};
+		let mut ext = crate::create_election_ext::<Runtime, Block>(rpc.clone(), config.at, pallets).await?;
+		if config.force_snapshot {
+			force_create_snapshot::<Runtime>(&mut ext)?;
 		};
 
 		log::debug!(target: LOG_TARGET, "+ solving with {:?}", config.solver);

--- a/utils/staking-miner/src/main.rs
+++ b/utils/staking-miner/src/main.rs
@@ -355,7 +355,10 @@ struct SharedConfig {
 	#[clap(long, short, default_value = DEFAULT_URI, env = "URI")]
 	uri: String,
 
-	/// The seed of a funded account in hex.
+	/// The path to a file containing the seed of the account. If the file is not found, the seed is
+	/// used as-is.
+	///
+	/// Can also be provided via the `SEED` environment variable.
 	///
 	/// WARNING: Don't use an account with a large stash for this. Based on how the bot is
 	/// configured, it might re-try and lose funds through transaction fees/deposits.

--- a/utils/staking-miner/src/main.rs
+++ b/utils/staking-miner/src/main.rs
@@ -343,6 +343,10 @@ struct DryRunConfig {
 	/// The solver algorithm to use.
 	#[clap(subcommand)]
 	solver: Solvers,
+
+	/// Force create a new snapshot, else expect one to exist onchain.
+	#[clap(long)]
+	force_snapshot: bool,
 }
 
 #[derive(Debug, Clone, Parser)]

--- a/utils/staking-miner/src/main.rs
+++ b/utils/staking-miner/src/main.rs
@@ -363,7 +363,7 @@ struct SharedConfig {
 	/// WARNING: Don't use an account with a large stash for this. Based on how the bot is
 	/// configured, it might re-try and lose funds through transaction fees/deposits.
 	#[clap(long, short, env = "SEED")]
-	seed: String,
+	seed_or_path: String,
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -597,7 +597,7 @@ async fn main() {
 	};
 
 	let signer_account = any_runtime! {
-		signer::signer_uri_from_string::<Runtime>(&shared.seed, &rpc)
+		signer::signer_uri_from_string::<Runtime>(&shared.seed_or_path, &rpc)
 			.await
 			.expect("Provided account is invalid, terminating.")
 	};

--- a/utils/staking-miner/src/signer.rs
+++ b/utils/staking-miner/src/signer.rs
@@ -57,9 +57,15 @@ pub(crate) async fn signer_uri_from_string<
 			Hash = Hash,
 		> + EPM::Config,
 >(
-	seed: &str,
+	mut seed_or_path: &str,
 	client: &SharedRpcClient,
 ) -> Result<Signer, Error<T>> {
+	seed_or_path = seed_or_path.trim();
+
+	let seed = match std::fs::read(seed_or_path) {
+		Ok(s) => String::from_utf8(s).map_err(|_| Error::<T>::AccountDoesNotExists)?,
+		Err(_) => seed_or_path.to_string(),
+	};
 	let seed = seed.trim();
 
 	let pair = Pair::from_string(seed, None)?;


### PR DESCRIPTION
This is a proposal backed by some arguments to remove the balancing post-processing from the offchain worker miners. 

- The OCW miners have limited heap capabilities, and running more iterations means we run OOM faster. If we remove the balancing, we can technically increase the 22500 limit a bit further (a separate PR for that comes next week)
- The signed miners are free to run a lot of balancing iterations as usual. Most solutions nowadays are submitted by signed miners. 
- I pulled the data of the last week of election on Polkadot as an example, to show that the balancing iterations, despite exhausting memory is not that useful. The below logs are taken from the `staking-miner`, re-running the election on the given hash heights, with 10 and 0 balancing iterations. The difference is mostly negligible.

```
trying 0x0cac7cc317a76441de0f9a24281f2f95c5b2cccad2494d2ec03062da813f795f
10 iterations
2022-02-26T20:42:54.448055Z  INFO staking-miner: solution score [1803701,000 DOT (18,037,010,000,485,553), 638455322,065 DOT (6,384,553,220,659,667,796), 14116209157518986346676639,845 DOT (141,162,091,575,189,863,466,766,398,451,066,164)] / deposit 40,931 DOT (409,314,233,968) / length 95378
none
2022-02-26T20:43:06.441847Z  INFO staking-miner: solution score [1803701,000 DOT (18,037,010,000,485,553), 638455322,065 DOT (6,384,553,220,659,667,796), 14282005905947265452667286,332 DOT (142,820,059,059,472,654,526,672,863,327,329,810)] / deposit 40,931 DOT (409,313,648,032) / length 95372

trying 0x8d4081d82e24e5a24c0aeadfc0886c0564fac650f8b575fa51fb51d06c97e589
10 iterations
2022-02-26T20:43:11.446797Z  INFO staking-miner: solution score [1803701,000 DOT (18,037,010,000,485,553), 632594631,964 DOT (6,325,946,319,641,526,504), 13838783840415539300500228,927 DOT (138,387,838,404,155,393,005,002,289,272,846,326)] / deposit 40,924 DOT (409,243,726,336) / length 94656
none
2022-02-26T20:43:23.094659Z  INFO staking-miner: solution score [1802293,311 DOT (18,022,933,116,011,499), 632594631,964 DOT (6,325,946,319,641,526,504), 13987813070104002697209896,400 DOT (139,878,130,701,040,026,972,098,964,000,908,608)] / deposit 40,924 DOT (409,242,847,432) / length 94647

trying 0xcb467ffca81175a254d2b489c7c174b0087831e2d17c623aa79f0e4d2f604be7
10 iterations
2022-02-26T20:43:29.104690Z  INFO staking-miner: solution score [1756389,705 DOT (17,563,897,055,194,964), 616032995,794 DOT (6,160,329,957,946,174,577), 13125213078725725077685778,287 DOT (131,252,130,787,257,250,776,857,782,877,090,011)] / deposit 40,946 DOT (409,469,116,384) / length 96964
none
2022-02-26T20:43:41.384131Z  INFO staking-miner: solution score [1754566,286 DOT (17,545,662,869,603,109), 616032995,794 DOT (6,160,329,957,946,174,577), 13291252492113613378734019,900 DOT (132,912,524,921,136,133,787,340,199,004,557,121)] / deposit 40,947 DOT (409,479,077,296) / length 97066

trying 0x5407116614762f989989b0492e6674fd68e37d11af9fd00a57076329f62d0489
10 iterations
2022-02-26T20:43:46.917181Z  INFO staking-miner: solution score [1774162,353 DOT (17,741,623,534,201,296), 615770938,661 DOT (6,157,709,386,614,513,387), 13103007061558991767777314,807 DOT (131,030,070,615,589,917,677,773,148,075,803,711)] / deposit 40,948 DOT (409,487,573,368) / length 97153
none
2022-02-26T20:43:59.410458Z  INFO staking-miner: solution score [1757118,740 DOT (17,571,187,402,363,348), 615770938,661 DOT (6,157,709,386,614,513,387), 13269734950246491775961698,574 DOT (132,697,349,502,464,917,759,616,985,744,921,765)] / deposit 40,947 DOT (409,474,585,120) / length 97020

trying 0x3e25f120b93cb42522bed6ec23d83bdd5b7ce637d17a092f5d7e73f83a831cb1
10 iterations
2022-02-26T20:44:05.502771Z  INFO staking-miner: solution score [1756339,579 DOT (17,563,395,790,676,563), 616230151,721 DOT (6,162,301,517,215,872,156), 13133461287947638895066669,025 DOT (131,334,612,879,476,388,950,666,690,250,660,312)] / deposit 40,949 DOT (409,494,213,976) / length 97221
none
2022-02-26T20:44:17.799465Z  INFO staking-miner: solution score [1754518,236 DOT (17,545,182,366,372,913), 616230151,721 DOT (6,162,301,517,215,872,156), 13304159295266630265951628,149 DOT (133,041,592,952,666,302,659,516,281,493,138,708)] / deposit 40,948 DOT (409,481,811,664) / length 97094

trying 0x39340a61fadc6ab878beb86987aaacdb6397b118720a5131e7642d85af21c86c
10 iterations
2022-02-26T20:44:23.386055Z  INFO staking-miner: solution score [1756339,579 DOT (17,563,395,790,676,563), 615666973,803 DOT (6,156,669,738,033,664,370), 13109817951659524919198039,051 DOT (131,098,179,516,595,249,191,980,390,514,929,102)] / deposit 40,948 DOT (409,485,034,312) / length 97127
none
2022-02-26T20:44:36.138488Z  INFO staking-miner: solution score [1752156,424 DOT (17,521,564,242,095,583), 615666973,803 DOT (6,156,669,738,033,664,370), 13280361743523132654919874,015 DOT (132,803,617,435,231,326,549,198,740,153,443,140)] / deposit 40,947 DOT (409,477,124,176) / length 97046
```

