### PR TITLE
Disputes which are unknown for the Runtime are sent with priority by the Provisioner when preparing inherent data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6956,6 +6956,7 @@ name = "polkadot-node-core-provisioner"
 version = "0.9.19"
 dependencies = [
  "bitvec",
+ "fatality",
  "futures 0.3.21",
  "futures-timer",
  "polkadot-node-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -203,6 +203,7 @@ try-runtime = [ "polkadot-cli/try-runtime" ]
 fast-runtime = [ "polkadot-cli/fast-runtime" ]
 runtime-metrics = [ "polkadot-cli/runtime-metrics" ]
 pyroscope = ["polkadot-cli/pyroscope"]
+staging-client = ["polkadot-cli/staging-client"]
 
 # Configuration for building a .deb package - for use with `cargo-deb`
 [package.metadata.deb]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -73,3 +73,4 @@ rococo-native = ["service/rococo-native"]
 
 malus = ["full-node", "service/malus"]
 runtime-metrics = ["service/runtime-metrics", "polkadot-node-metrics/runtime-metrics"]
+staging-client = ["service/staging-client"]

--- a/node/core/provisioner/Cargo.toml
+++ b/node/core/provisioner/Cargo.toml
@@ -23,4 +23,4 @@ polkadot-node-subsystem-test-helpers = { path = "../../subsystem-test-helpers" }
 test-helpers = { package = "polkadot-primitives-test-helpers", path = "../../../primitives/test-helpers" }
 
 [features]
-improved-onchain-disputes-import = []
+staging-client = []

--- a/node/core/provisioner/Cargo.toml
+++ b/node/core/provisioner/Cargo.toml
@@ -15,6 +15,7 @@ polkadot-node-subsystem = { path = "../../subsystem" }
 polkadot-node-subsystem-util = { path = "../../subsystem-util" }
 futures-timer = "3.0.2"
 rand = "0.8.5"
+fatality = "0.0.6"
 
 [dev-dependencies]
 sp-application-crypto = { git = "https://github.com/paritytech/substrate", branch = "master" }

--- a/node/core/provisioner/Cargo.toml
+++ b/node/core/provisioner/Cargo.toml
@@ -21,3 +21,6 @@ sp-application-crypto = { git = "https://github.com/paritytech/substrate", branc
 sp-keystore = { git = "https://github.com/paritytech/substrate", branch = "master" }
 polkadot-node-subsystem-test-helpers = { path = "../../subsystem-test-helpers" }
 test-helpers = { package = "polkadot-primitives-test-helpers", path = "../../../primitives/test-helpers" }
+
+[features]
+improved-onchain-disputes-import = []

--- a/node/core/provisioner/src/error.rs
+++ b/node/core/provisioner/src/error.rs
@@ -1,0 +1,83 @@
+// Copyright 2017-2022 Parity Technologies (UK) Ltd.
+// This file is part of Polkadot.
+
+// Polkadot is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Polkadot is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
+
+///! Error types for provisioner module
+use fatality;
+use futures::channel::{mpsc, oneshot};
+use polkadot_node_subsystem::errors::{ChainApiError, RuntimeApiError};
+use polkadot_node_subsystem_util as util;
+use polkadot_primitives::v2::Hash;
+use thiserror::Error;
+
+/// Errors in the provisioner.
+#[derive(Debug, Error)]
+#[allow(missing_docs)]
+pub enum Error {
+	#[error(transparent)]
+	Util(#[from] util::Error),
+
+	#[error("failed to get availability cores")]
+	CanceledAvailabilityCores(#[source] oneshot::Canceled),
+
+	#[error("failed to get persisted validation data")]
+	CanceledPersistedValidationData(#[source] oneshot::Canceled),
+
+	#[error("failed to get block number")]
+	CanceledBlockNumber(#[source] oneshot::Canceled),
+
+	#[error("failed to get backed candidates")]
+	CanceledBackedCandidates(#[source] oneshot::Canceled),
+
+	#[error("failed to get votes on dispute")]
+	CanceledCandidateVotes(#[source] oneshot::Canceled),
+
+	#[error(transparent)]
+	ChainApi(#[from] ChainApiError),
+
+	#[error(transparent)]
+	Runtime(#[from] RuntimeApiError),
+
+	#[error("failed to send message to ChainAPI")]
+	ChainApiMessageSend(#[source] mpsc::SendError),
+
+	#[error("failed to send message to CandidateBacking to get backed candidates")]
+	GetBackedCandidatesSend(#[source] mpsc::SendError),
+
+	#[error("failed to send return message with Inherents")]
+	InherentDataReturnChannel,
+
+	#[error(
+		"backed candidate does not correspond to selected candidate; check logic in provisioner"
+	)]
+	BackedCandidateOrderingProblem,
+}
+
+/// Used by `get_onchain_disputes` to represent errors related to fatching onchain disputes from the Runtime
+#[allow(dead_code)] // Remove when promoting to stable
+#[fatality::fatality]
+pub enum GetOnchainDisputesError {
+	#[fatal]
+	#[error("runtime subsystem is down")]
+	Channel,
+
+	#[error("runtime execution error occurred while fetching onchain disputes for parent {1}")]
+	Execution(#[source] RuntimeApiError, Hash),
+
+	#[error(
+		"runtime doesn't support RuntimeApiRequest::Disputes/RuntimeApiRequest::StagingDisputes for parent {1}"
+	)]
+	NotSupported(#[source] RuntimeApiError, Hash),
+}

--- a/node/core/provisioner/src/error.rs
+++ b/node/core/provisioner/src/error.rs
@@ -65,7 +65,7 @@ pub enum Error {
 	BackedCandidateOrderingProblem,
 }
 
-/// Used by `get_onchain_disputes` to represent errors related to fatching onchain disputes from the Runtime
+/// Used by `get_onchain_disputes` to represent errors related to fetching on-chain disputes from the Runtime
 #[allow(dead_code)] // Remove when promoting to stable
 #[fatality::fatality]
 pub enum GetOnchainDisputesError {

--- a/node/core/provisioner/src/lib.rs
+++ b/node/core/provisioner/src/lib.rs
@@ -719,7 +719,7 @@ async fn select_disputes(
 	// On error - an empty set is generated which doesn't affect the logic of the function.
 	// This is a staging feature, so if it is not enabled - create an empty HashMap by default. If it is
 	// enabled - the HashMap will be overridden with the on-chain data.
-	let onchain: HashMap<(SessionIndex, CandidateHash), DisputeState> = HashMap::new();
+	let onchain = HashMap::<(SessionIndex, CandidateHash), DisputeState>::new();
 	#[cfg(feature = "staging-client")]
 	let onchain = onchain_disputes::get_onchain_disputes(sender, _leaf.hash.clone())
 		.await

--- a/node/core/provisioner/src/lib.rs
+++ b/node/core/provisioner/src/lib.rs
@@ -707,7 +707,7 @@ async fn select_disputes(
 			) = active.into_iter().partition(|d| onchain.contains_key(d));
 
 			let active_subset = if unseen_onchain.len() > MAX_DISPUTES_FORWARDED_TO_RUNTIME {
-				// Even unseen onchain doesn't fit within the limit. Add as much as possible.
+				// Even unseen on-chain don't fit within the limit. Add as many as possible.
 				let mut unseen_subset = Vec::with_capacity(MAX_DISPUTES_FORWARDED_TO_RUNTIME);
 				extend_by_random_subset_without_repetition(
 					&mut unseen_subset,

--- a/node/core/provisioner/src/lib.rs
+++ b/node/core/provisioner/src/lib.rs
@@ -795,7 +795,7 @@ fn remove_known_disputes(
 	disputes: &mut Vec<(u32, CandidateHash)>,
 	known: &HashSet<(u32, CandidateHash)>,
 ) {
-	if known.len() > 0 {
+	if !known.is_empty() {
 		disputes.retain(|v| !known.contains(v));
 	}
 }

--- a/node/core/provisioner/src/lib.rs
+++ b/node/core/provisioner/src/lib.rs
@@ -701,13 +701,12 @@ fn extend_by_random_subset_without_repetition(
 	acc.sort_unstable_by(|a, b| a.0.cmp(&b.0));
 }
 
+const MAX_DISPUTES_FORWARDED_TO_RUNTIME: usize = 1_000;
 async fn select_disputes(
 	sender: &mut impl SubsystemSender,
 	metrics: &metrics::Metrics,
 	_leaf: &ActivatedLeaf,
 ) -> Result<MultiDisputeStatementSet, Error> {
-	const MAX_DISPUTES_FORWARDED_TO_RUNTIME: usize = 1_000;
-
 	// We use `RecentDisputes` instead of `ActiveDisputes` because redundancy is fine.
 	// It's heavier than `ActiveDisputes` but ensures that everything from the dispute
 	// window gets on-chain, unlike `ActiveDisputes`.

--- a/node/core/provisioner/src/lib.rs
+++ b/node/core/provisioner/src/lib.rs
@@ -722,7 +722,7 @@ async fn select_disputes(
 	// This is a staging feature, so if it is not enabled - create an empty HashSet by default. If it is
 	// enabled - the HashSet will be overriden with the on-chain data.
 	let onchain: HashSet<(SessionIndex, CandidateHash)> = HashSet::new();
-	#[cfg(feature = "improved-onchain-disputes-import")]
+	#[cfg(feature = "staging-client")]
 	let onchain = onchain_disputes::get_onchain_disputes(sender, leaf.hash.clone())
 		.await
 		.unwrap_or_default();

--- a/node/core/provisioner/src/lib.rs
+++ b/node/core/provisioner/src/lib.rs
@@ -700,7 +700,7 @@ async fn select_disputes(
 
 		let mut active = request_disputes(sender, RequestType::Active).await;
 		let active = if active.len() > MAX_DISPUTES_FORWARDED_TO_RUNTIME {
-			// Active disputes doesn't fit within the limit. Add the unseen onchain with priority.
+			// Active disputes don't fit within the limit. Prioritize unseen on-chain disputes.
 			let (seen_onchain, mut unseen_onchain): (
 				Vec<(SessionIndex, CandidateHash)>,
 				Vec<(SessionIndex, CandidateHash)>,

--- a/node/core/provisioner/src/lib.rs
+++ b/node/core/provisioner/src/lib.rs
@@ -719,6 +719,10 @@ async fn select_disputes(
 	// On chain disputes are fetched for the runtime. We don't want to include disputes the runtime already knows
 	// about in the inherent data.
 	// On error - an empty set is generated which doesn't affect the logic of the function.
+	// This is a staging feature, so if it is not enabled - create an empty HashSet by default. If it is
+	// enabled - the HashSet will be overriden with the on-chain data.
+	let onchain: HashSet<(SessionIndex, CandidateHash)> = HashSet::new();
+	#[cfg(feature = "improved-onchain-disputes-import")]
 	let onchain = onchain_disputes::get_onchain_disputes(sender, leaf.hash.clone())
 		.await
 		.unwrap_or_default();

--- a/node/core/provisioner/src/metrics.rs
+++ b/node/core/provisioner/src/metrics.rs
@@ -34,6 +34,11 @@ struct MetricsInner {
 pub struct Metrics(Option<MetricsInner>);
 
 impl Metrics {
+	/// Creates new dummy `Metrics` instance. Used for testing only.
+	pub fn new_dummy() -> Metrics {
+		Metrics(None)
+	}
+
 	pub(crate) fn on_inherent_data_request(&self, response: Result<(), ()>) {
 		if let Some(metrics) = &self.0 {
 			match response {

--- a/node/core/provisioner/src/metrics.rs
+++ b/node/core/provisioner/src/metrics.rs
@@ -31,14 +31,9 @@ struct MetricsInner {
 
 /// Provisioner metrics.
 #[derive(Default, Clone)]
-pub struct Metrics(Option<MetricsInner>);
+pub struct Metrics(pub(crate) Option<MetricsInner>);
 
 impl Metrics {
-	/// Creates new dummy `Metrics` instance. Used for testing only.
-	pub fn new_dummy() -> Metrics {
-		Metrics(None)
-	}
-
 	pub(crate) fn on_inherent_data_request(&self, response: Result<(), ()>) {
 		if let Some(metrics) = &self.0 {
 			match response {

--- a/node/core/provisioner/src/metrics.rs
+++ b/node/core/provisioner/src/metrics.rs
@@ -31,9 +31,14 @@ struct MetricsInner {
 
 /// Provisioner metrics.
 #[derive(Default, Clone)]
-pub struct Metrics(pub(crate) Option<MetricsInner>);
+pub struct Metrics(Option<MetricsInner>);
 
 impl Metrics {
+	/// Creates new dummy `Metrics` instance. Used for testing only.
+	pub fn new_dummy() -> Metrics {
+		Metrics(None)
+	}
+
 	pub(crate) fn on_inherent_data_request(&self, response: Result<(), ()>) {
 		if let Some(metrics) = &self.0 {
 			match response {

--- a/node/core/provisioner/src/metrics.rs
+++ b/node/core/provisioner/src/metrics.rs
@@ -35,6 +35,7 @@ pub struct Metrics(Option<MetricsInner>);
 
 impl Metrics {
 	/// Creates new dummy `Metrics` instance. Used for testing only.
+	#[cfg(test)]
 	pub fn new_dummy() -> Metrics {
 		Metrics(None)
 	}

--- a/node/core/provisioner/src/onchain_disputes.rs
+++ b/node/core/provisioner/src/onchain_disputes.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
-#![cfg(feature = "improved-onchain-disputes-import")]
+#![cfg(feature = "staging-client")]
 
 use crate::LOG_TARGET;
 use futures::channel::oneshot;

--- a/node/core/provisioner/src/onchain_disputes.rs
+++ b/node/core/provisioner/src/onchain_disputes.rs
@@ -31,7 +31,7 @@ pub enum GetOnchainDisputesErr {
 	NotSupported,
 }
 
-/// Gets the on-chain disputes at a given block nymber and returns them as a `HashSet` so that searching in them is cheap.
+/// Gets the on-chain disputes at a given block number and returns them as a `HashSet` so that searching in them is cheap.
 pub async fn get_onchain_disputes(
 	sender: &mut impl SubsystemSender,
 	relay_parent: Hash,

--- a/node/core/provisioner/src/onchain_disputes.rs
+++ b/node/core/provisioner/src/onchain_disputes.rs
@@ -23,8 +23,8 @@ use polkadot_node_subsystem::{
 	messages::{RuntimeApiMessage, RuntimeApiRequest},
 	SubsystemSender,
 };
-use polkadot_primitives::v2::{CandidateHash, Hash, SessionIndex};
-use std::collections::HashSet;
+use polkadot_primitives::v2::{CandidateHash, DisputeState, Hash, SessionIndex};
+use std::collections::HashMap;
 
 pub enum GetOnchainDisputesErr {
 	Channel,
@@ -36,7 +36,7 @@ pub enum GetOnchainDisputesErr {
 pub async fn get_onchain_disputes(
 	sender: &mut impl SubsystemSender,
 	relay_parent: Hash,
-) -> Result<HashSet<(SessionIndex, CandidateHash)>, GetOnchainDisputesErr> {
+) -> Result<HashMap<(SessionIndex, CandidateHash), DisputeState>, GetOnchainDisputesErr> {
 	gum::trace!(target: LOG_TARGET, ?relay_parent, "Fetching on-chain disputes");
 	let (tx, rx) = oneshot::channel();
 	sender
@@ -74,5 +74,5 @@ pub async fn get_onchain_disputes(
 				},
 			})
 		})
-		.map(|v| v.into_iter().map(|e| (e.0, e.1)).collect())
+		.map(|v| v.into_iter().map(|e| ((e.0, e.1), e.2)).collect())
 }

--- a/node/core/provisioner/src/onchain_disputes.rs
+++ b/node/core/provisioner/src/onchain_disputes.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
+#![cfg(feature = "improved-onchain-disputes-import")]
+
 use futures::channel::oneshot;
 use polkadot_node_subsystem::{
 	errors::RuntimeApiError,

--- a/node/core/provisioner/src/onchain_disputes.rs
+++ b/node/core/provisioner/src/onchain_disputes.rs
@@ -1,0 +1,69 @@
+// Copyright 2017-2022 Parity Technologies (UK) Ltd.
+// This file is part of Polkadot.
+
+// Polkadot is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Polkadot is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
+
+use futures::channel::oneshot;
+use polkadot_node_subsystem::{
+	errors::RuntimeApiError,
+	messages::{RuntimeApiMessage, RuntimeApiRequest},
+	SubsystemSender,
+};
+use polkadot_primitives::v2::{CandidateHash, Hash, SessionIndex};
+use std::collections::HashSet;
+
+pub enum GetOnchainDisputesErr {
+	Channel,
+	Execution,
+	NotSupported,
+}
+
+/// Gets the on-chain disputes at a given block nymber and returns them as a `HashSet` so that searching in them is cheap.
+pub async fn get_onchain_disputes(
+	sender: &mut impl SubsystemSender,
+	relay_parent: Hash,
+) -> Result<HashSet<(SessionIndex, CandidateHash)>, GetOnchainDisputesErr> {
+	gum::trace!("Fetching on-chain disputes", ?relay_parent);
+	let (tx, rx) = oneshot::channel();
+	sender
+		.send_message(
+			RuntimeApiMessage::Request(relay_parent, RuntimeApiRequest::Disputes(tx)).into(),
+		)
+		.await;
+
+	rx.await
+		.map_err(|_| {
+			gum::error!("Channel error occured while fetching on-chain disputes", ?relay_parent);
+			GetOnchainDisputesErr::Channel
+		})
+		.and_then(|res| {
+			res.map_err(|e| match e {
+				RuntimeApiError::Execution { .. } => {
+					gum::error!(
+						"Execution error occured while fetching on-chain disputes",
+						?relay_parent
+					);
+					GetOnchainDisputesErr::Execution
+				},
+				RuntimeApiError::NotSupported { .. } => {
+					gum::error!(
+						"Runtime doesn't support on-chain disputes fetching",
+						?relay_parent
+					);
+					GetOnchainDisputesErr::NotSupported
+				},
+			})
+		})
+		.map(|v| v.into_iter().map(|e| (e.0, e.1)).collect())
+}

--- a/node/core/provisioner/src/onchain_disputes.rs
+++ b/node/core/provisioner/src/onchain_disputes.rs
@@ -50,7 +50,7 @@ pub async fn get_onchain_disputes(
 			gum::error!(
 				target: LOG_TARGET,
 				?relay_parent,
-				"Channel error occured while fetching on-chain disputes"
+				"Channel error occurred while fetching on-chain disputes"
 			);
 			GetOnchainDisputesErr::Channel
 		})
@@ -60,7 +60,7 @@ pub async fn get_onchain_disputes(
 					gum::error!(
 						target: LOG_TARGET,
 						?relay_parent,
-						"Execution error occured while fetching on-chain disputes",
+						"Execution error occurred while fetching on-chain disputes",
 					);
 					GetOnchainDisputesErr::Execution
 				},

--- a/node/core/provisioner/src/onchain_disputes.rs
+++ b/node/core/provisioner/src/onchain_disputes.rs
@@ -41,7 +41,7 @@ pub async fn get_onchain_disputes(
 	let (tx, rx) = oneshot::channel();
 	sender
 		.send_message(
-			RuntimeApiMessage::Request(relay_parent, RuntimeApiRequest::Disputes(tx)).into(),
+			RuntimeApiMessage::Request(relay_parent, RuntimeApiRequest::StagingDisputes(tx)).into(),
 		)
 		.await;
 

--- a/node/core/provisioner/src/tests.rs
+++ b/node/core/provisioner/src/tests.rs
@@ -195,23 +195,12 @@ mod select_availability_bitfields {
 	}
 }
 
-mod select_candidates {
-	use super::{super::*, build_occupied_core, default_bitvec, occupied_core, scheduled_core};
-	use ::test_helpers::{dummy_candidate_descriptor, dummy_hash};
-	use polkadot_node_subsystem::messages::{
-		AllMessages, RuntimeApiMessage,
-		RuntimeApiRequest::{
-			AvailabilityCores, PersistedValidationData as PersistedValidationDataReq,
-		},
-	};
+mod common {
+	use super::super::*;
+	use polkadot_node_subsystem::messages::AllMessages;
 	use polkadot_node_subsystem_test_helpers::TestSubsystemSender;
-	use polkadot_primitives::v2::{
-		BlockNumber, CandidateCommitments, CommittedCandidateReceipt, PersistedValidationData,
-	};
 
-	const BLOCK_UNDER_PRODUCTION: BlockNumber = 128;
-
-	fn test_harness<OverseerFactory, Overseer, TestFactory, Test>(
+	pub fn test_harness<OverseerFactory, Overseer, TestFactory, Test>(
 		overseer_factory: OverseerFactory,
 		test_factory: TestFactory,
 	) where
@@ -228,6 +217,26 @@ mod select_candidates {
 
 		let _ = futures::executor::block_on(future::join(overseer, test));
 	}
+}
+
+mod select_candidates {
+	use super::{
+		super::*, build_occupied_core, common::test_harness, default_bitvec, occupied_core,
+		scheduled_core,
+	};
+	use ::test_helpers::{dummy_candidate_descriptor, dummy_hash};
+	use polkadot_node_subsystem::messages::{
+		AllMessages, RuntimeApiMessage,
+		RuntimeApiRequest::{
+			AvailabilityCores, PersistedValidationData as PersistedValidationDataReq,
+		},
+	};
+	use polkadot_node_subsystem_test_helpers::TestSubsystemSender;
+	use polkadot_primitives::v2::{
+		BlockNumber, CandidateCommitments, CommittedCandidateReceipt, PersistedValidationData,
+	};
+
+	const BLOCK_UNDER_PRODUCTION: BlockNumber = 128;
 
 	// For test purposes, we always return this set of availability cores:
 	//
@@ -484,5 +493,403 @@ mod select_candidates {
 				});
 			},
 		)
+	}
+}
+
+mod select_disputes {
+
+	use super::{super::*, common::test_harness};
+	use polkadot_node_subsystem::messages::{
+		AllMessages, DisputeCoordinatorMessage, RuntimeApiMessage, RuntimeApiRequest,
+	};
+	use polkadot_node_subsystem_test_helpers::TestSubsystemSender;
+	use std::sync::Arc;
+	use test_helpers;
+
+	// Global Test Data
+	fn recent_disputes(len: usize) -> Vec<(SessionIndex, CandidateHash)> {
+		let mut res = Vec::with_capacity(len);
+		for _ in 0..len {
+			res.push((0, CandidateHash(Hash::random())));
+		}
+
+		res
+	}
+
+	// same as recent_disputes() but with SessionIndex set to 1
+	fn active_disputes(len: usize) -> Vec<(SessionIndex, CandidateHash)> {
+		let mut res = Vec::with_capacity(len);
+		for _ in 0..len {
+			res.push((1, CandidateHash(Hash::random())));
+		}
+
+		res
+	}
+
+	fn leaf() -> ActivatedLeaf {
+		ActivatedLeaf {
+			hash: Hash::repeat_byte(0xAA),
+			number: 0xAA,
+			status: LeafStatus::Fresh,
+			span: Arc::new(jaeger::Span::Disabled),
+		}
+	}
+
+	async fn mock_overseer(
+		leaf: ActivatedLeaf,
+		mut receiver: mpsc::UnboundedReceiver<AllMessages>,
+		onchain_disputes: Result<Vec<(SessionIndex, CandidateHash, DisputeState)>, RuntimeApiError>,
+		recent_disputes: Vec<(SessionIndex, CandidateHash)>,
+		active_disputes: Vec<(SessionIndex, CandidateHash)>,
+	) {
+		while let Some(from_job) = receiver.next().await {
+			match from_job {
+				AllMessages::RuntimeApi(RuntimeApiMessage::Request(
+					_,
+					RuntimeApiRequest::Disputes(sender),
+				)) => {
+					let _ = sender.send(onchain_disputes.clone());
+				},
+				AllMessages::RuntimeApi(_) => panic!("Unexpected RuntimeApi request"),
+				AllMessages::DisputeCoordinator(DisputeCoordinatorMessage::RecentDisputes(
+					sender,
+				)) => {
+					let _ = sender.send(recent_disputes.clone());
+				},
+				AllMessages::DisputeCoordinator(DisputeCoordinatorMessage::ActiveDisputes(
+					sender,
+				)) => {
+					let _ = sender.send(active_disputes.clone());
+				},
+				AllMessages::DisputeCoordinator(
+					DisputeCoordinatorMessage::QueryCandidateVotes(disputes, sender),
+				) => {
+					let mut res = Vec::new();
+					let v = CandidateVotes {
+						candidate_receipt: test_helpers::dummy_candidate_receipt(leaf.hash.clone()),
+						valid: vec![],
+						invalid: vec![],
+					};
+					for r in disputes.iter() {
+						res.push((r.0, r.1, v.clone()));
+					}
+
+					let _ = sender.send(res);
+				},
+				_ => panic!("Unexpected message: {:?}", from_job),
+			}
+		}
+	}
+
+	#[test]
+	fn recent_disputes_are_withing_onchain_limit() {
+		const RECENT_DISPUTES_SIZE: usize = 10;
+		let metrics = metrics::Metrics::new_dummy();
+		let onchain_disputes = Ok(Vec::new());
+		let active_disputes = Vec::new();
+		let recent_disputes = recent_disputes(RECENT_DISPUTES_SIZE);
+
+		let recent_disputes_overseer = recent_disputes.clone();
+		test_harness(
+			|r| {
+				mock_overseer(
+					leaf(),
+					r,
+					onchain_disputes,
+					recent_disputes_overseer,
+					active_disputes,
+				)
+			},
+			|mut tx: TestSubsystemSender| async move {
+				let lf = leaf();
+				let disputes = select_disputes(&mut tx, &metrics, &lf).await.unwrap();
+
+				assert!(!disputes.is_empty());
+
+				let result = disputes.iter().zip(recent_disputes.iter());
+				// We should get all recent disputes.
+				for (d, r) in result {
+					assert_eq!(d.session, r.0);
+					assert_eq!(d.candidate_hash, r.1);
+				}
+			},
+		)
+	}
+
+	#[test]
+	fn recent_disputes_are_too_much_but_active_are_within_limit() {
+		const RECENT_DISPUTES_SIZE: usize = MAX_DISPUTES_FORWARDED_TO_RUNTIME + 10;
+		const ACTIVE_DISPUTES_SIZE: usize = MAX_DISPUTES_FORWARDED_TO_RUNTIME;
+		let metrics = metrics::Metrics::new_dummy();
+		let onchain_disputes = Ok(Vec::new());
+		let recent_disputes = recent_disputes(RECENT_DISPUTES_SIZE);
+		let active_disputes = active_disputes(ACTIVE_DISPUTES_SIZE);
+
+		let active_disputes_overseer = active_disputes.clone();
+		test_harness(
+			|r| {
+				mock_overseer(
+					leaf(),
+					r,
+					onchain_disputes,
+					recent_disputes,
+					active_disputes_overseer,
+				)
+			},
+			|mut tx: TestSubsystemSender| async move {
+				let lf = leaf();
+				let disputes = select_disputes(&mut tx, &metrics, &lf).await.unwrap();
+
+				assert!(!disputes.is_empty());
+
+				let result = disputes.iter().zip(active_disputes.iter());
+				// We should get all active disputes.
+				for (d, r) in result {
+					assert_eq!(d.session, r.0);
+					assert_eq!(d.candidate_hash, r.1);
+				}
+			},
+		)
+	}
+
+	#[test]
+	fn recent_disputes_are_too_much_but_active_are_less_than_the_limit() {
+		// In this case all active disputes + a random set of recent disputes should be returned
+		const RECENT_DISPUTES_SIZE: usize = MAX_DISPUTES_FORWARDED_TO_RUNTIME + 10;
+		const ACTIVE_DISPUTES_SIZE: usize = MAX_DISPUTES_FORWARDED_TO_RUNTIME - 10;
+		let metrics = metrics::Metrics::new_dummy();
+		let onchain_disputes = Ok(Vec::new());
+		let recent_disputes = recent_disputes(RECENT_DISPUTES_SIZE);
+		let active_disputes = active_disputes(ACTIVE_DISPUTES_SIZE);
+
+		let active_disputes_overseer = active_disputes.clone();
+		test_harness(
+			|r| {
+				mock_overseer(
+					leaf(),
+					r,
+					onchain_disputes,
+					recent_disputes,
+					active_disputes_overseer,
+				)
+			},
+			|mut tx: TestSubsystemSender| async move {
+				let lf = leaf();
+				let disputes = select_disputes(&mut tx, &metrics, &lf).await.unwrap();
+
+				assert!(!disputes.is_empty());
+
+				// Recent disputes are generated with `SessionIndex` = 0
+				let (res_recent, res_active): (Vec<DisputeStatementSet>, Vec<DisputeStatementSet>) =
+					disputes.into_iter().partition(|d| d.session == 0);
+
+				// It should be good enough the count the number of active disputes and not compare them one by one. Checking the exact values is already covered by the previous tests.
+				assert_eq!(res_active.len(), active_disputes.len()); // We have got all active disputes
+				assert_eq!(res_active.len() + res_recent.len(), MAX_DISPUTES_FORWARDED_TO_RUNTIME);
+				// And some recent ones.
+			},
+		)
+	}
+
+	//These tests rely on staging Runtime functions so they are separated and compiled conditionally.
+	#[cfg(feature = "staging-client")]
+	mod staging_tests {
+		use super::*;
+
+		fn dummy_dispute_state() -> DisputeState {
+			DisputeState {
+				validators_for: BitVec::new(),
+				validators_against: BitVec::new(),
+				start: 0,
+				concluded_at: None,
+			}
+		}
+
+		#[test]
+		fn recent_disputes_are_too_much_active_fits_test_recent_prioritisation() {
+			// In this case recent disputes are above `MAX_DISPUTES_FORWARDED_TO_RUNTIME` limit and the active ones are below it.
+			// The expected behaviour is to send all active disputes and extend the set with recent ones. During the extension the disputes unknown for the Runtime are added with priority.
+			const RECENT_DISPUTES_SIZE: usize = MAX_DISPUTES_FORWARDED_TO_RUNTIME + 10;
+			const ACTIVE_DISPUTES_SIZE: usize = MAX_DISPUTES_FORWARDED_TO_RUNTIME - 10;
+			const ONCHAIN_DISPUTE_SIZE: usize = RECENT_DISPUTES_SIZE - 9;
+			let metrics = metrics::Metrics::new_dummy();
+			let recent_disputes = recent_disputes(RECENT_DISPUTES_SIZE);
+			let active_disputes = active_disputes(ACTIVE_DISPUTES_SIZE);
+			let onchain_disputes: Result<
+				Vec<(SessionIndex, CandidateHash, DisputeState)>,
+				RuntimeApiError,
+			> = Ok(Vec::from(&recent_disputes[0..ONCHAIN_DISPUTE_SIZE])
+				.iter()
+				.map(|(session_index, candidate_hash)| {
+					(*session_index, candidate_hash.clone(), dummy_dispute_state())
+				})
+				.collect());
+			let active_disputes_overseer = active_disputes.clone();
+			let recent_disputes_overseer = recent_disputes.clone();
+			test_harness(
+				|r| {
+					mock_overseer(
+						leaf(),
+						r,
+						onchain_disputes,
+						recent_disputes_overseer,
+						active_disputes_overseer,
+					)
+				},
+				|mut tx: TestSubsystemSender| async move {
+					let lf = leaf();
+					let disputes = select_disputes(&mut tx, &metrics, &lf).await.unwrap();
+
+					assert!(!disputes.is_empty());
+
+					// Recent disputes are generated with `SessionIndex` = 0
+					let (res_recent, res_active): (
+						Vec<DisputeStatementSet>,
+						Vec<DisputeStatementSet>,
+					) = disputes.into_iter().partition(|d| d.session == 0);
+
+					// It should be good enough the count the number of the disputes and not compare them one by one as this was already covered in other tests.
+					assert_eq!(res_active.len(), active_disputes.len()); // We've got all active disputes.
+					assert_eq!(
+						res_recent.len(),
+						MAX_DISPUTES_FORWARDED_TO_RUNTIME - active_disputes.len()
+					); // And some recent ones.
+
+					// Check if the recent disputes were unknown for the Runtime.
+					let expected_recent_disputes =
+						Vec::from(&recent_disputes[ONCHAIN_DISPUTE_SIZE..]);
+					let res_recent_set: HashSet<(SessionIndex, CandidateHash)> = HashSet::from_iter(
+						res_recent.iter().map(|d| (d.session, d.candidate_hash)),
+					);
+
+					// Explicitly check that all unseen disputes are sent to the Runtime.
+					for d in &expected_recent_disputes {
+						assert_eq!(res_recent_set.contains(d), true);
+					}
+				},
+			)
+		}
+
+		#[test]
+		fn active_disputes_are_too_much_test_active_prioritisation() {
+			// In this case the active disputes are above the `MAX_DISPUTES_FORWARDED_TO_RUNTIME` limit so the unseen ones should be prioritised.
+			const RECENT_DISPUTES_SIZE: usize = MAX_DISPUTES_FORWARDED_TO_RUNTIME + 10;
+			const ACTIVE_DISPUTES_SIZE: usize = MAX_DISPUTES_FORWARDED_TO_RUNTIME + 10;
+			const ONCHAIN_DISPUTE_SIZE: usize = ACTIVE_DISPUTES_SIZE - 9;
+
+			let metrics = metrics::Metrics::new_dummy();
+			let recent_disputes = recent_disputes(RECENT_DISPUTES_SIZE);
+			let active_disputes = active_disputes(ACTIVE_DISPUTES_SIZE);
+			let onchain_disputes: Result<
+				Vec<(SessionIndex, CandidateHash, DisputeState)>,
+				RuntimeApiError,
+			> = Ok(Vec::from(&active_disputes[0..ONCHAIN_DISPUTE_SIZE])
+				.iter()
+				.map(|(session_index, candidate_hash)| {
+					(*session_index, candidate_hash.clone(), dummy_dispute_state())
+				})
+				.collect());
+			let active_disputes_overseer = active_disputes.clone();
+			let recent_disputes_overseer = recent_disputes.clone();
+			test_harness(
+				|r| {
+					mock_overseer(
+						leaf(),
+						r,
+						onchain_disputes,
+						recent_disputes_overseer,
+						active_disputes_overseer,
+					)
+				},
+				|mut tx: TestSubsystemSender| async move {
+					let lf = leaf();
+					let disputes = select_disputes(&mut tx, &metrics, &lf).await.unwrap();
+
+					assert!(!disputes.is_empty());
+
+					// Recent disputes are generated with `SessionIndex` = 0
+					let (res_recent, res_active): (
+						Vec<DisputeStatementSet>,
+						Vec<DisputeStatementSet>,
+					) = disputes.into_iter().partition(|d| d.session == 0);
+
+					// It should be good enough the count the number of the disputes and not compare them one by one
+					assert_eq!(res_recent.len(), 0); // We expect no recent disputes
+					assert_eq!(res_active.len(), MAX_DISPUTES_FORWARDED_TO_RUNTIME);
+
+					let expected_active_disputes =
+						Vec::from(&active_disputes[ONCHAIN_DISPUTE_SIZE..]);
+					let res_active_set: HashSet<(SessionIndex, CandidateHash)> = HashSet::from_iter(
+						res_active.iter().map(|d| (d.session, d.candidate_hash)),
+					);
+
+					// Explicitly check that the unseen disputes are delivered to the Runtime.
+					for d in &expected_active_disputes {
+						assert_eq!(res_active_set.contains(d), true);
+					}
+				},
+			)
+		}
+
+		#[test]
+		fn active_disputes_are_too_much_and_are_all_unseen() {
+			// In this case there are a lot of active disputes unseen by the Runtime. The focus of the test is to verify that in such cases known disputes are NOT sent to the Runtime.
+			const RECENT_DISPUTES_SIZE: usize = MAX_DISPUTES_FORWARDED_TO_RUNTIME + 10;
+			const ACTIVE_DISPUTES_SIZE: usize = MAX_DISPUTES_FORWARDED_TO_RUNTIME + 5;
+			const ONCHAIN_DISPUTE_SIZE: usize = 5;
+
+			let metrics = metrics::Metrics::new_dummy();
+			let recent_disputes = recent_disputes(RECENT_DISPUTES_SIZE);
+			let active_disputes = active_disputes(ACTIVE_DISPUTES_SIZE);
+			let onchain_disputes: Result<
+				Vec<(SessionIndex, CandidateHash, DisputeState)>,
+				RuntimeApiError,
+			> = Ok(Vec::from(&active_disputes[0..ONCHAIN_DISPUTE_SIZE])
+				.iter()
+				.map(|(session_index, candidate_hash)| {
+					(*session_index, candidate_hash.clone(), dummy_dispute_state())
+				})
+				.collect());
+			let active_disputes_overseer = active_disputes.clone();
+			let recent_disputes_overseer = recent_disputes.clone();
+			test_harness(
+				|r| {
+					mock_overseer(
+						leaf(),
+						r,
+						onchain_disputes,
+						recent_disputes_overseer,
+						active_disputes_overseer,
+					)
+				},
+				|mut tx: TestSubsystemSender| async move {
+					let lf = leaf();
+					let disputes = select_disputes(&mut tx, &metrics, &lf).await.unwrap();
+					assert!(!disputes.is_empty());
+
+					// Recent disputes are generated with `SessionIndex` = 0
+					let (res_recent, res_active): (
+						Vec<DisputeStatementSet>,
+						Vec<DisputeStatementSet>,
+					) = disputes.into_iter().partition(|d| d.session == 0);
+
+					// It should be good enough the count the number of the disputes and not compare them one by one
+					assert_eq!(res_recent.len(), 0);
+					assert_eq!(res_active.len(), MAX_DISPUTES_FORWARDED_TO_RUNTIME);
+
+					// For sure we don't want to see any of this disputes in the result
+					let unexpected_active_disputes =
+						Vec::from(&active_disputes[0..ONCHAIN_DISPUTE_SIZE]);
+					let res_active_set: HashSet<(SessionIndex, CandidateHash)> = HashSet::from_iter(
+						res_active.iter().map(|d| (d.session, d.candidate_hash)),
+					);
+
+					// Verify that the result DOESN'T contain known disputes (because there is an excessive number of unknown onces).
+					for d in &unexpected_active_disputes {
+						assert_eq!(res_active_set.contains(d), false);
+					}
+				},
+			)
+		}
 	}
 }

--- a/node/core/provisioner/src/tests.rs
+++ b/node/core/provisioner/src/tests.rs
@@ -586,7 +586,7 @@ mod select_disputes {
 	#[test]
 	fn recent_disputes_are_withing_onchain_limit() {
 		const RECENT_DISPUTES_SIZE: usize = 10;
-		let metrics = metrics::Metrics(None);
+		let metrics = metrics::Metrics::new_dummy();
 		let onchain_disputes = Ok(Vec::new());
 		let active_disputes = Vec::new();
 		let recent_disputes = recent_disputes(RECENT_DISPUTES_SIZE);
@@ -622,7 +622,7 @@ mod select_disputes {
 	fn recent_disputes_are_too_much_but_active_are_within_limit() {
 		const RECENT_DISPUTES_SIZE: usize = MAX_DISPUTES_FORWARDED_TO_RUNTIME + 10;
 		const ACTIVE_DISPUTES_SIZE: usize = MAX_DISPUTES_FORWARDED_TO_RUNTIME;
-		let metrics = metrics::Metrics(None);
+		let metrics = metrics::Metrics::new_dummy();
 		let onchain_disputes = Ok(Vec::new());
 		let recent_disputes = recent_disputes(RECENT_DISPUTES_SIZE);
 		let active_disputes = active_disputes(ACTIVE_DISPUTES_SIZE);
@@ -659,7 +659,7 @@ mod select_disputes {
 		// In this case all active disputes + a random set of recent disputes should be returned
 		const RECENT_DISPUTES_SIZE: usize = MAX_DISPUTES_FORWARDED_TO_RUNTIME + 10;
 		const ACTIVE_DISPUTES_SIZE: usize = MAX_DISPUTES_FORWARDED_TO_RUNTIME - 10;
-		let metrics = metrics::Metrics(None);
+		let metrics = metrics::Metrics::new_dummy();
 		let onchain_disputes = Ok(Vec::new());
 		let recent_disputes = recent_disputes(RECENT_DISPUTES_SIZE);
 		let active_disputes = active_disputes(ACTIVE_DISPUTES_SIZE);
@@ -714,7 +714,7 @@ mod select_disputes {
 			const RECENT_DISPUTES_SIZE: usize = MAX_DISPUTES_FORWARDED_TO_RUNTIME + 10;
 			const ACTIVE_DISPUTES_SIZE: usize = MAX_DISPUTES_FORWARDED_TO_RUNTIME - 10;
 			const ONCHAIN_DISPUTE_SIZE: usize = RECENT_DISPUTES_SIZE - 9;
-			let metrics = metrics::Metrics(None);
+			let metrics = metrics::Metrics::new_dummy();
 			let recent_disputes = recent_disputes(RECENT_DISPUTES_SIZE);
 			let active_disputes = active_disputes(ACTIVE_DISPUTES_SIZE);
 			let onchain_disputes: Result<
@@ -779,7 +779,7 @@ mod select_disputes {
 			const ACTIVE_DISPUTES_SIZE: usize = MAX_DISPUTES_FORWARDED_TO_RUNTIME + 10;
 			const ONCHAIN_DISPUTE_SIZE: usize = ACTIVE_DISPUTES_SIZE - 9;
 
-			let metrics = metrics::Metrics(None);
+			let metrics = metrics::Metrics::new_dummy();
 			let recent_disputes = recent_disputes(RECENT_DISPUTES_SIZE);
 			let active_disputes = active_disputes(ACTIVE_DISPUTES_SIZE);
 			let onchain_disputes: Result<
@@ -840,7 +840,7 @@ mod select_disputes {
 			const ACTIVE_DISPUTES_SIZE: usize = MAX_DISPUTES_FORWARDED_TO_RUNTIME + 5;
 			const ONCHAIN_DISPUTE_SIZE: usize = 5;
 
-			let metrics = metrics::Metrics(None);
+			let metrics = metrics::Metrics::new_dummy();
 			let recent_disputes = recent_disputes(RECENT_DISPUTES_SIZE);
 			let active_disputes = active_disputes(ACTIVE_DISPUTES_SIZE);
 			let onchain_disputes: Result<

--- a/node/core/provisioner/src/tests.rs
+++ b/node/core/provisioner/src/tests.rs
@@ -586,7 +586,7 @@ mod select_disputes {
 	#[test]
 	fn recent_disputes_are_withing_onchain_limit() {
 		const RECENT_DISPUTES_SIZE: usize = 10;
-		let metrics = metrics::Metrics::new_dummy();
+		let metrics = metrics::Metrics(None);
 		let onchain_disputes = Ok(Vec::new());
 		let active_disputes = Vec::new();
 		let recent_disputes = recent_disputes(RECENT_DISPUTES_SIZE);
@@ -622,7 +622,7 @@ mod select_disputes {
 	fn recent_disputes_are_too_much_but_active_are_within_limit() {
 		const RECENT_DISPUTES_SIZE: usize = MAX_DISPUTES_FORWARDED_TO_RUNTIME + 10;
 		const ACTIVE_DISPUTES_SIZE: usize = MAX_DISPUTES_FORWARDED_TO_RUNTIME;
-		let metrics = metrics::Metrics::new_dummy();
+		let metrics = metrics::Metrics(None);
 		let onchain_disputes = Ok(Vec::new());
 		let recent_disputes = recent_disputes(RECENT_DISPUTES_SIZE);
 		let active_disputes = active_disputes(ACTIVE_DISPUTES_SIZE);
@@ -659,7 +659,7 @@ mod select_disputes {
 		// In this case all active disputes + a random set of recent disputes should be returned
 		const RECENT_DISPUTES_SIZE: usize = MAX_DISPUTES_FORWARDED_TO_RUNTIME + 10;
 		const ACTIVE_DISPUTES_SIZE: usize = MAX_DISPUTES_FORWARDED_TO_RUNTIME - 10;
-		let metrics = metrics::Metrics::new_dummy();
+		let metrics = metrics::Metrics(None);
 		let onchain_disputes = Ok(Vec::new());
 		let recent_disputes = recent_disputes(RECENT_DISPUTES_SIZE);
 		let active_disputes = active_disputes(ACTIVE_DISPUTES_SIZE);
@@ -714,7 +714,7 @@ mod select_disputes {
 			const RECENT_DISPUTES_SIZE: usize = MAX_DISPUTES_FORWARDED_TO_RUNTIME + 10;
 			const ACTIVE_DISPUTES_SIZE: usize = MAX_DISPUTES_FORWARDED_TO_RUNTIME - 10;
 			const ONCHAIN_DISPUTE_SIZE: usize = RECENT_DISPUTES_SIZE - 9;
-			let metrics = metrics::Metrics::new_dummy();
+			let metrics = metrics::Metrics(None);
 			let recent_disputes = recent_disputes(RECENT_DISPUTES_SIZE);
 			let active_disputes = active_disputes(ACTIVE_DISPUTES_SIZE);
 			let onchain_disputes: Result<
@@ -779,7 +779,7 @@ mod select_disputes {
 			const ACTIVE_DISPUTES_SIZE: usize = MAX_DISPUTES_FORWARDED_TO_RUNTIME + 10;
 			const ONCHAIN_DISPUTE_SIZE: usize = ACTIVE_DISPUTES_SIZE - 9;
 
-			let metrics = metrics::Metrics::new_dummy();
+			let metrics = metrics::Metrics(None);
 			let recent_disputes = recent_disputes(RECENT_DISPUTES_SIZE);
 			let active_disputes = active_disputes(ACTIVE_DISPUTES_SIZE);
 			let onchain_disputes: Result<
@@ -840,7 +840,7 @@ mod select_disputes {
 			const ACTIVE_DISPUTES_SIZE: usize = MAX_DISPUTES_FORWARDED_TO_RUNTIME + 5;
 			const ONCHAIN_DISPUTE_SIZE: usize = 5;
 
-			let metrics = metrics::Metrics::new_dummy();
+			let metrics = metrics::Metrics(None);
 			let recent_disputes = recent_disputes(RECENT_DISPUTES_SIZE);
 			let active_disputes = active_disputes(ACTIVE_DISPUTES_SIZE);
 			let onchain_disputes: Result<

--- a/node/core/provisioner/src/tests.rs
+++ b/node/core/provisioner/src/tests.rs
@@ -546,7 +546,7 @@ mod select_disputes {
 			match from_job {
 				AllMessages::RuntimeApi(RuntimeApiMessage::Request(
 					_,
-					RuntimeApiRequest::Disputes(sender),
+					RuntimeApiRequest::StagingDisputes(sender),
 				)) => {
 					let _ = sender.send(onchain_disputes.clone());
 				},

--- a/node/core/provisioner/src/tests.rs
+++ b/node/core/provisioner/src/tests.rs
@@ -499,10 +499,12 @@ mod select_candidates {
 mod select_disputes {
 
 	use super::{super::*, common::test_harness};
-	use polkadot_node_subsystem::messages::{
-		AllMessages, DisputeCoordinatorMessage, RuntimeApiMessage, RuntimeApiRequest,
+	use polkadot_node_subsystem::{
+		messages::{AllMessages, DisputeCoordinatorMessage, RuntimeApiMessage, RuntimeApiRequest},
+		RuntimeApiError,
 	};
 	use polkadot_node_subsystem_test_helpers::TestSubsystemSender;
+	use polkadot_primitives::v2::DisputeState;
 	use std::sync::Arc;
 	use test_helpers;
 

--- a/node/core/runtime-api/src/cache.rs
+++ b/node/core/runtime-api/src/cache.rs
@@ -47,7 +47,7 @@ const ON_CHAIN_VOTES_CACHE_SIZE: usize = 3 * 1024;
 const PVFS_REQUIRE_PRECHECK_SIZE: usize = 1024;
 const VALIDATION_CODE_HASH_CACHE_SIZE: usize = 64 * 1024;
 const VERSION_CACHE_SIZE: usize = 4 * 1024;
-const DISPUTES_CACHE_SIZE: usize = 64 * 1024; // TODO: How much??
+const DISPUTES_CACHE_SIZE: usize = 64 * 1024;
 
 struct ResidentSizeOf<T>(T);
 

--- a/node/core/runtime-api/src/cache.rs
+++ b/node/core/runtime-api/src/cache.rs
@@ -463,5 +463,5 @@ pub(crate) enum RequestResult {
 	SubmitPvfCheckStatement(Hash, PvfCheckStatement, ValidatorSignature, ()),
 	ValidationCodeHash(Hash, ParaId, OccupiedCoreAssumption, Option<ValidationCodeHash>),
 	Version(Hash, u32),
-	Disputes(Hash, Vec<(SessionIndex, CandidateHash, DisputeState<BlockNumber>)>),
+	StagingDisputes(Hash, Vec<(SessionIndex, CandidateHash, DisputeState<BlockNumber>)>),
 }

--- a/node/core/runtime-api/src/lib.rs
+++ b/node/core/runtime-api/src/lib.rs
@@ -169,6 +169,8 @@ where
 				.cache_validation_code_hash((relay_parent, para_id, assumption), hash),
 			Version(relay_parent, version) =>
 				self.requests_cache.cache_version(relay_parent, version),
+			Disputes(relay_parent, disputes) =>
+				self.requests_cache.cache_disputes(relay_parent, disputes),
 		}
 	}
 
@@ -270,6 +272,8 @@ where
 			Request::ValidationCodeHash(para, assumption, sender) =>
 				query!(validation_code_hash(para, assumption), sender)
 					.map(|sender| Request::ValidationCodeHash(para, assumption, sender)),
+			Request::Disputes(sender) =>
+				query!(disputes(), sender).map(|sender| Request::Disputes(sender)),
 		}
 	}
 
@@ -526,5 +530,6 @@ where
 		},
 		Request::ValidationCodeHash(para, assumption, sender) =>
 			query!(ValidationCodeHash, validation_code_hash(para, assumption), ver = 2, sender),
+		Request::Disputes(sender) => query!(Disputes, staging_get_disputes(), ver = 2, sender),
 	}
 }

--- a/node/core/runtime-api/src/lib.rs
+++ b/node/core/runtime-api/src/lib.rs
@@ -169,7 +169,7 @@ where
 				.cache_validation_code_hash((relay_parent, para_id, assumption), hash),
 			Version(relay_parent, version) =>
 				self.requests_cache.cache_version(relay_parent, version),
-			Disputes(relay_parent, disputes) =>
+			StagingDisputes(relay_parent, disputes) =>
 				self.requests_cache.cache_disputes(relay_parent, disputes),
 		}
 	}
@@ -272,8 +272,8 @@ where
 			Request::ValidationCodeHash(para, assumption, sender) =>
 				query!(validation_code_hash(para, assumption), sender)
 					.map(|sender| Request::ValidationCodeHash(para, assumption, sender)),
-			Request::Disputes(sender) =>
-				query!(disputes(), sender).map(|sender| Request::Disputes(sender)),
+			Request::StagingDisputes(sender) =>
+				query!(disputes(), sender).map(|sender| Request::StagingDisputes(sender)),
 		}
 	}
 
@@ -530,6 +530,7 @@ where
 		},
 		Request::ValidationCodeHash(para, assumption, sender) =>
 			query!(ValidationCodeHash, validation_code_hash(para, assumption), ver = 2, sender),
-		Request::Disputes(sender) => query!(Disputes, staging_get_disputes(), ver = 2, sender),
+		Request::StagingDisputes(sender) =>
+			query!(StagingDisputes, staging_get_disputes(), ver = 2, sender),
 	}
 }

--- a/node/service/Cargo.toml
+++ b/node/service/Cargo.toml
@@ -198,3 +198,5 @@ runtime-metrics = [
 	"polkadot-runtime/runtime-metrics",
 	"polkadot-runtime-parachains/runtime-metrics"
 ]
+
+staging-client = ["polkadot-node-core-provisioner/staging-client"]

--- a/node/subsystem-types/src/messages.rs
+++ b/node/subsystem-types/src/messages.rs
@@ -40,7 +40,7 @@ use polkadot_node_primitives::{
 };
 use polkadot_primitives::v2::{
 	AuthorityDiscoveryId, BackedCandidate, BlockNumber, CandidateEvent, CandidateHash,
-	CandidateIndex, CandidateReceipt, CollatorId, CommittedCandidateReceipt, CoreState, GroupIndex,
+	CandidateIndex, CandidateReceipt, DisputeState, CollatorId, CommittedCandidateReceipt, CoreState, GroupIndex,
 	GroupRotationInfo, Hash, Header as BlockHeader, Id as ParaId, InboundDownwardMessage,
 	InboundHrmpMessage, MultiDisputeStatementSet, OccupiedCoreAssumption, PersistedValidationData,
 	PvfCheckStatement, SessionIndex, SessionInfo, SignedAvailabilityBitfield,
@@ -693,6 +693,10 @@ pub enum RuntimeApiRequest {
 		OccupiedCoreAssumption,
 		RuntimeApiSender<Option<ValidationCodeHash>>,
 	),
+	/// Returns all on-chain disputes at given block number.
+	// TODO: Do we need `DisputeState`
+	// TODO: Add staging prefix?
+	Disputes(RuntimeApiSender<Vec<(SessionIndex, CandidateHash, DisputeState<BlockNumber>)>>),
 }
 
 /// A message to the Runtime API subsystem.

--- a/node/subsystem-types/src/messages.rs
+++ b/node/subsystem-types/src/messages.rs
@@ -694,7 +694,9 @@ pub enum RuntimeApiRequest {
 		RuntimeApiSender<Option<ValidationCodeHash>>,
 	),
 	/// Returns all on-chain disputes at given block number.
-	Disputes(RuntimeApiSender<Vec<(SessionIndex, CandidateHash, DisputeState<BlockNumber>)>>),
+	StagingDisputes(
+		RuntimeApiSender<Vec<(SessionIndex, CandidateHash, DisputeState<BlockNumber>)>>,
+	),
 }
 
 /// A message to the Runtime API subsystem.

--- a/node/subsystem-types/src/messages.rs
+++ b/node/subsystem-types/src/messages.rs
@@ -694,8 +694,6 @@ pub enum RuntimeApiRequest {
 		RuntimeApiSender<Option<ValidationCodeHash>>,
 	),
 	/// Returns all on-chain disputes at given block number.
-	// TODO: Do we need `DisputeState`
-	// TODO: Add staging prefix?
 	Disputes(RuntimeApiSender<Vec<(SessionIndex, CandidateHash, DisputeState<BlockNumber>)>>),
 }
 

--- a/node/subsystem-types/src/messages.rs
+++ b/node/subsystem-types/src/messages.rs
@@ -40,12 +40,12 @@ use polkadot_node_primitives::{
 };
 use polkadot_primitives::v2::{
 	AuthorityDiscoveryId, BackedCandidate, BlockNumber, CandidateEvent, CandidateHash,
-	CandidateIndex, CandidateReceipt, DisputeState, CollatorId, CommittedCandidateReceipt, CoreState, GroupIndex,
-	GroupRotationInfo, Hash, Header as BlockHeader, Id as ParaId, InboundDownwardMessage,
-	InboundHrmpMessage, MultiDisputeStatementSet, OccupiedCoreAssumption, PersistedValidationData,
-	PvfCheckStatement, SessionIndex, SessionInfo, SignedAvailabilityBitfield,
-	SignedAvailabilityBitfields, ValidationCode, ValidationCodeHash, ValidatorId, ValidatorIndex,
-	ValidatorSignature,
+	CandidateIndex, CandidateReceipt, CollatorId, CommittedCandidateReceipt, CoreState,
+	DisputeState, GroupIndex, GroupRotationInfo, Hash, Header as BlockHeader, Id as ParaId,
+	InboundDownwardMessage, InboundHrmpMessage, MultiDisputeStatementSet, OccupiedCoreAssumption,
+	PersistedValidationData, PvfCheckStatement, SessionIndex, SessionInfo,
+	SignedAvailabilityBitfield, SignedAvailabilityBitfields, ValidationCode, ValidationCodeHash,
+	ValidatorId, ValidatorIndex, ValidatorSignature,
 };
 use polkadot_statement_table::v2::Misbehavior;
 use std::{

--- a/primitives/src/v2/mod.rs
+++ b/primitives/src/v2/mod.rs
@@ -1410,10 +1410,7 @@ impl MallocSizeOf for DisputeState {
 		let Self { validators_for, validators_against, start, concluded_at } = self;
 
 		// According to the documentation `.capacity()` might not return a byte aligned value, so just in case:
-		let align_eight = |d: usize| match d % 8 {
-			0 => d / 8,
-			_ => d / 8 + 1,
-		};
+		let align_eight = |d: usize| (d + 7) / 8;
 
 		align_eight(validators_for.capacity()) +
 			align_eight(validators_against.capacity()) +

--- a/primitives/src/v2/mod.rs
+++ b/primitives/src/v2/mod.rs
@@ -1403,6 +1403,18 @@ pub struct DisputeState<N = BlockNumber> {
 	pub concluded_at: Option<N>,
 }
 
+#[cfg(feature = "std")]
+impl MallocSizeOf for DisputeState {
+	fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
+		// BitVec is converted to slice to get its size dynamically.
+		// It's equal to calling .capacity() * sizeof::<u8>() but without hardcoding the actual T
+		std::mem::size_of_val(&*self.validators_for) +
+			std::mem::size_of_val(&*self.validators_against) +
+			self.start.size_of(ops) +
+			self.concluded_at.size_of(ops)
+	}
+}
+
 /// Parachains inherent-data passed into the runtime by a block author
 #[derive(Encode, Decode, Clone, PartialEq, RuntimeDebug, TypeInfo)]
 pub struct InherentData<HDR: HeaderT = Header> {


### PR DESCRIPTION
This PR adds logic which improves the efficiency of the on-chain disputes importing in provisioner subsystem. First step for resolving #4573

### Motivation
When the provisioner prepares inherent data (on message `RequestInherentData`) it requests all disputes the current node knows about from the disputes-coordinator (via `DisputeCoordinatorMessage::RecentDisputes` message). These disputes are sent to the Runtime no matter if they are already on-chain or not. Furthermore if the disputes count is too large - it is trimmed by randomly dropping disputes. This approach works but is not effective.

### What's changed in the PR
~Before preparing the disputes list the provisioner fetches all on-chain disputes by issuing a **staging API call** to the Runtime - `RuntimeApiRequest::Disputes`. Then the provisioner filters out the result from `DisputeCoordinatorMessage::RecentDisputes` by removing the disputes already imported on-chain. The rest of the logic remains the same.~
The description above is not correct. A dispute occurring and concluding within the time a single block is created is a quite happy case. So it is not acceptable to import a dispute once and consider it done, because the node might receive new votes for ongoing disputes and they will never be sent on chain.
For this reason the PR implements the following logic:

Case 1: All RECENT disputes can be sent to the Runtime
* `Provisioner` gets all RECENT disputes. They are sent to the runtime. 

Case 2: RECENT disputes are too much (more than `MAX_DISPUTES_FORWARDED_TO_RUNTIME`). ACTIVE disputes fit in the limit.
* `Provisioner` queries the Runtime about the disputes it knows about (with `RuntimeApiRequest::Disputes`).
* The set of ACTIVE disputes is extended with  RECENT ones until it reaches `MAX_DISPUTES_FORWARDED_TO_RUNTIME` limit. Disputes unknown to the Runtime are added with priority during the extension. 

Case 3: Both RECENT and ACTIVE disputes are more than `MAX_DISPUTES_FORWARDED_TO_RUNTIME` limit.
* `Provisioner` queries the Runtime about the disputes it knows about (with `RuntimeApiRequest::Disputes`).
* `Provisioner` adds creates a set of ACTIVE disputes with size `MAX_DISPUTES_FORWARDED_TO_RUNTIME`. Disputes unknown to the Runtime are added with priority in this set.

### Benefits
* Potentially smaller dispute set is set to the Runtime
* The chance to drop a dispute which is unknown on-chain is decreased thanks to the filtering mentioned above.

### Feature flag
Due to the usage of a staging API call the whole functionality is put behind a feature flag - `staging-client`. All features using staging Runtime calls will be behind this feature flag.