### PR TITLE
Add metrics to measure subsystem message processing time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4901,9 +4901,9 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -6817,6 +6817,7 @@ dependencies = [
  "sp-core",
  "sp-keyring",
  "sp-keystore",
+ "strum 0.24.0",
  "thiserror",
  "tracing-gum",
 ]
@@ -7059,6 +7060,7 @@ dependencies = [
  "polkadot-statement-table",
  "sc-network",
  "smallvec",
+ "strum 0.21.0",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
@@ -10997,6 +10999,15 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaf86bbcfd1fa9670b7a129f64fc0c9fcbbfe4f1bc4210e9e98fe71ffc12cde2"
+dependencies = [
+ "strum_macros 0.21.1",
+]
+
+[[package]]
+name = "strum"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cae14b91c7d11c9a851d3fbc80a963198998c2a64eec840477fa92d8ce9b70bb"
@@ -11011,6 +11022,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e96acfc1b70604b8b2f1ffa4c57e59176c7dbb05d556c71ecd2f5498a1dee7f8"
 dependencies = [
  "strum_macros 0.24.0",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d06aaeeee809dbc59eb4556183dd927df67db1540de5be8d3ec0b6636358a5ec"
+dependencies = [
+ "heck 0.3.3",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/node/core/dispute-coordinator/Cargo.toml
+++ b/node/core/dispute-coordinator/Cargo.toml
@@ -19,6 +19,7 @@ polkadot-node-subsystem = { path = "../../subsystem" }
 polkadot-node-subsystem-util = { path = "../../subsystem-util" }
 
 sc-keystore = { git = "https://github.com/paritytech/substrate", branch = "master" }
+strum = { version = "0.24", features = ["derive"] }
 
 
 [dev-dependencies]

--- a/node/core/dispute-coordinator/src/initialized.rs
+++ b/node/core/dispute-coordinator/src/initialized.rs
@@ -18,6 +18,7 @@
 
 use std::{
 	collections::{BTreeMap, HashSet},
+	convert::AsRef,
 	sync::Arc,
 };
 
@@ -504,6 +505,9 @@ impl Initialized {
 		message: DisputeCoordinatorMessage,
 		now: Timestamp,
 	) -> Result<Box<dyn FnOnce() -> JfyiResult<()>>> {
+		let label = message.as_ref().to_owned();
+		let timer = self.metrics.time_message_processing(&label);
+
 		match message {
 			DisputeCoordinatorMessage::ImportStatements {
 				candidate_hash,
@@ -622,6 +626,7 @@ impl Initialized {
 			},
 		}
 
+		drop(timer);
 		Ok(Box::new(|| Ok(())))
 	}
 

--- a/node/network/approval-distribution/src/lib.rs
+++ b/node/network/approval-distribution/src/lib.rs
@@ -39,7 +39,10 @@ use polkadot_primitives::v2::{
 	BlockNumber, CandidateIndex, Hash, SessionIndex, ValidatorIndex, ValidatorSignature,
 };
 use rand::{CryptoRng, Rng, SeedableRng};
-use std::collections::{hash_map, BTreeMap, HashMap, HashSet, VecDeque};
+use std::{
+	collections::{hash_map, BTreeMap, HashMap, HashSet, VecDeque},
+	convert::AsRef,
+};
 
 use self::metrics::Metrics;
 
@@ -1778,6 +1781,9 @@ impl ApprovalDistribution {
 		Context: SubsystemContext<Message = ApprovalDistributionMessage>,
 		Context: overseer::SubsystemContext<Message = ApprovalDistributionMessage>,
 	{
+		let label = msg.as_ref().to_owned();
+		let timer = metrics.time_message_processing(&label);
+
 		match msg {
 			ApprovalDistributionMessage::NetworkBridgeUpdateV1(event) => {
 				state.handle_network_msg(ctx, metrics, event, rng).await;
@@ -1817,6 +1823,8 @@ impl ApprovalDistribution {
 					.await;
 			},
 		}
+
+		drop(timer);
 	}
 }
 

--- a/node/subsystem-types/Cargo.toml
+++ b/node/subsystem-types/Cargo.toml
@@ -18,3 +18,4 @@ sc-network = { git = "https://github.com/paritytech/substrate", branch = "master
 smallvec = "1.8.0"
 substrate-prometheus-endpoint = { git = "https://github.com/paritytech/substrate", branch = "master" }
 thiserror = "1.0.30"
+strum = { version = "0.21", features = ["derive"] }

--- a/node/subsystem-types/src/messages.rs
+++ b/node/subsystem-types/src/messages.rs
@@ -53,6 +53,7 @@ use std::{
 	sync::Arc,
 	time::Duration,
 };
+use strum::AsRefStr;
 
 /// Network events as transmitted to other subsystems, wrapped in their message types.
 pub mod network_bridge_event;
@@ -228,7 +229,7 @@ impl BoundToRelayParent for CollatorProtocolMessage {
 ///
 /// NOTE: Any response oneshots might get cancelled if the `DisputeCoordinator` was not yet
 /// properly initialized for some reason.
-#[derive(Debug)]
+#[derive(AsRefStr, Debug)]
 pub enum DisputeCoordinatorMessage {
 	/// Import statements by validators about a candidate.
 	///
@@ -899,7 +900,7 @@ pub enum ApprovalVotingMessage {
 }
 
 /// Message to the Approval Distribution subsystem.
-#[derive(Debug, derive_more::From)]
+#[derive(AsRefStr, Debug, derive_more::From)]
 pub enum ApprovalDistributionMessage {
 	/// Notify the `ApprovalDistribution` subsystem about new blocks
 	/// and the candidates contained within them.


### PR DESCRIPTION
Implement https://github.com/paritytech/polkadot/issues/5387

This is just a test implementation, meant to gather more data to explain the high ToF times we are alredy seeing. It only looks at messages coming from other subsystems, and doesn't cover overseer signals. 