### PR TITLE
[Zombienet] add upgrade test

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -893,7 +893,7 @@ zombienet-tests-misc-upgrade-node:
     - export ZOMBIENET_INTEGRATION_TEST_IMAGE="docker.io/parity/polkadot:${BUILD_RELEASE_VERSION}"
     - export COL_IMAGE=${COLLATOR_IMAGE_NAME}:${COLLATOR_IMAGE_TAG}
     - BUILD_LINUX_JOB_ID="$(cat ./artifacts/BUILD_LINUX_JOB_ID)"
-    - export POLKADOT_PR_BIN_URL="https://gitlab.parity.io/parity/mirrors/polkadot/-/jobs/${BUILD_LINUX_JOB_ID}/artifacts/file/artifacts/polkadot"
+    - export POLKADOT_PR_BIN_URL="https://gitlab.parity.io/parity/mirrors/polkadot/-/jobs/${BUILD_LINUX_JOB_ID}/artifacts/raw/artifacts/polkadot"
   script:
     - /home/nonroot/zombie-net/scripts/ci/run-test-env-manager.sh
         --github-remote-dir="${GH_DIR}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,7 +32,7 @@ variables:
   CI_IMAGE:                        "paritytech/ci-linux:production"
   DOCKER_OS:                       "debian:stretch"
   ARCH:                            "x86_64"
-  ZOMBIENET_IMAGE:                 "docker.io/paritytech/zombienet:v1.2.62"
+  ZOMBIENET_IMAGE:                 "docker.io/paritytech/zombienet:v1.2.66"
   PIPELINE_SCRIPTS_TAG:            "v0.4"
 
 default:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -232,6 +232,8 @@ build-linux-stable:
     - echo -n ${VERSION} > ./artifacts/VERSION
     - echo -n ${EXTRATAG} > ./artifacts/EXTRATAG
     - echo -n ${CI_JOB_ID} > ./artifacts/BUILD_LINUX_JOB_ID
+    - RELEASE_VERSION=$(./artifacts/polkadot -V | awk '{print $2}'| awk -F "-" '{print $1}')
+    - echo -n "v${RELEASE_VERSION}" > ./artifacts/BUILD_RELEASE_VERSION
     - cp -r scripts/* ./artifacts
 
 test-linux-stable:
@@ -887,7 +889,8 @@ zombienet-tests-misc-upgrade-node:
     - echo "${PARACHAINS_IMAGE_NAME} ${PARACHAINS_IMAGE_TAG}"
     - echo "${GH_DIR}"
     - export DEBUG=zombie,zombie::network-node
-    - export ZOMBIENET_INTEGRATION_TEST_IMAGE="docker.io/parity/polkadot:latest"
+    - BUILD_RELEASE_VERSION="$(cat ./artifacts/BUILD_RELEASE_VERSION)"
+    - export ZOMBIENET_INTEGRATION_TEST_IMAGE="docker.io/parity/polkadot:${BUILD_RELEASE_VERSION}"
     - export COL_IMAGE=${COLLATOR_IMAGE_NAME}:${COLLATOR_IMAGE_TAG}
     - BUILD_LINUX_JOB_ID="$(cat ./artifacts/BUILD_LINUX_JOB_ID)"
     - export POLKADOT_PR_BIN_URL="https://gitlab.parity.io/parity/mirrors/polkadot/-/jobs/${BUILD_LINUX_JOB_ID}/artifacts/file/artifacts/polkadot"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,7 +32,7 @@ variables:
   CI_IMAGE:                        "paritytech/ci-linux:production"
   DOCKER_OS:                       "debian:stretch"
   ARCH:                            "x86_64"
-  ZOMBIENET_IMAGE:                 "docker.io/paritytech/zombienet:v1.2.61"
+  ZOMBIENET_IMAGE:                 "docker.io/paritytech/zombienet:v1.2.62"
   PIPELINE_SCRIPTS_TAG:            "v0.4"
 
 default:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,7 +32,7 @@ variables:
   CI_IMAGE:                        "paritytech/ci-linux:production"
   DOCKER_OS:                       "debian:stretch"
   ARCH:                            "x86_64"
-  ZOMBIENET_IMAGE:                 "docker.io/paritytech/zombienet:v1.2.66"
+  ZOMBIENET_IMAGE:                 "docker.io/paritytech/zombienet:v1.2.67"
   PIPELINE_SCRIPTS_TAG:            "v0.4"
 
 default:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,7 +32,7 @@ variables:
   CI_IMAGE:                        "paritytech/ci-linux:production"
   DOCKER_OS:                       "debian:stretch"
   ARCH:                            "x86_64"
-  ZOMBIENET_IMAGE:                 "docker.io/paritytech/zombienet:v1.2.56"
+  ZOMBIENET_IMAGE:                 "docker.io/paritytech/zombienet:v1.2.61"
   PIPELINE_SCRIPTS_TAG:            "v0.4"
 
 default:
@@ -231,6 +231,7 @@ build-linux-stable:
     - echo "Polkadot version = ${VERSION} (EXTRATAG = ${EXTRATAG})"
     - echo -n ${VERSION} > ./artifacts/VERSION
     - echo -n ${EXTRATAG} > ./artifacts/EXTRATAG
+    - echo -n ${CI_JOB_ID} > ./artifacts/BUILD_LINUX_JOB_ID
     - cp -r scripts/* ./artifacts
 
 test-linux-stable:
@@ -863,6 +864,37 @@ zombienet-tests-misc-paritydb:
     - /home/nonroot/zombie-net/scripts/ci/run-test-env-manager.sh
         --github-remote-dir="${GH_DIR}"
         --test="0001-paritydb.feature"
+  allow_failure:                   false
+  retry: 2
+  tags:
+    - zombienet-polkadot-integration-test
+
+zombienet-tests-misc-upgrade-node:
+  stage:                           stage3
+  image:                           "${ZOMBIENET_IMAGE}"
+  <<:                              *kubernetes-env
+  <<:                              *zombienet-refs
+  needs:
+    - job:                         publish-polkadot-debug-image
+    - job:                         publish-test-collators-image
+    - job:                         build-linux-stable
+      artifacts:                   true
+  variables:
+    GH_DIR:                        "https://github.com/paritytech/polkadot/tree/${CI_COMMIT_SHORT_SHA}/zombienet_tests/misc"
+  before_script:
+    - echo "Zombie-net Tests Config"
+    - echo "${ZOMBIENET_IMAGE_NAME}"
+    - echo "${PARACHAINS_IMAGE_NAME} ${PARACHAINS_IMAGE_TAG}"
+    - echo "${GH_DIR}"
+    - export DEBUG=zombie,zombie::network-node
+    - export ZOMBIENET_INTEGRATION_TEST_IMAGE="docker.io/parity/polkadot:latest"
+    - export COL_IMAGE=${COLLATOR_IMAGE_NAME}:${COLLATOR_IMAGE_TAG}
+    - BUILD_LINUX_JOB_ID="$(cat ./artifacts/BUILD_LINUX_JOB_ID)"
+    - export POLKADOT_PR_BIN_URL="https://gitlab.parity.io/parity/mirrors/polkadot/-/jobs/${BUILD_LINUX_JOB_ID}/artifacts/file/artifacts/polkadot"
+  script:
+    - /home/nonroot/zombie-net/scripts/ci/run-test-env-manager.sh
+        --github-remote-dir="${GH_DIR}"
+        --test="0002-upgrade-node.feature"
   allow_failure:                   false
   retry: 2
   tags:

--- a/zombienet_tests/misc/0002-download-polkadot-from-pr.sh
+++ b/zombienet_tests/misc/0002-download-polkadot-from-pr.sh
@@ -9,7 +9,9 @@ mkdir -p $TEMP_DIR
 export PATH=$TEMP_DIR:$PATH
 
 cd $TEMP_DIR
-#curl -L -O https://gitlab.parity.io/parity/mirrors/polkadot/-/jobs/1810914/artifacts/file/artifacts/polkadot
+# For testing using native provider you should set this env var
+# POLKADOT_PR_BIN_URL=https://gitlab.parity.io/parity/mirrors/polkadot/-/jobs/1810914/artifacts/file/artifacts/polkadot
+# with the version of polkadot you want to download.
 curl -L -O $POLKADOT_PR_BIN_URL
 chmod +x $TEMP_DIR/polkadot
 echo $(polkadot --version)

--- a/zombienet_tests/misc/0002-download-polkadot-from-pr.sh
+++ b/zombienet_tests/misc/0002-download-polkadot-from-pr.sh
@@ -2,6 +2,8 @@
 
 set -euxo pipefail
 
+echo $@
+
 CFG_DIR=/cfg
 
 # add CFG_DIR as first `looking dir` to allow to overrides commands.

--- a/zombienet_tests/misc/0002-download-polkadot-from-pr.sh
+++ b/zombienet_tests/misc/0002-download-polkadot-from-pr.sh
@@ -2,14 +2,14 @@
 
 set -euxo pipefail
 
-TEMP_DIR=/tmp/zombie
+CFG_DIR=/cfg
 
-# add /tmp/zombie as first `looking dir` to allow to overrides commands.
-mkdir -p $TEMP_DIR
-export PATH=$TEMP_DIR:$PATH
+# add CFG_DIR as first `looking dir` to allow to overrides commands.
+mkdir -p $CFG_DIR
+export PATH=$CFG_DIR:$PATH
 
-cd $TEMP_DIR
+cd $CFG_DIR
 # see 0002-upgrade-node.feature to view the args.
 curl -L -O $1
-chmod +x $TEMP_DIR/polkadot
+chmod +x $CFG_DIR/polkadot
 echo $(polkadot --version)

--- a/zombienet_tests/misc/0002-download-polkadot-from-pr.sh
+++ b/zombienet_tests/misc/0002-download-polkadot-from-pr.sh
@@ -9,9 +9,7 @@ mkdir -p $TEMP_DIR
 export PATH=$TEMP_DIR:$PATH
 
 cd $TEMP_DIR
-# For testing using native provider you should set this env var
-# POLKADOT_PR_BIN_URL=https://gitlab.parity.io/parity/mirrors/polkadot/-/jobs/1810914/artifacts/file/artifacts/polkadot
-# with the version of polkadot you want to download.
-curl -L -O $POLKADOT_PR_BIN_URL
+# see 0002-upgrade-node.feature to view the args.
+curl -L -O $1
 chmod +x $TEMP_DIR/polkadot
 echo $(polkadot --version)

--- a/zombienet_tests/misc/0002-download-polkadot-from-pr.sh
+++ b/zombienet_tests/misc/0002-download-polkadot-from-pr.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+TEMP_DIR=/tmp/zombie
+
+# add /tmp/zombie as first `looking dir` to allow to overrides commands.
+mkdir -p $TEMP_DIR
+export PATH=$TEMP_DIR:$PATH
+
+cd $TEMP_DIR
+#curl -L -O https://gitlab.parity.io/parity/mirrors/polkadot/-/jobs/1810914/artifacts/file/artifacts/polkadot
+curl -L -O $POLKADOT_PR_BIN_URL
+chmod +x $TEMP_DIR/polkadot
+echo $(polkadot --version)

--- a/zombienet_tests/misc/0002-upgrade-node.feature
+++ b/zombienet_tests/misc/0002-upgrade-node.feature
@@ -13,8 +13,8 @@ bob: reports block height is at least 15 within 240 seconds
 bob: parachain 2001 block height is at least 10 within 200 seconds
 charlie: reports block height is at least 20 within 320 seconds
 # upgrade both nodes
-alice: run ./0002-upgrade.sh within 200 seconds
-bob: run ./0002-upgrade.sh within 200 seconds
+alice: run ./0002-download-polkadot-from-pr.sh within 200 seconds
+bob: run ./0002-download-polkadot-from-pr.sh within 200 seconds
 alice: reports block height is at least 40 within 200 seconds
 bob: reports block height is at least 40 within 200 seconds
 alice: parachain 2000 block height is at least 30 within 240 seconds

--- a/zombienet_tests/misc/0002-upgrade-node.feature
+++ b/zombienet_tests/misc/0002-upgrade-node.feature
@@ -17,8 +17,10 @@ charlie: reports block height is at least 20 within 320 seconds
 # For testing using native provider you should set this env var
 # POLKADOT_PR_BIN_URL=https://gitlab.parity.io/parity/mirrors/polkadot/-/jobs/1810914/artifacts/file/artifacts/polkadot
 # with the version of polkadot you want to download.
-alice: run ./0002-download-polkadot-from-pr.sh with ["{{POLKADOT_PR_BIN_URL}}"] within 200 seconds
-bob: run ./0002-download-polkadot-from-pr.sh with ["{{POLKADOT_PR_BIN_URL}}"] within 200 seconds
+alice: run ./0002-download-polkadot-from-pr.sh with "{{POLKADOT_PR_BIN_URL}}" within 200 seconds
+alice: restart after 10 seconds
+bob: run ./0002-download-polkadot-from-pr.sh with "{{POLKADOT_PR_BIN_URL}}" within 200 seconds
+bob: restart after 10 seconds
 
 alice: reports block height is at least 40 within 200 seconds
 bob: reports block height is at least 40 within 200 seconds

--- a/zombienet_tests/misc/0002-upgrade-node.feature
+++ b/zombienet_tests/misc/0002-upgrade-node.feature
@@ -12,9 +12,14 @@ alice: parachain 2000 block height is at least 10 within 200 seconds
 bob: reports block height is at least 15 within 240 seconds
 bob: parachain 2001 block height is at least 10 within 200 seconds
 charlie: reports block height is at least 20 within 320 seconds
+
 # upgrade both nodes
-alice: run ./0002-download-polkadot-from-pr.sh within 200 seconds
-bob: run ./0002-download-polkadot-from-pr.sh within 200 seconds
+# For testing using native provider you should set this env var
+# POLKADOT_PR_BIN_URL=https://gitlab.parity.io/parity/mirrors/polkadot/-/jobs/1810914/artifacts/file/artifacts/polkadot
+# with the version of polkadot you want to download.
+alice: run ./0002-download-polkadot-from-pr.sh with ["$POLKADOT_PR_BIN_URL"] within 200 seconds
+bob: run ./0002-download-polkadot-from-pr.sh with ["$POLKADOT_PR_BIN_URL"] within 200 seconds
+
 alice: reports block height is at least 40 within 200 seconds
 bob: reports block height is at least 40 within 200 seconds
 alice: parachain 2000 block height is at least 30 within 240 seconds

--- a/zombienet_tests/misc/0002-upgrade-node.feature
+++ b/zombienet_tests/misc/0002-upgrade-node.feature
@@ -1,0 +1,21 @@
+Description: Smoke / Upgrade Node
+Network: ./0002-upgrade-node.toml
+Creds: config
+
+alice: is up
+bob: is up
+charlie: is up
+dave: is up
+ferdie: is up
+eve: is up
+
+alice: reports block height is at least 10 within 200 seconds
+alice: parachain 2000 block height is at least 10 within 200 seconds
+bob: reports block height is at least 15 within 240 seconds
+bob: parachain 2001 block height is at least 10 within 200 seconds
+charlie: reports block height is at least 20 within 320 seconds
+# upgrade both nodes
+alice: run ./0002-upgrade.sh within 200 seconds
+bob: run ./0002-upgrade.sh within 200 seconds
+alice: reports block height is at least 40 within 200 seconds
+bob: reports block height is at least 40 within 200 seconds

--- a/zombienet_tests/misc/0002-upgrade-node.feature
+++ b/zombienet_tests/misc/0002-upgrade-node.feature
@@ -17,8 +17,8 @@ charlie: reports block height is at least 20 within 320 seconds
 # For testing using native provider you should set this env var
 # POLKADOT_PR_BIN_URL=https://gitlab.parity.io/parity/mirrors/polkadot/-/jobs/1810914/artifacts/file/artifacts/polkadot
 # with the version of polkadot you want to download.
-alice: run ./0002-download-polkadot-from-pr.sh with ["$POLKADOT_PR_BIN_URL"] within 200 seconds
-bob: run ./0002-download-polkadot-from-pr.sh with ["$POLKADOT_PR_BIN_URL"] within 200 seconds
+alice: run ./0002-download-polkadot-from-pr.sh with ["{{POLKADOT_PR_BIN_URL}}"] within 200 seconds
+bob: run ./0002-download-polkadot-from-pr.sh with ["{{POLKADOT_PR_BIN_URL}}"] within 200 seconds
 
 alice: reports block height is at least 40 within 200 seconds
 bob: reports block height is at least 40 within 200 seconds

--- a/zombienet_tests/misc/0002-upgrade-node.feature
+++ b/zombienet_tests/misc/0002-upgrade-node.feature
@@ -21,6 +21,13 @@ bob: run ./0002-download-polkadot-from-pr.sh with "{{POLKADOT_PR_BIN_URL}}" with
 alice: restart after 5 seconds
 bob: restart after 5 seconds
 
+# process bootstrap
+sleep 30 seconds
+
+alice: is up within 10 seconds
+bob: is up within 10 seconds
+
+
 alice: parachain 2000 block height is at least 30 within 240 seconds
 bob: parachain 2001 block height is at least 30 within 240 seconds
 

--- a/zombienet_tests/misc/0002-upgrade-node.feature
+++ b/zombienet_tests/misc/0002-upgrade-node.feature
@@ -28,6 +28,6 @@ alice: is up within 10 seconds
 bob: is up within 10 seconds
 
 
-alice: parachain 2000 block height is at least 30 within 240 seconds
-bob: parachain 2001 block height is at least 30 within 240 seconds
+alice: parachain 2000 block height is at least 30 within 300 seconds
+bob: parachain 2001 block height is at least 30 within 120 seconds
 

--- a/zombienet_tests/misc/0002-upgrade-node.feature
+++ b/zombienet_tests/misc/0002-upgrade-node.feature
@@ -17,3 +17,5 @@ alice: run ./0002-upgrade.sh within 200 seconds
 bob: run ./0002-upgrade.sh within 200 seconds
 alice: reports block height is at least 40 within 200 seconds
 bob: reports block height is at least 40 within 200 seconds
+alice: parachain 2000 block height is at least 30 within 240 seconds
+bob: parachain 2001 block height is at least 30 within 240 seconds

--- a/zombienet_tests/misc/0002-upgrade-node.feature
+++ b/zombienet_tests/misc/0002-upgrade-node.feature
@@ -7,22 +7,20 @@ bob: is up
 charlie: is up
 dave: is up
 
-alice: reports block height is at least 10 within 200 seconds
 alice: parachain 2000 block height is at least 10 within 200 seconds
-bob: reports block height is at least 15 within 240 seconds
 bob: parachain 2001 block height is at least 10 within 200 seconds
-charlie: reports block height is at least 20 within 320 seconds
 
 # upgrade both nodes
 # For testing using native provider you should set this env var
-# POLKADOT_PR_BIN_URL=https://gitlab.parity.io/parity/mirrors/polkadot/-/jobs/1810914/artifacts/file/artifacts/polkadot
+# POLKADOT_PR_BIN_URL=https://gitlab.parity.io/parity/mirrors/polkadot/-/jobs/1842869/artifacts/raw/artifacts/polkadot
 # with the version of polkadot you want to download.
-alice: run ./0002-download-polkadot-from-pr.sh with "{{POLKADOT_PR_BIN_URL}}" within 200 seconds
-alice: restart after 10 seconds
-bob: run ./0002-download-polkadot-from-pr.sh with "{{POLKADOT_PR_BIN_URL}}" within 200 seconds
-bob: restart after 10 seconds
 
-alice: reports block height is at least 40 within 200 seconds
-bob: reports block height is at least 40 within 200 seconds
+# avg 30s in our infra
+alice: run ./0002-download-polkadot-from-pr.sh with "{{POLKADOT_PR_BIN_URL}}" within 40 seconds
+bob: run ./0002-download-polkadot-from-pr.sh with "{{POLKADOT_PR_BIN_URL}}" within 40 seconds
+alice: restart after 5 seconds
+bob: restart after 5 seconds
+
 alice: parachain 2000 block height is at least 30 within 240 seconds
 bob: parachain 2001 block height is at least 30 within 240 seconds
+

--- a/zombienet_tests/misc/0002-upgrade-node.feature
+++ b/zombienet_tests/misc/0002-upgrade-node.feature
@@ -6,8 +6,6 @@ alice: is up
 bob: is up
 charlie: is up
 dave: is up
-ferdie: is up
-eve: is up
 
 alice: reports block height is at least 10 within 200 seconds
 alice: parachain 2000 block height is at least 10 within 200 seconds

--- a/zombienet_tests/misc/0002-upgrade-node.toml
+++ b/zombienet_tests/misc/0002-upgrade-node.toml
@@ -1,0 +1,49 @@
+[settings]
+timeout = 1000
+
+[relaychain]
+default_image = "{{ZOMBIENET_INTEGRATION_TEST_IMAGE}}"
+chain = "rococo-local"
+
+
+  [[relaychain.nodes]]
+  name = "alice"
+  args = [ "-lparachain=debug,runtime=debug", "--db paritydb" ]
+
+  [[relaychain.nodes]]
+  name = "bob"
+  args = [ "-lparachain=debug,runtime=debug", "--db rocksdb"]
+
+  [[relaychain.nodes]]
+  name = "charlie"
+  args = [ "-lparachain=debug,runtime=debug" ]
+
+  [[relaychain.nodes]]
+  name = "dave"
+  args = [ "-lparachain=debug,runtime=debug" ]
+
+
+[[parachains]]
+id = 2000
+addToGenesis = true
+
+  [parachains.collator]
+  name = "collator01"
+  image = "{{COL_IMAGE}}"
+  command = "undying-collator"
+  args = ["-lparachain=debug"]
+
+[[parachains]]
+id = 2001
+addToGenesis = true
+
+  [parachains.collator]
+  name = "collator02"
+  image = "{{COL_IMAGE}}"
+  command = "undying-collator"
+  args = ["-lparachain=debug"]
+
+[types.Header]
+number = "u64"
+parent_hash = "Hash"
+post_state = "Hash"

--- a/zombienet_tests/misc/0002-upgrade-node.toml
+++ b/zombienet_tests/misc/0002-upgrade-node.toml
@@ -12,15 +12,15 @@ chain = "rococo-local"
 
   [[relaychain.nodes]]
   name = "bob"
-  args = [ "-lparachain=debug,runtime=debug", "--db rocksdb"]
+  args = [ "-lparachain=debug,runtime=debug", "--db rocksdb" ]
 
   [[relaychain.nodes]]
   name = "charlie"
-  args = [ "-lparachain=debug,runtime=debug" ]
+  args = [ "-lparachain=debug,runtime=debug", "--db paritydb" ]
 
   [[relaychain.nodes]]
   name = "dave"
-  args = [ "-lparachain=debug,runtime=debug" ]
+  args = [ "-lparachain=debug,runtime=debug", "--db rocksdb" ]
 
 
 [[parachains]]


### PR DESCRIPTION
Add upgrade test, for nodes using both `rocksdb` and `paritydb`. Those nodes are started using the latest released version (https://hub.docker.com/r/parity/polkadot/tags), after waiting for some blocks the process is restarted using the binary from `build-linux-stable` of the `pr` and we check again the block production.

Thanks!