### PR TITLE
Some improvements in the statement-distribution histograms

### DIFF
--- a/node/network/statement-distribution/src/metrics.rs
+++ b/node/network/statement-distribution/src/metrics.rs
@@ -16,6 +16,10 @@
 
 use polkadot_node_subsystem_util::metrics::{self, prometheus};
 
+/// Buckets more suitable for checking the typical latency values
+const HISTOGRAM_LATENCY_BUCKETS: &[f64] =
+	&[0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.75, 0.9, 1.0, 1.2, 1.5, 1.75];
+
 #[derive(Clone)]
 struct MetricsInner {
 	statements_distributed: prometheus::Counter<prometheus::U64>,
@@ -23,7 +27,7 @@ struct MetricsInner {
 	received_responses: prometheus::CounterVec<prometheus::U64>,
 	active_leaves_update: prometheus::Histogram,
 	share: prometheus::Histogram,
-	network_bridge_update_v1: prometheus::Histogram,
+	network_bridge_update_v1: prometheus::HistogramVec,
 	statements_unexpected: prometheus::CounterVec<prometheus::U64>,
 	created_message_size: prometheus::Gauge<prometheus::U64>,
 }
@@ -74,8 +78,14 @@ impl Metrics {
 	/// Provide a timer for `network_bridge_update_v1` which observes on drop.
 	pub fn time_network_bridge_update_v1(
 		&self,
+		message_type: &'static str,
 	) -> Option<metrics::prometheus::prometheus::HistogramTimer> {
-		self.0.as_ref().map(|metrics| metrics.network_bridge_update_v1.start_timer())
+		self.0.as_ref().map(|metrics| {
+			metrics
+				.network_bridge_update_v1
+				.with_label_values(&[message_type])
+				.start_timer()
+		})
 	}
 
 	/// Update the out-of-view statements counter for unexpected valid statements
@@ -137,24 +147,34 @@ impl metrics::Metrics for Metrics {
 				registry,
 			)?,
 			active_leaves_update: prometheus::register(
-				prometheus::Histogram::with_opts(prometheus::HistogramOpts::new(
-					"polkadot_parachain_statement_distribution_active_leaves_update",
-					"Time spent within `statement_distribution::active_leaves_update`",
-				))?,
+				prometheus::Histogram::with_opts(
+					prometheus::HistogramOpts::new(
+						"polkadot_parachain_statement_distribution_active_leaves_update",
+						"Time spent within `statement_distribution::active_leaves_update`",
+					)
+					.buckets(HISTOGRAM_LATENCY_BUCKETS.into()),
+				)?,
 				registry,
 			)?,
 			share: prometheus::register(
-				prometheus::Histogram::with_opts(prometheus::HistogramOpts::new(
-					"polkadot_parachain_statement_distribution_share",
-					"Time spent within `statement_distribution::share`",
-				))?,
+				prometheus::Histogram::with_opts(
+					prometheus::HistogramOpts::new(
+						"polkadot_parachain_statement_distribution_share",
+						"Time spent within `statement_distribution::share`",
+					)
+					.buckets(HISTOGRAM_LATENCY_BUCKETS.into()),
+				)?,
 				registry,
 			)?,
 			network_bridge_update_v1: prometheus::register(
-				prometheus::Histogram::with_opts(prometheus::HistogramOpts::new(
-					"polkadot_parachain_statement_distribution_network_bridge_update_v1",
-					"Time spent within `statement_distribution::network_bridge_update_v1`",
-				))?,
+				prometheus::HistogramVec::new(
+					prometheus::HistogramOpts::new(
+						"polkadot_parachain_statement_distribution_network_bridge_update_v1",
+						"Time spent within `statement_distribution::network_bridge_update_v1`",
+					)
+					.buckets(HISTOGRAM_LATENCY_BUCKETS.into()),
+					&["message_type"],
+				)?,
 				registry,
 			)?,
 			statements_unexpected: prometheus::register(


### PR DESCRIPTION
This PR is intended to do the following neats:

* Add more reasonable buckets for latencies
* Add granular timers for different network events instead of measuring everything in general
* Remove timers from events that actually does not involve any networking (less noise)