### PR TITLE
[ci] fix test-node-metrics dependency

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -349,7 +349,7 @@ test-node-metrics:
       artifacts:                   false
   <<:                              *docker-env
   <<:                              *compiler-info
-  <<:                              *common-refs
+  <<:                              *test-refs
   variables:
     RUST_TOOLCHAIN: stable
     # Enable debug assertions since we are running optimized builds for testing


### PR DESCRIPTION
Currently, ci pipeline on tag fails because of recent changes: `test-node-metrics` depends on `check-runtime` job. But the problem is that `check-runtime` job doesn't run on tag. I removed `test-node-metrics` from running on tag. It'll only run on PRs and master branch.