### PR TITLE
Weights corrected for `ump`

### DIFF
--- a/runtime/kusama/src/weights/runtime_parachains_ump.rs
+++ b/runtime/kusama/src/weights/runtime_parachains_ump.rs
@@ -43,7 +43,7 @@ use sp_std::marker::PhantomData;
 /// Weight functions for `runtime_parachains::ump`.
 pub struct WeightInfo<T>(PhantomData<T>);
 impl<T: frame_system::Config> runtime_parachains::ump::WeightInfo for WeightInfo<T> {
-	fn sink_process_upward_message(s: u32, ) -> Weight {
+	fn process_upward_message(s: u32, ) -> Weight {
 		(3_715_000 as Weight)
 			// Standard Error: 0
 			.saturating_add((2_000 as Weight).saturating_mul(s as Weight))

--- a/runtime/parachains/src/ump.rs
+++ b/runtime/parachains/src/ump.rs
@@ -119,7 +119,7 @@ impl<XcmExecutor: xcm::latest::ExecuteXcm<C::Call>, C: Config> UmpSink for XcmSi
 				// The benchmark is timing this whole function with different message sizes and a NOOP extrinsic to
 				// measure the size-dependent weight. But as we use the weight funtion **in** the benchmarked funtion we
 				// are taking call and control-flow overhead into account twice.
-				<C as Config>::WeightInfo::sink_process_upward_message(data.len() as u32),
+				<C as Config>::WeightInfo::process_upward_message(data.len() as u32),
 			)
 		});
 		match maybe_msg_and_weight {
@@ -186,7 +186,7 @@ impl fmt::Debug for AcceptanceCheckErr {
 /// Weight information of this pallet.
 pub trait WeightInfo {
 	fn service_overweight() -> Weight;
-	fn sink_process_upward_message(s: u32) -> Weight;
+	fn process_upward_message(s: u32) -> Weight;
 	fn clean_ump_after_outgoing() -> Weight;
 }
 
@@ -197,7 +197,7 @@ impl WeightInfo for TestWeightInfo {
 		Weight::MAX
 	}
 
-	fn sink_process_upward_message(_msg_size: u32) -> Weight {
+	fn process_upward_message(_msg_size: u32) -> Weight {
 		Weight::MAX
 	}
 

--- a/runtime/rococo/src/weights/runtime_parachains_ump.rs
+++ b/runtime/rococo/src/weights/runtime_parachains_ump.rs
@@ -43,7 +43,7 @@ use sp_std::marker::PhantomData;
 /// Weight functions for `runtime_parachains::ump`.
 pub struct WeightInfo<T>(PhantomData<T>);
 impl<T: frame_system::Config> runtime_parachains::ump::WeightInfo for WeightInfo<T> {
-	fn sink_process_upward_message(s: u32, ) -> Weight {
+	fn process_upward_message(s: u32, ) -> Weight {
 		(3_539_000 as Weight)
 			// Standard Error: 0
 			.saturating_add((2_000 as Weight).saturating_mul(s as Weight))

--- a/runtime/westend/src/weights/runtime_parachains_ump.rs
+++ b/runtime/westend/src/weights/runtime_parachains_ump.rs
@@ -43,7 +43,7 @@ use sp_std::marker::PhantomData;
 /// Weight functions for `runtime_parachains::ump`.
 pub struct WeightInfo<T>(PhantomData<T>);
 impl<T: frame_system::Config> runtime_parachains::ump::WeightInfo for WeightInfo<T> {
-	fn sink_process_upward_message(s: u32, ) -> Weight {
+	fn process_upward_message(s: u32, ) -> Weight {
 		(3_455_000 as Weight)
 			// Standard Error: 0
 			.saturating_add((2_000 as Weight).saturating_mul(s as Weight))


### PR DESCRIPTION
Noticed [in #5052](https://github.com/paritytech/polkadot/pull/5052#issuecomment-1066907001), https://github.com/paritytech/polkadot/pull/5103/ incorporated and works. 

`sink_process_upward_message` -> `process_upward_message` throughout to build and run benchmarks correctly. This IIUC should not require any re-runs of Kusama and Westend benchmarks. 


