### PR TITLE
Replace problematic unicode chars

### DIFF
--- a/scripts/ci/changelog/templates/runtime.md.tera
+++ b/scripts/ci/changelog/templates/runtime.md.tera
@@ -22,7 +22,7 @@
 🎁 Metadata version:		V{{ runtime.data.runtimes.compressed.subwasm.metadata_version }}
 🗳️ system.setCode hash:		{{ runtime.data.runtimes.compressed.subwasm.proposal_hash }}
 🗳️ authorizeUpgrade hash:	{{ runtime.data.runtimes.compressed.subwasm.parachain_authorize_upgrade_hash }}
-#️⃣ Blake2-256 hash:		{{ runtime.data.runtimes.compressed.subwasm.blake2_256 }}
+🗳️ Blake2-256 hash:		{{ runtime.data.runtimes.compressed.subwasm.blake2_256 }}
 📦 IPFS:			{{ runtime.data.runtimes.compressed.subwasm.ipfs_hash }}
 ```
 {%- endmacro runtime %}


### PR DESCRIPTION
The runtimes, before this PR, were rendered as:
```
...
#️⃣ Blake2-256 hash: ...
...
```

This is causing issues in the rendering in Element as #️⃣ translate to `#` (+ an invisible char) and `#` inserts a new chapter in the middle of a code block, breaking the whole rendering.

This PR replace the problematic char with another one that should be friendlier with Element.