### PR TITLE
fix approval-voting force-approve

### DIFF
--- a/node/core/approval-voting/src/import.rs
+++ b/node/core/approval-voting/src/import.rs
@@ -506,18 +506,6 @@ pub(crate) async fn handle_new_head(
 			children: Vec::new(),
 		};
 
-		if let Some(up_to) = force_approve {
-			gum::debug!(target: LOG_TARGET, ?block_hash, up_to, "Enacting force-approve");
-
-			let approved_hashes = crate::ops::force_approve(db, block_hash, up_to)
-				.map_err(|e| SubsystemError::with_origin("approval-voting", e))?;
-
-			// Notify chain-selection of all approved hashes.
-			for hash in approved_hashes {
-				ctx.send_message(ChainSelectionMessage::Approved(hash)).await;
-			}
-		}
-
 		gum::trace!(
 			target: LOG_TARGET,
 			?block_hash,
@@ -538,6 +526,21 @@ pub(crate) async fn handle_new_head(
 				)
 			})
 			.map_err(|e| SubsystemError::with_origin("approval-voting", e))?;
+
+		// force-approve needs to load the current block entry as well as all
+		// ancestors. this can only be done after writing the block entry above.
+		if let Some(up_to) = force_approve {
+			gum::debug!(target: LOG_TARGET, ?block_hash, up_to, "Enacting force-approve");
+
+			let approved_hashes = crate::ops::force_approve(db, block_hash, up_to)
+				.map_err(|e| SubsystemError::with_origin("approval-voting", e))?;
+
+			// Notify chain-selection of all approved hashes.
+			for hash in approved_hashes {
+				ctx.send_message(ChainSelectionMessage::Approved(hash)).await;
+			}
+		}
+
 		approval_meta.push(BlockApprovalMeta {
 			hash: block_hash,
 			number: block_header.number,


### PR DESCRIPTION
The force-approve logic was broken because it was trying to read a block entry before writing it.