### PR TITLE
ci: use production profile for all benchmarks (follow-up for #5100)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -529,11 +529,13 @@ update_polkadot_weights:           &update-weights
 update_kusama_weights:
   <<:                              *update-weights
   variables:
+    PROFILE:                       production
     RUNTIME:                       kusama
 
 update_westend_weights:
   <<:                              *update-weights
   variables:
+    PROFILE:                       production
     RUNTIME:                       westend
 
 #### stage:                        stage3


### PR DESCRIPTION
turns out kusama & westend didn't inherit it from update-weights