### PR TITLE
Customize check-dependent-* for release engineering

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -340,6 +340,9 @@ check-dependent-cumulus:
   variables:
     DEPENDENT_REPO: cumulus
     EXTRA_DEPENDENCIES: substrate
+    COMPANION_OVERRIDES: |
+      polkadot: release-v*
+      cumulus: polkadot-v*
 
 test-node-metrics:
   stage:                           stage2


### PR DESCRIPTION
See https://github.com/paritytech/pipeline-scripts/issues/32 for the request or [the usage section](https://github.com/paritytech/pipeline-scripts#check_dependent_project-usage) explanation for this feature.