### PR TITLE
Try to fix out of view statements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7219,6 +7219,7 @@ name = "polkadot-primitives-test-helpers"
 version = "0.9.18"
 dependencies = [
  "polkadot-primitives",
+ "rand 0.8.5",
  "sp-application-crypto",
  "sp-keyring",
  "sp-runtime",

--- a/node/network/approval-distribution/src/lib.rs
+++ b/node/network/approval-distribution/src/lib.rs
@@ -720,7 +720,7 @@ impl State {
 		// to all peers in the BlockEntry's known_by set who know about the block,
 		// excluding the peer in the source, if source has kind MessageSource::Peer.
 		let maybe_peer_id = source.peer_id();
-		let peers = entry
+		let mut peers = entry
 			.known_by
 			.keys()
 			.cloned()
@@ -729,8 +729,7 @@ impl State {
 
 		let assignments = vec![(assignment, claimed_candidate_index)];
 		let gossip_peers = &self.gossip_peers;
-		let peers =
-			util::choose_random_subset(|e| gossip_peers.contains(e), peers, MIN_GOSSIP_PEERS);
+		util::choose_random_subset(|e| gossip_peers.contains(e), &mut peers, MIN_GOSSIP_PEERS);
 
 		// Add the fingerprint of the assignment to the knowledge of each peer.
 		for peer in peers.iter() {
@@ -943,7 +942,7 @@ impl State {
 		// to all peers in the BlockEntry's known_by set who know about the block,
 		// excluding the peer in the source, if source has kind MessageSource::Peer.
 		let maybe_peer_id = source.peer_id();
-		let peers = entry
+		let mut peers = entry
 			.known_by
 			.keys()
 			.cloned()
@@ -951,8 +950,7 @@ impl State {
 			.collect::<Vec<_>>();
 
 		let gossip_peers = &self.gossip_peers;
-		let peers =
-			util::choose_random_subset(|e| gossip_peers.contains(e), peers, MIN_GOSSIP_PEERS);
+		util::choose_random_subset(|e| gossip_peers.contains(e), &mut peers, MIN_GOSSIP_PEERS);
 
 		// Add the fingerprint of the assignment to the knowledge of each peer.
 		for peer in peers.iter() {

--- a/node/network/bitfield-distribution/src/lib.rs
+++ b/node/network/bitfield-distribution/src/lib.rs
@@ -346,7 +346,7 @@ async fn relay_message<Context>(
 
 	let _span = span.child("interested-peers");
 	// pass on the bitfield distribution to all interested peers
-	let interested_peers = peer_views
+	let mut interested_peers = peer_views
 		.iter()
 		.filter_map(|(peer, view)| {
 			// check interest in the peer in this message's relay parent
@@ -363,9 +363,9 @@ async fn relay_message<Context>(
 			}
 		})
 		.collect::<Vec<PeerId>>();
-	let interested_peers = util::choose_random_subset(
+	util::choose_random_subset(
 		|e| gossip_peers.contains(e),
-		interested_peers,
+		&mut interested_peers,
 		MIN_GOSSIP_PEERS,
 	);
 	interested_peers.iter().for_each(|peer| {

--- a/node/network/statement-distribution/src/lib.rs
+++ b/node/network/statement-distribution/src/lib.rs
@@ -1458,11 +1458,11 @@ async fn handle_incoming_message<'a>(
 			Ok(()) => {},
 			Err(DeniedStatement::NotUseful) => return None,
 			Err(DeniedStatement::UsefulButKnown) => {
-				report_peer(ctx, peer, BENEFIT_VALID_STATEMENT).await;
 				// Note a received statement in the peer data
 				peer_data
 					.receive(&relay_parent, &fingerprint, max_message_count)
 					.expect("checked in `check_can_receive` above; qed");
+				report_peer(ctx, peer, BENEFIT_VALID_STATEMENT).await;
 
 				return None
 			},

--- a/node/network/statement-distribution/src/lib.rs
+++ b/node/network/statement-distribution/src/lib.rs
@@ -1459,6 +1459,13 @@ async fn handle_incoming_message<'a>(
 			Err(DeniedStatement::NotUseful) => return None,
 			Err(DeniedStatement::UsefulButKnown) => {
 				report_peer(ctx, peer, BENEFIT_VALID_STATEMENT).await;
+				// Note a received statement in the peer data
+				// TODO: Understand if we need to share our active statements with the
+				// peer in this case.
+				peer_data
+					.receive(&relay_parent, &fingerprint, max_message_count)
+					.unwrap_or_else(|_| unreachable!("checked in `check_can_receive` above; qed"));
+
 				return None
 			},
 		}

--- a/node/network/statement-distribution/src/lib.rs
+++ b/node/network/statement-distribution/src/lib.rs
@@ -1464,7 +1464,7 @@ async fn handle_incoming_message<'a>(
 				// peer in this case.
 				peer_data
 					.receive(&relay_parent, &fingerprint, max_message_count)
-					.unwrap_or_else(|_| unreachable!("checked in `check_can_receive` above; qed"));
+					.expect("checked in `check_can_receive` above; qed");
 
 				return None
 			},

--- a/node/network/statement-distribution/src/lib.rs
+++ b/node/network/statement-distribution/src/lib.rs
@@ -1460,8 +1460,6 @@ async fn handle_incoming_message<'a>(
 			Err(DeniedStatement::UsefulButKnown) => {
 				report_peer(ctx, peer, BENEFIT_VALID_STATEMENT).await;
 				// Note a received statement in the peer data
-				// TODO: Understand if we need to share our active statements with the
-				// peer in this case.
 				peer_data
 					.receive(&relay_parent, &fingerprint, max_message_count)
 					.expect("checked in `check_can_receive` above; qed");

--- a/node/network/statement-distribution/src/lib.rs
+++ b/node/network/statement-distribution/src/lib.rs
@@ -121,7 +121,7 @@ pub struct StatementDistributionSubsystem<R: rand::Rng> {
 	req_receiver: Option<IncomingRequestReceiver<request_v1::StatementFetchingRequest>>,
 	/// Prometheus metrics
 	metrics: Metrics,
-	/// PRG for peers selection logic
+	/// Pseudo-random generator for peers selection logic
 	rng: R,
 }
 

--- a/node/network/statement-distribution/src/lib.rs
+++ b/node/network/statement-distribution/src/lib.rs
@@ -61,6 +61,7 @@ use util::runtime::RuntimeInfo;
 use std::collections::{hash_map::Entry, HashMap, HashSet, VecDeque};
 
 use fatality::Nested;
+
 mod error;
 pub use error::{Error, FatalError, JfyiError, Result};
 
@@ -114,7 +115,7 @@ const LOG_TARGET: &str = "parachain::statement-distribution";
 const MAX_LARGE_STATEMENTS_PER_SENDER: usize = 20;
 
 /// The statement distribution subsystem.
-pub struct StatementDistributionSubsystem<R: rand::Rng> {
+pub struct StatementDistributionSubsystem<R> {
 	/// Pointer to a keystore, which is required for determining this node's validator index.
 	keystore: SyncCryptoStorePtr,
 	/// Receiver for incoming large statement requests.

--- a/node/network/statement-distribution/src/lib.rs
+++ b/node/network/statement-distribution/src/lib.rs
@@ -1041,8 +1041,7 @@ async fn circulate_statement<'a>(
 	let priority_set: HashSet<&PeerId> = priority_peers.iter().collect();
 	peers_to_send.retain(|p| !priority_set.contains(p));
 
-	let mut peers_to_send =
-		util::choose_random_subset(|e| gossip_peers.contains(e), peers_to_send, MIN_GOSSIP_PEERS);
+	util::choose_random_subset(|e| gossip_peers.contains(e), &mut peers_to_send, MIN_GOSSIP_PEERS);
 	// We don't want to use less peers, than we would without any priority peers:
 	let min_size = std::cmp::max(peers_to_send.len(), MIN_GOSSIP_PEERS);
 	// Make set full:

--- a/node/network/statement-distribution/src/tests.rs
+++ b/node/network/statement-distribution/src/tests.rs
@@ -2020,7 +2020,10 @@ fn handle_multiple_seconded_statements() {
 			handle.recv().await,
 			AllMessages::NetworkBridge(
 				NetworkBridgeMessage::ReportPeer(p, r)
-			) if p == peer_a && r == BENEFIT_VALID_STATEMENT_FIRST => {}
+			) => {
+				assert_eq!(p, peer_a);
+				assert_eq!(r, BENEFIT_VALID_STATEMENT_FIRST);
+			}
 		);
 
 		// After the first valid statement, we expect messages to be circulated
@@ -2028,7 +2031,10 @@ fn handle_multiple_seconded_statements() {
 			handle.recv().await,
 			AllMessages::CandidateBacking(
 				CandidateBackingMessage::Statement(r, s)
-			) if r == relay_parent_hash && s == statement => {}
+			) => {
+				assert_eq!(r, relay_parent_hash);
+				assert_eq!(s, statement);
+			}
 		);
 
 		assert_matches!(
@@ -2066,7 +2072,10 @@ fn handle_multiple_seconded_statements() {
 			handle.recv().await,
 			AllMessages::NetworkBridge(
 				NetworkBridgeMessage::ReportPeer(p, r)
-			) if p == peer_b && r == BENEFIT_VALID_STATEMENT => {}
+			) => {
+				assert_eq!(p, peer_b);
+				assert_eq!(r, BENEFIT_VALID_STATEMENT);
+			}
 		);
 
 		// Create a `Valid` statement
@@ -2114,14 +2123,20 @@ fn handle_multiple_seconded_statements() {
 			handle.recv().await,
 			AllMessages::NetworkBridge(
 				NetworkBridgeMessage::ReportPeer(p, r)
-			) if p == peer_a && r == BENEFIT_VALID_STATEMENT_FIRST => {}
+			) => {
+				assert_eq!(p, peer_a);
+				assert_eq!(r, BENEFIT_VALID_STATEMENT_FIRST);
+			}
 		);
 
 		assert_matches!(
 			handle.recv().await,
 			AllMessages::CandidateBacking(
 				CandidateBackingMessage::Statement(r, s)
-			) if r == relay_parent_hash && s == statement => {}
+			) => {
+				assert_eq!(r, relay_parent_hash);
+				assert_eq!(s, statement);
+			}
 		);
 
 		assert_matches!(
@@ -2161,7 +2176,10 @@ fn handle_multiple_seconded_statements() {
 			handle.recv().await,
 			AllMessages::NetworkBridge(
 				NetworkBridgeMessage::ReportPeer(p, r)
-			) if p == peer_b && r == BENEFIT_VALID_STATEMENT => {}
+			) => {
+				assert_eq!(p, peer_b);
+				assert_eq!(r, BENEFIT_VALID_STATEMENT);
+			}
 		);
 
 		handle.send(FromOverseer::Signal(OverseerSignal::Conclude)).await;

--- a/node/network/statement-distribution/src/tests.rs
+++ b/node/network/statement-distribution/src/tests.rs
@@ -29,7 +29,7 @@ use polkadot_node_network_protocol::{
 use polkadot_node_primitives::{Statement, UncheckedSignedFullStatement};
 use polkadot_node_subsystem_test_helpers::mock::make_ferdie_keystore;
 use polkadot_primitives::v2::{Hash, SessionInfo, ValidationCode};
-use polkadot_primitives_test_helpers::{dummy_committed_candidate_receipt, dummy_hash};
+use polkadot_primitives_test_helpers::{dummy_committed_candidate_receipt, dummy_hash, AlwaysZeroRng};
 use polkadot_subsystem::{
 	jaeger,
 	messages::{RuntimeApiMessage, RuntimeApiRequest},
@@ -511,6 +511,7 @@ fn peer_view_update_sends_messages() {
 			&active_heads,
 			new_view.clone(),
 			&Default::default(),
+			&mut AlwaysZeroRng{}
 		)
 		.await;
 
@@ -719,9 +720,10 @@ fn receiving_from_one_sends_to_another_and_to_candidate_backing() {
 	let (statement_req_receiver, _) = IncomingRequest::get_config_receiver();
 
 	let bg = async move {
-		let s = StatementDistributionSubsystem::new(
+		let s = StatementDistributionSubsystem::<AlwaysZeroRng>::new(
 			Arc::new(LocalKeystore::in_memory()),
 			statement_req_receiver,
+			Default::default(),
 			Default::default(),
 		);
 		s.run(ctx).await.unwrap();
@@ -911,10 +913,11 @@ fn receiving_large_statement_from_one_sends_to_another_and_to_candidate_backing(
 	let (statement_req_receiver, mut req_cfg) = IncomingRequest::get_config_receiver();
 
 	let bg = async move {
-		let s = StatementDistributionSubsystem::new(
+		let s = StatementDistributionSubsystem::<AlwaysZeroRng>::new(
 			make_ferdie_keystore(),
 			statement_req_receiver,
 			Default::default(),
+			Default::default()
 		);
 		s.run(ctx).await.unwrap();
 	};
@@ -1408,9 +1411,10 @@ fn share_prioritizes_backing_group() {
 	let (statement_req_receiver, mut req_cfg) = IncomingRequest::get_config_receiver();
 
 	let bg = async move {
-		let s = StatementDistributionSubsystem::new(
+		let s = StatementDistributionSubsystem::<AlwaysZeroRng>::new(
 			make_ferdie_keystore(),
 			statement_req_receiver,
+			Default::default(),
 			Default::default(),
 		);
 		s.run(ctx).await.unwrap();
@@ -1691,9 +1695,10 @@ fn peer_cant_flood_with_large_statements() {
 
 	let (statement_req_receiver, _) = IncomingRequest::get_config_receiver();
 	let bg = async move {
-		let s = StatementDistributionSubsystem::new(
+		let s = StatementDistributionSubsystem::<AlwaysZeroRng>::new(
 			make_ferdie_keystore(),
 			statement_req_receiver,
+			Default::default(),
 			Default::default(),
 		);
 		s.run(ctx).await.unwrap();
@@ -1881,9 +1886,10 @@ fn handle_multiple_seconded_statements() {
 	let (statement_req_receiver, _) = IncomingRequest::get_config_receiver();
 
 	let virtual_overseer_fut = async move {
-		let s = StatementDistributionSubsystem::new(
+		let s = StatementDistributionSubsystem::<AlwaysZeroRng>::new(
 			Arc::new(LocalKeystore::in_memory()),
 			statement_req_receiver,
+			Default::default(),
 			Default::default(),
 		);
 		s.run(ctx).await.unwrap();

--- a/node/network/statement-distribution/src/tests.rs
+++ b/node/network/statement-distribution/src/tests.rs
@@ -1859,7 +1859,7 @@ fn handle_multiple_seconded_statements() {
 	let hash_a = Hash::repeat_byte(1);
 
 	let candidate = {
-		let mut c = dummy_committed_candidate_receipt(dummy_hash());
+		let mut c = dummy_committed_candidate_receipt(hash_a);
 		c.descriptor.relay_parent = hash_a;
 		c.descriptor.para_id = 1.into();
 		c

--- a/node/network/statement-distribution/src/tests.rs
+++ b/node/network/statement-distribution/src/tests.rs
@@ -1842,6 +1842,18 @@ fn peer_cant_flood_with_large_statements() {
 	executor::block_on(future::join(test_fut, bg));
 }
 
+// This test addresses an issue when received knowledge is not updated on a
+// subsequent `Seconded` statements
+//
+// To trigger this issue, one should modify `circulate_statement` function
+// where there is a selection of lucky/unlucky peers to make all peers unlucky.
+// It could be done, for example, by avoiding calling to `peer_knowledge.send`:
+// `let peers_to_send: Vec<(PeerId, bool)> = peers_to_send` <--- here
+//
+// Secondly, the proposed change to update received knowledge of a peer in the
+// function `handle_incoming_message` must also be removed to reproduce the issue.
+// This is done after `active_head.check_useful_or_unknown` check where a statement
+// is useful but known.
 #[test]
 fn handle_multiple_seconded_statements() {
 	let hash_a = Hash::repeat_byte(1);
@@ -1960,8 +1972,8 @@ fn handle_multiple_seconded_statements() {
 				ValidatorId::ID,
 				Some(&Sr25519Keyring::Alice.to_seed()),
 			)
-				.await
-				.unwrap();
+			.await
+			.unwrap();
 
 			SignedFullStatement::sign(
 				&keystore,
@@ -1970,10 +1982,10 @@ fn handle_multiple_seconded_statements() {
 				ValidatorIndex(0),
 				&alice_public.into(),
 			)
-				.await
-				.ok()
-				.flatten()
-				.expect("should be signed")
+			.await
+			.ok()
+			.flatten()
+			.expect("should be signed")
 		};
 
 		// `PeerA` sends a `Seconded` message
@@ -2054,8 +2066,8 @@ fn handle_multiple_seconded_statements() {
 				ValidatorId::ID,
 				Some(&Sr25519Keyring::Alice.to_seed()),
 			)
-				.await
-				.unwrap();
+			.await
+			.unwrap();
 
 			SignedFullStatement::sign(
 				&keystore,
@@ -2064,10 +2076,10 @@ fn handle_multiple_seconded_statements() {
 				ValidatorIndex(0),
 				&alice_public.into(),
 			)
-				.await
-				.ok()
-				.flatten()
-				.expect("should be signed")
+			.await
+			.ok()
+			.flatten()
+			.expect("should be signed")
 		};
 
 		// `PeerA` sends a `Valid` message
@@ -2138,7 +2150,6 @@ fn handle_multiple_seconded_statements() {
 				NetworkBridgeMessage::ReportPeer(p, r)
 			) if p == peer_b && r == BENEFIT_VALID_STATEMENT => {}
 		);
-
 
 		handle.send(FromOverseer::Signal(OverseerSignal::Conclude)).await;
 	};

--- a/node/service/src/overseer.rs
+++ b/node/service/src/overseer.rs
@@ -63,6 +63,7 @@ pub use polkadot_node_core_dispute_coordinator::DisputeCoordinatorSubsystem;
 pub use polkadot_node_core_provisioner::ProvisionerSubsystem;
 pub use polkadot_node_core_pvf_checker::PvfCheckerSubsystem;
 pub use polkadot_node_core_runtime_api::RuntimeApiSubsystem;
+use polkadot_node_subsystem_util::rand::{self, SeedableRng};
 pub use polkadot_statement_distribution::StatementDistributionSubsystem;
 
 /// Arguments passed for overseer construction.
@@ -148,7 +149,7 @@ pub fn prepared_overseer_builder<'a, Spawner, RuntimeClient>(
 		CandidateValidationSubsystem,
 		PvfCheckerSubsystem,
 		CandidateBackingSubsystem<Spawner>,
-		StatementDistributionSubsystem,
+		StatementDistributionSubsystem<rand::rngs::StdRng>,
 		AvailabilityDistributionSubsystem,
 		AvailabilityRecoverySubsystem,
 		BitfieldSigningSubsystem<Spawner>,
@@ -255,6 +256,7 @@ where
 			keystore.clone(),
 			statement_req_receiver,
 			Metrics::register(registry)?,
+			rand::rngs::StdRng::from_entropy(),
 		))
 		.approval_distribution(ApprovalDistributionSubsystem::new(Metrics::register(registry)?))
 		.approval_voting(ApprovalVotingSubsystem::with_config(

--- a/node/subsystem-util/src/lib.rs
+++ b/node/subsystem-util/src/lib.rs
@@ -281,7 +281,7 @@ pub fn choose_random_subset<T, F: FnMut(&T) -> bool>(is_priority: F, v: &mut Vec
 	choose_random_subset_with_rng(is_priority, v, &mut rand::thread_rng(), min)
 }
 
-/// Choose a random subset of `min` elements using a specific Rng.
+/// Choose a random subset of `min` elements using a specific Random Generator `Rng`
 /// But always include `is_priority` elements.
 pub fn choose_random_subset_with_rng<T, F: FnMut(&T) -> bool, R: rand::Rng>(
 	is_priority: F,

--- a/node/subsystem-util/src/lib.rs
+++ b/node/subsystem-util/src/lib.rs
@@ -55,6 +55,7 @@ use polkadot_primitives::v2::{
 	PersistedValidationData, SessionIndex, SessionInfo, Signed, SigningContext, ValidationCode,
 	ValidationCodeHash, ValidatorId, ValidatorIndex, ValidatorSignature,
 };
+pub use rand;
 use sp_application_crypto::AppKey;
 use sp_core::{traits::SpawnNamed, ByteArray};
 use sp_keystore::{CryptoStore, Error as KeystoreError, SyncCryptoStorePtr};
@@ -68,7 +69,6 @@ use std::{
 	time::Duration,
 };
 use thiserror::Error;
-pub use rand;
 
 pub use metered_channel as metered;
 pub use polkadot_node_network_protocol::MIN_GOSSIP_PEERS;

--- a/node/subsystem-util/src/lib.rs
+++ b/node/subsystem-util/src/lib.rs
@@ -278,25 +278,32 @@ pub fn find_validator_group(
 /// But always include `is_priority` elements.
 pub fn choose_random_subset<T, F: FnMut(&T) -> bool>(
 	is_priority: F,
-	mut v: Vec<T>,
-	min: usize,
-) -> Vec<T> {
+	v: &mut Vec<T>,
+	min: usize) {
+	choose_random_subset_with_rng(is_priority, v, &mut rand::thread_rng(), min)
+}
+
+/// Choose a random subset of `min` elements.
+/// But always include `is_priority` elements.
+pub fn choose_random_subset_with_rng<T, F: FnMut(&T) -> bool, R: rand::Rng>(
+	is_priority: F,
+	v: &mut Vec<T>,
+	rng: &mut R,
+	min: usize) {
 	use rand::seq::SliceRandom as _;
 
 	// partition the elements into priority first
 	// the returned index is when non_priority elements start
-	let i = itertools::partition(&mut v, is_priority);
+	let i = itertools::partition(v.iter_mut(), is_priority);
 
 	if i >= min || v.len() <= i {
 		v.truncate(i);
-		return v
+		return;
 	}
 
-	let mut rng = rand::thread_rng();
-	v[i..].shuffle(&mut rng);
+	v[i..].shuffle(rng);
 
 	v.truncate(min);
-	v
 }
 
 /// Returns a `bool` with a probability of `a / b` of being true.

--- a/node/subsystem-util/src/lib.rs
+++ b/node/subsystem-util/src/lib.rs
@@ -276,10 +276,7 @@ pub fn find_validator_group(
 
 /// Choose a random subset of `min` elements.
 /// But always include `is_priority` elements.
-pub fn choose_random_subset<T, F: FnMut(&T) -> bool>(
-	is_priority: F,
-	v: &mut Vec<T>,
-	min: usize) {
+pub fn choose_random_subset<T, F: FnMut(&T) -> bool>(is_priority: F, v: &mut Vec<T>, min: usize) {
 	choose_random_subset_with_rng(is_priority, v, &mut rand::thread_rng(), min)
 }
 
@@ -289,7 +286,8 @@ pub fn choose_random_subset_with_rng<T, F: FnMut(&T) -> bool, R: rand::Rng>(
 	is_priority: F,
 	v: &mut Vec<T>,
 	rng: &mut R,
-	min: usize) {
+	min: usize,
+) {
 	use rand::seq::SliceRandom as _;
 
 	// partition the elements into priority first
@@ -298,7 +296,7 @@ pub fn choose_random_subset_with_rng<T, F: FnMut(&T) -> bool, R: rand::Rng>(
 
 	if i >= min || v.len() <= i {
 		v.truncate(i);
-		return;
+		return
 	}
 
 	v[i..].shuffle(rng);

--- a/node/subsystem-util/src/lib.rs
+++ b/node/subsystem-util/src/lib.rs
@@ -68,6 +68,7 @@ use std::{
 	time::Duration,
 };
 use thiserror::Error;
+pub use rand;
 
 pub use metered_channel as metered;
 pub use polkadot_node_network_protocol::MIN_GOSSIP_PEERS;
@@ -280,7 +281,7 @@ pub fn choose_random_subset<T, F: FnMut(&T) -> bool>(is_priority: F, v: &mut Vec
 	choose_random_subset_with_rng(is_priority, v, &mut rand::thread_rng(), min)
 }
 
-/// Choose a random subset of `min` elements.
+/// Choose a random subset of `min` elements using a specific Rng.
 /// But always include `is_priority` elements.
 pub fn choose_random_subset_with_rng<T, F: FnMut(&T) -> bool, R: rand::Rng>(
 	is_priority: F,
@@ -306,8 +307,11 @@ pub fn choose_random_subset_with_rng<T, F: FnMut(&T) -> bool, R: rand::Rng>(
 
 /// Returns a `bool` with a probability of `a / b` of being true.
 pub fn gen_ratio(a: usize, b: usize) -> bool {
-	use rand::Rng as _;
-	let mut rng = rand::thread_rng();
+	gen_ratio_rng(a, b, &mut rand::thread_rng())
+}
+
+/// Returns a `bool` with a probability of `a / b` of being true.
+pub fn gen_ratio_rng<R: rand::Rng>(a: usize, b: usize, rng: &mut R) -> bool {
 	rng.gen_ratio(a as u32, b as u32)
 }
 

--- a/node/subsystem-util/src/tests.rs
+++ b/node/subsystem-util/src/tests.rs
@@ -260,7 +260,7 @@ fn subset_generation_check() {
 #[test]
 fn subset_predefined_generation_check() {
 	let mut values = (0_u8..=25).collect::<Vec<_>>();
-	choose_random_subset_with_rng::<u8, _, _>(|_| false, &mut values, &mut AlwaysZeroRng {}, 12);
+	choose_random_subset_with_rng::<u8, _, _>(|_| false, &mut values, &mut AlwaysZeroRng, 12);
 	assert_eq!(values.len(), 12);
 	for (idx, v) in dbg!(values).into_iter().enumerate() {
 		// Since shuffle actually shuffles the indexes from 1..len, then

--- a/node/subsystem-util/src/tests.rs
+++ b/node/subsystem-util/src/tests.rs
@@ -25,7 +25,7 @@ use polkadot_node_subsystem::{
 };
 use polkadot_node_subsystem_test_helpers::{self as test_helpers, make_subsystem_context};
 use polkadot_primitives::v2::Hash;
-use polkadot_primitives_test_helpers::{dummy_candidate_receipt, dummy_hash};
+use polkadot_primitives_test_helpers::{dummy_candidate_receipt, dummy_hash, AlwaysZeroRng};
 use std::{
 	pin::Pin,
 	sync::{
@@ -252,7 +252,19 @@ fn subset_generation_check() {
 	// 12 even numbers exist
 	choose_random_subset::<u8, _>(|v| v & 0x01 == 0, &mut values, 12);
 	values.sort();
-	for (idx, v) in dbg!(chosen).into_iter().enumerate() {
+	for (idx, v) in dbg!(values).into_iter().enumerate() {
 		assert_eq!(v as usize, idx * 2);
+	}
+}
+
+#[test]
+fn subset_predefined_generation_check() {
+	let mut values = (0_u8..=25).collect::<Vec<_>>();
+	choose_random_subset_with_rng::<u8, _, _>(|_| false, &mut values, &mut AlwaysZeroRng {}, 12);
+	assert_eq!(values.len(), 12);
+	for (idx, v) in dbg!(values).into_iter().enumerate() {
+		// Since shuffle actually shuffles the indexes from 1..len, then
+		// our PRG that returns zeroes will shuffle 0 and 1, 1 and 2, ... len-2 and len-1
+		assert_eq!(v as usize, idx + 1);
 	}
 }

--- a/node/subsystem-util/src/tests.rs
+++ b/node/subsystem-util/src/tests.rs
@@ -248,10 +248,10 @@ fn tick_tack_metronome() {
 
 #[test]
 fn subset_generation_check() {
-	let values = (0_u8..=25).collect::<Vec<_>>();
+	let mut values = (0_u8..=25).collect::<Vec<_>>();
 	// 12 even numbers exist
-	let mut chosen = choose_random_subset::<u8, _>(|v| v & 0x01 == 0, values, 12);
-	chosen.sort();
+	choose_random_subset::<u8, _>(|v| v & 0x01 == 0, &mut values, 12);
+	values.sort();
 	for (idx, v) in dbg!(chosen).into_iter().enumerate() {
 		assert_eq!(v as usize, idx * 2);
 	}

--- a/primitives/test-helpers/Cargo.toml
+++ b/primitives/test-helpers/Cargo.toml
@@ -9,3 +9,4 @@ sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "master
 sp-application-crypto = { package = "sp-application-crypto", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master" }
 polkadot-primitives = { path = "../" }
+rand = "0.8.5"

--- a/primitives/test-helpers/src/lib.rs
+++ b/primitives/test-helpers/src/lib.rs
@@ -228,7 +228,7 @@ impl TestCandidateBuilder {
 
 /// A special `Rng` that always returns zero for testing something that implied
 /// to be random but should not be random in the tests
-pub struct AlwaysZeroRng {}
+pub struct AlwaysZeroRng;
 
 impl Default for AlwaysZeroRng {
 	fn default() -> Self {

--- a/primitives/test-helpers/src/lib.rs
+++ b/primitives/test-helpers/src/lib.rs
@@ -26,7 +26,7 @@ use polkadot_primitives::v2::{
 	CommittedCandidateReceipt, Hash, HeadData, Id as ParaId, ValidationCode, ValidationCodeHash,
 	ValidatorId,
 };
-use rand::RngCore;
+pub use rand;
 use sp_application_crypto::sr25519;
 use sp_keyring::Sr25519Keyring;
 use sp_runtime::generic::Digest;
@@ -230,7 +230,12 @@ impl TestCandidateBuilder {
 /// to be random but should not be random in the tests
 pub struct AlwaysZeroRng {}
 
-impl RngCore for AlwaysZeroRng {
+impl Default for AlwaysZeroRng {
+	fn default() -> Self {
+		Self {}
+	}
+}
+impl rand::RngCore for AlwaysZeroRng {
 	fn next_u32(&mut self) -> u32 {
 		0_u32
 	}

--- a/primitives/test-helpers/src/lib.rs
+++ b/primitives/test-helpers/src/lib.rs
@@ -26,6 +26,7 @@ use polkadot_primitives::v2::{
 	CommittedCandidateReceipt, Hash, HeadData, Id as ParaId, ValidationCode, ValidationCodeHash,
 	ValidatorId,
 };
+use rand::RngCore;
 use sp_application_crypto::sr25519;
 use sp_keyring::Sr25519Keyring;
 use sp_runtime::generic::Digest;
@@ -222,5 +223,30 @@ impl TestCandidateBuilder {
 		descriptor.para_id = self.para_id;
 		descriptor.pov_hash = self.pov_hash;
 		CandidateReceipt { descriptor, commitments_hash: self.commitments_hash }
+	}
+}
+
+/// A special `Rng` that always returns zero for testing something that implied
+/// to be random but should not be random in the tests
+pub struct AlwaysZeroRng {}
+
+impl RngCore for AlwaysZeroRng {
+	fn next_u32(&mut self) -> u32 {
+		0_u32
+	}
+
+	fn next_u64(&mut self) -> u64 {
+		0_u64
+	}
+
+	fn fill_bytes(&mut self, dest: &mut [u8]) {
+		for element in dest.iter_mut() {
+			*element = 0_u8;
+		}
+	}
+
+	fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand::Error> {
+		self.fill_bytes(dest);
+		Ok(())
 	}
 }


### PR DESCRIPTION
This issue happens when some peer sends a good but already known `Seconded` statement and the statement-distribution code does not update the `statements_received` field in the `peer_knowledge` structure. Subsequently, a `Valid` statement causes `out-of-view` message that is incorrectly emitted and causes reputation lose.