### PR TITLE
Fix test `full_block_council_election_cost`

### DIFF
--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -2125,7 +2125,9 @@ mod test_fees {
 			"can support {} voters in a single block for council elections; total bond {}",
 			voters, cost_dollars,
 		);
-		assert!(cost_dollars > 150_000); // DOLLAR ~ new DOT ~ 10e10
+		// The minimal number of voters we expect per block.
+		assert!(voters >= 1_000);
+		assert!(cost_dollars >= 10_000);
 	}
 
 	#[test]


### PR DESCRIPTION
Reduce the constants of `full_block_council_election_cost` to unblock https://github.com/paritytech/polkadot/pull/5767  
The new constants should have enough leeway and not error when we just update the weights.