### PR TITLE
Remove debug_assert to allow Fungible(0)

### DIFF
--- a/xcm/src/v1/multiasset.rs
+++ b/xcm/src/v1/multiasset.rs
@@ -157,7 +157,6 @@ impl Fungibility {
 
 impl From<u128> for Fungibility {
 	fn from(amount: u128) -> Fungibility {
-		debug_assert_ne!(amount, 0);
 		Fungibility::Fungible(amount)
 	}
 }


### PR DESCRIPTION
This PR removes a `debug_assert` which checked any `Fungible` amount was > 0 only when converting `From<u128>`.

My assumption is that a `Fungible(0)` is valid. If that's not the case, then this should be enforced very differently (for starters, it should not depend on build configuration).