### PR TITLE
Revert approval voting

### DIFF
--- a/node/core/approval-voting/src/approval_db/v1/mod.rs
+++ b/node/core/approval-voting/src/approval_db/v1/mod.rs
@@ -95,6 +95,9 @@ impl Backend for DbBackend {
 						stored_block_range.encode(),
 					);
 				},
+				BackendWriteOp::DeleteStoredBlockRange => {
+					tx.delete(self.config.col_data, &STORED_BLOCKS_KEY);
+				},
 				BackendWriteOp::WriteBlocksAtHeight(h, blocks) => {
 					tx.put_vec(self.config.col_data, &blocks_at_height_key(h), blocks.encode());
 				},

--- a/node/core/approval-voting/src/backend.rs
+++ b/node/core/approval-voting/src/backend.rs
@@ -67,8 +67,11 @@ pub trait Backend {
 // Status of block range in the `OverlayedBackend`.
 #[derive(PartialEq)]
 enum BlockRangeStatus {
+	// Value has not been modified.
 	NotModified,
+	// Value has been deleted
 	Deleted,
+	// Value has been updated.
 	Inserted(StoredBlockRange),
 }
 

--- a/node/core/approval-voting/src/backend.rs
+++ b/node/core/approval-voting/src/backend.rs
@@ -145,8 +145,6 @@ impl<'a, B: 'a + Backend> OverlayedBackend<'a, B> {
 		self.inner.load_candidate_entry(candidate_hash)
 	}
 
-	// The assumption is that stored block range is only None on initialization.
-	// Therefore, there is no need to delete_stored_block_range.
 	pub fn write_stored_block_range(&mut self, range: StoredBlockRange) {
 		self.stored_block_range = Some(Some(range));
 	}

--- a/node/core/approval-voting/src/lib.rs
+++ b/node/core/approval-voting/src/lib.rs
@@ -340,6 +340,105 @@ impl ApprovalVotingSubsystem {
 			metrics,
 		}
 	}
+
+	/// Revert to the block corresponding to the specified `hash`.
+	/// The revert is not allowed for blocks older than the last finalized one.
+	pub fn revert_to(&self, hash: Hash) -> Result<(), SubsystemError> {
+		let config = approval_db::v1::Config { col_data: self.db_config.col_data };
+		let mut backend = approval_db::v1::DbBackend::new(self.db.clone(), config);
+		let mut overlay = OverlayedBackend::new(&backend);
+
+		let mut entry = match overlay.load_block_entry(&hash)? {
+			Some(entry) => entry,
+			None => {
+				// This may only happen if hash corresponds to genesis or if
+				// we're trying to revert below the last finalized block.
+				// Revert to genesis block should be handled specially since no
+				// information about it is persisted as a block entry.
+				let blocks = overlay.load_blocks_at_height(&1).unwrap_or_default();
+				let is_genesis = blocks
+					.first()
+					.and_then(|hash| overlay.load_block_entry(hash).ok())
+					.flatten()
+					.map(|entry| entry.parent_hash() == hash)
+					.unwrap_or_default();
+				if !is_genesis {
+					return Err(SubsystemError::Context(
+						"Trying to revert below last finalized block".to_string(),
+					))
+				}
+
+				// TODO: check if dummy entry is removed
+				// We use part of the information contained in the finalized block
+				// children (that are expected to be in the tree) to construct a
+				// dummy block entry for the last finalized block. This will be
+				// wiped as soon as the next block is finalized.
+				let entry = approval_db::v1::BlockEntry {
+					block_hash: hash,
+					block_number: 0,
+					parent_hash: Hash::default(),
+					session: 1,
+					slot: Slot::from(1),
+					relay_vrf_story: [0u8; 32],
+					candidates: Vec::new(),
+					approved_bitfield: approval_db::v1::Bitfield::from_slice(&[]),
+					children: blocks,
+				};
+
+				// This becomes the first entry according to the block number.
+				//backend.write_blocks_by_number(block_number, vec![hash]);
+
+				entry.into()
+			},
+		};
+
+		let mut stack: Vec<_> = std::mem::take(&mut entry.children)
+			.into_iter()
+			.map(|h| (h, entry.block_number() + 1))
+			.collect();
+
+		// Write revert point block entry without the children.
+		overlay.write_block_entry(entry);
+
+		while let Some((hash, number)) = stack.pop() {
+			let mut blocks_at_height = overlay.load_blocks_at_height(&number)?;
+			blocks_at_height.retain(|h| h != &hash);
+			overlay.write_blocks_at_height(number, blocks_at_height);
+
+			if let Some(entry) = overlay.load_block_entry(&hash)? {
+				// Before going through the candidates loop is important to first remove the block
+				// entry.
+				overlay.delete_block_entry(&hash);
+
+				// >>> NOTE / TODO / FIXME <<
+				// THIS EXTREMELLY VERBOSE COMMENTS PURPOSE IS ONLY TO SIMPLIFY CODE REVIEW
+				// REMOVE COMMENTS BEFORE MERGE
+				//
+				// For each candidate in `candidates` of `BlockEntry`:
+				// 1. Use the `CandidateHash` with `load_candidate_entry` to load the `CandidateEntry`.
+				// 2. Remove from the `block_assignments` the entries corresponding to `BlockEntry` hash.
+				// 3. If the candidate is not referenced by any other block (i.e. `block_assignments`
+				//    is empty) then we can remove the entry using `delete_candidate_entry`.
+				for (_, candidate_hash) in entry.candidates() {
+					if let Some(mut candidate_entry) =
+						overlay.load_candidate_entry(candidate_hash)?
+					{
+						candidate_entry.block_assignments.remove(&hash);
+						if candidate_entry.block_assignments.is_empty() {
+							overlay.delete_candidate_entry(candidate_hash);
+						} else {
+							overlay.write_candidate_entry(candidate_entry);
+						}
+					}
+				}
+
+				stack.extend(entry.children.into_iter().map(|h| (h, number + 1)));
+			}
+		}
+
+		let ops = overlay.into_write_ops();
+		backend.write(ops)
+	}
 }
 
 impl<Context> overseer::Subsystem<Context, SubsystemError> for ApprovalVotingSubsystem

--- a/node/core/approval-voting/src/ops.rs
+++ b/node/core/approval-voting/src/ops.rs
@@ -327,11 +327,12 @@ pub fn revert_to(
 			(children, children_height)
 		},
 		None => {
-			let children_height = overlay.load_stored_blocks()?
-                .map(|range| range.0)
-                .ok_or_else(|| {
-                    SubsystemError::Context("no available blocks to infer revert point heightlookup failure for first block".to_string())
-                })?;
+			let children_height =
+				overlay.load_stored_blocks()?.map(|range| range.0).ok_or_else(|| {
+					SubsystemError::Context(
+						"no available blocks to infer revert point height".to_string(),
+					)
+				})?;
 
 			let children = overlay.load_blocks_at_height(&children_height)?;
 

--- a/node/core/approval-voting/src/ops.rs
+++ b/node/core/approval-voting/src/ops.rs
@@ -332,22 +332,22 @@ pub fn revert_to(
 			// but we should consider that revert is a "one-shot" and very
 			// sporadic operation.
 			let blocks = overlay.load_all_blocks()?;
-			let entry = blocks
+			let child_entry = blocks
 				.first()
 				.and_then(|hash| overlay.load_block_entry(hash).ok())
 				.flatten()
 				.ok_or_else(|| {
-					SubsystemError::Context(format!("Unexpected lookup failure for block {}", hash))
+					SubsystemError::Context(format!("lookup failure for block {}", hash))
 				})?;
 
 			// The parent is expected to be the revert point
-			if entry.parent_hash() != hash {
+			if child_entry.parent_hash() != hash {
 				return Err(SubsystemError::Context(
 					"revert below last finalized block or corrupted storage".to_string(),
 				))
 			}
 
-			let children_height = entry.block_number();
+			let children_height = child_entry.block_number();
 			let children = overlay.load_blocks_at_height(&children_height)?;
 			(children, children_height)
 		},

--- a/node/core/approval-voting/src/tests.rs
+++ b/node/core/approval-voting/src/tests.rs
@@ -306,6 +306,9 @@ impl Backend for TestStoreInner {
 				BackendWriteOp::WriteStoredBlockRange(stored_block_range) => {
 					self.stored_block_range = Some(stored_block_range);
 				},
+				BackendWriteOp::DeleteStoredBlockRange => {
+					self.stored_block_range = None;
+				},
 				BackendWriteOp::WriteBlocksAtHeight(h, blocks) => {
 					self.blocks_at_height.insert(h, blocks);
 				},

--- a/node/core/chain-selection/src/lib.rs
+++ b/node/core/chain-selection/src/lib.rs
@@ -318,9 +318,9 @@ impl ChainSelectionSubsystem {
 
 	/// Revert to the block corresponding to the specified `hash`.
 	/// The revert is not allowed for blocks older than the last finalized one.
-	pub fn revert(&self, hash: Hash) -> Result<(), Error> {
-		let backend_config = db_backend::v1::Config { col_data: self.config.col_data };
-		let mut backend = db_backend::v1::DbBackend::new(self.db.clone(), backend_config);
+	pub fn revert_to(&self, hash: Hash) -> Result<(), Error> {
+		let config = db_backend::v1::Config { col_data: self.config.col_data };
+		let mut backend = db_backend::v1::DbBackend::new(self.db.clone(), config);
 
 		let ops = tree::revert_to(&backend, hash)?.into_write_ops();
 

--- a/node/core/chain-selection/src/lib.rs
+++ b/node/core/chain-selection/src/lib.rs
@@ -317,7 +317,7 @@ impl ChainSelectionSubsystem {
 	}
 
 	/// Revert to the block corresponding to the specified `hash`.
-	/// The revert is not allowed for blocks older than the last finalized one.
+	/// The operation is not allowed for blocks older than the last finalized one.
 	pub fn revert_to(&self, hash: Hash) -> Result<(), Error> {
 		let config = db_backend::v1::Config { col_data: self.config.col_data };
 		let mut backend = db_backend::v1::DbBackend::new(self.db.clone(), config);

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -1493,6 +1493,8 @@ impl ExecuteWithClient for RevertConsensus {
 		Api: polkadot_client::RuntimeApiCollection<StateBackend = Backend::State>,
 		Client: AbstractClient<Block, Backend, Api = Api> + 'static,
 	{
+		// Revert consensus-related components.
+		// The operations are not correlated, thus call order is not relevant.
 		babe::revert(client.clone(), self.backend, self.blocks)?;
 		grandpa::revert(client, self.blocks)?;
 		Ok(())

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -1464,24 +1464,11 @@ fn revert_approval_voting(db: Arc<dyn Database>, hash: Hash) -> sp_blockchain::R
 		slot_duration_millis: Default::default(),
 	};
 
-	struct DummyOracle;
-	impl consensus_common::SyncOracle for DummyOracle {
-		fn is_major_syncing(&mut self) -> bool {
-			false
-		}
-		fn is_offline(&mut self) -> bool {
-			false
-		}
-	}
-
-	// Construct an approval voting subsystem with a dummy sync oracle and keystore.
-	// This dummy components are not be used by the revert and are only necessary
-	// for construction.
 	let approval_voting = approval_voting_subsystem::ApprovalVotingSubsystem::with_config(
 		config,
 		db,
 		Arc::new(sc_keystore::LocalKeystore::in_memory()),
-		Box::new(DummyOracle),
+		Box::new(consensus_common::NoNetwork),
 		approval_voting_subsystem::Metrics::default(),
 	);
 

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -37,7 +37,9 @@ use {
 	beefy_gadget::notification::{BeefyBestBlockSender, BeefySignedCommitmentSender},
 	grandpa::{self, FinalityProofProvider as GrandpaFinalityProofProvider},
 	gum::info,
-	polkadot_node_core_approval_voting::Config as ApprovalVotingConfig,
+	polkadot_node_core_approval_voting::{
+		self as approval_voting_subsystem, Config as ApprovalVotingConfig,
+	},
 	polkadot_node_core_av_store::Config as AvailabilityConfig,
 	polkadot_node_core_av_store::Error as AvailabilityError,
 	polkadot_node_core_candidate_validation::Config as CandidateValidationConfig,
@@ -1403,6 +1405,92 @@ pub fn build_full(
 	Err(Error::NoRuntime)
 }
 
+/// Reverts the node state down to at most the last finalized block.
+///
+/// In particular this reverts:
+/// - `ChainSelectionSubsystem` data in the parachains-db.
+/// - Low level Babe and Grandpa consensus data.
+#[cfg(feature = "full-node")]
+pub fn revert_backend(
+	client: Arc<Client>,
+	backend: Arc<FullBackend>,
+	blocks: BlockNumber,
+	config: Configuration,
+) -> Result<(), Error> {
+	let best_number = client.info().best_number;
+	let finalized = client.info().finalized_number;
+	let revertible = blocks.min(best_number - finalized);
+
+	if revertible == 0 {
+		return Ok(())
+	}
+
+	let number = best_number - revertible;
+	let hash = client.block_hash_from_id(&BlockId::Number(number))?.ok_or(
+		sp_blockchain::Error::Backend(format!(
+			"Unexpected hash lookup failure for block number: {}",
+			number
+		)),
+	)?;
+
+	let parachains_db = open_database(&config.database)
+		.map_err(|err| sp_blockchain::Error::Backend(err.to_string()))?;
+
+	// Revert approval voting subsystem
+	revert_approval_voting(parachains_db.clone(), hash)?;
+
+	// Revert chain-selection subsystem
+	revert_chain_selection(parachains_db, hash)?;
+
+	// Revert Substrate consensus related components
+	client.execute_with(RevertConsensus { blocks, backend })?;
+
+	Ok(())
+}
+
+fn revert_chain_selection(db: Arc<dyn Database>, hash: Hash) -> sp_blockchain::Result<()> {
+	let config = chain_selection_subsystem::Config {
+		col_data: parachains_db::REAL_COLUMNS.col_chain_selection_data,
+		stagnant_check_interval: chain_selection_subsystem::StagnantCheckInterval::never(),
+	};
+
+	let chain_selection = chain_selection_subsystem::ChainSelectionSubsystem::new(config, db);
+
+	chain_selection
+		.revert_to(hash)
+		.map_err(|err| sp_blockchain::Error::Backend(err.to_string()))
+}
+
+fn revert_approval_voting(db: Arc<dyn Database>, hash: Hash) -> sp_blockchain::Result<()> {
+	let config = approval_voting_subsystem::Config {
+		col_data: parachains_db::REAL_COLUMNS.col_approval_data,
+		slot_duration_millis: Default::default(),
+	};
+
+	struct DummyOracle;
+	impl consensus_common::SyncOracle for DummyOracle {
+		fn is_major_syncing(&mut self) -> bool {
+			false
+		}
+		fn is_offline(&mut self) -> bool {
+			false
+		}
+	}
+
+	// Construct a usable approval voting subsystem with a dummy sync oracle and keystore.
+	let approval_voting = approval_voting_subsystem::ApprovalVotingSubsystem::with_config(
+		config,
+		db,
+		Arc::new(sc_keystore::LocalKeystore::in_memory()),
+		Box::new(DummyOracle),
+		approval_voting_subsystem::Metrics::default(),
+	);
+
+	approval_voting
+		.revert_to(hash)
+		.map_err(|err| sp_blockchain::Error::Backend(err.to_string()))
+}
+
 struct RevertConsensus {
 	blocks: BlockNumber,
 	backend: Arc<FullBackend>,
@@ -1423,48 +1511,4 @@ impl ExecuteWithClient for RevertConsensus {
 		grandpa::revert(client, self.blocks)?;
 		Ok(())
 	}
-}
-
-/// Reverts the node state down to at most the last finalized block.
-///
-/// In particular this reverts:
-/// - `ChainSelectionSubsystem` data in the parachains-db.
-/// - Low level Babe and Grandpa consensus data.
-#[cfg(feature = "full-node")]
-pub fn revert_backend(
-	client: Arc<Client>,
-	backend: Arc<FullBackend>,
-	blocks: BlockNumber,
-	config: Configuration,
-) -> Result<(), Error> {
-	let best_number = client.info().best_number;
-	let finalized = client.info().finalized_number;
-	let revertible = blocks.min(best_number - finalized);
-
-	let number = best_number - revertible;
-	let hash = client.block_hash_from_id(&BlockId::Number(number))?.ok_or(
-		sp_blockchain::Error::Backend(format!(
-			"Unexpected hash lookup failure for block number: {}",
-			number
-		)),
-	)?;
-
-	let parachains_db = open_database(&config.database)
-		.map_err(|err| sp_blockchain::Error::Backend(err.to_string()))?;
-
-	let config = chain_selection_subsystem::Config {
-		col_data: parachains_db::REAL_COLUMNS.col_chain_selection_data,
-		stagnant_check_interval: chain_selection_subsystem::StagnantCheckInterval::never(),
-	};
-
-	let chain_selection =
-		chain_selection_subsystem::ChainSelectionSubsystem::new(config, parachains_db);
-
-	chain_selection
-		.revert(hash)
-		.map_err(|err| sp_blockchain::Error::Backend(err.to_string()))?;
-
-	client.execute_with(RevertConsensus { blocks, backend })?;
-
-	Ok(())
 }


### PR DESCRIPTION
Partially addresses https://github.com/paritytech/polkadot/issues/5396

This PR is a follow up of https://github.com/paritytech/polkadot/pull/5350 and addresses the revert of the `ApprovalVoting` subsystem.

The operation api is similar to the one exposed by the `ChainSelection` subsystem.

No particular blockers were found. 