### PR TITLE
allow re-use and avoid compiling kusama parachain code

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -43,7 +43,7 @@ sp-trie = { git = "https://github.com/paritytech/substrate", branch = "master", 
 substrate-build-script-utils = { git = "https://github.com/paritytech/substrate", branch = "master" }
 
 [features]
-default = ["wasmtime", "db", "cli", "full-node", "trie-memory-tracker", "polkadot-native"]
+default = ["wasmtime", "db", "cli", "hostperfcheck", "full-node", "trie-memory-tracker", "polkadot-native"]
 wasmtime = ["sc-cli/wasmtime"]
 db = ["service/db"]
 cli = [
@@ -55,7 +55,6 @@ cli = [
 	"try-runtime-cli",
 	"polkadot-client",
 	"polkadot-node-core-pvf",
-	"polkadot-performance-test",
 ]
 runtime-benchmarks = ["service/runtime-benchmarks", "polkadot-node-metrics/runtime-benchmarks"]
 trie-memory-tracker = ["sp-trie/memory-tracker"]
@@ -63,6 +62,7 @@ full-node = ["service/full-node"]
 try-runtime = ["service/try-runtime"]
 fast-runtime = ["service/fast-runtime"]
 pyroscope = ["pyro"]
+hostperfcheck = ["polkadot-performance-test"]
 
 # Configure the native runtimes to use. Polkadot is enabled by default.
 #

--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -247,16 +247,20 @@ macro_rules! unwrap_client {
 /// Should only be used in release build since the check would take too much time otherwise.
 fn host_perf_check() -> Result<()> {
 	#[cfg(not(build_type = "release"))]
-	return Err(PerfCheckError::WrongBuildType.into());
-
-	#[allow(unreachable_code)]
-	#[cfg(not(feature = "hostperfcheck"))]
-	return Err(PerfCheckError::FeatureNotEnabled { feature: "hostperfcheck" }.into());
-
-	#[cfg(all(build_type = "release", feature = "hostperfcheck"))]
 	{
-		crate::host_perf_check::host_perf_check()?;
-		Ok(())
+		return Err(PerfCheckError::WrongBuildType.into())
+	}
+	#[cfg(build_type = "release")]
+	{
+		#[cfg(not(feature = "hostperfcheck"))]
+		{
+			return Err(PerfCheckError::FeatureNotEnabled { feature: "hostperfcheck" }.into())
+		}
+		#[cfg(feature = "hostperfcheck")]
+		{
+			crate::host_perf_check::host_perf_check()?;
+			return Ok(())
+		}
 	}
 }
 

--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -247,11 +247,11 @@ macro_rules! unwrap_client {
 /// Should only be used in release build since the check would take too much time otherwise.
 fn host_perf_check() -> Result<()> {
 	#[cfg(not(build_type = "release"))]
-	return Err(PerfCheckError::WrongBuildType.into())
+	return Err(PerfCheckError::WrongBuildType.into());
 
 	#[allow(unreachable_code)]
 	#[cfg(not(feature = "hostperfcheck"))]
-	return Err(PerfCheckError::FeatureNotEnabled { feature: "hostperfcheck" }.into())
+	return Err(PerfCheckError::FeatureNotEnabled { feature: "hostperfcheck" }.into());
 
 	#[cfg(all(build_type = "release", feature = "hostperfcheck"))]
 	{

--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -247,10 +247,13 @@ macro_rules! unwrap_client {
 /// Should only be used in release build since the check would take too much time otherwise.
 fn host_perf_check() -> Result<()> {
 	#[cfg(not(build_type = "release"))]
-	{
-		Err(PerfCheckError::WrongBuildType.into())
-	}
-	#[cfg(build_type = "release")]
+	return Err(PerfCheckError::WrongBuildType.into())
+
+	#[allow(unreachable_code)]
+	#[cfg(not(feature = "hostperfcheck"))]
+	return Err(PerfCheckError::FeatureNotEnabled { feature: "hostperfcheck" }.into())
+
+	#[cfg(all(build_type = "release", feature = "hostperfcheck"))]
 	{
 		crate::host_perf_check::host_perf_check()?;
 		Ok(())

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -24,7 +24,7 @@ mod cli;
 mod command;
 #[cfg(feature = "cli")]
 mod error;
-#[cfg(all(feature = "cli", build_type = "release"))]
+#[cfg(all(feature = "hostperfcheck", build_type = "release"))]
 mod host_perf_check;
 
 #[cfg(feature = "full-node")]

--- a/node/test/performance-test/src/lib.rs
+++ b/node/test/performance-test/src/lib.rs
@@ -36,6 +36,9 @@ pub enum PerfCheckError {
 	#[error("This subcommand is only available in release mode")]
 	WrongBuildType,
 
+	#[error("This subcommand is only available when compiled with `{feature}`")]
+	FeatureNotEnabled { feature: &'static str },
+
 	#[error("No wasm code found for running the performance test")]
 	WasmBinaryMissing,
 


### PR DESCRIPTION
When re-using polkadot-cli for a custom collator, having to compile the kusama runtime. This PR adds a new default on feature that enables the test runtime conditionally and allows to use the `cli` flat without adding the extra compile time.