### PR TITLE
`runtime-api`: remove internal queue to make ToFs relevant again

### DIFF
--- a/node/core/runtime-api/src/lib.rs
+++ b/node/core/runtime-api/src/lib.rs
@@ -276,7 +276,7 @@ where
 		let metrics = self.metrics.clone();
 		let (sender, receiver) = oneshot::channel();
 
-		// TODO: https://github.com/paritytech/polkadot/issues/5546
+		// TODO: make the cache great again https://github.com/paritytech/polkadot/issues/5546
 		let request = match self.query_cache(relay_parent.clone(), request) {
 			Some(request) => request,
 			None => return,

--- a/node/core/runtime-api/src/lib.rs
+++ b/node/core/runtime-api/src/lib.rs
@@ -51,8 +51,9 @@ mod tests;
 
 const LOG_TARGET: &str = "parachain::runtime-api";
 
-/// The number of maximum runtime API requests can be executed in parallel. Further requests will be buffered.
-const MAX_PARALLEL_REQUESTS: usize = 1;
+/// The number of maximum runtime API requests can be executed in parallel.
+/// Further requests will backpressure the overseer channels.
+const MAX_PARALLEL_REQUESTS: usize = 4;
 
 /// The name of the blocking task that executes a runtime API request.
 const API_REQUEST_TASK_NAME: &str = "polkadot-runtime-api-request";
@@ -277,6 +278,7 @@ where
 		let metrics = self.metrics.clone();
 		let (sender, receiver) = oneshot::channel();
 
+		// TODO: Check if an existing request is already running.
 		let request = match self.query_cache(relay_parent.clone(), request) {
 			Some(request) => request,
 			None => return,

--- a/node/core/runtime-api/src/lib.rs
+++ b/node/core/runtime-api/src/lib.rs
@@ -322,7 +322,11 @@ where
 	Client::Api: ParachainHost<Block> + BabeApi<Block> + AuthorityDiscoveryApi<Block>,
 {
 	loop {
-		// This adds some back pressure when the subsystem is running at `MAX_PARALLEL_REQUESTS`.
+		// Let's add some back pressure when the subsystem is running at `MAX_PARALLEL_REQUESTS`.
+		// This can never block forever, because `active_requests` is owned by this task and any mutations
+		// happen either in `poll_requests` or `spawn_request` - so if `is_busy` returns true, then
+		// even if all of the requests finish before us calling `poll_requests` the `active_requests` length
+		// remains invariant.
 		if subsystem.is_busy() {
 			// Since we are not using any internal waiting queues, we need to wait for exactly
 			// one request to complete before we can read the next one from the overseer channel.

--- a/node/core/runtime-api/src/lib.rs
+++ b/node/core/runtime-api/src/lib.rs
@@ -276,7 +276,7 @@ where
 		let metrics = self.metrics.clone();
 		let (sender, receiver) = oneshot::channel();
 
-		// TODO: https://github.com/paritytech/polkadot/issues/5486
+		// TODO: https://github.com/paritytech/polkadot/issues/5546
 		let request = match self.query_cache(relay_parent.clone(), request) {
 			Some(request) => request,
 			None => return,

--- a/node/core/runtime-api/src/lib.rs
+++ b/node/core/runtime-api/src/lib.rs
@@ -52,7 +52,7 @@ mod tests;
 const LOG_TARGET: &str = "parachain::runtime-api";
 
 /// The number of maximum runtime API requests can be executed in parallel. Further requests will be buffered.
-const MAX_PARALLEL_REQUESTS: usize = 4;
+const MAX_PARALLEL_REQUESTS: usize = 1;
 
 /// The name of the blocking task that executes a runtime API request.
 const API_REQUEST_TASK_NAME: &str = "polkadot-runtime-api-request";
@@ -66,8 +66,6 @@ pub struct RuntimeApiSubsystem<Client> {
 	active_requests: FuturesUnordered<oneshot::Receiver<Option<RequestResult>>>,
 	/// Requests results cache
 	requests_cache: RequestResultCache,
-	/// Active requests cache
-	
 }
 
 impl<Client> RuntimeApiSubsystem<Client> {

--- a/node/core/runtime-api/src/lib.rs
+++ b/node/core/runtime-api/src/lib.rs
@@ -52,7 +52,7 @@ mod tests;
 const LOG_TARGET: &str = "parachain::runtime-api";
 
 /// The number of maximum runtime API requests can be executed in parallel.
-/// Further requests will backpressure the overseer channels.
+/// Further requests will backpressure the bounded channel.
 const MAX_PARALLEL_REQUESTS: usize = 4;
 
 /// The name of the blocking task that executes a runtime API request.


### PR DESCRIPTION
https://github.com/paritytech/polkadot/issues/5486
Added overseer back pressure by removing the internal waiting queue to make the ToFs great again.
