### PR TITLE
dispute-distribution: downgrade a warn

### DIFF
--- a/node/network/dispute-distribution/src/receiver/error.rs
+++ b/node/network/dispute-distribution/src/receiver/error.rs
@@ -65,6 +65,14 @@ pub fn log_error(result: Result<()>) -> std::result::Result<(), FatalError> {
 			tracing::debug!(target: LOG_TARGET, error = ?error);
 			Ok(())
 		},
+		Err(JfyiError::NotAValidator(peer)) => {
+			tracing::debug!(
+				target: LOG_TARGET,
+				?peer,
+				"Dropping message from peer (unknown authority id)"
+			);
+			Ok(())
+		},
 		Err(error) => {
 			tracing::warn!(target: LOG_TARGET, error = ?error);
 			Ok(())

--- a/node/network/dispute-distribution/src/receiver/mod.rs
+++ b/node/network/dispute-distribution/src/receiver/mod.rs
@@ -206,12 +206,7 @@ where
 				})
 				.map_err(|_| JfyiError::SendResponse(peer))?;
 
-			tracing::debug!(
-				target: LOG_TARGET,
-				?peer,
-				"Dropping message from peer (unknown authority id)"
-			);
-			return Ok(())
+			return Err(JfyiError::NotAValidator(peer).into())
 		}
 
 		// Immediately drop requests from peers that already have requests in flight or have

--- a/node/network/dispute-distribution/src/receiver/mod.rs
+++ b/node/network/dispute-distribution/src/receiver/mod.rs
@@ -206,7 +206,12 @@ where
 				})
 				.map_err(|_| JfyiError::SendResponse(peer))?;
 
-			return Err(JfyiError::NotAValidator(peer).into())
+			tracing::debug!(
+				target: LOG_TARGET,
+				?peer,
+				"Dropping message from peer (unknown authority id)"
+			);
+			return Ok(())
 		}
 
 		// Immediately drop requests from peers that already have requests in flight or have


### PR DESCRIPTION
The warning is quite spammy if we our authority-discovery cache is not full and the unknown validators is constantly trying to resend.