### PR TITLE
[ci] Add timeout to update-weights jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -518,6 +518,7 @@ publish-s3-release:                &publish-s3
 
 update_polkadot_weights:           &update-weights
   stage:                           stage2
+  timeout:                         1d
   when:                            manual
   variables:
     RUNTIME:                       polkadot


### PR DESCRIPTION
Currently timeout for all jobs is 1 day which is too much especially when a job hangs for some reasons. PR sets timeout 1 day only from `update-weights` jobs. For other jobs default timeout will be 2 hours (it's going to be set in repo settings)

https://github.com/paritytech/ci_cd/issues/543