### PR TITLE
pvf-checker: enable subsystem on all chains

### DIFF
--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -801,7 +801,7 @@ where
 	let auth_or_collator = role.is_authority() || is_collator.is_collator();
 	let requires_overseer_for_chain_sel = local_keystore.is_some() && auth_or_collator;
 
-	let pvf_checker_enabled = !is_collator.is_collator() && chain_spec.is_versi();
+	let pvf_checker_enabled = !is_collator.is_collator();
 
 	let select_chain = if requires_overseer_for_chain_sel {
 		let metrics =

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -801,7 +801,7 @@ where
 	let auth_or_collator = role.is_authority() || is_collator.is_collator();
 	let requires_overseer_for_chain_sel = local_keystore.is_some() && auth_or_collator;
 
-	let pvf_checker_enabled = !is_collator.is_collator();
+	let pvf_checker_enabled = role.is_authority() && !is_collator.is_collator();
 
 	let select_chain = if requires_overseer_for_chain_sel {
 		let metrics =


### PR DESCRIPTION
Part of https://github.com/paritytech/polkadot/issues/3211

Previously it was only enabled on Versi