### PR TITLE
Changed Bonding & SlashDefer Duration in Westend

### DIFF
--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -475,10 +475,10 @@ pallet_staking_reward_curve::build! {
 parameter_types! {
 	// Six sessions in an era (6 hours).
 	pub const SessionsPerEra: SessionIndex = 6;
-	// 28 eras for unbonding (7 days).
-	pub const BondingDuration: sp_staking::EraIndex = 28;
-	// 27 eras in which slashes can be cancelled (slightly less than 7 days).
-	pub const SlashDeferDuration: sp_staking::EraIndex = 27;
+	// 2 eras for unbonding (12 hours).
+	pub const BondingDuration: sp_staking::EraIndex = 2;
+	// 1 era in which slashes can be cancelled (6 hours).
+	pub const SlashDeferDuration: sp_staking::EraIndex = 1;
 	pub const RewardCurve: &'static PiecewiseLinear<'static> = &REWARD_CURVE;
 	pub const MaxNominatorRewardedPerValidator: u32 = 64;
 	pub const OffendingValidatorsThreshold: Perbill = Perbill::from_percent(17);


### PR DESCRIPTION
### Description
Kindly suggesting to reduce the `Bonding Duration` (and hence also the `SlashDefer Duration` slightly less) in Westend so that teams can execute their tests faster. 

The new proposed time frames are the following :  
- Bonding Duration to 12 hours (= 2 eras) and 
- Slash Defer Duration to 6 hours (= 1 era) 

### Why 12 and 6 (or 2 and 1) ?
The specific values are suggested since I realised (from testing locally and trying out different bonding values) that I could not insert anything less than a whole era (6h in westend) or positive integer multiples of an era. So based on this assumption, the shortest time frame for Bonding Duration would be 2 eras since SlashDefer needs to be slightly less so 1 era. Please do correct me if I am wrong but I think this is related to the fact that these constants are of type `EraIndex` which is a `u32`.