### PR TITLE
Add publish docker staking-miner

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -456,7 +456,7 @@ publish-staking-miner-image:
   <<:                              *publish-refs
   variables:
     <<:                            *image-variables
-    # scripts/ci/dockerfiles/malus_injected.Dockerfile
+    # scripts/ci/dockerfiles/staking-miner/staking-miner_injected.Dockerfile
     DOCKERFILE:                    ci/dockerfiles/staking-miner/staking-miner_injected.Dockerfile
     IMAGE_NAME:                    docker.io/paritytech/staking-miner
     GIT_STRATEGY:                  none

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -453,7 +453,10 @@ publish-malus-image:
 publish-staking-miner:
   stage:                           stage2
   <<:                              *build-push-image
-  <<:                              *publish-refs
+  # uncomment after debug
+  # <<:                              *publish-refs
+  # remove after debug
+  <<:                              *common-refs
   variables:
     <<:                            *image-variables
     # scripts/ci/dockerfiles/malus_injected.Dockerfile

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -106,12 +106,22 @@ default:
     - if: $CI_COMMIT_REF_NAME == "master"
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
 
-.publish-refs:                     &publish-refs
+.deploy-testnet-refs:              &deploy-testnet-refs
   rules:
     - if: $CI_PIPELINE_SOURCE == "pipeline"
       when: never
     - if: $CI_PIPELINE_SOURCE == "schedule"
     - if: $CI_COMMIT_REF_NAME == "master"
+
+.publish-refs:                     &publish-refs
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "pipeline"
+      when: never
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+    - if: $CI_PIPELINE_SOURCE == "web" &&
+          $CI_COMMIT_REF_NAME == "master"
+    - if: $CI_COMMIT_REF_NAME == "master"
+    - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
 
 .build-push-image:                 &build-push-image
   <<:                              *kubernetes-env
@@ -264,6 +274,22 @@ build-malus:
     - echo -n "${CI_COMMIT_REF_NAME}" > ./artifacts/VERSION
     - echo -n "${CI_COMMIT_REF_NAME}-${CI_COMMIT_SHORT_SHA}" > ./artifacts/EXTRATAG
     - echo "polkadot-test-malus = $(cat ./artifacts/VERSION) (EXTRATAG = $(cat ./artifacts/EXTRATAG))"
+    - cp -r ./scripts/* ./artifacts
+
+build-staking-miner:
+  stage:                           stage1
+  <<:                              *collect-artifacts
+  <<:                              *docker-env
+  <<:                              *compiler-info
+  <<:                              *common-refs
+  script:
+    - time cargo build --locked --release --package staking-miner
+    # pack artifacts
+    - mkdir -p ./artifacts
+    - mv ./target/release/staking-miner ./artifacts/.
+    - echo -n "${CI_COMMIT_REF_NAME}" > ./artifacts/VERSION
+    - echo -n "${CI_COMMIT_REF_NAME}-${CI_COMMIT_SHORT_SHA}" > ./artifacts/EXTRATAG
+    - echo "staking-miner = $(cat ./artifacts/VERSION) (EXTRATAG = $(cat ./artifacts/EXTRATAG))"
     - cp -r ./scripts/* ./artifacts
 
 #### stage:                        stage2
@@ -423,6 +449,23 @@ publish-malus-image:
     reports:
       # this artifact is used in zombienet-tests job
       dotenv: ./artifacts/malus.env
+
+publish-staking-miner:
+  stage:                           stage2
+  <<:                              *build-push-image
+  <<:                              *publish-refs
+  variables:
+    <<:                            *image-variables
+    # scripts/ci/dockerfiles/malus_injected.Dockerfile
+    DOCKERFILE:                    ci/dockerfiles/staking-miner/staking-miner_injected.Dockerfile
+    IMAGE_NAME:                    docker.io/paritytech/staking-miner
+    GIT_STRATEGY:                  none
+    DOCKER_USER:                   ${Docker_Hub_User_Parity}
+    DOCKER_PASS:                   ${Docker_Hub_Pass_Parity}
+  needs:
+    - job:                         build-staking-miner
+      artifacts:                   true
+
 
 publish-s3-release:                &publish-s3
   stage:                           stage3
@@ -586,7 +629,7 @@ deploy-parity-testnet:
   needs:
     - job:                         test-deterministic-wasm
       artifacts:                   false
-  <<:                              *publish-refs
+  <<:                              *deploy-testnet-refs
   variables:
     POLKADOT_CI_COMMIT_NAME:       "${CI_COMMIT_REF_NAME}"
     POLKADOT_CI_COMMIT_REF:        "${CI_COMMIT_SHORT_SHA}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -453,10 +453,7 @@ publish-malus-image:
 publish-staking-miner:
   stage:                           stage2
   <<:                              *build-push-image
-  # uncomment after debug
-  # <<:                              *publish-refs
-  # remove after debug
-  <<:                              *common-refs
+  <<:                              *publish-refs
   variables:
     <<:                            *image-variables
     # scripts/ci/dockerfiles/malus_injected.Dockerfile

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -450,7 +450,7 @@ publish-malus-image:
       # this artifact is used in zombienet-tests job
       dotenv: ./artifacts/malus.env
 
-publish-staking-miner:
+publish-staking-miner-image:
   stage:                           stage2
   <<:                              *build-push-image
   <<:                              *publish-refs


### PR DESCRIPTION
The PR adds 2 jobs: the first one build `staking-miner` binary and the second one creates docker image with it and publishes with 2 tags: `ref_name` (e.g. `master`, `v0.9.23`, etc) and `ref_name-short_commit_sha` (e.g. `master-7443bc4f`)

Close https://github.com/paritytech/ci_cd/issues/442 
Close https://github.com/paritytech/ci_cd/issues/459