### PR TITLE
MultiAssets can be indexed and constructed with capacity

### DIFF
--- a/xcm/src/v1/multiasset.rs
+++ b/xcm/src/v1/multiasset.rs
@@ -644,5 +644,14 @@ mod tests {
 			Fungibility::Fungible(index_10 as u128),
 		));
 		assert_eq!(multi_assets[index_10], asset_10);
+
+		// index mutation
+		let index_6 = 6usize;
+		let asset_x = MultiAsset::from((
+			AssetId::Abstract(alloc::format!("{}", 20).as_bytes().to_vec()),
+			Fungibility::Fungible(20u128),
+		));
+		multi_assets[index_6] = asset_x.clone();
+		assert_eq!(multi_assets[index_6], asset_x);
 	}
 }


### PR DESCRIPTION
1. Allow to construct `MultiAssets` with capacity.
2. `MultiAssets` can be indexed.