### PR TITLE
[ci] Return production image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,8 +29,7 @@ variables:
   GIT_STRATEGY:                    fetch
   GIT_DEPTH:                       100
   CI_SERVER_NAME:                  "GitLab CI"
-  # change to production when this image is published
-  CI_IMAGE:                        "paritytech/ci-linux:staging@sha256:2c90b67f1452ed2d7236c2cd13f6224053a833d521b3630650b679f00874e0a9"
+  CI_IMAGE:                        "paritytech/ci-linux:production"
   DOCKER_OS:                       "debian:stretch"
   ARCH:                            "x86_64"
   ZOMBIENET_IMAGE:                 "docker.io/paritytech/zombienet:v1.2.25"


### PR DESCRIPTION
`production` image with latest rust stable and nightly was published, changing it back in ci

cc https://github.com/paritytech/ci_cd/issues/535