### PR TITLE
Remove Superfluous Test in Crowdloan Migration

### DIFF
--- a/runtime/common/src/crowdloan/migration.rs
+++ b/runtime/common/src/crowdloan/migration.rs
@@ -53,7 +53,6 @@ pub mod crowdloan_index_migration {
 				total_balance >= fund.raised,
 				"Total balance is not equal to the funds raised."
 			);
-			ensure!(total_balance > Zero::zero(), "Total balance is equal to zero.");
 		}
 
 		Ok(())

--- a/runtime/common/src/crowdloan/migration.rs
+++ b/runtime/common/src/crowdloan/migration.rs
@@ -121,7 +121,6 @@ pub mod crowdloan_index_migration {
 				total_balance >= fund.raised,
 				"Total balance in new account is different than the funds raised."
 			);
-			ensure!(total_balance > Zero::zero(), "Total balance in the account is zero.");
 		}
 
 		Ok(())


### PR DESCRIPTION
This check is not needed, and can occur if a completed crowdloan has not been dissolved.