### PR TITLE
Improve error handling in approval voting block import

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6682,6 +6682,7 @@ dependencies = [
  "sp-keyring",
  "sp-keystore",
  "sp-runtime",
+ "thiserror",
  "tracing-gum",
 ]
 

--- a/node/core/approval-voting/Cargo.toml
+++ b/node/core/approval-voting/Cargo.toml
@@ -15,6 +15,7 @@ merlin = "2.0"
 schnorrkel = "0.9.1"
 kvdb = "0.11.0"
 derive_more = "0.99.17"
+thiserror = "1.0.30"
 
 polkadot-node-subsystem = { path = "../../subsystem" }
 polkadot-node-subsystem-util = { path = "../../subsystem-util" }

--- a/node/core/approval-voting/src/import.rs
+++ b/node/core/approval-voting/src/import.rs
@@ -106,8 +106,7 @@ enum ImportedBlockInfoError {
 	VrfInfoUnavailable,
 }
 
-// Computes information about the imported block. Returns `None` if the info couldn't be extracted -
-// failure to communicate with overseer,
+/// Computes information about the imported block. Returns an error if the info couldn't be extracted.
 async fn imported_block_info(
 	ctx: &mut (impl SubsystemContext + overseer::SubsystemContext),
 	env: ImportedBlockInfoEnv<'_>,

--- a/node/core/approval-voting/src/import.rs
+++ b/node/core/approval-voting/src/import.rs
@@ -993,7 +993,7 @@ pub(crate) mod tests {
 
 				let info = imported_block_info(&mut ctx, env, hash, &header).await;
 
-				assert_matches!(info, Err(ImportedBlockInfoError::SessionInfoUnavailable));
+				assert_matches!(info, Err(ImportedBlockInfoError::BlockFromAncientSession));
 			})
 		};
 

--- a/node/subsystem-types/src/errors.rs
+++ b/node/subsystem-types/src/errors.rs
@@ -21,8 +21,8 @@ use crate::JaegerError;
 /// A description of an error causing the runtime API request to be unservable.
 #[derive(thiserror::Error, Debug, Clone)]
 pub enum RuntimeApiError {
-	/// The runtime API cannot be executed due to a
-	#[error("The runtime API '{runtime_api_name}' cannot be executed")]
+	/// The runtime API cannot be executed due to a runtime error.
+	#[error("The runtime API '{runtime_api_name}' cannot be executed: {source}")]
 	Execution {
 		/// The runtime API being called
 		runtime_api_name: &'static str,


### PR DESCRIPTION
We already print out a warning here, so we might as well also print out the actual error message instead of just ignoring it.

(Motivation: I was investigating [this issue](https://github.com/paritytech/substrate/issues/11132) which triggers this warning. I'd like to have the WASM stack trace printed out in the error message when something panics; we can't do that if the errors are ignored and never printed out the first place.)