### PR TITLE
[ci] update block- and extrinsic base weights

### DIFF
--- a/scripts/run_benches_for_runtime.sh
+++ b/scripts/run_benches_for_runtime.sh
@@ -37,3 +37,12 @@ while read -r line; do
     --output="./runtime/${runtime}/src/weights/${pallet/::/_}.rs"
 done < "${runtime}_pallets"
 rm "${runtime}_pallets"
+
+# Benchmark base weights
+./target/production/polkadot benchmark-overhead \
+  --chain="${runtime}-dev" \
+  --execution=wasm \
+  --wasm-execution=compiled \
+  --weight-path="runtime/${runtime}/constants/src/weights/" \
+  --warmup=10 \
+  --repeat=100


### PR DESCRIPTION
After https://github.com/paritytech/polkadot/pull/5202, https://github.com/paritytech/polkadot/pull/5137, and https://github.com/paritytech/substrate/pull/11091 are done, we can run these benches as part of the usual weights jobs