### PR TITLE
Add missing markdown code block delimiter

### DIFF
--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -226,6 +226,7 @@ impl pallet_staking::BenchmarkingConfig for StakingBenchmarkingConfig {
 /// 	pub LaunchPeriod: BlockNumber = prod_or_fast!(7 * DAYS, 1, "KSM_LAUNCH_PERIOD");
 /// 	pub const VotingPeriod: BlockNumber = prod_or_fast!(7 * DAYS, 1 * MINUTES);
 /// }
+/// ```
 #[macro_export]
 macro_rules! prod_or_fast {
 	($prod:expr, $test:expr) => {


### PR DESCRIPTION
Sorry about the silly PR, but this thing keeps throwing off my syntax highlighting.