### PR TITLE
Prospective Parachains: track candidate parent nodes in a fragment tree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6728,7 +6728,6 @@ name = "polkadot-node-core-prospective-parachains"
 version = "0.9.16"
 dependencies = [
  "assert_matches",
- "bitvec 1.0.0",
  "fatality",
  "futures",
  "parity-scale-codec 2.3.1",

--- a/node/core/backing/src/tests/prospective_parachains.rs
+++ b/node/core/backing/src/tests/prospective_parachains.rs
@@ -282,7 +282,10 @@ async fn assert_hypothetical_depth_requests(
 						request
 					),
 				};
-				let resp = std::mem::take(&mut expected_requests[idx].1);
+				let resp = std::mem::take(&mut expected_requests[idx].1)
+					.into_iter()
+					.map(|d| (d, ProspectiveCandidateParentState::Backed))
+					.collect();
 				tx.send(resp).unwrap();
 
 				expected_requests.remove(idx);

--- a/node/core/prospective-parachains/Cargo.toml
+++ b/node/core/prospective-parachains/Cargo.toml
@@ -10,7 +10,6 @@ gum = { package = "tracing-gum", path = "../../gum" }
 parity-scale-codec = "2"
 thiserror = "1.0.30"
 fatality = "0.0.6"
-bitvec = "1"
 
 polkadot-primitives = { path = "../../../primitives" }
 polkadot-node-primitives = { path = "../../primitives" }

--- a/node/network/collator-protocol/src/validator_side/mod.rs
+++ b/node/network/collator-protocol/src/validator_side/mod.rs
@@ -1145,6 +1145,7 @@ async fn process_msg<Context>(
 				);
 			}
 		},
+		Backed(..) => {},
 		Invalid(parent, candidate_receipt) => {
 			let id = match state.pending_candidates.entry(parent) {
 				Entry::Occupied(entry)

--- a/node/overseer/src/lib.rs
+++ b/node/overseer/src/lib.rs
@@ -606,6 +606,7 @@ pub struct Overseer<SupportsParachains> {
 	#[subsystem(ProspectiveParachainsMessage, sends: [
 		RuntimeApiMessage,
 		ChainApiMessage,
+		CollatorProtocolMessage,
 	])]
 	prospective_parachains: ProspectiveParachains,
 


### PR DESCRIPTION
Needed for #5054

> We'll need to make use of GetHypotheticalDepths from https://github.com/paritytech/polkadot/pull/4913
> ...
> **We should only fetch & second collations that are either built on top of the root of some fragment tree or have a parent which is backed. We could relax this somewhat to fetch & second collations that are built on top of a Seconded candidate which we've validated locally, but that'd be more complex and the 'backed' rule should work OK although it's not as efficient.**

Previous version of `GetHypotheticalDepths` doesn't give any info about parent node being seconded/backed. Now:
1. Fragment tree tracks candidate hash of a parent node for each depth
2. Prospective parachains looks up this candidate status in candidate storage (0 depth is special)

Also forward `CandidateSeconded` notifications to collator protocol