### PR TITLE
unbreak substrate checks

### DIFF
--- a/node/overseer/overseer-gen/proc-macro/Cargo.toml
+++ b/node/overseer/overseer-gen/proc-macro/Cargo.toml
@@ -26,7 +26,7 @@ thiserror = "1"
 gum = { package = "tracing-gum", path = "../../../gum" }
 
 [features]
-default = ["graph", "expand"]
+default = []
 # write the expanded version to a `overlord-expansion.[a-f0-9]{10}.rs`
 # in the `OUT_DIR` as defined by `cargo` for the `expander` crate.
 expand = []


### PR DESCRIPTION
Disable features that write to `OUT_DIR` since `substrate` CI does not like that.

CC @shawntabrizi 

Ref https://github.com/paritytech/ci_cd/issues/433