### PR TITLE
Migrate Slot Depositors in Crowdloan Migration

### DIFF
--- a/runtime/common/src/crowdloan/migration.rs
+++ b/runtime/common/src/crowdloan/migration.rs
@@ -178,7 +178,7 @@ pub mod crowdloan_index_migration {
 			}
 			if new_account_found {
 				log::info!(
-					target: "runtime",
+					target: "runtime::crowdloan",
 					"para_id={:?}, new_fund_account={:?}, leases={:?}",
 					para_id, new_fund_account, leases,
 				);

--- a/runtime/common/src/crowdloan/migration.rs
+++ b/runtime/common/src/crowdloan/migration.rs
@@ -15,7 +15,7 @@
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
 use super::*;
-use frame_support::generate_storage_alias;
+use frame_support::{generate_storage_alias, Twox64Concat};
 
 /// Migrations for using fund index to create fund accounts instead of para ID.
 pub mod crowdloan_index_migration {
@@ -29,6 +29,11 @@ pub mod crowdloan_index_migration {
 	pub fn pre_migrate<T: Config>() -> Result<(), &'static str> {
 		// `NextTrieIndex` should have a value.
 		generate_storage_alias!(Crowdloan, NextTrieIndex => Value<FundIndex>);
+
+		generate_storage_alias!(
+			Slots,
+			Leases<T: Config> => Map<(Twox64Concat, ParaId), Vec<Option<(T::AccountId, BalanceOf<T>)>>>
+		);
 		let next_index = NextTrieIndex::get().unwrap_or_default();
 		ensure!(next_index > 0, "Next index is zero, which implies no migration is needed.");
 
@@ -38,7 +43,6 @@ pub mod crowdloan_index_migration {
 			next_index,
 		);
 
-		// Each fund should have some non-zero balance.
 		for (para_id, fund) in Funds::<T>::iter() {
 			let old_fund_account = old_fund_account_id::<T>(para_id);
 			let total_balance = CurrencyOf::<T>::total_balance(&old_fund_account);
@@ -49,10 +53,29 @@ pub mod crowdloan_index_migration {
 				para_id, old_fund_account, total_balance, fund.raised
 			);
 
+			// Each fund should have some non-zero balance.
 			ensure!(
 				total_balance >= fund.raised,
 				"Total balance is not equal to the funds raised."
 			);
+
+			let leases = Leases::<T>::get(para_id).unwrap_or_default();
+			let mut found_lease_deposit = false;
+			for maybe_deposit in leases.iter() {
+				if let Some((who, _amount)) = maybe_deposit {
+					if *who == old_fund_account {
+						found_lease_deposit = true;
+						break
+					}
+				}
+			}
+			if found_lease_deposit {
+				log::info!(
+					target: "runtime",
+					"para_id={:?}, old_fund_account={:?}, leases={:?}",
+					para_id, old_fund_account, leases,
+				);
+			}
 		}
 
 		Ok(())
@@ -66,6 +89,10 @@ pub mod crowdloan_index_migration {
 		// First migrate `NextTrieIndex` counter to `NextFundIndex`.
 		generate_storage_alias!(Crowdloan, NextTrieIndex => Value<FundIndex>);
 
+		generate_storage_alias!(
+			Slots,
+			Leases<T: Config> => Map<(Twox64Concat, ParaId), Vec<Option<(T::AccountId, BalanceOf<T>)>>>
+		);
 		let next_index = NextTrieIndex::take().unwrap_or_default();
 		NextFundIndex::<T>::set(next_index);
 
@@ -78,10 +105,21 @@ pub mod crowdloan_index_migration {
 
 			// Funds should only have a free balance and a reserve balance. Both of these are in the
 			// `Account` storage item, so we just swap them.
-			let account_info = frame_system::Account::<T>::take(old_fund_account);
-			frame_system::Account::<T>::insert(new_fund_account, account_info);
+			let account_info = frame_system::Account::<T>::take(&old_fund_account);
+			frame_system::Account::<T>::insert(&new_fund_account, account_info);
 
 			weight = weight.saturating_add(T::DbWeight::get().reads_writes(1, 2));
+
+			let mut leases = Leases::<T>::get(para_id).unwrap_or_default();
+			for maybe_deposit in leases.iter_mut() {
+				if let Some((who, _amount)) = maybe_deposit {
+					if *who == old_fund_account {
+						*who = new_fund_account.clone();
+					}
+				}
+			}
+
+			Leases::<T>::insert(para_id, leases);
 		}
 
 		weight
@@ -91,6 +129,11 @@ pub mod crowdloan_index_migration {
 		// `NextTrieIndex` should not have a value, and `NextFundIndex` should.
 		generate_storage_alias!(Crowdloan, NextTrieIndex => Value<FundIndex>);
 		ensure!(NextTrieIndex::get().is_none(), "NextTrieIndex still has a value.");
+
+		generate_storage_alias!(
+			Slots,
+			Leases<T: Config> => Map<(Twox64Concat, ParaId), Vec<Option<(T::AccountId, BalanceOf<T>)>>>
+		);
 
 		let next_index = NextFundIndex::<T>::get();
 		log::info!(
@@ -121,6 +164,25 @@ pub mod crowdloan_index_migration {
 				total_balance >= fund.raised,
 				"Total balance in new account is different than the funds raised."
 			);
+
+			let leases = Leases::<T>::get(para_id).unwrap_or_default();
+			let mut new_account_found = false;
+			for maybe_deposit in leases.iter() {
+				if let Some((who, _amount)) = maybe_deposit {
+					if *who == old_fund_account {
+						panic!("Old fund account found after migration!");
+					} else if *who == new_fund_account {
+						new_account_found = true;
+					}
+				}
+			}
+			if new_account_found {
+				log::info!(
+					target: "runtime",
+					"para_id={:?}, new_fund_account={:?}, leases={:?}",
+					para_id, new_fund_account, leases,
+				);
+			}
 		}
 
 		Ok(())

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -109,7 +109,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("kusama"),
 	impl_name: create_runtime_str!("parity-kusama"),
 	authoring_version: 2,
-	spec_version: 9180,
+	spec_version: 9181,
 	impl_version: 0,
 	#[cfg(not(feature = "disable-runtime-api"))]
 	apis: RUNTIME_API_VERSIONS,

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -107,7 +107,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("polkadot"),
 	impl_name: create_runtime_str!("parity-polkadot"),
 	authoring_version: 0,
-	spec_version: 9180,
+	spec_version: 9181,
 	impl_version: 0,
 	#[cfg(not(feature = "disable-runtime-api"))]
 	apis: RUNTIME_API_VERSIONS,


### PR DESCRIPTION
This PR fixes an issue with the existing Crowdloan migration (https://github.com/paritytech/polkadot/pull/4772), where the deposits tracking in the Slots pallet was not migrated to the new accounts.