### PR TITLE
[ci] scripts: don't rebuild for every pallet benchmark

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -514,7 +514,6 @@ update_polkadot_weights:           &update-weights
   stage:                           stage2
   when:                            manual
   variables:
-    PROFILE:                       production
     RUNTIME:                       polkadot
   artifacts:
     paths:
@@ -529,13 +528,11 @@ update_polkadot_weights:           &update-weights
 update_kusama_weights:
   <<:                              *update-weights
   variables:
-    PROFILE:                       production
     RUNTIME:                       kusama
 
 update_westend_weights:
   <<:                              *update-weights
   variables:
-    PROFILE:                       production
     RUNTIME:                       westend
 
 #### stage:                        stage3

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -519,7 +519,7 @@ update_polkadot_weights:           &update-weights
     paths:
       - ${RUNTIME}_weights_${CI_COMMIT_SHORT_SHA}.patch
   script:
-    - ./scripts/run_benches_for_runtime.sh $RUNTIME $PROFILE
+    - ./scripts/run_benches_for_runtime.sh $RUNTIME
     - git diff -P > ${RUNTIME}_weights_${CI_COMMIT_SHORT_SHA}.patch
   # uses the "shell" executors
   tags:

--- a/scripts/run_benches_for_runtime.sh
+++ b/scripts/run_benches_for_runtime.sh
@@ -1,17 +1,18 @@
 #!/bin/bash
 
+set -e
+
 # Runs all benchmarks for all pallets, for a given runtime, provided by $1
 # Should be run on a reference machine to gain accurate benchmarks
 # current reference machine: https://github.com/paritytech/substrate/pull/5848
 
 runtime="$1"
-profile="$2"
-standard_args="--profile $profile --locked --features=runtime-benchmarks"
 
 echo "[+] Running all benchmarks for $runtime"
 
-# shellcheck disable=SC2086
-cargo +nightly run $standard_args benchmark \
+cargo +nightly build --profile production --locked --features=runtime-benchmarks
+
+target/production/polkadot benchmark \
     --chain "${runtime}-dev" \
     --list |\
   tail -n+2 |\
@@ -23,17 +24,16 @@ cargo +nightly run $standard_args benchmark \
 while read -r line; do
   pallet="$(echo "$line" | cut -d' ' -f1)";
   echo "Runtime: $runtime. Pallet: $pallet";
-# shellcheck disable=SC2086
-cargo +nightly run $standard_args -- benchmark \
-  --chain="${runtime}-dev" \
-  --steps=50 \
-  --repeat=20 \
-  --pallet="$pallet" \
-  --extrinsic="*" \
-  --execution=wasm \
-  --wasm-execution=compiled \
-  --heap-pages=4096 \
-  --header=./file_header.txt \
-  --output="./runtime/${runtime}/src/weights/${pallet/::/_}.rs"
+  target/production/polkadot benchmark \
+    --chain="${runtime}-dev" \
+    --steps=50 \
+    --repeat=20 \
+    --pallet="$pallet" \
+    --extrinsic="*" \
+    --execution=wasm \
+    --wasm-execution=compiled \
+    --heap-pages=4096 \
+    --header=./file_header.txt \
+    --output="./runtime/${runtime}/src/weights/${pallet/::/_}.rs"
 done < "${runtime}_pallets"
 rm "${runtime}_pallets"

--- a/scripts/run_benches_for_runtime.sh
+++ b/scripts/run_benches_for_runtime.sh
@@ -24,7 +24,8 @@ cargo +nightly build --profile production --locked --features=runtime-benchmarks
 while read -r line; do
   pallet="$(echo "$line" | cut -d' ' -f1)";
   echo "Runtime: $runtime. Pallet: $pallet";
-  ./target/production/polkadot benchmark \
+  # '!' has the side effect of bypassing errexit / set -e
+  ! ./target/production/polkadot benchmark \
     --chain="${runtime}-dev" \
     --steps=50 \
     --repeat=20 \

--- a/scripts/run_benches_for_runtime.sh
+++ b/scripts/run_benches_for_runtime.sh
@@ -12,7 +12,7 @@ echo "[+] Running all benchmarks for $runtime"
 
 cargo +nightly build --profile production --locked --features=runtime-benchmarks
 
-target/production/polkadot benchmark \
+./target/production/polkadot benchmark \
     --chain "${runtime}-dev" \
     --list |\
   tail -n+2 |\
@@ -24,7 +24,7 @@ target/production/polkadot benchmark \
 while read -r line; do
   pallet="$(echo "$line" | cut -d' ' -f1)";
   echo "Runtime: $runtime. Pallet: $pallet";
-  target/production/polkadot benchmark \
+  ./target/production/polkadot benchmark \
     --chain="${runtime}-dev" \
     --steps=50 \
     --repeat=20 \


### PR DESCRIPTION
the `cargo run` in the benchmark loop was rebuilding polkadot for every pallet benchmark, which in our tests took approximately 1 hour per pallet with the production profile enabled

instead, build once and re-use the binary