### PR TITLE
backport minimum weight to fee to master

### DIFF
--- a/parachain/test-parachains/Cargo.toml
+++ b/parachain/test-parachains/Cargo.toml
@@ -6,7 +6,7 @@ description = "Integration tests using the test-parachains"
 edition = "2021"
 
 [dependencies]
-tiny-keccak = "2.0.2"
+tiny-keccak = { version = "2.0.2", features = ["keccak"] }
 parity-scale-codec = { version = "3.1.5", default-features = false, features = ["derive"] }
 
 adder = { package = "test-parachain-adder", path = "adder" }

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -81,11 +81,13 @@ parameter_types! {
 	pub const TargetBlockFullness: Perquintill = Perquintill::from_percent(25);
 	/// The adjustment variable of the runtime. Higher values will cause `TargetBlockFullness` to
 	/// change the fees more rapidly.
-	pub AdjustmentVariable: Multiplier = Multiplier::saturating_from_rational(3, 100_000);
+	// pub AdjustmentVariable: Multiplier = Multiplier::saturating_from_rational(3, 100_000);
+	pub AdjustmentVariable: Multiplier = Multiplier::saturating_from_rational(3, 1000);
 	/// Minimum amount of the multiplier. This value cannot be too low. A test case should ensure
 	/// that combined with `AdjustmentVariable`, we can recover from the minimum.
 	/// See `multiplier_can_grow_from_zero`.
-	pub MinimumMultiplier: Multiplier = Multiplier::saturating_from_rational(1, 1_000_000u128);
+	// pub MinimumMultiplier: Multiplier = Multiplier::saturating_from_rational(1, 1_000_000u128);
+	pub MinimumMultiplier: Multiplier = Multiplier::saturating_from_rational(1, 1_000u128);
 	/// Maximum length of block. Up to 5MB.
 	pub BlockLength: limits::BlockLength =
 	limits::BlockLength::max_with_normal_ratio(5 * 1024 * 1024, NORMAL_DISPATCH_RATIO);
@@ -243,117 +245,4 @@ macro_rules! prod_or_fast {
 			$prod
 		}
 	};
-}
-
-#[cfg(test)]
-mod multiplier_tests {
-	use super::*;
-	use frame_support::{
-		parameter_types,
-		weights::{DispatchClass, Weight},
-	};
-	use sp_core::H256;
-	use sp_runtime::{
-		testing::Header,
-		traits::{BlakeTwo256, Convert, IdentityLookup, One},
-		Perbill,
-	};
-
-	type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;
-	type Block = frame_system::mocking::MockBlock<Runtime>;
-
-	frame_support::construct_runtime!(
-		pub enum Runtime where
-			Block = Block,
-			NodeBlock = Block,
-			UncheckedExtrinsic = UncheckedExtrinsic,
-		{
-			System: frame_system::{Pallet, Call, Config, Storage, Event<T>}
-		}
-	);
-
-	parameter_types! {
-		pub const BlockHashCount: u64 = 250;
-		pub const AvailableBlockRatio: Perbill = Perbill::one();
-		pub BlockLength: frame_system::limits::BlockLength =
-			frame_system::limits::BlockLength::max(2 * 1024);
-		pub BlockWeights: frame_system::limits::BlockWeights =
-			frame_system::limits::BlockWeights::simple_max(1024);
-	}
-
-	impl frame_system::Config for Runtime {
-		type BaseCallFilter = frame_support::traits::Everything;
-		type BlockWeights = BlockWeights;
-		type BlockLength = ();
-		type DbWeight = ();
-		type Origin = Origin;
-		type Index = u64;
-		type BlockNumber = u64;
-		type Call = Call;
-		type Hash = H256;
-		type Hashing = BlakeTwo256;
-		type AccountId = u64;
-		type Lookup = IdentityLookup<Self::AccountId>;
-		type Header = Header;
-		type Event = Event;
-		type BlockHashCount = BlockHashCount;
-		type Version = ();
-		type PalletInfo = PalletInfo;
-		type AccountData = ();
-		type OnNewAccount = ();
-		type OnKilledAccount = ();
-		type SystemWeightInfo = ();
-		type SS58Prefix = ();
-		type OnSetCode = ();
-		type MaxConsumers = frame_support::traits::ConstU32<16>;
-	}
-
-	fn run_with_system_weight<F>(w: Weight, mut assertions: F)
-	where
-		F: FnMut() -> (),
-	{
-		let mut t: sp_io::TestExternalities = frame_system::GenesisConfig::default()
-			.build_storage::<Runtime>()
-			.unwrap()
-			.into();
-		t.execute_with(|| {
-			System::set_block_consumed_resources(w, 0);
-			assertions()
-		});
-	}
-
-	#[test]
-	fn multiplier_can_grow_from_zero() {
-		let minimum_multiplier = MinimumMultiplier::get();
-		let target = TargetBlockFullness::get() *
-			BlockWeights::get().get(DispatchClass::Normal).max_total.unwrap();
-		// if the min is too small, then this will not change, and we are doomed forever.
-		// the weight is 1/100th bigger than target.
-		run_with_system_weight(target * 101 / 100, || {
-			let next = SlowAdjustingFeeUpdate::<Runtime>::convert(minimum_multiplier);
-			assert!(next > minimum_multiplier, "{:?} !>= {:?}", next, minimum_multiplier);
-		})
-	}
-
-	#[test]
-	#[ignore]
-	fn multiplier_growth_simulator() {
-		// assume the multiplier is initially set to its minimum. We update it with values twice the
-		//target (target is 25%, thus 50%) and we see at which point it reaches 1.
-		let mut multiplier = MinimumMultiplier::get();
-		let block_weight = TargetBlockFullness::get() *
-			BlockWeights::get().get(DispatchClass::Normal).max_total.unwrap() *
-			2;
-		let mut blocks = 0;
-		while multiplier <= Multiplier::one() {
-			run_with_system_weight(block_weight, || {
-				let next = SlowAdjustingFeeUpdate::<Runtime>::convert(multiplier);
-				// ensure that it is growing as well.
-				assert!(next > multiplier, "{:?} !>= {:?}", next, multiplier);
-				multiplier = next;
-			});
-			blocks += 1;
-			println!("block = {} multiplier {:?}", blocks, multiplier);
-		}
-	}
 }

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -81,13 +81,11 @@ parameter_types! {
 	pub const TargetBlockFullness: Perquintill = Perquintill::from_percent(25);
 	/// The adjustment variable of the runtime. Higher values will cause `TargetBlockFullness` to
 	/// change the fees more rapidly.
-	// pub AdjustmentVariable: Multiplier = Multiplier::saturating_from_rational(3, 100_000);
 	pub AdjustmentVariable: Multiplier = Multiplier::saturating_from_rational(3, 1000);
 	/// Minimum amount of the multiplier. This value cannot be too low. A test case should ensure
 	/// that combined with `AdjustmentVariable`, we can recover from the minimum.
 	/// See `multiplier_can_grow_from_zero`.
-	// pub MinimumMultiplier: Multiplier = Multiplier::saturating_from_rational(1, 1_000_000u128);
-	pub MinimumMultiplier: Multiplier = Multiplier::saturating_from_rational(1, 1_000u128);
+	pub MinimumMultiplier: Multiplier = Multiplier::saturating_from_rational(1, 10u128);
 	/// Maximum length of block. Up to 5MB.
 	pub BlockLength: limits::BlockLength =
 	limits::BlockLength::max_with_normal_ratio(5 * 1024 * 1024, NORMAL_DISPATCH_RATIO);

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -81,7 +81,7 @@ parameter_types! {
 	pub const TargetBlockFullness: Perquintill = Perquintill::from_percent(25);
 	/// The adjustment variable of the runtime. Higher values will cause `TargetBlockFullness` to
 	/// change the fees more rapidly.
-	pub AdjustmentVariable: Multiplier = Multiplier::saturating_from_rational(3, 1000);
+	pub AdjustmentVariable: Multiplier = Multiplier::saturating_from_rational(3, 10_000);
 	/// Minimum amount of the multiplier. This value cannot be too low. A test case should ensure
 	/// that combined with `AdjustmentVariable`, we can recover from the minimum.
 	/// See `multiplier_can_grow_from_zero`.

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -81,7 +81,7 @@ parameter_types! {
 	pub const TargetBlockFullness: Perquintill = Perquintill::from_percent(25);
 	/// The adjustment variable of the runtime. Higher values will cause `TargetBlockFullness` to
 	/// change the fees more rapidly.
-	pub AdjustmentVariable: Multiplier = Multiplier::saturating_from_rational(3, 10_000);
+	pub AdjustmentVariable: Multiplier = Multiplier::saturating_from_rational(75, 1000_000);
 	/// Minimum amount of the multiplier. This value cannot be too low. A test case should ensure
 	/// that combined with `AdjustmentVariable`, we can recover from the minimum.
 	/// See `multiplier_can_grow_from_zero`.

--- a/runtime/kusama/Cargo.toml
+++ b/runtime/kusama/Cargo.toml
@@ -98,7 +98,7 @@ xcm-builder = { package = "xcm-builder", path = "../../xcm/xcm-builder", default
 
 [dev-dependencies]
 hex-literal = "0.3.4"
-tiny-keccak = "2.0.2"
+tiny-keccak = { version = "2.0.2", features = ["keccak"] }
 keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate", branch = "master" }
 sp-trie = { git = "https://github.com/paritytech/substrate", branch = "master" }
 separator = "0.4.1"

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -2177,8 +2177,8 @@ mod multiplier_tests {
 	use super::*;
 	use frame_support::{dispatch::GetDispatchInfo, traits::OnFinalize};
 	use runtime_common::{MinimumMultiplier, TargetBlockFullness};
-	use sp_runtime::traits::{Convert, One};
 	use separator::Separatable;
+	use sp_runtime::traits::Convert;
 
 	fn run_with_system_weight<F>(w: Weight, mut assertions: F)
 	where
@@ -2237,7 +2237,7 @@ mod multiplier_tests {
 			pallet_transaction_payment::NextFeeMultiplier::<Runtime>::set(MinimumMultiplier::get());
 		});
 
-		while multiplier <= Multiplier::from_u32(2) {
+		while multiplier <= Multiplier::from_u32(1) {
 			t.execute_with(|| {
 				// imagine this tx was called.
 				let fee = TransactionPayment::compute_fee(len, &info, 0);
@@ -2253,7 +2253,10 @@ mod multiplier_tests {
 
 				println!(
 					"block = {} / multiplier {:?} / fee = {:?} / fess so far {:?}",
-					blocks, multiplier, fee.separated_string(), fees_paid.separated_string()
+					blocks,
+					multiplier,
+					fee.separated_string(),
+					fees_paid.separated_string()
 				);
 			});
 			blocks += 1;
@@ -2265,7 +2268,6 @@ mod multiplier_tests {
 		// assume the multiplier is initially set to its minimum. We update it with values twice the
 		//target (target is 25%, thus 50%) and we see at which point it reaches 1.
 		let mut multiplier = Multiplier::from_u32(2);
-		let block_weight = 0;
 		let mut blocks = 0;
 
 		let mut t: sp_io::TestExternalities = frame_system::GenesisConfig::default()
@@ -2286,10 +2288,7 @@ mod multiplier_tests {
 				assert!(next < multiplier, "{:?} !>= {:?}", next, multiplier);
 				multiplier = next;
 
-				println!(
-					"block = {} / multiplier {:?}",
-					blocks, multiplier
-				);
+				println!("block = {} / multiplier {:?}", blocks, multiplier);
 			});
 			blocks += 1;
 		}

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -2171,3 +2171,127 @@ mod tests_fess {
 		assert_eq_error_rate!(deposit, UNITS * 16 / 100, UNITS / 100);
 	}
 }
+
+#[cfg(test)]
+mod multiplier_tests {
+	use super::*;
+	use frame_support::{dispatch::GetDispatchInfo, traits::OnFinalize};
+	use runtime_common::{MinimumMultiplier, TargetBlockFullness};
+	use sp_runtime::traits::{Convert, One};
+	use separator::Separatable;
+
+	fn run_with_system_weight<F>(w: Weight, mut assertions: F)
+	where
+		F: FnMut() -> (),
+	{
+		let mut t: sp_io::TestExternalities = frame_system::GenesisConfig::default()
+			.build_storage::<Runtime>()
+			.unwrap()
+			.into();
+		t.execute_with(|| {
+			System::set_block_consumed_resources(w, 0);
+			assertions()
+		});
+	}
+
+	#[test]
+	fn multiplier_can_grow_from_zero() {
+		let minimum_multiplier = MinimumMultiplier::get();
+		let target = TargetBlockFullness::get() *
+			BlockWeights::get().get(DispatchClass::Normal).max_total.unwrap();
+		// if the min is too small, then this will not change, and we are doomed forever.
+		// the weight is 1/100th bigger than target.
+		run_with_system_weight(target * 101 / 100, || {
+			let next = SlowAdjustingFeeUpdate::<Runtime>::convert(minimum_multiplier);
+			assert!(next > minimum_multiplier, "{:?} !>= {:?}", next, minimum_multiplier);
+		})
+	}
+
+	#[test]
+	fn multiplier_growth_simulator() {
+		// assume the multiplier is initially set to its minimum. We update it with values twice the
+		//target (target is 25%, thus 50%) and we see at which point it reaches 1.
+		let mut multiplier = MinimumMultiplier::get();
+		let block_weight = BlockWeights::get().get(DispatchClass::Normal).max_total.unwrap();
+		let mut blocks = 0;
+		let mut fees_paid = 0;
+
+		let call = frame_system::Call::<Runtime>::fill_block {
+			ratio: Perbill::from_rational(
+				block_weight,
+				BlockWeights::get().get(DispatchClass::Normal).max_total.unwrap(),
+			),
+		};
+		println!("calling {:?}", call);
+		let info = call.get_dispatch_info();
+		// convert to outer call.
+		let call = Call::System(call);
+		let len = call.using_encoded(|e| e.len()) as u32;
+
+		let mut t: sp_io::TestExternalities = frame_system::GenesisConfig::default()
+			.build_storage::<Runtime>()
+			.unwrap()
+			.into();
+		// set the minimum
+		t.execute_with(|| {
+			pallet_transaction_payment::NextFeeMultiplier::<Runtime>::set(MinimumMultiplier::get());
+		});
+
+		while multiplier <= Multiplier::from_u32(2) {
+			t.execute_with(|| {
+				// imagine this tx was called.
+				let fee = TransactionPayment::compute_fee(len, &info, 0);
+				fees_paid += fee;
+
+				// this will update the multiplier.
+				System::set_block_consumed_resources(block_weight, 0);
+				TransactionPayment::on_finalize(1);
+				let next = TransactionPayment::next_fee_multiplier();
+
+				assert!(next > multiplier, "{:?} !>= {:?}", next, multiplier);
+				multiplier = next;
+
+				println!(
+					"block = {} / multiplier {:?} / fee = {:?} / fess so far {:?}",
+					blocks, multiplier, fee.separated_string(), fees_paid.separated_string()
+				);
+			});
+			blocks += 1;
+		}
+	}
+
+	#[test]
+	fn multiplier_cool_down_simulator() {
+		// assume the multiplier is initially set to its minimum. We update it with values twice the
+		//target (target is 25%, thus 50%) and we see at which point it reaches 1.
+		let mut multiplier = Multiplier::from_u32(2);
+		let block_weight = 0;
+		let mut blocks = 0;
+
+		let mut t: sp_io::TestExternalities = frame_system::GenesisConfig::default()
+			.build_storage::<Runtime>()
+			.unwrap()
+			.into();
+		// set the minimum
+		t.execute_with(|| {
+			pallet_transaction_payment::NextFeeMultiplier::<Runtime>::set(multiplier);
+		});
+
+		while multiplier > Multiplier::from_u32(0) {
+			t.execute_with(|| {
+				// this will update the multiplier.
+				TransactionPayment::on_finalize(1);
+				let next = TransactionPayment::next_fee_multiplier();
+
+				assert!(next < multiplier, "{:?} !>= {:?}", next, multiplier);
+				multiplier = next;
+
+				println!(
+					"block = {} / multiplier {:?}",
+					blocks, multiplier
+				);
+			});
+			blocks += 1;
+		}
+	}
+}

--- a/runtime/polkadot/Cargo.toml
+++ b/runtime/polkadot/Cargo.toml
@@ -91,7 +91,7 @@ xcm-builder = { package = "xcm-builder", path = "../../xcm/xcm-builder", default
 
 [dev-dependencies]
 hex-literal = "0.3.4"
-tiny-keccak = "2.0.2"
+tiny-keccak = { version = "2.0.2", features = ["keccak"] }
 keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate", branch = "master" }
 sp-trie = { git = "https://github.com/paritytech/substrate", branch = "master" }
 trie-db = "0.23.1"

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -2062,6 +2062,8 @@ mod test_fees {
 
 		test_with_multiplier(min_multiplier);
 		test_with_multiplier(Multiplier::saturating_from_rational(1, 1u128));
+		test_with_multiplier(Multiplier::saturating_from_rational(1, 1_0u128));
+		test_with_multiplier(Multiplier::saturating_from_rational(1, 1_00u128));
 		test_with_multiplier(Multiplier::saturating_from_rational(1, 1_000u128));
 		test_with_multiplier(Multiplier::saturating_from_rational(1, 1_000_000u128));
 		test_with_multiplier(Multiplier::saturating_from_rational(1, 1_000_000_000u128));
@@ -2156,6 +2158,7 @@ mod multiplier_tests {
 	use frame_support::{dispatch::GetDispatchInfo, traits::OnFinalize};
 	use runtime_common::{MinimumMultiplier, TargetBlockFullness};
 	use sp_runtime::traits::{Convert, One};
+	use separator::Separatable;
 
 	fn run_with_system_weight<F>(w: Weight, mut assertions: F)
 	where
@@ -2214,7 +2217,7 @@ mod multiplier_tests {
 			pallet_transaction_payment::NextFeeMultiplier::<Runtime>::set(MinimumMultiplier::get());
 		});
 
-		while multiplier <= Multiplier::one() {
+		while multiplier <= Multiplier::from_u32(2) {
 			t.execute_with(|| {
 				// imagine this tx was called.
 				let fee = TransactionPayment::compute_fee(len, &info, 0);
@@ -2230,7 +2233,42 @@ mod multiplier_tests {
 
 				println!(
 					"block = {} / multiplier {:?} / fee = {:?} / fess so far {:?}",
-					blocks, multiplier, fee, fees_paid
+					blocks, multiplier, fee.separated_string(), fees_paid.separated_string()
+				);
+			});
+			blocks += 1;
+		}
+	}
+
+	#[test]
+	fn multiplier_cool_down_simulator() {
+		// assume the multiplier is initially set to its minimum. We update it with values twice the
+		//target (target is 25%, thus 50%) and we see at which point it reaches 1.
+		let mut multiplier = Multiplier::from_u32(2);
+		let block_weight = 0;
+		let mut blocks = 0;
+
+		let mut t: sp_io::TestExternalities = frame_system::GenesisConfig::default()
+			.build_storage::<Runtime>()
+			.unwrap()
+			.into();
+		// set the minimum
+		t.execute_with(|| {
+			pallet_transaction_payment::NextFeeMultiplier::<Runtime>::set(multiplier);
+		});
+
+		while multiplier > Multiplier::from_u32(0) {
+			t.execute_with(|| {
+				// this will update the multiplier.
+				TransactionPayment::on_finalize(1);
+				let next = TransactionPayment::next_fee_multiplier();
+
+				assert!(next < multiplier, "{:?} !>= {:?}", next, multiplier);
+				multiplier = next;
+
+				println!(
+					"block = {} / multiplier {:?}",
+					blocks, multiplier
 				);
 			});
 			blocks += 1;

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -2023,7 +2023,6 @@ mod test_fees {
 	}
 
 	#[test]
-	#[ignore]
 	fn block_cost() {
 		let max_block_weight = BlockWeights::get().max_block;
 		let raw_fee = WeightToFee::weight_to_fee(&max_block_weight);
@@ -2036,7 +2035,6 @@ mod test_fees {
 	}
 
 	#[test]
-	#[ignore]
 	fn transfer_cost_min_multiplier() {
 		let min_multiplier = MinimumMultiplier::get();
 		let call = pallet_balances::Call::<Runtime>::transfer_keep_alive {
@@ -2149,5 +2147,93 @@ mod test {
 			reduce the size of Call.
 			If the limit is too strong, maybe consider increase the limit",
 		);
+	}
+}
+
+#[cfg(test)]
+mod multiplier_tests {
+	use super::*;
+	use frame_support::{dispatch::GetDispatchInfo, traits::OnFinalize};
+	use runtime_common::{MinimumMultiplier, TargetBlockFullness};
+	use sp_runtime::traits::{Convert, One};
+
+	fn run_with_system_weight<F>(w: Weight, mut assertions: F)
+	where
+		F: FnMut() -> (),
+	{
+		let mut t: sp_io::TestExternalities = frame_system::GenesisConfig::default()
+			.build_storage::<Runtime>()
+			.unwrap()
+			.into();
+		t.execute_with(|| {
+			System::set_block_consumed_resources(w, 0);
+			assertions()
+		});
+	}
+
+	#[test]
+	fn multiplier_can_grow_from_zero() {
+		let minimum_multiplier = MinimumMultiplier::get();
+		let target = TargetBlockFullness::get() *
+			BlockWeights::get().get(DispatchClass::Normal).max_total.unwrap();
+		// if the min is too small, then this will not change, and we are doomed forever.
+		// the weight is 1/100th bigger than target.
+		run_with_system_weight(target * 101 / 100, || {
+			let next = SlowAdjustingFeeUpdate::<Runtime>::convert(minimum_multiplier);
+			assert!(next > minimum_multiplier, "{:?} !>= {:?}", next, minimum_multiplier);
+		})
+	}
+
+	#[test]
+	fn multiplier_growth_simulator() {
+		// assume the multiplier is initially set to its minimum. We update it with values twice the
+		//target (target is 25%, thus 50%) and we see at which point it reaches 1.
+		let mut multiplier = MinimumMultiplier::get();
+		let block_weight = BlockWeights::get().get(DispatchClass::Normal).max_total.unwrap();
+		let mut blocks = 0;
+		let mut fees_paid = 0;
+
+		let call = frame_system::Call::<Runtime>::fill_block {
+			ratio: Perbill::from_rational(
+				block_weight,
+				BlockWeights::get().get(DispatchClass::Normal).max_total.unwrap(),
+			),
+		};
+		println!("calling {:?}", call);
+		let info = call.get_dispatch_info();
+		// convert to outer call.
+		let call = Call::System(call);
+		let len = call.using_encoded(|e| e.len()) as u32;
+
+		let mut t: sp_io::TestExternalities = frame_system::GenesisConfig::default()
+			.build_storage::<Runtime>()
+			.unwrap()
+			.into();
+		// set the minimum
+		t.execute_with(|| {
+			pallet_transaction_payment::NextFeeMultiplier::<Runtime>::set(MinimumMultiplier::get());
+		});
+
+		while multiplier <= Multiplier::one() {
+			t.execute_with(|| {
+				// imagine this tx was called.
+				let fee = TransactionPayment::compute_fee(len, &info, 0);
+				fees_paid += fee;
+
+				// this will update the multiplier.
+				System::set_block_consumed_resources(block_weight, 0);
+				TransactionPayment::on_finalize(1);
+				let next = TransactionPayment::next_fee_multiplier();
+
+				assert!(next > multiplier, "{:?} !>= {:?}", next, multiplier);
+				multiplier = next;
+
+				println!(
+					"block = {} / multiplier {:?} / fee = {:?} / fess so far {:?}",
+					blocks, multiplier, fee, fees_paid
+				);
+			});
+			blocks += 1;
+		}
 	}
 }

--- a/runtime/test-runtime/Cargo.toml
+++ b/runtime/test-runtime/Cargo.toml
@@ -65,7 +65,7 @@ xcm = { path = "../../xcm", default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.3.4"
-tiny-keccak = "2.0.2"
+tiny-keccak = { version = "2.0.2", features = ["keccak"] }
 keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate", branch = "master" }
 sp-trie = { git = "https://github.com/paritytech/substrate", branch = "master" }
 serde_json = "1.0.81"

--- a/runtime/westend/Cargo.toml
+++ b/runtime/westend/Cargo.toml
@@ -94,7 +94,7 @@ xcm-builder = { package = "xcm-builder", path = "../../xcm/xcm-builder", default
 
 [dev-dependencies]
 hex-literal = "0.3.4"
-tiny-keccak = "2.0.2"
+tiny-keccak = { version = "2.0.2", features = ["keccak"] }
 keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate", branch = "master" }
 sp-trie = { git = "https://github.com/paritytech/substrate", branch = "master" }
 serde_json = "1.0.81"


### PR DESCRIPTION
backports https://github.com/paritytech/polkadot/pull/5738 to master. 

This slightly increases the adjustment of weight fee, and more importantly increases the minimum value of weight to fee multiplier to 0.1, instead of being a near-zero value. 

This has no impact on fees, since the weight fee is so small now that it has no effect.

Example of transfer fee with different weight multipliers:

```
multiplier = FixedU128(0.100000000000000000) // fee details = FeeDetails { inclusion_fee: Some(InclusionFee { base_fee: 10000000, len_fee: 140000000, adjusted_weight_fee: 1574520 }), tip: 0 } // final fee = "151,574,520"
multiplier = FixedU128(1.000000000000000000) // fee details = FeeDetails { inclusion_fee: Some(InclusionFee { base_fee: 10000000, len_fee: 140000000, adjusted_weight_fee: 15745200 }), tip: 0 } // final fee = "165,745,200"
multiplier = FixedU128(0.100000000000000000) // fee details = FeeDetails { inclusion_fee: Some(InclusionFee { base_fee: 10000000, len_fee: 140000000, adjusted_weight_fee: 1574520 }), tip: 0 } // final fee = "151,574,520"
multiplier = FixedU128(0.010000000000000000) // fee details = FeeDetails { inclusion_fee: Some(InclusionFee { base_fee: 10000000, len_fee: 140000000, adjusted_weight_fee: 157452 }), tip: 0 } // final fee = "150,157,452"
multiplier = FixedU128(0.001000000000000000) // fee details = FeeDetails { inclusion_fee: Some(InclusionFee { base_fee: 10000000, len_fee: 140000000, adjusted_weight_fee: 15745 }), tip: 0 } // final fee = "150,015,745"
multiplier = FixedU128(0.000001000000000000) // fee details = FeeDetails { inclusion_fee: Some(InclusionFee { base_fee: 10000000, len_fee: 140000000, adjusted_weight_fee: 15 }), tip: 0 } // final fee = "150,000,015"
multiplier = FixedU128(0.000000001000000000) // fee details = FeeDetails { inclusion_fee: Some(InclusionFee { base_fee: 10000000, len_fee: 140000000, adjusted_weight_fee: 0 }), tip: 0 } // final fee = "150,000,000"
```