### PR TITLE
pvf: unignore `terminates_on_timeout` test

### DIFF
--- a/node/core/pvf/tests/it/main.rs
+++ b/node/core/pvf/tests/it/main.rs
@@ -78,7 +78,6 @@ impl TestHost {
 }
 
 #[async_std::test]
-#[ignore]
 async fn terminates_on_timeout() {
 	let host = TestHost::new();
 


### PR DESCRIPTION
Was ignored [here](https://github.com/paritytech/polkadot/pull/5145/commits/6a21cc84634d70e3e49ca24972203dcad93b6daf) at the time because of [this](https://gitlab.parity.io/parity/mirrors/polkadot/-/jobs/1457003). It is unclear why was it happening.

I was trying to reproduce this locally by continually repeating the test and it never failed for me. I think it is OK to reenable.