### PR TITLE
Update Westend Trusted Teleporters

### DIFF
--- a/runtime/westend/src/xcm_config.rs
+++ b/runtime/westend/src/xcm_config.rs
@@ -75,19 +75,15 @@ pub type XcmRouter = (
 
 parameter_types! {
 	pub const Westmint: MultiLocation = Parachain(1000).into();
-	pub const Encointer: MultiLocation = Parachain(1001).into();
-	pub const Collectives: MultiLocation = Parachain(1002).into();
+	pub const Collectives: MultiLocation = Parachain(1001).into();
 	pub const WestendForWestmint: (MultiAssetFilter, MultiLocation) =
 		(Wild(AllOf { fun: WildFungible, id: Concrete(WndLocation::get()) }), Westmint::get());
-	pub const WestendForEncointer: (MultiAssetFilter, MultiLocation) =
-		(Wild(AllOf { fun: WildFungible, id: Concrete(WndLocation::get()) }), Encointer::get());
 	pub const WestendForCollectives: (MultiAssetFilter, MultiLocation) =
 		(Wild(AllOf { fun: WildFungible, id: Concrete(WndLocation::get()) }), Collectives::get());
 	pub const MaxInstructions: u32 = 100;
 }
 pub type TrustedTeleporters = (
 	xcm_builder::Case<WestendForWestmint>,
-	xcm_builder::Case<WestendForEncointer>,
 	xcm_builder::Case<WestendForCollectives>,
 );
 

--- a/runtime/westend/src/xcm_config.rs
+++ b/runtime/westend/src/xcm_config.rs
@@ -82,10 +82,8 @@ parameter_types! {
 		(Wild(AllOf { fun: WildFungible, id: Concrete(WndLocation::get()) }), Collectives::get());
 	pub const MaxInstructions: u32 = 100;
 }
-pub type TrustedTeleporters = (
-	xcm_builder::Case<WestendForWestmint>,
-	xcm_builder::Case<WestendForCollectives>,
-);
+pub type TrustedTeleporters =
+	(xcm_builder::Case<WestendForWestmint>, xcm_builder::Case<WestendForCollectives>);
 
 /// The barriers one of which must be passed for an XCM message to be executed.
 pub type Barrier = (


### PR DESCRIPTION
- Encointer is offboarding from Westend (using Rococo for testing)
- Will change Collectives ParaId to 1001. Kind of painful but long term it's more convenient to have the same ID on Westend as is planned on Polkadot.