### PR TITLE
Fix build script for the builder image

### DIFF
--- a/scripts/dockerfiles/polkadot/build.sh
+++ b/scripts/dockerfiles/polkadot/build.sh
@@ -8,17 +8,20 @@ PROJECT_ROOT=`git rev-parse --show-toplevel`
 cd $PROJECT_ROOT
 
 # Find the current version from Cargo.toml
-VERSION=`grep "^version" ./cli/Cargo.toml | egrep -o "([0-9\.]+)"`
+VERSION=`grep "^version" ./cli/Cargo.toml | egrep -o "([0-9\.]+-?[0-9]+)"`
 GITUSER=parity
 GITREPO=polkadot
 
 # Build the image
 echo "Building ${GITUSER}/${GITREPO}:latest docker image, hang on!"
-time docker build -f ./scripts/dockerfiles/polkadot/polkadot_builder.Dockerfile -t ${GITUSER}/${GITREPO}:latest .
-docker tag ${GITUSER}/${GITREPO}:latest ${GITUSER}/${GITREPO}:v${VERSION}
+time docker build \
+    -f ./scripts/dockerfiles/polkadot/polkadot_builder.Dockerfile \
+    -t ${GITUSER}/${GITREPO}:latest \
+    -t ${GITUSER}/${GITREPO}:v${VERSION} \
+    .
 
 # Show the list of available images for this repo
-echo "Image is ready"
+echo "Your Docker image for $GITUSER/$GITREPO is ready"
 docker images | grep ${GITREPO}
 
 popd


### PR DESCRIPTION
Allows handling versions with dash such as `v1.2.3-1`.

fix #4743