### PR TITLE
[Zombienet] update the image to the version 1.2.51 globally

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,7 +32,7 @@ variables:
   CI_IMAGE:                        "paritytech/ci-linux:production"
   DOCKER_OS:                       "debian:stretch"
   ARCH:                            "x86_64"
-  ZOMBIENET_IMAGE:                 "docker.io/paritytech/zombienet:v1.2.50"
+  ZOMBIENET_IMAGE:                 "docker.io/paritytech/zombienet:v1.2.25"
   PIPELINE_SCRIPTS_TAG:            "v0.4"
 
 default:
@@ -827,7 +827,7 @@ zombienet-tests-malus-dispute-valid:
 
 zombienet-tests-deregister-register-validator:
   stage:                           stage3
-  image:                           "${ZOMBIENET_IMAGE}"
+  image:                           "docker.io/paritytech/zombienet:v1.2.47"
   <<:                              *kubernetes-env
   <<:                              *zombienet-refs
   needs:
@@ -856,7 +856,7 @@ zombienet-tests-beefy-and-mmr:
   stage:                           stage3
   <<:                              *kubernetes-env
   <<:                              *zombienet-refs
-  image:                           "${ZOMBIENET_IMAGE}"
+  image:                           "docker.io/paritytech/zombienet:v1.2.50"
   needs:
     - job:                         publish-polkadot-debug-image
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,7 +32,7 @@ variables:
   CI_IMAGE:                        "paritytech/ci-linux:production"
   DOCKER_OS:                       "debian:stretch"
   ARCH:                            "x86_64"
-  ZOMBIENET_IMAGE:                 "docker.io/paritytech/zombienet:v1.2.25"
+  ZOMBIENET_IMAGE:                 "docker.io/paritytech/zombienet:v1.2.51"
   PIPELINE_SCRIPTS_TAG:            "v0.4"
 
 default:
@@ -827,7 +827,7 @@ zombienet-tests-malus-dispute-valid:
 
 zombienet-tests-deregister-register-validator:
   stage:                           stage3
-  image:                           "docker.io/paritytech/zombienet:v1.2.47"
+  image:                           "${ZOMBIENET_IMAGE}"
   <<:                              *kubernetes-env
   <<:                              *zombienet-refs
   needs:
@@ -854,9 +854,9 @@ zombienet-tests-deregister-register-validator:
 
 zombienet-tests-beefy-and-mmr:
   stage:                           stage3
+  image:                           "${ZOMBIENET_IMAGE}"
   <<:                              *kubernetes-env
   <<:                              *zombienet-refs
-  image:                           "docker.io/paritytech/zombienet:v1.2.50"
   needs:
     - job:                         publish-polkadot-debug-image
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -742,7 +742,6 @@ zombienet-test-parachains-upgrade-smoke-test:
   stage:                           stage3
   <<:                              *kubernetes-env
   <<:                              *zombienet-refs
-  image:                           "docker.io/paritytech/zombienet:v1.2.45"
   needs:
     - job:                         publish-polkadot-debug-image
     - job:                         publish-malus-image
@@ -771,7 +770,6 @@ zombienet-tests-misc-paritydb:
   stage:                           stage3
   <<:                              *kubernetes-env
   <<:                              *zombienet-refs
-  image:                           "docker.io/paritytech/zombienet:v1.2.49"
   needs:
     - job:                         publish-polkadot-debug-image
     - job:                         publish-test-collators-image

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -740,6 +740,7 @@ zombienet-tests-parachains-disputes:
 
 zombienet-test-parachains-upgrade-smoke-test:
   stage:                           stage3
+  image:                           "${ZOMBIENET_IMAGE}"
   <<:                              *kubernetes-env
   <<:                              *zombienet-refs
   needs:
@@ -768,6 +769,7 @@ zombienet-test-parachains-upgrade-smoke-test:
 
 zombienet-tests-misc-paritydb:
   stage:                           stage3
+  image:                           "${ZOMBIENET_IMAGE}"
   <<:                              *kubernetes-env
   <<:                              *zombienet-refs
   needs:


### PR DESCRIPTION
Hi @sandreim, this rollback the global version to use the one that handle the `undefined` metrics cases.

Thanks!