### PR TITLE
Use unbounded channel for local bitfields distribution

### DIFF
--- a/node/network/bitfield-distribution/src/lib.rs
+++ b/node/network/bitfield-distribution/src/lib.rs
@@ -28,6 +28,7 @@ use polkadot_node_network_protocol::{
 	self as net_protocol,
 	grid_topology::{RandomRouting, RequiredRouting, SessionGridTopology},
 	v1 as protocol_v1, OurView, PeerId, UnifiedReputationChange as Rep, Versioned, View,
+	MIN_GOSSIP_PEERS,
 };
 use polkadot_node_subsystem::{
 	jaeger, messages::*, overseer, ActiveLeavesUpdate, FromOverseer, OverseerSignal, PerLeafSpan,
@@ -56,6 +57,9 @@ const COST_PEER_DUPLICATE_MESSAGE: Rep =
 const BENEFIT_VALID_MESSAGE_FIRST: Rep =
 	Rep::BenefitMinorFirst("Valid message with new information");
 const BENEFIT_VALID_MESSAGE: Rep = Rep::BenefitMinor("Valid message");
+
+/// Maximum number of messages being sent via unbounded channel (per relay parent)
+const MAX_UNBOUND_MESSAGES_PER_RELAY_PARENT: usize = MIN_GOSSIP_PEERS;
 
 /// Checked signed availability bitfield that is distributed
 /// to other peers.
@@ -160,6 +164,9 @@ struct PerRelayParentData {
 
 	/// The span for this leaf/relay parent.
 	span: PerLeafSpan,
+
+	/// Number of messages sent via unbounded channels (to prevent spam)
+	unbounded_messages_count: usize,
 }
 
 impl PerRelayParentData {
@@ -176,6 +183,7 @@ impl PerRelayParentData {
 			one_per_validator: Default::default(),
 			message_sent_to_peer: Default::default(),
 			message_received_from_peer: Default::default(),
+			unbounded_messages_count: 0,
 		}
 	}
 
@@ -404,6 +412,7 @@ async fn relay_message<Context>(
 		relay_parent,
 		ProvisionableData::Bitfield(relay_parent, message.signed_availability.clone()),
 	));
+	job_data.unbounded_messages_count = job_data.unbounded_messages_count.saturating_add(1);
 
 	drop(_span);
 	let total_peers = peer_views.len();
@@ -462,11 +471,20 @@ async fn relay_message<Context>(
 		);
 	} else {
 		let _span = span.child("gossip");
-		ctx.send_message(NetworkBridgeMessage::SendValidationMessage(
-			interested_peers,
-			message.into_validation_protocol(),
-		))
-		.await;
+
+		if job_data.unbounded_messages_count < MAX_UNBOUND_MESSAGES_PER_RELAY_PARENT {
+			ctx.send_unbounded_message(NetworkBridgeMessage::SendValidationMessage(
+				interested_peers,
+				message.into_validation_protocol(),
+			));
+			job_data.unbounded_messages_count = job_data.unbounded_messages_count.saturating_add(1);
+		} else {
+			ctx.send_message(NetworkBridgeMessage::SendValidationMessage(
+				interested_peers,
+				message.into_validation_protocol(),
+			))
+			.await;
+		}
 	}
 }
 

--- a/node/network/bitfield-distribution/src/lib.rs
+++ b/node/network/bitfield-distribution/src/lib.rs
@@ -400,11 +400,10 @@ async fn relay_message<Context>(
 
 	let _span = span.child("provisionable");
 	// notify the overseer about a new and valid signed bitfield
-	ctx.send_message(ProvisionerMessage::ProvisionableData(
+	ctx.send_unbounded_message(ProvisionerMessage::ProvisionableData(
 		relay_parent,
 		ProvisionableData::Bitfield(relay_parent, message.signed_availability.clone()),
-	))
-	.await;
+	));
 
 	drop(_span);
 	let total_peers = peer_views.len();

--- a/node/network/bitfield-distribution/src/tests.rs
+++ b/node/network/bitfield-distribution/src/tests.rs
@@ -74,6 +74,7 @@ fn prewarmed_state(
 					message_received_from_peer: hashmap!{},
 					message_sent_to_peer: hashmap!{},
 					span: PerLeafSpan::new(Arc::new(jaeger::Span::Disabled), "test"),
+					unbounded_messages_count: 0,
 				},
 		},
 		peer_views: peers.iter().cloned().map(|peer| (peer, view!(relay_parent))).collect(),
@@ -106,6 +107,7 @@ fn state_with_view(
 					message_received_from_peer: hashmap! {},
 					message_sent_to_peer: hashmap! {},
 					span: PerLeafSpan::new(Arc::new(jaeger::Span::Disabled), "test"),
+					unbounded_messages_count: 0,
 				},
 			)
 		})


### PR DESCRIPTION
This PR is intended to address short-term issues described in #5510. It limits number of the unbounded messages per relay parent, however, a better sollution is to use priorities as described in #5517.