### PR TITLE
Remove Duplicate Traits

### DIFF
--- a/bridges/bin/rialto-parachain/node/src/command.rs
+++ b/bridges/bin/rialto-parachain/node/src/command.rs
@@ -23,7 +23,6 @@ use codec::Encode;
 use cumulus_client_service::genesis::generate_genesis_block;
 use cumulus_primitives_core::ParaId;
 use log::info;
-use polkadot_parachain::primitives::AccountIdConversion;
 use rialto_parachain_runtime::{Block, RuntimeApi};
 use sc_cli::{
 	ChainSpec, CliConfiguration, DefaultConfigurationValues, ImportParams, KeystoreParams,
@@ -31,7 +30,7 @@ use sc_cli::{
 };
 use sc_service::config::{BasePath, PrometheusConfig};
 use sp_core::hexdisplay::HexDisplay;
-use sp_runtime::traits::Block as BlockT;
+use sp_runtime::traits::{Block as BlockT, AccountIdConversion};
 use std::{io::Write, net::SocketAddr};
 
 fn load_spec(

--- a/parachain/src/primitives.rs
+++ b/parachain/src/primitives.rs
@@ -274,59 +274,6 @@ impl IsSystem for Sibling {
 	}
 }
 
-/// This type can be converted into and possibly from an [`AccountId`] (which itself is generic).
-pub trait AccountIdConversion<AccountId>: Sized {
-	/// Convert into an account ID. This is infallible.
-	fn into_account(&self) -> AccountId;
-
-	/// Try to convert an account ID into this type. Might not succeed.
-	fn try_from_account(a: &AccountId) -> Option<Self>;
-}
-
-// TODO: Remove all of this, move sp-runtime::AccountIdConversion to own crate and and use that.
-// #360
-struct TrailingZeroInput<'a>(&'a [u8]);
-impl<'a> parity_scale_codec::Input for TrailingZeroInput<'a> {
-	fn remaining_len(&mut self) -> Result<Option<usize>, parity_scale_codec::Error> {
-		Ok(None)
-	}
-
-	fn read(&mut self, into: &mut [u8]) -> Result<(), parity_scale_codec::Error> {
-		let len = into.len().min(self.0.len());
-		into[..len].copy_from_slice(&self.0[..len]);
-		for i in &mut into[len..] {
-			*i = 0;
-		}
-		self.0 = &self.0[len..];
-		Ok(())
-	}
-}
-
-/// Format is b"para" ++ encode(parachain ID) ++ 00.... where 00... is indefinite trailing
-/// zeroes to fill [`AccountId`].
-impl<T: Encode + Decode> AccountIdConversion<T> for Id {
-	fn into_account(&self) -> T {
-		(b"para", self)
-			.using_encoded(|b| T::decode(&mut TrailingZeroInput(b)))
-			.expect("infinite length input; no invalid inputs for type; qed")
-	}
-
-	fn try_from_account(x: &T) -> Option<Self> {
-		x.using_encoded(|d| {
-			if &d[0..4] != b"para" {
-				return None
-			}
-			let mut cursor = &d[4..];
-			let result = Decode::decode(&mut cursor).ok()?;
-			if cursor.iter().all(|x| *x == 0) {
-				Some(result)
-			} else {
-				None
-			}
-		})
-	}
-}
-
 /// A type that uniquely identifies an HRMP channel. An HRMP channel is established between two paras.
 /// In text, we use the notation `(A, B)` to specify a channel between A and B. The channels are
 /// unidirectional, meaning that `(A, B)` and `(B, A)` refer to different channels. The convention is

--- a/xcm/pallet-xcm/src/tests.rs
+++ b/xcm/pallet-xcm/src/tests.rs
@@ -22,8 +22,8 @@ use frame_support::{
 	assert_noop, assert_ok,
 	traits::{Currency, Hooks},
 };
-use polkadot_parachain::primitives::{AccountIdConversion, Id as ParaId};
-use sp_runtime::traits::{BlakeTwo256, Hash};
+use polkadot_parachain::primitives::Id as ParaId;
+use sp_runtime::traits::{BlakeTwo256, Hash, AccountIdConversion};
 use xcm::prelude::*;
 use xcm_builder::AllowKnownQueryResponses;
 use xcm_executor::{traits::ShouldExecute, XcmExecutor};

--- a/xcm/pallet-xcm/src/tests.rs
+++ b/xcm/pallet-xcm/src/tests.rs
@@ -23,7 +23,7 @@ use frame_support::{
 	traits::{Currency, Hooks},
 };
 use polkadot_parachain::primitives::Id as ParaId;
-use sp_runtime::traits::{BlakeTwo256, Hash, AccountIdConversion};
+use sp_runtime::traits::{AccountIdConversion, BlakeTwo256, Hash};
 use xcm::prelude::*;
 use xcm_builder::AllowKnownQueryResponses;
 use xcm_executor::{traits::ShouldExecute, XcmExecutor};


### PR DESCRIPTION
Found these traits laying around the Parachain Primitives, all of which exist in `sp-runtime` already.

https://github.com/paritytech/polkadot/issues/360 was supposed to track this but was prematurely closed.

I see no reason why these traits need to be duplicated at this point.

Cumulus Companion: https://github.com/paritytech/cumulus/pull/1264