### PR TITLE
WIP: Westend like Polkadot should have 10 decimal places

### DIFF
--- a/node/service/src/chain_spec.rs
+++ b/node/service/src/chain_spec.rs
@@ -1158,7 +1158,7 @@ pub fn westend_staging_testnet_config() -> Result<WestendChainSpec, String> {
 		),
 		Some(DEFAULT_PROTOCOL_ID),
 		None,
-		None,
+		Some(polkadot_chain_spec_properties()),
 		Default::default(),
 	))
 }
@@ -1909,7 +1909,7 @@ pub fn westend_local_testnet_config() -> Result<WestendChainSpec, String> {
 		None,
 		Some(DEFAULT_PROTOCOL_ID),
 		None,
-		None,
+		Some(polkadot_chain_spec_properties()),
 		Default::default(),
 	))
 }


### PR DESCRIPTION
We fixed up the polkadot-js chain properties for polkadot like networks so there were no surprises when testing polkadot teleporting in this PR: https://github.com/paritytech/polkadot/pull/5369 

We should do this for Westend also. Westend is the testbed for Polkadot and so should have 10 decimal places like Polkadot.
(Not doing this would be leaving a footgun around for someone in the future.)