### PR TITLE
[ci] benchmarks: suppress wrong exit code

### DIFF
--- a/scripts/run_benches_for_runtime.sh
+++ b/scripts/run_benches_for_runtime.sh
@@ -46,3 +46,6 @@ rm "${runtime}_pallets"
   --weight-path="runtime/${runtime}/constants/src/weights/" \
   --warmup=10 \
   --repeat=100
+
+
+true


### PR DESCRIPTION
The script uses '!' to prevent set -e failures,
however a $? of `0` becomes exit code 1 if it is the last command ran.

This `true` makes sure that $? is 0 when we reach the end,
instead of carrying over a failure which would otherwise cause
the whole CI job to abort.