### PR TITLE
Update storage weights

### DIFF
--- a/runtime/polkadot/constants/src/weights/paritydb_weights.rs
+++ b/runtime/polkadot/constants/src/weights/paritydb_weights.rs
@@ -15,6 +15,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! THIS FILE WAS AUTO-GENERATED USING THE SUBSTRATE BENCHMARK CLI VERSION 4.0.0-dev
+//! DATE: 2022-03-30 (Y/M/D)
+//!
+//! DATABASE: `ParityDb`, RUNTIME: `Polkadot`
+//! BLOCK-NUM: `BlockId::Number(9653477)`
+//! SKIP-WRITE: `false`, SKIP-READ: `false`, WARMUPS: `1`
+//! STATE-VERSION: `V0`, STATE-CACHE-SIZE: `0`
+//! WEIGHT-PATH: `runtime/polkadot/constants/src/weights/`
+//! METRIC: `Average`, WEIGHT-MUL: `1.1`, WEIGHT-ADD: `0`
+
+// Executed Command:
+//   ./target/production/polkadot
+//   benchmark-storage
+//   --db=paritydb
+//   --state-version=0
+//   --mul=1.1
+//   --weight-path=runtime/polkadot/constants/src/weights/
+
+/// Storage DB weights for the `Polkadot` runtime and `ParityDb`.
 pub mod constants {
 	use frame_support::{
 		parameter_types,
@@ -25,8 +44,35 @@ pub mod constants {
 		/// `ParityDB` can be enabled with a feature flag, but is still experimental. These weights
 		/// are available for brave runtime engineers who may want to try this out as default.
 		pub const ParityDbWeight: RuntimeDbWeight = RuntimeDbWeight {
-			read: 8_000 * constants::WEIGHT_PER_NANOS,
-			write: 50_000 * constants::WEIGHT_PER_NANOS,
+			/// Time to read one storage item.
+			/// Calculated by multiplying the *Average* of all values with `1.1` and adding `0`.
+			///
+			/// Stats [NS]:
+			///   Min, Max: 4_611, 13_478_005
+			///   Average:  10_750
+			///   Median:   10_655
+			///   Std-Dev:  12214.49
+			///
+			/// Percentiles [NS]:
+			///   99th: 14_451
+			///   95th: 12_588
+			///   75th: 11_200
+			read: 11_826 * constants::WEIGHT_PER_NANOS,
+
+			/// Time to write one storage item.
+			/// Calculated by multiplying the *Average* of all values with `1.1` and adding `0`.
+			///
+			/// Stats [NS]:
+			///   Min, Max: 8_023, 47_367_740
+			///   Average:  34_592
+			///   Median:   32_703
+			///   Std-Dev:  49417.24
+			///
+			/// Percentiles [NS]:
+			///   99th: 69_379
+			///   95th: 47_168
+			///   75th: 35_252
+			write: 38_052 * constants::WEIGHT_PER_NANOS,
 		};
 	}
 
@@ -39,7 +85,7 @@ pub mod constants {
 		// NOTE: If this test fails but you are sure that the generated values are fine,
 		// you can delete it.
 		#[test]
-		fn sane() {
+		fn bound() {
 			// At least 1 µs.
 			assert!(
 				W::get().reads(1) >= constants::WEIGHT_PER_MICROS,

--- a/runtime/polkadot/constants/src/weights/rocksdb_weights.rs
+++ b/runtime/polkadot/constants/src/weights/rocksdb_weights.rs
@@ -15,6 +15,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! THIS FILE WAS AUTO-GENERATED USING THE SUBSTRATE BENCHMARK CLI VERSION 4.0.0-dev
+//! DATE: 2022-03-29 (Y/M/D)
+//!
+//! DATABASE: `RocksDb`, RUNTIME: `Polkadot`
+//! BLOCK-NUM: `BlockId::Number(9643856)`
+//! SKIP-WRITE: `false`, SKIP-READ: `false`, WARMUPS: `1`
+//! STATE-VERSION: `V0`, STATE-CACHE-SIZE: `0`
+//! WEIGHT-PATH: `runtime/polkadot/constants/src/weights/`
+//! METRIC: `Average`, WEIGHT-MUL: `1.1`, WEIGHT-ADD: `0`
+
+// Executed Command:
+//   ./target/production/polkadot
+//   benchmark-storage
+//   --state-version=0
+//   --mul=1.1
+//   --weight-path=runtime/polkadot/constants/src/weights/
+
+/// Storage DB weights for the `Polkadot` runtime and `RocksDb`.
 pub mod constants {
 	use frame_support::{
 		parameter_types,
@@ -25,8 +43,35 @@ pub mod constants {
 		/// By default, Substrate uses `RocksDB`, so this will be the weight used throughout
 		/// the runtime.
 		pub const RocksDbWeight: RuntimeDbWeight = RuntimeDbWeight {
-			read: 25_000 * constants::WEIGHT_PER_NANOS,
-			write: 100_000 * constants::WEIGHT_PER_NANOS,
+			/// Time to read one storage item.
+			/// Calculated by multiplying the *Average* of all values with `1.1` and adding `0`.
+			///
+			/// Stats [NS]:
+			///   Min, Max: 5_015, 1_441_022
+			///   Average:  18_635
+			///   Median:   17_795
+			///   Std-Dev:  4829.75
+			///
+			/// Percentiles [NS]:
+			///   99th: 32_074
+			///   95th: 26_658
+			///   75th: 19_363
+			read: 20_499 * constants::WEIGHT_PER_NANOS,
+
+			/// Time to write one storage item.
+			/// Calculated by multiplying the *Average* of all values with `1.1` and adding `0`.
+			///
+			/// Stats [NS]:
+			///   Min, Max: 16_368, 34_500_937
+			///   Average:  75_882
+			///   Median:   74_236
+			///   Std-Dev:  64706.41
+			///
+			/// Percentiles [NS]:
+			///   99th: 111_151
+			///   95th: 92_666
+			///   75th: 80_297
+			write: 83_471 * constants::WEIGHT_PER_NANOS,
 		};
 	}
 
@@ -39,7 +84,7 @@ pub mod constants {
 		// NOTE: If this test fails but you are sure that the generated values are fine,
 		// you can delete it.
 		#[test]
-		fn sane() {
+		fn bound() {
 			// At least 1 µs.
 			assert!(
 				W::get().reads(1) >= constants::WEIGHT_PER_MICROS,


### PR DESCRIPTION
Update RocksDB storage weights.  
- Read: 25µs -> 20.5µs
- Write: 100µs -> 83.47µs

Update ParityDB storage weigts:
- Read: 8µs -> 11.8µs
- Write: 50µs -> 38µs

We add 10% to the average to account for future state growth.  
I could do the same for Kusama if needed.  

How to reproduce these results on reference hardware:  
1. Optional: Download a snapshot from [Polkachu](https://polkachu.com/snapshots/) if you don't have a synced node
2. Run the benchmark and generate the weight files (add a `--db=paritydb` for ParityDb).
You may need to pass in the `--base-path` command if you extracted the snapshot into a different directory.
```sh
./target/production/polkadot benchmark-storage --state-version=0 --mul=1.1 --weight-path=runtime/polkadot/constants/src/weights/
```