### PR TITLE
Integrate `benchmark-block`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6437,6 +6437,7 @@ dependencies = [
  "frame-benchmarking-cli",
  "futures 0.3.21",
  "log",
+ "polkadot-client",
  "polkadot-node-core-pvf",
  "polkadot-node-metrics",
  "polkadot-performance-test",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -21,6 +21,7 @@ futures = "0.3.21"
 pyro = { package = "pyroscope", version = "0.3.1", optional = true }
 
 service = { package = "polkadot-service", path = "../node/service", default-features = false, optional = true }
+polkadot-client = { path = "../node/client", optional = true }
 polkadot-node-core-pvf = { path = "../node/core/pvf", optional = true }
 polkadot-performance-test = { path = "../node/test/performance-test", optional = true }
 
@@ -50,6 +51,7 @@ cli = [
 	"sc-tracing",
 	"frame-benchmarking-cli",
 	"try-runtime-cli",
+	"polkadot-client",
 	"polkadot-node-core-pvf",
 	"polkadot-performance-test",
 ]

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -60,7 +60,7 @@ pub enum Subcommand {
 		about = "Benchmark the execution time of historic blocks and compare it to their consumed weight."
 	)]
 	BenchmarkBlock(frame_benchmarking_cli::BlockCmd),
-	
+
 	/// Sub command for benchmarking the storage speed.
 	#[clap(name = "benchmark-storage", about = "Benchmark storage speed.")]
 	BenchmarkStorage(frame_benchmarking_cli::StorageCmd),

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -54,6 +54,14 @@ pub enum Subcommand {
 	#[clap(name = "benchmark", about = "Benchmark runtime pallets.")]
 	Benchmark(frame_benchmarking_cli::BenchmarkCmd),
 
+	/// Benchmark the execution time of historic blocks and compare it to their consumed weight.
+	#[clap(
+		name = "benchmark-block",
+		about = "Benchmark the execution time of historic blocks and compare it to their consumed weight."
+	)]
+	BenchmarkBlock(frame_benchmarking_cli::BlockCmd),
+	
+	/// Sub command for benchmarking the storage speed.
 	#[clap(name = "benchmark-storage", about = "Benchmark storage speed.")]
 	BenchmarkStorage(frame_benchmarking_cli::StorageCmd),
 

--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -478,7 +478,6 @@ pub fn run() -> Result<()> {
 		Some(Subcommand::BenchmarkBlock(cmd)) => {
 			let runner = cli.create_runner(cmd)?;
 			let chain_spec = &runner.config().chain_spec;
-			set_default_ss58_version(chain_spec);
 
 			#[cfg(feature = "rococo-native")]
 			if chain_spec.is_rococo() || chain_spec.is_wococo() || chain_spec.is_versi() {

--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -475,6 +475,66 @@ pub fn run() -> Result<()> {
 			#[cfg(not(feature = "polkadot-native"))]
 			panic!("No runtime feature (polkadot, kusama, westend, rococo) is enabled")
 		},
+		Some(Subcommand::BenchmarkBlock(cmd)) => {
+			let runner = cli.create_runner(cmd)?;
+			let chain_spec = &runner.config().chain_spec;
+			set_default_ss58_version(chain_spec);
+
+			#[cfg(feature = "rococo-native")]
+			if chain_spec.is_rococo() || chain_spec.is_wococo() || chain_spec.is_versi() {
+				return Ok(runner.async_run(|mut config| {
+					let (client, _, _, task_manager) = service::new_chain_ops(&mut config, None)?;
+
+					if let polkadot_client::Client::Rococo(pd) = &*client {
+						Ok((cmd.run(pd.clone()).map_err(Error::SubstrateCli), task_manager))
+					} else {
+						unreachable!("Checked above; qed")
+					}
+				})?)
+			}
+
+			#[cfg(feature = "kusama-native")]
+			if chain_spec.is_kusama() {
+				return Ok(runner.async_run(|mut config| {
+					let (client, _, _, task_manager) = service::new_chain_ops(&mut config, None)?;
+
+					if let polkadot_client::Client::Kusama(pd) = &*client {
+						Ok((cmd.run(pd.clone()).map_err(Error::SubstrateCli), task_manager))
+					} else {
+						unreachable!("Checked above; qed")
+					}
+				})?)
+			}
+
+			#[cfg(feature = "westend-native")]
+			if chain_spec.is_westend() {
+				return Ok(runner.async_run(|mut config| {
+					let (client, _, _, task_manager) = service::new_chain_ops(&mut config, None)?;
+
+					if let polkadot_client::Client::Westend(pd) = &*client {
+						Ok((cmd.run(pd.clone()).map_err(Error::SubstrateCli), task_manager))
+					} else {
+						unreachable!("Checked above; qed")
+					}
+				})?)
+			}
+
+			#[cfg(feature = "polkadot-native")]
+			{
+				return Ok(runner.async_run(|mut config| {
+					let (client, _, _, task_manager) = service::new_chain_ops(&mut config, None)?;
+
+					if let polkadot_client::Client::Polkadot(pd) = &*client {
+						Ok((cmd.run(pd.clone()).map_err(Error::SubstrateCli), task_manager))
+					} else {
+						unreachable!("Checked above; qed")
+					}
+				})?)
+			}
+
+			#[cfg(not(feature = "polkadot-native"))]
+			unreachable!("No runtime feature (polkadot, kusama, westend, rococo) is enabled")
+		},
 		Some(Subcommand::BenchmarkStorage(cmd)) => {
 			let runner = cli.create_runner(cmd)?;
 			let chain_spec = &runner.config().chain_spec;

--- a/tests/benchmark_block_works.rs
+++ b/tests/benchmark_block_works.rs
@@ -74,8 +74,6 @@ fn benchmark_block(runtime: &str, base_path: &Path, block: u32) -> Result<(), St
 		.args(["benchmark-block", "--chain", &runtime])
 		.arg("-d")
 		.arg(base_path)
-		.arg("--weight-path")
-		.arg(base_path)
 		.args(["--pruning", "archive"])
 		.args(["--from", &block.to_string(), "--to", &block.to_string()])
 		.args(["--repeat", "2"])

--- a/tests/benchmark_block_works.rs
+++ b/tests/benchmark_block_works.rs
@@ -1,0 +1,91 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2022 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+// Unix only since it uses signals.
+#![cfg(unix)]
+
+use assert_cmd::cargo::cargo_bin;
+use std::{process::Command, path::Path, time::Duration, result::Result};
+use tempfile::tempdir;
+use nix::{
+	sys::signal::{kill, Signal::SIGINT},
+	unistd::Pid,
+};
+
+pub mod common;
+
+static RUNTIMES: [&'static str; 6] = ["polkadot", "kusama", "westend", "rococo", "wococo", "versi"];
+
+/// `benchmark-block` works for all dev runtimes using the wasm executor.
+#[tokio::test]
+async fn benchmark_block_works() {
+	for runtime in RUNTIMES {
+		let tmp_dir = tempdir().expect("could not create a temp dir");
+		let base_path = tmp_dir.path();
+		let runtime = format!("{}-dev", runtime);
+
+		// Build a chain with a single block.
+		build_chain(&runtime, base_path).await.unwrap();
+		// Benchmark the that one.
+		benchmark_block(&runtime, base_path, 1).unwrap();
+	}
+}
+
+/// Builds a chain with one block for the given runtime and base path.
+async fn build_chain(runtime: &str, base_path: &Path) -> Result<(), String> {
+	let mut cmd = Command::new(cargo_bin("polkadot"))
+		.args(["--chain", &runtime, "--force-authoring", "--alice"])
+		.arg("-d")
+		.arg(base_path)
+		.arg("--port")
+		.arg("33034")
+		.spawn()
+		.unwrap();
+
+	// Wait for the chain to produce one block.
+	let ok = common::wait_n_finalized_blocks(1, Duration::from_secs(60)).await;
+	// Send SIGINT to node.
+	kill(Pid::from_raw(cmd.id().try_into().unwrap()), SIGINT).unwrap();
+	// Wait for the node to handle it and exit.
+	assert!(common::wait_for(&mut cmd, 30).map(|x| x.success()).unwrap_or_default());
+
+	ok.map_err(|e| format!("Node did not build the chain: {:?}", e))
+}
+
+/// Benchmarks the given block with the wasm executor.
+fn benchmark_block(runtime: &str, base_path: &Path, block: u32) -> Result<(), String> {
+	// Invoke `benchmark-block` with all options to make sure that they are valid.
+	let status = Command::new(cargo_bin("polkadot"))
+	.args(["benchmark-block", "--chain", &runtime])
+		.arg("-d")
+		.arg(base_path)
+		.arg("--weight-path")
+		.arg(base_path)
+		.args(["--pruning", "archive"])
+		.args(["--from", &block.to_string(), "--to",&block.to_string()])
+		.args(["--repeat", "2"])
+		.args(["--execution", "wasm", "--wasm-execution", "compiled"])
+		.status()
+		.map_err(|e| format!("command failed: {:?}", e))?;
+
+	if !status.success() {
+		return Err("Command failed".into())
+	}
+
+	Ok(())
+}

--- a/tests/benchmark_block_works.rs
+++ b/tests/benchmark_block_works.rs
@@ -20,12 +20,12 @@
 #![cfg(unix)]
 
 use assert_cmd::cargo::cargo_bin;
-use std::{process::Command, path::Path, time::Duration, result::Result};
-use tempfile::tempdir;
 use nix::{
 	sys::signal::{kill, Signal::SIGINT},
 	unistd::Pid,
 };
+use std::{path::Path, process::Command, result::Result, time::Duration};
+use tempfile::tempdir;
 
 pub mod common;
 
@@ -71,13 +71,13 @@ async fn build_chain(runtime: &str, base_path: &Path) -> Result<(), String> {
 fn benchmark_block(runtime: &str, base_path: &Path, block: u32) -> Result<(), String> {
 	// Invoke `benchmark-block` with all options to make sure that they are valid.
 	let status = Command::new(cargo_bin("polkadot"))
-	.args(["benchmark-block", "--chain", &runtime])
+		.args(["benchmark-block", "--chain", &runtime])
 		.arg("-d")
 		.arg(base_path)
 		.arg("--weight-path")
 		.arg(base_path)
 		.args(["--pruning", "archive"])
-		.args(["--from", &block.to_string(), "--to",&block.to_string()])
+		.args(["--from", &block.to_string(), "--to", &block.to_string()])
 		.args(["--repeat", "2"])
 		.args(["--execution", "wasm", "--wasm-execution", "compiled"])
 		.status()


### PR DESCRIPTION
Integrate the `benchmark-block` command to compare block execution time to consumed weight.
Example output from https://github.com/paritytech/substrate/pull/11091:  
```pre
Block 46 with  5299 tx used  67.04% of its weight ( 1,011,772,407 of  1,509,238,171 ns)    
Block 47 with  5299 tx used  65.75% of its weight (   992,298,518 of  1,509,238,171 ns)    
Block 48 with   208 tx used  69.95% of its weight (    47,328,881 of     67,660,429 ns)    
Block 49 with     2 tx used  69.93% of its weight (     6,524,096 of      9,329,057 ns)
```

Last one :relieved:. I will refactor afterwards to clean this up https://github.com/paritytech/substrate/issues/11140 
Currently working on a test.  

Example invocation to measure some historic polkadot blocks:  
```sh
./target/release/polkadot benchmark-block --from 9500000 --to 9500005 --execution wasm --wasm-execution compiled --pruning archive --db paritydb

```