### PR TITLE
Require signed authority discovery records

### DIFF
--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -992,6 +992,8 @@ where
 		let (worker, service) = sc_authority_discovery::new_worker_and_service_with_config(
 			sc_authority_discovery::WorkerConfig {
 				publish_non_global_ips: auth_disc_publish_non_global_ips,
+				// Require that authority discovery records are signed.
+				strict_record_validation: true,
 				..Default::default()
 			},
 			client.clone(),


### PR DESCRIPTION
Nodes are already publishing signed records since 0.9.17, but now we
also enable the validation of the signature.

Closes: https://github.com/paritytech/polkadot/issues/4499