### PR TITLE
Several small fixes to the templates of the release notes

### DIFF
--- a/scripts/ci/changelog/templates/changes_misc.md.tera
+++ b/scripts/ci/changelog/templates/changes_misc.md.tera
@@ -12,7 +12,7 @@
             {%- endif -%}
         {% endif -%}
     {% endif -%}
-{% endfor %}
+{% endfor -%}
 
 ### Misc
 

--- a/scripts/ci/changelog/templates/global_priority.md.tera
+++ b/scripts/ci/changelog/templates/global_priority.md.tera
@@ -18,12 +18,5 @@
     {%- set global_prio = substrate_prio -%}
 {%- endif -%}
 
-{# We show the result #}
+{#- We show the result #}
 {{ m_p::high_priority(p=global_prio, changes=changes) }}
-
-<!--
-- Polkadot: {{ polkadot_prio }}
-- Substrate: {{ substrate_prio }}
--->
-
-{# todo: show high prio list here #}

--- a/scripts/ci/changelog/templates/high_priority.md.tera
+++ b/scripts/ci/changelog/templates/high_priority.md.tera
@@ -21,17 +21,15 @@
 
 {% if p >= 3 %}
 The changes motivating this priority level are:
-
 {% for pr in changes | sort(attribute="merged_at") -%}
     {%- if pr.meta.C -%}
         {%- if pr.meta.C.value == p %}
 - {{ m_c::change(c=pr) }}
-{%- if pr.meta.B and pr.meta.B.value == 7 %}
-(RUNTIME)
+{%- if pr.meta.B and pr.meta.B.value == 7 %} (RUNTIME)
 {% endif %}
         {%- endif -%}
     {%- endif -%}
-{%- endfor %}
+{%- endfor -%}
 {%- else -%}
 <!-- No relevant Priority label as been detected for p={{ p }} -->
 {%- endif -%}

--- a/scripts/ci/changelog/templates/host_functions.md.tera
+++ b/scripts/ci/changelog/templates/host_functions.md.tera
@@ -20,6 +20,7 @@
 {%- if host_fn_count == 0 %}
 ℹ️ This release does not contain any new host functions.
 {% elif host_fn_count == 1 -%}
+{# ---- #}
 ⚠️ The runtimes in this release contain one new **host function**.
 
 ⚠️ It is critical that you update your client before the chain switches to the new runtime.

--- a/scripts/ci/changelog/templates/migrations-db.md.tera
+++ b/scripts/ci/changelog/templates/migrations-db.md.tera
@@ -1,4 +1,4 @@
-{%- import "change.md.tera" as m_c %}
+{% import "change.md.tera" as m_c %}
 {%- set_global db_migration_count = 0 -%}
 {%- for pr in changes -%}
     {%- if pr.meta.B and pr.meta.B.value == 0 %}
@@ -6,7 +6,7 @@
     {%- elif pr.meta.E and pr.meta.E.value == 2 -%}
         {%- set_global db_migration_count = db_migration_count + 1 -%}
     {%- endif -%}
-{%- endfor -%}
+{%- endfor %}
 
 ## Database Migrations
 

--- a/scripts/ci/changelog/templates/migrations-runtime.md.tera
+++ b/scripts/ci/changelog/templates/migrations-runtime.md.tera
@@ -6,7 +6,7 @@
     {%- elif pr.meta.E and pr.meta.E.value == 1 -%}
         {%- set_global runtime_migration_count = runtime_migration_count + 1 -%}
     {%- endif -%}
-{%- endfor -%}
+{%- endfor %}
 
 ## Runtime Migrations
 

--- a/scripts/ci/changelog/templates/runtime.md.tera
+++ b/scripts/ci/changelog/templates/runtime.md.tera
@@ -16,13 +16,13 @@
 <!-- pkg    : {{ runtime.data.pkg }} -->
 
 ```
-🏋️ Runtime Size:		{{ runtime.data.runtimes.compressed.subwasm.size | filesizeformat }} ({{ runtime.data.runtimes.compressed.subwasm.size }} bytes)
-🔥 Core Version:		{{ runtime.data.runtimes.compressed.subwasm.core_version }}
-🗜 Compressed:			{{ compressed }}: {{ comp_ratio | round(method="ceil", precision=2) }}%
-🎁 Metadata version:		V{{ runtime.data.runtimes.compressed.subwasm.metadata_version }}
-🗳️ system.setCode hash:		{{ runtime.data.runtimes.compressed.subwasm.proposal_hash }}
-🗳️ authorizeUpgrade hash:	{{ runtime.data.runtimes.compressed.subwasm.parachain_authorize_upgrade_hash }}
-🗳️ Blake2-256 hash:		{{ runtime.data.runtimes.compressed.subwasm.blake2_256 }}
-📦 IPFS:			{{ runtime.data.runtimes.compressed.subwasm.ipfs_hash }}
+🏋️ Runtime Size:           {{ runtime.data.runtimes.compressed.subwasm.size | filesizeformat }} ({{ runtime.data.runtimes.compressed.subwasm.size }} bytes)
+🔥 Core Version:           {{ runtime.data.runtimes.compressed.subwasm.core_version }}
+🗜 Compressed:             {{ compressed }}: {{ comp_ratio | round(method="ceil", precision=2) }}%
+🎁 Metadata version:       V{{ runtime.data.runtimes.compressed.subwasm.metadata_version }}
+🗳️ system.setCode hash:    {{ runtime.data.runtimes.compressed.subwasm.proposal_hash }}
+🗳️ authorizeUpgrade hash:  {{ runtime.data.runtimes.compressed.subwasm.parachain_authorize_upgrade_hash }}
+🗳️ Blake2-256 hash:        {{ runtime.data.runtimes.compressed.subwasm.blake2_256 }}
+📦 IPFS:                   {{ runtime.data.runtimes.compressed.subwasm.ipfs_hash }}
 ```
 {%- endmacro runtime %}

--- a/scripts/ci/changelog/templates/runtimes.md.tera
+++ b/scripts/ci/changelog/templates/runtimes.md.tera
@@ -1,6 +1,8 @@
 {# This include shows the list and details of the runtimes #}
 {%- import "runtime.md.tera" as m_r -%}
 
+{# ---  #}
+
 ## Runtimes
 
 {% set rtm = srtool[0] -%}

--- a/scripts/ci/changelog/templates/template.md.tera
+++ b/scripts/ci/changelog/templates/template.md.tera
@@ -17,7 +17,6 @@ This release contains the changes from `{{ env.REF1 | replace(from="refs/tags/",
 
 {# -- Manual free notes section -- #}
 {% include "_free_notes.md.tera" -%}
-{# --------------------------------- #}
 
 {# -- Important automatic section -- #}
 {% include "global_priority.md.tera" -%}


### PR DESCRIPTION
Fixing some spacing, new lines, etc...
- includes into the templates some fixes for what is usually fixed by hand
- improve new lines (ie new lines before new chapters)
- switch runtime alignment to spaces (formerly tabs), that should make **both** GH and Element happpy
