### PR TITLE
Companion to #11081, upgrade paritydb version.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5948,9 +5948,9 @@ dependencies = [
 
 [[package]]
 name = "parity-db"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "865edee5b792f537356d9e55cbc138e7f4718dc881a7ea45a18b37bf61c21e3d"
+checksum = "3d121a9af17a43efd0a38c6afa508b927ba07785bd4709efb2ac03bf77efef8d"
 dependencies = [
  "blake2-rfc",
  "crc32fast",

--- a/node/service/Cargo.toml
+++ b/node/service/Cargo.toml
@@ -68,7 +68,7 @@ serde = { version = "1.0.136", features = ["derive"] }
 thiserror = "1.0.30"
 kvdb = "0.11.0"
 kvdb-rocksdb = { version = "0.15.1", optional = true }
-parity-db = { version = "0.3.8", optional = true }
+parity-db = { version = "0.3.9", optional = true }
 async-trait = "0.1.52"
 lru = "0.7"
 

--- a/node/subsystem-util/Cargo.toml
+++ b/node/subsystem-util/Cargo.toml
@@ -34,7 +34,7 @@ sp-keystore = { git = "https://github.com/paritytech/substrate", branch = "maste
 
 kvdb = "0.11.0"
 parity-util-mem = { version = "0.11", default-features = false }
-parity-db = { version = "0.3.8" }
+parity-db = { version = "0.3.9" }
 
 [dev-dependencies]
 assert_matches = "1.4.0"


### PR DESCRIPTION
companion to https://github.com/paritytech/substrate/pull/11081

Cumulus companion: https://github.com/paritytech/cumulus/pull/1101