### PR TITLE
Revert "req/resp: use IfDisconnected::ImmediateError (#4253)"

### DIFF
--- a/node/network/availability-distribution/src/pov_requester/mod.rs
+++ b/node/network/availability-distribution/src/pov_requester/mod.rs
@@ -66,7 +66,10 @@ where
 
 	ctx.send_message(NetworkBridgeMessage::SendRequests(
 		vec![full_req],
-		IfDisconnected::ImmediateError,
+		// We are supposed to be connected to validators of our group via `PeerSet`,
+		// but at session boundaries that is kind of racy, in case a connection takes
+		// longer to get established, so we try to connect in any case.
+		IfDisconnected::TryConnect,
 	))
 	.await;
 

--- a/node/network/availability-distribution/src/requester/fetch_task/mod.rs
+++ b/node/network/availability-distribution/src/requester/fetch_task/mod.rs
@@ -329,7 +329,7 @@ impl RunningTask {
 
 		self.sender
 			.send(FromFetchTask::Message(AllMessages::NetworkBridge(
-				NetworkBridgeMessage::SendRequests(vec![requests], IfDisconnected::ImmediateError),
+				NetworkBridgeMessage::SendRequests(vec![requests], IfDisconnected::TryConnect),
 			)))
 			.await
 			.map_err(|_| TaskError::ShuttingDown)?;

--- a/node/network/availability-distribution/src/requester/fetch_task/tests.rs
+++ b/node/network/availability-distribution/src/requester/fetch_task/tests.rs
@@ -230,7 +230,7 @@ impl TestRun {
 		match msg {
 			AllMessages::NetworkBridge(NetworkBridgeMessage::SendRequests(
 				reqs,
-				IfDisconnected::ImmediateError,
+				IfDisconnected::TryConnect,
 			)) => {
 				let mut valid_responses = 0;
 				for req in reqs {

--- a/node/network/availability-distribution/src/tests/state.rs
+++ b/node/network/availability-distribution/src/tests/state.rs
@@ -216,7 +216,7 @@ impl TestState {
 			match msg {
 				AllMessages::NetworkBridge(NetworkBridgeMessage::SendRequests(
 					reqs,
-					IfDisconnected::ImmediateError,
+					IfDisconnected::TryConnect,
 				)) => {
 					for req in reqs {
 						// Forward requests:

--- a/node/network/availability-recovery/src/lib.rs
+++ b/node/network/availability-recovery/src/lib.rs
@@ -206,7 +206,7 @@ impl RequestFromBackers {
 				.send_message(
 					NetworkBridgeMessage::SendRequests(
 						vec![Requests::AvailableDataFetching(req)],
-						IfDisconnected::ImmediateError,
+						IfDisconnected::TryConnect,
 					)
 					.into(),
 				)
@@ -350,7 +350,7 @@ impl RequestChunksFromValidators {
 
 		sender
 			.send_message(
-				NetworkBridgeMessage::SendRequests(requests, IfDisconnected::ImmediateError).into(),
+				NetworkBridgeMessage::SendRequests(requests, IfDisconnected::TryConnect).into(),
 			)
 			.await;
 	}

--- a/node/network/availability-recovery/src/tests.rs
+++ b/node/network/availability-recovery/src/tests.rs
@@ -285,7 +285,7 @@ impl TestState {
 				AllMessages::NetworkBridge(
 					NetworkBridgeMessage::SendRequests(
 						requests,
-						IfDisconnected::ImmediateError,
+						IfDisconnected::TryConnect,
 					)
 				) => {
 					for req in requests {
@@ -334,7 +334,7 @@ impl TestState {
 				AllMessages::NetworkBridge(
 					NetworkBridgeMessage::SendRequests(
 						mut requests,
-						IfDisconnected::ImmediateError,
+						IfDisconnected::TryConnect,
 					)
 				) => {
 					assert_eq!(requests.len(), 1);

--- a/node/network/dispute-distribution/src/sender/send_task.rs
+++ b/node/network/dispute-distribution/src/sender/send_task.rs
@@ -270,7 +270,11 @@ async fn send_requests<Context: SubsystemContext>(
 		statuses.insert(receiver, DeliveryStatus::Pending(remote_handle));
 	}
 
-	let msg = NetworkBridgeMessage::SendRequests(reqs, IfDisconnected::ImmediateError);
+	let msg = NetworkBridgeMessage::SendRequests(
+		reqs,
+		// We should be connected, but the hell - if not, try!
+		IfDisconnected::TryConnect,
+	);
 	ctx.send_message(AllMessages::NetworkBridge(msg)).await;
 	Ok(statuses)
 }

--- a/node/network/dispute-distribution/src/tests/mod.rs
+++ b/node/network/dispute-distribution/src/tests/mod.rs
@@ -664,7 +664,7 @@ async fn check_sent_requests(
 	assert_matches!(
 		handle.recv().await,
 		AllMessages::NetworkBridge(
-			NetworkBridgeMessage::SendRequests(reqs, IfDisconnected::ImmediateError)
+			NetworkBridgeMessage::SendRequests(reqs, IfDisconnected::TryConnect)
 		) => {
 			let reqs: Vec<_> = reqs.into_iter().map(|r|
 				assert_matches!(


### PR DESCRIPTION
This reverts commit c18d42d495d686979d96c1777628064ca074bc35.