### PR TITLE
Add a sudo proxy to Westend and Rococo

### DIFF
--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -972,6 +972,7 @@ parameter_types! {
 pub enum ProxyType {
 	Any,
 	CancelProxy,
+	Sudo,
 	Auction,
 }
 impl Default for ProxyType {
@@ -985,6 +986,9 @@ impl InstanceFilter<Call> for ProxyType {
 			ProxyType::Any => true,
 			ProxyType::CancelProxy => {
 				matches!(c, Call::Proxy(pallet_proxy::Call::reject_announcement { .. }))
+			},
+			ProxyType::Sudo => {
+				matches!(c, Call::Sudo(..) | Call::Utility(..))
 			},
 			ProxyType::Auction => matches!(
 				c,

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -752,6 +752,7 @@ pub enum ProxyType {
 	SudoBalances,
 	IdentityJudgement,
 	CancelProxy,
+	Sudo,
 	Auction,
 }
 impl Default for ProxyType {
@@ -820,6 +821,9 @@ impl InstanceFilter<Call> for ProxyType {
 			),
 			ProxyType::CancelProxy => {
 				matches!(c, Call::Proxy(pallet_proxy::Call::reject_announcement { .. }))
+			},
+			ProxyType::Sudo => {
+				matches!(c, Call::Sudo(..) | Call::Utility(..))
 			},
 			ProxyType::Auction => matches!(
 				c,


### PR DESCRIPTION
This PR adds a new ProxyType called `Sudo` to Westend and Rococo.
