### PR TITLE
Add epoch index to well known keys

### DIFF
--- a/primitives/src/v2/mod.rs
+++ b/primitives/src/v2/mod.rs
@@ -179,7 +179,7 @@ pub mod well_known_keys {
 	/// The current epoch index.
 	///
 	/// The storage item should be access as a `u64` encoded value.
-	pub const EPOCH_INDEX: &[u8] = 
+	pub const EPOCH_INDEX: &[u8] =
 		&hex!["1cb6f36e027abb2091cfb5110ab5087f38316cbf8fa0da822a20ac1c55bf1be3"];
 
 	/// The current relay chain block randomness

--- a/primitives/src/v2/mod.rs
+++ b/primitives/src/v2/mod.rs
@@ -176,6 +176,12 @@ pub mod well_known_keys {
 	//     <Hrmp as Store>::HrmpEgressChannelsIndex::prefix_hash();
 	//
 
+	/// The current epoch index.
+	///
+	/// The storage item should be access as a `u64` encoded value.
+	pub const EPOCH_INDEX: &[u8] = 
+		&hex!["1cb6f36e027abb2091cfb5110ab5087f38316cbf8fa0da822a20ac1c55bf1be3"];
+
 	/// The current relay chain block randomness
 	///
 	/// The storage item should be accessed as a `schnorrkel::Randomness` encoded value.


### PR DESCRIPTION
Adds relay chain babe epoch index to well known keys. We want to use this on Moonbeam to decide when to update the babe epoch randomness values stored locally. Also for executing randomness request fulfillment upon epoch changes.

The test to compute this key: https://github.com/4meta5/substrate/commit/7a34b399edf18625ff66d80cf6a1d163c8f3da64

