### PR TITLE
Add UmpSink Config

### DIFF
--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -1210,7 +1210,8 @@ parameter_types! {
 
 impl parachains_ump::Config for Runtime {
 	type Event = Event;
-	type UmpSink = ();
+	type UmpSink =
+		crate::parachains_ump::XcmSink<xcm_executor::XcmExecutor<xcm_config::XcmConfig>, Runtime>;
 	type FirstMessageFactorPercent = FirstMessageFactorPercent;
 	type ExecuteOverweightOrigin = EnsureRoot<AccountId>;
 }


### PR DESCRIPTION
I took what was in Kusama, but not sure if Polkadot would need a change.

Addition to https://github.com/paritytech/polkadot/pull/4809 to allow paras to return teleports and reserve backed transfers.