### PR TITLE
Add spotlight support

### DIFF
--- a/scripts/ci/changelog/templates/host_functions.md.tera
+++ b/scripts/ci/changelog/templates/host_functions.md.tera
@@ -14,8 +14,7 @@
 {%- endfor -%}
 
 <!-- {{ host_fn_count }} host functions were detected -->
-
-{%- if host_fn_count == 0 -%}
+{% if host_fn_count == 0 -%}
 <!-- ℹ️ This release does not contain any new host functions. -->
 {% elif host_fn_count == 1 -%}
 ## Host functions

--- a/scripts/ci/changelog/templates/spotlights.md.tera
+++ b/scripts/ci/changelog/templates/spotlights.md.tera
@@ -1,0 +1,30 @@
+
+{#- First we check if there are any -#}
+{%- set_global spotlight_count = 0 -%}
+
+{%- for pr in changes -%}
+    {%- if pr.meta.S and pr.meta.S.value == 1 %}
+        {%- set_global spotlight_count = spotlight_count + 1 -%}
+    {%- endif -%}
+{% endfor %}
+
+{#- then we show them -#}
+<!-- Found {{ spotlight_count }} spotlight(s) -->
+{% if spotlight_count > 0 %}
+
+## Spotlights
+
+Spotlights are important changes that we think are worth noting, independently from their priority.
+
+{% for pr in changes -%}
+    {%- if pr.meta.S and pr.meta.S.value == 1 %}
+    {%- if pr.body %}
+- [`#{{pr.number}}`]({{pr.html_url}}) | {{ pr.title}}
+> {{pr.body | linebreaksbr }}
+{% endif -%}
+    {% endif -%}
+{% endfor %}
+
+{%- else -%}
+<!-- No Spotlight found in this release -->
+{% endif %}

--- a/scripts/ci/changelog/templates/template.md.tera
+++ b/scripts/ci/changelog/templates/template.md.tera
@@ -25,6 +25,8 @@ This release contains the changes from `{{ env.REF1 }}` to `{{ env.REF2 }}`.
 
 {% include "migrations-runtime.md.tera" -%}
 
+{% include "spotlights.md.tera" -%}
+
 {% include "runtimes.md.tera" -%}
 
 {% include "changes.md.tera" -%}


### PR DESCRIPTION
This PR adds support for "Spotlight" changes.

The requirements to having Spotlight PR in releases are:
- [ ] This PR merged
- [ ] Create new `S1 - Spotlight` label
- [ ] Add S1 label to a PR

NOTE: `S1 - Spotlight` PRs are considered regardless of the other labels. A `S1 - Spotlight` PR also labelled `B0-Silent` **will** show up.

Spotlights are PR that are labelled with the (yet to be created) new label `S1 - Spotlight`.

The priority of Spotlight changes is ignored and all Spotlights will show up in the release notes with a special treatment:
- full title is shown untruncated
- full body is shown untruncated

Spotlight PRs should be carefully prepared with a comprehensible and title and a comprehensive body/description.
In order to protect the release notes from markdown that could break the release notes structure, the body is shown as quote (so the markdown of the body is NOT rendered but bodies with markdown remain readable).

Here is an example of rendered release note using a few (random) changes labelled as **Spotlight**:

<img width="858" alt="image" src="https://user-images.githubusercontent.com/738724/167817055-3d5105f6-a36b-41fd-b81d-ae234e9da8b5.png">
 