### PR TITLE
Double approval checking timeout.

### DIFF
--- a/node/primitives/src/lib.rs
+++ b/node/primitives/src/lib.rs
@@ -72,7 +72,7 @@ pub const BACKING_EXECUTION_TIMEOUT: Duration = Duration::from_secs(2);
 /// ensure that in the absence of extremely large disparities between hardware,
 /// blocks that pass backing are considerd executable by approval checkers or
 /// dispute participants.
-pub const APPROVAL_EXECUTION_TIMEOUT: Duration = Duration::from_secs(6);
+pub const APPROVAL_EXECUTION_TIMEOUT: Duration = Duration::from_secs(12);
 
 /// Linked to `MAX_FINALITY_LAG` in relay chain selection,
 /// `MAX_HEADS_LOOK_BACK` in `approval-voting` and


### PR DESCRIPTION
In reality execution time seems to fluctuate more than expected. The only negative effect I can see by this change right now, is that finality lag can get a bit higher in the worst case. Seems to be a better tradeoff than too easy slashing of validators. Any other effects a larger timeout might have? @rphmeier 