### PR TITLE
chore: make debug log less noisy

### DIFF
--- a/node/core/bitfield-signing/src/lib.rs
+++ b/node/core/bitfield-signing/src/lib.rs
@@ -171,15 +171,16 @@ async fn construct_availability_bitfield(
 	)
 	.await?;
 
+	let core_bits = FromIterator::from_iter(results.into_iter());
 	tracing::debug!(
 		target: LOG_TARGET,
 		?relay_parent,
-		"Signing Bitfield for {} cores: {:?}",
-		availability_cores.len(),
-		results,
+		"Signing Bitfield for {core_count} cores: {core_bits}",
+		core_count = availability_cores.len(),
+		core_bits = core_bits,
 	);
 
-	Ok(AvailabilityBitfield(FromIterator::from_iter(results)))
+	Ok(AvailabilityBitfield(core_bits))
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
Converts the display of `[false, true, false, true, true]` to `[0, 1, 0, 1, 1]` which improves readability in grafana/loki.

![image](https://user-images.githubusercontent.com/667047/157426335-7b8b98f8-e6e2-48ad-b4b8-5cd36f04f3db.png)
