### PR TITLE
Run benchmarks with `--steps=2`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -925,20 +925,17 @@ short-benchmark-polkadot:          &short-bench
   variables:
     RUNTIME:                       polkadot
   script:
-    - ./artifacts/polkadot benchmark pallet --execution wasm --wasm-execution compiled --chain $RUNTIME-dev --pallet "*" --extrinsic "*" --steps 1 --repeat 1
-  allow_failure:                   true
+    - ./artifacts/polkadot benchmark pallet --execution wasm --wasm-execution compiled --chain $RUNTIME-dev --pallet "*" --extrinsic "*" --steps 2 --repeat 1
 
 short-benchmark-kusama:
   <<:                              *short-bench
   variables:
     RUNTIME:                       kusama
-  allow_failure:                   true
 
 short-benchmark-westend:
   <<:                              *short-bench
   variables:
     RUNTIME:                       westend
-  allow_failure:                   true
 
 #### stage:                        .post
 


### PR DESCRIPTION
Formerly the benchmarks were being executed with at least two values even when called with `--steps=1`.
[substrate/#11890](https://github.com/paritytech/substrate/pull/11890) changed this to explicitly require at least `--steps=2` to make it more explicit.