### PR TITLE
`runtime api`: cache test

### DIFF
--- a/node/core/runtime-api/src/lib.rs
+++ b/node/core/runtime-api/src/lib.rs
@@ -51,8 +51,9 @@ mod tests;
 
 const LOG_TARGET: &str = "parachain::runtime-api";
 
-/// The number of maximum runtime API requests can be executed in parallel. Further requests will be buffered.
-const MAX_PARALLEL_REQUESTS: usize = 1;
+/// The number of maximum runtime API requests can be executed in parallel.
+/// Further requests will backpressure the overseer channels.
+const MAX_PARALLEL_REQUESTS: usize = 4;
 
 /// The name of the blocking task that executes a runtime API request.
 const API_REQUEST_TASK_NAME: &str = "polkadot-runtime-api-request";
@@ -277,6 +278,7 @@ where
 		let metrics = self.metrics.clone();
 		let (sender, receiver) = oneshot::channel();
 
+		// TODO: Check if an existing request is already running.
 		let request = match self.query_cache(relay_parent.clone(), request) {
 			Some(request) => request,
 			None => return,

--- a/node/core/runtime-api/src/lib.rs
+++ b/node/core/runtime-api/src/lib.rs
@@ -52,7 +52,7 @@ mod tests;
 const LOG_TARGET: &str = "parachain::runtime-api";
 
 /// The number of maximum runtime API requests can be executed in parallel. Further requests will be buffered.
-const MAX_PARALLEL_REQUESTS: usize = 4;
+const MAX_PARALLEL_REQUESTS: usize = 1;
 
 /// The name of the blocking task that executes a runtime API request.
 const API_REQUEST_TASK_NAME: &str = "polkadot-runtime-api-request";
@@ -66,8 +66,6 @@ pub struct RuntimeApiSubsystem<Client> {
 	active_requests: FuturesUnordered<oneshot::Receiver<Option<RequestResult>>>,
 	/// Requests results cache
 	requests_cache: RequestResultCache,
-	/// Active requests cache
-	
 }
 
 impl<Client> RuntimeApiSubsystem<Client> {

--- a/node/core/runtime-api/src/lib.rs
+++ b/node/core/runtime-api/src/lib.rs
@@ -52,7 +52,7 @@ mod tests;
 const LOG_TARGET: &str = "parachain::runtime-api";
 
 /// The number of maximum runtime API requests can be executed in parallel.
-/// Further requests will backpressure the overseer channels.
+/// Further requests will backpressure the bounded channel.
 const MAX_PARALLEL_REQUESTS: usize = 4;
 
 /// The name of the blocking task that executes a runtime API request.


### PR DESCRIPTION
https://github.com/paritytech/polkadot/issues/5486
Added overseer back pressure by removing the internal waiting queue, so ToFs are relevant.

Changed `MAX_PARALLEL_REQUESTS` to see if deduplicating parallel requests improves cache efficiency.
