### PR TITLE
Introduce XcmConversionError

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12657,6 +12657,7 @@ name = "xcm"
 version = "0.9.18"
 dependencies = [
  "derivative",
+ "frame-support",
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",

--- a/runtime/common/src/xcm_sender.rs
+++ b/runtime/common/src/xcm_sender.rs
@@ -68,7 +68,7 @@ impl<T: configuration::Config + dmp::Config, W: xcm::WrapVersion, P: PriceForPar
 		let config = <configuration::Pallet<T>>::config();
 		let para = id.into();
 		let price = P::price_for_parachain_delivery(para, &xcm);
-		let blob = W::wrap_version(&d, xcm).map_err(|()| DestinationUnsupported)?.encode();
+		let blob = W::wrap_version(&d, xcm).map_err(DestinationUnsupported)?.encode();
 		<dmp::Pallet<T>>::can_queue_downward_message(&config, &para, &blob)
 			.map_err(Into::<SendError>::into)?;
 

--- a/xcm/Cargo.toml
+++ b/xcm/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 impl-trait-for-tuples = "0.2.2"
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 parity-scale-codec = { version = "3.1.2", default-features = false, features = [ "derive", "max-encoded-len" ] }
 scale-info = { version = "2.0.0", default-features = false, features = ["derive"] }
 sp-io = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
@@ -20,6 +21,7 @@ default = ["std"]
 wasm-api = []
 runtime-benchmarks = []
 std = [
+	"frame-support/std",
 	"parity-scale-codec/std",
 	"scale-info/std",
 	"serde",

--- a/xcm/pallet-xcm/src/tests.rs
+++ b/xcm/pallet-xcm/src/tests.rs
@@ -24,7 +24,7 @@ use frame_support::{
 };
 use polkadot_parachain::primitives::{AccountIdConversion, Id as ParaId};
 use sp_runtime::traits::{BlakeTwo256, Hash};
-use xcm::{latest::QueryResponseInfo, prelude::*};
+use xcm::{latest::QueryResponseInfo, prelude::*, VersionedConversionError};
 use xcm_builder::AllowKnownQueryResponses;
 use xcm_executor::{traits::ShouldExecute, XcmExecutor};
 
@@ -963,7 +963,10 @@ fn subscriber_side_subscription_works() {
 
 		// This message cannot be sent to a v2 remote.
 		let v2_msg = xcm::v2::Xcm::<()>(vec![xcm::v2::Instruction::Trap(0)]);
-		assert_eq!(XcmPallet::wrap_version(&remote, v2_msg.clone()), Err(()));
+		assert_eq!(
+			XcmPallet::wrap_version(&remote, v2_msg.clone()),
+			Err(VersionedConversionError::UnsupportedVersion)
+		);
 
 		let message = Xcm(vec![
 			// Remote upgraded to XCM v2
@@ -1002,7 +1005,10 @@ fn auto_subscription_works() {
 			XcmPallet::wrap_version(&remote_v2, msg_v2.clone()),
 			Ok(VersionedXcm::from(msg_v2.clone())),
 		);
-		assert_eq!(XcmPallet::wrap_version(&remote_v2, msg_v3.clone()), Err(()));
+		assert_eq!(
+			XcmPallet::wrap_version(&remote_v2, msg_v3.clone()),
+			Err(VersionedConversionError::UnsupportedVersion),
+		);
 
 		let expected = vec![(remote_v2.clone().into(), 2)];
 		assert_eq!(VersionDiscoveryQueue::<Test>::get().into_inner(), expected);
@@ -1011,7 +1017,10 @@ fn auto_subscription_works() {
 			XcmPallet::wrap_version(&remote_v3, msg_v2.clone()),
 			Ok(VersionedXcm::from(msg_v2.clone())),
 		);
-		assert_eq!(XcmPallet::wrap_version(&remote_v3, msg_v3.clone()), Err(()));
+		assert_eq!(
+			XcmPallet::wrap_version(&remote_v3, msg_v3.clone()),
+			Err(VersionedConversionError::UnsupportedVersion),
+		);
 
 		let expected = vec![(remote_v2.clone().into(), 2), (remote_v3.clone().into(), 2)];
 		assert_eq!(VersionDiscoveryQueue::<Test>::get().into_inner(), expected);
@@ -1082,7 +1091,10 @@ fn auto_subscription_works() {
 			XcmPallet::wrap_version(&remote_v2, msg_v2.clone()),
 			Ok(VersionedXcm::V2(msg_v2))
 		);
-		assert_eq!(XcmPallet::wrap_version(&remote_v2, msg_v3.clone()), Err(()));
+		assert_eq!(
+			XcmPallet::wrap_version(&remote_v2, msg_v3.clone()),
+			Err(VersionedConversionError::UnsupportedVersion),
+		);
 	})
 }
 

--- a/xcm/procedural/src/v3.rs
+++ b/xcm/procedural/src/v3.rs
@@ -172,8 +172,8 @@ pub mod junctions {
 
 		quote! {
 			impl core::convert::TryFrom<crate::v2::Junctions> for Junctions {
-				type Error = ();
-				fn try_from(mut old: crate::v2::Junctions) -> core::result::Result<Self, ()> {
+				type Error = ConversionError;
+				fn try_from(mut old: crate::v2::Junctions) -> core::result::Result<Self, ConversionError> {
 					use Junctions::*;
 					Ok(match old {
 						crate::v2::Junctions::Here => Here,

--- a/xcm/src/v3/junction.rs
+++ b/xcm/src/v3/junction.rs
@@ -16,7 +16,7 @@
 
 //! Support data structures for `MultiLocation`, primarily the `Junction` datatype.
 
-use super::{Junctions, MultiLocation};
+use super::{ConversionError, Junctions, MultiLocation};
 use crate::{
 	v2::{
 		BodyId as OldBodyId, BodyPart as OldBodyPart, Junction as OldJunction,
@@ -98,8 +98,8 @@ pub enum BodyId {
 }
 
 impl TryFrom<OldBodyId> for BodyId {
-	type Error = ();
-	fn try_from(value: OldBodyId) -> Result<Self, ()> {
+	type Error = ConversionError;
+	fn try_from(value: OldBodyId) -> Result<Self, ConversionError> {
 		use OldBodyId::*;
 		Ok(match value {
 			Unit => Self::Unit,
@@ -109,7 +109,7 @@ impl TryFrom<OldBodyId> for BodyId {
 					r.copy_from_slice(&n[..]);
 					Self::Moniker(r)
 				} else {
-					return Err(())
+					return Err(ConversionError::BadMonikerLength)
 				},
 			Index(n) => Self::Index(n),
 			Executive => Self::Executive,
@@ -169,8 +169,8 @@ impl BodyPart {
 }
 
 impl TryFrom<OldBodyPart> for BodyPart {
-	type Error = ();
-	fn try_from(value: OldBodyPart) -> Result<Self, ()> {
+	type Error = ConversionError;
+	fn try_from(value: OldBodyPart) -> Result<Self, ConversionError> {
 		use OldBodyPart::*;
 		Ok(match value {
 			Voice => Self::Voice,
@@ -274,8 +274,8 @@ impl From<u128> for Junction {
 }
 
 impl TryFrom<OldJunction> for Junction {
-	type Error = ();
-	fn try_from(value: OldJunction) -> Result<Self, ()> {
+	type Error = ConversionError;
+	fn try_from(value: OldJunction) -> Result<Self, ConversionError> {
 		use OldJunction::*;
 		Ok(match value {
 			Parachain(id) => Self::Parachain(id),
@@ -285,7 +285,7 @@ impl TryFrom<OldJunction> for Junction {
 			AccountKey20 { network, key } => Self::AccountKey20 { network: network.into(), key },
 			PalletInstance(index) => Self::PalletInstance(index),
 			GeneralIndex(id) => Self::GeneralIndex(id),
-			GeneralKey(_key) => return Err(()),
+			GeneralKey(_key) => return Err(ConversionError::CannotConvertGeneralKey),
 			OnlyChild => Self::OnlyChild,
 			Plurality { id, part } =>
 				Self::Plurality { id: id.try_into()?, part: part.try_into()? },

--- a/xcm/src/v3/junctions.rs
+++ b/xcm/src/v3/junctions.rs
@@ -16,7 +16,7 @@
 
 //! XCM `Junctions`/`InteriorMultiLocation` datatype.
 
-use super::{Junction, MultiLocation, NetworkId};
+use super::{ConversionError, Junction, MultiLocation, NetworkId};
 use core::{convert::TryFrom, mem, result};
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;

--- a/xcm/src/v3/mod.rs
+++ b/xcm/src/v3/mod.rs
@@ -44,8 +44,8 @@ pub use multilocation::{
 	Ancestor, AncestorThen, InteriorMultiLocation, MultiLocation, Parent, ParentThen,
 };
 pub use traits::{
-	send_xcm, validate_send, Error, ExecuteXcm, Outcome, PreparedMessage, Result, SendError,
-	SendResult, SendXcm, Unwrappable, Weight, XcmHash,
+	send_xcm, validate_send, ConversionError, Error, ExecuteXcm, Outcome, PreparedMessage, Result,
+	SendError, SendResult, SendXcm, Unwrappable, Weight, XcmHash,
 };
 // These parts of XCM v2 are unchanged in XCM v3, and are re-imported here.
 pub use super::v2::{OriginKind, WeightLimit};
@@ -169,6 +169,7 @@ pub mod prelude {
 			AssetId::{self, *},
 			AssetInstance::{self, *},
 			BodyId, BodyPart, Error as XcmError, ExecuteXcm,
+			ConversionError as XcmConversionError,
 			Fungibility::{self, *},
 			Instruction::*,
 			InteriorMultiLocation,
@@ -1142,8 +1143,8 @@ pub mod opaque {
 
 // Convert from a v2 response to a v3 response.
 impl TryFrom<OldResponse> for Response {
-	type Error = ();
-	fn try_from(old_response: OldResponse) -> result::Result<Self, ()> {
+	type Error = ConversionError;
+	fn try_from(old_response: OldResponse) -> result::Result<Self, ConversionError> {
 		match old_response {
 			OldResponse::Assets(assets) => Ok(Self::Assets(assets.try_into()?)),
 			OldResponse::Version(version) => Ok(Self::Version(version)),
@@ -1158,16 +1159,16 @@ impl TryFrom<OldResponse> for Response {
 
 // Convert from a v2 XCM to a v3 XCM.
 impl<Call> TryFrom<OldXcm<Call>> for Xcm<Call> {
-	type Error = ();
-	fn try_from(old_xcm: OldXcm<Call>) -> result::Result<Self, ()> {
+	type Error = ConversionError;
+	fn try_from(old_xcm: OldXcm<Call>) -> result::Result<Self, ConversionError> {
 		Ok(Xcm(old_xcm.0.into_iter().map(TryInto::try_into).collect::<result::Result<_, _>>()?))
 	}
 }
 
 // Convert from a v2 instruction to a v3 instruction.
 impl<Call> TryFrom<OldInstruction<Call>> for Instruction<Call> {
-	type Error = ();
-	fn try_from(old_instruction: OldInstruction<Call>) -> result::Result<Self, ()> {
+	type Error = ConversionError;
+	fn try_from(old_instruction: OldInstruction<Call>) -> result::Result<Self, ConversionError> {
 		use OldInstruction::*;
 		Ok(match old_instruction {
 			WithdrawAsset(assets) => Self::WithdrawAsset(assets.try_into()?),

--- a/xcm/src/v3/multilocation.rs
+++ b/xcm/src/v3/multilocation.rs
@@ -16,7 +16,7 @@
 
 //! XCM `MultiLocation` datatype.
 
-use super::{Junction, Junctions};
+use super::{Junction, Junctions, ConversionError};
 use crate::{v2::MultiLocation as OldMultiLocation, VersionedMultiLocation};
 use core::{
 	convert::{TryFrom, TryInto},
@@ -446,8 +446,8 @@ impl MultiLocation {
 }
 
 impl TryFrom<OldMultiLocation> for MultiLocation {
-	type Error = ();
-	fn try_from(x: OldMultiLocation) -> result::Result<Self, ()> {
+	type Error = ConversionError;
+	fn try_from(x: OldMultiLocation) -> result::Result<Self, ConversionError> {
 		Ok(MultiLocation { parents: x.parents, interior: x.interior.try_into()? })
 	}
 }

--- a/xcm/src/v3/traits.rs
+++ b/xcm/src/v3/traits.rs
@@ -16,7 +16,7 @@
 
 //! Cross-Consensus Message format data structures.
 
-use crate::v2::Error as OldError;
+use crate::{v2::Error as OldError, VersionedConversionError};
 use core::result;
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
@@ -126,6 +126,9 @@ pub enum Error {
 	/// The state was not in a condition where the operation was valid to make.
 	#[codec(index = 32)]
 	NoPermission,
+	/// Some error was thrown while trying to convert the XCM to V3.
+	#[codec(index = 33)]
+	FailedToConvertToXcmV3(ConversionError),
 
 	// Errors that happen prior to instructions being executed. These fall outside of the XCM spec.
 	/// XCM version not able to be handled.
@@ -153,8 +156,8 @@ impl MaxEncodedLen for Error {
 }
 
 impl TryFrom<OldError> for Error {
-	type Error = ();
-	fn try_from(old_error: OldError) -> result::Result<Error, ()> {
+	type Error = ConversionError;
+	fn try_from(old_error: OldError) -> result::Result<Error, ConversionError> {
 		use OldError::*;
 		Ok(match old_error {
 			Overflow => Self::Overflow,
@@ -179,7 +182,7 @@ impl TryFrom<OldError> for Error {
 			NotHoldingFees => Self::NotHoldingFees,
 			TooExpensive => Self::TooExpensive,
 			Trap(i) => Self::Trap(i),
-			_ => return Err(()),
+			_ => return Err(ConversionError::UnsupportedXcmErrorVariant),
 		})
 	}
 }
@@ -190,7 +193,10 @@ impl From<SendError> for Error {
 			SendError::NotApplicable | SendError::Unroutable | SendError::MissingArgument =>
 				Error::Unroutable,
 			SendError::Transport(s) => Error::Transport(s),
-			SendError::DestinationUnsupported => Error::DestinationUnsupported,
+			SendError::DestinationUnsupported(VersionedConversionError::UnsupportedVersion) =>
+				Error::DestinationUnsupported,
+			SendError::DestinationUnsupported(VersionedConversionError::V3(e)) =>
+				Error::FailedToConvertToXcmV3(e),
 			SendError::ExceedsMaxMessageSize => Error::ExceedsMaxMessageSize,
 			SendError::Fees => Error::FeesNotMet,
 		}
@@ -198,6 +204,16 @@ impl From<SendError> for Error {
 }
 
 pub type Result = result::Result<(), Error>;
+
+#[derive(Copy, Clone, Encode, Decode, Eq, PartialEq, Debug, TypeInfo, frame_support::PalletError)]
+pub enum ConversionError {
+	AssetIdLengthExceeded,
+	BadMonikerLength,
+	CannotConvertBlob,
+	CannotConvertGeneralKey,
+	MaxAssetCountExceeded,
+	UnsupportedXcmErrorVariant,
+}
 
 /// Local weight type; execution time in picoseconds.
 pub type Weight = u64;
@@ -336,7 +352,7 @@ pub enum SendError {
 	Unroutable,
 	/// The given message cannot be translated into a format that the destination can be expected
 	/// to interpret.
-	DestinationUnsupported,
+	DestinationUnsupported(VersionedConversionError),
 	/// Message could not be sent due to its size exceeding the maximum allowed by the transport
 	/// layer.
 	ExceedsMaxMessageSize,


### PR DESCRIPTION
Create two new types `ConversionError` and `VersionedConversionError` so that XCM APIs that attempt to convert from older versions of XCM to newer ones would throw a `ConversionError` instead of just `()`.

Each variant of the `ConversionError` enum will indicate the reason why the error was thrown. The `VersionedConversionError` enum is then used to wrap the `ConversionError` into one of its variants to indicate which version that the code was attempting to upgrade to threw an error.

One of the design considerations here is that converting from newer versions to older versions will not generate a `ConversionError`, and instead would still result in a catch-all  `UnsupportedVersion` error. This is so that we push people towards using newer XCM versions, instead of continually supporting older versions, because technically speaking, older version will indeed be unsupported as time goes by.