### PR TITLE
Add release-engineering to CI files' reviewers

### DIFF
--- a/.github/pr-custom-review.yml
+++ b/.github/pr-custom-review.yml
@@ -19,19 +19,20 @@ rules:
     check_type: changed_files
     condition:
       include: .*
-      # excluding files from 'Runtime files' and 'CI team' rules
+      # excluding files from 'Runtime files' and 'CI files' rules
       exclude: ^runtime/(kusama|polkadot)/src/[^/]+\.rs$|^\.gitlab-ci\.yml|^scripts/ci/.*|^\.github/.*
     min_approvals: 2
     teams:
       - core-devs
 
-  - name: CI team
+  - name: CI files
     check_type: changed_files
     condition:
       include: ^\.gitlab-ci\.yml|^scripts/ci/.*|^\.github/.*
     min_approvals: 2
     teams:
       - ci
+      - release-engineering
 
 prevent-review-request:
   teams:


### PR DESCRIPTION
@paritytech/release-engineering frequently edits the files reviewed by CI, for instance

- https://github.com/paritytech/polkadot/commits/master/scripts/ci?until=2022-06-27
- https://github.com/paritytech/polkadot/commits/master/.github?until=2022-06-27

The ownership of files in those directories either overlaps with @paritytech/ci or are instead owned by @paritytech/release-engineering, therefore it makes sense to more accurately represent their ownership through pr-custom-review's rules.

After discussion on Matrix, @TriplEight mentioned that it would be fine for @paritytech/release-engineering to be included in the "CI files" rule. If that's not acceptable for some reason, please suggest alternatives in the comments.