### PR TITLE
Send back empty votes + log in approval-voting in case candidate entry is missing.

### DIFF
--- a/node/core/approval-voting/src/lib.rs
+++ b/node/core/approval-voting/src/lib.rs
@@ -1210,8 +1210,24 @@ async fn get_approval_signatures_for_candidate<Context>(
 	candidate_hash: CandidateHash,
 	tx: oneshot::Sender<HashMap<ValidatorIndex, ValidatorSignature>>,
 ) -> SubsystemResult<()> {
+	let send_votes = |votes| {
+		if let Err(_) = tx.send(votes) {
+			gum::debug!(
+				target: LOG_TARGET,
+				"Sending approval signatures back failed, as receiver got closed."
+			);
+		}
+	};
 	let entry = match db.load_candidate_entry(&candidate_hash)? {
-		None => return Ok(()),
+		None => {
+			send_votes(HashMap::new());
+			gum::debug!(
+				target: LOG_TARGET,
+				?candidate_hash,
+				"Votes got requested, but candidate was not found in db."
+			);
+			return Ok(())
+		},
 		Some(e) => e,
 	};
 
@@ -1261,13 +1277,7 @@ async fn get_approval_signatures_for_candidate<Context>(
 				target: LOG_TARGET,
 				"Request for approval signatures got cancelled by `approval-distribution`."
 			),
-			Some(Ok(votes)) =>
-				if let Err(_) = tx.send(votes) {
-					gum::debug!(
-						target: LOG_TARGET,
-						"Sending approval signatures back failed, as receiver got closed"
-					);
-				},
+			Some(Ok(votes)) => send_votes(votes),
 		}
 	};
 

--- a/node/core/approval-voting/src/lib.rs
+++ b/node/core/approval-voting/src/lib.rs
@@ -1224,7 +1224,7 @@ async fn get_approval_signatures_for_candidate<Context>(
 			gum::debug!(
 				target: LOG_TARGET,
 				?candidate_hash,
-				"Votes got requested, but candidate was not found in db."
+				"Sent back empty votes because the candidate was not found in db."
 			);
 			return Ok(())
 		},


### PR DESCRIPTION
This is how it was intended in the first place. Interesting though, why there is no candidate entry in some cases on disputes.

This should fix these warnings on Kusama:

```
WARN tokio-runtime-worker parachain::dispute-coordinator: Fetch for approval votes got cancelled, only expected during shutdown!
```

to be confirmed.