### PR TITLE
Bump strum to 0.24.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6664,7 +6664,7 @@ dependencies = [
  "rand_chacha 0.3.1",
  "sc-authority-discovery",
  "sc-network",
- "strum 0.24.0",
+ "strum 0.24.1",
  "thiserror",
  "tracing-gum",
 ]
@@ -10692,9 +10692,9 @@ dependencies = [
 
 [[package]]
 name = "strum"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e96acfc1b70604b8b2f1ffa4c57e59176c7dbb05d556c71ecd2f5498a1dee7f8"
+checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
 dependencies = [
  "strum_macros 0.24.0",
 ]


### PR DESCRIPTION
We are seeing failing dependency check jobs which can not resolve `strum` version which was recently bumped in substrate: https://gitlab.parity.io/parity/mirrors/polkadot/-/jobs/1698724

