### PR TITLE
Fix regexp to find the repo name

### DIFF
--- a/.github/workflows/release-01_branch-check.yml
+++ b/.github/workflows/release-01_branch-check.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  tag_rc:
+  check_branch:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources

--- a/scripts/ci/github/check-rel-br
+++ b/scripts/ci/github/check-rel-br
@@ -9,7 +9,7 @@
 
 grv=$(git remote --verbose | grep push)
 export RUST_LOG=none
-REPO=$(echo "$grv" | cut -d ' ' -f1 | cut -d$'\t' -f2 | cut -d '/' -f2 | cut -d '.' -f1 | sort | uniq)
+REPO=$(echo "$grv" | cut -d ' ' -f1 | cut -d$'\t' -f2 | sed 's/.*github.com\/\(.*\)/\1/g' | cut -d '/' -f2 | cut -d '.' -f1 | sort | uniq)
 echo "[+] Detected repo: $REPO"
 
 BRANCH=$(git branch --show-current)


### PR DESCRIPTION
Currently the `branch check` worfklow [fails](https://github.com/paritytech/polkadot/actions/workflows/release-01_branch-check.yml) because the regexp to extract the name of the repo from `git remote --verbose | grep push` did not support https remotes.

This PR fixes that.