### PR TITLE
strengthen signals-received atomics

### DIFF
--- a/node/overseer/overseer-gen/src/lib.rs
+++ b/node/overseer/overseer-gen/src/lib.rs
@@ -196,8 +196,9 @@ pub struct SignalsReceived(Arc<AtomicUsize>);
 impl SignalsReceived {
 	/// Load the current value of received signals.
 	pub fn load(&self) -> usize {
-		// It's imperative that we don't underestimate the amount
-		// of signals received.
+		// It's imperative that we prevent reading a stale value from memory because of reordering. 
+		// Memory barrier to ensure that no reads or writes in the current thread before this load are reordered.
+		// All writes in other threads using release semantics become visible to the current thread.
 		self.0.load(atomic::Ordering::Acquire)
 	}
 

--- a/node/overseer/overseer-gen/src/lib.rs
+++ b/node/overseer/overseer-gen/src/lib.rs
@@ -196,13 +196,14 @@ pub struct SignalsReceived(Arc<AtomicUsize>);
 impl SignalsReceived {
 	/// Load the current value of received signals.
 	pub fn load(&self) -> usize {
-		// off by a few is ok
-		self.0.load(atomic::Ordering::Relaxed)
+		// It's imperative that we don't underestimate the amount
+		// of signals received.
+		self.0.load(atomic::Ordering::Acquire)
 	}
 
 	/// Increase the number of signals by one.
 	pub fn inc(&self) {
-		self.0.fetch_add(1, atomic::Ordering::Acquire);
+		self.0.fetch_add(1, atomic::Ordering::AcqRel);
 	}
 }
 

--- a/node/overseer/overseer-gen/src/lib.rs
+++ b/node/overseer/overseer-gen/src/lib.rs
@@ -196,7 +196,7 @@ pub struct SignalsReceived(Arc<AtomicUsize>);
 impl SignalsReceived {
 	/// Load the current value of received signals.
 	pub fn load(&self) -> usize {
-		// It's imperative that we prevent reading a stale value from memory because of reordering. 
+		// It's imperative that we prevent reading a stale value from memory because of reordering.
 		// Memory barrier to ensure that no reads or writes in the current thread before this load are reordered.
 		// All writes in other threads using release semantics become visible to the current thread.
 		self.0.load(atomic::Ordering::Acquire)


### PR DESCRIPTION
I think atomic races here could lead to a bug where messages could get stuck unprocessed for a few seconds. Or to bugs where messages are processed before they should be (although this is less likely, still very possible). The current implementation of `load` using `Relaxed` means that it's not guaranteed to read the same value as `inc` calls issued on other threads. i.e. it claims it's acceptable for a subsystem to underestimate the number of signals received.

Every message between subsystems is tagged with a `n_signals_received` and the receiving `SubsystemContext` doesn't yield the message to the outer subsystem until the number of signals received locally is >= `n_signals_received`.
https://github.com/paritytech/polkadot/blob/f4b4f531d036205dfcda3761ffbc54bd57050886/node/overseer/overseer-gen/proc-macro/src/impl_misc.rs#L166-L186

We can get Type I and Type II errors.

Type I: The sending subsystem under-estimates the number of signals it has received. This causes the receiving subsystem to process the message too early, violating the guarantees of the overseer.
Type II: The receiving subsystem under-estimates the number of signals it has received. This causes the subsystem to wrongly `.await` on the next signal (L177 linked above), which may not come for 6 or more seconds, delaying all messages from being processed.

Type II errors only happen when the task is moved across threads between calls to `poll` and immediately `poll`ed again.

I'm a little rusty on atomics, so I don't know what effects doing more `Acquire` operations might have on performance. I expect something like CPU cache wipes? Curious to know more.