### PR TITLE
update mick jaeger and add some sanity unit tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7025,27 +7025,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "polkadot-node-tracing-gum"
-version = "0.9.17"
-dependencies = [
- "polkadot-node-jaeger",
- "polkadot-node-tracing-gum-proc-macro",
- "tracing",
-]
-
-[[package]]
-name = "polkadot-node-tracing-gum-proc-macro"
-version = "0.9.17"
-dependencies = [
- "assert_matches",
- "expander 0.0.5",
- "proc-macro-crate 1.1.3",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "polkadot-overseer"
 version = "0.9.17"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4456,9 +4456,9 @@ dependencies = [
 
 [[package]]
 name = "mick-jaeger"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd2c2cc134e57461f0898b0e921f0a7819b5e3f3a4335b9aa390ce81a5f36fb9"
+checksum = "69672161530e8aeca1d1400fbf3f1a1747ff60ea604265a4e906c2442df20532"
 dependencies = [
  "futures 0.3.21",
  "rand 0.8.5",
@@ -7022,6 +7022,27 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tracing",
+]
+
+[[package]]
+name = "polkadot-node-tracing-gum"
+version = "0.9.17"
+dependencies = [
+ "polkadot-node-jaeger",
+ "polkadot-node-tracing-gum-proc-macro",
+ "tracing",
+]
+
+[[package]]
+name = "polkadot-node-tracing-gum-proc-macro"
+version = "0.9.17"
+dependencies = [
+ "assert_matches",
+ "expander 0.0.5",
+ "proc-macro-crate 1.1.3",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/node/jaeger/Cargo.toml
+++ b/node/jaeger/Cargo.toml
@@ -7,7 +7,7 @@ description = "Polkadot Jaeger primitives"
 
 [dependencies]
 async-std = "1.8.0"
-mick-jaeger = "0.1.7"
+mick-jaeger = "0.1.8"
 lazy_static = "1.4"
 parking_lot = "0.12.0"
 polkadot-primitives = { path = "../../primitives" }

--- a/node/jaeger/src/lib.rs
+++ b/node/jaeger/src/lib.rs
@@ -148,6 +148,10 @@ impl Jaeger {
 		Ok(())
 	}
 
+	/// Create a span, but defer the evaluation/transformation into a `TraceIdentifier`.
+	///
+	/// The deferal allows to avoid the additional CPU runtime cost in case of
+	/// items that are not a pre-computed hash by themselves.
 	pub(crate) fn span<F>(&self, lazy_hash: F, span_name: &'static str) -> Option<mick_jaeger::Span>
 	where
 		F: Fn() -> TraceIdentifier,

--- a/node/jaeger/src/lib.rs
+++ b/node/jaeger/src/lib.rs
@@ -92,6 +92,21 @@ impl Jaeger {
 		Ok(())
 	}
 
+	/// Provide a no-thrills test setup helper.
+	#[cfg(test)]
+	pub fn test_setup() {
+		let mut instance = INSTANCE.write();
+		match *instance {
+			Self::Launched { .. } => {},
+			_ => {
+				let (traces_in, _traces_out) = mick_jaeger::init(mick_jaeger::Config {
+					service_name: "polkadot-jaeger-test".to_owned(),
+				});
+				*instance = Self::Launched { traces_in };
+			},
+		}
+	}
+
 	/// Spawn the background task in order to send the tracing information out via UDP
 	#[cfg(not(target_os = "unknown"))]
 	pub fn launch<S: SpawnNamed>(self, spawner: S) -> result::Result<(), JaegerError> {

--- a/node/jaeger/src/lib.rs
+++ b/node/jaeger/src/lib.rs
@@ -150,7 +150,7 @@ impl Jaeger {
 
 	/// Create a span, but defer the evaluation/transformation into a `TraceIdentifier`.
 	///
-	/// The deferal allows to avoid the additional CPU runtime cost in case of
+	/// The deferral allows to avoid the additional CPU runtime cost in case of
 	/// items that are not a pre-computed hash by themselves.
 	pub(crate) fn span<F>(&self, lazy_hash: F, span_name: &'static str) -> Option<mick_jaeger::Span>
 	where

--- a/node/jaeger/src/spans.rs
+++ b/node/jaeger/src/spans.rs
@@ -480,7 +480,7 @@ mod tests {
 			.zip(trace_id.to_be_bytes().iter())
 			.enumerate()
 		{
-			assert_eq!(*a, *b, "Index [{idx}] does not match: {a} != {b}", idx, a, b);
+			assert_eq!(*a, *b, "Index [{}] does not match: {} != {}", idx, a, b);
 		}
 	}
 


### PR DESCRIPTION
Part of the investigation related to https://github.com/paritytech/polkadot/issues/5045

Verifies the correctness of the `TraceID` generation.

CC @lazam once this is merged, we should be good to check if the identifiers are now _truely_ working.