### PR TITLE
Backport of #5822: [ci] Add timeout to benchmark jobs (#5822)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -518,6 +518,7 @@ publish-s3-release:                &publish-s3
 
 update_polkadot_weights:           &update-weights
   stage:                           stage2
+  timeout:                         1d
   when:                            manual
   variables:
     RUNTIME:                       polkadot


### PR DESCRIPTION
Backport of #5822 into to 0.9.27 release branch