### PR TITLE
`1.into()` -> `ParaId::from(1_u32)`

### DIFF
--- a/runtime/common/src/assigned_slots.rs
+++ b/runtime/common/src/assigned_slots.rs
@@ -738,7 +738,7 @@ mod tests {
 			run_to_block(1);
 
 			assert_noop!(
-				AssignedSlots::assign_perm_parachain_slot(Origin::root(), ParaId::from(1),),
+				AssignedSlots::assign_perm_parachain_slot(Origin::root(), ParaId::from(1_u32),),
 				Error::<Test>::ParaDoesntExist
 			);
 		});
@@ -750,7 +750,7 @@ mod tests {
 			run_to_block(1);
 
 			assert_noop!(
-				AssignedSlots::assign_perm_parachain_slot(Origin::signed(1), ParaId::from(1),),
+				AssignedSlots::assign_perm_parachain_slot(Origin::signed(1), ParaId::from(1_u32),),
 				BadOrigin
 			);
 		});
@@ -763,14 +763,14 @@ mod tests {
 
 			assert_ok!(TestRegistrar::<Test>::register(
 				1,
-				ParaId::from(1),
+				ParaId::from(1_u32),
 				dummy_head_data(),
 				dummy_validation_code(),
 			));
-			assert_ok!(TestRegistrar::<Test>::make_parachain(ParaId::from(1)));
+			assert_ok!(TestRegistrar::<Test>::make_parachain(ParaId::from(1_u32)));
 
 			assert_noop!(
-				AssignedSlots::assign_perm_parachain_slot(Origin::root(), ParaId::from(1),),
+				AssignedSlots::assign_perm_parachain_slot(Origin::root(), ParaId::from(1_u32),),
 				Error::<Test>::NotParathread
 			);
 		});
@@ -783,16 +783,16 @@ mod tests {
 
 			assert_ok!(TestRegistrar::<Test>::register(
 				1,
-				ParaId::from(1),
+				ParaId::from(1_u32),
 				dummy_head_data(),
 				dummy_validation_code(),
 			));
 
 			// Register lease in current lease period
-			assert_ok!(Slots::lease_out(ParaId::from(1), &1, 1, 1, 1));
+			assert_ok!(Slots::lease_out(ParaId::from(1_u32), &1, 1, 1, 1));
 			// Try to assign a perm slot in current period fails
 			assert_noop!(
-				AssignedSlots::assign_perm_parachain_slot(Origin::root(), ParaId::from(1),),
+				AssignedSlots::assign_perm_parachain_slot(Origin::root(), ParaId::from(1_u32),),
 				Error::<Test>::OngoingLeaseExists
 			);
 
@@ -800,10 +800,10 @@ mod tests {
 			assert_ok!(Slots::clear_all_leases(Origin::root(), 1.into()));
 
 			// Register lease for next lease period
-			assert_ok!(Slots::lease_out(ParaId::from(1), &1, 1, 2, 1));
+			assert_ok!(Slots::lease_out(ParaId::from(1_u32), &1, 1, 2, 1));
 			// Should be detected and also fail
 			assert_noop!(
-				AssignedSlots::assign_perm_parachain_slot(Origin::root(), ParaId::from(1),),
+				AssignedSlots::assign_perm_parachain_slot(Origin::root(), ParaId::from(1_u32),),
 				Error::<Test>::OngoingLeaseExists
 			);
 		});
@@ -816,31 +816,37 @@ mod tests {
 
 			assert_ok!(TestRegistrar::<Test>::register(
 				1,
-				ParaId::from(1),
+				ParaId::from(1_u32),
 				dummy_head_data(),
 				dummy_validation_code(),
 			));
 
 			assert_ok!(TestRegistrar::<Test>::register(
 				2,
-				ParaId::from(2),
+				ParaId::from(2_u32),
 				dummy_head_data(),
 				dummy_validation_code(),
 			));
 
 			assert_ok!(TestRegistrar::<Test>::register(
 				3,
-				ParaId::from(3),
+				ParaId::from(3_u32),
 				dummy_head_data(),
 				dummy_validation_code(),
 			));
 
-			assert_ok!(AssignedSlots::assign_perm_parachain_slot(Origin::root(), ParaId::from(1),));
-			assert_ok!(AssignedSlots::assign_perm_parachain_slot(Origin::root(), ParaId::from(2),));
+			assert_ok!(AssignedSlots::assign_perm_parachain_slot(
+				Origin::root(),
+				ParaId::from(1_u32),
+			));
+			assert_ok!(AssignedSlots::assign_perm_parachain_slot(
+				Origin::root(),
+				ParaId::from(2_u32),
+			));
 			assert_eq!(AssignedSlots::permanent_slot_count(), 2);
 
 			assert_noop!(
-				AssignedSlots::assign_perm_parachain_slot(Origin::root(), ParaId::from(3),),
+				AssignedSlots::assign_perm_parachain_slot(Origin::root(), ParaId::from(3_u32),),
 				Error::<Test>::MaxPermanentSlotsExceeded
 			);
 		});
@@ -853,35 +859,38 @@ mod tests {
 			run_to_block(block);
 			assert_ok!(TestRegistrar::<Test>::register(
 				1,
-				ParaId::from(1),
+				ParaId::from(1_u32),
 				dummy_head_data(),
 				dummy_validation_code(),
 			));
 
 			assert_eq!(AssignedSlots::permanent_slot_count(), 0);
-			assert_eq!(AssignedSlots::permanent_slots(ParaId::from(1)), None);
+			assert_eq!(AssignedSlots::permanent_slots(ParaId::from(1_u32)), None);
 
-			assert_ok!(AssignedSlots::assign_perm_parachain_slot(Origin::root(), ParaId::from(1),));
+			assert_ok!(AssignedSlots::assign_perm_parachain_slot(
+				Origin::root(),
+				ParaId::from(1_u32),
+			));
 
 			// Para is a parachain for PermanentSlotLeasePeriodLength * LeasePeriod blocks
 			while block < 9 {
 				println!("block #{}", block);
 
-				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(1)), true);
+				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(1_u32)), true);
 
 				assert_eq!(AssignedSlots::permanent_slot_count(), 1);
-				assert_eq!(AssignedSlots::has_permanent_slot(ParaId::from(1)), true);
-				assert_eq!(AssignedSlots::permanent_slots(ParaId::from(1)), Some((0, 3)));
+				assert_eq!(AssignedSlots::has_permanent_slot(ParaId::from(1_u32)), true);
+				assert_eq!(AssignedSlots::permanent_slots(ParaId::from(1_u32)), Some((0, 3)));
 
-				assert_eq!(Slots::already_leased(ParaId::from(1), 0, 2), true);
+				assert_eq!(Slots::already_leased(ParaId::from(1_u32), 0, 2), true);
 
 				block += 1;
 				run_to_block(block);
 			}
 
 			// Para lease ended, downgraded back to parathread
-			assert_eq!(TestRegistrar::<Test>::is_parathread(ParaId::from(1)), true);
-			assert_eq!(Slots::already_leased(ParaId::from(1), 0, 5), false);
+			assert_eq!(TestRegistrar::<Test>::is_parathread(ParaId::from(1_u32)), true);
+			assert_eq!(Slots::already_leased(ParaId::from(1_u32), 0, 5), false);
 		});
 	}
 
@@ -893,7 +902,7 @@ mod tests {
 			assert_noop!(
 				AssignedSlots::assign_temp_parachain_slot(
 					Origin::root(),
-					ParaId::from(1),
+					ParaId::from(1_u32),
 					SlotLeasePeriodStart::Current
 				),
 				Error::<Test>::ParaDoesntExist
@@ -909,7 +918,7 @@ mod tests {
 			assert_noop!(
 				AssignedSlots::assign_temp_parachain_slot(
 					Origin::signed(1),
-					ParaId::from(1),
+					ParaId::from(1_u32),
 					SlotLeasePeriodStart::Current
 				),
 				BadOrigin
@@ -924,16 +933,16 @@ mod tests {
 
 			assert_ok!(TestRegistrar::<Test>::register(
 				1,
-				ParaId::from(1),
+				ParaId::from(1_u32),
 				dummy_head_data(),
 				dummy_validation_code(),
 			));
-			assert_ok!(TestRegistrar::<Test>::make_parachain(ParaId::from(1)));
+			assert_ok!(TestRegistrar::<Test>::make_parachain(ParaId::from(1_u32)));
 
 			assert_noop!(
 				AssignedSlots::assign_temp_parachain_slot(
 					Origin::root(),
-					ParaId::from(1),
+					ParaId::from(1_u32),
 					SlotLeasePeriodStart::Current
 				),
 				Error::<Test>::NotParathread
@@ -948,18 +957,18 @@ mod tests {
 
 			assert_ok!(TestRegistrar::<Test>::register(
 				1,
-				ParaId::from(1),
+				ParaId::from(1_u32),
 				dummy_head_data(),
 				dummy_validation_code(),
 			));
 
 			// Register lease in current lease period
-			assert_ok!(Slots::lease_out(ParaId::from(1), &1, 1, 1, 1));
+			assert_ok!(Slots::lease_out(ParaId::from(1_u32), &1, 1, 1, 1));
 			// Try to assign a perm slot in current period fails
 			assert_noop!(
 				AssignedSlots::assign_temp_parachain_slot(
 					Origin::root(),
-					ParaId::from(1),
+					ParaId::from(1_u32),
 					SlotLeasePeriodStart::Current
 				),
 				Error::<Test>::OngoingLeaseExists
@@ -969,12 +978,12 @@ mod tests {
 			assert_ok!(Slots::clear_all_leases(Origin::root(), 1.into()));
 
 			// Register lease for next lease period
-			assert_ok!(Slots::lease_out(ParaId::from(1), &1, 1, 2, 1));
+			assert_ok!(Slots::lease_out(ParaId::from(1_u32), &1, 1, 2, 1));
 			// Should be detected and also fail
 			assert_noop!(
 				AssignedSlots::assign_temp_parachain_slot(
 					Origin::root(),
-					ParaId::from(1),
+					ParaId::from(1_u32),
 					SlotLeasePeriodStart::Current
 				),
 				Error::<Test>::OngoingLeaseExists
@@ -1008,14 +1017,14 @@ mod tests {
 			// Attempt to assign one more temp slot
 			assert_ok!(TestRegistrar::<Test>::register(
 				7,
-				ParaId::from(7),
+				ParaId::from(7_u32),
 				dummy_head_data(),
 				dummy_validation_code(),
 			));
 			assert_noop!(
 				AssignedSlots::assign_temp_parachain_slot(
 					Origin::root(),
-					ParaId::from(7),
+					ParaId::from(7_u32),
 					SlotLeasePeriodStart::Current
 				),
 				Error::<Test>::MaxTemporarySlotsExceeded
@@ -1030,16 +1039,16 @@ mod tests {
 			run_to_block(block);
 			assert_ok!(TestRegistrar::<Test>::register(
 				1,
-				ParaId::from(1),
+				ParaId::from(1_u32),
 				dummy_head_data(),
 				dummy_validation_code(),
 			));
 
-			assert_eq!(AssignedSlots::temporary_slots(ParaId::from(1)), None);
+			assert_eq!(AssignedSlots::temporary_slots(ParaId::from(1_u32)), None);
 
 			assert_ok!(AssignedSlots::assign_temp_parachain_slot(
 				Origin::root(),
-				ParaId::from(1),
+				ParaId::from(1_u32),
 				SlotLeasePeriodStart::Current
 			));
 			assert_eq!(AssignedSlots::temporary_slot_count(), 1);
@@ -1050,14 +1059,14 @@ mod tests {
 			while block < 6 {
 				println!("block #{}", block);
 				println!("lease period #{}", AssignedSlots::current_lease_period_index());
-				println!("lease {:?}", Slots::lease(ParaId::from(1)));
+				println!("lease {:?}", Slots::lease(ParaId::from(1_u32)));
 
-				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(1)), true);
+				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(1_u32)), true);
 
-				assert_eq!(AssignedSlots::has_temporary_slot(ParaId::from(1)), true);
+				assert_eq!(AssignedSlots::has_temporary_slot(ParaId::from(1_u32)), true);
 				assert_eq!(AssignedSlots::active_temporary_slot_count(), 1);
 				assert_eq!(
-					AssignedSlots::temporary_slots(ParaId::from(1)),
+					AssignedSlots::temporary_slots(ParaId::from(1_u32)),
 					Some(ParachainTemporarySlot {
 						manager: 1,
 						period_begin: 0,
@@ -1067,7 +1076,7 @@ mod tests {
 					})
 				);
 
-				assert_eq!(Slots::already_leased(ParaId::from(1), 0, 1), true);
+				assert_eq!(Slots::already_leased(ParaId::from(1_u32), 0, 1), true);
 
 				block += 1;
 				run_to_block(block);
@@ -1076,11 +1085,11 @@ mod tests {
 			// Block 6
 			println!("block #{}", block);
 			println!("lease period #{}", AssignedSlots::current_lease_period_index());
-			println!("lease {:?}", Slots::lease(ParaId::from(1)));
+			println!("lease {:?}", Slots::lease(ParaId::from(1_u32)));
 
 			// Para lease ended, downgraded back to parathread
-			assert_eq!(TestRegistrar::<Test>::is_parathread(ParaId::from(1)), true);
-			assert_eq!(Slots::already_leased(ParaId::from(1), 0, 3), false);
+			assert_eq!(TestRegistrar::<Test>::is_parathread(ParaId::from(1_u32)), true);
+			assert_eq!(Slots::already_leased(ParaId::from(1_u32), 0, 3), false);
 			assert_eq!(AssignedSlots::active_temporary_slot_count(), 0);
 
 			// Block 12
@@ -1088,10 +1097,10 @@ mod tests {
 			run_to_block(12);
 			println!("block #{}", block);
 			println!("lease period #{}", AssignedSlots::current_lease_period_index());
-			println!("lease {:?}", Slots::lease(ParaId::from(1)));
+			println!("lease {:?}", Slots::lease(ParaId::from(1_u32)));
 
-			assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(1)), true);
-			assert_eq!(Slots::already_leased(ParaId::from(1), 4, 5), true);
+			assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(1_u32)), true);
+			assert_eq!(Slots::already_leased(ParaId::from(1_u32), 4, 5), true);
 			assert_eq!(AssignedSlots::active_temporary_slot_count(), 1);
 		});
 	}
@@ -1129,11 +1138,11 @@ mod tests {
 					run_to_block(n);
 				}
 				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(0)), true);
-				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(1)), false);
-				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(2)), true);
-				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(3)), false);
-				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(4)), false);
-				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(5)), false);
+				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(1_u32)), false);
+				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(2_u32)), true);
+				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(3_u32)), false);
+				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(4_u32)), false);
+				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(5_u32)), false);
 				assert_eq!(AssignedSlots::active_temporary_slot_count(), 2);
 			}
 
@@ -1141,11 +1150,11 @@ mod tests {
 			for n in 6..=11 {
 				run_to_block(n);
 				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(0)), false);
-				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(1)), true);
-				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(2)), false);
-				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(3)), true);
-				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(4)), false);
-				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(5)), false);
+				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(1_u32)), true);
+				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(2_u32)), false);
+				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(3_u32)), true);
+				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(4_u32)), false);
+				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(5_u32)), false);
 				assert_eq!(AssignedSlots::active_temporary_slot_count(), 2);
 			}
 
@@ -1153,11 +1162,11 @@ mod tests {
 			for n in 12..=17 {
 				run_to_block(n);
 				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(0)), false);
-				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(1)), false);
-				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(2)), false);
-				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(3)), false);
-				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(4)), true);
-				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(5)), true);
+				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(1_u32)), false);
+				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(2_u32)), false);
+				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(3_u32)), false);
+				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(4_u32)), true);
+				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(5_u32)), true);
 				assert_eq!(AssignedSlots::active_temporary_slot_count(), 2);
 			}
 
@@ -1165,11 +1174,11 @@ mod tests {
 			for n in 18..=23 {
 				run_to_block(n);
 				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(0)), true);
-				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(1)), false);
-				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(2)), true);
-				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(3)), false);
-				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(4)), false);
-				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(5)), false);
+				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(1_u32)), false);
+				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(2_u32)), true);
+				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(3_u32)), false);
+				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(4_u32)), false);
+				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(5_u32)), false);
 				assert_eq!(AssignedSlots::active_temporary_slot_count(), 2);
 			}
 
@@ -1177,11 +1186,11 @@ mod tests {
 			for n in 24..=29 {
 				run_to_block(n);
 				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(0)), false);
-				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(1)), true);
-				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(2)), false);
-				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(3)), true);
-				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(4)), false);
-				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(5)), false);
+				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(1_u32)), true);
+				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(2_u32)), false);
+				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(3_u32)), true);
+				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(4_u32)), false);
+				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(5_u32)), false);
 				assert_eq!(AssignedSlots::active_temporary_slot_count(), 2);
 			}
 
@@ -1189,11 +1198,11 @@ mod tests {
 			for n in 30..=35 {
 				run_to_block(n);
 				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(0)), false);
-				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(1)), false);
-				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(2)), false);
-				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(3)), false);
-				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(4)), true);
-				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(5)), true);
+				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(1_u32)), false);
+				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(2_u32)), false);
+				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(3_u32)), false);
+				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(4_u32)), true);
+				assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(5_u32)), true);
 				assert_eq!(AssignedSlots::active_temporary_slot_count(), 2);
 			}
 		});
@@ -1205,7 +1214,7 @@ mod tests {
 			run_to_block(1);
 
 			assert_noop!(
-				AssignedSlots::unassign_parachain_slot(Origin::root(), ParaId::from(1),),
+				AssignedSlots::unassign_parachain_slot(Origin::root(), ParaId::from(1_u32),),
 				Error::<Test>::SlotNotAssigned
 			);
 		});
@@ -1217,7 +1226,7 @@ mod tests {
 			run_to_block(1);
 
 			assert_noop!(
-				AssignedSlots::assign_perm_parachain_slot(Origin::signed(1), ParaId::from(1),),
+				AssignedSlots::assign_perm_parachain_slot(Origin::signed(1), ParaId::from(1_u32),),
 				BadOrigin
 			);
 		});
@@ -1230,22 +1239,27 @@ mod tests {
 
 			assert_ok!(TestRegistrar::<Test>::register(
 				1,
-				ParaId::from(1),
+				ParaId::from(1_u32),
 				dummy_head_data(),
 				dummy_validation_code(),
 			));
 
-			assert_ok!(AssignedSlots::assign_perm_parachain_slot(Origin::root(), ParaId::from(1),));
+			assert_ok!(AssignedSlots::assign_perm_parachain_slot(
+				Origin::root(),
+				ParaId::from(1_u32),
+			));
 
-			assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(1)), true);
+			assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(1_u32)), true);
 
-			assert_ok!(AssignedSlots::unassign_parachain_slot(Origin::root(), ParaId::from(1),));
+			assert_ok!(
+				AssignedSlots::unassign_parachain_slot(Origin::root(), ParaId::from(1_u32),)
+			);
 
 			assert_eq!(AssignedSlots::permanent_slot_count(), 0);
-			assert_eq!(AssignedSlots::has_permanent_slot(ParaId::from(1)), false);
-			assert_eq!(AssignedSlots::permanent_slots(ParaId::from(1)), None);
+			assert_eq!(AssignedSlots::has_permanent_slot(ParaId::from(1_u32)), false);
+			assert_eq!(AssignedSlots::permanent_slots(ParaId::from(1_u32)), None);
 
-			assert_eq!(Slots::already_leased(ParaId::from(1), 0, 2), false);
+			assert_eq!(Slots::already_leased(ParaId::from(1_u32), 0, 2), false);
 		});
 	}
 
@@ -1256,27 +1270,29 @@ mod tests {
 
 			assert_ok!(TestRegistrar::<Test>::register(
 				1,
-				ParaId::from(1),
+				ParaId::from(1_u32),
 				dummy_head_data(),
 				dummy_validation_code(),
 			));
 
 			assert_ok!(AssignedSlots::assign_temp_parachain_slot(
 				Origin::root(),
-				ParaId::from(1),
+				ParaId::from(1_u32),
 				SlotLeasePeriodStart::Current
 			));
 
-			assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(1)), true);
+			assert_eq!(TestRegistrar::<Test>::is_parachain(ParaId::from(1_u32)), true);
 
-			assert_ok!(AssignedSlots::unassign_parachain_slot(Origin::root(), ParaId::from(1),));
+			assert_ok!(
+				AssignedSlots::unassign_parachain_slot(Origin::root(), ParaId::from(1_u32),)
+			);
 
 			assert_eq!(AssignedSlots::temporary_slot_count(), 0);
 			assert_eq!(AssignedSlots::active_temporary_slot_count(), 0);
-			assert_eq!(AssignedSlots::has_temporary_slot(ParaId::from(1)), false);
-			assert_eq!(AssignedSlots::temporary_slots(ParaId::from(1)), None);
+			assert_eq!(AssignedSlots::has_temporary_slot(ParaId::from(1_u32)), false);
+			assert_eq!(AssignedSlots::temporary_slots(ParaId::from(1_u32)), None);
 
-			assert_eq!(Slots::already_leased(ParaId::from(1), 0, 1), false);
+			assert_eq!(Slots::already_leased(ParaId::from(1_u32), 0, 1), false);
 		});
 	}
 }

--- a/runtime/common/src/auctions.rs
+++ b/runtime/common/src/auctions.rs
@@ -1383,8 +1383,8 @@ mod tests {
 		new_test_ext().execute_with(|| {
 			run_to_block(1);
 			assert_ok!(Auctions::new_auction(Origin::signed(6), 1, 1));
-			let para_1 = ParaId::from(1);
-			let para_2 = ParaId::from(2);
+			let para_1 = ParaId::from(1_u32);
+			let para_2 = ParaId::from(2_u32);
 
 			// Make a bid and reserve a balance
 			assert_ok!(Auctions::bid(Origin::signed(1), para_1, 1, 1, 4, 10));
@@ -1407,9 +1407,9 @@ mod tests {
 		new_test_ext().execute_with(|| {
 			run_to_block(1);
 			assert_ok!(Auctions::new_auction(Origin::signed(6), 9, 1));
-			let para_1 = ParaId::from(1);
-			let para_2 = ParaId::from(2);
-			let para_3 = ParaId::from(3);
+			let para_1 = ParaId::from(1_u32);
+			let para_2 = ParaId::from(2_u32);
+			let para_3 = ParaId::from(3_u32);
 
 			// Make bids
 			assert_ok!(Auctions::bid(Origin::signed(1), para_1, 1, 1, 4, 10));
@@ -1522,9 +1522,9 @@ mod tests {
 
 			run_to_block(1);
 			assert_ok!(Auctions::new_auction(Origin::signed(6), 9, 11));
-			let para_1 = ParaId::from(1);
-			let para_2 = ParaId::from(2);
-			let para_3 = ParaId::from(3);
+			let para_1 = ParaId::from(1_u32);
+			let para_2 = ParaId::from(2_u32);
+			let para_3 = ParaId::from(3_u32);
 
 			// Make bids
 			assert_ok!(Auctions::bid(Origin::signed(1), para_1, 1, 11, 14, 10));
@@ -1782,7 +1782,7 @@ mod benchmarking {
 			Auctions::<T>::new_auction(RawOrigin::Root.into(), duration, lease_period_index)?;
 
 			let para = ParaId::from(0);
-			let new_para = ParaId::from(1);
+			let new_para = ParaId::from(1_u32);
 
 			// Register the paras
 			let owner = account("owner", 0, 0);

--- a/runtime/common/src/crowdloan/mod.rs
+++ b/runtime/common/src/crowdloan/mod.rs
@@ -1964,7 +1964,7 @@ mod benchmarking {
 
 	benchmarks! {
 		create {
-			let para_id = ParaId::from(1);
+			let para_id = ParaId::from(1_u32);
 			let cap = BalanceOf::<T>::max_value();
 			let first_period = 0u32.into();
 			let last_period = 3u32.into();
@@ -2052,7 +2052,7 @@ mod benchmarking {
 		}
 
 		edit {
-			let para_id = ParaId::from(1);
+			let para_id = ParaId::from(1_u32);
 			let cap = BalanceOf::<T>::max_value();
 			let first_period = 0u32.into();
 			let last_period = 3u32.into();

--- a/runtime/common/src/slots/mod.rs
+++ b/runtime/common/src/slots/mod.rs
@@ -631,7 +631,7 @@ mod tests {
 
 			assert_ok!(TestRegistrar::<Test>::register(
 				1,
-				ParaId::from(1),
+				ParaId::from(1_u32),
 				dummy_head_data(),
 				dummy_validation_code()
 			));
@@ -662,7 +662,7 @@ mod tests {
 
 			assert_ok!(TestRegistrar::<Test>::register(
 				1,
-				ParaId::from(1),
+				ParaId::from(1_u32),
 				dummy_head_data(),
 				dummy_validation_code()
 			));
@@ -705,7 +705,7 @@ mod tests {
 
 			assert_ok!(TestRegistrar::<Test>::register(
 				1,
-				ParaId::from(1),
+				ParaId::from(1_u32),
 				dummy_head_data(),
 				dummy_validation_code()
 			));
@@ -755,7 +755,7 @@ mod tests {
 
 			assert_ok!(TestRegistrar::<Test>::register(
 				1,
-				ParaId::from(1),
+				ParaId::from(1_u32),
 				dummy_head_data(),
 				dummy_validation_code()
 			));
@@ -790,7 +790,7 @@ mod tests {
 
 			assert_ok!(TestRegistrar::<Test>::register(
 				1,
-				ParaId::from(1),
+				ParaId::from(1_u32),
 				dummy_head_data(),
 				dummy_validation_code()
 			));
@@ -833,7 +833,7 @@ mod tests {
 
 			assert_ok!(TestRegistrar::<Test>::register(
 				1,
-				ParaId::from(1),
+				ParaId::from(1_u32),
 				dummy_head_data(),
 				dummy_validation_code()
 			));
@@ -858,7 +858,7 @@ mod tests {
 			}
 
 			// Leases is empty.
-			assert!(Leases::<Test>::get(ParaId::from(1)).is_empty());
+			assert!(Leases::<Test>::get(ParaId::from(1_u32)).is_empty());
 		});
 	}
 
@@ -869,13 +869,13 @@ mod tests {
 
 			assert_ok!(TestRegistrar::<Test>::register(
 				1,
-				ParaId::from(1),
+				ParaId::from(1_u32),
 				dummy_head_data(),
 				dummy_validation_code()
 			));
 			assert_ok!(TestRegistrar::<Test>::register(
 				1,
-				ParaId::from(2),
+				ParaId::from(2_u32),
 				dummy_head_data(),
 				dummy_validation_code()
 			));
@@ -900,19 +900,19 @@ mod tests {
 			run_to_block(1);
 			assert_ok!(TestRegistrar::<Test>::register(
 				1,
-				ParaId::from(1),
+				ParaId::from(1_u32),
 				dummy_head_data(),
 				dummy_validation_code()
 			));
 			assert_ok!(TestRegistrar::<Test>::register(
 				1,
-				ParaId::from(2),
+				ParaId::from(2_u32),
 				dummy_head_data(),
 				dummy_validation_code()
 			));
 			assert_ok!(TestRegistrar::<Test>::register(
 				1,
-				ParaId::from(3),
+				ParaId::from(3_u32),
 				dummy_head_data(),
 				dummy_validation_code()
 			));
@@ -920,9 +920,9 @@ mod tests {
 			// We will directly manipulate leases to emulate some kind of failure in the system.
 			// Para 1 will have no leases
 			// Para 2 will have a lease period in the current index
-			Leases::<Test>::insert(ParaId::from(2), vec![Some((0, 0))]);
+			Leases::<Test>::insert(ParaId::from(2_u32), vec![Some((0, 0))]);
 			// Para 3 will have a lease period in a future index
-			Leases::<Test>::insert(ParaId::from(3), vec![None, None, Some((0, 0))]);
+			Leases::<Test>::insert(ParaId::from(3_u32), vec![None, None, Some((0, 0))]);
 
 			// Para 1 should fail cause they don't have any leases
 			assert_noop!(

--- a/runtime/parachains/src/configuration/migration.rs
+++ b/runtime/parachains/src/configuration/migration.rs
@@ -20,6 +20,6 @@ use frame_support::traits::StorageVersion;
 
 /// The current storage version.
 ///
-/// v0-v1: https://github.com/paritytech/polkadot/pull/3575
-/// v1-v2: https://github.com/paritytech/polkadot/pull/4420
+/// v0-v1: <https://github.com/paritytech/polkadot/pull/3575>
+/// v1-v2: <https://github.com/paritytech/polkadot/pull/4420>
 pub const STORAGE_VERSION: StorageVersion = StorageVersion::new(2);

--- a/runtime/parachains/src/inclusion/tests.rs
+++ b/runtime/parachains/src/inclusion/tests.rs
@@ -306,9 +306,9 @@ pub(crate) fn make_vdata_hash(para_id: ParaId) -> Option<Hash> {
 
 #[test]
 fn collect_pending_cleans_up_pending() {
-	let chain_a = ParaId::from(1);
-	let chain_b = ParaId::from(2);
-	let thread_a = ParaId::from(3);
+	let chain_a = ParaId::from(1_u32);
+	let chain_b = ParaId::from(2_u32);
+	let thread_a = ParaId::from(3_u32);
 
 	let paras = vec![(chain_a, true), (chain_b, true), (thread_a, false)];
 	new_test_ext(genesis_config(paras)).execute_with(|| {
@@ -364,9 +364,9 @@ fn collect_pending_cleans_up_pending() {
 
 #[test]
 fn bitfield_checks() {
-	let chain_a = ParaId::from(1);
-	let chain_b = ParaId::from(2);
-	let thread_a = ParaId::from(3);
+	let chain_a = ParaId::from(1_u32);
+	let chain_b = ParaId::from(2_u32);
+	let thread_a = ParaId::from(3_u32);
 
 	let paras = vec![(chain_a, true), (chain_b, true), (thread_a, false)];
 	let validators = vec![
@@ -705,9 +705,9 @@ fn bitfield_checks() {
 
 #[test]
 fn supermajority_bitfields_trigger_availability() {
-	let chain_a = ParaId::from(1);
-	let chain_b = ParaId::from(2);
-	let thread_a = ParaId::from(3);
+	let chain_a = ParaId::from(1_u32);
+	let chain_b = ParaId::from(2_u32);
+	let thread_a = ParaId::from(3_u32);
 
 	let paras = vec![(chain_a, true), (chain_b, true), (thread_a, false)];
 	let validators = vec![
@@ -890,9 +890,9 @@ fn supermajority_bitfields_trigger_availability() {
 
 #[test]
 fn candidate_checks() {
-	let chain_a = ParaId::from(1);
-	let chain_b = ParaId::from(2);
-	let thread_a = ParaId::from(3);
+	let chain_a = ParaId::from(1_u32);
+	let chain_b = ParaId::from(2_u32);
+	let thread_a = ParaId::from(3_u32);
 
 	// The block number of the relay-parent for testing.
 	const RELAY_PARENT_NUM: BlockNumber = 4;
@@ -1433,9 +1433,9 @@ fn candidate_checks() {
 
 #[test]
 fn backing_works() {
-	let chain_a = ParaId::from(1);
-	let chain_b = ParaId::from(2);
-	let thread_a = ParaId::from(3);
+	let chain_a = ParaId::from(1_u32);
+	let chain_b = ParaId::from(2_u32);
+	let thread_a = ParaId::from(3_u32);
 
 	// The block number of the relay-parent for testing.
 	const RELAY_PARENT_NUM: BlockNumber = 4;
@@ -1715,7 +1715,7 @@ fn backing_works() {
 
 #[test]
 fn can_include_candidate_with_ok_code_upgrade() {
-	let chain_a = ParaId::from(1);
+	let chain_a = ParaId::from(1_u32);
 
 	// The block number of the relay-parent for testing.
 	const RELAY_PARENT_NUM: BlockNumber = 4;
@@ -1821,9 +1821,9 @@ fn can_include_candidate_with_ok_code_upgrade() {
 
 #[test]
 fn session_change_wipes() {
-	let chain_a = ParaId::from(1);
-	let chain_b = ParaId::from(2);
-	let thread_a = ParaId::from(3);
+	let chain_a = ParaId::from(1_u32);
+	let chain_b = ParaId::from(2_u32);
+	let thread_a = ParaId::from(3_u32);
 
 	let paras = vec![(chain_a, true), (chain_b, true), (thread_a, false)];
 	let validators = vec![

--- a/runtime/parachains/src/reward_points.rs
+++ b/runtime/parachains/src/reward_points.rs
@@ -17,7 +17,7 @@
 //! An implementation of the `RewardValidators` trait used by `inclusion` that employs
 //! `pallet-staking` to compute the rewards.
 //!
-//! Based on https://research.web3.foundation/en/latest/polkadot/overview/2-token-economics.html
+//! Based on <https://research.web3.foundation/en/latest/polkadot/overview/2-token-economics.html>
 //! which doesn't currently mention availability bitfields. As such, we don't reward them
 //! for the time being, although we will build schemes to do so in the future.
 

--- a/runtime/parachains/src/scheduler/tests.rs
+++ b/runtime/parachains/src/scheduler/tests.rs
@@ -227,10 +227,10 @@ fn session_change_prunes_cores_beyond_retries_and_those_from_non_live_parathread
 	};
 	let max_parathread_retries = default_config().parathread_retries;
 
-	let thread_a = ParaId::from(1);
-	let thread_b = ParaId::from(2);
-	let thread_c = ParaId::from(3);
-	let thread_d = ParaId::from(4);
+	let thread_a = ParaId::from(1_u32);
+	let thread_b = ParaId::from(2_u32);
+	let thread_c = ParaId::from(3_u32);
+	let thread_d = ParaId::from(4_u32);
 
 	let collator = CollatorId::from(Sr25519Keyring::Alice.public());
 
@@ -330,8 +330,8 @@ fn session_change_shuffles_validators() {
 
 	assert_eq!(default_config().parathread_cores, 3);
 	new_test_ext(genesis_config).execute_with(|| {
-		let chain_a = ParaId::from(1);
-		let chain_b = ParaId::from(2);
+		let chain_a = ParaId::from(1_u32);
+		let chain_b = ParaId::from(2_u32);
 
 		// ensure that we have 5 groups by registering 2 parachains.
 		schedule_blank_para(chain_a, true);
@@ -387,9 +387,9 @@ fn session_change_takes_only_max_per_core() {
 	};
 
 	new_test_ext(genesis_config).execute_with(|| {
-		let chain_a = ParaId::from(1);
-		let chain_b = ParaId::from(2);
-		let chain_c = ParaId::from(3);
+		let chain_a = ParaId::from(1_u32);
+		let chain_b = ParaId::from(2_u32);
+		let chain_c = ParaId::from(3_u32);
 
 		// ensure that we have 5 groups by registering 2 parachains.
 		schedule_blank_para(chain_a, true);
@@ -434,12 +434,12 @@ fn schedule_schedules() {
 		..Default::default()
 	};
 
-	let chain_a = ParaId::from(1);
-	let chain_b = ParaId::from(2);
+	let chain_a = ParaId::from(1_u32);
+	let chain_b = ParaId::from(2_u32);
 
-	let thread_a = ParaId::from(3);
-	let thread_b = ParaId::from(4);
-	let thread_c = ParaId::from(5);
+	let thread_a = ParaId::from(3_u32);
+	let thread_b = ParaId::from(4_u32);
+	let thread_c = ParaId::from(5_u32);
 
 	let collator = CollatorId::from(Sr25519Keyring::Alice.public());
 
@@ -559,14 +559,14 @@ fn schedule_schedules_including_just_freed() {
 		..Default::default()
 	};
 
-	let chain_a = ParaId::from(1);
-	let chain_b = ParaId::from(2);
+	let chain_a = ParaId::from(1_u32);
+	let chain_b = ParaId::from(2_u32);
 
-	let thread_a = ParaId::from(3);
-	let thread_b = ParaId::from(4);
-	let thread_c = ParaId::from(5);
-	let thread_d = ParaId::from(6);
-	let thread_e = ParaId::from(7);
+	let thread_a = ParaId::from(3_u32);
+	let thread_b = ParaId::from(4_u32);
+	let thread_c = ParaId::from(5_u32);
+	let thread_d = ParaId::from(6_u32);
+	let thread_e = ParaId::from(7_u32);
 
 	let collator = CollatorId::from(Sr25519Keyring::Alice.public());
 
@@ -735,9 +735,9 @@ fn schedule_clears_availability_cores() {
 		..Default::default()
 	};
 
-	let chain_a = ParaId::from(1);
-	let chain_b = ParaId::from(2);
-	let chain_c = ParaId::from(3);
+	let chain_a = ParaId::from(1_u32);
+	let chain_b = ParaId::from(2_u32);
+	let chain_c = ParaId::from(3_u32);
 
 	new_test_ext(genesis_config).execute_with(|| {
 		assert_eq!(default_config().parathread_cores, 3);
@@ -841,8 +841,8 @@ fn schedule_rotates_groups() {
 		..Default::default()
 	};
 
-	let thread_a = ParaId::from(1);
-	let thread_b = ParaId::from(2);
+	let thread_a = ParaId::from(1_u32);
+	let thread_b = ParaId::from(2_u32);
 
 	let collator = CollatorId::from(Sr25519Keyring::Alice.public());
 
@@ -913,8 +913,8 @@ fn parathread_claims_are_pruned_after_retries() {
 		..Default::default()
 	};
 
-	let thread_a = ParaId::from(1);
-	let thread_b = ParaId::from(2);
+	let thread_a = ParaId::from(1_u32);
+	let thread_b = ParaId::from(2_u32);
 
 	let collator = CollatorId::from(Sr25519Keyring::Alice.public());
 
@@ -974,8 +974,8 @@ fn availability_predicate_works() {
 			thread_availability_period < group_rotation_frequency
 	);
 
-	let chain_a = ParaId::from(1);
-	let thread_a = ParaId::from(2);
+	let chain_a = ParaId::from(1_u32);
+	let thread_a = ParaId::from(2_u32);
 
 	new_test_ext(genesis_config).execute_with(|| {
 		schedule_blank_para(chain_a, true);
@@ -1069,8 +1069,8 @@ fn next_up_on_available_uses_next_scheduled_or_none_for_thread() {
 		..Default::default()
 	};
 
-	let thread_a = ParaId::from(1);
-	let thread_b = ParaId::from(2);
+	let thread_a = ParaId::from(1_u32);
+	let thread_b = ParaId::from(2_u32);
 
 	let collator = CollatorId::from(Sr25519Keyring::Alice.public());
 
@@ -1141,8 +1141,8 @@ fn next_up_on_time_out_reuses_claim_if_nothing_queued() {
 		..Default::default()
 	};
 
-	let thread_a = ParaId::from(1);
-	let thread_b = ParaId::from(2);
+	let thread_a = ParaId::from(1_u32);
+	let thread_b = ParaId::from(2_u32);
 
 	let collator = CollatorId::from(Sr25519Keyring::Alice.public());
 
@@ -1219,7 +1219,7 @@ fn next_up_on_available_is_parachain_always() {
 		..Default::default()
 	};
 
-	let chain_a = ParaId::from(1);
+	let chain_a = ParaId::from(1_u32);
 
 	new_test_ext(genesis_config).execute_with(|| {
 		schedule_blank_para(chain_a, true);
@@ -1273,7 +1273,7 @@ fn next_up_on_time_out_is_parachain_always() {
 		..Default::default()
 	};
 
-	let chain_a = ParaId::from(1);
+	let chain_a = ParaId::from(1_u32);
 
 	new_test_ext(genesis_config).execute_with(|| {
 		schedule_blank_para(chain_a, true);
@@ -1326,8 +1326,8 @@ fn session_change_requires_reschedule_dropping_removed_paras() {
 
 	assert_eq!(default_config().parathread_cores, 3);
 	new_test_ext(genesis_config).execute_with(|| {
-		let chain_a = ParaId::from(1);
-		let chain_b = ParaId::from(2);
+		let chain_a = ParaId::from(1_u32);
+		let chain_b = ParaId::from(2_u32);
 
 		// ensure that we have 5 groups by registering 2 parachains.
 		schedule_blank_para(chain_a, true);
@@ -1401,8 +1401,8 @@ fn parathread_claims_are_pruned_after_deregistration() {
 		..Default::default()
 	};
 
-	let thread_a = ParaId::from(1);
-	let thread_b = ParaId::from(2);
+	let thread_a = ParaId::from(1_u32);
+	let thread_b = ParaId::from(2_u32);
 
 	let collator = CollatorId::from(Sr25519Keyring::Alice.public());
 

--- a/runtime/parachains/src/session_info.rs
+++ b/runtime/parachains/src/session_info.rs
@@ -17,7 +17,7 @@
 //! The session info pallet provides information about validator sets
 //! from prior sessions needed for approvals and disputes.
 //!
-//! See https://w3f.github.io/parachain-implementers-guide/runtime/session_info.html.
+//! See <https://w3f.github.io/parachain-implementers-guide/runtime/session_info.html>.
 
 use crate::{
 	configuration, paras, scheduler, shared,


### PR DESCRIPTION
Be explicit about the types. `rustc` causes for this particular one a myriad of error messages when an unrelated issue pops up.

Extracted from #5314 