### PR TITLE
enable disputes on all chains

### DIFF
--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -731,23 +731,16 @@ where
 	let auth_or_collator = role.is_authority() || is_collator.is_collator();
 	let requires_overseer_for_chain_sel = local_keystore.is_some() && auth_or_collator;
 
-	let disputes_enabled = chain_spec.is_rococo() ||
-		chain_spec.is_kusama() ||
-		chain_spec.is_westend() ||
-		chain_spec.is_versi() ||
-		chain_spec.is_wococo();
-
 	let pvf_checker_enabled = !is_collator.is_collator() && chain_spec.is_versi();
 
 	let select_chain = if requires_overseer_for_chain_sel {
 		let metrics =
 			polkadot_node_subsystem_util::metrics::Metrics::register(prometheus_registry.as_ref())?;
 
-		SelectRelayChain::new_disputes_aware(
+		SelectRelayChain::new_with_overseer(
 			basics.backend.clone(),
 			overseer_handle.clone(),
 			metrics,
-			disputes_enabled,
 		)
 	} else {
 		SelectRelayChain::new_longest_chain(basics.backend.clone())
@@ -1006,7 +999,6 @@ where
 					candidate_validation_config,
 					chain_selection_config,
 					dispute_coordinator_config,
-					disputes_enabled,
 					pvf_checker_enabled,
 				},
 			)

--- a/node/service/src/overseer.rs
+++ b/node/service/src/overseer.rs
@@ -108,8 +108,6 @@ where
 	pub chain_selection_config: ChainSelectionConfig,
 	/// Configuration for the dispute coordinator subsystem.
 	pub dispute_coordinator_config: DisputeCoordinatorConfig,
-	/// Enable to disputes.
-	pub disputes_enabled: bool,
 	/// Enable PVF pre-checking
 	pub pvf_checker_enabled: bool,
 }
@@ -138,7 +136,6 @@ pub fn prepared_overseer_builder<'a, Spawner, RuntimeClient>(
 		candidate_validation_config,
 		chain_selection_config,
 		dispute_coordinator_config,
-		disputes_enabled,
 		pvf_checker_enabled,
 	}: OverseerGenArgs<'a, Spawner, RuntimeClient>,
 ) -> Result<
@@ -243,7 +240,7 @@ where
 		))
 		.provisioner(ProvisionerSubsystem::new(
 			spawner.clone(),
-			ProvisionerConfig { disputes_enabled },
+			ProvisionerConfig,
 			Metrics::register(registry)?,
 		))
 		.runtime_api(RuntimeApiSubsystem::new(
@@ -269,16 +266,12 @@ where
 			authority_discovery_service.clone(),
 			Metrics::register(registry)?,
 		))
-		.dispute_coordinator(if disputes_enabled {
-			DisputeCoordinatorSubsystem::new(
-				parachains_db.clone(),
-				dispute_coordinator_config,
-				keystore.clone(),
-				Metrics::register(registry)?,
-			)
-		} else {
-			DisputeCoordinatorSubsystem::dummy()
-		})
+		.dispute_coordinator(DisputeCoordinatorSubsystem::new(
+			parachains_db.clone(),
+			dispute_coordinator_config,
+			keystore.clone(),
+			Metrics::register(registry)?,
+		))
 		.dispute_distribution(DisputeDistributionSubsystem::new(
 			keystore.clone(),
 			dispute_req_receiver,

--- a/node/service/src/relay_chain_selection.rs
+++ b/node/service/src/relay_chain_selection.rs
@@ -163,30 +163,13 @@ where
 
 	/// Create a new [`SelectRelayChain`] wrapping the given chain backend
 	/// and a handle to the overseer.
-	pub fn new_disputes_aware(
-		backend: Arc<B>,
-		overseer: Handle,
-		metrics: Metrics,
-		disputes_enabled: bool,
-	) -> Self {
-		gum::debug!(
-			target: LOG_TARGET,
-			"Using {} chain selection algorithm",
-			if disputes_enabled {
-				"dispute aware relay"
-			} else {
-				// no disputes are queried, that logic is disabled
-				// in `fn finality_target_with_longest_chain`.
-				"short-circuited relay"
-			}
-		);
+	pub fn new_with_overseer(backend: Arc<B>, overseer: Handle, metrics: Metrics) -> Self {
+		gum::debug!(target: LOG_TARGET, "Using dispute aware relay-chain selection algorithm",);
+
 		SelectRelayChain {
 			longest_chain: sc_consensus::LongestChain::new(backend.clone()),
 			selection: IsDisputesAwareWithOverseer::Yes(SelectRelayChainInner::new(
-				backend,
-				overseer,
-				metrics,
-				disputes_enabled,
+				backend, overseer, metrics,
 			)),
 		}
 	}
@@ -243,7 +226,6 @@ where
 pub struct SelectRelayChainInner<B, OH> {
 	backend: Arc<B>,
 	overseer: OH,
-	disputes_enabled: bool,
 	metrics: Metrics,
 }
 
@@ -254,8 +236,8 @@ where
 {
 	/// Create a new [`SelectRelayChainInner`] wrapping the given chain backend
 	/// and a handle to the overseer.
-	pub fn new(backend: Arc<B>, overseer: OH, metrics: Metrics, disputes_enabled: bool) -> Self {
-		SelectRelayChainInner { backend, overseer, metrics, disputes_enabled }
+	pub fn new(backend: Arc<B>, overseer: OH, metrics: Metrics) -> Self {
+		SelectRelayChainInner { backend, overseer, metrics }
 	}
 
 	fn block_header(&self, hash: Hash) -> Result<PolkadotHeader, ConsensusError> {
@@ -293,7 +275,6 @@ where
 			backend: self.backend.clone(),
 			overseer: self.overseer.clone(),
 			metrics: self.metrics.clone(),
-			disputes_enabled: self.disputes_enabled,
 		}
 	}
 }
@@ -391,7 +372,7 @@ where
 		let mut overseer = self.overseer.clone();
 		gum::trace!(target: LOG_TARGET, ?best_leaf, "Longest chain");
 
-		let subchain_head = if self.disputes_enabled {
+		let subchain_head = {
 			let (tx, rx) = oneshot::channel();
 			overseer
 				.send_msg(
@@ -411,13 +392,6 @@ where
 				// No viable leaves containing the block.
 				None => return Ok(target_hash),
 				Some(best) => best,
-			}
-		} else {
-			gum::trace!(target: LOG_TARGET, ?best_leaf, "Dummy disputes active");
-			if best_leaf == target_hash {
-				return Ok(target_hash)
-			} else {
-				best_leaf
 			}
 		};
 
@@ -492,7 +466,7 @@ where
 		let lag = initial_leaf_number.saturating_sub(subchain_number);
 		self.metrics.note_approval_checking_finality_lag(lag);
 
-		let (lag, subchain_head) = if self.disputes_enabled {
+		let (lag, subchain_head) = {
 			// Prevent sending flawed data to the dispute-coordinator.
 			if Some(subchain_block_descriptions.len() as _) !=
 				subchain_number.checked_sub(target_number)
@@ -543,8 +517,6 @@ where
 						return Ok(target_hash)
 					},
 				};
-			(lag, subchain_head)
-		} else {
 			(lag, subchain_head)
 		};
 

--- a/node/service/src/tests.rs
+++ b/node/service/src/tests.rs
@@ -83,7 +83,6 @@ fn test_harness<T: Future<Output = VirtualOverseer>>(
 		Arc::new(case_vars.chain.clone()),
 		context.sender().clone(),
 		Default::default(),
-		true,
 	);
 
 	let target_hash = case_vars.target_block.clone();


### PR DESCRIPTION
This activates the disputes protocol on all validator nodes on all chains. Previously, disputes were only enabled on Kusama, Rococo, Versi, and a few others.