### PR TITLE
split NetworkBridge into two subsystems

### DIFF
--- a/node/network/gossip-support/src/lib.rs
+++ b/node/network/gossip-support/src/lib.rs
@@ -22,7 +22,7 @@
 //! which limits the amount of messages sent and received
 //! to be an order of sqrt of the validators. Our neighbors
 //! in this graph will be forwarded to the network bridge with
-//! the `NetworkBridgeMessage::NewGossipTopology` message.
+//! the `NetworkBridgeInMessage::NewGossipTopology` message.
 
 use std::{
 	collections::{HashMap, HashSet},
@@ -45,8 +45,8 @@ use polkadot_node_network_protocol::{
 };
 use polkadot_node_subsystem::{
 	messages::{
-		GossipSupportMessage, NetworkBridgeEvent, NetworkBridgeMessage, RuntimeApiMessage,
-		RuntimeApiRequest,
+		GossipSupportMessage, NetworkBridgeEvent, NetworkBridgeInMessage, NetworkBridgeMessage,
+		RuntimeApiMessage, RuntimeApiRequest,
 	},
 	overseer, ActiveLeavesUpdate, FromOrchestra, OverseerSignal, SpawnedSubsystem, SubsystemError,
 };
@@ -538,7 +538,7 @@ async fn update_gossip_topology(
 		.collect();
 
 	sender
-		.send_message(NetworkBridgeMessage::NewGossipTopology {
+		.send_message(NetworkBridgeInMessage::NewGossipTopology {
 			session: session_index,
 			our_neighbors_x: row_neighbors,
 			our_neighbors_y: column_neighbors,

--- a/node/overseer/src/dummy.rs
+++ b/node/overseer/src/dummy.rs
@@ -85,6 +85,7 @@ pub fn dummy_overseer_builder<'a, Spawner, SupportsParachains>(
 		DummySubsystem,
 		DummySubsystem,
 		DummySubsystem,
+		DummySubsystem,
 	>,
 	SubsystemError,
 >
@@ -126,6 +127,7 @@ pub fn one_for_all_overseer_builder<'a, Spawner, SupportsParachains, Sub>(
 		Sub,
 		Sub,
 		Sub,
+		Sub,
 	>,
 	SubsystemError,
 >
@@ -143,6 +145,7 @@ where
 		+ Subsystem<OverseerSubsystemContext<ChainApiMessage>, SubsystemError>
 		+ Subsystem<OverseerSubsystemContext<CollationGenerationMessage>, SubsystemError>
 		+ Subsystem<OverseerSubsystemContext<CollatorProtocolMessage>, SubsystemError>
+		+ Subsystem<OverseerSubsystemContext<NetworkBridgeInMessage>, SubsystemError>
 		+ Subsystem<OverseerSubsystemContext<NetworkBridgeMessage>, SubsystemError>
 		+ Subsystem<OverseerSubsystemContext<ProvisionerMessage>, SubsystemError>
 		+ Subsystem<OverseerSubsystemContext<RuntimeApiMessage>, SubsystemError>
@@ -169,6 +172,7 @@ where
 		.chain_api(subsystem.clone())
 		.collation_generation(subsystem.clone())
 		.collator_protocol(subsystem.clone())
+		.network_bridge_in(subsystem.clone())
 		.network_bridge(subsystem.clone())
 		.provisioner(subsystem.clone())
 		.runtime_api(subsystem.clone())

--- a/node/overseer/src/lib.rs
+++ b/node/overseer/src/lib.rs
@@ -83,8 +83,8 @@ use polkadot_node_subsystem_types::messages::{
 	BitfieldSigningMessage, CandidateBackingMessage, CandidateValidationMessage, ChainApiMessage,
 	ChainSelectionMessage, CollationGenerationMessage, CollatorProtocolMessage,
 	DisputeCoordinatorMessage, DisputeDistributionMessage, GossipSupportMessage,
-	NetworkBridgeMessage, ProvisionerMessage, PvfCheckerMessage, RuntimeApiMessage,
-	StatementDistributionMessage,
+	NetworkBridgeInMessage, NetworkBridgeMessage, ProvisionerMessage, PvfCheckerMessage,
+	RuntimeApiMessage, StatementDistributionMessage,
 };
 pub use polkadot_node_subsystem_types::{
 	errors::{SubsystemError, SubsystemResult},
@@ -530,7 +530,7 @@ pub struct Overseer<SupportsParachains> {
 	])]
 	availability_store: AvailabilityStore,
 
-	#[subsystem(NetworkBridgeMessage, sends: [
+	#[subsystem(NetworkBridgeInMessage, sends: [
 		BitfieldDistributionMessage,
 		StatementDistributionMessage,
 		ApprovalDistributionMessage,
@@ -539,7 +539,10 @@ pub struct Overseer<SupportsParachains> {
 		CollationGenerationMessage,
 		CollatorProtocolMessage,
 	])]
-	network_bridge: NetworkBridge,
+	network_bridge_in: NetworkBridgeIn,
+
+	#[subsystem(NetworkBridgeMessage, sends: [])]
+	network_bridge: NetworkBridgeOut,
 
 	#[subsystem(blocking, ChainApiMessage, sends: [])]
 	chain_api: ChainApi,
@@ -576,6 +579,7 @@ pub struct Overseer<SupportsParachains> {
 
 	#[subsystem(GossipSupportMessage, sends: [
 		NetworkBridgeMessage,
+		NetworkBridgeInMessage, // FIXME move this into the GossipSupport subsystem
 		RuntimeApiMessage,
 		ChainSelectionMessage,
 	])]

--- a/node/subsystem-types/src/messages.rs
+++ b/node/subsystem-types/src/messages.rs
@@ -318,7 +318,36 @@ pub enum DisputeDistributionMessage {
 	SendDispute(DisputeMessage),
 }
 
-/// Messages received by the network bridge subsystem.
+/// Messages received from other subsystems.
+///
+/// A dummy.
+#[derive(Debug)]
+pub enum NetworkBridgeInMessage {
+	/// Inform the distribution subsystems about the new
+	/// gossip network topology formed.
+	///
+	/// The only reason to have this here, is the availability of the
+	/// authority discovery service, otherwise, the `GossipSupport`
+	/// subsystem would make more sense.
+	NewGossipTopology {
+		/// The session info this gossip topology is concerned with.
+		session: SessionIndex,
+		/// Ids of our neighbors in the X dimensions of the new gossip topology,
+		/// along with their validator indices within the session.
+		///
+		/// We're not necessarily connected to all of them, but we should
+		/// try to be.
+		our_neighbors_x: HashMap<AuthorityDiscoveryId, ValidatorIndex>,
+		/// Ids of our neighbors in the X dimensions of the new gossip topology,
+		/// along with their validator indices within the session.
+		///
+		/// We're not necessarily connected to all of them, but we should
+		/// try to be.
+		our_neighbors_y: HashMap<AuthorityDiscoveryId, ValidatorIndex>,
+	},
+}
+
+/// Messages received from other subsystems by the network bridge subsystem.
 #[derive(Debug)]
 pub enum NetworkBridgeMessage {
 	/// Report a peer for their actions.
@@ -375,24 +404,6 @@ pub enum NetworkBridgeMessage {
 		/// The peer set we want the connection on.
 		peer_set: PeerSet,
 	},
-	/// Inform the distribution subsystems about the new
-	/// gossip network topology formed.
-	NewGossipTopology {
-		/// The session info this gossip topology is concerned with.
-		session: SessionIndex,
-		/// Ids of our neighbors in the X dimensions of the new gossip topology,
-		/// along with their validator indices within the session.
-		///
-		/// We're not necessarily connected to all of them, but we should
-		/// try to be.
-		our_neighbors_x: HashMap<AuthorityDiscoveryId, ValidatorIndex>,
-		/// Ids of our neighbors in the X dimensions of the new gossip topology,
-		/// along with their validator indices within the session.
-		///
-		/// We're not necessarily connected to all of them, but we should
-		/// try to be.
-		our_neighbors_y: HashMap<AuthorityDiscoveryId, ValidatorIndex>,
-	},
 }
 
 impl NetworkBridgeMessage {
@@ -408,7 +419,6 @@ impl NetworkBridgeMessage {
 			Self::ConnectToValidators { .. } => None,
 			Self::ConnectToResolvedValidators { .. } => None,
 			Self::SendRequests { .. } => None,
-			Self::NewGossipTopology { .. } => None,
 		}
 	}
 }


### PR DESCRIPTION
Split `NetworkBridgeSubsystem` into `In` and `Out` parts, where `In` and `Out` are respective to the network. So `In` handles incoming _network_ messages, `Out` handles messages that are meant to go to the network. `NewGossipTopology` should be moved into `GossipSupportSubsystem`, it currently lives in `In`, where it does not belong.

* [ ] split `In` and `Out` into separate files
* [ ] make `Shared` actually shared MUST FIX
* [ ] move `NewGossipTopolgy` into `GossipSupport`
* [ ] flatten the subsystems a bit, many pointless 10-line `fn` indirections adding a lot of boiler plate without any value