### PR TITLE
Let PR titles spread accross multiple lines in the release notes

### DIFF
--- a/scripts/ci/changelog/templates/change.md.tera
+++ b/scripts/ci/changelog/templates/change.md.tera
@@ -38,5 +38,5 @@
 {%- else -%}
 {%- set xcm = "" -%}
 {%- endif -%}
-{{- repo }} {{ audit }}[`#{{c.number}}`]({{c.html_url}}) {{- prio }} - {{ c.title | capitalize | truncate(length=60, end="…") }}{{xcm }}
+{{- repo }} {{ audit }}[`#{{c.number}}`]({{c.html_url}}) {{- prio }} - {{ c.title | capitalize | truncate(length=120, end="…") }}{{xcm }}
 {%- endmacro change -%}


### PR DESCRIPTION
Truncate at 120 chars vs the previous 60.
60 was barely triggering in the past so 120 favors completeness of the information vs having 100% everything fit on a single line.