### PR TITLE
Avoid potential Default implementation for ()

### DIFF
--- a/xcm/xcm-builder/src/fungibles_adapter.rs
+++ b/xcm/xcm-builder/src/fungibles_adapter.rs
@@ -176,9 +176,7 @@ impl<
 		if CheckAsset::contains(&asset_id) {
 			// This is an asset whose teleports we track.
 			if let Some(checking_account) = CheckingAccount::get() {
-			    	Assets::can_withdraw(asset_id, &checking_account, amount)
-					.into_result()
-					.map_err(|_| XcmError::NotWithdrawable)?;
+			    	Assets::can_withdraw(asset_id, &checking_account, amount).into_result().map_err(|_| XcmError::NotWithdrawable)?;
 			}
 		}
 		Ok(())

--- a/xcm/xcm-builder/src/fungibles_adapter.rs
+++ b/xcm/xcm-builder/src/fungibles_adapter.rs
@@ -176,7 +176,7 @@ impl<
 		if CheckAsset::contains(&asset_id) {
 			// This is an asset whose teleports we track.
 			if let Some(checking_account) = CheckingAccount::get() {
-			    	Assets::can_withdraw(asset_id, &checking_account, amount)
+				Assets::can_withdraw(asset_id, &checking_account, amount)
 					.into_result()
 					.map_err(|_| XcmError::NotWithdrawable)?;
 			}

--- a/xcm/xcm-builder/src/fungibles_adapter.rs
+++ b/xcm/xcm-builder/src/fungibles_adapter.rs
@@ -176,7 +176,9 @@ impl<
 		if CheckAsset::contains(&asset_id) {
 			// This is an asset whose teleports we track.
 			if let Some(checking_account) = CheckingAccount::get() {
-			    	Assets::can_withdraw(asset_id, &checking_account, amount).into_result().map_err(|_| XcmError::NotWithdrawable)?;
+			    	Assets::can_withdraw(asset_id, &checking_account, amount)
+					.into_result()
+					.map_err(|_| XcmError::NotWithdrawable)?;
 			}
 		}
 		Ok(())


### PR DESCRIPTION
Compared to implementation here
https://github.com/paritytech/polkadot/blob/master/xcm/xcm-builder/src/currency_adapter.rs#L93
Try to use the same CurrencyAdapter implementation.

Otherwise. If we use () for CheckAccount, it will require AccountId with Default trait (Which usually AccountId32 does not)