### PR TITLE
add GHA support to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,7 @@ updates:
       - dependency-name: "sub-tokens"
     schedule:
       interval: "daily"
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: daily


### PR DESCRIPTION
This PR add GitHub Actions support by `dependabot`