### PR TITLE
[ON ICE] metered w/o metering being used

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7049,6 +7049,7 @@ version = "0.9.18"
 dependencies = [
  "derive_more",
  "futures 0.3.21",
+ "metered-channel",
  "polkadot-node-jaeger",
  "polkadot-node-network-protocol",
  "polkadot-node-primitives",

--- a/node/core/approval-voting/src/lib.rs
+++ b/node/core/approval-voting/src/lib.rs
@@ -43,6 +43,7 @@ use polkadot_node_subsystem::{
 };
 use polkadot_node_subsystem_util::{
 	database::Database,
+	metered::oneshot as metered_oneshot,
 	metrics::{self, prometheus},
 	rolling_session_window::{
 		new_session_window_size, RollingSessionWindow, SessionWindowSize, SessionWindowUpdate,
@@ -952,7 +953,8 @@ async fn handle_actions(
 			} => {
 				// TODO: Log confirmation results in an efficient way:
 				// https://github.com/paritytech/polkadot/issues/5156
-				let (pending_confirmation, _confirmation_rx) = oneshot::channel();
+				let (pending_confirmation, _confirmation_rx) =
+					metered_oneshot::channel("pending_confirmation");
 				ctx.send_message(DisputeCoordinatorMessage::ImportStatements {
 					candidate_hash,
 					candidate_receipt,

--- a/node/core/backing/src/lib.rs
+++ b/node/core/backing/src/lib.rs
@@ -36,6 +36,7 @@ use polkadot_node_primitives::{
 };
 use polkadot_node_subsystem_util::{
 	self as util,
+	metered::oneshot as metered_oneshot,
 	metrics::{self, prometheus},
 	request_from_runtime, request_session_index_for_child, request_validator_groups,
 	request_validators, FromJobCommand, JobSender, Validator,
@@ -893,7 +894,8 @@ impl CandidateBackingJob {
 		{
 			// TODO: Log confirmation results in an efficient way:
 			// https://github.com/paritytech/polkadot/issues/5156
-			let (pending_confirmation, _confirmation_rx) = oneshot::channel();
+			let (pending_confirmation, _confirmation_rx) =
+				metered_oneshot::channel("import_statements");
 			sender
 				.send_message(DisputeCoordinatorMessage::ImportStatements {
 					candidate_hash,

--- a/node/metered-channel/src/oneshot.rs
+++ b/node/metered-channel/src/oneshot.rs
@@ -352,7 +352,7 @@ mod tests {
 		let _ = env_logger::builder().is_test(true).filter_level(LevelFilter::Trace).try_init();
 
 		let pool = ThreadPool::new().unwrap();
-		let (tx, rx) = channel(name, CoarseDuration::from_secs(1), CoarseDuration::from_secs(3));
+		let (tx, rx) = channel_with_timeouts(name, CoarseDuration::from_millis(500), CoarseDuration::from_secs(1));
 		futures::executor::block_on(async move {
 			let handle_receiver = pool.spawn_with_handle(gen_receiver_test(rx)).unwrap();
 			let handle_sender = pool.spawn_with_handle(gen_sender_test(tx)).unwrap();

--- a/node/network/dispute-distribution/src/sender/mod.rs
+++ b/node/network/dispute-distribution/src/sender/mod.rs
@@ -20,7 +20,7 @@ use futures::channel::{mpsc, oneshot};
 
 use polkadot_node_network_protocol::request_response::v1::DisputeRequest;
 use polkadot_node_primitives::{CandidateVotes, DisputeMessage, SignedDisputeStatement};
-use polkadot_node_subsystem_util::runtime::RuntimeInfo;
+use polkadot_node_subsystem_util::{metered::oneshot as metered_oneshot, runtime::RuntimeInfo};
 use polkadot_primitives::v2::{CandidateHash, DisputeStatement, Hash, SessionIndex};
 use polkadot_subsystem::{
 	messages::{AllMessages, DisputeCoordinatorMessage},
@@ -353,7 +353,7 @@ async fn get_candidate_votes<Context: SubsystemContext>(
 	session_index: SessionIndex,
 	candidate_hash: CandidateHash,
 ) -> JfyiErrorResult<Option<CandidateVotes>> {
-	let (tx, rx) = oneshot::channel();
+	let (tx, rx) = metered_oneshot::channel("get_candidate_votes");
 	ctx.send_message(AllMessages::DisputeCoordinator(
 		DisputeCoordinatorMessage::QueryCandidateVotes(vec![(session_index, candidate_hash)], tx),
 	))

--- a/node/subsystem-types/Cargo.toml
+++ b/node/subsystem-types/Cargo.toml
@@ -18,3 +18,4 @@ sc-network = { git = "https://github.com/paritytech/substrate", branch = "master
 smallvec = "1.8.0"
 substrate-prometheus-endpoint = { git = "https://github.com/paritytech/substrate", branch = "master" }
 thiserror = "1.0.30"
+metered-channel = { path = "../metered-channel" }

--- a/node/subsystem-types/src/lib.rs
+++ b/node/subsystem-types/src/lib.rs
@@ -27,6 +27,8 @@ use std::{fmt, sync::Arc};
 pub use polkadot_primitives::v2::{BlockNumber, Hash};
 use smallvec::SmallVec;
 
+pub use metered_channel as metered;
+
 pub mod errors;
 pub mod messages;
 

--- a/node/subsystem-types/src/messages.rs
+++ b/node/subsystem-types/src/messages.rs
@@ -23,6 +23,8 @@
 //! Subsystems' APIs are defined separately from their implementation, leading to easier mocking.
 
 use futures::channel::oneshot;
+use metered_channel::oneshot as metered_oneshot;
+
 use sc_network::Multiaddr;
 use thiserror::Error;
 
@@ -268,7 +270,7 @@ pub enum DisputeCoordinatorMessage {
 		///		- or other explicit votes on that candidate already recorded
 		///		- or recovered availability for the candidate
 		///		- or the imported statements are backing/approval votes, which are always accepted.
-		pending_confirmation: oneshot::Sender<ImportStatementsResult>,
+		pending_confirmation: metered_oneshot::MeteredSender<ImportStatementsResult>,
 	},
 	/// Fetch a list of all recent disputes the co-ordinator is aware of.
 	/// These are disputes which have occurred any time in recent sessions,
@@ -280,7 +282,7 @@ pub enum DisputeCoordinatorMessage {
 	/// Get candidate votes for a candidate.
 	QueryCandidateVotes(
 		Vec<(SessionIndex, CandidateHash)>,
-		oneshot::Sender<Vec<(SessionIndex, CandidateHash, CandidateVotes)>>,
+		metered_oneshot::MeteredSender<Vec<(SessionIndex, CandidateHash, CandidateVotes)>>,
 	),
 	/// Sign and issue local dispute votes. A value of `true` indicates validity, and `false` invalidity.
 	IssueLocalStatement(SessionIndex, CandidateHash, CandidateReceipt, bool),


### PR DESCRIPTION
This the basic approach to do metered changes, it uses default timeouts of 6 seconds (warning) and 360 seconds to behave as if the sender would be dropped.

Currently `<_ as Measurable>::measurements()` on completion of the future is _not_ evaluated.


Note: I'd like to collect some feedback and usage, I am not 100% convinced we want this after all and that the cost / gain benefit really is there.