### PR TITLE
Switch to using distroless in Dockerfiles

### DIFF
--- a/scripts/ci/dockerfiles/polkadot_injected_debug.Dockerfile
+++ b/scripts/ci/dockerfiles/polkadot_injected_debug.Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/ubuntu:20.04
+FROM docker.io/library/debian:11.3
 
 # metadata
 ARG VCS_REF

--- a/scripts/ci/dockerfiles/polkadot_injected_release.Dockerfile
+++ b/scripts/ci/dockerfiles/polkadot_injected_release.Dockerfile
@@ -10,9 +10,9 @@ ARG GPG_KEYSERVER="keyserver.ubuntu.com"
 # install tools
 RUN set -eu -o pipefail && \
 	apk add --no-cache curl gnupg && \
-	curl -fsSL -o polkadot https://github.com/paritytech/polkadot/releases/download/${POLKADOT_VERSION}/polkadot && \
-	curl -fsSL -o polkadot.sha256 https://github.com/paritytech/polkadot/releases/download/${POLKADOT_VERSION}/polkadot.sha256 && \
-	curl -fsSL -o polkadot.asc https://github.com/paritytech/polkadot/releases/download/${POLKADOT_VERSION}/polkadot.asc && \
+	curl -fsSL -o polkadot https://releases.parity.io/polkadot/x86_64-debian:stretch/${POLKADOT_VERSION}/polkadot && \
+	curl -fsSL -o polkadot.sha256 https://releases.parity.io/polkadot/x86_64-debian:stretch/${POLKADOT_VERSION}/polkadot.sha256 && \
+	curl -fsSL -o polkadot.asc https://releases.parity.io/polkadot/x86_64-debian:stretch/${POLKADOT_VERSION}/polkadot.asc && \
 	sha256sum -c polkadot.sha256 && \
 	gpg --keyserver ${GPG_KEYSERVER} --recv-keys ${POLKADOT_GPGKEY} && \
 	gpg --verify polkadot.asc polkadot && \

--- a/scripts/ci/dockerfiles/staking-miner/staking-miner_builder.Dockerfile
+++ b/scripts/ci/dockerfiles/staking-miner/staking-miner_builder.Dockerfile
@@ -10,11 +10,12 @@ LABEL description="This is the build stage. Here we create the binary."
 
 WORKDIR /app
 COPY . /app
-RUN cargo build --locked --$PROFILE --package staking-miner
+RUN cargo build --locked --${PROFILE} --package staking-miner
 
 # ===== SECOND STAGE ======
-
-FROM docker.io/library/ubuntu:20.04
+# gcr.io/distroless/cc-debian11:nonroot
+FROM gcr.io/distroless/cc-debian11@sha256:c2e1b5b0c64e3a44638e79246130d480ff09645d543d27e82ffd46a6e78a3ce3
+ARG PROFILE=release
 LABEL description="This is the 2nd stage: a very small image where we copy the binary."
 LABEL io.parity.image.authors="devops-team@parity.io" \
 	io.parity.image.vendor="Parity Technologies" \
@@ -25,22 +26,16 @@ LABEL io.parity.image.authors="devops-team@parity.io" \
 	io.parity.image.created="${BUILD_DATE}" \
 	io.parity.image.documentation="https://github.com/paritytech/polkadot/"
 
-ARG PROFILE=release
-COPY --from=builder /app/target/$PROFILE/staking-miner /usr/local/bin
-
-RUN useradd -u 1000 -U -s /bin/sh miner && \
-	rm -rf /usr/bin /usr/sbin
+COPY --from=builder /app/target/$PROFILE/staking-miner /staking-miner
 
 # show backtraces
 ENV RUST_BACKTRACE 1
-
-USER miner
 
 ENV SEED=""
 ENV URI="wss://rpc.polkadot.io"
 ENV RUST_LOG="info"
 
 # check if the binary works in this container
-RUN /usr/local/bin/staking-miner --version
+RUN ["/staking-miner", "--version"]
 
-ENTRYPOINT [ "/usr/local/bin/staking-miner" ]
+ENTRYPOINT [ "/staking-miner" ]

--- a/scripts/ci/dockerfiles/staking-miner/staking-miner_injected.Dockerfile
+++ b/scripts/ci/dockerfiles/staking-miner/staking-miner_injected.Dockerfile
@@ -1,4 +1,5 @@
-FROM docker.io/library/ubuntu:20.04
+# gcr.io/distroless/cc-debian11:nonroot
+FROM gcr.io/distroless/cc-debian11@sha256:c2e1b5b0c64e3a44638e79246130d480ff09645d543d27e82ffd46a6e78a3ce3
 
 # metadata
 ARG VCS_REF
@@ -17,27 +18,14 @@ LABEL io.parity.image.authors="devops-team@parity.io" \
 # show backtraces
 ENV RUST_BACKTRACE 1
 
-# install tools and dependencies
-RUN apt-get update && \
-	DEBIAN_FRONTEND=noninteractive apt-get install -y \
-		libssl1.1 \
-		ca-certificates && \
-# apt cleanup
-	apt-get autoremove -y && \
-	apt-get clean && \
-	find /var/lib/apt/lists/ -type f -not -name lock -delete; \
-	useradd -u 1000 -U -s /bin/sh miner
-
 # add binary to docker image
-COPY ./staking-miner /usr/local/bin
-
-USER miner
+COPY ./staking-miner /staking-miner
 
 ENV SEED=""
 ENV URI="wss://rpc.polkadot.io"
 ENV RUST_LOG="info"
 
 # check if the binary works in this container
-RUN /usr/local/bin/staking-miner --version
+RUN ["/staking-miner", "--version"]
 
-ENTRYPOINT [ "/usr/local/bin/staking-miner" ]
+ENTRYPOINT [ "/staking-miner" ]


### PR DESCRIPTION
Signed-off-by: bakhtin <a@bakhtin.net>

We currently use a [full blown ubuntu:20.04](https://github.com/paritytech/polkadot/blob/4d72c27767e0d8be6417292c579ab969fc1ad1bb/scripts/ci/dockerfiles/polkadot/polkadot_builder.Dockerfile#L10) for Polkadot release images. While useful for debugging, an Ubuntu image contains packages that are not required to run a Polkadot node. 
Using a fat Docker image:
- increases the network bandwidth as larger image needs to be pulled. It is especially important in orchestrated environments (like Kubernetes) when pulls happen often;
- widens the attack surface due to a larger number of dependencies in a resulting image;
- decreases noise/signal ratio of security scanners as it should scan through more packages

In this change request I refactored dockerfiles for Polkadot and Staking Miner. It seems that `collator` and `malus` images are mostly used by internal Parity teams. So I did not touch them.

I switched to [Google's Distroless](https://github.com/GoogleContainerTools/distroless) for a resulting image in a multistage build. Distroless is a very minimal Docker image that tailored to only contain dependencies required for a particular programming language. For Rust it only contains glibc and its dependencies. See https://github.com/GoogleContainerTools/distroless/blob/main/cc/BUILD for how the base image is built.

The resulting image is 26% smaller (149MB vs 203MB). The base image is now just 18% (22MB) out of the final size vs 60% (73MB).

## **Breaking Changes**

A resulting image does not contain a shell. It may become a **breaking change** for some consumers of the image. One place where it will certainly break is Helm charts as we're using shell invocations there: https://github.com/paritytech/helm-charts/blob/858e50af71f5bdde3e8a4e4bfbb80ea4f1b6dfe5/charts/node/templates/statefulset.yaml#L315
There might be other places that I'm unaware of. I will try to refactor the Helm chart but we should really communicate the shell removal to the community.

Nevertheless, it is too optimistic to rely on a presence of a shell in a Docker image. Any preparations should be done outside of the running image (e.g., in initContainers).