### PR TITLE
[ci] add update_rococo_weights job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -535,6 +535,11 @@ update_westend_weights:
   variables:
     RUNTIME:                       westend
 
+update_rococo_weights:
+  <<:                              *update-weights
+  variables:
+    RUNTIME:                       rococo
+
 #### stage:                        stage3
 
 build-rustdoc:


### PR DESCRIPTION
This'll allow us to generate the weights in the same way we do it for the other 3 runtimes