### PR TITLE
CI: Require Kusama benchmark to pass

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -821,8 +821,6 @@ short-benchmark-kusama:
   <<:                              *short-bench
   variables:
     RUNTIME:                       kusama
-  # FIXME: https://github.com/paritytech/substrate/issues/11130
-  allow_failure:                   true
 
 short-benchmark-westend:
   <<:                              *short-bench


### PR DESCRIPTION
https://github.com/paritytech/substrate/pull/11137 fixed the last failing bench, we can now require all to pass.