### PR TITLE
ci Pin gha versions

### DIFF
--- a/.github/workflows/auto-label-prs.yml
+++ b/.github/workflows/auto-label-prs.yml
@@ -8,13 +8,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Label drafts
-        uses: andymckay/labeler@master
+        uses: andymckay/labeler@e6c4322d0397f3240f0e7e30a33b5c5df2d39e90 # 1.0.4
         if: github.event.pull_request.draft == true
         with:
           add-labels: 'A3-inprogress'
           remove-labels: 'A0-pleasereview'
       - name: Label PRs
-        uses: andymckay/labeler@master
+        uses: andymckay/labeler@e6c4322d0397f3240f0e7e30a33b5c5df2d39e90 # 1.0.4
         if: github.event.pull_request.draft == false && ! contains(github.event.pull_request.labels.*.name, 'A2-insubstantial')
         with:
           add-labels: 'A0-pleasereview'

--- a/.github/workflows/release-10_candidate.yml
+++ b/.github/workflows/release-10_candidate.yml
@@ -34,7 +34,7 @@ jobs:
             echo "::set-output name=first_rc::true"
           fi
       - name: Apply new tag
-        uses: tvdias/github-tagger@v0.0.2
+        uses: tvdias/github-tagger@ed7350546e3e503b5e942dffd65bc8751a95e49d # v0.0.2
         with:
           # We can't use the normal GITHUB_TOKEN for the following reason:
           # https://docs.github.com/en/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token
@@ -42,7 +42,7 @@ jobs:
           repo-token: "${{ secrets.RELEASE_BRANCH_TOKEN }}"
           tag: ${{ steps.compute_tag.outputs.new_tag }}
       - id: create-issue
-        uses: JasonEtco/create-an-issue@v2
+        uses: JasonEtco/create-an-issue@9e6213aec58987fa7d2f4deb8b256b99e63107a2 # v2.6.0
         # Only create the issue if it's the first release candidate
         if: steps.compute_tag.outputs.first_rc == 'true'
         env:


### PR DESCRIPTION
In order to improve our security posture with GitHub Actions usage. I've made a version pinning ether to commit hash or to specific version.

Related issues and policy:
https://github.com/paritytech/ci_cd/issues/464
https://github.com/paritytech/ci_cd/wiki/Policies-and-regulations:-GitHub-Actions-usage-policies