### PR TITLE
[ci] don't exclude frame_system from weights benchmarks

### DIFF
--- a/scripts/run_benches_for_runtime.sh
+++ b/scripts/run_benches_for_runtime.sh
@@ -17,8 +17,7 @@ cargo +nightly build --profile production --locked --features=runtime-benchmarks
     --list |\
   tail -n+2 |\
   cut -d',' -f1 |\
-  uniq | \
-  grep -v frame_system > "${runtime}_pallets"
+  uniq > "${runtime}_pallets"
 
 # For each pallet found in the previous command, run benches on each function
 while read -r line; do


### PR DESCRIPTION
while preparing the weights in https://github.com/paritytech/polkadot/pull/5097 i [noticed](https://github.com/paritytech/polkadot/pull/5097#issuecomment-1069010794) that `frame_system` benchmarks are explicitly not ran by the default CI scripts, though i can't think of a good reason why - this change includes them again