### PR TITLE
Westend xcm: collectives parachain is trusted teleporter

### DIFF
--- a/runtime/westend/src/xcm_config.rs
+++ b/runtime/westend/src/xcm_config.rs
@@ -76,14 +76,20 @@ pub type XcmRouter = (
 parameter_types! {
 	pub const Westmint: MultiLocation = Parachain(1000).into();
 	pub const Encointer: MultiLocation = Parachain(1001).into();
+	pub const Collectives: MultiLocation = Parachain(1002).into();
 	pub const WestendForWestmint: (MultiAssetFilter, MultiLocation) =
 		(Wild(AllOf { fun: WildFungible, id: Concrete(WndLocation::get()) }), Westmint::get());
 	pub const WestendForEncointer: (MultiAssetFilter, MultiLocation) =
 		(Wild(AllOf { fun: WildFungible, id: Concrete(WndLocation::get()) }), Encointer::get());
+	pub const WestendForCollectives: (MultiAssetFilter, MultiLocation) =
+		(Wild(AllOf { fun: WildFungible, id: Concrete(WndLocation::get()) }), Collectives::get());
 	pub const MaxInstructions: u32 = 100;
 }
-pub type TrustedTeleporters =
-	(xcm_builder::Case<WestendForWestmint>, xcm_builder::Case<WestendForEncointer>);
+pub type TrustedTeleporters = (
+	xcm_builder::Case<WestendForWestmint>,
+	xcm_builder::Case<WestendForEncointer>,
+	xcm_builder::Case<WestendForCollectives>,
+);
 
 /// The barriers one of which must be passed for an XCM message to be executed.
 pub type Barrier = (


### PR DESCRIPTION
Collectives parachain is getting onboarded in westend network. 

Collectives parachain runtime must be able to teleport assets to the relay chain.
The slashed assets of the member of alliance gets teleported to the relay chain treasury. 
Related PR https://github.com/paritytech/cumulus/pull/1433