### PR TITLE
upgrade coarsetime to 0.1.22 to fix a potential panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1138,9 +1138,9 @@ dependencies = [
 
 [[package]]
 name = "coarsetime"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "441947d9f3582f20b35fdd2bc5ada3a8c74c9ea380d66268607cb399b510ee08"
+checksum = "454038500439e141804c655b4cd1bc6a70bcb95cd2bc9463af5661b6956f0e46"
 dependencies = [
  "libc",
  "once_cell",

--- a/node/metered-channel/Cargo.toml
+++ b/node/metered-channel/Cargo.toml
@@ -13,7 +13,7 @@ gum = { package = "tracing-gum", path = "../gum" }
 thiserror = "1.0.30"
 crossbeam-queue = "0.3.5"
 nanorand = { version = "0.7.0", default-features = false, features = ["wyrand"] }
-coarsetime = "0.1.21"
+coarsetime = "^0.1.22"
 
 [dev-dependencies]
 futures = { version = "0.3.21", features = ["thread-pool"] }


### PR DESCRIPTION
Currently there is a cfg switch that I misparsed to use the other branch. This unifies the two branches in https://github.com/jedisct1/rust-coarsetime/pull/21 ~~which has yet to make it into a release~~ just made it into `0.1.22` .