### PR TITLE
Improve `dispute-coordinator` message burstiness handling

### DIFF
--- a/node/core/provisioner/src/lib.rs
+++ b/node/core/provisioner/src/lib.rs
@@ -641,7 +641,8 @@ async fn request_disputes(
 		RequestType::Recent => DisputeCoordinatorMessage::RecentDisputes(tx),
 		RequestType::Active => DisputeCoordinatorMessage::ActiveDisputes(tx),
 	};
-	sender.send_message(msg.into()).await;
+	// Bounded by block production - `ProvisionerMessage::RequestInherentData`.
+	sender.send_unbounded_message(msg.into());
 
 	let recent_disputes = match rx.await {
 		Ok(r) => r,
@@ -659,9 +660,10 @@ async fn request_votes(
 	disputes_to_query: Vec<(SessionIndex, CandidateHash)>,
 ) -> Vec<(SessionIndex, CandidateHash, CandidateVotes)> {
 	let (tx, rx) = oneshot::channel();
-	sender
-		.send_message(DisputeCoordinatorMessage::QueryCandidateVotes(disputes_to_query, tx).into())
-		.await;
+	// Bounded by block production - `ProvisionerMessage::RequestInherentData`.
+	sender.send_unbounded_message(
+		DisputeCoordinatorMessage::QueryCandidateVotes(disputes_to_query, tx).into(),
+	);
 
 	match rx.await {
 		Ok(v) => v,

--- a/node/overseer/src/lib.rs
+++ b/node/overseer/src/lib.rs
@@ -415,6 +415,7 @@ pub async fn forward_events<P: BlockchainEvents<Block>>(client: Arc<P>, mut hand
 	signal=OverseerSignal,
 	error=SubsystemError,
 	network=NetworkBridgeEvent<VersionedValidationProtocol>,
+	message_capacity=2048,
 )]
 pub struct Overseer<SupportsParachains> {
 	#[subsystem(no_dispatch, CandidateValidationMessage)]


### PR DESCRIPTION
https://github.com/paritytech/polkadot/issues/5445

Implemented message channel size increase and `provisioner`, `dispute-coordinator` unbounded channel usage for reading `dispute-coordinator` data.