### PR TITLE
polkadot-node-subsystem package rename mish mash cleanup 

### DIFF
--- a/node/core/av-store/Cargo.toml
+++ b/node/core/av-store/Cargo.toml
@@ -14,7 +14,7 @@ bitvec = "1.0.0"
 
 parity-scale-codec = { version = "3.1.2", features = ["derive"] }
 erasure = { package = "polkadot-erasure-coding", path = "../../../erasure-coding" }
-polkadot-subsystem = { package = "polkadot-node-subsystem", path = "../../subsystem" }
+polkadot-node-subsystem = {path = "../../subsystem" }
 polkadot-node-subsystem-util = { path = "../../subsystem-util" }
 polkadot-overseer = { path = "../../overseer" }
 polkadot-primitives = { path = "../../../primitives" }

--- a/node/core/av-store/src/lib.rs
+++ b/node/core/av-store/src/lib.rs
@@ -37,7 +37,7 @@ use polkadot_node_subsystem_util as util;
 use polkadot_primitives::v2::{
 	BlockNumber, CandidateEvent, CandidateHash, CandidateReceipt, Hash, Header, ValidatorIndex,
 };
-use polkadot_subsystem::{
+use polkadot_node_subsystem::{
 	errors::{ChainApiError, RuntimeApiError},
 	messages::{AvailabilityStoreMessage, ChainApiMessage},
 	overseer, ActiveLeavesUpdate, FromOverseer, OverseerSignal, SpawnedSubsystem, SubsystemContext,

--- a/node/core/av-store/src/lib.rs
+++ b/node/core/av-store/src/lib.rs
@@ -33,15 +33,15 @@ use polkadot_node_subsystem_util::database::{DBTransaction, Database};
 
 use bitvec::{order::Lsb0 as BitOrderLsb0, vec::BitVec};
 use polkadot_node_primitives::{AvailableData, ErasureChunk};
-use polkadot_node_subsystem_util as util;
-use polkadot_primitives::v2::{
-	BlockNumber, CandidateEvent, CandidateHash, CandidateReceipt, Hash, Header, ValidatorIndex,
-};
 use polkadot_node_subsystem::{
 	errors::{ChainApiError, RuntimeApiError},
 	messages::{AvailabilityStoreMessage, ChainApiMessage},
 	overseer, ActiveLeavesUpdate, FromOverseer, OverseerSignal, SpawnedSubsystem, SubsystemContext,
 	SubsystemError,
+};
+use polkadot_node_subsystem_util as util;
+use polkadot_primitives::v2::{
+	BlockNumber, CandidateEvent, CandidateHash, CandidateReceipt, Hash, Header, ValidatorIndex,
 };
 
 mod metrics;

--- a/node/core/av-store/src/tests.rs
+++ b/node/core/av-store/src/tests.rs
@@ -28,7 +28,7 @@ use polkadot_primitives::v2::{
 	CandidateHash, CandidateReceipt, CoreIndex, GroupIndex, HeadData, Header,
 	PersistedValidationData, ValidatorId,
 };
-use polkadot_subsystem::{
+use polkadot_node_subsystem::{
 	errors::RuntimeApiError,
 	jaeger,
 	messages::{AllMessages, RuntimeApiMessage, RuntimeApiRequest},

--- a/node/core/av-store/src/tests.rs
+++ b/node/core/av-store/src/tests.rs
@@ -22,17 +22,17 @@ use futures::{channel::oneshot, executor, future, Future};
 use ::test_helpers::TestCandidateBuilder;
 use parking_lot::Mutex;
 use polkadot_node_primitives::{AvailableData, BlockData, PoV, Proof};
-use polkadot_node_subsystem_test_helpers as test_helpers;
-use polkadot_node_subsystem_util::{database::Database, TimeoutExt};
-use polkadot_primitives::v2::{
-	CandidateHash, CandidateReceipt, CoreIndex, GroupIndex, HeadData, Header,
-	PersistedValidationData, ValidatorId,
-};
 use polkadot_node_subsystem::{
 	errors::RuntimeApiError,
 	jaeger,
 	messages::{AllMessages, RuntimeApiMessage, RuntimeApiRequest},
 	ActivatedLeaf, ActiveLeavesUpdate, LeafStatus,
+};
+use polkadot_node_subsystem_test_helpers as test_helpers;
+use polkadot_node_subsystem_util::{database::Database, TimeoutExt};
+use polkadot_primitives::v2::{
+	CandidateHash, CandidateReceipt, CoreIndex, GroupIndex, HeadData, Header,
+	PersistedValidationData, ValidatorId,
 };
 use sp_keyring::Sr25519Keyring;
 

--- a/node/core/backing/Cargo.toml
+++ b/node/core/backing/Cargo.toml
@@ -9,7 +9,7 @@ futures = "0.3.21"
 sp-keystore = { git = "https://github.com/paritytech/substrate", branch = "master" }
 polkadot-primitives = { path = "../../../primitives" }
 polkadot-node-primitives = { path = "../../primitives" }
-polkadot-subsystem = { package = "polkadot-node-subsystem", path = "../../subsystem" }
+polkadot-node-subsystem = {path = "../../subsystem" }
 polkadot-node-subsystem-util = { path = "../../subsystem-util" }
 erasure-coding = { package = "polkadot-erasure-coding", path = "../../../erasure-coding" }
 statement-table = { package = "polkadot-statement-table", path = "../../../statement-table" }

--- a/node/core/backing/src/error.rs
+++ b/node/core/backing/src/error.rs
@@ -19,7 +19,7 @@ use futures::channel::{mpsc, oneshot};
 
 use polkadot_node_subsystem_util::Error as UtilError;
 use polkadot_primitives::v2::BackedCandidate;
-use polkadot_subsystem::{messages::ValidationFailed, SubsystemError};
+use polkadot_node_subsystem::{messages::ValidationFailed, SubsystemError};
 
 use crate::LOG_TARGET;
 

--- a/node/core/backing/src/error.rs
+++ b/node/core/backing/src/error.rs
@@ -17,9 +17,9 @@
 use fatality::Nested;
 use futures::channel::{mpsc, oneshot};
 
+use polkadot_node_subsystem::{messages::ValidationFailed, SubsystemError};
 use polkadot_node_subsystem_util::Error as UtilError;
 use polkadot_primitives::v2::BackedCandidate;
-use polkadot_node_subsystem::{messages::ValidationFailed, SubsystemError};
 
 use crate::LOG_TARGET;
 

--- a/node/core/backing/src/lib.rs
+++ b/node/core/backing/src/lib.rs
@@ -43,7 +43,7 @@ use polkadot_primitives::v2::{
 	CommittedCandidateReceipt, CoreIndex, CoreState, Hash, Id as ParaId, SessionIndex,
 	SigningContext, ValidatorId, ValidatorIndex, ValidatorSignature, ValidityAttestation,
 };
-use polkadot_subsystem::{
+use polkadot_node_subsystem::{
 	jaeger,
 	messages::{
 		AllMessages, AvailabilityDistributionMessage, AvailabilityStoreMessage,

--- a/node/core/backing/src/lib.rs
+++ b/node/core/backing/src/lib.rs
@@ -34,15 +34,6 @@ use polkadot_node_primitives::{
 	AvailableData, InvalidCandidate, PoV, SignedDisputeStatement, SignedFullStatement, Statement,
 	ValidationResult, BACKING_EXECUTION_TIMEOUT,
 };
-use polkadot_node_subsystem_util::{
-	self as util, request_from_runtime, request_session_index_for_child, request_validator_groups,
-	request_validators, Validator,
-};
-use polkadot_primitives::v2::{
-	BackedCandidate, CandidateCommitments, CandidateHash, CandidateReceipt, CollatorId,
-	CommittedCandidateReceipt, CoreIndex, CoreState, Hash, Id as ParaId, SessionIndex,
-	SigningContext, ValidatorId, ValidatorIndex, ValidatorSignature, ValidityAttestation,
-};
 use polkadot_node_subsystem::{
 	jaeger,
 	messages::{
@@ -53,6 +44,15 @@ use polkadot_node_subsystem::{
 	},
 	overseer, ActiveLeavesUpdate, FromOverseer, OverseerSignal, PerLeafSpan, SpawnedSubsystem,
 	Stage, SubsystemContext, SubsystemError, SubsystemSender,
+};
+use polkadot_node_subsystem_util::{
+	self as util, request_from_runtime, request_session_index_for_child, request_validator_groups,
+	request_validators, Validator,
+};
+use polkadot_primitives::v2::{
+	BackedCandidate, CandidateCommitments, CandidateHash, CandidateReceipt, CollatorId,
+	CommittedCandidateReceipt, CoreIndex, CoreState, Hash, Id as ParaId, SessionIndex,
+	SigningContext, ValidatorId, ValidatorIndex, ValidatorSignature, ValidityAttestation,
 };
 use sp_keystore::SyncCryptoStorePtr;
 use statement_table::{

--- a/node/core/backing/src/tests.rs
+++ b/node/core/backing/src/tests.rs
@@ -27,7 +27,7 @@ use polkadot_primitives::v2::{
 	CandidateDescriptor, CollatorId, GroupRotationInfo, HeadData, PersistedValidationData,
 	ScheduledCore,
 };
-use polkadot_subsystem::{
+use polkadot_node_subsystem::{
 	messages::{CollatorProtocolMessage, RuntimeApiMessage, RuntimeApiRequest, ValidationFailed},
 	ActivatedLeaf, ActiveLeavesUpdate, FromOverseer, LeafStatus, OverseerSignal,
 };

--- a/node/core/backing/src/tests.rs
+++ b/node/core/backing/src/tests.rs
@@ -22,14 +22,14 @@ use ::test_helpers::{
 use assert_matches::assert_matches;
 use futures::{future, Future};
 use polkadot_node_primitives::{BlockData, InvalidCandidate};
+use polkadot_node_subsystem::{
+	messages::{CollatorProtocolMessage, RuntimeApiMessage, RuntimeApiRequest, ValidationFailed},
+	ActivatedLeaf, ActiveLeavesUpdate, FromOverseer, LeafStatus, OverseerSignal,
+};
 use polkadot_node_subsystem_test_helpers as test_helpers;
 use polkadot_primitives::v2::{
 	CandidateDescriptor, CollatorId, GroupRotationInfo, HeadData, PersistedValidationData,
 	ScheduledCore,
-};
-use polkadot_node_subsystem::{
-	messages::{CollatorProtocolMessage, RuntimeApiMessage, RuntimeApiRequest, ValidationFailed},
-	ActivatedLeaf, ActiveLeavesUpdate, FromOverseer, LeafStatus, OverseerSignal,
 };
 use sp_application_crypto::AppKey;
 use sp_keyring::Sr25519Keyring;

--- a/node/core/candidate-validation/Cargo.toml
+++ b/node/core/candidate-validation/Cargo.toml
@@ -15,7 +15,7 @@ parity-scale-codec = { version = "3.1.2", default-features = false, features = [
 polkadot-primitives = { path = "../../../primitives" }
 polkadot-parachain = { path = "../../../parachain" }
 polkadot-node-primitives = { path = "../../primitives" }
-polkadot-node-subsystem = { package = "polkadot-node-subsystem", path = "../../subsystem" }
+polkadot-node-subsystem = {path = "../../subsystem" }
 polkadot-node-subsystem-util = { path = "../../subsystem-util" }
 
 [target.'cfg(not(any(target_os = "android", target_os = "unknown")))'.dependencies]

--- a/node/core/chain-api/Cargo.toml
+++ b/node/core/chain-api/Cargo.toml
@@ -9,7 +9,7 @@ futures = "0.3.21"
 gum = { package = "tracing-gum", path = "../../gum" }
 sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "master" }
 polkadot-primitives = { path = "../../../primitives" }
-polkadot-subsystem = { package = "polkadot-node-subsystem", path = "../../subsystem" }
+polkadot-node-subsystem = {path = "../../subsystem" }
 polkadot-node-subsystem-util = { path = "../../subsystem-util" }
 sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sc-consensus-babe = { git = "https://github.com/paritytech/substrate", branch = "master" }

--- a/node/core/chain-api/src/lib.rs
+++ b/node/core/chain-api/src/lib.rs
@@ -37,11 +37,11 @@ use futures::prelude::*;
 use sc_client_api::AuxStore;
 use sp_blockchain::HeaderBackend;
 
-use polkadot_primitives::v2::{Block, BlockId};
 use polkadot_node_subsystem::{
 	messages::ChainApiMessage, overseer, FromOverseer, OverseerSignal, SpawnedSubsystem,
 	SubsystemContext, SubsystemError, SubsystemResult,
 };
+use polkadot_primitives::v2::{Block, BlockId};
 
 mod metrics;
 use self::metrics::Metrics;

--- a/node/core/chain-api/src/lib.rs
+++ b/node/core/chain-api/src/lib.rs
@@ -38,7 +38,7 @@ use sc_client_api::AuxStore;
 use sp_blockchain::HeaderBackend;
 
 use polkadot_primitives::v2::{Block, BlockId};
-use polkadot_subsystem::{
+use polkadot_node_subsystem::{
 	messages::ChainApiMessage, overseer, FromOverseer, OverseerSignal, SpawnedSubsystem,
 	SubsystemContext, SubsystemError, SubsystemResult,
 };

--- a/node/core/runtime-api/Cargo.toml
+++ b/node/core/runtime-api/Cargo.toml
@@ -16,7 +16,7 @@ sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sp-consensus-babe = { git = "https://github.com/paritytech/substrate", branch = "master" }
 
 polkadot-primitives = { path = "../../../primitives" }
-polkadot-subsystem = { package = "polkadot-node-subsystem", path = "../../subsystem" }
+polkadot-node-subsystem = {path = "../../subsystem" }
 polkadot-node-subsystem-util = { path = "../../subsystem-util" }
 
 [dev-dependencies]

--- a/node/core/runtime-api/src/lib.rs
+++ b/node/core/runtime-api/src/lib.rs
@@ -26,7 +26,7 @@ use polkadot_primitives::{
 	runtime_api::ParachainHost,
 	v2::{Block, BlockId, Hash},
 };
-use polkadot_subsystem::{
+use polkadot_node_subsystem::{
 	errors::RuntimeApiError,
 	messages::{RuntimeApiMessage, RuntimeApiRequest as Request},
 	overseer, FromOverseer, OverseerSignal, SpawnedSubsystem, SubsystemContext, SubsystemError,

--- a/node/core/runtime-api/src/lib.rs
+++ b/node/core/runtime-api/src/lib.rs
@@ -22,15 +22,15 @@
 #![deny(unused_crate_dependencies)]
 #![warn(missing_docs)]
 
-use polkadot_primitives::{
-	runtime_api::ParachainHost,
-	v2::{Block, BlockId, Hash},
-};
 use polkadot_node_subsystem::{
 	errors::RuntimeApiError,
 	messages::{RuntimeApiMessage, RuntimeApiRequest as Request},
 	overseer, FromOverseer, OverseerSignal, SpawnedSubsystem, SubsystemContext, SubsystemError,
 	SubsystemResult,
+};
+use polkadot_primitives::{
+	runtime_api::ParachainHost,
+	v2::{Block, BlockId, Hash},
 };
 
 use sp_api::ProvideRuntimeApi;

--- a/node/network/availability-distribution/Cargo.toml
+++ b/node/network/availability-distribution/Cargo.toml
@@ -10,8 +10,8 @@ gum = { package = "tracing-gum", path = "../../gum" }
 parity-scale-codec = { version = "3.1.2", features = ["std"] }
 polkadot-primitives = { path = "../../../primitives" }
 polkadot-erasure-coding = { path = "../../../erasure-coding" }
-polkadot-subsystem = { package = "polkadot-node-subsystem", path = "../../subsystem" }
 polkadot-node-network-protocol = { path = "../../network/protocol" }
+polkadot-node-subsystem = { path = "../../subsystem" }
 polkadot-node-subsystem-util = { path = "../../subsystem-util" }
 polkadot-node-primitives = { path = "../../primitives" }
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "master", features = ["std"] }
@@ -23,7 +23,7 @@ lru = "0.7.5"
 fatality = "0.0.6"
 
 [dev-dependencies]
-polkadot-subsystem-testhelpers = { package = "polkadot-node-subsystem-test-helpers", path = "../../subsystem-test-helpers" }
+polkadot-node-subsystem-test-helpers = { path = "../../subsystem-test-helpers" }
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "master", features = ["std"] }
 sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sp-tracing = { git = "https://github.com/paritytech/substrate", branch = "master" }

--- a/node/network/availability-distribution/src/error.rs
+++ b/node/network/availability-distribution/src/error.rs
@@ -23,8 +23,8 @@ use polkadot_primitives::v2::SessionIndex;
 
 use futures::channel::oneshot;
 
-use polkadot_node_subsystem_util::runtime;
 use polkadot_node_subsystem::{ChainApiError, SubsystemError};
+use polkadot_node_subsystem_util::runtime;
 
 use crate::LOG_TARGET;
 

--- a/node/network/availability-distribution/src/error.rs
+++ b/node/network/availability-distribution/src/error.rs
@@ -24,7 +24,7 @@ use polkadot_primitives::v2::SessionIndex;
 use futures::channel::oneshot;
 
 use polkadot_node_subsystem_util::runtime;
-use polkadot_subsystem::{ChainApiError, SubsystemError};
+use polkadot_node_subsystem::{ChainApiError, SubsystemError};
 
 use crate::LOG_TARGET;
 

--- a/node/network/availability-distribution/src/lib.rs
+++ b/node/network/availability-distribution/src/lib.rs
@@ -19,7 +19,7 @@ use futures::{future::Either, FutureExt, StreamExt, TryFutureExt};
 use sp_keystore::SyncCryptoStorePtr;
 
 use polkadot_node_network_protocol::request_response::{v1, IncomingRequestReceiver};
-use polkadot_subsystem::{
+use polkadot_node_subsystem::{
 	messages::AvailabilityDistributionMessage, overseer, FromOverseer, OverseerSignal,
 	SpawnedSubsystem, SubsystemContext, SubsystemError,
 };

--- a/node/network/availability-distribution/src/pov_requester/mod.rs
+++ b/node/network/availability-distribution/src/pov_requester/mod.rs
@@ -26,7 +26,7 @@ use polkadot_node_network_protocol::request_response::{
 use polkadot_node_primitives::PoV;
 use polkadot_node_subsystem_util::runtime::RuntimeInfo;
 use polkadot_primitives::v2::{AuthorityDiscoveryId, CandidateHash, Hash, ValidatorIndex};
-use polkadot_subsystem::{
+use polkadot_node_subsystem::{
 	jaeger,
 	messages::{IfDisconnected, NetworkBridgeMessage},
 	SubsystemContext,
@@ -133,11 +133,11 @@ mod tests {
 	use sp_core::testing::TaskExecutor;
 
 	use polkadot_node_primitives::BlockData;
-	use polkadot_primitives::v2::{CandidateHash, Hash, ValidatorIndex};
-	use polkadot_subsystem::messages::{
+	use polkadot_node_subsystem::messages::{
 		AllMessages, AvailabilityDistributionMessage, RuntimeApiMessage, RuntimeApiRequest,
 	};
-	use polkadot_subsystem_testhelpers as test_helpers;
+	use polkadot_node_subsystem_test_helpers as test_helpers;
+	use polkadot_primitives::v2::{CandidateHash, Hash, ValidatorIndex};
 	use test_helpers::mock::make_ferdie_keystore;
 
 	use super::*;

--- a/node/network/availability-distribution/src/pov_requester/mod.rs
+++ b/node/network/availability-distribution/src/pov_requester/mod.rs
@@ -24,13 +24,13 @@ use polkadot_node_network_protocol::request_response::{
 	OutgoingRequest, Recipient,
 };
 use polkadot_node_primitives::PoV;
-use polkadot_node_subsystem_util::runtime::RuntimeInfo;
-use polkadot_primitives::v2::{AuthorityDiscoveryId, CandidateHash, Hash, ValidatorIndex};
 use polkadot_node_subsystem::{
 	jaeger,
 	messages::{IfDisconnected, NetworkBridgeMessage},
 	SubsystemContext,
 };
+use polkadot_node_subsystem_util::runtime::RuntimeInfo;
+use polkadot_primitives::v2::{AuthorityDiscoveryId, CandidateHash, Hash, ValidatorIndex};
 
 use crate::{
 	error::{Error, FatalError, JfyiError, Result},

--- a/node/network/availability-distribution/src/requester/fetch_task/mod.rs
+++ b/node/network/availability-distribution/src/requester/fetch_task/mod.rs
@@ -28,14 +28,14 @@ use polkadot_node_network_protocol::request_response::{
 	v1::{ChunkFetchingRequest, ChunkFetchingResponse},
 };
 use polkadot_node_primitives::ErasureChunk;
-use polkadot_primitives::v2::{
-	AuthorityDiscoveryId, BlakeTwo256, CandidateHash, GroupIndex, Hash, HashT, OccupiedCore,
-	SessionIndex,
-};
-use polkadot_subsystem::{
+use polkadot_node_subsystem::{
 	jaeger,
 	messages::{AllMessages, AvailabilityStoreMessage, IfDisconnected, NetworkBridgeMessage},
 	SubsystemContext,
+};
+use polkadot_primitives::v2::{
+	AuthorityDiscoveryId, BlakeTwo256, CandidateHash, GroupIndex, Hash, HashT, OccupiedCore,
+	SessionIndex,
 };
 
 use crate::{

--- a/node/network/availability-distribution/src/requester/fetch_task/tests.rs
+++ b/node/network/availability-distribution/src/requester/fetch_task/tests.rs
@@ -30,6 +30,7 @@ use sp_keyring::Sr25519Keyring;
 
 use polkadot_node_network_protocol::request_response::{v1, Recipient};
 use polkadot_node_primitives::{BlockData, PoV, Proof};
+use polkadot_node_subsystem::messages::AllMessages;
 use polkadot_primitives::v2::{CandidateHash, ValidatorIndex};
 
 use super::*;

--- a/node/network/availability-distribution/src/requester/mod.rs
+++ b/node/network/availability-distribution/src/requester/mod.rs
@@ -34,7 +34,7 @@ use futures::{
 
 use polkadot_node_subsystem_util::runtime::{get_occupied_cores, RuntimeInfo};
 use polkadot_primitives::v2::{CandidateHash, Hash, OccupiedCore, SessionIndex};
-use polkadot_subsystem::{
+use polkadot_node_subsystem::{
 	messages::{AllMessages, ChainApiMessage},
 	ActivatedLeaf, ActiveLeavesUpdate, LeafStatus, SubsystemContext,
 };

--- a/node/network/availability-distribution/src/requester/mod.rs
+++ b/node/network/availability-distribution/src/requester/mod.rs
@@ -32,12 +32,12 @@ use futures::{
 	Stream,
 };
 
-use polkadot_node_subsystem_util::runtime::{get_occupied_cores, RuntimeInfo};
-use polkadot_primitives::v2::{CandidateHash, Hash, OccupiedCore, SessionIndex};
 use polkadot_node_subsystem::{
 	messages::{AllMessages, ChainApiMessage},
 	ActivatedLeaf, ActiveLeavesUpdate, LeafStatus, SubsystemContext,
 };
+use polkadot_node_subsystem_util::runtime::{get_occupied_cores, RuntimeInfo};
+use polkadot_primitives::v2::{CandidateHash, Hash, OccupiedCore, SessionIndex};
 
 use super::{FatalError, Metrics, Result, LOG_TARGET};
 

--- a/node/network/availability-distribution/src/requester/session_cache.rs
+++ b/node/network/availability-distribution/src/requester/session_cache.rs
@@ -19,11 +19,11 @@ use std::collections::HashSet;
 use lru::LruCache;
 use rand::{seq::SliceRandom, thread_rng};
 
+use polkadot_node_subsystem::SubsystemContext;
 use polkadot_node_subsystem_util::runtime::RuntimeInfo;
 use polkadot_primitives::v2::{
 	AuthorityDiscoveryId, GroupIndex, Hash, SessionIndex, ValidatorIndex,
 };
-use polkadot_node_subsystem::SubsystemContext;
 
 use crate::{
 	error::{Error, Result},

--- a/node/network/availability-distribution/src/requester/session_cache.rs
+++ b/node/network/availability-distribution/src/requester/session_cache.rs
@@ -23,7 +23,7 @@ use polkadot_node_subsystem_util::runtime::RuntimeInfo;
 use polkadot_primitives::v2::{
 	AuthorityDiscoveryId, GroupIndex, Hash, SessionIndex, ValidatorIndex,
 };
-use polkadot_subsystem::SubsystemContext;
+use polkadot_node_subsystem::SubsystemContext;
 
 use crate::{
 	error::{Error, Result},

--- a/node/network/availability-distribution/src/requester/tests.rs
+++ b/node/network/availability-distribution/src/requester/tests.rs
@@ -25,14 +25,14 @@ use polkadot_primitives::v2::{
 	BlockNumber, CoreState, GroupIndex, Hash, Id, ScheduledCore, SessionIndex, SessionInfo,
 };
 
-use polkadot_subsystem::{
+use polkadot_node_subsystem::{
 	messages::{
 		AllMessages, AvailabilityDistributionMessage, AvailabilityStoreMessage, ChainApiMessage,
 		NetworkBridgeMessage, RuntimeApiMessage, RuntimeApiRequest,
 	},
 	ActivatedLeaf, ActiveLeavesUpdate, LeafStatus,
 };
-use polkadot_subsystem_testhelpers::{
+use polkadot_node_subsystem_test_helpers::{
 	make_subsystem_context, mock::make_ferdie_keystore, TestSubsystemContext,
 	TestSubsystemContextHandle,
 };

--- a/node/network/availability-distribution/src/responder.rs
+++ b/node/network/availability-distribution/src/responder.rs
@@ -26,8 +26,8 @@ use polkadot_node_network_protocol::{
 	UnifiedReputationChange as Rep,
 };
 use polkadot_node_primitives::{AvailableData, ErasureChunk};
-use polkadot_primitives::v2::{CandidateHash, ValidatorIndex};
 use polkadot_node_subsystem::{jaeger, messages::AvailabilityStoreMessage, SubsystemSender};
+use polkadot_primitives::v2::{CandidateHash, ValidatorIndex};
 
 use crate::{
 	error::{JfyiError, Result},

--- a/node/network/availability-distribution/src/responder.rs
+++ b/node/network/availability-distribution/src/responder.rs
@@ -27,7 +27,7 @@ use polkadot_node_network_protocol::{
 };
 use polkadot_node_primitives::{AvailableData, ErasureChunk};
 use polkadot_primitives::v2::{CandidateHash, ValidatorIndex};
-use polkadot_subsystem::{jaeger, messages::AvailabilityStoreMessage, SubsystemSender};
+use polkadot_node_subsystem::{jaeger, messages::AvailabilityStoreMessage, SubsystemSender};
 
 use crate::{
 	error::{JfyiError, Result},

--- a/node/network/availability-distribution/src/tests/mod.rs
+++ b/node/network/availability-distribution/src/tests/mod.rs
@@ -22,7 +22,7 @@ use polkadot_node_network_protocol::request_response::IncomingRequest;
 use polkadot_primitives::v2::CoreState;
 use sp_keystore::SyncCryptoStorePtr;
 
-use polkadot_subsystem_testhelpers as test_helpers;
+use polkadot_node_subsystem_test_helpers as test_helpers;
 
 use super::*;
 

--- a/node/network/availability-distribution/src/tests/state.rs
+++ b/node/network/availability-distribution/src/tests/state.rs
@@ -21,7 +21,7 @@ use std::{
 };
 
 use polkadot_node_subsystem_util::TimeoutExt;
-use polkadot_subsystem_testhelpers::TestSubsystemContextHandle;
+use polkadot_node_subsystem_test_helpers::TestSubsystemContextHandle;
 
 use futures::{
 	channel::{mpsc, oneshot},
@@ -39,18 +39,18 @@ use polkadot_node_network_protocol::{
 	request_response::{v1, IncomingRequest, OutgoingRequest, Requests},
 };
 use polkadot_node_primitives::ErasureChunk;
-use polkadot_primitives::v2::{
-	CandidateHash, CoreState, GroupIndex, Hash, Id as ParaId, ScheduledCore, SessionInfo,
-	ValidatorIndex,
-};
-use polkadot_subsystem::{
+use polkadot_node_subsystem::{
 	messages::{
 		AllMessages, AvailabilityDistributionMessage, AvailabilityStoreMessage, ChainApiMessage,
 		NetworkBridgeMessage, RuntimeApiMessage, RuntimeApiRequest,
 	},
 	ActivatedLeaf, ActiveLeavesUpdate, FromOverseer, LeafStatus, OverseerSignal,
 };
-use polkadot_subsystem_testhelpers as test_helpers;
+use polkadot_node_subsystem_test_helpers as test_helpers;
+use polkadot_primitives::v2::{
+	CandidateHash, CoreState, GroupIndex, Hash, Id as ParaId, ScheduledCore, SessionInfo,
+	ValidatorIndex,
+};
 use test_helpers::{mock::make_ferdie_keystore, SingleItemSink};
 
 use super::mock::{make_session_info, OccupiedCoreBuilder};

--- a/node/network/availability-distribution/src/tests/state.rs
+++ b/node/network/availability-distribution/src/tests/state.rs
@@ -20,8 +20,8 @@ use std::{
 	time::Duration,
 };
 
-use polkadot_node_subsystem_util::TimeoutExt;
 use polkadot_node_subsystem_test_helpers::TestSubsystemContextHandle;
+use polkadot_node_subsystem_util::TimeoutExt;
 
 use futures::{
 	channel::{mpsc, oneshot},

--- a/node/network/availability-recovery/Cargo.toml
+++ b/node/network/availability-recovery/Cargo.toml
@@ -15,7 +15,7 @@ gum = { package = "tracing-gum", path = "../../gum" }
 polkadot-erasure-coding = { path = "../../../erasure-coding" }
 polkadot-primitives = { path = "../../../primitives" }
 polkadot-node-primitives = { path = "../../primitives" }
-polkadot-subsystem = { package = "polkadot-node-subsystem", path = "../../subsystem" }
+polkadot-node-subsystem = {path = "../../subsystem" }
 polkadot-node-subsystem-util = { path = "../../subsystem-util" }
 polkadot-node-network-protocol = { path = "../../network/protocol" }
 parity-scale-codec = { version = "3.1.2", default-features = false, features = ["derive"] }
@@ -32,5 +32,5 @@ sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "master
 sp-application-crypto = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sc-network = { git = "https://github.com/paritytech/substrate", branch = "master" }
 
-polkadot-subsystem-test-helpers = { package = "polkadot-node-subsystem-test-helpers", path = "../../subsystem-test-helpers" }
+polkadot-node-subsystem-test-helpers = { path = "../../subsystem-test-helpers" }
 polkadot-primitives-test-helpers = { path = "../../../primitives/test-helpers" }

--- a/node/network/availability-recovery/src/error.rs
+++ b/node/network/availability-recovery/src/error.rs
@@ -23,7 +23,7 @@ use thiserror::Error;
 #[derive(Debug, Error)]
 pub enum Error {
 	#[error(transparent)]
-	Subsystem(#[from] polkadot_subsystem::SubsystemError),
+	Subsystem(#[from] polkadot_node_subsystem::SubsystemError),
 
 	#[error("failed to query full data from store")]
 	CanceledQueryFullData(#[source] oneshot::Canceled),
@@ -35,7 +35,7 @@ pub enum Error {
 	CanceledResponseSender,
 
 	#[error(transparent)]
-	Runtime(#[from] polkadot_subsystem::errors::RuntimeApiError),
+	Runtime(#[from] polkadot_node_subsystem::errors::RuntimeApiError),
 
 	#[error(transparent)]
 	Erasure(#[from] polkadot_erasure_coding::Error),

--- a/node/network/availability-recovery/src/lib.rs
+++ b/node/network/availability-recovery/src/lib.rs
@@ -52,7 +52,7 @@ use polkadot_primitives::v2::{
 	AuthorityDiscoveryId, BlakeTwo256, BlockNumber, CandidateHash, CandidateReceipt, GroupIndex,
 	Hash, HashT, SessionIndex, SessionInfo, ValidatorId, ValidatorIndex,
 };
-use polkadot_subsystem::{
+use polkadot_node_subsystem::{
 	errors::RecoveryError,
 	jaeger,
 	messages::{AvailabilityRecoveryMessage, AvailabilityStoreMessage, NetworkBridgeMessage},

--- a/node/network/availability-recovery/src/lib.rs
+++ b/node/network/availability-recovery/src/lib.rs
@@ -47,11 +47,6 @@ use polkadot_node_network_protocol::{
 	IfDisconnected, UnifiedReputationChange as Rep,
 };
 use polkadot_node_primitives::{AvailableData, ErasureChunk};
-use polkadot_node_subsystem_util::request_session_info;
-use polkadot_primitives::v2::{
-	AuthorityDiscoveryId, BlakeTwo256, BlockNumber, CandidateHash, CandidateReceipt, GroupIndex,
-	Hash, HashT, SessionIndex, SessionInfo, ValidatorId, ValidatorIndex,
-};
 use polkadot_node_subsystem::{
 	errors::RecoveryError,
 	jaeger,
@@ -59,6 +54,11 @@ use polkadot_node_subsystem::{
 	overseer::{self, Subsystem},
 	ActiveLeavesUpdate, FromOverseer, OverseerSignal, SpawnedSubsystem, SubsystemContext,
 	SubsystemError, SubsystemResult, SubsystemSender,
+};
+use polkadot_node_subsystem_util::request_session_info;
+use polkadot_primitives::v2::{
+	AuthorityDiscoveryId, BlakeTwo256, BlockNumber, CandidateHash, CandidateReceipt, GroupIndex,
+	Hash, HashT, SessionIndex, SessionInfo, ValidatorId, ValidatorIndex,
 };
 
 mod error;

--- a/node/network/availability-recovery/src/tests.rs
+++ b/node/network/availability-recovery/src/tests.rs
@@ -29,15 +29,15 @@ use sc_network::config::RequestResponseConfig;
 
 use polkadot_erasure_coding::{branches, obtain_chunks_v1 as obtain_chunks};
 use polkadot_node_primitives::{BlockData, PoV, Proof};
-use polkadot_node_subsystem_util::TimeoutExt;
-use polkadot_primitives::v2::{AuthorityDiscoveryId, HeadData, PersistedValidationData};
-use polkadot_primitives_test_helpers::{dummy_candidate_receipt, dummy_hash};
 use polkadot_node_subsystem::{
 	jaeger,
 	messages::{AllMessages, RuntimeApiMessage, RuntimeApiRequest},
 	ActivatedLeaf, LeafStatus,
 };
 use polkadot_node_subsystem_test_helpers::{make_subsystem_context, TestSubsystemContextHandle};
+use polkadot_node_subsystem_util::TimeoutExt;
+use polkadot_primitives::v2::{AuthorityDiscoveryId, HeadData, PersistedValidationData};
+use polkadot_primitives_test_helpers::{dummy_candidate_receipt, dummy_hash};
 
 type VirtualOverseer = TestSubsystemContextHandle<AvailabilityRecoveryMessage>;
 

--- a/node/network/availability-recovery/src/tests.rs
+++ b/node/network/availability-recovery/src/tests.rs
@@ -32,12 +32,12 @@ use polkadot_node_primitives::{BlockData, PoV, Proof};
 use polkadot_node_subsystem_util::TimeoutExt;
 use polkadot_primitives::v2::{AuthorityDiscoveryId, HeadData, PersistedValidationData};
 use polkadot_primitives_test_helpers::{dummy_candidate_receipt, dummy_hash};
-use polkadot_subsystem::{
+use polkadot_node_subsystem::{
 	jaeger,
 	messages::{AllMessages, RuntimeApiMessage, RuntimeApiRequest},
 	ActivatedLeaf, LeafStatus,
 };
-use polkadot_subsystem_test_helpers::{make_subsystem_context, TestSubsystemContextHandle};
+use polkadot_node_subsystem_test_helpers::{make_subsystem_context, TestSubsystemContextHandle};
 
 type VirtualOverseer = TestSubsystemContextHandle<AvailabilityRecoveryMessage>;
 

--- a/node/network/bitfield-distribution/Cargo.toml
+++ b/node/network/bitfield-distribution/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 futures = "0.3.21"
 gum = { package = "tracing-gum", path = "../../gum" }
 polkadot-primitives = { path = "../../../primitives" }
-polkadot-subsystem = { package = "polkadot-node-subsystem", path = "../../subsystem" }
+polkadot-node-subsystem = {path = "../../subsystem" }
 polkadot-node-subsystem-util = { path = "../../subsystem-util" }
 polkadot-node-network-protocol = { path = "../../network/protocol" }
 rand = "0.8"

--- a/node/network/bitfield-distribution/src/lib.rs
+++ b/node/network/bitfield-distribution/src/lib.rs
@@ -29,13 +29,13 @@ use polkadot_node_network_protocol::{
 	grid_topology::{RandomRouting, RequiredRouting, SessionGridTopology},
 	v1 as protocol_v1, OurView, PeerId, UnifiedReputationChange as Rep, Versioned, View,
 };
-use polkadot_node_subsystem_util::{self as util};
-use polkadot_primitives::v2::{
-	Hash, SessionIndex, SignedAvailabilityBitfield, SigningContext, ValidatorId,
-};
 use polkadot_node_subsystem::{
 	jaeger, messages::*, overseer, ActiveLeavesUpdate, FromOverseer, OverseerSignal, PerLeafSpan,
 	SpawnedSubsystem, SubsystemContext, SubsystemError, SubsystemResult,
+};
+use polkadot_node_subsystem_util::{self as util};
+use polkadot_primitives::v2::{
+	Hash, SessionIndex, SignedAvailabilityBitfield, SigningContext, ValidatorId,
 };
 use rand::{CryptoRng, Rng, SeedableRng};
 use std::collections::{HashMap, HashSet};

--- a/node/network/bitfield-distribution/src/lib.rs
+++ b/node/network/bitfield-distribution/src/lib.rs
@@ -33,7 +33,7 @@ use polkadot_node_subsystem_util::{self as util};
 use polkadot_primitives::v2::{
 	Hash, SessionIndex, SignedAvailabilityBitfield, SigningContext, ValidatorId,
 };
-use polkadot_subsystem::{
+use polkadot_node_subsystem::{
 	jaeger, messages::*, overseer, ActiveLeavesUpdate, FromOverseer, OverseerSignal, PerLeafSpan,
 	SpawnedSubsystem, SubsystemContext, SubsystemError, SubsystemResult,
 };

--- a/node/network/bitfield-distribution/src/tests.rs
+++ b/node/network/bitfield-distribution/src/tests.rs
@@ -23,7 +23,7 @@ use polkadot_node_network_protocol::{our_view, view, ObservedRole};
 use polkadot_node_subsystem_test_helpers::make_subsystem_context;
 use polkadot_node_subsystem_util::TimeoutExt;
 use polkadot_primitives::v2::{AvailabilityBitfield, Signed, ValidatorIndex};
-use polkadot_subsystem::{
+use polkadot_node_subsystem::{
 	jaeger,
 	jaeger::{PerLeafSpan, Span},
 };

--- a/node/network/bitfield-distribution/src/tests.rs
+++ b/node/network/bitfield-distribution/src/tests.rs
@@ -20,13 +20,13 @@ use bitvec::bitvec;
 use futures::executor;
 use maplit::hashmap;
 use polkadot_node_network_protocol::{our_view, view, ObservedRole};
-use polkadot_node_subsystem_test_helpers::make_subsystem_context;
-use polkadot_node_subsystem_util::TimeoutExt;
-use polkadot_primitives::v2::{AvailabilityBitfield, Signed, ValidatorIndex};
 use polkadot_node_subsystem::{
 	jaeger,
 	jaeger::{PerLeafSpan, Span},
 };
+use polkadot_node_subsystem_test_helpers::make_subsystem_context;
+use polkadot_node_subsystem_util::TimeoutExt;
+use polkadot_primitives::v2::{AvailabilityBitfield, Signed, ValidatorIndex};
 use rand_chacha::ChaCha12Rng;
 use sp_application_crypto::AppKey;
 use sp_core::Pair as PairT;

--- a/node/network/bridge/Cargo.toml
+++ b/node/network/bridge/Cargo.toml
@@ -13,7 +13,7 @@ polkadot-primitives = { path = "../../../primitives" }
 parity-scale-codec = { version = "3.1.2", default-features = false, features = ["derive"] }
 sc-network = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sp-consensus = { git = "https://github.com/paritytech/substrate", branch = "master" }
-polkadot-subsystem = { package = "polkadot-node-subsystem", path = "../../subsystem" }
+polkadot-node-subsystem = {path = "../../subsystem" }
 polkadot-overseer = { path = "../../overseer" }
 polkadot-node-network-protocol = { path = "../protocol" }
 polkadot-node-subsystem-util = { path = "../../subsystem-util"}

--- a/node/network/bridge/src/lib.rs
+++ b/node/network/bridge/src/lib.rs
@@ -33,9 +33,6 @@ use polkadot_node_network_protocol::{
 	v1 as protocol_v1, ObservedRole, OurView, PeerId, ProtocolVersion,
 	UnifiedReputationChange as Rep, Versioned, View,
 };
-use polkadot_node_subsystem_util::metrics::{self, prometheus};
-use polkadot_overseer::gen::{OverseerError, Subsystem};
-use polkadot_primitives::v2::{AuthorityDiscoveryId, BlockNumber, Hash, ValidatorIndex};
 use polkadot_node_subsystem::{
 	errors::{SubsystemError, SubsystemResult},
 	messages::{
@@ -45,6 +42,9 @@ use polkadot_node_subsystem::{
 	overseer, ActivatedLeaf, ActiveLeavesUpdate, FromOverseer, OverseerSignal, SpawnedSubsystem,
 	SubsystemContext, SubsystemSender,
 };
+use polkadot_node_subsystem_util::metrics::{self, prometheus};
+use polkadot_overseer::gen::{OverseerError, Subsystem};
+use polkadot_primitives::v2::{AuthorityDiscoveryId, BlockNumber, Hash, ValidatorIndex};
 
 /// Peer set info for network initialization.
 ///

--- a/node/network/bridge/src/lib.rs
+++ b/node/network/bridge/src/lib.rs
@@ -36,7 +36,7 @@ use polkadot_node_network_protocol::{
 use polkadot_node_subsystem_util::metrics::{self, prometheus};
 use polkadot_overseer::gen::{OverseerError, Subsystem};
 use polkadot_primitives::v2::{AuthorityDiscoveryId, BlockNumber, Hash, ValidatorIndex};
-use polkadot_subsystem::{
+use polkadot_node_subsystem::{
 	errors::{SubsystemError, SubsystemResult},
 	messages::{
 		network_bridge_event::{NewGossipTopology, TopologyPeerInfo},

--- a/node/network/bridge/src/tests.rs
+++ b/node/network/bridge/src/tests.rs
@@ -37,7 +37,7 @@ use polkadot_node_subsystem_test_helpers::{
 use polkadot_node_subsystem_util::metered;
 use polkadot_primitives::v2::AuthorityDiscoveryId;
 use polkadot_primitives_test_helpers::dummy_collator_signature;
-use polkadot_subsystem::{
+use polkadot_node_subsystem::{
 	jaeger,
 	messages::{
 		ApprovalDistributionMessage, BitfieldDistributionMessage, GossipSupportMessage,

--- a/node/network/bridge/src/tests.rs
+++ b/node/network/bridge/src/tests.rs
@@ -31,12 +31,6 @@ use sc_network::{Event as NetworkEvent, IfDisconnected};
 use polkadot_node_network_protocol::{
 	request_response::outgoing::Requests, view, ObservedRole, Versioned,
 };
-use polkadot_node_subsystem_test_helpers::{
-	SingleItemSink, SingleItemStream, TestSubsystemContextHandle,
-};
-use polkadot_node_subsystem_util::metered;
-use polkadot_primitives::v2::AuthorityDiscoveryId;
-use polkadot_primitives_test_helpers::dummy_collator_signature;
 use polkadot_node_subsystem::{
 	jaeger,
 	messages::{
@@ -45,6 +39,12 @@ use polkadot_node_subsystem::{
 	},
 	ActiveLeavesUpdate, FromOverseer, LeafStatus, OverseerSignal,
 };
+use polkadot_node_subsystem_test_helpers::{
+	SingleItemSink, SingleItemStream, TestSubsystemContextHandle,
+};
+use polkadot_node_subsystem_util::metered;
+use polkadot_primitives::v2::AuthorityDiscoveryId;
+use polkadot_primitives_test_helpers::dummy_collator_signature;
 use sc_network::Multiaddr;
 use sp_keyring::Sr25519Keyring;
 

--- a/node/network/collator-protocol/Cargo.toml
+++ b/node/network/collator-protocol/Cargo.toml
@@ -18,7 +18,7 @@ polkadot-primitives = { path = "../../../primitives" }
 polkadot-node-network-protocol = { path = "../../network/protocol" }
 polkadot-node-primitives = { path = "../../primitives" }
 polkadot-node-subsystem-util = { path = "../../subsystem-util" }
-polkadot-subsystem = { package = "polkadot-node-subsystem", path = "../../subsystem" }
+polkadot-node-subsystem = {path = "../../subsystem" }
 fatality = "0.0.6"
 thiserror = "1.0.31"
 
@@ -32,5 +32,5 @@ sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "master
 sc-network = { git = "https://github.com/paritytech/substrate", branch = "master" }
 parity-scale-codec = { version = "3.1.2", features = ["std"] }
 
-polkadot-subsystem-testhelpers = { package = "polkadot-node-subsystem-test-helpers", path = "../../subsystem-test-helpers" }
+polkadot-node-subsystem-test-helpers = { path = "../../subsystem-test-helpers" }
 polkadot-primitives-test-helpers = { path = "../../../primitives/test-helpers" }

--- a/node/network/collator-protocol/src/collator_side/mod.rs
+++ b/node/network/collator-protocol/src/collator_side/mod.rs
@@ -36,6 +36,11 @@ use polkadot_node_network_protocol::{
 	v1 as protocol_v1, OurView, PeerId, UnifiedReputationChange as Rep, Versioned, View,
 };
 use polkadot_node_primitives::{CollationSecondedSignal, PoV, Statement};
+use polkadot_node_subsystem::{
+	jaeger,
+	messages::{CollatorProtocolMessage, NetworkBridgeEvent, NetworkBridgeMessage},
+	overseer, FromOverseer, OverseerSignal, PerLeafSpan, SubsystemContext,
+};
 use polkadot_node_subsystem_util::{
 	metrics::{self, prometheus},
 	runtime::{get_availability_cores, get_group_rotation_info, RuntimeInfo},
@@ -44,11 +49,6 @@ use polkadot_node_subsystem_util::{
 use polkadot_primitives::v2::{
 	AuthorityDiscoveryId, CandidateHash, CandidateReceipt, CollatorPair, CoreIndex, CoreState,
 	Hash, Id as ParaId,
-};
-use polkadot_node_subsystem::{
-	jaeger,
-	messages::{CollatorProtocolMessage, NetworkBridgeEvent, NetworkBridgeMessage},
-	overseer, FromOverseer, OverseerSignal, PerLeafSpan, SubsystemContext,
 };
 
 use super::LOG_TARGET;

--- a/node/network/collator-protocol/src/collator_side/mod.rs
+++ b/node/network/collator-protocol/src/collator_side/mod.rs
@@ -45,7 +45,7 @@ use polkadot_primitives::v2::{
 	AuthorityDiscoveryId, CandidateHash, CandidateReceipt, CollatorPair, CoreIndex, CoreState,
 	Hash, Id as ParaId,
 };
-use polkadot_subsystem::{
+use polkadot_node_subsystem::{
 	jaeger,
 	messages::{CollatorProtocolMessage, NetworkBridgeEvent, NetworkBridgeMessage},
 	overseer, FromOverseer, OverseerSignal, PerLeafSpan, SubsystemContext,

--- a/node/network/collator-protocol/src/collator_side/tests.rs
+++ b/node/network/collator-protocol/src/collator_side/tests.rs
@@ -31,18 +31,18 @@ use sp_runtime::traits::AppVerify;
 
 use polkadot_node_network_protocol::{our_view, request_response::IncomingRequest, view};
 use polkadot_node_primitives::BlockData;
-use polkadot_node_subsystem_util::TimeoutExt;
-use polkadot_primitives::v2::{
-	AuthorityDiscoveryId, CollatorPair, GroupRotationInfo, ScheduledCore, SessionIndex,
-	SessionInfo, ValidatorId, ValidatorIndex,
-};
-use polkadot_primitives_test_helpers::TestCandidateBuilder;
 use polkadot_node_subsystem::{
 	jaeger,
 	messages::{AllMessages, RuntimeApiMessage, RuntimeApiRequest},
 	ActivatedLeaf, ActiveLeavesUpdate, LeafStatus,
 };
 use polkadot_node_subsystem_test_helpers as test_helpers;
+use polkadot_node_subsystem_util::TimeoutExt;
+use polkadot_primitives::v2::{
+	AuthorityDiscoveryId, CollatorPair, GroupRotationInfo, ScheduledCore, SessionIndex,
+	SessionInfo, ValidatorId, ValidatorIndex,
+};
+use polkadot_primitives_test_helpers::TestCandidateBuilder;
 
 #[derive(Clone)]
 struct TestState {

--- a/node/network/collator-protocol/src/collator_side/tests.rs
+++ b/node/network/collator-protocol/src/collator_side/tests.rs
@@ -37,12 +37,12 @@ use polkadot_primitives::v2::{
 	SessionInfo, ValidatorId, ValidatorIndex,
 };
 use polkadot_primitives_test_helpers::TestCandidateBuilder;
-use polkadot_subsystem::{
+use polkadot_node_subsystem::{
 	jaeger,
 	messages::{AllMessages, RuntimeApiMessage, RuntimeApiRequest},
 	ActivatedLeaf, ActiveLeavesUpdate, LeafStatus,
 };
-use polkadot_subsystem_testhelpers as test_helpers;
+use polkadot_node_subsystem_test_helpers as test_helpers;
 
 #[derive(Clone)]
 struct TestState {

--- a/node/network/collator-protocol/src/error.rs
+++ b/node/network/collator-protocol/src/error.rs
@@ -19,8 +19,8 @@
 
 use polkadot_node_network_protocol::request_response::incoming;
 use polkadot_node_primitives::UncheckedSignedFullStatement;
-use polkadot_node_subsystem_util::runtime;
 use polkadot_node_subsystem::errors::SubsystemError;
+use polkadot_node_subsystem_util::runtime;
 
 use crate::LOG_TARGET;
 

--- a/node/network/collator-protocol/src/error.rs
+++ b/node/network/collator-protocol/src/error.rs
@@ -20,7 +20,7 @@
 use polkadot_node_network_protocol::request_response::incoming;
 use polkadot_node_primitives::UncheckedSignedFullStatement;
 use polkadot_node_subsystem_util::runtime;
-use polkadot_subsystem::errors::SubsystemError;
+use polkadot_node_subsystem::errors::SubsystemError;
 
 use crate::LOG_TARGET;
 

--- a/node/network/collator-protocol/src/lib.rs
+++ b/node/network/collator-protocol/src/lib.rs
@@ -33,7 +33,7 @@ use polkadot_node_network_protocol::{
 };
 use polkadot_primitives::v2::CollatorPair;
 
-use polkadot_subsystem::{
+use polkadot_node_subsystem::{
 	errors::SubsystemError,
 	messages::{CollatorProtocolMessage, NetworkBridgeMessage},
 	overseer, SpawnedSubsystem, SubsystemContext, SubsystemSender,

--- a/node/network/collator-protocol/src/validator_side/mod.rs
+++ b/node/network/collator-protocol/src/validator_side/mod.rs
@@ -46,7 +46,7 @@ use polkadot_node_network_protocol::{
 use polkadot_node_primitives::{PoV, SignedFullStatement};
 use polkadot_node_subsystem_util::metrics::{self, prometheus};
 use polkadot_primitives::v2::{CandidateReceipt, CollatorId, Hash, Id as ParaId};
-use polkadot_subsystem::{
+use polkadot_node_subsystem::{
 	jaeger,
 	messages::{
 		CandidateBackingMessage, CollatorProtocolMessage, IfDisconnected, NetworkBridgeEvent,

--- a/node/network/collator-protocol/src/validator_side/mod.rs
+++ b/node/network/collator-protocol/src/validator_side/mod.rs
@@ -44,8 +44,6 @@ use polkadot_node_network_protocol::{
 	v1 as protocol_v1, OurView, PeerId, UnifiedReputationChange as Rep, Versioned, View,
 };
 use polkadot_node_primitives::{PoV, SignedFullStatement};
-use polkadot_node_subsystem_util::metrics::{self, prometheus};
-use polkadot_primitives::v2::{CandidateReceipt, CollatorId, Hash, Id as ParaId};
 use polkadot_node_subsystem::{
 	jaeger,
 	messages::{
@@ -54,6 +52,8 @@ use polkadot_node_subsystem::{
 	},
 	overseer, FromOverseer, OverseerSignal, PerLeafSpan, SubsystemContext, SubsystemSender,
 };
+use polkadot_node_subsystem_util::metrics::{self, prometheus};
+use polkadot_primitives::v2::{CandidateReceipt, CollatorId, Hash, Id as ParaId};
 
 use crate::error::Result;
 

--- a/node/network/collator-protocol/src/validator_side/tests.rs
+++ b/node/network/collator-protocol/src/validator_side/tests.rs
@@ -36,8 +36,8 @@ use polkadot_primitives::v2::{
 use polkadot_primitives_test_helpers::{
 	dummy_candidate_descriptor, dummy_candidate_receipt_bad_sig, dummy_hash,
 };
-use polkadot_subsystem::messages::{AllMessages, RuntimeApiMessage, RuntimeApiRequest};
-use polkadot_subsystem_testhelpers as test_helpers;
+use polkadot_node_subsystem::messages::{AllMessages, RuntimeApiMessage, RuntimeApiRequest};
+use polkadot_node_subsystem_test_helpers as test_helpers;
 
 const ACTIVITY_TIMEOUT: Duration = Duration::from_millis(500);
 const DECLARE_TIMEOUT: Duration = Duration::from_millis(25);

--- a/node/network/collator-protocol/src/validator_side/tests.rs
+++ b/node/network/collator-protocol/src/validator_side/tests.rs
@@ -28,6 +28,8 @@ use polkadot_node_network_protocol::{
 	ObservedRole,
 };
 use polkadot_node_primitives::BlockData;
+use polkadot_node_subsystem::messages::{AllMessages, RuntimeApiMessage, RuntimeApiRequest};
+use polkadot_node_subsystem_test_helpers as test_helpers;
 use polkadot_node_subsystem_util::TimeoutExt;
 use polkadot_primitives::v2::{
 	CollatorPair, CoreState, GroupIndex, GroupRotationInfo, OccupiedCore, ScheduledCore,
@@ -36,8 +38,6 @@ use polkadot_primitives::v2::{
 use polkadot_primitives_test_helpers::{
 	dummy_candidate_descriptor, dummy_candidate_receipt_bad_sig, dummy_hash,
 };
-use polkadot_node_subsystem::messages::{AllMessages, RuntimeApiMessage, RuntimeApiRequest};
-use polkadot_node_subsystem_test_helpers as test_helpers;
 
 const ACTIVITY_TIMEOUT: Duration = Duration::from_millis(500);
 const DECLARE_TIMEOUT: Duration = Duration::from_millis(25);

--- a/node/network/dispute-distribution/Cargo.toml
+++ b/node/network/dispute-distribution/Cargo.toml
@@ -11,7 +11,7 @@ derive_more = "0.99.17"
 parity-scale-codec = { version = "3.1.2", features = ["std"] }
 polkadot-primitives = { path = "../../../primitives" }
 polkadot-erasure-coding = { path = "../../../erasure-coding" }
-polkadot-subsystem = { package = "polkadot-node-subsystem", path = "../../subsystem" }
+polkadot-node-subsystem = {path = "../../subsystem" }
 polkadot-node-network-protocol = { path = "../../network/protocol" }
 polkadot-node-subsystem-util = { path = "../../subsystem-util" }
 polkadot-node-primitives = { path = "../../primitives" }
@@ -24,7 +24,7 @@ lru = "0.7.5"
 
 [dev-dependencies]
 async-trait = "0.1.53"
-polkadot-subsystem-testhelpers = { package = "polkadot-node-subsystem-test-helpers", path = "../../subsystem-test-helpers" }
+polkadot-node-subsystem-test-helpers = { path = "../../subsystem-test-helpers" }
 sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sp-tracing = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sc-keystore = { git = "https://github.com/paritytech/substrate", branch = "master" }

--- a/node/network/dispute-distribution/src/error.rs
+++ b/node/network/dispute-distribution/src/error.rs
@@ -18,7 +18,7 @@
 //! Error handling related code and Error/Result definitions.
 
 use polkadot_node_subsystem_util::runtime;
-use polkadot_subsystem::SubsystemError;
+use polkadot_node_subsystem::SubsystemError;
 
 use crate::{sender, LOG_TARGET};
 

--- a/node/network/dispute-distribution/src/error.rs
+++ b/node/network/dispute-distribution/src/error.rs
@@ -17,8 +17,8 @@
 
 //! Error handling related code and Error/Result definitions.
 
-use polkadot_node_subsystem_util::runtime;
 use polkadot_node_subsystem::SubsystemError;
+use polkadot_node_subsystem_util::runtime;
 
 use crate::{sender, LOG_TARGET};
 

--- a/node/network/dispute-distribution/src/lib.rs
+++ b/node/network/dispute-distribution/src/lib.rs
@@ -31,11 +31,11 @@ use sp_keystore::SyncCryptoStorePtr;
 
 use polkadot_node_network_protocol::request_response::{incoming::IncomingRequestReceiver, v1};
 use polkadot_node_primitives::DISPUTE_WINDOW;
-use polkadot_node_subsystem_util::{runtime, runtime::RuntimeInfo};
 use polkadot_node_subsystem::{
 	messages::DisputeDistributionMessage, overseer, FromOverseer, OverseerSignal, SpawnedSubsystem,
 	SubsystemContext, SubsystemError,
 };
+use polkadot_node_subsystem_util::{runtime, runtime::RuntimeInfo};
 
 /// ## The sender [`DisputeSender`]
 ///

--- a/node/network/dispute-distribution/src/lib.rs
+++ b/node/network/dispute-distribution/src/lib.rs
@@ -32,7 +32,7 @@ use sp_keystore::SyncCryptoStorePtr;
 use polkadot_node_network_protocol::request_response::{incoming::IncomingRequestReceiver, v1};
 use polkadot_node_primitives::DISPUTE_WINDOW;
 use polkadot_node_subsystem_util::{runtime, runtime::RuntimeInfo};
-use polkadot_subsystem::{
+use polkadot_node_subsystem::{
 	messages::DisputeDistributionMessage, overseer, FromOverseer, OverseerSignal, SpawnedSubsystem,
 	SubsystemContext, SubsystemError,
 };

--- a/node/network/dispute-distribution/src/receiver/mod.rs
+++ b/node/network/dispute-distribution/src/receiver/mod.rs
@@ -39,11 +39,11 @@ use polkadot_node_network_protocol::{
 	PeerId, UnifiedReputationChange as Rep,
 };
 use polkadot_node_primitives::DISPUTE_WINDOW;
-use polkadot_node_subsystem_util::{runtime, runtime::RuntimeInfo};
 use polkadot_node_subsystem::{
 	messages::{AllMessages, DisputeCoordinatorMessage, ImportStatementsResult},
 	SubsystemSender,
 };
+use polkadot_node_subsystem_util::{runtime, runtime::RuntimeInfo};
 
 use crate::{
 	metrics::{FAILED, SUCCEEDED},

--- a/node/network/dispute-distribution/src/receiver/mod.rs
+++ b/node/network/dispute-distribution/src/receiver/mod.rs
@@ -40,7 +40,7 @@ use polkadot_node_network_protocol::{
 };
 use polkadot_node_primitives::DISPUTE_WINDOW;
 use polkadot_node_subsystem_util::{runtime, runtime::RuntimeInfo};
-use polkadot_subsystem::{
+use polkadot_node_subsystem::{
 	messages::{AllMessages, DisputeCoordinatorMessage, ImportStatementsResult},
 	SubsystemSender,
 };

--- a/node/network/dispute-distribution/src/sender/error.rs
+++ b/node/network/dispute-distribution/src/sender/error.rs
@@ -18,8 +18,8 @@
 //! Error handling related code and Error/Result definitions.
 
 use polkadot_node_primitives::disputes::DisputeMessageCheckError;
-use polkadot_node_subsystem_util::runtime;
 use polkadot_node_subsystem::SubsystemError;
+use polkadot_node_subsystem_util::runtime;
 
 #[allow(missing_docs)]
 #[fatality::fatality(splitable)]

--- a/node/network/dispute-distribution/src/sender/error.rs
+++ b/node/network/dispute-distribution/src/sender/error.rs
@@ -19,7 +19,7 @@
 
 use polkadot_node_primitives::disputes::DisputeMessageCheckError;
 use polkadot_node_subsystem_util::runtime;
-use polkadot_subsystem::SubsystemError;
+use polkadot_node_subsystem::SubsystemError;
 
 #[allow(missing_docs)]
 #[fatality::fatality(splitable)]

--- a/node/network/dispute-distribution/src/sender/mod.rs
+++ b/node/network/dispute-distribution/src/sender/mod.rs
@@ -20,12 +20,12 @@ use futures::channel::{mpsc, oneshot};
 
 use polkadot_node_network_protocol::request_response::v1::DisputeRequest;
 use polkadot_node_primitives::{CandidateVotes, DisputeMessage, SignedDisputeStatement};
-use polkadot_node_subsystem_util::runtime::RuntimeInfo;
-use polkadot_primitives::v2::{CandidateHash, DisputeStatement, Hash, SessionIndex};
 use polkadot_node_subsystem::{
 	messages::{AllMessages, DisputeCoordinatorMessage},
 	ActiveLeavesUpdate, SubsystemContext,
 };
+use polkadot_node_subsystem_util::runtime::RuntimeInfo;
+use polkadot_primitives::v2::{CandidateHash, DisputeStatement, Hash, SessionIndex};
 
 /// For each ongoing dispute we have a `SendTask` which takes care of it.
 ///

--- a/node/network/dispute-distribution/src/sender/mod.rs
+++ b/node/network/dispute-distribution/src/sender/mod.rs
@@ -22,7 +22,7 @@ use polkadot_node_network_protocol::request_response::v1::DisputeRequest;
 use polkadot_node_primitives::{CandidateVotes, DisputeMessage, SignedDisputeStatement};
 use polkadot_node_subsystem_util::runtime::RuntimeInfo;
 use polkadot_primitives::v2::{CandidateHash, DisputeStatement, Hash, SessionIndex};
-use polkadot_subsystem::{
+use polkadot_node_subsystem::{
 	messages::{AllMessages, DisputeCoordinatorMessage},
 	ActiveLeavesUpdate, SubsystemContext,
 };

--- a/node/network/dispute-distribution/src/sender/send_task.rs
+++ b/node/network/dispute-distribution/src/sender/send_task.rs
@@ -26,13 +26,13 @@ use polkadot_node_network_protocol::{
 	},
 	IfDisconnected,
 };
-use polkadot_node_subsystem_util::{metrics, runtime::RuntimeInfo};
-use polkadot_primitives::v2::{
-	AuthorityDiscoveryId, CandidateHash, Hash, SessionIndex, ValidatorIndex,
-};
 use polkadot_node_subsystem::{
 	messages::{AllMessages, NetworkBridgeMessage},
 	SubsystemContext,
+};
+use polkadot_node_subsystem_util::{metrics, runtime::RuntimeInfo};
+use polkadot_primitives::v2::{
+	AuthorityDiscoveryId, CandidateHash, Hash, SessionIndex, ValidatorIndex,
 };
 
 use super::error::{FatalError, Result};

--- a/node/network/dispute-distribution/src/sender/send_task.rs
+++ b/node/network/dispute-distribution/src/sender/send_task.rs
@@ -30,7 +30,7 @@ use polkadot_node_subsystem_util::{metrics, runtime::RuntimeInfo};
 use polkadot_primitives::v2::{
 	AuthorityDiscoveryId, CandidateHash, Hash, SessionIndex, ValidatorIndex,
 };
-use polkadot_subsystem::{
+use polkadot_node_subsystem::{
 	messages::{AllMessages, NetworkBridgeMessage},
 	SubsystemContext,
 };

--- a/node/network/dispute-distribution/src/tests/mod.rs
+++ b/node/network/dispute-distribution/src/tests/mod.rs
@@ -41,9 +41,6 @@ use polkadot_node_network_protocol::{
 	IfDisconnected,
 };
 use polkadot_node_primitives::{CandidateVotes, UncheckedDisputeMessage};
-use polkadot_primitives::v2::{
-	AuthorityDiscoveryId, CandidateHash, Hash, SessionIndex, SessionInfo,
-};
 use polkadot_node_subsystem::{
 	messages::{
 		AllMessages, DisputeCoordinatorMessage, DisputeDistributionMessage, ImportStatementsResult,
@@ -53,6 +50,9 @@ use polkadot_node_subsystem::{
 };
 use polkadot_node_subsystem_test_helpers::{
 	mock::make_ferdie_keystore, subsystem_test_harness, TestSubsystemContextHandle,
+};
+use polkadot_primitives::v2::{
+	AuthorityDiscoveryId, CandidateHash, Hash, SessionIndex, SessionInfo,
 };
 
 use self::mock::{

--- a/node/network/dispute-distribution/src/tests/mod.rs
+++ b/node/network/dispute-distribution/src/tests/mod.rs
@@ -44,14 +44,14 @@ use polkadot_node_primitives::{CandidateVotes, UncheckedDisputeMessage};
 use polkadot_primitives::v2::{
 	AuthorityDiscoveryId, CandidateHash, Hash, SessionIndex, SessionInfo,
 };
-use polkadot_subsystem::{
+use polkadot_node_subsystem::{
 	messages::{
 		AllMessages, DisputeCoordinatorMessage, DisputeDistributionMessage, ImportStatementsResult,
 		NetworkBridgeMessage, RuntimeApiMessage, RuntimeApiRequest,
 	},
 	ActivatedLeaf, ActiveLeavesUpdate, FromOverseer, LeafStatus, OverseerSignal, Span,
 };
-use polkadot_subsystem_testhelpers::{
+use polkadot_node_subsystem_test_helpers::{
 	mock::make_ferdie_keystore, subsystem_test_harness, TestSubsystemContextHandle,
 };
 

--- a/node/network/statement-distribution/Cargo.toml
+++ b/node/network/statement-distribution/Cargo.toml
@@ -11,7 +11,7 @@ gum = { package = "tracing-gum", path = "../../gum" }
 polkadot-primitives = { path = "../../../primitives" }
 sp-staking = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 sp-keystore = { git = "https://github.com/paritytech/substrate", branch = "master" }
-polkadot-subsystem = { package = "polkadot-node-subsystem", path = "../../subsystem" }
+polkadot-node-subsystem = {path = "../../subsystem" }
 polkadot-node-primitives = { path = "../../primitives" }
 polkadot-node-subsystem-util = { path = "../../subsystem-util" }
 polkadot-node-network-protocol = { path = "../../network/protocol" }

--- a/node/network/statement-distribution/src/error.rs
+++ b/node/network/statement-distribution/src/error.rs
@@ -20,7 +20,7 @@
 use polkadot_node_network_protocol::PeerId;
 use polkadot_node_subsystem_util::runtime;
 use polkadot_primitives::v2::{CandidateHash, Hash};
-use polkadot_subsystem::SubsystemError;
+use polkadot_node_subsystem::SubsystemError;
 
 use crate::LOG_TARGET;
 

--- a/node/network/statement-distribution/src/error.rs
+++ b/node/network/statement-distribution/src/error.rs
@@ -18,9 +18,9 @@
 //! Error handling related code and Error/Result definitions.
 
 use polkadot_node_network_protocol::PeerId;
+use polkadot_node_subsystem::SubsystemError;
 use polkadot_node_subsystem_util::runtime;
 use polkadot_primitives::v2::{CandidateHash, Hash};
-use polkadot_node_subsystem::SubsystemError;
 
 use crate::LOG_TARGET;
 

--- a/node/network/statement-distribution/src/lib.rs
+++ b/node/network/statement-distribution/src/lib.rs
@@ -40,7 +40,7 @@ use polkadot_primitives::v2::{
 	SignedStatement, SigningContext, UncheckedSignedStatement, ValidatorId, ValidatorIndex,
 	ValidatorSignature,
 };
-use polkadot_subsystem::{
+use polkadot_node_subsystem::{
 	jaeger,
 	messages::{
 		AllMessages, CandidateBackingMessage, NetworkBridgeEvent, NetworkBridgeMessage,

--- a/node/network/statement-distribution/src/lib.rs
+++ b/node/network/statement-distribution/src/lib.rs
@@ -35,11 +35,6 @@ use polkadot_node_network_protocol::{
 use polkadot_node_primitives::{SignedFullStatement, Statement, UncheckedSignedFullStatement};
 use polkadot_node_subsystem_util::{self as util, rand, MIN_GOSSIP_PEERS};
 
-use polkadot_primitives::v2::{
-	AuthorityDiscoveryId, CandidateHash, CommittedCandidateReceipt, CompactStatement, Hash,
-	SignedStatement, SigningContext, UncheckedSignedStatement, ValidatorId, ValidatorIndex,
-	ValidatorSignature,
-};
 use polkadot_node_subsystem::{
 	jaeger,
 	messages::{
@@ -48,6 +43,11 @@ use polkadot_node_subsystem::{
 	},
 	overseer, ActiveLeavesUpdate, FromOverseer, OverseerSignal, PerLeafSpan, SpawnedSubsystem,
 	SubsystemContext, SubsystemError,
+};
+use polkadot_primitives::v2::{
+	AuthorityDiscoveryId, CandidateHash, CommittedCandidateReceipt, CompactStatement, Hash,
+	SignedStatement, SigningContext, UncheckedSignedStatement, ValidatorId, ValidatorIndex,
+	ValidatorSignature,
 };
 
 use futures::{

--- a/node/network/statement-distribution/src/requester.rs
+++ b/node/network/statement-distribution/src/requester.rs
@@ -30,7 +30,7 @@ use polkadot_node_network_protocol::{
 };
 use polkadot_node_subsystem_util::TimeoutExt;
 use polkadot_primitives::v2::{CandidateHash, CommittedCandidateReceipt, Hash};
-use polkadot_subsystem::{Span, Stage};
+use polkadot_node_subsystem::{Span, Stage};
 
 use crate::{metrics::Metrics, COST_WRONG_HASH, LOG_TARGET};
 

--- a/node/network/statement-distribution/src/requester.rs
+++ b/node/network/statement-distribution/src/requester.rs
@@ -28,9 +28,9 @@ use polkadot_node_network_protocol::{
 	},
 	PeerId, UnifiedReputationChange,
 };
+use polkadot_node_subsystem::{Span, Stage};
 use polkadot_node_subsystem_util::TimeoutExt;
 use polkadot_primitives::v2::{CandidateHash, CommittedCandidateReceipt, Hash};
-use polkadot_node_subsystem::{Span, Stage};
 
 use crate::{metrics::Metrics, COST_WRONG_HASH, LOG_TARGET};
 

--- a/node/network/statement-distribution/src/tests.rs
+++ b/node/network/statement-distribution/src/tests.rs
@@ -27,15 +27,15 @@ use polkadot_node_network_protocol::{
 	view, ObservedRole,
 };
 use polkadot_node_primitives::{Statement, UncheckedSignedFullStatement};
-use polkadot_node_subsystem_test_helpers::mock::make_ferdie_keystore;
-use polkadot_primitives::v2::{Hash, SessionInfo, ValidationCode};
-use polkadot_primitives_test_helpers::{
-	dummy_committed_candidate_receipt, dummy_hash, AlwaysZeroRng,
-};
 use polkadot_node_subsystem::{
 	jaeger,
 	messages::{network_bridge_event, RuntimeApiMessage, RuntimeApiRequest},
 	ActivatedLeaf, LeafStatus,
+};
+use polkadot_node_subsystem_test_helpers::mock::make_ferdie_keystore;
+use polkadot_primitives::v2::{Hash, SessionInfo, ValidationCode};
+use polkadot_primitives_test_helpers::{
+	dummy_committed_candidate_receipt, dummy_hash, AlwaysZeroRng,
 };
 use sc_keystore::LocalKeystore;
 use sp_application_crypto::{sr25519::Pair, AppKey, Pair as TraitPair};

--- a/node/network/statement-distribution/src/tests.rs
+++ b/node/network/statement-distribution/src/tests.rs
@@ -32,7 +32,7 @@ use polkadot_primitives::v2::{Hash, SessionInfo, ValidationCode};
 use polkadot_primitives_test_helpers::{
 	dummy_committed_candidate_receipt, dummy_hash, AlwaysZeroRng,
 };
-use polkadot_subsystem::{
+use polkadot_node_subsystem::{
 	jaeger,
 	messages::{network_bridge_event, RuntimeApiMessage, RuntimeApiRequest},
 	ActivatedLeaf, LeafStatus,

--- a/node/service/Cargo.toml
+++ b/node/service/Cargo.toml
@@ -81,7 +81,7 @@ polkadot-parachain = { path = "../../parachain" }
 polkadot-primitives = { path = "../../primitives" }
 polkadot-node-primitives = { path = "../primitives" }
 polkadot-rpc = { path = "../../rpc" }
-polkadot-subsystem = { package = "polkadot-node-subsystem", path = "../subsystem" }
+polkadot-node-subsystem = {path = "../subsystem" }
 polkadot-node-subsystem-util = { path = "../subsystem-util" }
 polkadot-runtime-parachains = { path = "../../runtime/parachains" }
 polkadot-node-network-protocol = { path = "../network/protocol" }

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -65,7 +65,7 @@ pub use {
 };
 
 #[cfg(feature = "full-node")]
-use polkadot_subsystem::jaeger;
+use polkadot_node_subsystem::jaeger;
 
 use std::{sync::Arc, time::Duration};
 
@@ -221,7 +221,7 @@ pub enum Error {
 	Telemetry(#[from] telemetry::Error),
 
 	#[error(transparent)]
-	Jaeger(#[from] polkadot_subsystem::jaeger::JaegerError),
+	Jaeger(#[from] polkadot_node_subsystem::jaeger::JaegerError),
 
 	#[cfg(feature = "full-node")]
 	#[error(transparent)]

--- a/node/service/src/relay_chain_selection.rs
+++ b/node/service/src/relay_chain_selection.rs
@@ -39,14 +39,14 @@ use super::{HeaderProvider, HeaderProviderProvider};
 use consensus_common::{Error as ConsensusError, SelectChain};
 use futures::channel::oneshot;
 use polkadot_node_primitives::MAX_FINALITY_LAG as PRIMITIVES_MAX_FINALITY_LAG;
+use polkadot_node_subsystem::messages::{
+	ApprovalVotingMessage, ChainSelectionMessage, DisputeCoordinatorMessage,
+	HighestApprovedAncestorBlock,
+};
 use polkadot_node_subsystem_util::metrics::{self, prometheus};
 use polkadot_overseer::{AllMessages, Handle};
 use polkadot_primitives::v2::{
 	Block as PolkadotBlock, BlockNumber, Hash, Header as PolkadotHeader,
-};
-use polkadot_node_subsystem::messages::{
-	ApprovalVotingMessage, ChainSelectionMessage, DisputeCoordinatorMessage,
-	HighestApprovedAncestorBlock,
 };
 use std::sync::Arc;
 

--- a/node/service/src/relay_chain_selection.rs
+++ b/node/service/src/relay_chain_selection.rs
@@ -44,7 +44,7 @@ use polkadot_overseer::{AllMessages, Handle};
 use polkadot_primitives::v2::{
 	Block as PolkadotBlock, BlockNumber, Hash, Header as PolkadotHeader,
 };
-use polkadot_subsystem::messages::{
+use polkadot_node_subsystem::messages::{
 	ApprovalVotingMessage, ChainSelectionMessage, DisputeCoordinatorMessage,
 	HighestApprovedAncestorBlock,
 };

--- a/node/service/src/tests.rs
+++ b/node/service/src/tests.rs
@@ -18,9 +18,9 @@ use super::{relay_chain_selection::*, *};
 
 use futures::channel::oneshot::Receiver;
 use polkadot_node_primitives::approval::{VRFOutput, VRFProof};
+use polkadot_node_subsystem::messages::{AllMessages, BlockDescription};
 use polkadot_node_subsystem_test_helpers as test_helpers;
 use polkadot_node_subsystem_util::TimeoutExt;
-use polkadot_node_subsystem::messages::{AllMessages, BlockDescription};
 use polkadot_test_client::Sr25519Keyring;
 use sp_consensus_babe::{
 	digests::{CompatibleDigestItem, PreDigest, SecondaryVRFPreDigest},
@@ -36,11 +36,11 @@ use assert_matches::assert_matches;
 use std::{sync::Arc, time::Duration};
 
 use futures::{channel::oneshot, prelude::*};
-use polkadot_primitives::v2::{Block, BlockNumber, Hash, Header};
 use polkadot_node_subsystem::messages::{
 	ApprovalVotingMessage, ChainSelectionMessage, DisputeCoordinatorMessage,
 	HighestApprovedAncestorBlock,
 };
+use polkadot_primitives::v2::{Block, BlockNumber, Hash, Header};
 
 use polkadot_node_subsystem_test_helpers::TestSubsystemSender;
 use polkadot_overseer::{SubsystemContext, SubsystemSender};

--- a/node/service/src/tests.rs
+++ b/node/service/src/tests.rs
@@ -20,7 +20,7 @@ use futures::channel::oneshot::Receiver;
 use polkadot_node_primitives::approval::{VRFOutput, VRFProof};
 use polkadot_node_subsystem_test_helpers as test_helpers;
 use polkadot_node_subsystem_util::TimeoutExt;
-use polkadot_subsystem::messages::{AllMessages, BlockDescription};
+use polkadot_node_subsystem::messages::{AllMessages, BlockDescription};
 use polkadot_test_client::Sr25519Keyring;
 use sp_consensus_babe::{
 	digests::{CompatibleDigestItem, PreDigest, SecondaryVRFPreDigest},
@@ -37,7 +37,7 @@ use std::{sync::Arc, time::Duration};
 
 use futures::{channel::oneshot, prelude::*};
 use polkadot_primitives::v2::{Block, BlockNumber, Hash, Header};
-use polkadot_subsystem::messages::{
+use polkadot_node_subsystem::messages::{
 	ApprovalVotingMessage, ChainSelectionMessage, DisputeCoordinatorMessage,
 	HighestApprovedAncestorBlock,
 };

--- a/node/subsystem-util/Cargo.toml
+++ b/node/subsystem-util/Cargo.toml
@@ -19,7 +19,7 @@ gum = { package = "tracing-gum", path = "../gum" }
 derive_more = "0.99.17"
 lru = "0.7.5"
 
-polkadot-node-subsystem = { package = "polkadot-node-subsystem", path = "../subsystem" }
+polkadot-node-subsystem = {path = "../subsystem" }
 polkadot-node-jaeger = { path = "../jaeger" }
 polkadot-node-metrics = { path = "../metrics" }
 polkadot-node-network-protocol = { path = "../network/protocol" }


### PR DESCRIPTION
We had a wild mix of usages of `polkadot-node-subsystem`, `polkadot-subsystem` as well as `polkadot-subsystem-testhelpers`, `polkadot-subsystem-test-helpers` and `polkadot-node-subsystem-test-helpers`. All unified now.

Extraction from #5314 