### PR TITLE
Increase timeout, as it seems to be hit on CI occasionally.

### DIFF
--- a/node/network/approval-distribution/src/tests.rs
+++ b/node/network/approval-distribution/src/tests.rs
@@ -75,7 +75,7 @@ fn test_harness<T: Future<Output = VirtualOverseer>>(
 	state
 }
 
-const TIMEOUT: Duration = Duration::from_millis(100);
+const TIMEOUT: Duration = Duration::from_millis(200);
 
 async fn overseer_send(overseer: &mut VirtualOverseer, msg: ApprovalDistributionMessage) {
 	gum::trace!(msg = ?msg, "Sending message");


### PR DESCRIPTION
If this keeps being a problem, we might also increase the channel size:

https://github.com/paritytech/polkadot/blob/88d66ac669c5f9c5d82651ff70fda9691f4e0ece/node/subsystem-test-helpers/src/lib.rs#L239

Resolves: #5417