### PR TITLE
[ci] update approval rules

### DIFF
--- a/.github/pr-custom-review.yml
+++ b/.github/pr-custom-review.yml
@@ -19,10 +19,19 @@ rules:
     check_type: changed_files
     condition:
       include: .*
-      exclude: ^runtime/(kusama|polkadot)/src/[^/]+\.rs$
+      # excluding files from 'Runtime files' and 'CI team' rules
+      exclude: ^runtime/(kusama|polkadot)/src/[^/]+\.rs$|\.gitlab-ci.yml|scripts/ci/.*|\.github/.*
     min_approvals: 2
     teams:
       - core-devs
+
+  - name: CI team
+    check_type: changed_files
+    condition:
+      include: \.gitlab-ci.yml|scripts/ci/.*|\.github/.*
+    min_approvals: 1
+    teams:
+      - ci
 
 prevent-review-request:
   teams:


### PR DESCRIPTION
This PR update `pr-custom-review` rules according to https://github.com/paritytech/ci_cd/issues/405

* removes mandatory approval by the @paritytech/core-devs team of CI files `.gitlab-ci.yml`, `.github/.*`, `scripts/ci/.*`
* introduces new approval rule for the CI related stuff  `.gitlab-ci.yml`, `.github/.*`, `scripts/ci/.*` by @paritytech/ci team