### PR TITLE
prepare orchestra crate publishing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4325,23 +4325,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "metered-channel"
-version = "0.9.22"
-dependencies = [
- "assert_matches",
- "coarsetime",
- "crossbeam-queue",
- "derive_more",
- "env_logger 0.9.0",
- "futures 0.3.21",
- "futures-timer",
- "log",
- "nanorand",
- "thiserror",
- "tracing",
-]
-
-[[package]]
 name = "mick-jaeger"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4827,15 +4810,15 @@ dependencies = [
 
 [[package]]
 name = "orchestra"
-version = "0.9.22"
+version = "0.0.1"
 dependencies = [
  "async-trait",
  "dyn-clonable",
  "futures 0.3.21",
  "futures-timer",
- "metered-channel",
  "orchestra-proc-macro",
  "pin-project 1.0.10",
+ "prioritized-metered-channel",
  "rustversion",
  "thiserror",
  "tracing",
@@ -4844,7 +4827,7 @@ dependencies = [
 
 [[package]]
 name = "orchestra-proc-macro"
-version = "0.9.22"
+version = "0.0.1"
 dependencies = [
  "assert_matches",
  "expander 0.0.6",
@@ -6825,11 +6808,11 @@ dependencies = [
  "futures-timer",
  "hyper",
  "log",
- "metered-channel",
  "nix 0.24.1",
  "parity-scale-codec",
  "polkadot-primitives",
  "polkadot-test-service",
+ "prioritized-metered-channel",
  "prometheus-parse",
  "sc-cli",
  "sc-client-api",
@@ -6947,7 +6930,6 @@ dependencies = [
  "lazy_static",
  "log",
  "lru 0.7.5",
- "metered-channel",
  "parity-db",
  "parity-scale-codec",
  "parity-util-mem",
@@ -6962,6 +6944,7 @@ dependencies = [
  "polkadot-overseer",
  "polkadot-primitives",
  "polkadot-primitives-test-helpers",
+ "prioritized-metered-channel",
  "rand 0.8.5",
  "sp-application-crypto",
  "sp-core",
@@ -6980,7 +6963,6 @@ dependencies = [
  "futures 0.3.21",
  "futures-timer",
  "lru 0.7.5",
- "metered-channel",
  "orchestra",
  "parity-util-mem",
  "parking_lot 0.12.0",
@@ -6990,6 +6972,7 @@ dependencies = [
  "polkadot-node-subsystem-types",
  "polkadot-primitives",
  "polkadot-primitives-test-helpers",
+ "prioritized-metered-channel",
  "sc-client-api",
  "sp-api",
  "sp-core",
@@ -7762,6 +7745,23 @@ dependencies = [
  "impl-serde",
  "scale-info",
  "uint",
+]
+
+[[package]]
+name = "prioritized-metered-channel"
+version = "0.1.1"
+dependencies = [
+ "assert_matches",
+ "coarsetime",
+ "crossbeam-queue",
+ "derive_more",
+ "env_logger 0.9.0",
+ "futures 0.3.21",
+ "futures-timer",
+ "log",
+ "nanorand",
+ "thiserror",
+ "tracing",
 ]
 
 [[package]]

--- a/node/metered-channel/Cargo.toml
+++ b/node/metered-channel/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
-name = "metered-channel"
-version = "0.9.22"
+name = "prioritized-metered-channel"
+version = "0.1.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
-description = "Channels with attached Meters"
+description = "Channels with attached Meters, prioritization coming soon™"
+repository = "https://github.com/paritytech/polkadot.git"
 license = "MIT OR Apache-2.0"
 
 [dependencies]

--- a/node/metered-channel/Cargo.toml
+++ b/node/metered-channel/Cargo.toml
@@ -3,7 +3,7 @@ name = "prioritized-metered-channel"
 version = "0.1.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
-description = "Channels with attached Meters, prioritization coming soon™"
+description = "Channels with built-in observability and message priorizitazion (coming soon™)"
 repository = "https://github.com/paritytech/polkadot.git"
 license = "MIT OR Apache-2.0"
 

--- a/node/metrics/Cargo.toml
+++ b/node/metrics/Cargo.toml
@@ -10,7 +10,7 @@ futures = "0.3.21"
 futures-timer = "3.0.2"
 gum = { package = "tracing-gum", path = "../gum" }
 
-metered-channel = { path = "../metered-channel" }
+metered = { package = "prioritized-metered-channel", path = "../metered-channel" }
 
 # Both `sc-service` and `sc-cli` are required by runtime metrics `logger_hook()`.
 sc-service = { git = "https://github.com/paritytech/substrate", branch = "master" }

--- a/node/metrics/src/lib.rs
+++ b/node/metrics/src/lib.rs
@@ -24,7 +24,7 @@
 #![deny(missing_docs)]
 #![deny(unused_imports)]
 
-pub use metered_channel as metered;
+pub use metered;
 
 /// Cyclic metric collection support.
 pub mod metronome;

--- a/node/overseer/Cargo.toml
+++ b/node/overseer/Cargo.toml
@@ -22,7 +22,7 @@ parity-util-mem = { version = "0.11.0", default-features = false }
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
 
 [dev-dependencies]
-metered-channel = { path = "../metered-channel" }
+metered = { package = "prioritized-metered-channel", path = "../metered-channel" }
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
 futures = { version = "0.3.21", features = ["thread-pool"] }
 femme = "2.2.1"

--- a/node/overseer/orchestra/Cargo.toml
+++ b/node/overseer/orchestra/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "orchestra"
-version = "0.9.22"
+version = "0.0.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 description = "Generate an orchestra of subsystems from a single struct."
+repository = "https://github.com/paritytech/polkadot"
 license = "MIT OR Apache-2.0"
 autoexamples = false
 
@@ -12,8 +13,8 @@ tracing = "0.1.34"
 futures = "0.3"
 async-trait = "0.1"
 thiserror = "1"
-metered = { package = "metered-channel", path = "../../metered-channel" }
-orchestra-proc-macro = { path = "./proc-macro" }
+metered = { package = "prioritized-metered-channel", version = "0.1.1", path = "../../metered-channel" }
+orchestra-proc-macro = { version = "0.0.1", path = "./proc-macro" }
 futures-timer = "3.0.2"
 pin-project = "1.0"
 dyn-clonable = "0.9"

--- a/node/overseer/orchestra/proc-macro/Cargo.toml
+++ b/node/overseer/orchestra/proc-macro/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "orchestra-proc-macro"
-version = "0.9.22"
+version = "0.0.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 description = "Generate an orchestra of subsystems from a single annotated struct definition."
+repository = "https://github.com/paritytech/polkadot"
 license = "MIT OR Apache-2.0"
 
 [package.metadata.docs.rs]

--- a/node/overseer/src/tests.rs
+++ b/node/overseer/src/tests.rs
@@ -39,7 +39,7 @@ use crate::{
 	gen::Delay,
 	HeadSupportsParachains,
 };
-use metered_channel as metered;
+use metered;
 
 use assert_matches::assert_matches;
 use sp_core::crypto::Pair as _;

--- a/node/subsystem-util/Cargo.toml
+++ b/node/subsystem-util/Cargo.toml
@@ -26,7 +26,7 @@ polkadot-node-network-protocol = { path = "../network/protocol" }
 polkadot-primitives = { path = "../../primitives" }
 polkadot-node-primitives = { path = "../primitives" }
 polkadot-overseer = { path = "../overseer" }
-metered-channel = { path = "../metered-channel" }
+metered = { package = "prioritized-metered-channel", path = "../metered-channel" }
 
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sp-application-crypto = { git = "https://github.com/paritytech/substrate", branch = "master" }

--- a/node/subsystem-util/src/lib.rs
+++ b/node/subsystem-util/src/lib.rs
@@ -68,7 +68,7 @@ use std::{
 };
 use thiserror::Error;
 
-pub use metered_channel as metered;
+pub use metered;
 pub use polkadot_node_network_protocol::MIN_GOSSIP_PEERS;
 
 pub use determine_new_blocks::determine_new_blocks;


### PR DESCRIPTION
Prepare it to be published as an independent crate (all crates are reserved to avoid the squatting pitfal).

* `metered-channel` -> `prioritized-metered-channel` in prep for #5517 
* apply a definite version `0.0.1` for `prioritized-metered-channel`, `orchestra` and `orchestra-proc-macro`
* use `metered = { package = "prioritized-metered-channel", .. }` consistently


Note publishing with unleash is currently borked due to https://github.com/paritytech/cargo-unleash/issues/77 , so the following _should_ work but currently does not. One has to publish them one by one

```
cargo unleash version set 0.0.1 -p orchestra -p orchestra-proc-macro
cargo unleash em-dragons --dry-run -p orchestra -p orchestra-proc-macro -p prioritized-metered-channel
```
