### PR TITLE
Fix Benchmark Regressions in Polkadot Parachain Auction System

### DIFF
--- a/runtime/common/src/auctions.rs
+++ b/runtime/common/src/auctions.rs
@@ -1772,6 +1772,10 @@ mod benchmarking {
 
 		// Worst case scenario a new bid comes in which kicks out an existing bid for the same slot.
 		bid {
+			// If there is an offset, we need to be on that block to be able to do lease things.
+			let (_, offset) = T::Leaser::lease_period_length();
+			frame_system::Pallet::<T>::set_block_number(offset + One::one());
+
 			// Create a new auction
 			let duration = T::BlockNumber::max_value();
 			let lease_period_index = LeasePeriodOf::<T>::zero();
@@ -1818,8 +1822,12 @@ mod benchmarking {
 		// Worst case: 10 bidders taking all wining spots, and we need to calculate the winner for auction end.
 		// Entire winner map should be full and removed at the end of the benchmark.
 		on_initialize {
+			// If there is an offset, we need to be on that block to be able to do lease things.
+			let (lease_length, offset) = T::Leaser::lease_period_length();
+			frame_system::Pallet::<T>::set_block_number(offset + One::one());
+
 			// Create a new auction
-			let duration: T::BlockNumber = 99u32.into();
+			let duration: T::BlockNumber = lease_length / 2u32.into();
 			let lease_period_index = LeasePeriodOf::<T>::zero();
 			let now = frame_system::Pallet::<T>::block_number();
 			Auctions::<T>::new_auction(RawOrigin::Root.into(), duration, lease_period_index)?;
@@ -1857,8 +1865,12 @@ mod benchmarking {
 
 		// Worst case: 10 bidders taking all wining spots, and winning data is full.
 		cancel_auction {
+			// If there is an offset, we need to be on that block to be able to do lease things.
+			let (lease_length, offset) = T::Leaser::lease_period_length();
+			frame_system::Pallet::<T>::set_block_number(offset + One::one());
+
 			// Create a new auction
-			let duration: T::BlockNumber = 99u32.into();
+			let duration: T::BlockNumber = lease_length / 2u32.into();
 			let lease_period_index = LeasePeriodOf::<T>::zero();
 			let now = frame_system::Pallet::<T>::block_number();
 			Auctions::<T>::new_auction(RawOrigin::Root.into(), duration, lease_period_index)?;

--- a/runtime/common/src/crowdloan/mod.rs
+++ b/runtime/common/src/crowdloan/mod.rs
@@ -2014,7 +2014,7 @@ mod benchmarking {
 			let caller: T::AccountId = whitelisted_caller();
 			let contributor = account("contributor", 0, 0);
 			contribute_fund::<T>(&contributor, fund_index);
-			frame_system::Pallet::<T>::set_block_number(200u32.into());
+			frame_system::Pallet::<T>::set_block_number(T::BlockNumber::max_value());
 		}: _(RawOrigin::Signed(caller), contributor.clone(), fund_index)
 		verify {
 			assert_last_event::<T>(Event::<T>::Withdrew(contributor, fund_index, T::MinContribution::get()).into());
@@ -2034,7 +2034,7 @@ mod benchmarking {
 			}
 
 			let caller: T::AccountId = whitelisted_caller();
-			frame_system::Pallet::<T>::set_block_number(200u32.into());
+			frame_system::Pallet::<T>::set_block_number(T::BlockNumber::max_value());
 		}: _(RawOrigin::Signed(caller), fund_index)
 		verify {
 			assert_last_event::<T>(Event::<T>::AllRefunded(fund_index).into());

--- a/runtime/common/src/slots.rs
+++ b/runtime/common/src/slots.rs
@@ -981,7 +981,7 @@ mod benchmarking {
 	use super::*;
 	use frame_support::assert_ok;
 	use frame_system::RawOrigin;
-	use sp_runtime::traits::Bounded;
+	use sp_runtime::traits::{Bounded, One};
 
 	use frame_benchmarking::{account, benchmarks, whitelisted_caller};
 
@@ -1015,6 +1015,8 @@ mod benchmarking {
 
 	benchmarks! {
 		force_lease {
+			// If there is an offset, we need to be on that block to be able to do lease things.
+			frame_system::Pallet::<T>::set_block_number(T::LeaseOffset::get() + One::one());
 			let para = ParaId::from(1337);
 			let leaser: T::AccountId = account("leaser", 0, 0);
 			T::Currency::make_free_balance_be(&leaser, BalanceOf::<T>::max_value());
@@ -1034,6 +1036,9 @@ mod benchmarking {
 
 			let period_begin = 1u32.into();
 			let period_count = 4u32.into();
+
+			// If there is an offset, we need to be on that block to be able to do lease things.
+			frame_system::Pallet::<T>::set_block_number(T::LeaseOffset::get() + One::one());
 
 			// Make T parathreads
 			let paras_info = (0..t).map(|i| {
@@ -1084,6 +1089,9 @@ mod benchmarking {
 		clear_all_leases {
 			let max_people = 8;
 			let (para, _) = register_a_parathread::<T>(1);
+
+			// If there is an offset, we need to be on that block to be able to do lease things.
+			frame_system::Pallet::<T>::set_block_number(T::LeaseOffset::get() + One::one());
 
 			for i in 0 .. max_people {
 				let leaser = account("lease_deposit", i, 0);

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -1696,6 +1696,7 @@ mod benches {
 		// Polkadot
 		// NOTE: Make sure to prefix these with `runtime_common::` so
 		// the that path resolves correctly in the generated file.
+		[runtime_common::auctions, Auctions]
 		[runtime_common::claims, Claims]
 		[runtime_common::crowdloan, Crowdloan]
 		[runtime_common::slots, Slots]


### PR DESCRIPTION
https://github.com/paritytech/polkadot/issues/5138

Most of these breaks were introduced with the Lease Period Offset, and just needed to adjust the block number that events happen on.