### PR TITLE
Additional tracing in provisioner

### DIFF
--- a/node/core/provisioner/src/lib.rs
+++ b/node/core/provisioner/src/lib.rs
@@ -269,6 +269,15 @@ impl ProvisionerJob {
 			self.metrics.on_inherent_data_request(Err(()));
 		} else {
 			self.metrics.on_inherent_data_request(Ok(()));
+			gum::debug!(
+				target: LOG_TARGET,
+				signed_bitfield_count = self.signed_bitfields.len(),
+				signed_bitfields = ?self.signed_bitfields,
+				backed_candidates_count = self.backed_candidates.len(),
+				backed_candidates = ?self.backed_candidates,
+				disputes_enabled,
+				"inherent data sent successfully"
+			);
 		}
 	}
 
@@ -335,6 +344,18 @@ async fn send_inherent_data(
 	};
 	let candidates =
 		select_candidates(&availability_cores, &bitfields, candidates, leaf.hash, from_job).await?;
+
+	gum::debug!(
+		target: LOG_TARGET,
+		disputes_enabled = disputes_enabled,
+		candidates = ?candidates,
+		availability_cores = ?availability_cores,
+		disputes_count = disputes.len(),
+		bitfields = ?bitfields,
+		bitfields_count = bitfields.len(),
+		candidates_count = candidates.len(),
+		"inherent data prepared",
+	);
 
 	let inherent_data =
 		ProvisionerInherentData { bitfields, backed_candidates: candidates, disputes };

--- a/node/core/provisioner/src/lib.rs
+++ b/node/core/provisioner/src/lib.rs
@@ -388,6 +388,7 @@ fn select_availability_bitfields(
 	gum::debug!(
 		target: LOG_TARGET,
 		bitfields_count = bitfields.len(),
+		?leaf_hash,
 		"bitfields count before selection"
 	);
 
@@ -451,7 +452,7 @@ async fn select_candidates(
 	let mut selected_candidates =
 		Vec::with_capacity(candidates.len().min(availability_cores.len()));
 
-	gum::debug!(target: LOG_TARGET, "{} candidates before selection", candidates.len());
+	gum::debug!(target: LOG_TARGET, leaf_hash=?relay_parent, "{} candidates before selection", candidates.len());
 
 	for (core_idx, core) in availability_cores.iter().enumerate() {
 		let (scheduled_core, assumption) = match core {
@@ -503,6 +504,7 @@ async fn select_candidates(
 			let candidate_hash = candidate.hash();
 			gum::trace!(
 				target: LOG_TARGET,
+				leaf_hash=?relay_parent,
 				"Selecting candidate {}. para_id={} core={}",
 				candidate_hash,
 				candidate.descriptor.para_id,

--- a/node/core/provisioner/src/tests.rs
+++ b/node/core/provisioner/src/tests.rs
@@ -84,7 +84,8 @@ mod select_availability_bitfields {
 			block_on(signed_bitfield(&keystore, bitvec, ValidatorIndex(1))),
 		];
 
-		let mut selected_bitfields = select_availability_bitfields(&cores, &bitfields);
+		let mut selected_bitfields =
+			select_availability_bitfields(&cores, &bitfields, &Hash::repeat_byte(0));
 		selected_bitfields.sort_by_key(|bitfield| bitfield.validator_index());
 
 		assert_eq!(selected_bitfields.len(), 2);
@@ -122,7 +123,8 @@ mod select_availability_bitfields {
 			block_on(signed_bitfield(&keystore, bitvec2.clone(), ValidatorIndex(2))),
 		];
 
-		let selected_bitfields = select_availability_bitfields(&cores, &bitfields);
+		let selected_bitfields =
+			select_availability_bitfields(&cores, &bitfields, &Hash::repeat_byte(0));
 
 		// selects only the valid bitfield
 		assert_eq!(selected_bitfields.len(), 1);
@@ -145,7 +147,8 @@ mod select_availability_bitfields {
 			block_on(signed_bitfield(&keystore, bitvec1.clone(), ValidatorIndex(1))),
 		];
 
-		let selected_bitfields = select_availability_bitfields(&cores, &bitfields);
+		let selected_bitfields =
+			select_availability_bitfields(&cores, &bitfields, &Hash::repeat_byte(0));
 		assert_eq!(selected_bitfields.len(), 1);
 		assert_eq!(selected_bitfields[0].payload().0, bitvec1.clone());
 	}
@@ -182,7 +185,8 @@ mod select_availability_bitfields {
 			block_on(signed_bitfield(&keystore, bitvec1.clone(), ValidatorIndex(1))),
 		];
 
-		let selected_bitfields = select_availability_bitfields(&cores, &bitfields);
+		let selected_bitfields =
+			select_availability_bitfields(&cores, &bitfields, &Hash::repeat_byte(0));
 		assert_eq!(selected_bitfields.len(), 4);
 		assert_eq!(selected_bitfields[0].payload().0, bitvec0);
 		assert_eq!(selected_bitfields[1].payload().0, bitvec1);


### PR DESCRIPTION
Add debug logs for `fn send_inherent_data`.