### PR TITLE
Remove File Name from Benchmark Script

### DIFF
--- a/scripts/ci/run_benches_for_runtime.sh
+++ b/scripts/ci/run_benches_for_runtime.sh
@@ -39,7 +39,7 @@ for PALLET in "${PALLETS[@]}"; do
     --execution=wasm \
     --wasm-execution=compiled \
     --header=./file_header.txt \
-    --output="./runtime/${runtime}/src/weights/${PALLET/::/_}.rs" 2>&1
+    --output="./runtime/${runtime}/src/weights/" 2>&1
   )
   if [ $? -ne 0 ]; then
     echo "$OUTPUT" >> "$ERR_FILE"


### PR DESCRIPTION
When a file name is not specified, one is automatically generated by the benchmarking pipeline.

In the case the same pallet is benchmarked multiple times for multiple instances, different names are generated, so it is important in this case not to specify a name.