### PR TITLE
Update versi initial_authorities

### DIFF
--- a/node/service/src/chain_spec.rs
+++ b/node/service/src/chain_spec.rs
@@ -1115,19 +1115,26 @@ fn versi_staging_testnet_config_genesis(wasm_binary: &[u8]) -> rococo_runtime::G
 			//5Ey8RkgbfT2aJyXjHg9KgUxDVbY64LGdx328compLvRE3fzG
 			hex!["8073f07bcddc9bd1542a7d3ea80fb6b5638e4589645e0da07a43910c4dcee85d"].into(),
 			//5FNF9A2TFd8PgutZd8bdPpbR1WSZCcjtnggd9EEq3oVKVM36
-			hex!["92152f39b165099df481ab7780f375f496fada5544e8b66cab67df4c493f3128"].unchecked_into(),
+			hex!["92152f39b165099df481ab7780f375f496fada5544e8b66cab67df4c493f3128"]
+				.unchecked_into(),
 			//5GL8faNkBoJS6TeZANDGjo8PcPyPs5WZQ85J5uB4jqPpyvh8
-			hex!["bcb520ea39e9bf69cb47b4dda167dafde1da01f01bb7d2c091ab50fb7bf8f1d7"].unchecked_into(),
+			hex!["bcb520ea39e9bf69cb47b4dda167dafde1da01f01bb7d2c091ab50fb7bf8f1d7"]
+				.unchecked_into(),
 			//5EycsfQxcsFBjJ6setX8yivnceNiBoZtiQkcryvNQA9K4ULK
-			hex!["80d3b315a556758b44a2bf7467c2320e5840693c502ea686a89de6fc09c6ff38"].unchecked_into(),
+			hex!["80d3b315a556758b44a2bf7467c2320e5840693c502ea686a89de6fc09c6ff38"]
+				.unchecked_into(),
 			//5DjqDw5NMmFdiafR9oVKZLasjY96jsd4sM5sdhMi8CT29vKx
-			hex!["4a139a3d919f44ba4709d65c9bd5e1c3c9392b4572e7e1cb28c73bd7591ad51c"].unchecked_into(),
+			hex!["4a139a3d919f44ba4709d65c9bd5e1c3c9392b4572e7e1cb28c73bd7591ad51c"]
+				.unchecked_into(),
 			//5F7Ka1qtTNVLityecYunrePHew3xCzV8HwZcrGZ9fuCS9NWv
-			hex!["86b36952561d89ba10ffc70d0daffcd6fdd55899dfe5c6e051135087b6b1e30b"].unchecked_into(),
+			hex!["86b36952561d89ba10ffc70d0daffcd6fdd55899dfe5c6e051135087b6b1e30b"]
+				.unchecked_into(),
 			//5Hb3UnjMkuTWN47mKFxFfrad3gG8QzVNHogq3Nmj9drmnQPZ
-			hex!["f45095e49de853e229bb15c402483d7633a5eba25da2c38e4fd3a94df4550151"].unchecked_into(),
+			hex!["f45095e49de853e229bb15c402483d7633a5eba25da2c38e4fd3a94df4550151"]
+				.unchecked_into(),
 			//5EEFWe2ssjEToHmFcj8wCpbZxf8HPRVmDVKzjzwHmigDobTR
-			hex!["02dcfd39de094705787507db7a674840350592d9dd33c89256444915d9c35bd541"].unchecked_into(),
+			hex!["02dcfd39de094705787507db7a674840350592d9dd33c89256444915d9c35bd541"]
+				.unchecked_into(),
 		),
 		(
 			//versi-bootnode-1
@@ -1136,19 +1143,26 @@ fn versi_staging_testnet_config_genesis(wasm_binary: &[u8]) -> rococo_runtime::G
 			//5D51C2P7GMEyQCfxLiQz77DrkDiywnX21kKkwjskBNWWLxwv
 			hex!["2c76957e95c326c576780c1b9628bc69b1862ea66e5fd614ddafe3a0dcc13d42"].into(),
 			//5FLny6BTcXSWMjZHgaiEbh5GPgyoTuDjqmd4PCCakKDPyYQL
-			hex!["90f9d4bdfa86aa74e7ae0540604a30001e7161ea129b10790168aa82cf140217"].unchecked_into(),
+			hex!["90f9d4bdfa86aa74e7ae0540604a30001e7161ea129b10790168aa82cf140217"]
+				.unchecked_into(),
 			//5CpyzFD8PePkdLNCpMkGSoHp5xQy4bNoga4fgSV3gik9A5gV
-			hex!["21c5192e4837d49aaa84978cf50b042a7fefb6859a9ec36dbf31e47afa251106"].unchecked_into(),
+			hex!["21c5192e4837d49aaa84978cf50b042a7fefb6859a9ec36dbf31e47afa251106"]
+				.unchecked_into(),
 			//5HB5z5q5d2AdeT6EiQHd4KTweUr7m3KTZfvcMVJPBZfwh98v
-			hex!["e20b20f0e0e9ef3e7067cb686f5e863fd199ea9d15278f5c5a3f4e996c6b1b01"].unchecked_into(),
+			hex!["e20b20f0e0e9ef3e7067cb686f5e863fd199ea9d15278f5c5a3f4e996c6b1b01"]
+				.unchecked_into(),
 			//5FTqYsXezAyeKREwBwMjrQURFMZ9VSVWLom4TNo514aD9F7A
-			hex!["96593dfd0b6a3df882e9e59f72254d510b5b3bc8426a14519c52e10366331220"].unchecked_into(),
+			hex!["96593dfd0b6a3df882e9e59f72254d510b5b3bc8426a14519c52e10366331220"]
+				.unchecked_into(),
 			//5HGhpDMW91xYabtKr29vUTuJqtsz1rucuEKiRz5cMUfYKVeG
-			hex!["e653f839e0a45f87ff64be931d88c2c675027f97f78db1dbc4e5c3b177e68a67"].unchecked_into(),
+			hex!["e653f839e0a45f87ff64be931d88c2c675027f97f78db1dbc4e5c3b177e68a67"]
+				.unchecked_into(),
 			//5HKqyEHGaAo7zZYxeY5Q4Ti1B2ooXKYvvPBzjNXan3Fpz8z2
-			hex!["e8b928d70c45e2bec1d701e3bb74fed373848759edf8038780f2391233f0fd56"].unchecked_into(),
+			hex!["e8b928d70c45e2bec1d701e3bb74fed373848759edf8038780f2391233f0fd56"]
+				.unchecked_into(),
 			//5FezXdtwcWVutVyGJm498mWF4PpR3RRNjrpEYt7vLMrUaq11
-			hex!["0386f6aced2d95c885ef955f2309a377546e6d3b05ec65e3c0fe1b60b51780d9cb"].unchecked_into(),
+			hex!["0386f6aced2d95c885ef955f2309a377546e6d3b05ec65e3c0fe1b60b51780d9cb"]
+				.unchecked_into(),
 		),
 		(
 			//versi-bootnode-2
@@ -1157,19 +1171,26 @@ fn versi_staging_testnet_config_genesis(wasm_binary: &[u8]) -> rococo_runtime::G
 			//5GYkr1M6niodK8wnfotoNyuyMfT8wkT7tiBBj7enkLDjg1kr
 			hex!["c655dd98e6b25308042cc7e2a4089b0771ac9706f093714b1752f7186cdff903"].into(),
 			//5EWkYHRWeLtsZ9ZZcTLt4hvsZ7vFeCyu5N8SFGvghNWN9BMX
-			hex!["6c55e1180722f0a2d03a52cd84e759e7bfc2ee0cf3d639557013e8f191534503"].unchecked_into(),
+			hex!["6c55e1180722f0a2d03a52cd84e759e7bfc2ee0cf3d639557013e8f191534503"]
+				.unchecked_into(),
 			//5ExhjXhUcbD6BDDS4B4EUoDkxTWxuh2eADJS9XkrRMBSfp4a
-			hex!["8020d0489180c87dd10ff6bc18dc4ff0b5b5561f232782c6f81834cd61ce6d37"].unchecked_into(),
+			hex!["8020d0489180c87dd10ff6bc18dc4ff0b5b5561f232782c6f81834cd61ce6d37"]
+				.unchecked_into(),
 			//5F7YM3nbu6MpYpaLhnTr44dyvkte1T6T5ZPxznRPkL6NA5JY
-			hex!["86de6bb5cba98095c96ce82161f28f1d5f95a143167512f5796ea816d572fb35"].unchecked_into(),
+			hex!["86de6bb5cba98095c96ce82161f28f1d5f95a143167512f5796ea816d572fb35"]
+				.unchecked_into(),
 			//5DyXfRM9Q7y9ai88iRwUL9PhGsFu1qsuXkUhV96HyN2QzPB5
-			hex!["5485ec8e2cf71922706e2276a9e3bcce1e1fd0719d987a2948cf7fbdf6d23e18"].unchecked_into(),
+			hex!["5485ec8e2cf71922706e2276a9e3bcce1e1fd0719d987a2948cf7fbdf6d23e18"]
+				.unchecked_into(),
 			//5Hp5F5ANNvzfAPrAKjMAervCzkrjBTBD1G8FosrVAtAvsA5K
-			hex!["fe40b656eb50bf060345437f1cf1443ccdb38b757dc16fcdcec38f3db624cb19"].unchecked_into(),
+			hex!["fe40b656eb50bf060345437f1cf1443ccdb38b757dc16fcdcec38f3db624cb19"]
+				.unchecked_into(),
 			//5FjR5ZGcphJwa8ASbN4Zy7G68CBSYncMCvnzb8NKjgavRu8c
-			hex!["a23acac4f679a303340473c47cf06dba6dd8cb25c31e4a198ac03198cb03bb0e"].unchecked_into(),
+			hex!["a23acac4f679a303340473c47cf06dba6dd8cb25c31e4a198ac03198cb03bb0e"]
+				.unchecked_into(),
 			//5CuBp8GJhoEGPsqP7hxbMZFbvfqCXPtfGGqHyPg4TA6VjYZm
-			hex!["0342fa2e397cc25068d5264a9cddeec09eb7649e204b0fcff16bf72ec2a47121c3"].unchecked_into(),
+			hex!["0342fa2e397cc25068d5264a9cddeec09eb7649e204b0fcff16bf72ec2a47121c3"]
+				.unchecked_into(),
 		),
 		(
 			//versi-bootnode-3
@@ -1178,19 +1199,26 @@ fn versi_staging_testnet_config_genesis(wasm_binary: &[u8]) -> rococo_runtime::G
 			//5GCTSeDTPkTYb2wDgqBNfZCHyrsPNrQ7o3gaqxhBisxw2y1j
 			hex!["b6da5fd68be99a24ee305870cbb4dbfbbf990b2c136fef5b86fde9ac3484027e"].into(),
 			//5Dqqu4PZ6CEfLmuHMq1Zh445sNoWMyGJ2koKDvViJaSNSym1
-			hex!["4ea95885e872aa9d0f1e0f02585d87d9014fcd0ee3c675d841adf332b328dd76"].unchecked_into(),
+			hex!["4ea95885e872aa9d0f1e0f02585d87d9014fcd0ee3c675d841adf332b328dd76"]
+				.unchecked_into(),
 			//5G112ibbo5RpVoEZzfk925XC5ZhudgGGcVp89EtjH8p4sgSd
-			hex!["ae1dc33683dfc96f85041e45acef7bcbe689bdaca2e6de30921e67cae9f04466"].unchecked_into(),
+			hex!["ae1dc33683dfc96f85041e45acef7bcbe689bdaca2e6de30921e67cae9f04466"]
+				.unchecked_into(),
 			//5G8uMor82Z361AL26srzShBJPcZW2WeBWnyQ8zY8HeVT8iDc
-			hex!["b424a2d066d145ca99b33272102629e03f2de893f18eab1a4a7e00d82e99084e"].unchecked_into(),
+			hex!["b424a2d066d145ca99b33272102629e03f2de893f18eab1a4a7e00d82e99084e"]
+				.unchecked_into(),
 			//5Cvs52pMzW6ygaKuy9PqBuqd486aaXEi3jGrdAvSPcBqAuMN
-			hex!["264148d4090f3e25889513c2fabc16a1f5868beec84a416587f67bb7408ff47a"].unchecked_into(),
+			hex!["264148d4090f3e25889513c2fabc16a1f5868beec84a416587f67bb7408ff47a"]
+				.unchecked_into(),
 			//5CV7RehhbrMXhRy5ULMLz1Z6K9phjAHTh7NciS32PAxcdhUS
-			hex!["129d3a979bad7850a525b3fe2941f70a9405657fdd213819fba209cf00206434"].unchecked_into(),
+			hex!["129d3a979bad7850a525b3fe2941f70a9405657fdd213819fba209cf00206434"]
+				.unchecked_into(),
 			//5CvZfiLpvRFXnL3TnQ6q174AaKU5ZbEEApDfXqyfwTZthpxp
-			hex!["2606b43856617293a0f9743979a812c18d6dd3940aa5cb42765385d925165b51"].unchecked_into(),
+			hex!["2606b43856617293a0f9743979a812c18d6dd3940aa5cb42765385d925165b51"]
+				.unchecked_into(),
 			//5EwUULMqszegdrs8Papyu2goesMzQqiRVFd5HBo95KabrJn3
-			hex!["03cdaac2af6282482e37761f74cd86f70b0dff46faa38fea38babec5c639113ea0"].unchecked_into(),
+			hex!["03cdaac2af6282482e37761f74cd86f70b0dff46faa38fea38babec5c639113ea0"]
+				.unchecked_into(),
 		),
 		(
 			//versi-bootnode-4
@@ -1199,19 +1227,26 @@ fn versi_staging_testnet_config_genesis(wasm_binary: &[u8]) -> rococo_runtime::G
 			//5H8hp25gnTvVuePYD5DkYnzS3nSuWm3y9tdrh1omFj8U8wxm
 			hex!["e039fec00afaebd9af15014440e1febe07a2effa1c72bfca738ca770c5eb177f"].into(),
 			//5H3Yis5m8ikyU8nUHGYNfvvPyFtHPDb19KGTxYhweznNJHUH
-			hex!["dc4b2c14c9f977b976354aeee6e1dfc849b5757eea2e11f7dc6fe4e0a34d4939"].unchecked_into(),
+			hex!["dc4b2c14c9f977b976354aeee6e1dfc849b5757eea2e11f7dc6fe4e0a34d4939"]
+				.unchecked_into(),
 			//5Dp77hZ1bG4kdkVa2LR44dZqCDrLDfgfRpSygZTCVrhHuFjX
-			hex!["4d56154951c76353b204066dbff0fec9b335854a1608f8d4ca04375c78adfb39"].unchecked_into(),
+			hex!["4d56154951c76353b204066dbff0fec9b335854a1608f8d4ca04375c78adfb39"]
+				.unchecked_into(),
 			//5D5aY6RacUAtLQPRJLNfYUogDmJxQKpuRfGSm75mFLU25cdM
-			hex!["2ce6d63237e54cb99d830b5fdf7ad097d5954a0102b77527211b337cda84ca09"].unchecked_into(),
+			hex!["2ce6d63237e54cb99d830b5fdf7ad097d5954a0102b77527211b337cda84ca09"]
+				.unchecked_into(),
 			//5Hpvfs89hBjqEF1cXUiKZXBv4no1oC2mHw1NpQ11C6XCgMGW
-			hex!["fee71993dbcfc41bd6a053ab9f9705f377c71b875f8abcbb2081c241f9f3a31e"].unchecked_into(),
+			hex!["fee71993dbcfc41bd6a053ab9f9705f377c71b875f8abcbb2081c241f9f3a31e"]
+				.unchecked_into(),
 			//5EPXP8yv65npdoSig3ru22XXS4CYeK1W5P2pGXrTSu13CnUo
-			hex!["66d2de6592d6ec8093a7ef738595e70174306e3d5399306a114e41348b218c3f"].unchecked_into(),
+			hex!["66d2de6592d6ec8093a7ef738595e70174306e3d5399306a114e41348b218c3f"]
+				.unchecked_into(),
 			//5HGTYBcTgosXkVGUchpPT2VYi5QEhYNbYgUdXhX1NQwpAYGD
-			hex!["e623e93ada87315b9b67125577bcf38d63351eba661767e8d4c7f82de214bb42"].unchecked_into(),
+			hex!["e623e93ada87315b9b67125577bcf38d63351eba661767e8d4c7f82de214bb42"]
+				.unchecked_into(),
 			//5EbCRa9Bhjy2b5MDcSAUXZJaNgZSQG8BHFFDoEVKcrrTmNib
-			hex!["030cc28a18b53affcc5983e0e4e2f874bd81af4da90243110e7ee685661d90dd15"].unchecked_into(),
+			hex!["030cc28a18b53affcc5983e0e4e2f874bd81af4da90243110e7ee685661d90dd15"]
+				.unchecked_into(),
 		),
 		(
 			//versi-bootnode-5
@@ -1220,19 +1255,26 @@ fn versi_staging_testnet_config_genesis(wasm_binary: &[u8]) -> rococo_runtime::G
 			//5ERiUsDFC7W25CPJ7nZXQRa1hCNW3z5wdMNWeEfNJLQgVHuU
 			hex!["687eb8a75f901f5484d59aebab21d9738f8423f74748144c4d8a90a57220de31"].into(),
 			//5FsX7MZEXD8PV4VMKitxHJDQHaw9aufVYDeHj9TnSZMxh19Z
-			hex!["a8690eb5c4394f2dac264ff2a970009c4807cc3ea1c23e5b8b1b522e3bc94617"].unchecked_into(),
+			hex!["a8690eb5c4394f2dac264ff2a970009c4807cc3ea1c23e5b8b1b522e3bc94617"]
+				.unchecked_into(),
 			//5E2BMeeNPfHoaoeGkRcwuSXmHxQKt7kkVWwzzg1EyeM9Uxsq
-			hex!["568b4d8776812f8314825dab808aab07dd98019b60e3b897946df389507b89ac"].unchecked_into(),
+			hex!["568b4d8776812f8314825dab808aab07dd98019b60e3b897946df389507b89ac"]
+				.unchecked_into(),
 			//5GNT2rvcVbiyXoBEFCEmyuKPHCeyU7t6Z9b9P9QZZQt5zkyP
-			hex!["be7972bbc4ce359af881678ee1ccdcbc1b649bcbc6f82c9c849c051bac818f03"].unchecked_into(),
+			hex!["be7972bbc4ce359af881678ee1ccdcbc1b649bcbc6f82c9c849c051bac818f03"]
+				.unchecked_into(),
 			//5CDkpJJQDfjwrhWG6mHMQehLLvykkqcutcU8hyv5qR5cxeAs
-			hex!["06e72b8577559c32b628b1ec4b1ee1c75b2fc6ba02b286f569b96e3055a6b759"].unchecked_into(),
+			hex!["06e72b8577559c32b628b1ec4b1ee1c75b2fc6ba02b286f569b96e3055a6b759"]
+				.unchecked_into(),
 			//5FgrEDFDrbmghpVaeg59cy5hsRk5bNpXcKBy9sCg8STa9KZ8
-			hex!["a045b736887076556955e5ad890b074734af90d704e1efaf3b6c8713d90b0d27"].unchecked_into(),
+			hex!["a045b736887076556955e5ad890b074734af90d704e1efaf3b6c8713d90b0d27"]
+				.unchecked_into(),
 			//5GTFG9KW6j628acwSV9GgjNxMRenUihEvBGfoz8L74EGog9t
-			hex!["c2220ceedfb0bc06b2b66023beec32efb9ec2be9c1f17de34b66ed8188322e34"].unchecked_into(),
+			hex!["c2220ceedfb0bc06b2b66023beec32efb9ec2be9c1f17de34b66ed8188322e34"]
+				.unchecked_into(),
 			//5DebHv79jFE6WPrTPyc5Ks7yzcYrQCnqJ16k6F2CCqXJDLQt
-			hex!["035a4034a2786140da49c5568609ca1e82d1a7a1d526cdc0eb0c0e467d53522c5d"].unchecked_into(),
+			hex!["035a4034a2786140da49c5568609ca1e82d1a7a1d526cdc0eb0c0e467d53522c5d"]
+				.unchecked_into(),
 		),
 		(
 			//versi-bootnode-6
@@ -1241,19 +1283,26 @@ fn versi_staging_testnet_config_genesis(wasm_binary: &[u8]) -> rococo_runtime::G
 			//5CofQrypXYMKDygCjfshuaTeN92NhRh4kApgjnK99rgCm1Aq
 			hex!["20c3526ed124f9119185c079d6670461c88e04d76f1ef2cb38b02ff3c24f081a"].into(),
 			//5Fv73X7dtFm15hqYG338MNJ1qw351BbgjzFAh3rgXdjDFaCT
-			hex!["aa61c7a624b0289509c41a7f76a28193fe5c84ec21a55a5068529c39f8797e31"].unchecked_into(),
+			hex!["aa61c7a624b0289509c41a7f76a28193fe5c84ec21a55a5068529c39f8797e31"]
+				.unchecked_into(),
 			//5EvP4zKAJDnj7JSomquk2pVRucYG6vvcepf6b6Hpjv95hKHf
-			hex!["7e5b7e136f9836ce5e0eaf44ea234de57843f71401c2d769987480f96558211b"].unchecked_into(),
+			hex!["7e5b7e136f9836ce5e0eaf44ea234de57843f71401c2d769987480f96558211b"]
+				.unchecked_into(),
 			//5EcGLLCftCN9zGM3sB769kJfZrPDsdvrSskUubGhP8nCH6Zr
-			hex!["708a66cf5c7af82c651ecdb9be402af15d867e9c17ac9dfac7db7da1945ae20c"].unchecked_into(),
+			hex!["708a66cf5c7af82c651ecdb9be402af15d867e9c17ac9dfac7db7da1945ae20c"]
+				.unchecked_into(),
 			//5DAgS6rUfqrVec19jTSZkMFJdQWLUT3WtnvdnHBmigYWadSk
-			hex!["30cae9e96670adf8ee5eefcdeeea68d72100a1001bb4a585783500dccd47fc5d"].unchecked_into(),
+			hex!["30cae9e96670adf8ee5eefcdeeea68d72100a1001bb4a585783500dccd47fc5d"]
+				.unchecked_into(),
 			//5HMfW3gxehXWQzTs7xLcau5jFe5448PB7BzJKzTTUNPbN6xc
-			hex!["ea1c68e01f6c3fcf125ff1829bfb0783ce593fc2c0a208a7ac256c2f959df87c"].unchecked_into(),
+			hex!["ea1c68e01f6c3fcf125ff1829bfb0783ce593fc2c0a208a7ac256c2f959df87c"]
+				.unchecked_into(),
 			//5CrF49SzojrG99QMbSJfQAuqaC8Ui23mk8V4crWwfZ2tbA68
-			hex!["22bb108dac5180f543a64ee46b3156538c0ab4c8f683ea692f7ffdebd49ec464"].unchecked_into(),
+			hex!["22bb108dac5180f543a64ee46b3156538c0ab4c8f683ea692f7ffdebd49ec464"]
+				.unchecked_into(),
 			//5CYFbx7uC7voQh7otWP9EMyCR62GxxNySNpJhFkUtoBe3VVG
-			hex!["037634779c308fb279373f1399fe6ba11c980913103417db3d4a910a72d9f5f95d"].unchecked_into(),
+			hex!["037634779c308fb279373f1399fe6ba11c980913103417db3d4a910a72d9f5f95d"]
+				.unchecked_into(),
 		),
 		(
 			//versi-bootnode-7
@@ -1262,19 +1311,26 @@ fn versi_staging_testnet_config_genesis(wasm_binary: &[u8]) -> rococo_runtime::G
 			//5FYk4J9j7Vce4fLLQQCb7RwdgrXbZ4rBrPPuak8rwaZhDXyt
 			hex!["9a16faa9bdd42666484f587f5f3ba9b3d24c0e9f66e1a602a91e3efbdb250f65"].into(),
 			//5DLugVPwnwTdpxcoL54UVrJy22mBWR1ojy6ft589NSm23jSB
-			hex!["3897f6fb853c16ef740ca9c287e82fadaa22a432e9652ce9fe79d1c3cc884d43"].unchecked_into(),
+			hex!["3897f6fb853c16ef740ca9c287e82fadaa22a432e9652ce9fe79d1c3cc884d43"]
+				.unchecked_into(),
 			//5Ddf9e2CRXeqFaJ7xqvndZwGTY3waxPXCEdYgR81gYfyMTwz
-			hex!["455e37c505d65a7c2ed94277a886457eed79f54e90e4982224f9c2d25eec3afb"].unchecked_into(),
+			hex!["455e37c505d65a7c2ed94277a886457eed79f54e90e4982224f9c2d25eec3afb"]
+				.unchecked_into(),
 			//5Eh7u54DiiGH4QUj8sbkL8gDgW5vMh7SP5JFVa8CBMCQvkqi
-			hex!["743e3b6949a62ecd51275790a3bf288266e71bb4c4296c7d097bbed18b4e0f6c"].unchecked_into(),
+			hex!["743e3b6949a62ecd51275790a3bf288266e71bb4c4296c7d097bbed18b4e0f6c"]
+				.unchecked_into(),
 			//5HontyHjLF3jQD7sqwKbKn1u3oFDPX2aoiqnQw1UGDBT1MKc
-			hex!["fe09af4e8d343fedabd0399dfb879d61c17d5144efb9318ee6cd19bc9419ea0c"].unchecked_into(),
+			hex!["fe09af4e8d343fedabd0399dfb879d61c17d5144efb9318ee6cd19bc9419ea0c"]
+				.unchecked_into(),
 			//5CSyR1g4pHHzQ7ppafUhXcg6RiqNJpsN5sbrVLnCfX9DCCUp
-			hex!["10fbc546e5615fa403516302ba67ff5139cbf2d6e289e9dbb77b41e1bd643b71"].unchecked_into(),
+			hex!["10fbc546e5615fa403516302ba67ff5139cbf2d6e289e9dbb77b41e1bd643b71"]
+				.unchecked_into(),
 			//5HGaFebZR87Yz94GA52uc8eb7k9nLwEqjqdmYUAfk9SveXah
-			hex!["e63a83f6bb16b18a42e8f4df6ff4e93f0b9b56f0339963ef43e6eb6a84723122"].unchecked_into(),
+			hex!["e63a83f6bb16b18a42e8f4df6ff4e93f0b9b56f0339963ef43e6eb6a84723122"]
+				.unchecked_into(),
 			//5EZ1QLHJM6R2Z7tafMREmjnEpTWNozsq2YQsVhRDQu1KWEHM
-			hex!["02a11607acf8e14511325c451468c2671514280349929bc0924e18da23f33677de"].unchecked_into(),
+			hex!["02a11607acf8e14511325c451468c2671514280349929bc0924e18da23f33677de"]
+				.unchecked_into(),
 		),
 	];
 

--- a/node/service/src/chain_spec.rs
+++ b/node/service/src/chain_spec.rs
@@ -1085,6 +1085,272 @@ fn rococo_staging_testnet_config_genesis(wasm_binary: &[u8]) -> rococo_runtime::
 	}
 }
 
+#[cfg(feature = "rococo-native")]
+fn versi_staging_testnet_config_genesis(wasm_binary: &[u8]) -> rococo_runtime::GenesisConfig {
+	use hex_literal::hex;
+	use sp_core::crypto::UncheckedInto;
+
+	// subkey inspect "$SECRET"
+	let endowed_accounts = vec![
+		// 5DwBmEFPXRESyEam5SsQF1zbWSCn2kCjyLW51hJHXe9vW4xs
+		hex!["52bc71c1eca5353749542dfdf0af97bf764f9c2f44e860cd485f1cd86400f649"].into(),
+	];
+
+	// ./scripts/prepare-test-net.sh 7 (i = versi-bootnode-$i)
+	let initial_authorities: Vec<(
+		AccountId,
+		AccountId,
+		BabeId,
+		GrandpaId,
+		ImOnlineId,
+		ValidatorId,
+		AssignmentId,
+		AuthorityDiscoveryId,
+		BeefyId,
+	)> = vec![
+		(
+			//versi-bootnode-0
+			//5DV3X8jaZ2pwUFnApusxSQc3hPZrbCKByvdGfLvwFqcKXRte
+			hex!["3ecc50bca30f045f94cc609ea3acf859ec2f2b93abd551e48394fa227ecb213d"].into(),
+			//5Ey8RkgbfT2aJyXjHg9KgUxDVbY64LGdx328compLvRE3fzG
+			hex!["8073f07bcddc9bd1542a7d3ea80fb6b5638e4589645e0da07a43910c4dcee85d"].into(),
+			//5FNF9A2TFd8PgutZd8bdPpbR1WSZCcjtnggd9EEq3oVKVM36
+			hex!["92152f39b165099df481ab7780f375f496fada5544e8b66cab67df4c493f3128"].unchecked_into(),
+			//5GL8faNkBoJS6TeZANDGjo8PcPyPs5WZQ85J5uB4jqPpyvh8
+			hex!["bcb520ea39e9bf69cb47b4dda167dafde1da01f01bb7d2c091ab50fb7bf8f1d7"].unchecked_into(),
+			//5EycsfQxcsFBjJ6setX8yivnceNiBoZtiQkcryvNQA9K4ULK
+			hex!["80d3b315a556758b44a2bf7467c2320e5840693c502ea686a89de6fc09c6ff38"].unchecked_into(),
+			//5DjqDw5NMmFdiafR9oVKZLasjY96jsd4sM5sdhMi8CT29vKx
+			hex!["4a139a3d919f44ba4709d65c9bd5e1c3c9392b4572e7e1cb28c73bd7591ad51c"].unchecked_into(),
+			//5F7Ka1qtTNVLityecYunrePHew3xCzV8HwZcrGZ9fuCS9NWv
+			hex!["86b36952561d89ba10ffc70d0daffcd6fdd55899dfe5c6e051135087b6b1e30b"].unchecked_into(),
+			//5Hb3UnjMkuTWN47mKFxFfrad3gG8QzVNHogq3Nmj9drmnQPZ
+			hex!["f45095e49de853e229bb15c402483d7633a5eba25da2c38e4fd3a94df4550151"].unchecked_into(),
+			//5EEFWe2ssjEToHmFcj8wCpbZxf8HPRVmDVKzjzwHmigDobTR
+			hex!["02dcfd39de094705787507db7a674840350592d9dd33c89256444915d9c35bd541"].unchecked_into(),
+		),
+		(
+			//versi-bootnode-1
+			//5Cag9DRBPYVHdpT4jTeciPeSikrFXmo6RvM7tvWTQgbtmVz8
+			hex!["16db97014b8c694fc3d7651d05f114d28dd3d106cddc5086738299709540c606"].into(),
+			//5D51C2P7GMEyQCfxLiQz77DrkDiywnX21kKkwjskBNWWLxwv
+			hex!["2c76957e95c326c576780c1b9628bc69b1862ea66e5fd614ddafe3a0dcc13d42"].into(),
+			//5FLny6BTcXSWMjZHgaiEbh5GPgyoTuDjqmd4PCCakKDPyYQL
+			hex!["90f9d4bdfa86aa74e7ae0540604a30001e7161ea129b10790168aa82cf140217"].unchecked_into(),
+			//5CpyzFD8PePkdLNCpMkGSoHp5xQy4bNoga4fgSV3gik9A5gV
+			hex!["21c5192e4837d49aaa84978cf50b042a7fefb6859a9ec36dbf31e47afa251106"].unchecked_into(),
+			//5HB5z5q5d2AdeT6EiQHd4KTweUr7m3KTZfvcMVJPBZfwh98v
+			hex!["e20b20f0e0e9ef3e7067cb686f5e863fd199ea9d15278f5c5a3f4e996c6b1b01"].unchecked_into(),
+			//5FTqYsXezAyeKREwBwMjrQURFMZ9VSVWLom4TNo514aD9F7A
+			hex!["96593dfd0b6a3df882e9e59f72254d510b5b3bc8426a14519c52e10366331220"].unchecked_into(),
+			//5HGhpDMW91xYabtKr29vUTuJqtsz1rucuEKiRz5cMUfYKVeG
+			hex!["e653f839e0a45f87ff64be931d88c2c675027f97f78db1dbc4e5c3b177e68a67"].unchecked_into(),
+			//5HKqyEHGaAo7zZYxeY5Q4Ti1B2ooXKYvvPBzjNXan3Fpz8z2
+			hex!["e8b928d70c45e2bec1d701e3bb74fed373848759edf8038780f2391233f0fd56"].unchecked_into(),
+			//5FezXdtwcWVutVyGJm498mWF4PpR3RRNjrpEYt7vLMrUaq11
+			hex!["0386f6aced2d95c885ef955f2309a377546e6d3b05ec65e3c0fe1b60b51780d9cb"].unchecked_into(),
+		),
+		(
+			//versi-bootnode-2
+			//5GYgFK92vZj833faADWvFvtfQNEMKJruA6hfnQAb3Pwj9CMU
+			hex!["c64663074d7725f30a8c3fcc199758a4ee663c1c17ffe3043019b70e7b25281f"].into(),
+			//5GYkr1M6niodK8wnfotoNyuyMfT8wkT7tiBBj7enkLDjg1kr
+			hex!["c655dd98e6b25308042cc7e2a4089b0771ac9706f093714b1752f7186cdff903"].into(),
+			//5EWkYHRWeLtsZ9ZZcTLt4hvsZ7vFeCyu5N8SFGvghNWN9BMX
+			hex!["6c55e1180722f0a2d03a52cd84e759e7bfc2ee0cf3d639557013e8f191534503"].unchecked_into(),
+			//5ExhjXhUcbD6BDDS4B4EUoDkxTWxuh2eADJS9XkrRMBSfp4a
+			hex!["8020d0489180c87dd10ff6bc18dc4ff0b5b5561f232782c6f81834cd61ce6d37"].unchecked_into(),
+			//5F7YM3nbu6MpYpaLhnTr44dyvkte1T6T5ZPxznRPkL6NA5JY
+			hex!["86de6bb5cba98095c96ce82161f28f1d5f95a143167512f5796ea816d572fb35"].unchecked_into(),
+			//5DyXfRM9Q7y9ai88iRwUL9PhGsFu1qsuXkUhV96HyN2QzPB5
+			hex!["5485ec8e2cf71922706e2276a9e3bcce1e1fd0719d987a2948cf7fbdf6d23e18"].unchecked_into(),
+			//5Hp5F5ANNvzfAPrAKjMAervCzkrjBTBD1G8FosrVAtAvsA5K
+			hex!["fe40b656eb50bf060345437f1cf1443ccdb38b757dc16fcdcec38f3db624cb19"].unchecked_into(),
+			//5FjR5ZGcphJwa8ASbN4Zy7G68CBSYncMCvnzb8NKjgavRu8c
+			hex!["a23acac4f679a303340473c47cf06dba6dd8cb25c31e4a198ac03198cb03bb0e"].unchecked_into(),
+			//5CuBp8GJhoEGPsqP7hxbMZFbvfqCXPtfGGqHyPg4TA6VjYZm
+			hex!["0342fa2e397cc25068d5264a9cddeec09eb7649e204b0fcff16bf72ec2a47121c3"].unchecked_into(),
+		),
+		(
+			//versi-bootnode-3
+			//5F7EdNXunchNw4DnsSqXnhMZXLQRxuo1my2Ea86suAJYyzLE
+			hex!["86a2c6550f0e7372bbe64ad6e8bd4417dac9895278036a6ddbce442dde507178"].into(),
+			//5GCTSeDTPkTYb2wDgqBNfZCHyrsPNrQ7o3gaqxhBisxw2y1j
+			hex!["b6da5fd68be99a24ee305870cbb4dbfbbf990b2c136fef5b86fde9ac3484027e"].into(),
+			//5Dqqu4PZ6CEfLmuHMq1Zh445sNoWMyGJ2koKDvViJaSNSym1
+			hex!["4ea95885e872aa9d0f1e0f02585d87d9014fcd0ee3c675d841adf332b328dd76"].unchecked_into(),
+			//5G112ibbo5RpVoEZzfk925XC5ZhudgGGcVp89EtjH8p4sgSd
+			hex!["ae1dc33683dfc96f85041e45acef7bcbe689bdaca2e6de30921e67cae9f04466"].unchecked_into(),
+			//5G8uMor82Z361AL26srzShBJPcZW2WeBWnyQ8zY8HeVT8iDc
+			hex!["b424a2d066d145ca99b33272102629e03f2de893f18eab1a4a7e00d82e99084e"].unchecked_into(),
+			//5Cvs52pMzW6ygaKuy9PqBuqd486aaXEi3jGrdAvSPcBqAuMN
+			hex!["264148d4090f3e25889513c2fabc16a1f5868beec84a416587f67bb7408ff47a"].unchecked_into(),
+			//5CV7RehhbrMXhRy5ULMLz1Z6K9phjAHTh7NciS32PAxcdhUS
+			hex!["129d3a979bad7850a525b3fe2941f70a9405657fdd213819fba209cf00206434"].unchecked_into(),
+			//5CvZfiLpvRFXnL3TnQ6q174AaKU5ZbEEApDfXqyfwTZthpxp
+			hex!["2606b43856617293a0f9743979a812c18d6dd3940aa5cb42765385d925165b51"].unchecked_into(),
+			//5EwUULMqszegdrs8Papyu2goesMzQqiRVFd5HBo95KabrJn3
+			hex!["03cdaac2af6282482e37761f74cd86f70b0dff46faa38fea38babec5c639113ea0"].unchecked_into(),
+		),
+		(
+			//versi-bootnode-4
+			//5Enyc7KFiNo3cya5nrDe4iwMGxMFxcJHGqAcraKnnrEocL8T
+			hex!["78b5ca28f56ae0022fa876d5ced684e18ed1afdb4fa1e6da5c1d26389ad9a434"].into(),
+			//5H8hp25gnTvVuePYD5DkYnzS3nSuWm3y9tdrh1omFj8U8wxm
+			hex!["e039fec00afaebd9af15014440e1febe07a2effa1c72bfca738ca770c5eb177f"].into(),
+			//5H3Yis5m8ikyU8nUHGYNfvvPyFtHPDb19KGTxYhweznNJHUH
+			hex!["dc4b2c14c9f977b976354aeee6e1dfc849b5757eea2e11f7dc6fe4e0a34d4939"].unchecked_into(),
+			//5Dp77hZ1bG4kdkVa2LR44dZqCDrLDfgfRpSygZTCVrhHuFjX
+			hex!["4d56154951c76353b204066dbff0fec9b335854a1608f8d4ca04375c78adfb39"].unchecked_into(),
+			//5D5aY6RacUAtLQPRJLNfYUogDmJxQKpuRfGSm75mFLU25cdM
+			hex!["2ce6d63237e54cb99d830b5fdf7ad097d5954a0102b77527211b337cda84ca09"].unchecked_into(),
+			//5Hpvfs89hBjqEF1cXUiKZXBv4no1oC2mHw1NpQ11C6XCgMGW
+			hex!["fee71993dbcfc41bd6a053ab9f9705f377c71b875f8abcbb2081c241f9f3a31e"].unchecked_into(),
+			//5EPXP8yv65npdoSig3ru22XXS4CYeK1W5P2pGXrTSu13CnUo
+			hex!["66d2de6592d6ec8093a7ef738595e70174306e3d5399306a114e41348b218c3f"].unchecked_into(),
+			//5HGTYBcTgosXkVGUchpPT2VYi5QEhYNbYgUdXhX1NQwpAYGD
+			hex!["e623e93ada87315b9b67125577bcf38d63351eba661767e8d4c7f82de214bb42"].unchecked_into(),
+			//5EbCRa9Bhjy2b5MDcSAUXZJaNgZSQG8BHFFDoEVKcrrTmNib
+			hex!["030cc28a18b53affcc5983e0e4e2f874bd81af4da90243110e7ee685661d90dd15"].unchecked_into(),
+		),
+		(
+			//versi-bootnode-5
+			//5HisWy38kugc3Ay4XAsrg1DAU3pJfsQhmPToY5Y726ZbunV8
+			hex!["fa49031c0aef3f7c987ff7c1511f36ff1bd5545aaa9cbec76d939b617fae6f5d"].into(),
+			//5ERiUsDFC7W25CPJ7nZXQRa1hCNW3z5wdMNWeEfNJLQgVHuU
+			hex!["687eb8a75f901f5484d59aebab21d9738f8423f74748144c4d8a90a57220de31"].into(),
+			//5FsX7MZEXD8PV4VMKitxHJDQHaw9aufVYDeHj9TnSZMxh19Z
+			hex!["a8690eb5c4394f2dac264ff2a970009c4807cc3ea1c23e5b8b1b522e3bc94617"].unchecked_into(),
+			//5E2BMeeNPfHoaoeGkRcwuSXmHxQKt7kkVWwzzg1EyeM9Uxsq
+			hex!["568b4d8776812f8314825dab808aab07dd98019b60e3b897946df389507b89ac"].unchecked_into(),
+			//5GNT2rvcVbiyXoBEFCEmyuKPHCeyU7t6Z9b9P9QZZQt5zkyP
+			hex!["be7972bbc4ce359af881678ee1ccdcbc1b649bcbc6f82c9c849c051bac818f03"].unchecked_into(),
+			//5CDkpJJQDfjwrhWG6mHMQehLLvykkqcutcU8hyv5qR5cxeAs
+			hex!["06e72b8577559c32b628b1ec4b1ee1c75b2fc6ba02b286f569b96e3055a6b759"].unchecked_into(),
+			//5FgrEDFDrbmghpVaeg59cy5hsRk5bNpXcKBy9sCg8STa9KZ8
+			hex!["a045b736887076556955e5ad890b074734af90d704e1efaf3b6c8713d90b0d27"].unchecked_into(),
+			//5GTFG9KW6j628acwSV9GgjNxMRenUihEvBGfoz8L74EGog9t
+			hex!["c2220ceedfb0bc06b2b66023beec32efb9ec2be9c1f17de34b66ed8188322e34"].unchecked_into(),
+			//5DebHv79jFE6WPrTPyc5Ks7yzcYrQCnqJ16k6F2CCqXJDLQt
+			hex!["035a4034a2786140da49c5568609ca1e82d1a7a1d526cdc0eb0c0e467d53522c5d"].unchecked_into(),
+		),
+		(
+			//versi-bootnode-6
+			//5CkxZrGeGfpQApMw6HAtBF9xiPgxoA3Ei7xZ69aRry6iGzNL
+			hex!["1eb355a44a059486fb38a3ef359f315c84d078f46fca3abf8a7a12a68ef69630"].into(),
+			//5CofQrypXYMKDygCjfshuaTeN92NhRh4kApgjnK99rgCm1Aq
+			hex!["20c3526ed124f9119185c079d6670461c88e04d76f1ef2cb38b02ff3c24f081a"].into(),
+			//5Fv73X7dtFm15hqYG338MNJ1qw351BbgjzFAh3rgXdjDFaCT
+			hex!["aa61c7a624b0289509c41a7f76a28193fe5c84ec21a55a5068529c39f8797e31"].unchecked_into(),
+			//5EvP4zKAJDnj7JSomquk2pVRucYG6vvcepf6b6Hpjv95hKHf
+			hex!["7e5b7e136f9836ce5e0eaf44ea234de57843f71401c2d769987480f96558211b"].unchecked_into(),
+			//5EcGLLCftCN9zGM3sB769kJfZrPDsdvrSskUubGhP8nCH6Zr
+			hex!["708a66cf5c7af82c651ecdb9be402af15d867e9c17ac9dfac7db7da1945ae20c"].unchecked_into(),
+			//5DAgS6rUfqrVec19jTSZkMFJdQWLUT3WtnvdnHBmigYWadSk
+			hex!["30cae9e96670adf8ee5eefcdeeea68d72100a1001bb4a585783500dccd47fc5d"].unchecked_into(),
+			//5HMfW3gxehXWQzTs7xLcau5jFe5448PB7BzJKzTTUNPbN6xc
+			hex!["ea1c68e01f6c3fcf125ff1829bfb0783ce593fc2c0a208a7ac256c2f959df87c"].unchecked_into(),
+			//5CrF49SzojrG99QMbSJfQAuqaC8Ui23mk8V4crWwfZ2tbA68
+			hex!["22bb108dac5180f543a64ee46b3156538c0ab4c8f683ea692f7ffdebd49ec464"].unchecked_into(),
+			//5CYFbx7uC7voQh7otWP9EMyCR62GxxNySNpJhFkUtoBe3VVG
+			hex!["037634779c308fb279373f1399fe6ba11c980913103417db3d4a910a72d9f5f95d"].unchecked_into(),
+		),
+		(
+			//versi-bootnode-7
+			//5EyVyQG5L4zY9xTrpqrH4NYFeTxz6Nv7QVi7mAKxashEDaDn
+			hex!["80bc77f11e1eeb294548f05fc00b3069aac59b8281f85eb22515c954bededf52"].into(),
+			//5FYk4J9j7Vce4fLLQQCb7RwdgrXbZ4rBrPPuak8rwaZhDXyt
+			hex!["9a16faa9bdd42666484f587f5f3ba9b3d24c0e9f66e1a602a91e3efbdb250f65"].into(),
+			//5DLugVPwnwTdpxcoL54UVrJy22mBWR1ojy6ft589NSm23jSB
+			hex!["3897f6fb853c16ef740ca9c287e82fadaa22a432e9652ce9fe79d1c3cc884d43"].unchecked_into(),
+			//5Ddf9e2CRXeqFaJ7xqvndZwGTY3waxPXCEdYgR81gYfyMTwz
+			hex!["455e37c505d65a7c2ed94277a886457eed79f54e90e4982224f9c2d25eec3afb"].unchecked_into(),
+			//5Eh7u54DiiGH4QUj8sbkL8gDgW5vMh7SP5JFVa8CBMCQvkqi
+			hex!["743e3b6949a62ecd51275790a3bf288266e71bb4c4296c7d097bbed18b4e0f6c"].unchecked_into(),
+			//5HontyHjLF3jQD7sqwKbKn1u3oFDPX2aoiqnQw1UGDBT1MKc
+			hex!["fe09af4e8d343fedabd0399dfb879d61c17d5144efb9318ee6cd19bc9419ea0c"].unchecked_into(),
+			//5CSyR1g4pHHzQ7ppafUhXcg6RiqNJpsN5sbrVLnCfX9DCCUp
+			hex!["10fbc546e5615fa403516302ba67ff5139cbf2d6e289e9dbb77b41e1bd643b71"].unchecked_into(),
+			//5HGaFebZR87Yz94GA52uc8eb7k9nLwEqjqdmYUAfk9SveXah
+			hex!["e63a83f6bb16b18a42e8f4df6ff4e93f0b9b56f0339963ef43e6eb6a84723122"].unchecked_into(),
+			//5EZ1QLHJM6R2Z7tafMREmjnEpTWNozsq2YQsVhRDQu1KWEHM
+			hex!["02a11607acf8e14511325c451468c2671514280349929bc0924e18da23f33677de"].unchecked_into(),
+		),
+	];
+
+	const ENDOWMENT: u128 = 1_000_000 * ROC;
+	const STASH: u128 = 100 * ROC;
+
+	rococo_runtime::GenesisConfig {
+		system: rococo_runtime::SystemConfig { code: wasm_binary.to_vec() },
+		balances: rococo_runtime::BalancesConfig {
+			balances: endowed_accounts
+				.iter()
+				.map(|k: &AccountId| (k.clone(), ENDOWMENT))
+				.chain(initial_authorities.iter().map(|x| (x.0.clone(), STASH)))
+				.collect(),
+		},
+		beefy: Default::default(),
+		indices: rococo_runtime::IndicesConfig { indices: vec![] },
+		session: rococo_runtime::SessionConfig {
+			keys: initial_authorities
+				.iter()
+				.map(|x| {
+					(
+						x.0.clone(),
+						x.0.clone(),
+						rococo_session_keys(
+							x.2.clone(),
+							x.3.clone(),
+							x.4.clone(),
+							x.5.clone(),
+							x.6.clone(),
+							x.7.clone(),
+							x.8.clone(),
+						),
+					)
+				})
+				.collect::<Vec<_>>(),
+		},
+		babe: rococo_runtime::BabeConfig {
+			authorities: Default::default(),
+			epoch_config: Some(rococo_runtime::BABE_GENESIS_EPOCH_CONFIG),
+		},
+		grandpa: Default::default(),
+		im_online: Default::default(),
+		collective: Default::default(),
+		membership: Default::default(),
+		authority_discovery: rococo_runtime::AuthorityDiscoveryConfig { keys: vec![] },
+		sudo: rococo_runtime::SudoConfig { key: Some(endowed_accounts[0].clone()) },
+		paras: rococo_runtime::ParasConfig { paras: vec![] },
+		hrmp: Default::default(),
+		configuration: rococo_runtime::ConfigurationConfig {
+			config: default_parachains_host_configuration(),
+		},
+		registrar: rococo_runtime::RegistrarConfig {
+			next_free_para_id: polkadot_primitives::v2::LOWEST_PUBLIC_ID,
+		},
+		xcm_pallet: Default::default(),
+		transaction_payment: Default::default(),
+		bridge_rococo_grandpa: rococo_runtime::BridgeRococoGrandpaConfig {
+			owner: Some(endowed_accounts[0].clone()),
+			..Default::default()
+		},
+		bridge_wococo_grandpa: rococo_runtime::BridgeWococoGrandpaConfig {
+			owner: Some(endowed_accounts[0].clone()),
+			..Default::default()
+		},
+		bridge_rococo_messages: rococo_runtime::BridgeRococoMessagesConfig {
+			owner: Some(endowed_accounts[0].clone()),
+			..Default::default()
+		},
+		bridge_wococo_messages: rococo_runtime::BridgeWococoMessagesConfig {
+			owner: Some(endowed_accounts[0].clone()),
+			..Default::default()
+		},
+	}
+}
+
 /// Returns the properties for the [`PolkadotChainSpec`].
 pub fn polkadot_chain_spec_properties() -> serde_json::map::Map<String, serde_json::Value> {
 	serde_json::json!({
@@ -1212,7 +1478,7 @@ pub fn versi_staging_testnet_config() -> Result<RococoChainSpec, String> {
 		"versi_staging_testnet",
 		ChainType::Live,
 		move || RococoGenesisExt {
-			runtime_genesis_config: rococo_staging_testnet_config_genesis(wasm_binary),
+			runtime_genesis_config: versi_staging_testnet_config_genesis(wasm_binary),
 			session_length_in_blocks: Some(100),
 		},
 		boot_nodes,


### PR DESCRIPTION
Versi has new `initial_authorities`. It is now different from the rococo. 


## Changes
I just copy paste the `rococo_staging_testnet_config_genesis` function and updated `initial_authorities`. Most probably there are the correct and elegant way how to do it. 