### PR TITLE
Change request-response protocol names to include genesis hash & fork id

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6667,6 +6667,7 @@ dependencies = [
  "derive_more",
  "fatality",
  "futures",
+ "hex",
  "parity-scale-codec",
  "polkadot-node-jaeger",
  "polkadot-node-primitives",

--- a/node/network/availability-distribution/src/tests/mod.rs
+++ b/node/network/availability-distribution/src/tests/mod.rs
@@ -19,7 +19,7 @@ use std::collections::HashSet;
 use futures::{executor, future, Future};
 
 use polkadot_node_network_protocol::request_response::IncomingRequest;
-use polkadot_primitives::v2::CoreState;
+use polkadot_primitives::v2::{CoreState, Hash};
 use sp_keystore::SyncCryptoStorePtr;
 
 use polkadot_node_subsystem_test_helpers as test_helpers;
@@ -41,9 +41,12 @@ fn test_harness<T: Future<Output = ()>>(
 
 	let pool = sp_core::testing::TaskExecutor::new();
 	let (context, virtual_overseer) = test_helpers::make_subsystem_context(pool.clone());
+	let genesis_hash = Hash::repeat_byte(0xff);
 
-	let (pov_req_receiver, pov_req_cfg) = IncomingRequest::get_config_receiver();
-	let (chunk_req_receiver, chunk_req_cfg) = IncomingRequest::get_config_receiver();
+	let (pov_req_receiver, pov_req_cfg) =
+		IncomingRequest::get_config_receiver(&genesis_hash, &None);
+	let (chunk_req_receiver, chunk_req_cfg) =
+		IncomingRequest::get_config_receiver(&genesis_hash, &None);
 	let subsystem = AvailabilityDistributionSubsystem::new(
 		keystore,
 		IncomingRequestReceivers { pov_req_receiver, chunk_req_receiver },

--- a/node/network/availability-distribution/src/tests/mod.rs
+++ b/node/network/availability-distribution/src/tests/mod.rs
@@ -43,10 +43,9 @@ fn test_harness<T: Future<Output = ()>>(
 	let (context, virtual_overseer) = test_helpers::make_subsystem_context(pool.clone());
 	let genesis_hash = Hash::repeat_byte(0xff);
 
-	let (pov_req_receiver, pov_req_cfg) =
-		IncomingRequest::get_config_receiver(&genesis_hash, &None);
+	let (pov_req_receiver, pov_req_cfg) = IncomingRequest::get_config_receiver(&genesis_hash, None);
 	let (chunk_req_receiver, chunk_req_cfg) =
-		IncomingRequest::get_config_receiver(&genesis_hash, &None);
+		IncomingRequest::get_config_receiver(&genesis_hash, None);
 	let subsystem = AvailabilityDistributionSubsystem::new(
 		keystore,
 		IncomingRequestReceivers { pov_req_receiver, chunk_req_receiver },

--- a/node/network/availability-distribution/src/tests/mod.rs
+++ b/node/network/availability-distribution/src/tests/mod.rs
@@ -18,7 +18,7 @@ use std::collections::HashSet;
 
 use futures::{executor, future, Future};
 
-use polkadot_node_network_protocol::request_response::IncomingRequest;
+use polkadot_node_network_protocol::request_response::{IncomingRequest, ReqProtocolNames};
 use polkadot_primitives::v2::{CoreState, Hash};
 use sp_keystore::SyncCryptoStorePtr;
 
@@ -42,10 +42,11 @@ fn test_harness<T: Future<Output = ()>>(
 	let pool = sp_core::testing::TaskExecutor::new();
 	let (context, virtual_overseer) = test_helpers::make_subsystem_context(pool.clone());
 	let genesis_hash = Hash::repeat_byte(0xff);
+	let req_protocol_names = ReqProtocolNames::new(&genesis_hash, None);
 
-	let (pov_req_receiver, pov_req_cfg) = IncomingRequest::get_config_receiver(&genesis_hash, None);
+	let (pov_req_receiver, pov_req_cfg) = IncomingRequest::get_config_receiver(&req_protocol_names);
 	let (chunk_req_receiver, chunk_req_cfg) =
-		IncomingRequest::get_config_receiver(&genesis_hash, None);
+		IncomingRequest::get_config_receiver(&req_protocol_names);
 	let subsystem = AvailabilityDistributionSubsystem::new(
 		keystore,
 		IncomingRequestReceivers { pov_req_receiver, chunk_req_receiver },

--- a/node/network/availability-recovery/src/tests.rs
+++ b/node/network/availability-recovery/src/tests.rs
@@ -57,7 +57,7 @@ fn test_harness_fast_path<T: Future<Output = (VirtualOverseer, RequestResponseCo
 	let (context, virtual_overseer) = make_subsystem_context(pool.clone());
 
 	let (collation_req_receiver, req_cfg) =
-		IncomingRequest::get_config_receiver(&GENESIS_HASH, None);
+		IncomingRequest::get_config_receiver(&ReqProtocolNames::new(&GENESIS_HASH, None));
 	let subsystem =
 		AvailabilityRecoverySubsystem::with_fast_path(collation_req_receiver, Metrics::new_dummy());
 	let subsystem = async {

--- a/node/network/availability-recovery/src/tests.rs
+++ b/node/network/availability-recovery/src/tests.rs
@@ -57,7 +57,7 @@ fn test_harness_fast_path<T: Future<Output = (VirtualOverseer, RequestResponseCo
 	let (context, virtual_overseer) = make_subsystem_context(pool.clone());
 
 	let (collation_req_receiver, req_cfg) =
-		IncomingRequest::get_config_receiver(&GENESIS_HASH, &None);
+		IncomingRequest::get_config_receiver(&GENESIS_HASH, None);
 	let subsystem =
 		AvailabilityRecoverySubsystem::with_fast_path(collation_req_receiver, Metrics::new_dummy());
 	let subsystem = async {
@@ -92,7 +92,7 @@ fn test_harness_chunks_only<T: Future<Output = (VirtualOverseer, RequestResponse
 	let (context, virtual_overseer) = make_subsystem_context(pool.clone());
 
 	let (collation_req_receiver, req_cfg) =
-		IncomingRequest::get_config_receiver(&GENESIS_HASH, &None);
+		IncomingRequest::get_config_receiver(&GENESIS_HASH, None);
 	let subsystem = AvailabilityRecoverySubsystem::with_chunks_only(
 		collation_req_receiver,
 		Metrics::new_dummy(),

--- a/node/network/availability-recovery/src/tests.rs
+++ b/node/network/availability-recovery/src/tests.rs
@@ -36,10 +36,13 @@ use polkadot_node_subsystem::{
 };
 use polkadot_node_subsystem_test_helpers::{make_subsystem_context, TestSubsystemContextHandle};
 use polkadot_node_subsystem_util::TimeoutExt;
-use polkadot_primitives::v2::{AuthorityDiscoveryId, HeadData, PersistedValidationData};
+use polkadot_primitives::v2::{AuthorityDiscoveryId, Hash, HeadData, PersistedValidationData};
 use polkadot_primitives_test_helpers::{dummy_candidate_receipt, dummy_hash};
 
 type VirtualOverseer = TestSubsystemContextHandle<AvailabilityRecoveryMessage>;
+
+// Deterministic genesis hash for protocol names
+const GENESIS_HASH: Hash = Hash::repeat_byte(0xff);
 
 fn test_harness_fast_path<T: Future<Output = (VirtualOverseer, RequestResponseConfig)>>(
 	test: impl FnOnce(VirtualOverseer, RequestResponseConfig) -> T,
@@ -53,7 +56,8 @@ fn test_harness_fast_path<T: Future<Output = (VirtualOverseer, RequestResponseCo
 
 	let (context, virtual_overseer) = make_subsystem_context(pool.clone());
 
-	let (collation_req_receiver, req_cfg) = IncomingRequest::get_config_receiver();
+	let (collation_req_receiver, req_cfg) =
+		IncomingRequest::get_config_receiver(&GENESIS_HASH, &None);
 	let subsystem =
 		AvailabilityRecoverySubsystem::with_fast_path(collation_req_receiver, Metrics::new_dummy());
 	let subsystem = async {
@@ -87,7 +91,8 @@ fn test_harness_chunks_only<T: Future<Output = (VirtualOverseer, RequestResponse
 
 	let (context, virtual_overseer) = make_subsystem_context(pool.clone());
 
-	let (collation_req_receiver, req_cfg) = IncomingRequest::get_config_receiver();
+	let (collation_req_receiver, req_cfg) =
+		IncomingRequest::get_config_receiver(&GENESIS_HASH, &None);
 	let subsystem = AvailabilityRecoverySubsystem::with_chunks_only(
 		collation_req_receiver,
 		Metrics::new_dummy(),

--- a/node/network/availability-recovery/src/tests.rs
+++ b/node/network/availability-recovery/src/tests.rs
@@ -21,7 +21,7 @@ use futures::{executor, future};
 use futures_timer::Delay;
 
 use parity_scale_codec::Encode;
-use polkadot_node_network_protocol::request_response::IncomingRequest;
+use polkadot_node_network_protocol::request_response::{IncomingRequest, ReqProtocolNames};
 
 use super::*;
 
@@ -92,7 +92,7 @@ fn test_harness_chunks_only<T: Future<Output = (VirtualOverseer, RequestResponse
 	let (context, virtual_overseer) = make_subsystem_context(pool.clone());
 
 	let (collation_req_receiver, req_cfg) =
-		IncomingRequest::get_config_receiver(&GENESIS_HASH, None);
+		IncomingRequest::get_config_receiver(&ReqProtocolNames::new(&GENESIS_HASH, None));
 	let subsystem = AvailabilityRecoverySubsystem::with_chunks_only(
 		collation_req_receiver,
 		Metrics::new_dummy(),

--- a/node/network/bridge/src/network.rs
+++ b/node/network/bridge/src/network.rs
@@ -14,11 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::{
-	borrow::Cow,
-	collections::{HashMap, HashSet},
-	sync::Arc,
-};
+use std::{borrow::Cow, collections::HashSet, sync::Arc};
 
 use async_trait::async_trait;
 use futures::{prelude::*, stream::BoxStream};
@@ -32,7 +28,7 @@ use sc_network::{
 
 use polkadot_node_network_protocol::{
 	peer_set::PeerSet,
-	request_response::{OutgoingRequest, Protocol, Recipient, Requests},
+	request_response::{OutgoingRequest, Recipient, ReqProtocolNames, Requests},
 	PeerId, ProtocolVersion, UnifiedReputationChange as Rep,
 };
 use polkadot_primitives::v2::{AuthorityDiscoveryId, Block, Hash};
@@ -101,7 +97,7 @@ pub trait Network: Clone + Send + 'static {
 		&self,
 		authority_discovery: &mut AD,
 		req: Requests,
-		req_protocols: &HashMap<Protocol, Cow<'static, str>>,
+		req_protocol_names: &ReqProtocolNames,
 		if_disconnected: IfDisconnected,
 	);
 
@@ -158,7 +154,7 @@ impl Network for Arc<NetworkService<Block, Hash>> {
 		&self,
 		authority_discovery: &mut AD,
 		req: Requests,
-		req_protocols: &HashMap<Protocol, Cow<'static, str>>,
+		req_protocol_names: &ReqProtocolNames,
 		if_disconnected: IfDisconnected,
 	) {
 		let (protocol, OutgoingRequest { peer, payload, pending_response }) = req.encode_request();
@@ -204,10 +200,7 @@ impl Network for Arc<NetworkService<Block, Hash>> {
 		NetworkService::start_request(
 			&*self,
 			peer_id,
-			req_protocols
-				.get(&protocol)
-				.expect("all `protocol` names are generated via `strum`; qed")
-				.clone(),
+			req_protocol_names.get_name(protocol),
 			payload,
 			pending_response,
 			if_disconnected,

--- a/node/network/bridge/src/rx/tests.rs
+++ b/node/network/bridge/src/rx/tests.rs
@@ -16,7 +16,7 @@
 
 use super::*;
 use futures::{channel::oneshot, executor, stream::BoxStream};
-use polkadot_node_network_protocol::{self as net_protocol, request_response::Protocol, OurView};
+use polkadot_node_network_protocol::{self as net_protocol, OurView};
 use polkadot_node_subsystem::{messages::NetworkBridgeEvent, ActivatedLeaf};
 
 use assert_matches::assert_matches;
@@ -31,7 +31,8 @@ use std::{
 use sc_network::{Event as NetworkEvent, IfDisconnected};
 
 use polkadot_node_network_protocol::{
-	request_response::outgoing::Requests, view, ObservedRole, Versioned,
+	request_response::{outgoing::Requests, ReqProtocolNames},
+	view, ObservedRole, Versioned,
 };
 use polkadot_node_subsystem::{
 	jaeger,
@@ -117,7 +118,7 @@ impl Network for TestNetwork {
 		&self,
 		_: &mut AD,
 		_: Requests,
-		_: &HashMap<Protocol, Cow<'static, str>>,
+		_: &ReqProtocolNames,
 		_: IfDisconnected,
 	) {
 	}

--- a/node/network/bridge/src/rx/tests.rs
+++ b/node/network/bridge/src/rx/tests.rs
@@ -16,7 +16,7 @@
 
 use super::*;
 use futures::{channel::oneshot, executor, stream::BoxStream};
-use polkadot_node_network_protocol::{self as net_protocol, OurView};
+use polkadot_node_network_protocol::{self as net_protocol, request_response::Protocol, OurView};
 use polkadot_node_subsystem::{messages::NetworkBridgeEvent, ActivatedLeaf};
 
 use assert_matches::assert_matches;
@@ -117,6 +117,7 @@ impl Network for TestNetwork {
 		&self,
 		_: &mut AD,
 		_: Requests,
+		_: &HashMap<Protocol, Cow<'static, str>>,
 		_: IfDisconnected,
 	) {
 	}

--- a/node/network/bridge/src/tx/tests.rs
+++ b/node/network/bridge/src/tx/tests.rs
@@ -30,7 +30,7 @@ use polkadot_node_network_protocol::{
 use polkadot_node_subsystem::{FromOrchestra, OverseerSignal};
 use polkadot_node_subsystem_test_helpers::TestSubsystemContextHandle;
 use polkadot_node_subsystem_util::metered;
-use polkadot_primitives::v2::AuthorityDiscoveryId;
+use polkadot_primitives::v2::{AuthorityDiscoveryId, Hash};
 use polkadot_primitives_test_helpers::dummy_collator_signature;
 use sc_network::Multiaddr;
 use sp_keyring::Sr25519Keyring;
@@ -104,6 +104,7 @@ impl Network for TestNetwork {
 		&self,
 		_: &mut AD,
 		_: Requests,
+		_: &HashMap<Protocol, Cow<'static, str>>,
 		_: IfDisconnected,
 	) {
 	}
@@ -182,7 +183,10 @@ fn test_harness<T: Future<Output = VirtualOverseer>>(test: impl FnOnce(TestHarne
 	let (context, virtual_overseer) =
 		polkadot_node_subsystem_test_helpers::make_subsystem_context(pool);
 
-	let bridge_out = NetworkBridgeTx::new(network, discovery, Metrics(None));
+	let genesis_hash = Hash::repeat_byte(0xff);
+	let protocol_names = Protocol::protocol_names(&genesis_hash, &None);
+
+	let bridge_out = NetworkBridgeTx::new(network, discovery, Metrics(None), protocol_names);
 
 	let network_bridge_out_fut = run_network_out(bridge_out, context)
 		.map_err(|e| panic!("bridge-out subsystem execution failed {:?}", e))

--- a/node/network/bridge/src/tx/tests.rs
+++ b/node/network/bridge/src/tx/tests.rs
@@ -25,7 +25,8 @@ use std::{borrow::Cow, collections::HashSet};
 use sc_network::{Event as NetworkEvent, IfDisconnected};
 
 use polkadot_node_network_protocol::{
-	request_response::outgoing::Requests, ObservedRole, Versioned,
+	request_response::{outgoing::Requests, ReqProtocolNames},
+	ObservedRole, Versioned,
 };
 use polkadot_node_subsystem::{FromOrchestra, OverseerSignal};
 use polkadot_node_subsystem_test_helpers::TestSubsystemContextHandle;
@@ -104,7 +105,7 @@ impl Network for TestNetwork {
 		&self,
 		_: &mut AD,
 		_: Requests,
-		_: &HashMap<Protocol, Cow<'static, str>>,
+		_: &ReqProtocolNames,
 		_: IfDisconnected,
 	) {
 	}
@@ -184,7 +185,7 @@ fn test_harness<T: Future<Output = VirtualOverseer>>(test: impl FnOnce(TestHarne
 		polkadot_node_subsystem_test_helpers::make_subsystem_context(pool);
 
 	let genesis_hash = Hash::repeat_byte(0xff);
-	let protocol_names = Protocol::protocol_names(&genesis_hash, &None);
+	let protocol_names = ReqProtocolNames::new(genesis_hash, None);
 
 	let bridge_out = NetworkBridgeTx::new(network, discovery, Metrics(None), protocol_names);
 

--- a/node/network/bridge/src/validator_discovery.rs
+++ b/node/network/bridge/src/validator_discovery.rs
@@ -163,7 +163,7 @@ mod tests {
 	use async_trait::async_trait;
 	use futures::stream::BoxStream;
 	use polkadot_node_network_protocol::{
-		request_response::{outgoing::Requests, Protocol},
+		request_response::{outgoing::Requests, ReqProtocolNames},
 		PeerId,
 	};
 	use sc_network::{Event as NetworkEvent, IfDisconnected};
@@ -239,7 +239,7 @@ mod tests {
 			&self,
 			_: &mut AD,
 			_: Requests,
-			_: &HashMap<Protocol, Cow<'static, str>>,
+			_: &ReqProtocolNames,
 			_: IfDisconnected,
 		) {
 		}

--- a/node/network/bridge/src/validator_discovery.rs
+++ b/node/network/bridge/src/validator_discovery.rs
@@ -162,7 +162,10 @@ mod tests {
 
 	use async_trait::async_trait;
 	use futures::stream::BoxStream;
-	use polkadot_node_network_protocol::{request_response::outgoing::Requests, PeerId};
+	use polkadot_node_network_protocol::{
+		request_response::{outgoing::Requests, Protocol},
+		PeerId,
+	};
 	use sc_network::{Event as NetworkEvent, IfDisconnected};
 	use sp_keyring::Sr25519Keyring;
 	use std::{
@@ -236,6 +239,7 @@ mod tests {
 			&self,
 			_: &mut AD,
 			_: Requests,
+			_: &HashMap<Protocol, Cow<'static, str>>,
 			_: IfDisconnected,
 		) {
 		}

--- a/node/network/collator-protocol/src/collator_side/tests.rs
+++ b/node/network/collator-protocol/src/collator_side/tests.rs
@@ -29,7 +29,11 @@ use sp_core::crypto::Pair;
 use sp_keyring::Sr25519Keyring;
 use sp_runtime::traits::AppVerify;
 
-use polkadot_node_network_protocol::{our_view, request_response::IncomingRequest, view};
+use polkadot_node_network_protocol::{
+	our_view,
+	request_response::{IncomingRequest, ReqProtocolNames},
+	view,
+};
 use polkadot_node_primitives::BlockData;
 use polkadot_node_subsystem::{
 	jaeger,
@@ -202,9 +206,10 @@ fn test_harness<T: Future<Output = TestHarness>>(
 	let (context, virtual_overseer) = test_helpers::make_subsystem_context(pool.clone());
 
 	let genesis_hash = Hash::repeat_byte(0xff);
+	let req_protocol_names = ReqProtocolNames::new(&genesis_hash, None);
 
 	let (collation_req_receiver, req_cfg) =
-		IncomingRequest::get_config_receiver(&genesis_hash, None);
+		IncomingRequest::get_config_receiver(&req_protocol_names);
 	let subsystem = async {
 		run(context, local_peer_id, collator_pair, collation_req_receiver, Default::default())
 			.await

--- a/node/network/collator-protocol/src/collator_side/tests.rs
+++ b/node/network/collator-protocol/src/collator_side/tests.rs
@@ -201,7 +201,10 @@ fn test_harness<T: Future<Output = TestHarness>>(
 
 	let (context, virtual_overseer) = test_helpers::make_subsystem_context(pool.clone());
 
-	let (collation_req_receiver, req_cfg) = IncomingRequest::get_config_receiver();
+	let genesis_hash = Hash::repeat_byte(0xff);
+
+	let (collation_req_receiver, req_cfg) =
+		IncomingRequest::get_config_receiver(&genesis_hash, &None);
 	let subsystem = async {
 		run(context, local_peer_id, collator_pair, collation_req_receiver, Default::default())
 			.await

--- a/node/network/collator-protocol/src/collator_side/tests.rs
+++ b/node/network/collator-protocol/src/collator_side/tests.rs
@@ -204,7 +204,7 @@ fn test_harness<T: Future<Output = TestHarness>>(
 	let genesis_hash = Hash::repeat_byte(0xff);
 
 	let (collation_req_receiver, req_cfg) =
-		IncomingRequest::get_config_receiver(&genesis_hash, &None);
+		IncomingRequest::get_config_receiver(&genesis_hash, None);
 	let subsystem = async {
 		run(context, local_peer_id, collator_pair, collation_req_receiver, Default::default())
 			.await

--- a/node/network/dispute-distribution/src/tests/mod.rs
+++ b/node/network/dispute-distribution/src/tests/mod.rs
@@ -31,7 +31,7 @@ use parity_scale_codec::{Decode, Encode};
 use sc_network::config::RequestResponseConfig;
 
 use polkadot_node_network_protocol::{
-	request_response::{v1::DisputeRequest, IncomingRequest},
+	request_response::{v1::DisputeRequest, IncomingRequest, ReqProtocolNames},
 	PeerId,
 };
 use sp_keyring::Sr25519Keyring;
@@ -724,7 +724,8 @@ where
 	let keystore = make_ferdie_keystore();
 
 	let genesis_hash = Hash::repeat_byte(0xff);
-	let (req_receiver, req_cfg) = IncomingRequest::get_config_receiver(&genesis_hash, None);
+	let req_protocol_names = ReqProtocolNames::new(&genesis_hash, None);
+	let (req_receiver, req_cfg) = IncomingRequest::get_config_receiver(&req_protocol_names);
 	let subsystem = DisputeDistributionSubsystem::new(
 		keystore,
 		req_receiver,

--- a/node/network/dispute-distribution/src/tests/mod.rs
+++ b/node/network/dispute-distribution/src/tests/mod.rs
@@ -723,7 +723,8 @@ where
 	sp_tracing::try_init_simple();
 	let keystore = make_ferdie_keystore();
 
-	let (req_receiver, req_cfg) = IncomingRequest::get_config_receiver();
+	let genesis_hash = Hash::repeat_byte(0xff);
+	let (req_receiver, req_cfg) = IncomingRequest::get_config_receiver(&genesis_hash, &None);
 	let subsystem = DisputeDistributionSubsystem::new(
 		keystore,
 		req_receiver,

--- a/node/network/dispute-distribution/src/tests/mod.rs
+++ b/node/network/dispute-distribution/src/tests/mod.rs
@@ -724,7 +724,7 @@ where
 	let keystore = make_ferdie_keystore();
 
 	let genesis_hash = Hash::repeat_byte(0xff);
-	let (req_receiver, req_cfg) = IncomingRequest::get_config_receiver(&genesis_hash, &None);
+	let (req_receiver, req_cfg) = IncomingRequest::get_config_receiver(&genesis_hash, None);
 	let subsystem = DisputeDistributionSubsystem::new(
 		keystore,
 		req_receiver,

--- a/node/network/protocol/Cargo.toml
+++ b/node/network/protocol/Cargo.toml
@@ -7,6 +7,7 @@ description = "Primitives types for the Node-side"
 
 [dependencies]
 async-trait = "0.1.53"
+hex = "0.4.3"
 polkadot-primitives = { path = "../../../primitives" }
 polkadot-node-primitives = { path = "../../primitives" }
 polkadot-node-jaeger = { path = "../../jaeger" }

--- a/node/network/protocol/src/request_response/incoming/mod.rs
+++ b/node/network/protocol/src/request_response/incoming/mod.rs
@@ -55,8 +55,11 @@ where
 	///
 	/// This Register that config with substrate networking and receive incoming requests via the
 	/// returned `IncomingRequestReceiver`.
-	pub fn get_config_receiver() -> (IncomingRequestReceiver<Req>, RequestResponseConfig) {
-		let (raw, cfg) = Req::PROTOCOL.get_config();
+	pub fn get_config_receiver<Hash: AsRef<[u8]>>(
+		genesis_hash: &Hash,
+		fork_id: &Option<String>,
+	) -> (IncomingRequestReceiver<Req>, RequestResponseConfig) {
+		let (raw, cfg) = Req::PROTOCOL.get_config(genesis_hash, fork_id);
 		(IncomingRequestReceiver { raw, phantom: PhantomData {} }, cfg)
 	}
 

--- a/node/network/protocol/src/request_response/incoming/mod.rs
+++ b/node/network/protocol/src/request_response/incoming/mod.rs
@@ -25,7 +25,7 @@ use parity_scale_codec::{Decode, Encode};
 
 use sc_network::{config as netconfig, config::RequestResponseConfig, PeerId};
 
-use super::IsRequest;
+use super::{IsRequest, ReqProtocolNames};
 use crate::UnifiedReputationChange;
 
 mod error;
@@ -55,11 +55,10 @@ where
 	///
 	/// This Register that config with substrate networking and receive incoming requests via the
 	/// returned `IncomingRequestReceiver`.
-	pub fn get_config_receiver<Hash: AsRef<[u8]>>(
-		genesis_hash: &Hash,
-		fork_id: Option<&str>,
+	pub fn get_config_receiver(
+		req_protocol_names: &ReqProtocolNames,
 	) -> (IncomingRequestReceiver<Req>, RequestResponseConfig) {
-		let (raw, cfg) = Req::PROTOCOL.get_config(genesis_hash, fork_id);
+		let (raw, cfg) = Req::PROTOCOL.get_config(req_protocol_names);
 		(IncomingRequestReceiver { raw, phantom: PhantomData {} }, cfg)
 	}
 

--- a/node/network/protocol/src/request_response/incoming/mod.rs
+++ b/node/network/protocol/src/request_response/incoming/mod.rs
@@ -22,7 +22,6 @@ use futures::{
 };
 
 use parity_scale_codec::{Decode, Encode};
-use polkadot_primitives::v2::Hash;
 
 use sc_network::{config as netconfig, config::RequestResponseConfig, PeerId};
 
@@ -56,7 +55,7 @@ where
 	///
 	/// This Register that config with substrate networking and receive incoming requests via the
 	/// returned `IncomingRequestReceiver`.
-	pub fn get_config_receiver(
+	pub fn get_config_receiver<Hash: AsRef<[u8]>>(
 		genesis_hash: &Hash,
 		fork_id: Option<&str>,
 	) -> (IncomingRequestReceiver<Req>, RequestResponseConfig) {

--- a/node/network/protocol/src/request_response/incoming/mod.rs
+++ b/node/network/protocol/src/request_response/incoming/mod.rs
@@ -22,6 +22,7 @@ use futures::{
 };
 
 use parity_scale_codec::{Decode, Encode};
+use polkadot_primitives::v2::Hash;
 
 use sc_network::{config as netconfig, config::RequestResponseConfig, PeerId};
 
@@ -55,9 +56,9 @@ where
 	///
 	/// This Register that config with substrate networking and receive incoming requests via the
 	/// returned `IncomingRequestReceiver`.
-	pub fn get_config_receiver<Hash: AsRef<[u8]>>(
+	pub fn get_config_receiver(
 		genesis_hash: &Hash,
-		fork_id: &Option<String>,
+		fork_id: Option<&str>,
 	) -> (IncomingRequestReceiver<Req>, RequestResponseConfig) {
 		let (raw, cfg) = Req::PROTOCOL.get_config(genesis_hash, fork_id);
 		(IncomingRequestReceiver { raw, phantom: PhantomData {} }, cfg)

--- a/node/network/protocol/src/request_response/mod.rs
+++ b/node/network/protocol/src/request_response/mod.rs
@@ -274,7 +274,7 @@ pub trait IsRequest {
 	const PROTOCOL: Protocol;
 }
 
-/// Type for getting protocol names using genesis hash & fork id.
+/// Type for getting on the wire [`Protocol`] names using genesis hash & fork id.
 pub struct ReqProtocolNames {
 	names: HashMap<Protocol, Cow<'static, str>>,
 }
@@ -289,7 +289,7 @@ impl ReqProtocolNames {
 		Self { names }
 	}
 
-	/// Get on-the-wire [`Protocol`] name.
+	/// Get on the wire [`Protocol`] name.
 	pub fn get_name(&self, protocol: Protocol) -> Cow<'static, str> {
 		self.names
 			.get(&protocol)

--- a/node/network/protocol/src/request_response/mod.rs
+++ b/node/network/protocol/src/request_response/mod.rs
@@ -290,7 +290,7 @@ impl Protocol {
 	}
 
 	/// All protocol names as understood by substrate networking for specific `genesis_hash`
-	/// and `fork_id`, represented by a HashMap.
+	/// and `fork_id`, represented by a hash map.
 	pub fn protocol_names<Hash: AsRef<[u8]>>(
 		genesis_hash: &Hash,
 		fork_id: &Option<String>,

--- a/node/network/protocol/src/request_response/mod.rs
+++ b/node/network/protocol/src/request_response/mod.rs
@@ -35,7 +35,7 @@
 use std::{borrow::Cow, collections::HashMap, time::Duration, u64};
 
 use futures::channel::mpsc;
-use polkadot_primitives::v2::{Hash, MAX_CODE_SIZE, MAX_POV_SIZE};
+use polkadot_primitives::v2::{MAX_CODE_SIZE, MAX_POV_SIZE};
 use strum::{EnumIter, IntoEnumIterator};
 
 pub use sc_network::{config as network, config::RequestResponseConfig};
@@ -126,7 +126,7 @@ impl Protocol {
 	///
 	/// Returns a receiver for messages received on this protocol and the requested
 	/// `ProtocolConfig`.
-	pub fn get_config(
+	pub fn get_config<Hash: AsRef<[u8]>>(
 		self,
 		genesis_hash: &Hash,
 		fork_id: Option<&str>,
@@ -266,7 +266,11 @@ impl Protocol {
 	}
 
 	/// Protocol name of this protocol, as understood by substrate networking.
-	pub fn get_name(self, genesis_hash: &Hash, fork_id: Option<&str>) -> Cow<'static, str> {
+	pub fn get_name<Hash: AsRef<[u8]>>(
+		self,
+		genesis_hash: &Hash,
+		fork_id: Option<&str>,
+	) -> Cow<'static, str> {
 		let prefix = if let Some(fork_id) = fork_id {
 			format!("/{}/{}", hex::encode(genesis_hash), fork_id)
 		} else {
@@ -302,7 +306,7 @@ pub struct ReqProtocolNames {
 
 impl ReqProtocolNames {
 	/// Construct [`ReqProtocolNames`] from `genesis_hash` and `fork_id`
-	pub fn new(genesis_hash: Hash, fork_id: Option<&str>) -> Self {
+	pub fn new<Hash: AsRef<[u8]>>(genesis_hash: Hash, fork_id: Option<&str>) -> Self {
 		let mut names = HashMap::new();
 		for protocol in Protocol::iter() {
 			names.insert(protocol, protocol.get_name(&genesis_hash, fork_id));

--- a/node/network/protocol/src/request_response/mod.rs
+++ b/node/network/protocol/src/request_response/mod.rs
@@ -274,13 +274,13 @@ pub trait IsRequest {
 	const PROTOCOL: Protocol;
 }
 
-/// Type for getting protocol names using genesis hash & fork id
+/// Type for getting protocol names using genesis hash & fork id.
 pub struct ReqProtocolNames {
 	names: HashMap<Protocol, Cow<'static, str>>,
 }
 
 impl ReqProtocolNames {
-	/// Construct [`ReqProtocolNames`] from `genesis_hash` and `fork_id`
+	/// Construct [`ReqProtocolNames`] from `genesis_hash` and `fork_id`.
 	pub fn new<Hash: AsRef<[u8]>>(genesis_hash: Hash, fork_id: Option<&str>) -> Self {
 		let mut names = HashMap::new();
 		for protocol in Protocol::iter() {
@@ -289,7 +289,7 @@ impl ReqProtocolNames {
 		Self { names }
 	}
 
-	/// Get on-the-wire [`Protocol`] name
+	/// Get on-the-wire [`Protocol`] name.
 	pub fn get_name(&self, protocol: Protocol) -> Cow<'static, str> {
 		self.names
 			.get(&protocol)

--- a/node/network/statement-distribution/src/tests.rs
+++ b/node/network/statement-distribution/src/tests.rs
@@ -22,7 +22,7 @@ use parity_scale_codec::{Decode, Encode};
 use polkadot_node_network_protocol::{
 	request_response::{
 		v1::{StatementFetchingRequest, StatementFetchingResponse},
-		IncomingRequest, Recipient, Requests,
+		IncomingRequest, Recipient, ReqProtocolNames, Requests,
 	},
 	view, ObservedRole,
 };
@@ -727,7 +727,8 @@ fn receiving_from_one_sends_to_another_and_to_candidate_backing() {
 	let pool = sp_core::testing::TaskExecutor::new();
 	let (ctx, mut handle) = polkadot_node_subsystem_test_helpers::make_subsystem_context(pool);
 
-	let (statement_req_receiver, _) = IncomingRequest::get_config_receiver(&GENESIS_HASH, None);
+	let req_protocol_names = ReqProtocolNames::new(&GENESIS_HASH, None);
+	let (statement_req_receiver, _) = IncomingRequest::get_config_receiver(&req_protocol_names);
 
 	let bg = async move {
 		let s = StatementDistributionSubsystem::new(
@@ -920,8 +921,9 @@ fn receiving_large_statement_from_one_sends_to_another_and_to_candidate_backing(
 	let pool = sp_core::testing::TaskExecutor::new();
 	let (ctx, mut handle) = polkadot_node_subsystem_test_helpers::make_subsystem_context(pool);
 
+	let req_protocol_names = ReqProtocolNames::new(&GENESIS_HASH, None);
 	let (statement_req_receiver, mut req_cfg) =
-		IncomingRequest::get_config_receiver(&GENESIS_HASH, None);
+		IncomingRequest::get_config_receiver(&req_protocol_names);
 
 	let bg = async move {
 		let s = StatementDistributionSubsystem::new(
@@ -1433,8 +1435,9 @@ fn share_prioritizes_backing_group() {
 	let pool = sp_core::testing::TaskExecutor::new();
 	let (ctx, mut handle) = polkadot_node_subsystem_test_helpers::make_subsystem_context(pool);
 
+	let req_protocol_names = ReqProtocolNames::new(&GENESIS_HASH, None);
 	let (statement_req_receiver, mut req_cfg) =
-		IncomingRequest::get_config_receiver(&GENESIS_HASH, None);
+		IncomingRequest::get_config_receiver(&req_protocol_names);
 
 	let bg = async move {
 		let s = StatementDistributionSubsystem::new(
@@ -1729,7 +1732,8 @@ fn peer_cant_flood_with_large_statements() {
 	let pool = sp_core::testing::TaskExecutor::new();
 	let (ctx, mut handle) = polkadot_node_subsystem_test_helpers::make_subsystem_context(pool);
 
-	let (statement_req_receiver, _) = IncomingRequest::get_config_receiver(&GENESIS_HASH, None);
+	let req_protocol_names = ReqProtocolNames::new(&GENESIS_HASH, None);
+	let (statement_req_receiver, _) = IncomingRequest::get_config_receiver(&req_protocol_names);
 	let bg = async move {
 		let s = StatementDistributionSubsystem::new(
 			make_ferdie_keystore(),
@@ -1933,7 +1937,8 @@ fn handle_multiple_seconded_statements() {
 	let pool = sp_core::testing::TaskExecutor::new();
 	let (ctx, mut handle) = polkadot_node_subsystem_test_helpers::make_subsystem_context(pool);
 
-	let (statement_req_receiver, _) = IncomingRequest::get_config_receiver(&GENESIS_HASH, None);
+	let req_protocol_names = ReqProtocolNames::new(&GENESIS_HASH, None);
+	let (statement_req_receiver, _) = IncomingRequest::get_config_receiver(&req_protocol_names);
 
 	let virtual_overseer_fut = async move {
 		let s = StatementDistributionSubsystem::new(

--- a/node/network/statement-distribution/src/tests.rs
+++ b/node/network/statement-distribution/src/tests.rs
@@ -727,7 +727,7 @@ fn receiving_from_one_sends_to_another_and_to_candidate_backing() {
 	let pool = sp_core::testing::TaskExecutor::new();
 	let (ctx, mut handle) = polkadot_node_subsystem_test_helpers::make_subsystem_context(pool);
 
-	let (statement_req_receiver, _) = IncomingRequest::get_config_receiver(&GENESIS_HASH, &None);
+	let (statement_req_receiver, _) = IncomingRequest::get_config_receiver(&GENESIS_HASH, None);
 
 	let bg = async move {
 		let s = StatementDistributionSubsystem::new(
@@ -921,7 +921,7 @@ fn receiving_large_statement_from_one_sends_to_another_and_to_candidate_backing(
 	let (ctx, mut handle) = polkadot_node_subsystem_test_helpers::make_subsystem_context(pool);
 
 	let (statement_req_receiver, mut req_cfg) =
-		IncomingRequest::get_config_receiver(&GENESIS_HASH, &None);
+		IncomingRequest::get_config_receiver(&GENESIS_HASH, None);
 
 	let bg = async move {
 		let s = StatementDistributionSubsystem::new(
@@ -1434,7 +1434,7 @@ fn share_prioritizes_backing_group() {
 	let (ctx, mut handle) = polkadot_node_subsystem_test_helpers::make_subsystem_context(pool);
 
 	let (statement_req_receiver, mut req_cfg) =
-		IncomingRequest::get_config_receiver(&GENESIS_HASH, &None);
+		IncomingRequest::get_config_receiver(&GENESIS_HASH, None);
 
 	let bg = async move {
 		let s = StatementDistributionSubsystem::new(
@@ -1729,7 +1729,7 @@ fn peer_cant_flood_with_large_statements() {
 	let pool = sp_core::testing::TaskExecutor::new();
 	let (ctx, mut handle) = polkadot_node_subsystem_test_helpers::make_subsystem_context(pool);
 
-	let (statement_req_receiver, _) = IncomingRequest::get_config_receiver(&GENESIS_HASH, &None);
+	let (statement_req_receiver, _) = IncomingRequest::get_config_receiver(&GENESIS_HASH, None);
 	let bg = async move {
 		let s = StatementDistributionSubsystem::new(
 			make_ferdie_keystore(),
@@ -1933,7 +1933,7 @@ fn handle_multiple_seconded_statements() {
 	let pool = sp_core::testing::TaskExecutor::new();
 	let (ctx, mut handle) = polkadot_node_subsystem_test_helpers::make_subsystem_context(pool);
 
-	let (statement_req_receiver, _) = IncomingRequest::get_config_receiver(&GENESIS_HASH, &None);
+	let (statement_req_receiver, _) = IncomingRequest::get_config_receiver(&GENESIS_HASH, None);
 
 	let virtual_overseer_fut = async move {
 		let s = StatementDistributionSubsystem::new(

--- a/node/network/statement-distribution/src/tests.rs
+++ b/node/network/statement-distribution/src/tests.rs
@@ -44,6 +44,9 @@ use sp_keyring::Sr25519Keyring;
 use sp_keystore::{CryptoStore, SyncCryptoStore, SyncCryptoStorePtr};
 use std::{iter::FromIterator as _, sync::Arc, time::Duration};
 
+// Some deterministic genesis hash for protocol names
+const GENESIS_HASH: Hash = Hash::repeat_byte(0xff);
+
 #[test]
 fn active_head_accepts_only_2_seconded_per_validator() {
 	let validators = vec![
@@ -724,7 +727,7 @@ fn receiving_from_one_sends_to_another_and_to_candidate_backing() {
 	let pool = sp_core::testing::TaskExecutor::new();
 	let (ctx, mut handle) = polkadot_node_subsystem_test_helpers::make_subsystem_context(pool);
 
-	let (statement_req_receiver, _) = IncomingRequest::get_config_receiver();
+	let (statement_req_receiver, _) = IncomingRequest::get_config_receiver(&GENESIS_HASH, &None);
 
 	let bg = async move {
 		let s = StatementDistributionSubsystem::new(
@@ -917,7 +920,8 @@ fn receiving_large_statement_from_one_sends_to_another_and_to_candidate_backing(
 	let pool = sp_core::testing::TaskExecutor::new();
 	let (ctx, mut handle) = polkadot_node_subsystem_test_helpers::make_subsystem_context(pool);
 
-	let (statement_req_receiver, mut req_cfg) = IncomingRequest::get_config_receiver();
+	let (statement_req_receiver, mut req_cfg) =
+		IncomingRequest::get_config_receiver(&GENESIS_HASH, &None);
 
 	let bg = async move {
 		let s = StatementDistributionSubsystem::new(
@@ -1429,7 +1433,8 @@ fn share_prioritizes_backing_group() {
 	let pool = sp_core::testing::TaskExecutor::new();
 	let (ctx, mut handle) = polkadot_node_subsystem_test_helpers::make_subsystem_context(pool);
 
-	let (statement_req_receiver, mut req_cfg) = IncomingRequest::get_config_receiver();
+	let (statement_req_receiver, mut req_cfg) =
+		IncomingRequest::get_config_receiver(&GENESIS_HASH, &None);
 
 	let bg = async move {
 		let s = StatementDistributionSubsystem::new(
@@ -1724,7 +1729,7 @@ fn peer_cant_flood_with_large_statements() {
 	let pool = sp_core::testing::TaskExecutor::new();
 	let (ctx, mut handle) = polkadot_node_subsystem_test_helpers::make_subsystem_context(pool);
 
-	let (statement_req_receiver, _) = IncomingRequest::get_config_receiver();
+	let (statement_req_receiver, _) = IncomingRequest::get_config_receiver(&GENESIS_HASH, &None);
 	let bg = async move {
 		let s = StatementDistributionSubsystem::new(
 			make_ferdie_keystore(),
@@ -1928,7 +1933,7 @@ fn handle_multiple_seconded_statements() {
 	let pool = sp_core::testing::TaskExecutor::new();
 	let (ctx, mut handle) = polkadot_node_subsystem_test_helpers::make_subsystem_context(pool);
 
-	let (statement_req_receiver, _) = IncomingRequest::get_config_receiver();
+	let (statement_req_receiver, _) = IncomingRequest::get_config_receiver(&GENESIS_HASH, &None);
 
 	let virtual_overseer_fut = async move {
 		let s = StatementDistributionSubsystem::new(

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -859,20 +859,23 @@ where
 
 	let fork_id = config.chain_spec.fork_id().map(ToOwned::to_owned);
 
-	let (pov_req_receiver, cfg) = IncomingRequest::get_config_receiver(&genesis_hash, &fork_id);
+	let (pov_req_receiver, cfg) =
+		IncomingRequest::get_config_receiver(&genesis_hash, fork_id.as_deref());
 	config.network.request_response_protocols.push(cfg);
-	let (chunk_req_receiver, cfg) = IncomingRequest::get_config_receiver(&genesis_hash, &fork_id);
+	let (chunk_req_receiver, cfg) =
+		IncomingRequest::get_config_receiver(&genesis_hash, fork_id.as_deref());
 	config.network.request_response_protocols.push(cfg);
 	let (collation_req_receiver, cfg) =
-		IncomingRequest::get_config_receiver(&genesis_hash, &fork_id);
+		IncomingRequest::get_config_receiver(&genesis_hash, fork_id.as_deref());
 	config.network.request_response_protocols.push(cfg);
 	let (available_data_req_receiver, cfg) =
-		IncomingRequest::get_config_receiver(&genesis_hash, &fork_id);
+		IncomingRequest::get_config_receiver(&genesis_hash, fork_id.as_deref());
 	config.network.request_response_protocols.push(cfg);
 	let (statement_req_receiver, cfg) =
-		IncomingRequest::get_config_receiver(&genesis_hash, &fork_id);
+		IncomingRequest::get_config_receiver(&genesis_hash, fork_id.as_deref());
 	config.network.request_response_protocols.push(cfg);
-	let (dispute_req_receiver, cfg) = IncomingRequest::get_config_receiver(&genesis_hash, &fork_id);
+	let (dispute_req_receiver, cfg) =
+		IncomingRequest::get_config_receiver(&genesis_hash, fork_id.as_deref());
 	config.network.request_response_protocols.push(cfg);
 
 	let grandpa_hard_forks = if config.chain_spec.is_kusama() {

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -46,6 +46,7 @@ use {
 		self as chain_selection_subsystem, Config as ChainSelectionConfig,
 	},
 	polkadot_node_core_dispute_coordinator::Config as DisputeCoordinatorConfig,
+	polkadot_node_network_protocol::request_response::ReqProtocolNames,
 	polkadot_overseer::BlockInfo,
 	sc_client_api::{BlockBackend, ExecutorProvider},
 	sp_core::traits::SpawnNamed,
@@ -857,25 +858,20 @@ where
 		config.network.extra_sets.extend(peer_sets_info(is_authority));
 	}
 
-	let fork_id = config.chain_spec.fork_id().map(ToOwned::to_owned);
+	let req_protocol_names = ReqProtocolNames::new(&genesis_hash, config.chain_spec.fork_id());
 
-	let (pov_req_receiver, cfg) =
-		IncomingRequest::get_config_receiver(&genesis_hash, fork_id.as_deref());
+	let (pov_req_receiver, cfg) = IncomingRequest::get_config_receiver(&req_protocol_names);
 	config.network.request_response_protocols.push(cfg);
-	let (chunk_req_receiver, cfg) =
-		IncomingRequest::get_config_receiver(&genesis_hash, fork_id.as_deref());
+	let (chunk_req_receiver, cfg) = IncomingRequest::get_config_receiver(&req_protocol_names);
 	config.network.request_response_protocols.push(cfg);
-	let (collation_req_receiver, cfg) =
-		IncomingRequest::get_config_receiver(&genesis_hash, fork_id.as_deref());
+	let (collation_req_receiver, cfg) = IncomingRequest::get_config_receiver(&req_protocol_names);
 	config.network.request_response_protocols.push(cfg);
 	let (available_data_req_receiver, cfg) =
-		IncomingRequest::get_config_receiver(&genesis_hash, fork_id.as_deref());
+		IncomingRequest::get_config_receiver(&req_protocol_names);
 	config.network.request_response_protocols.push(cfg);
-	let (statement_req_receiver, cfg) =
-		IncomingRequest::get_config_receiver(&genesis_hash, fork_id.as_deref());
+	let (statement_req_receiver, cfg) = IncomingRequest::get_config_receiver(&req_protocol_names);
 	config.network.request_response_protocols.push(cfg);
-	let (dispute_req_receiver, cfg) =
-		IncomingRequest::get_config_receiver(&genesis_hash, fork_id.as_deref());
+	let (dispute_req_receiver, cfg) = IncomingRequest::get_config_receiver(&req_protocol_names);
 	config.network.request_response_protocols.push(cfg);
 
 	let grandpa_hard_forks = if config.chain_spec.is_kusama() {
@@ -1065,7 +1061,7 @@ where
 					dispute_coordinator_config,
 					pvf_checker_enabled,
 					overseer_message_channel_capacity_override,
-					fork_id,
+					req_protocol_names,
 				},
 			)
 			.map_err(|e| {

--- a/node/service/src/overseer.rs
+++ b/node/service/src/overseer.rs
@@ -202,7 +202,7 @@ where
 
 	let req_protocol_names = ReqProtocolNames::new(
 		runtime_client.hash(0).ok().flatten().expect("Genesis block exists; qed"),
-		fork_id,
+		fork_id.as_deref(),
 	);
 
 	let builder = Overseer::builder()

--- a/node/service/src/overseer.rs
+++ b/node/service/src/overseer.rs
@@ -25,7 +25,7 @@ use polkadot_node_core_candidate_validation::Config as CandidateValidationConfig
 use polkadot_node_core_chain_selection::Config as ChainSelectionConfig;
 use polkadot_node_core_dispute_coordinator::Config as DisputeCoordinatorConfig;
 use polkadot_node_network_protocol::request_response::{
-	v1 as request_v1, IncomingRequestReceiver, Protocol as RequestsProtocol,
+	v1 as request_v1, IncomingRequestReceiver, ReqProtocolNames,
 };
 #[cfg(any(feature = "malus", test))]
 pub use polkadot_overseer::{
@@ -200,9 +200,9 @@ where
 
 	let network_bridge_metrics: NetworkBridgeMetrics = Metrics::register(registry)?;
 
-	let requests_protocols = RequestsProtocol::protocol_names(
-		&runtime_client.hash(0).ok().flatten().expect("Genesis block exists; qed"),
-		&fork_id,
+	let req_protocol_names = ReqProtocolNames::new(
+		runtime_client.hash(0).ok().flatten().expect("Genesis block exists; qed"),
+		fork_id,
 	);
 
 	let builder = Overseer::builder()
@@ -210,7 +210,7 @@ where
 			network_service.clone(),
 			authority_discovery_service.clone(),
 			network_bridge_metrics.clone(),
-			requests_protocols,
+			req_protocol_names,
 		))
 		.network_bridge_rx(NetworkBridgeRxSubsystem::new(
 			network_service.clone(),

--- a/node/service/src/overseer.rs
+++ b/node/service/src/overseer.rs
@@ -119,9 +119,8 @@ where
 	pub pvf_checker_enabled: bool,
 	/// Overseer channel capacity override.
 	pub overseer_message_channel_capacity_override: Option<usize>,
-	/// Fork ID from the client spec to only talk to "our" nodes if multiple chains
-	/// have the same genesis hash.
-	pub fork_id: Option<String>,
+	/// Request-response protocol names source.
+	pub req_protocol_names: ReqProtocolNames,
 }
 
 /// Obtain a prepared `OverseerBuilder`, that is initialized
@@ -150,7 +149,7 @@ pub fn prepared_overseer_builder<'a, Spawner, RuntimeClient>(
 		dispute_coordinator_config,
 		pvf_checker_enabled,
 		overseer_message_channel_capacity_override,
-		fork_id,
+		req_protocol_names,
 	}: OverseerGenArgs<'a, Spawner, RuntimeClient>,
 ) -> Result<
 	InitializedOverseerBuilder<
@@ -199,11 +198,6 @@ where
 	let spawner = SpawnGlue(spawner);
 
 	let network_bridge_metrics: NetworkBridgeMetrics = Metrics::register(registry)?;
-
-	let req_protocol_names = ReqProtocolNames::new(
-		runtime_client.hash(0).ok().flatten().expect("Genesis block exists; qed"),
-		fork_id.as_deref(),
-	);
 
 	let builder = Overseer::builder()
 		.network_bridge_tx(NetworkBridgeTxSubsystem::new(

--- a/roadmap/implementers-guide/src/node/disputes/dispute-distribution.md
+++ b/roadmap/implementers-guide/src/node/disputes/dispute-distribution.md
@@ -30,7 +30,7 @@ This design should result in a protocol that is:
 
 #### Disputes
 
-Protocol: `"/polkadot/send_dispute/1"`
+Protocol: `"/<genesis_hash>/<fork_id>/send_dispute/1"`
 
 Request:
 
@@ -86,7 +86,7 @@ enum DisputeResponse {
 
 #### Vote Recovery
 
-Protocol: `"/polkadot/req_votes/1"`
+Protocol: `"/<genesis_hash>/<fork_id>/req_votes/1"`
 
 ```rust
 struct IHaveVotesRequest {


### PR DESCRIPTION
## Description

This is a follow-up PR to https://github.com/paritytech/substrate/pull/11938 to rename Polkadot request-response protocols similarly to Substrate changes, originally discussed in https://github.com/paritytech/substrate/issues/7746.

## Open questions

This PR doesn't cover all Polkadot protocols --- changing `validation` & `collation` notification protocols requires a bit of refactoring, so I'm going to create a different PR for them. Please let me know if I missed some other protocols.