### PR TITLE
ensure proxy branches are independent

### DIFF
--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -1229,7 +1229,7 @@ impl InstanceFilter<Call> for ProxyType {
 			(x, y) if x == y => true,
 			(ProxyType::Any, _) => true,
 			(_, ProxyType::Any) => false,
-			(ProxyType::NonTransfer, _) => true,
+			(ProxyType::NonTransfer, y) => y != ProxyType::Any,
 			_ => false,
 		}
 	}

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -1212,7 +1212,7 @@ impl InstanceFilter<Call> for ProxyType {
 			(x, y) if x == y => true,
 			(ProxyType::Any, _) => true,
 			(_, ProxyType::Any) => false,
-			(ProxyType::NonTransfer, _) => true,
+			(ProxyType::NonTransfer, y) => y != ProxyType::Any,
 			_ => false,
 		}
 	}

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -833,7 +833,7 @@ impl InstanceFilter<Call> for ProxyType {
 			(x, y) if x == y => true,
 			(ProxyType::Any, _) => true,
 			(_, ProxyType::Any) => false,
-			(ProxyType::NonTransfer, _) => true,
+			(ProxyType::NonTransfer, y) => y != ProxyType::Any,
 			_ => false,
 		}
 	}


### PR DESCRIPTION
There's a bit of debate on whether match arms are evaluated in a certain order and whether that will be guaranteed for all time in the future. This change makes sure the match arms are independent of ordering so we have no future surprises.