### PR TITLE
[ci] Improve cancel-pipeline job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -325,7 +325,7 @@ build-staking-miner:
   stage:                           stage2
   # this is an artificial job dependency, for pipeline optimization using GitLab's DAGs
   needs:
-    - job:                         check-fmt
+    - job:                         cargo-fmt
       artifacts:                   false
   <<:                              *docker-env
   <<:                              *test-pr-refs
@@ -354,7 +354,7 @@ test-node-metrics:
   stage:                           stage2
   # this is an artificial job dependency, for pipeline optimization using GitLab's DAGs
   needs:
-    - job:                         check-fmt
+    - job:                         cargo-fmt
       artifacts:                   false
   <<:                              *docker-env
   <<:                              *compiler-info

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -619,11 +619,6 @@ check-try-runtime:
       artifacts:                   false
   <<:                              *test-refs
   <<:                              *docker-env
-  <<:                              *pipeline-stopper-artifacts
-  before_script:
-    - rustup show
-    - cargo --version
-    - *pipeline-stopper-vars
   script:
     # Check that everything compiles with `try-runtime` feature flag.
     - cargo check --features try-runtime --all
@@ -1010,7 +1005,3 @@ cancel-pipeline-test-linux-stable:
   needs:
     - job:                         test-linux-stable
 
-cancel-pipeline-check-try-runtime:
-  extends:                         .cancel-pipeline-template
-  needs:
-    - job:                         check-try-runtime

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -626,7 +626,6 @@ check-try-runtime:
     - *pipeline-stopper-vars
   script:
     # Check that everything compiles with `try-runtime` feature flag.
-    - exit 1
     - cargo check --features try-runtime --all
 
 check-no-default-features:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -247,7 +247,7 @@ test-linux-stable:
     # but still want to have debug assertions.
     RUSTFLAGS: "-Cdebug-assertions=y -Dwarnings"
   script:
-    - time cargo nextest run --workspace --profile testnet --verbose --locked --features=runtime-benchmarks,runtime-metrics
+    - time cargo test --workspace --profile testnet --verbose --locked --features=runtime-benchmarks,runtime-metrics
 
 
 
@@ -625,8 +625,8 @@ check-try-runtime:
     - *pipeline-stopper-vars
   script:
     # Check that everything compiles with `try-runtime` feature flag.
+    - exit 1
     - cargo check --features try-runtime --all
-    - sccache -s
 
 check-no-default-features:
   stage:                           stage3

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -54,6 +54,19 @@ default:
     paths:
       - ./artifacts/
 
+# collecting vars for pipeline stopper
+# they will be used if the job fails
+.pipeline-stopper-vars:            &pipeline-stopper-vars
+    - echo "FAILED_JOB_URL=${CI_JOB_URL}" > pipeline-stopper.env
+    - echo "FAILED_JOB_NAME=${CI_JOB_NAME}" >> pipeline-stopper.env
+    - echo "FAILED_JOB_NAME=${CI_JOB_NAME}" >> pipeline-stopper.env
+    - echo "PR_NUM=${CI_COMMIT_REF_NAME}" >> pipeline-stopper.env
+
+.pipeline-stopper-artifacts:       &pipeline-stopper-artifacts
+  artifacts:
+     reports:
+       dotenv: pipeline-stopper.env
+
 .kubernetes-env:                   &kubernetes-env
   retry:
     max: 2
@@ -222,15 +235,19 @@ build-linux-stable:
 test-linux-stable:
   stage:                           stage1
   <<:                              *docker-env
-  <<:                              *compiler-info
   <<:                              *common-refs
+  <<:                              *pipeline-stopper-artifacts
+  before_script:
+    - rustup show
+    - cargo --version
+    - *pipeline-stopper-vars
   variables:
     RUST_TOOLCHAIN: stable
     # Enable debug assertions since we are running optimized builds for testing
     # but still want to have debug assertions.
     RUSTFLAGS: "-Cdebug-assertions=y -Dwarnings"
   script:
-    - time cargo test --workspace --profile testnet --verbose --locked --features=runtime-benchmarks,runtime-metrics
+    - time cargo nextest run --workspace --profile testnet --verbose --locked --features=runtime-benchmarks,runtime-metrics
 
 
 
@@ -601,7 +618,11 @@ check-try-runtime:
       artifacts:                   false
   <<:                              *test-refs
   <<:                              *docker-env
-  <<:                              *compiler-info
+  <<:                              *pipeline-stopper-artifacts
+  before_script:
+    - rustup show
+    - cargo --version
+    - *pipeline-stopper-vars
   script:
     # Check that everything compiles with `try-runtime` feature flag.
     - cargo check --features try-runtime --all
@@ -974,17 +995,22 @@ short-benchmark-westend:
       when: on_failure
   variables:
     PROJECT_ID:                    "${CI_PROJECT_ID}"
+    PROJECT_NAME:                  "${CI_PROJECT_NAME}"
     PIPELINE_ID:                   "${CI_PIPELINE_ID}"
-  trigger:                         "parity/infrastructure/ci_cd/pipeline-stopper"
+    FAILED_JOB_URL:                "${FAILED_JOB_URL}"
+    FAILED_JOB_NAME:               "${FAILED_JOB_NAME}"
+    PR_NUM:                        "${PR_NUM}"
+  trigger:
+    project:                       "parity/infrastructure/ci_cd/pipeline-stopper"
+    # remove branch, when pipeline-stopper for polakdot is updated to the same branch
+    branch:                        "as-improve"
 
 cancel-pipeline-test-linux-stable:
   extends:                         .cancel-pipeline-template
   needs:
     - job:                         test-linux-stable
-      artifacts:                   false
 
 cancel-pipeline-check-try-runtime:
   extends:                         .cancel-pipeline-template
   needs:
     - job:                         check-try-runtime
-      artifacts:                   false

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -619,6 +619,7 @@ check-try-runtime:
       artifacts:                   false
   <<:                              *test-refs
   <<:                              *docker-env
+  <<:                              *compiler-info
   script:
     # Check that everything compiles with `try-runtime` feature flag.
     - cargo check --features try-runtime --all

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -185,7 +185,8 @@ check-runtime:
   stage:                           stage1
   image:                           paritytech/tools:latest
   <<:                              *kubernetes-env
-  <<:                              *test-refs
+  rules:
+    - if: $CI_COMMIT_REF_NAME =~ /^release-v[0-9]+\.[0-9]+.*$/      # i.e. release-v0.9.27
   variables:
     GITLAB_API:                    "https://gitlab.parity.io/api/v4"
     GITHUB_API_PROJECT:            "parity%2Finfrastructure%2Fgithub-api"
@@ -324,7 +325,7 @@ build-staking-miner:
   stage:                           stage2
   # this is an artificial job dependency, for pipeline optimization using GitLab's DAGs
   needs:
-    - job:                         check-runtime
+    - job:                         check-fmt
       artifacts:                   false
   <<:                              *docker-env
   <<:                              *test-pr-refs
@@ -353,7 +354,7 @@ test-node-metrics:
   stage:                           stage2
   # this is an artificial job dependency, for pipeline optimization using GitLab's DAGs
   needs:
-    - job:                         check-runtime
+    - job:                         check-fmt
       artifacts:                   false
   <<:                              *docker-env
   <<:                              *compiler-info


### PR DESCRIPTION
The PR improves `cancel-pipeline` job. It posts a message in PR when the one of the `Required` jobs is broken. See examples below. 

cc https://github.com/paritytech/ci_cd/issues/548