### PR TITLE
Update metric before bailing out

### DIFF
--- a/node/network/gossip-support/src/lib.rs
+++ b/node/network/gossip-support/src/lib.rs
@@ -256,12 +256,13 @@ where
 					}
 				}
 
-				// Gossip topology is only relevant for authorities in the current session.
-				let our_index =
-					ensure_i_am_an_authority(&self.keystore, &session_info.discovery_keys).await?;
-
 				if is_new_session {
 					self.update_authority_status_metrics(&session_info).await;
+
+					// Gossip topology is only relevant for authorities in the current session.
+					let our_index =
+						ensure_i_am_an_authority(&self.keystore, &session_info.discovery_keys)
+							.await?;
 
 					update_gossip_topology(
 						sender,
@@ -281,10 +282,12 @@ where
 		let maybe_index =
 			match ensure_i_am_an_authority(&self.keystore, &session_info.discovery_keys).await {
 				Ok(index) => {
+					gum::trace!(target: LOG_TARGET, "We are now an authority",);
 					self.metrics.on_is_authority();
 					Some(index)
 				},
 				Err(util::Error::NotAValidator) => {
+					gum::trace!(target: LOG_TARGET, "We are no longer an authority",);
 					self.metrics.on_is_not_authority();
 					self.metrics.on_is_not_parachain_validator();
 					None
@@ -301,8 +304,10 @@ where
 			// if our index is in this set to avoid searching for the keys.
 			// https://github.com/paritytech/polkadot/blob/a52dca2be7840b23c19c153cf7e110b1e3e475f8/runtime/parachains/src/configuration.rs#L148
 			if validator_index < parachain_validators_this_session {
+				gum::trace!(target: LOG_TARGET, "We are now a parachain validator",);
 				self.metrics.on_is_parachain_validator();
 			} else {
+				gum::trace!(target: LOG_TARGET, "We are no longer a parachain validator",);
 				self.metrics.on_is_not_parachain_validator();
 			}
 		}

--- a/node/network/gossip-support/src/lib.rs
+++ b/node/network/gossip-support/src/lib.rs
@@ -277,6 +277,7 @@ where
 
 	// Checks if the node is an authority and also updates `polkadot_node_is_authority` and
 	// `polkadot_node_is_parachain_validator` metrics accordingly.
+	// On success, returns the index of our keys in `session_info.discovery_keys`.
 	async fn check_authority_status_and_update_metrics(
 		&mut self,
 		session_info: &SessionInfo,


### PR DESCRIPTION
Fixes #5664.

The initial implementation (introduced in 0.9.16) was not handling errors correctly - effectively bailing out when we're no longer a validator - [see here](https://github.com/paritytech/polkadot/blob/8bb84d23a6f298530ea9286596a3d962dab43384/node/network/gossip-support/src/lib.rs#L270). This used to work fine until https://github.com/paritytech/polkadot/commit/8bb84d23a6f298530ea9286596a3d962dab43384 because it was always done against `determine_relevant_authorities` output which includes the validators from past sessions, while the secondary check inside the update code would check against current session (the new session). The mentioned change introduces topology changes that make the initial check to be performed on the current session authorities only, resulting in not updating the metrics to 0 when a validator is removed from the active set.