### PR TITLE
[ci] change polkadot binary extra tag

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -194,9 +194,7 @@ build-linux-stable:
     - sha256sum polkadot | tee polkadot.sha256
     - shasum -c polkadot.sha256
     - popd
-    - EXTRATAG="$(./artifacts/polkadot --version |
-        sed -n -r 's/^polkadot ([0-9.]+.*-[0-9a-f]{7,13})-.*$/\1/p')"
-    - EXTRATAG="${CI_COMMIT_REF_NAME}-${EXTRATAG}-$(cut -c 1-8 ./artifacts/polkadot.sha256)"
+    - EXTRATAG="${CI_COMMIT_REF_NAME}-${CI_COMMIT_SHORT_SHA}"
     - echo "Polkadot version = ${VERSION} (EXTRATAG = ${EXTRATAG})"
     - echo -n ${VERSION} > ./artifacts/VERSION
     - echo -n ${EXTRATAG} > ./artifacts/EXTRATAG


### PR DESCRIPTION
Currently `EXTRATAG` which is used for polkadot-debug image looks like `PR#/Tag/Branch name-polkadot version-first 8 symbols of binary sha256` which might be confusing. PR changes `EXTRATAG` to `PR#/Tag/Branch name-short commit sha`

Closes https://github.com/paritytech/ci_cd/issues/416