### PR TITLE
Sligth improvements to the collator side metrics and logs

### DIFF
--- a/node/network/collator-protocol/src/collator_side/mod.rs
+++ b/node/network/collator-protocol/src/collator_side/mod.rs
@@ -136,7 +136,7 @@ impl metrics::Metrics for Metrics {
 				prometheus::Histogram::with_opts(prometheus::HistogramOpts::new(
 					"polkadot_parachain_collator_protocol_collator_process_msg",
 					"Time spent within `collator_protocol_collator::process_msg`",
-				).buckets(vec![0.005, 0.01, 0.05, 0.1, 0.25, 0.5, 0.75, 1.0, 1.5]))?,
+				).buckets(vec![0.001, 0.002, 0.005, 0.01, 0.025, 0.05, 0.1, 0.15, 0.25, 0.35, 0.5, 0.75, 1.0]))?,
 				registry,
 			)?,
 		};

--- a/node/network/collator-protocol/src/collator_side/mod.rs
+++ b/node/network/collator-protocol/src/collator_side/mod.rs
@@ -98,8 +98,13 @@ impl Metrics {
 	}
 
 	/// Provide a timer for `distribute_collation` which observes on drop.
-	fn time_collation_distribution(&self, label: &'static str) -> Option<prometheus::prometheus::HistogramTimer> {
-		self.0.as_ref().map(|metrics| metrics.collation_distribution_time.with_label_values(&[label]).start_timer())
+	fn time_collation_distribution(
+		&self,
+		label: &'static str,
+	) -> Option<prometheus::prometheus::HistogramTimer> {
+		self.0.as_ref().map(|metrics| {
+			metrics.collation_distribution_time.with_label_values(&[label]).start_timer()
+		})
 	}
 }
 
@@ -139,18 +144,30 @@ impl metrics::Metrics for Metrics {
 				registry,
 			)?,
 			process_msg: prometheus::register(
-				prometheus::Histogram::with_opts(prometheus::HistogramOpts::new(
-					"polkadot_parachain_collator_protocol_collator_process_msg",
-					"Time spent within `collator_protocol_collator::process_msg`",
-				).buckets(vec![0.001, 0.002, 0.005, 0.01, 0.025, 0.05, 0.1, 0.15, 0.25, 0.35, 0.5, 0.75, 1.0]))?,
+				prometheus::Histogram::with_opts(
+					prometheus::HistogramOpts::new(
+						"polkadot_parachain_collator_protocol_collator_process_msg",
+						"Time spent within `collator_protocol_collator::process_msg`",
+					)
+					.buckets(vec![
+						0.001, 0.002, 0.005, 0.01, 0.025, 0.05, 0.1, 0.15, 0.25, 0.35, 0.5, 0.75,
+						1.0,
+					]),
+				)?,
 				registry,
 			)?,
 			collation_distribution_time: prometheus::register(
-				prometheus::HistogramVec::new(prometheus::HistogramOpts::new(
-					"polkadot_parachain_collator_protocol_collator_distribution_time",
-					"Time spent within `collator_protocol_collator::distribute_collation`",
-				).buckets(vec![0.001, 0.002, 0.005, 0.01, 0.025, 0.05, 0.1, 0.15, 0.25, 0.35, 0.5, 0.75, 1.0]),
-				&["state"])?,
+				prometheus::HistogramVec::new(
+					prometheus::HistogramOpts::new(
+						"polkadot_parachain_collator_protocol_collator_distribution_time",
+						"Time spent within `collator_protocol_collator::distribute_collation`",
+					)
+					.buckets(vec![
+						0.001, 0.002, 0.005, 0.01, 0.025, 0.05, 0.1, 0.15, 0.25, 0.35, 0.5, 0.75,
+						1.0,
+					]),
+					&["state"],
+				)?,
 				registry,
 			)?,
 		};
@@ -796,8 +813,7 @@ where
 						"received a valid `CollationSeconded`",
 					);
 					let _ = sender.send(CollationSecondedSignal { statement, relay_parent });
-				}
-				else {
+				} else {
 					gum::warn!(
 						target: LOG_TARGET,
 						?statement,

--- a/node/network/collator-protocol/src/collator_side/mod.rs
+++ b/node/network/collator-protocol/src/collator_side/mod.rs
@@ -610,13 +610,13 @@ where
 {
 	use CollatorProtocolMessage::*;
 
-	let _timer = state.metrics.time_process_msg();
-
 	match msg {
 		CollateOn(id) => {
 			state.collating_on = Some(id);
 		},
 		DistributeCollation(receipt, pov, result_sender) => {
+			// We should count only this shoulder in the histogram, as other shoulders are just rubbish
+			let _timer = state.metrics.time_process_msg();
 			let _span1 = state
 				.span_per_relay_parent
 				.get(&receipt.descriptor.relay_parent)

--- a/node/network/collator-protocol/src/collator_side/mod.rs
+++ b/node/network/collator-protocol/src/collator_side/mod.rs
@@ -136,7 +136,7 @@ impl metrics::Metrics for Metrics {
 				prometheus::Histogram::with_opts(prometheus::HistogramOpts::new(
 					"polkadot_parachain_collator_protocol_collator_process_msg",
 					"Time spent within `collator_protocol_collator::process_msg`",
-				))?,
+				).buckets(vec![0.005, 0.01, 0.05, 0.1, 0.25, 0.5, 0.75, 1.0, 1.5]))?,
 				registry,
 			)?,
 		};


### PR DESCRIPTION
This PR tries to address the following issues:

* Better buckets configuration for the histograms
* Split different timers logically: processing timer, distribution timer, send timer
* Slightly improve logging where relevant