### PR TITLE
chore: bump zombienet version

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,7 +32,7 @@ variables:
   CI_IMAGE:                        "paritytech/ci-linux:production"
   DOCKER_OS:                       "debian:stretch"
   ARCH:                            "x86_64"
-  ZOMBIENET_IMAGE:                 "docker.io/paritytech/zombienet:v1.2.51"
+  ZOMBIENET_IMAGE:                 "docker.io/paritytech/zombienet:v1.2.56"
   PIPELINE_SCRIPTS_TAG:            "v0.4"
 
 default:


### PR DESCRIPTION
Bump zombienet, this new version set the baseline resources for pods in CI.

cc @sandreim.