### PR TITLE
Prevent reserve transfer of assets to trusted teleporters

### DIFF
--- a/runtime/kusama/src/xcm_config.rs
+++ b/runtime/kusama/src/xcm_config.rs
@@ -20,7 +20,11 @@ use super::{
 	parachains_origin, AccountId, Balances, Call, CouncilCollective, Event, Origin, ParaId,
 	Runtime, WeightToFee, XcmPallet,
 };
-use frame_support::{match_types, parameter_types, traits::{Everything, EverythingBut}, weights::Weight};
+use frame_support::{
+	match_types, parameter_types,
+	traits::{Everything, EverythingBut},
+	weights::Weight,
+};
 use runtime_common::{xcm_sender, ToAuthor};
 use xcm::latest::prelude::*;
 use xcm_builder::{
@@ -105,7 +109,7 @@ parameter_types! {
 	pub const KusamaForEncointer: (MultiAssetFilter, MultiLocation) = (Kusama::get(), Parachain(1001).into());
 }
 pub type TrustedTeleporters =
-	(xcm_builder::Case<KusamaForStatemine>,  xcm_builder::Case<KusamaForEncointer>);
+	(xcm_builder::Case<KusamaForStatemine>, xcm_builder::Case<KusamaForEncointer>);
 
 match_types! {
 	pub type OnlyTrustedTeleporters: impl Contains<(MultiLocation, crate::Vec<MultiAsset>)> = {

--- a/runtime/polkadot/src/xcm_config.rs
+++ b/runtime/polkadot/src/xcm_config.rs
@@ -188,6 +188,7 @@ impl pallet_xcm::Config for Runtime {
 	type XcmExecuteFilter = Nothing; // == Deny All
 	type XcmExecutor = xcm_executor::XcmExecutor<XcmConfig>;
 	type XcmTeleportFilter = Everything; // == Allow All
+
 	// Anyone is able to use reserve transfers regardless of who they are and what they want to
 	// transfer (unless it is trustfully teleportable, in which case do that instead as is simpler)
 	type XcmReserveTransferFilter = EverythingBut<OnlyTrustedTeleporters>;

--- a/runtime/rococo/src/xcm_config.rs
+++ b/runtime/rococo/src/xcm_config.rs
@@ -21,7 +21,7 @@ use super::{
 	XcmPallet,
 };
 use frame_support::{
-	parameter_types, match_types,
+	match_types, parameter_types,
 	traits::{Everything, EverythingBut, IsInVec, Nothing},
 	weights::Weight,
 };

--- a/runtime/westend/src/xcm_config.rs
+++ b/runtime/westend/src/xcm_config.rs
@@ -21,7 +21,7 @@ use super::{
 	WeightToFee, XcmPallet,
 };
 use frame_support::{
-	parameter_types, match_types,
+	match_types, parameter_types,
 	traits::{Everything, EverythingBut, Nothing},
 };
 use runtime_common::{xcm_sender, ToAuthor};


### PR DESCRIPTION
Why: you get into a pickle trying to undo the reserve transfer,
as kusama only regards itself as a reserve (not statemine) so the return fails leaving the assets in the sovereign account on kusama. ( See https://github.com/paritytech/polkadot/issues/5233 ) 

The sibling PR to this is https://github.com/paritytech/cumulus/pull/1144