### PR TITLE
Backport releasenotes fix #5494

### DIFF
--- a/scripts/ci/changelog/templates/_free_notes.md.tera
+++ b/scripts/ci/changelog/templates/_free_notes.md.tera
@@ -1,0 +1,10 @@
+
+{# This file uses the Markdown format with additional templating such as this comment. -#}
+{# Such a comment will not show up in the rendered release notes. -#}
+{# The content of this file (if any) will be inserted at the top of the release notes -#}
+{# and generated for each new release candidate. -#}
+{# Ensure you leave an empty line at both top and bottom of this file. -#}
+
+<!-- Such a comment will be rendered but remain invisible in the rendered markdown -->
+<!-- Edit below this line -->
+<!-- Edit above this line -->

--- a/scripts/ci/changelog/templates/compiler.md.tera
+++ b/scripts/ci/changelog/templates/compiler.md.tera
@@ -1,6 +1,7 @@
 ## Rust compiler versions
 
-This release was tested against the following versions of `rustc`. Other versions may work.
+This release was built and tested against the following versions of `rustc`.
+Other versions may work.
 
 - Rust Stable: `{{ env.RUSTC_STABLE }}`
 - Rust Nightly: `{{ env.RUSTC_NIGHTLY }}`

--- a/scripts/ci/changelog/templates/debug.md.tera
+++ b/scripts/ci/changelog/templates/debug.md.tera
@@ -1,8 +1,6 @@
 {%- set to_ignore = changes | filter(attribute="meta.B.value", value=0) %}
 
 <!--
-## Debug
-
 changes:
  - total: {{ changes | length }}
  - silent: {{ to_ignore | length }}

--- a/scripts/ci/changelog/templates/docker_image.md.tera
+++ b/scripts/ci/changelog/templates/docker_image.md.tera
@@ -1,11 +1,11 @@
-<!--
+
 ## Docker images
 
-The docker image for this release can be found in [Docker hub](https://hub.docker.com/r/parity/polkadot-collator/tags?page=1&ordering=last_updated).
+The docker image for this release can be found in [Docker hub](https://hub.docker.com/r/parity/polkadot-collator/tags?page=1&ordering=last_updated)
+(It will be available a few minutes after this release was published).
 
 You may also pull it with:
 
 ```
 docker pull parity/polkadot-collator:latest
 ```
--->

--- a/scripts/ci/changelog/templates/host_functions.md.tera
+++ b/scripts/ci/changelog/templates/host_functions.md.tera
@@ -15,16 +15,16 @@
 
 <!-- {{ host_fn_count }} host functions were detected -->
 
-{%- if host_fn_count == 0 -%}
-<!-- ℹ️ This release does not contain any new host functions. -->
-{% elif host_fn_count == 1 -%}
 ## Host functions
 
+{%- if host_fn_count == 0 %}
+ℹ️ This release does not contain any new host functions.
+{% elif host_fn_count == 1 -%}
 ⚠️ The runtimes in this release contain one new **host function**.
 
-⚠️ It is critical that you update your client before the chain switches to the new runtimes.
+⚠️ It is critical that you update your client before the chain switches to the new runtime.
 {%- else -%}
 ⚠️ The runtimes in this release contain {{ host_fn_count }} new **host function{{ host_fn_count | pluralize }}**.
 
-⚠️ It is critical that you update your client before the chain switches to the new runtimes.
+⚠️ It is critical that you update your client before the chain switches to the new runtime.
 {%- endif %}

--- a/scripts/ci/changelog/templates/migrations-db.md.tera
+++ b/scripts/ci/changelog/templates/migrations-db.md.tera
@@ -16,10 +16,10 @@
 {% endfor -%}
 
 {%- if db_migration_count == 0 -%}
-No Database migration detected in this release.
+ℹ️ There is no database migration in this release.
 {% else  %}
 
-There is {{ db_migration_count }} database migration(s) in this release.
+⚠️ There is {{ db_migration_count }} database migration(s) in this release.
 
 Database migrations are operations bringing your database to the latest stand.
 Some migrations may break compatibility and making a backup of your database is highly recommended.

--- a/scripts/ci/changelog/templates/migrations-runtime.md.tera
+++ b/scripts/ci/changelog/templates/migrations-runtime.md.tera
@@ -16,10 +16,10 @@
 {% endfor -%}
 
 {%- if runtime_migration_count == 0 -%}
-No Runtime migration detected in this release.
+ℹ️ There is no runtime migration in this release.
 {% else  %}
 
-There is {{ runtime_migration_count }} runtime migration(s) in this release.
+⚠️ There is {{ runtime_migration_count }} runtime migration(s) in this release.
 
 Runtime migrations are operations running once during a runtime upgrade.
 {%- endif %}

--- a/scripts/ci/changelog/templates/pre_release.md.tera
+++ b/scripts/ci/changelog/templates/pre_release.md.tera
@@ -4,7 +4,7 @@
 **Release candidates** are **pre-releases** may not be final.
 Although they are reasonably tested, there may be additional changes or issues
 before an official release is tagged. Use at your own discretion, and consider
-only using published releases on critical production infrastructure.
+only using final releases on critical production infrastructure.
 </details>
 {% else -%}
 <!-- NOT a pre-release-->

--- a/scripts/ci/changelog/templates/template.md.tera
+++ b/scripts/ci/changelog/templates/template.md.tera
@@ -3,7 +3,7 @@
 {% include "pre_release.md.tera" -%}
 
 {% if env.PRE_RELEASE == "true" -%}
-This pre-release contains the changes from `{{ env.REF1 }}` to `{{ env.REF2 }}`.
+This pre-release contains the changes from `{{ env.REF1 | replace(from="refs/tags/", to="") }}` to `{{ env.REF2 | replace(from="refs/tags/", to="") }}`.
 {%- else -%}
 This release contains the changes from `{{ env.REF1 }}` to `{{ env.REF2 }}`.
 {% endif -%}
@@ -15,15 +15,21 @@ This release contains the changes from `{{ env.REF1 }}` to `{{ env.REF2 }}`.
 {%- set DOT = "[P]" -%}
 {%- set SUB = "[S]" -%}
 
+{# -- Manual free notes section -- #}
+{% include "_free_notes.md.tera" -%}
+{# --------------------------------- #}
+
+{# -- Important automatic section -- #}
 {% include "global_priority.md.tera" -%}
 
 {% include "host_functions.md.tera" -%}
 
-{% include "compiler.md.tera" -%}
-
 {% include "migrations-db.md.tera" -%}
 
 {% include "migrations-runtime.md.tera" -%}
+{# --------------------------------- #}
+
+{% include "compiler.md.tera" -%}
 
 {% include "runtimes.md.tera" -%}
 


### PR DESCRIPTION
* Move compiler information below priority information

* Show docker section by default

* Show a mention even if there are no host functions

* Fix the wording for the migrations

* Fix some wording

* Include free notes section

* Fix spacing issue

* Rename the free notes template

* Few minor changes including reworking the tag rendering