### PR TITLE
bump transaction_version for rococo (#5760)

### DIFF
--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -102,7 +102,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	apis: RUNTIME_API_VERSIONS,
 	#[cfg(feature = "disable-runtime-api")]
 	apis: sp_version::create_apis_vec![[]],
-	transaction_version: 0,
+	transaction_version: 1,
 	state_version: 0,
 };
 


### PR DESCRIPTION
* bump transcation_version

* revert back transaction version for kusama and plokadot as they were bumped in the previous release

See also https://github.com/paritytech/polkadot/pull/5830