### PR TITLE
Network bridge changes for asynchronous backing + update subsystems to handle versioned packets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6060,6 +6060,7 @@ dependencies = [
 name = "polkadot-availability-bitfield-distribution"
 version = "0.9.28"
 dependencies = [
+ "always-assert",
  "assert_matches",
  "bitvec 1.0.0",
  "env_logger 0.9.0",

--- a/node/core/backing/src/tests/mod.rs
+++ b/node/core/backing/src/tests/mod.rs
@@ -33,6 +33,7 @@ use polkadot_node_subsystem::{
 use polkadot_node_subsystem_test_helpers as test_helpers;
 use polkadot_primitives::v2::{
 	CandidateDescriptor, GroupRotationInfo, HeadData, PersistedValidationData, ScheduledCore,
+	SessionIndex,
 };
 use sp_application_crypto::AppKey;
 use sp_keyring::Sr25519Keyring;

--- a/node/network/approval-distribution/src/lib.rs
+++ b/node/network/approval-distribution/src/lib.rs
@@ -26,7 +26,7 @@ use polkadot_node_network_protocol::{
 	grid_topology::{RandomRouting, RequiredRouting, SessionGridTopologies, SessionGridTopology},
 	peer_set::ValidationVersion,
 	v1 as protocol_v1, vstaging as protocol_vstaging, PeerId, UnifiedReputationChange as Rep,
-	Versioned, View, VersionedValidationProtocol,
+	Versioned, VersionedValidationProtocol, View,
 };
 use polkadot_node_primitives::approval::{
 	AssignmentCert, BlockApprovalMeta, IndirectAssignmentCert, IndirectSignedApprovalVote,
@@ -449,7 +449,8 @@ impl State {
 			let sender = ctx.sender();
 			for (peer_id, data) in self.peer_data.iter() {
 				let intersection = data.view.iter().filter(|h| new_hashes.contains(h));
-				let view_intersection = View::new(intersection.cloned(), data.view.finalized_number);
+				let view_intersection =
+					View::new(intersection.cloned(), data.view.finalized_number);
 				Self::unify_with_peer(
 					sender,
 					metrics,

--- a/node/network/approval-distribution/src/lib.rs
+++ b/node/network/approval-distribution/src/lib.rs
@@ -24,7 +24,9 @@ use futures::{channel::oneshot, FutureExt as _};
 use polkadot_node_network_protocol::{
 	self as net_protocol,
 	grid_topology::{RandomRouting, RequiredRouting, SessionGridTopologies, SessionGridTopology},
-	v1 as protocol_v1, PeerId, UnifiedReputationChange as Rep, Versioned, View,
+	peer_set::ValidationVersion,
+	v1 as protocol_v1, vstaging as protocol_vstaging, PeerId, UnifiedReputationChange as Rep,
+	Versioned, View, VersionedValidationProtocol,
 };
 use polkadot_node_primitives::approval::{
 	AssignmentCert, BlockApprovalMeta, IndirectAssignmentCert, IndirectSignedApprovalVote,
@@ -150,6 +152,15 @@ enum Resend {
 	No,
 }
 
+/// Data stored on a per-peer basis.
+#[derive(Debug)]
+struct PeerData {
+	/// The peer's view.
+	view: View,
+	/// The peer's protocol version.
+	version: ValidationVersion,
+}
+
 /// The [`State`] struct is responsible for tracking the overall state of the subsystem.
 ///
 /// It tracks metadata about our view of the unfinalized chain,
@@ -169,7 +180,7 @@ struct State {
 	pending_known: HashMap<Hash, Vec<(PeerId, PendingMessage)>>,
 
 	/// Peer data is partially stored here, and partially inline within the [`BlockEntry`]s
-	peer_views: HashMap<PeerId, View>,
+	peer_data: HashMap<PeerId, PeerData>,
 
 	/// Keeps a topology for various different sessions.
 	topologies: SessionGridTopologies,
@@ -330,14 +341,30 @@ impl State {
 		rng: &mut (impl CryptoRng + Rng),
 	) {
 		match event {
-			NetworkBridgeEvent::PeerConnected(peer_id, role, _, _) => {
+			NetworkBridgeEvent::PeerConnected(peer_id, role, version, _) => {
 				// insert a blank view if none already present
 				gum::trace!(target: LOG_TARGET, ?peer_id, ?role, "Peer connected");
-				self.peer_views.entry(peer_id).or_default();
+				let version = match ValidationVersion::try_from(version).ok() {
+					Some(v) => v,
+					None => {
+						// sanity: network bridge is supposed to detect this already.
+						gum::trace!(
+							target: LOG_TARGET,
+							?peer_id,
+							?version,
+							"Unsupported protocol version"
+						);
+						return
+					},
+				};
+
+				self.peer_data
+					.entry(peer_id)
+					.or_insert_with(|| PeerData { version, view: Default::default() });
 			},
 			NetworkBridgeEvent::PeerDisconnected(peer_id) => {
 				gum::trace!(target: LOG_TARGET, ?peer_id, "Peer disconnected");
-				self.peer_views.remove(&peer_id);
+				self.peer_data.remove(&peer_id);
 				self.blocks.iter_mut().for_each(|(_hash, entry)| {
 					entry.known_by.remove(&peer_id);
 				})
@@ -370,7 +397,7 @@ impl State {
 					live
 				});
 			},
-			NetworkBridgeEvent::PeerMessage(peer_id, Versioned::V1(msg)) => {
+			NetworkBridgeEvent::PeerMessage(peer_id, msg) => {
 				self.process_incoming_peer_message(ctx, metrics, peer_id, msg, rng).await;
 			},
 		}
@@ -420,16 +447,17 @@ impl State {
 
 		{
 			let sender = ctx.sender();
-			for (peer_id, view) in self.peer_views.iter() {
-				let intersection = view.iter().filter(|h| new_hashes.contains(h));
-				let view_intersection = View::new(intersection.cloned(), view.finalized_number);
+			for (peer_id, data) in self.peer_data.iter() {
+				let intersection = data.view.iter().filter(|h| new_hashes.contains(h));
+				let view_intersection = View::new(intersection.cloned(), data.view.finalized_number);
 				Self::unify_with_peer(
 					sender,
 					metrics,
 					&mut self.blocks,
 					&self.topologies,
-					self.peer_views.len(),
+					self.peer_data.len(),
 					peer_id.clone(),
+					data.version,
 					view_intersection,
 					rng,
 				)
@@ -506,6 +534,7 @@ impl State {
 
 		adjust_required_routing_and_propagate(
 			ctx,
+			&self.peer_data,
 			&mut self.blocks,
 			&self.topologies,
 			|block_entry| block_entry.session == session,
@@ -523,13 +552,16 @@ impl State {
 		ctx: &mut Context,
 		metrics: &Metrics,
 		peer_id: PeerId,
-		msg: protocol_v1::ApprovalDistributionMessage,
+		msg: net_protocol::ApprovalDistributionMessage,
 		rng: &mut R,
 	) where
 		R: CryptoRng + Rng,
 	{
 		match msg {
-			protocol_v1::ApprovalDistributionMessage::Assignments(assignments) => {
+			Versioned::V1(protocol_v1::ApprovalDistributionMessage::Assignments(assignments)) |
+			Versioned::VStaging(protocol_vstaging::ApprovalDistributionMessage::Assignments(
+				assignments,
+			)) => {
 				gum::trace!(
 					target: LOG_TARGET,
 					peer_id = %peer_id,
@@ -570,7 +602,10 @@ impl State {
 					.await;
 				}
 			},
-			protocol_v1::ApprovalDistributionMessage::Approvals(approvals) => {
+			Versioned::V1(protocol_v1::ApprovalDistributionMessage::Approvals(approvals)) |
+			Versioned::VStaging(protocol_vstaging::ApprovalDistributionMessage::Approvals(
+				approvals,
+			)) => {
 				gum::trace!(
 					target: LOG_TARGET,
 					peer_id = %peer_id,
@@ -623,9 +658,14 @@ impl State {
 	{
 		gum::trace!(target: LOG_TARGET, ?view, "Peer view change");
 		let finalized_number = view.finalized_number;
-		let old_view =
-			self.peer_views.get_mut(&peer_id).map(|d| std::mem::replace(d, view.clone()));
-		let old_finalized_number = old_view.map(|v| v.finalized_number).unwrap_or(0);
+		let (peer_protocol_version, old_finalized_number) = match self
+			.peer_data
+			.get_mut(&peer_id)
+			.map(|d| (d.version, std::mem::replace(&mut d.view, view.clone())))
+		{
+			Some((v, view)) => (v, view.finalized_number),
+			None => return, // unknown peer
+		};
 
 		// we want to prune every block known_by peer up to (including) view.finalized_number
 		let blocks = &mut self.blocks;
@@ -650,8 +690,9 @@ impl State {
 			metrics,
 			&mut self.blocks,
 			&self.topologies,
-			self.peer_views.len(),
+			self.peer_data.len(),
 			peer_id.clone(),
+			peer_protocol_version,
 			view,
 			rng,
 		)
@@ -894,7 +935,7 @@ impl State {
 		// then messages will be sent when we get it.
 
 		let assignments = vec![(assignment, claimed_candidate_index)];
-		let n_peers_total = self.peer_views.len();
+		let n_peers_total = self.peer_data.len();
 		let source_peer = source.peer_id();
 
 		let mut peer_filter = move |peer| {
@@ -918,31 +959,62 @@ impl State {
 			route_random
 		};
 
-		let peers = entry.known_by.keys().filter(|p| peer_filter(p)).cloned().collect::<Vec<_>>();
+		let (v1_peers, vstaging_peers) = {
+			let peer_data = &self.peer_data;
+			let peers = entry
+				.known_by
+				.keys()
+				.filter_map(|p| peer_data.get(&p).map(|pd| (p, pd.version)))
+				.filter(|(p, _)| peer_filter(p))
+				.map(|(p, v)| (p.clone(), v))
+				.collect::<Vec<_>>();
 
-		// Add the metadata of the assignment to the knowledge of each peer.
-		for peer in peers.iter() {
-			// we already filtered peers above, so this should always be Some
-			if let Some(peer_knowledge) = entry.known_by.get_mut(peer) {
-				peer_knowledge.sent.insert(message_subject.clone(), message_kind);
+			// Add the metadata of the assignment to the knowledge of each peer.
+			for (peer, _) in peers.iter() {
+				// we already filtered peers above, so this should always be Some
+				if let Some(peer_knowledge) = entry.known_by.get_mut(peer) {
+					peer_knowledge.sent.insert(message_subject.clone(), message_kind);
+				}
 			}
+
+			if !peers.is_empty() {
+				gum::trace!(
+					target: LOG_TARGET,
+					?block_hash,
+					?claimed_candidate_index,
+					local = source.peer_id().is_none(),
+					num_peers = peers.len(),
+					"Sending an assignment to peers",
+				);
+			}
+
+			let v1_peers = peers
+				.iter()
+				.filter(|(_, v)| v == &ValidationVersion::V1)
+				.map(|p| p.0.clone())
+				.collect::<Vec<_>>();
+
+			let vstaging_peers = peers
+				.iter()
+				.filter(|(_, v)| v == &ValidationVersion::VStaging)
+				.map(|p| p.0.clone())
+				.collect::<Vec<_>>();
+
+			(v1_peers, vstaging_peers)
+		};
+
+		if !v1_peers.is_empty() {
+			ctx.send_message(NetworkBridgeTxMessage::SendValidationMessage(
+				v1_peers,
+				versioned_assignments_packet(ValidationVersion::V1, assignments.clone()),
+			))
+			.await;
 		}
 
-		if !peers.is_empty() {
-			gum::trace!(
-				target: LOG_TARGET,
-				?block_hash,
-				?claimed_candidate_index,
-				local = source.peer_id().is_none(),
-				num_peers = peers.len(),
-				"Sending an assignment to peers",
-			);
-
+		if !vstaging_peers.is_empty() {
 			ctx.send_message(NetworkBridgeTxMessage::SendValidationMessage(
-				peers,
-				Versioned::V1(protocol_v1::ValidationProtocol::ApprovalDistribution(
-					protocol_v1::ApprovalDistributionMessage::Assignments(assignments),
-				)),
+				vstaging_peers,
+				versioned_assignments_packet(ValidationVersion::VStaging, assignments.clone()),
 			))
 			.await;
 		}
@@ -1173,38 +1245,64 @@ impl State {
 			in_topology || knowledge.sent.contains(message_subject, MessageKind::Assignment)
 		};
 
-		let peers = entry
-			.known_by
-			.iter()
-			.filter(|(p, k)| peer_filter(p, k))
-			.map(|(p, _)| p)
-			.cloned()
-			.collect::<Vec<_>>();
+		let (v1_peers, vstaging_peers) = {
+			let peer_data = &self.peer_data;
+			let peers = entry
+				.known_by
+				.iter()
+				.filter_map(|(p, k)| peer_data.get(&p).map(|pd| (p, k, pd.version)))
+				.filter(|(p, k, _)| peer_filter(p, k))
+				.map(|(p, _, v)| (p.clone(), v))
+				.collect::<Vec<_>>();
 
-		// Add the metadata of the assignment to the knowledge of each peer.
-		for peer in peers.iter() {
-			// we already filtered peers above, so this should always be Some
-			if let Some(entry) = entry.known_by.get_mut(peer) {
-				entry.sent.insert(message_subject.clone(), message_kind);
+			// Add the metadata of the assignment to the knowledge of each peer.
+			for (peer, _) in peers.iter() {
+				// we already filtered peers above, so this should always be Some
+				if let Some(peer_knowledge) = entry.known_by.get_mut(peer) {
+					peer_knowledge.sent.insert(message_subject.clone(), message_kind);
+				}
 			}
+
+			if !peers.is_empty() {
+				gum::trace!(
+					target: LOG_TARGET,
+					?block_hash,
+					?candidate_index,
+					local = source.peer_id().is_none(),
+					num_peers = peers.len(),
+					"Sending an approval to peers",
+				);
+			}
+
+			let v1_peers = peers
+				.iter()
+				.filter(|(_, v)| v == &ValidationVersion::V1)
+				.map(|p| p.0.clone())
+				.collect::<Vec<_>>();
+
+			let vstaging_peers = peers
+				.iter()
+				.filter(|(_, v)| v == &ValidationVersion::VStaging)
+				.map(|p| p.0.clone())
+				.collect::<Vec<_>>();
+
+			(v1_peers, vstaging_peers)
+		};
+
+		let approvals = vec![vote];
+
+		if !v1_peers.is_empty() {
+			ctx.send_message(NetworkBridgeTxMessage::SendValidationMessage(
+				v1_peers,
+				versioned_approvals_packet(ValidationVersion::V1, approvals.clone()),
+			))
+			.await;
 		}
 
-		if !peers.is_empty() {
-			let approvals = vec![vote];
-			gum::trace!(
-				target: LOG_TARGET,
-				?block_hash,
-				?candidate_index,
-				local = source.peer_id().is_none(),
-				num_peers = peers.len(),
-				"Sending an approval to peers",
-			);
-
+		if !vstaging_peers.is_empty() {
 			ctx.send_message(NetworkBridgeTxMessage::SendValidationMessage(
-				peers,
-				Versioned::V1(protocol_v1::ValidationProtocol::ApprovalDistribution(
-					protocol_v1::ApprovalDistributionMessage::Approvals(approvals),
-				)),
+				vstaging_peers,
+				versioned_approvals_packet(ValidationVersion::VStaging, approvals),
 			))
 			.await;
 		}
@@ -1260,6 +1358,7 @@ impl State {
 		topologies: &SessionGridTopologies,
 		total_peers: usize,
 		peer_id: PeerId,
+		peer_protocol_version: ValidationVersion,
 		view: View,
 		rng: &mut (impl CryptoRng + Rng),
 	) {
@@ -1373,9 +1472,7 @@ impl State {
 			sender
 				.send_message(NetworkBridgeTxMessage::SendValidationMessage(
 					vec![peer_id.clone()],
-					Versioned::V1(protocol_v1::ValidationProtocol::ApprovalDistribution(
-						protocol_v1::ApprovalDistributionMessage::Assignments(assignments_to_send),
-					)),
+					versioned_assignments_packet(peer_protocol_version, assignments_to_send),
 				))
 				.await;
 		}
@@ -1391,9 +1488,7 @@ impl State {
 			sender
 				.send_message(NetworkBridgeTxMessage::SendValidationMessage(
 					vec![peer_id],
-					Versioned::V1(protocol_v1::ValidationProtocol::ApprovalDistribution(
-						protocol_v1::ApprovalDistributionMessage::Approvals(approvals_to_send),
-					)),
+					versioned_approvals_packet(peer_protocol_version, approvals_to_send),
 				))
 				.await;
 		}
@@ -1421,6 +1516,7 @@ impl State {
 
 		adjust_required_routing_and_propagate(
 			ctx,
+			&self.peer_data,
 			&mut self.blocks,
 			&self.topologies,
 			|block_entry| {
@@ -1448,6 +1544,7 @@ impl State {
 
 		adjust_required_routing_and_propagate(
 			ctx,
+			&self.peer_data,
 			&mut self.blocks,
 			&self.topologies,
 			|block_entry| {
@@ -1505,6 +1602,7 @@ impl State {
 #[overseer::contextbounds(ApprovalDistribution, prefix = self::overseer)]
 async fn adjust_required_routing_and_propagate<Context, BlockFilter, RoutingModifier>(
 	ctx: &mut Context,
+	peer_data: &HashMap<PeerId, PeerData>,
 	blocks: &mut HashMap<Hash, BlockEntry>,
 	topologies: &SessionGridTopologies,
 	block_filter: BlockFilter,
@@ -1592,21 +1690,27 @@ async fn adjust_required_routing_and_propagate<Context, BlockFilter, RoutingModi
 	// Send messages in accumulated packets, assignments preceding approvals.
 
 	for (peer, assignments_packet) in peer_assignments {
+		let versioned_packet = match peer_data.get(&peer).map(|pd| pd.version) {
+			None => continue,
+			Some(v) => versioned_assignments_packet(v, assignments_packet),
+		};
+
 		ctx.send_message(NetworkBridgeTxMessage::SendValidationMessage(
 			vec![peer],
-			Versioned::V1(protocol_v1::ValidationProtocol::ApprovalDistribution(
-				protocol_v1::ApprovalDistributionMessage::Assignments(assignments_packet),
-			)),
+			versioned_packet,
 		))
 		.await;
 	}
 
 	for (peer, approvals_packet) in peer_approvals {
+		let versioned_packet = match peer_data.get(&peer).map(|pd| pd.version) {
+			None => continue,
+			Some(v) => versioned_approvals_packet(v, approvals_packet),
+		};
+
 		ctx.send_message(NetworkBridgeTxMessage::SendValidationMessage(
 			vec![peer],
-			Versioned::V1(protocol_v1::ValidationProtocol::ApprovalDistribution(
-				protocol_v1::ApprovalDistributionMessage::Approvals(approvals_packet),
-			)),
+			versioned_packet,
 		))
 		.await;
 	}
@@ -1734,6 +1838,38 @@ impl ApprovalDistribution {
 				}
 			},
 		}
+	}
+}
+
+fn versioned_approvals_packet(
+	version: ValidationVersion,
+	approvals: Vec<IndirectSignedApprovalVote>,
+) -> VersionedValidationProtocol {
+	match version {
+		ValidationVersion::V1 =>
+			Versioned::V1(protocol_v1::ValidationProtocol::ApprovalDistribution(
+				protocol_v1::ApprovalDistributionMessage::Approvals(approvals),
+			)),
+		ValidationVersion::VStaging =>
+			Versioned::VStaging(protocol_vstaging::ValidationProtocol::ApprovalDistribution(
+				protocol_vstaging::ApprovalDistributionMessage::Approvals(approvals),
+			)),
+	}
+}
+
+fn versioned_assignments_packet(
+	version: ValidationVersion,
+	assignments: Vec<(IndirectAssignmentCert, CandidateIndex)>,
+) -> VersionedValidationProtocol {
+	match version {
+		ValidationVersion::V1 =>
+			Versioned::V1(protocol_v1::ValidationProtocol::ApprovalDistribution(
+				protocol_v1::ApprovalDistributionMessage::Assignments(assignments),
+			)),
+		ValidationVersion::VStaging =>
+			Versioned::VStaging(protocol_vstaging::ValidationProtocol::ApprovalDistribution(
+				protocol_vstaging::ApprovalDistributionMessage::Assignments(assignments),
+			)),
 	}
 }
 

--- a/node/network/approval-distribution/src/tests.rs
+++ b/node/network/approval-distribution/src/tests.rs
@@ -800,7 +800,7 @@ fn update_peer_view() {
 		virtual_overseer
 	});
 
-	assert_eq!(state.peer_views.get(peer).map(|v| v.finalized_number), Some(0));
+	assert_eq!(state.peer_data.get(peer).map(|data| data.view.finalized_number), Some(0));
 	assert_eq!(
 		state
 			.blocks
@@ -852,7 +852,7 @@ fn update_peer_view() {
 		virtual_overseer
 	});
 
-	assert_eq!(state.peer_views.get(peer).map(|v| v.finalized_number), Some(2));
+	assert_eq!(state.peer_data.get(peer).map(|data| data.view.finalized_number), Some(2));
 	assert_eq!(
 		state
 			.blocks
@@ -882,7 +882,10 @@ fn update_peer_view() {
 		virtual_overseer
 	});
 
-	assert_eq!(state.peer_views.get(peer).map(|v| v.finalized_number), Some(finalized_number));
+	assert_eq!(
+		state.peer_data.get(peer).map(|data| data.view.finalized_number),
+		Some(finalized_number)
+	);
 	assert!(state.blocks.get(&hash_c).unwrap().known_by.get(peer).is_none());
 }
 
@@ -2228,3 +2231,6 @@ fn resends_messages_periodically() {
 		virtual_overseer
 	});
 }
+
+// TODO [now]: some tests for vstaging peers: receiving and sending from peers with
+// different protocol versions.

--- a/node/network/bitfield-distribution/Cargo.toml
+++ b/node/network/bitfield-distribution/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 
 [dependencies]
+always-assert = "0.1"
 futures = "0.3.21"
 gum = { package = "tracing-gum", path = "../../gum" }
 polkadot-primitives = { path = "../../../primitives" }

--- a/node/network/bitfield-distribution/src/lib.rs
+++ b/node/network/bitfield-distribution/src/lib.rs
@@ -22,6 +22,7 @@
 
 #![deny(unused_crate_dependencies)]
 
+use always_assert::never;
 use futures::{channel::oneshot, FutureExt};
 
 use polkadot_node_network_protocol::{
@@ -29,7 +30,9 @@ use polkadot_node_network_protocol::{
 	grid_topology::{
 		RandomRouting, RequiredRouting, SessionBoundGridTopologyStorage, SessionGridTopology,
 	},
-	v1 as protocol_v1, OurView, PeerId, UnifiedReputationChange as Rep, Versioned, View,
+	peer_set::{ProtocolVersion, ValidationVersion},
+	v1 as protocol_v1, vstaging as protocol_vstaging, OurView, PeerId,
+	UnifiedReputationChange as Rep, Versioned, View,
 };
 use polkadot_node_subsystem::{
 	jaeger, messages::*, overseer, ActiveLeavesUpdate, FromOrchestra, OverseerSignal, PerLeafSpan,
@@ -69,16 +72,54 @@ struct BitfieldGossipMessage {
 }
 
 impl BitfieldGossipMessage {
-	fn into_validation_protocol(self) -> net_protocol::VersionedValidationProtocol {
-		self.into_network_message().into()
+	fn into_validation_protocol(
+		self,
+		recipient_version: ProtocolVersion,
+	) -> net_protocol::VersionedValidationProtocol {
+		self.into_network_message(recipient_version).into()
 	}
 
-	fn into_network_message(self) -> net_protocol::BitfieldDistributionMessage {
-		Versioned::V1(protocol_v1::BitfieldDistributionMessage::Bitfield(
-			self.relay_parent,
-			self.signed_availability.into(),
-		))
+	fn into_network_message(
+		self,
+		recipient_version: ProtocolVersion,
+	) -> net_protocol::BitfieldDistributionMessage {
+		match ValidationVersion::try_from(recipient_version).ok() {
+			Some(ValidationVersion::V1) =>
+				Versioned::V1(protocol_v1::BitfieldDistributionMessage::Bitfield(
+					self.relay_parent,
+					self.signed_availability.into(),
+				)),
+			Some(ValidationVersion::VStaging) =>
+				Versioned::VStaging(protocol_vstaging::BitfieldDistributionMessage::Bitfield(
+					self.relay_parent,
+					self.signed_availability.into(),
+				)),
+			None => {
+				never!("Peers should only have supported protocol versions.");
+
+				gum::warn!(
+					target: LOG_TARGET,
+					version = ?recipient_version,
+					"Unknown protocol version provided for message recipient"
+				);
+
+				// fall back to v1 to avoid
+				Versioned::V1(protocol_v1::BitfieldDistributionMessage::Bitfield(
+					self.relay_parent,
+					self.signed_availability.into(),
+				))
+			},
+		}
 	}
+}
+
+/// Data stored on a per-peer basis.
+#[derive(Debug)]
+pub struct PeerData {
+	/// The peer's view.
+	view: View,
+	/// The peer's protocol version.
+	version: ProtocolVersion,
 }
 
 /// Data used to track information of peers and relay parents the
@@ -87,7 +128,7 @@ impl BitfieldGossipMessage {
 struct ProtocolState {
 	/// Track all active peers and their views
 	/// to determine what is relevant to them.
-	peer_views: HashMap<PeerId, View>,
+	peer_data: HashMap<PeerId, PeerData>,
 
 	/// The current and previous gossip topologies
 	topologies: SessionBoundGridTopologyStorage,
@@ -334,7 +375,7 @@ async fn handle_bitfield_distribution<Context>(
 		ctx,
 		job_data,
 		topology,
-		&mut state.peer_views,
+		&mut state.peer_data,
 		validator,
 		msg,
 		required_routing,
@@ -353,7 +394,7 @@ async fn relay_message<Context>(
 	ctx: &mut Context,
 	job_data: &mut PerRelayParentData,
 	topology: &SessionGridTopology,
-	peer_views: &mut HashMap<PeerId, View>,
+	peers: &mut HashMap<PeerId, PeerData>,
 	validator: ValidatorId,
 	message: BitfieldGossipMessage,
 	required_routing: RequiredRouting,
@@ -371,16 +412,16 @@ async fn relay_message<Context>(
 	.await;
 
 	drop(_span);
-	let total_peers = peer_views.len();
+	let total_peers = peers.len();
 	let mut random_routing: RandomRouting = Default::default();
 
 	let _span = span.child("interested-peers");
 	// pass on the bitfield distribution to all interested peers
-	let interested_peers = peer_views
+	let interested_peers = peers
 		.iter()
-		.filter_map(|(peer, view)| {
+		.filter_map(|(peer, data)| {
 			// check interest in the peer in this message's relay parent
-			if view.contains(&message.relay_parent) {
+			if data.view.contains(&message.relay_parent) {
 				let message_needed =
 					job_data.message_from_validator_needed_by_peer(&peer, &validator);
 				if message_needed {
@@ -395,7 +436,7 @@ async fn relay_message<Context>(
 					};
 
 					if need_routing {
-						Some(peer.clone())
+						Some((peer.clone(), data.version))
 					} else {
 						None
 					}
@@ -406,9 +447,9 @@ async fn relay_message<Context>(
 				None
 			}
 		})
-		.collect::<Vec<PeerId>>();
+		.collect::<Vec<(PeerId, ProtocolVersion)>>();
 
-	interested_peers.iter().for_each(|peer| {
+	interested_peers.iter().for_each(|(peer, _)| {
 		// track the message as sent for this peer
 		job_data
 			.message_sent_to_peer
@@ -427,11 +468,33 @@ async fn relay_message<Context>(
 		);
 	} else {
 		let _span = span.child("gossip");
-		ctx.send_message(NetworkBridgeTxMessage::SendValidationMessage(
-			interested_peers,
-			message.into_validation_protocol(),
-		))
-		.await;
+		let v1_interested_peers = interested_peers
+			.iter()
+			.filter(|(_, v)| v == &ValidationVersion::V1.into())
+			.map(|(p, _)| p.clone())
+			.collect::<Vec<_>>();
+
+		let vstaging_interested_peers = interested_peers
+			.iter()
+			.filter(|(_, v)| v == &ValidationVersion::VStaging.into())
+			.map(|(p, _)| p.clone())
+			.collect::<Vec<_>>();
+
+		if !v1_interested_peers.is_empty() {
+			ctx.send_message(NetworkBridgeTxMessage::SendValidationMessage(
+				v1_interested_peers,
+				message.clone().into_validation_protocol(ValidationVersion::V1.into()),
+			))
+			.await;
+		}
+
+		if !vstaging_interested_peers.is_empty() {
+			ctx.send_message(NetworkBridgeTxMessage::SendValidationMessage(
+				vstaging_interested_peers,
+				message.into_validation_protocol(ValidationVersion::VStaging.into()),
+			))
+			.await
+		}
 	}
 }
 
@@ -442,10 +505,20 @@ async fn process_incoming_peer_message<Context>(
 	state: &mut ProtocolState,
 	metrics: &Metrics,
 	origin: PeerId,
-	message: protocol_v1::BitfieldDistributionMessage,
+	message: net_protocol::BitfieldDistributionMessage,
 	rng: &mut (impl CryptoRng + Rng),
 ) {
-	let protocol_v1::BitfieldDistributionMessage::Bitfield(relay_parent, bitfield) = message;
+	let (relay_parent, bitfield) = match message {
+		Versioned::V1(protocol_v1::BitfieldDistributionMessage::Bitfield(
+			relay_parent,
+			bitfield,
+		)) => (relay_parent, bitfield),
+		Versioned::VStaging(protocol_vstaging::BitfieldDistributionMessage::Bitfield(
+			relay_parent,
+			bitfield,
+		)) => (relay_parent, bitfield),
+	};
+
 	gum::trace!(
 		target: LOG_TARGET,
 		peer = %origin,
@@ -543,7 +616,7 @@ async fn process_incoming_peer_message<Context>(
 		ctx,
 		job_data,
 		topology,
-		&mut state.peer_views,
+		&mut state.peer_data,
 		validator,
 		message,
 		required_routing,
@@ -567,15 +640,18 @@ async fn handle_network_msg<Context>(
 	let _timer = metrics.time_handle_network_msg();
 
 	match bridge_message {
-		NetworkBridgeEvent::PeerConnected(peer, role, _, _) => {
+		NetworkBridgeEvent::PeerConnected(peer, role, version, _) => {
 			gum::trace!(target: LOG_TARGET, ?peer, ?role, "Peer connected");
 			// insert if none already present
-			state.peer_views.entry(peer).or_default();
+			state
+				.peer_data
+				.entry(peer)
+				.or_insert_with(|| PeerData { view: View::default(), version });
 		},
 		NetworkBridgeEvent::PeerDisconnected(peer) => {
 			gum::trace!(target: LOG_TARGET, ?peer, "Peer disconnected");
 			// get rid of superfluous data
-			state.peer_views.remove(&peer);
+			state.peer_data.remove(&peer);
 		},
 		NetworkBridgeEvent::NewGossipTopology(gossip_topology) => {
 			let session_index = gossip_topology.session;
@@ -590,12 +666,21 @@ async fn handle_network_msg<Context>(
 			);
 
 			for new_peer in newly_added {
-				// in case we already knew that peer in the past
-				// it might have had an existing view, we use to initialize
-				// and minimize the delta on `PeerViewChange` to be sent
-				if let Some(old_view) = state.peer_views.remove(&new_peer) {
-					handle_peer_view_change(ctx, state, new_peer, old_view, rng).await;
-				}
+				let old_view = match state.peer_data.get_mut(&new_peer) {
+					Some(d) => {
+						// in case we already knew that peer in the past
+						// it might have had an existing view, we use to initialize
+						// and minimize the delta on `PeerViewChange` to be sent
+						std::mem::replace(&mut d.view, Default::default())
+					},
+					None => {
+						// For peers which are currently unknown, we'll send topology-related
+						// messages to them when they connect and send their first view update.
+						continue
+					},
+				};
+
+				handle_peer_view_change(ctx, state, new_peer, old_view, rng).await;
 			}
 		},
 		NetworkBridgeEvent::PeerViewChange(peerid, new_view) => {
@@ -606,7 +691,7 @@ async fn handle_network_msg<Context>(
 			gum::trace!(target: LOG_TARGET, ?new_view, "Our view change");
 			handle_our_view_change(state, new_view);
 		},
-		NetworkBridgeEvent::PeerMessage(remote, Versioned::V1(message)) =>
+		NetworkBridgeEvent::PeerMessage(remote, message) =>
 			process_incoming_peer_message(ctx, state, metrics, remote, message, rng).await,
 	}
 }
@@ -635,6 +720,9 @@ fn handle_our_view_change(state: &mut ProtocolState, view: OurView) {
 
 // Send the difference between two views which were not sent
 // to that particular peer.
+//
+// This requires that there is an entry in the `peer_data` field for the
+// peer.
 #[overseer::contextbounds(BitfieldDistribution, prefix=self::overseer)]
 async fn handle_peer_view_change<Context>(
 	ctx: &mut Context,
@@ -643,13 +731,20 @@ async fn handle_peer_view_change<Context>(
 	view: View,
 	rng: &mut (impl CryptoRng + Rng),
 ) {
-	let added = state
-		.peer_views
-		.entry(origin.clone())
-		.or_default()
-		.replace_difference(view)
-		.cloned()
-		.collect::<Vec<_>>();
+	let peer_data = match state.peer_data.get_mut(&origin) {
+		None => {
+			gum::warn!(
+				target: LOG_TARGET,
+				peer = ?origin,
+				"Attempted to update peer view for unknown peer."
+			);
+
+			return
+		},
+		Some(pd) => pd,
+	};
+
+	let added = peer_data.view.replace_difference(view).cloned().collect::<Vec<_>>();
 
 	let topology = state.topologies.get_current_topology();
 	let is_gossip_peer = topology.route_to_peer(RequiredRouting::GridXY, &origin);
@@ -716,6 +811,12 @@ async fn send_tracked_gossip_message<Context>(
 		"Sending gossip message"
 	);
 
+	let version = if let Some(peer_data) = state.peer_data.get(&dest) {
+		peer_data.version
+	} else {
+		return
+	};
+
 	job_data
 		.message_sent_to_peer
 		.entry(dest.clone())
@@ -724,7 +825,7 @@ async fn send_tracked_gossip_message<Context>(
 
 	ctx.send_message(NetworkBridgeTxMessage::SendValidationMessage(
 		vec![dest],
-		message.into_validation_protocol(),
+		message.into_validation_protocol(version),
 	))
 	.await;
 }

--- a/node/network/bitfield-distribution/src/lib.rs
+++ b/node/network/bitfield-distribution/src/lib.rs
@@ -811,11 +811,8 @@ async fn send_tracked_gossip_message<Context>(
 		"Sending gossip message"
 	);
 
-	let version = if let Some(peer_data) = state.peer_data.get(&dest) {
-		peer_data.version
-	} else {
-		return
-	};
+	let version =
+		if let Some(peer_data) = state.peer_data.get(&dest) { peer_data.version } else { return };
 
 	job_data
 		.message_sent_to_peer

--- a/node/network/bitfield-distribution/src/lib.rs
+++ b/node/network/bitfield-distribution/src/lib.rs
@@ -468,17 +468,19 @@ async fn relay_message<Context>(
 		);
 	} else {
 		let _span = span.child("gossip");
-		let v1_interested_peers = interested_peers
-			.iter()
-			.filter(|(_, v)| v == &ValidationVersion::V1.into())
-			.map(|(p, _)| p.clone())
-			.collect::<Vec<_>>();
 
-		let vstaging_interested_peers = interested_peers
-			.iter()
-			.filter(|(_, v)| v == &ValidationVersion::VStaging.into())
-			.map(|(p, _)| p.clone())
-			.collect::<Vec<_>>();
+		let filter_by_version = |peers: &[(PeerId, ProtocolVersion)],
+		                         version: ValidationVersion| {
+			peers
+				.iter()
+				.filter(|(_, v)| v == &version.into())
+				.map(|(peer_id, _)| *peer_id)
+				.collect::<Vec<_>>()
+		};
+
+		let v1_interested_peers = filter_by_version(&interested_peers, ValidationVersion::V1);
+		let vstaging_interested_peers =
+			filter_by_version(&interested_peers, ValidationVersion::VStaging);
 
 		if !v1_interested_peers.is_empty() {
 			ctx.send_message(NetworkBridgeTxMessage::SendValidationMessage(

--- a/node/network/bitfield-distribution/src/tests.rs
+++ b/node/network/bitfield-distribution/src/tests.rs
@@ -52,10 +52,7 @@ fn dummy_rng() -> ChaCha12Rng {
 }
 
 fn peer_data_v1(view: View) -> PeerData {
-	PeerData {
-		view,
-		version: ValidationVersion::V1.into(),
-	}
+	PeerData { view, version: ValidationVersion::V1.into() }
 }
 
 /// A very limited state, only interested in the relay parent of the
@@ -222,7 +219,10 @@ fn receive_invalid_signature() {
 			&mut ctx,
 			&mut state,
 			&Default::default(),
-			NetworkBridgeEvent::PeerMessage(peer_b.clone(), invalid_msg.into_network_message(ValidationVersion::V1.into())),
+			NetworkBridgeEvent::PeerMessage(
+				peer_b.clone(),
+				invalid_msg.into_network_message(ValidationVersion::V1.into())
+			),
 			&mut rng,
 		));
 
@@ -233,7 +233,10 @@ fn receive_invalid_signature() {
 			&mut ctx,
 			&mut state,
 			&Default::default(),
-			NetworkBridgeEvent::PeerMessage(peer_b.clone(), invalid_msg_2.into_network_message(ValidationVersion::V1.into())),
+			NetworkBridgeEvent::PeerMessage(
+				peer_b.clone(),
+				invalid_msg_2.into_network_message(ValidationVersion::V1.into())
+			),
 			&mut rng,
 		));
 		// reputation change due to invalid signature
@@ -293,7 +296,10 @@ fn receive_invalid_validator_index() {
 			&mut ctx,
 			&mut state,
 			&Default::default(),
-			NetworkBridgeEvent::PeerMessage(peer_b.clone(), msg.into_network_message(ValidationVersion::V1.into())),
+			NetworkBridgeEvent::PeerMessage(
+				peer_b.clone(),
+				msg.into_network_message(ValidationVersion::V1.into())
+			),
 			&mut rng,
 		));
 
@@ -356,7 +362,10 @@ fn receive_duplicate_messages() {
 			&mut ctx,
 			&mut state,
 			&Default::default(),
-			NetworkBridgeEvent::PeerMessage(peer_b.clone(), msg.clone().into_network_message(ValidationVersion::V1.into()),),
+			NetworkBridgeEvent::PeerMessage(
+				peer_b.clone(),
+				msg.clone().into_network_message(ValidationVersion::V1.into()),
+			),
 			&mut rng,
 		));
 
@@ -389,7 +398,10 @@ fn receive_duplicate_messages() {
 			&mut ctx,
 			&mut state,
 			&Default::default(),
-			NetworkBridgeEvent::PeerMessage(peer_a.clone(), msg.clone().into_network_message(ValidationVersion::V1.into()),),
+			NetworkBridgeEvent::PeerMessage(
+				peer_a.clone(),
+				msg.clone().into_network_message(ValidationVersion::V1.into()),
+			),
 			&mut rng,
 		));
 
@@ -408,7 +420,10 @@ fn receive_duplicate_messages() {
 			&mut ctx,
 			&mut state,
 			&Default::default(),
-			NetworkBridgeEvent::PeerMessage(peer_b.clone(), msg.clone().into_network_message(ValidationVersion::V1.into()),),
+			NetworkBridgeEvent::PeerMessage(
+				peer_b.clone(),
+				msg.clone().into_network_message(ValidationVersion::V1.into()),
+			),
 			&mut rng,
 		));
 
@@ -605,7 +620,10 @@ fn changing_view() {
 			&mut ctx,
 			&mut state,
 			&Default::default(),
-			NetworkBridgeEvent::PeerMessage(peer_b.clone(), msg.clone().into_network_message(ValidationVersion::V1.into()),),
+			NetworkBridgeEvent::PeerMessage(
+				peer_b.clone(),
+				msg.clone().into_network_message(ValidationVersion::V1.into()),
+			),
 			&mut rng,
 		));
 
@@ -641,7 +659,10 @@ fn changing_view() {
 		));
 
 		assert!(state.peer_data.contains_key(&peer_b));
-		assert_eq!(&state.peer_data.get(&peer_b).expect("Must contain value for peer B").view, &view![]);
+		assert_eq!(
+			&state.peer_data.get(&peer_b).expect("Must contain value for peer B").view,
+			&view![]
+		);
 
 		// on rx of the same message, since we are not interested,
 		// should give penalty
@@ -649,7 +670,10 @@ fn changing_view() {
 			&mut ctx,
 			&mut state,
 			&Default::default(),
-			NetworkBridgeEvent::PeerMessage(peer_b.clone(), msg.clone().into_network_message(ValidationVersion::V1.into()),),
+			NetworkBridgeEvent::PeerMessage(
+				peer_b.clone(),
+				msg.clone().into_network_message(ValidationVersion::V1.into()),
+			),
 			&mut rng,
 		));
 
@@ -681,7 +705,10 @@ fn changing_view() {
 			&mut ctx,
 			&mut state,
 			&Default::default(),
-			NetworkBridgeEvent::PeerMessage(peer_a.clone(), msg.clone().into_network_message(ValidationVersion::V1.into()),),
+			NetworkBridgeEvent::PeerMessage(
+				peer_a.clone(),
+				msg.clone().into_network_message(ValidationVersion::V1.into()),
+			),
 			&mut rng,
 		));
 
@@ -745,7 +772,10 @@ fn do_not_send_message_back_to_origin() {
 			&mut ctx,
 			&mut state,
 			&Default::default(),
-			NetworkBridgeEvent::PeerMessage(peer_b.clone(), msg.clone().into_network_message(ValidationVersion::V1.into()),),
+			NetworkBridgeEvent::PeerMessage(
+				peer_b.clone(),
+				msg.clone().into_network_message(ValidationVersion::V1.into()),
+			),
 			&mut rng,
 		));
 
@@ -851,7 +881,10 @@ fn topology_test() {
 			&mut ctx,
 			&mut state,
 			&Default::default(),
-			NetworkBridgeEvent::PeerMessage(peers_x[0].clone(), msg.clone().into_network_message(ValidationVersion::V1.into()),),
+			NetworkBridgeEvent::PeerMessage(
+				peers_x[0].clone(),
+				msg.clone().into_network_message(ValidationVersion::V1.into()),
+			),
 			&mut rng,
 		));
 

--- a/node/network/bridge/src/network.rs
+++ b/node/network/bridge/src/network.rs
@@ -59,6 +59,9 @@ pub(crate) fn send_message<M>(
 ) where
 	M: Encode + Clone,
 {
+	if peers.is_empty() {
+		return
+	}
 	let message = {
 		let encoded = message.encode();
 		metrics.on_notification_sent(peer_set, version, encoded.len(), peers.len());

--- a/node/network/bridge/src/rx/mod.rs
+++ b/node/network/bridge/src/rx/mod.rs
@@ -466,7 +466,7 @@ where
 						if expected_versions[PeerSet::Validation] ==
 							Some(ValidationVersion::V1.into())
 						{
-							handle_v1_peer_messages::<protocol_v1::ValidationProtocol, _>(
+							handle_peer_messages::<protocol_v1::ValidationProtocol, _>(
 								remote.clone(),
 								PeerSet::Validation,
 								&mut shared.0.lock().validation_peers,
@@ -476,8 +476,13 @@ where
 						} else if expected_versions[PeerSet::Validation] ==
 							Some(ValidationVersion::VStaging.into())
 						{
-							// TODO [now]
-							unimplemented!()
+							handle_peer_messages::<protocol_vstaging::ValidationProtocol, _>(
+								remote.clone(),
+								PeerSet::Validation,
+								&mut shared.0.lock().validation_peers,
+								v_messages,
+								&metrics,
+							)
 						} else {
 							gum::warn!(
 								target: LOG_TARGET,
@@ -504,7 +509,7 @@ where
 						if expected_versions[PeerSet::Collation] ==
 							Some(CollationVersion::V1.into())
 						{
-							handle_v1_peer_messages::<protocol_v1::CollationProtocol, _>(
+							handle_peer_messages::<protocol_v1::CollationProtocol, _>(
 								remote.clone(),
 								PeerSet::Collation,
 								&mut shared.0.lock().collation_peers,
@@ -514,8 +519,13 @@ where
 						} else if expected_versions[PeerSet::Collation] ==
 							Some(CollationVersion::VStaging.into())
 						{
-							// TODO [now]
-							unimplemented!()
+							handle_peer_messages::<protocol_vstaging::CollationProtocol, _>(
+								remote.clone(),
+								PeerSet::Collation,
+								&mut shared.0.lock().collation_peers,
+								c_messages,
+								&metrics,
+							)
 						} else {
 							gum::warn!(
 								target: LOG_TARGET,
@@ -830,7 +840,7 @@ fn update_our_view<Net, Context>(
 
 // Handle messages on a specific v1 peer-set. The peer is expected to be connected on that
 // peer-set.
-fn handle_v1_peer_messages<RawMessage: Decode, OutMessage: From<RawMessage>>(
+fn handle_peer_messages<RawMessage: Decode, OutMessage: From<RawMessage>>(
 	peer: PeerId,
 	peer_set: PeerSet,
 	peers: &mut HashMap<PeerId, PeerData>,

--- a/node/network/bridge/src/rx/mod.rs
+++ b/node/network/bridge/src/rx/mod.rs
@@ -268,11 +268,10 @@ where
 						)
 						.await;
 
-						match ValidationVersion::try_from(version).ok() {
-							None => unreachable!(
-								"try_get_protocol has already checked version is known; qed"
-							),
-							Some(ValidationVersion::V1) => send_message(
+						match ValidationVersion::try_from(version)
+							.expect("try_get_protocol has already checked version is known; qed")
+						{
+							ValidationVersion::V1 => send_message(
 								&mut network_service,
 								vec![peer],
 								PeerSet::Validation,
@@ -283,7 +282,7 @@ where
 								),
 								&metrics,
 							),
-							Some(ValidationVersion::VStaging) => send_message(
+							ValidationVersion::VStaging => send_message(
 								&mut network_service,
 								vec![peer],
 								PeerSet::Validation,
@@ -311,11 +310,10 @@ where
 						)
 						.await;
 
-						match CollationVersion::try_from(version).ok() {
-							None => unreachable!(
-								"try_get_protocol has already checked version is known; qed"
-							),
-							Some(CollationVersion::V1) => send_message(
+						match CollationVersion::try_from(version)
+							.expect("try_get_protocol has already checked version is known; qed")
+						{
+							CollationVersion::V1 => send_message(
 								&mut network_service,
 								vec![peer],
 								PeerSet::Collation,
@@ -326,7 +324,7 @@ where
 								),
 								&metrics,
 							),
-							Some(CollationVersion::VStaging) => send_message(
+							CollationVersion::VStaging => send_message(
 								&mut network_service,
 								vec![peer],
 								PeerSet::Collation,

--- a/node/network/bridge/src/rx/tests.rs
+++ b/node/network/bridge/src/rx/tests.rs
@@ -1197,3 +1197,10 @@ fn our_view_updates_decreasing_order_and_limited_to_max() {
 		virtual_overseer
 	});
 }
+
+// TODO [now]: test that vstaging peers are accepted.
+
+// TODO [now]: test that vstaging peers are sent view update wire messages with the
+// vstaging format.
+
+// TODO [now]: check that v2 messages are sent to the correct subsystem.

--- a/node/network/bridge/src/rx/tests.rs
+++ b/node/network/bridge/src/rx/tests.rs
@@ -25,6 +25,7 @@ use parking_lot::Mutex;
 use std::{
 	collections::HashSet,
 	sync::atomic::{AtomicBool, Ordering},
+	task::Poll,
 };
 
 use sc_network::{Event as NetworkEvent, IfDisconnected, ProtocolName};
@@ -46,7 +47,7 @@ use polkadot_node_subsystem_test_helpers::{
 	SingleItemSink, SingleItemStream, TestSubsystemContextHandle,
 };
 use polkadot_node_subsystem_util::metered;
-use polkadot_primitives::v2::{AuthorityDiscoveryId, Hash};
+use polkadot_primitives::v2::{AuthorityDiscoveryId, CandidateHash, Hash};
 
 use sc_network::Multiaddr;
 use sp_keyring::Sr25519Keyring;
@@ -136,8 +137,7 @@ impl Network for TestNetwork {
 	}
 
 	fn disconnect_peer(&self, who: PeerId, protocol: ProtocolName) {
-		let (peer_set, version) = self.protocol_names.try_get_protocol(&protocol).unwrap();
-		assert_eq!(version, peer_set.get_main_version());
+		let (peer_set, _) = self.protocol_names.try_get_protocol(&protocol).unwrap();
 
 		self.action_tx
 			.lock()
@@ -146,8 +146,7 @@ impl Network for TestNetwork {
 	}
 
 	fn write_notification(&self, who: PeerId, protocol: ProtocolName, message: Vec<u8>) {
-		let (peer_set, version) = self.protocol_names.try_get_protocol(&protocol).unwrap();
-		assert_eq!(version, peer_set.get_main_version());
+		let (peer_set, _) = self.protocol_names.try_get_protocol(&protocol).unwrap();
 
 		self.action_tx
 			.lock()
@@ -189,10 +188,17 @@ impl TestNetworkHandle {
 		v
 	}
 
-	async fn connect_peer(&mut self, peer: PeerId, peer_set: PeerSet, role: ObservedRole) {
+	async fn connect_peer(
+		&mut self,
+		peer: PeerId,
+		protocol_version: ValidationVersion,
+		peer_set: PeerSet,
+		role: ObservedRole,
+	) {
+		let protocol_version = ProtocolVersion::from(protocol_version);
 		self.send_network_event(NetworkEvent::NotificationStreamOpened {
 			remote: peer,
-			protocol: self.protocol_names.get_main_name(peer_set),
+			protocol: self.protocol_names.get_name(peer_set, protocol_version),
 			negotiated_fallback: None,
 			role: role.into(),
 		})
@@ -404,10 +410,20 @@ fn send_our_view_upon_connection() {
 		handle.await_mode_switch().await;
 
 		network_handle
-			.connect_peer(peer.clone(), PeerSet::Validation, ObservedRole::Full)
+			.connect_peer(
+				peer.clone(),
+				ValidationVersion::V1,
+				PeerSet::Validation,
+				ObservedRole::Full,
+			)
 			.await;
 		network_handle
-			.connect_peer(peer.clone(), PeerSet::Collation, ObservedRole::Full)
+			.connect_peer(
+				peer.clone(),
+				ValidationVersion::V1,
+				PeerSet::Collation,
+				ObservedRole::Full,
+			)
 			.await;
 
 		let view = view![head];
@@ -451,10 +467,20 @@ fn sends_view_updates_to_peers() {
 		handle.await_mode_switch().await;
 
 		network_handle
-			.connect_peer(peer_a.clone(), PeerSet::Validation, ObservedRole::Full)
+			.connect_peer(
+				peer_a.clone(),
+				ValidationVersion::V1,
+				PeerSet::Validation,
+				ObservedRole::Full,
+			)
 			.await;
 		network_handle
-			.connect_peer(peer_b.clone(), PeerSet::Collation, ObservedRole::Full)
+			.connect_peer(
+				peer_b.clone(),
+				ValidationVersion::V1,
+				PeerSet::Collation,
+				ObservedRole::Full,
+			)
 			.await;
 
 		let actions = network_handle.next_network_actions(2).await;
@@ -512,10 +538,20 @@ fn do_not_send_view_update_until_synced() {
 		assert_ne!(peer_a, peer_b);
 
 		network_handle
-			.connect_peer(peer_a.clone(), PeerSet::Validation, ObservedRole::Full)
+			.connect_peer(
+				peer_a.clone(),
+				ValidationVersion::V1,
+				PeerSet::Validation,
+				ObservedRole::Full,
+			)
 			.await;
 		network_handle
-			.connect_peer(peer_b.clone(), PeerSet::Collation, ObservedRole::Full)
+			.connect_peer(
+				peer_b.clone(),
+				ValidationVersion::V1,
+				PeerSet::Collation,
+				ObservedRole::Full,
+			)
 			.await;
 
 		{
@@ -605,10 +641,20 @@ fn do_not_send_view_update_when_only_finalized_block_changed() {
 		let peer_b = PeerId::random();
 
 		network_handle
-			.connect_peer(peer_a.clone(), PeerSet::Validation, ObservedRole::Full)
+			.connect_peer(
+				peer_a.clone(),
+				ValidationVersion::V1,
+				PeerSet::Validation,
+				ObservedRole::Full,
+			)
 			.await;
 		network_handle
-			.connect_peer(peer_b.clone(), PeerSet::Validation, ObservedRole::Full)
+			.connect_peer(
+				peer_b.clone(),
+				ValidationVersion::V1,
+				PeerSet::Validation,
+				ObservedRole::Full,
+			)
 			.await;
 
 		let hash_a = Hash::repeat_byte(1);
@@ -664,7 +710,12 @@ fn peer_view_updates_sent_via_overseer() {
 		let peer = PeerId::random();
 
 		network_handle
-			.connect_peer(peer.clone(), PeerSet::Validation, ObservedRole::Full)
+			.connect_peer(
+				peer.clone(),
+				ValidationVersion::V1,
+				PeerSet::Validation,
+				ObservedRole::Full,
+			)
 			.await;
 
 		let view = view![Hash::repeat_byte(1)];
@@ -714,7 +765,12 @@ fn peer_messages_sent_via_overseer() {
 		let peer = PeerId::random();
 
 		network_handle
-			.connect_peer(peer.clone(), PeerSet::Validation, ObservedRole::Full)
+			.connect_peer(
+				peer.clone(),
+				ValidationVersion::V1,
+				PeerSet::Validation,
+				ObservedRole::Full,
+			)
 			.await;
 
 		// bridge will inform about all connected peers.
@@ -786,10 +842,20 @@ fn peer_disconnect_from_just_one_peerset() {
 		let peer = PeerId::random();
 
 		network_handle
-			.connect_peer(peer.clone(), PeerSet::Validation, ObservedRole::Full)
+			.connect_peer(
+				peer.clone(),
+				ValidationVersion::V1,
+				PeerSet::Validation,
+				ObservedRole::Full,
+			)
 			.await;
 		network_handle
-			.connect_peer(peer.clone(), PeerSet::Collation, ObservedRole::Full)
+			.connect_peer(
+				peer.clone(),
+				ValidationVersion::V1,
+				PeerSet::Collation,
+				ObservedRole::Full,
+			)
 			.await;
 
 		// bridge will inform about all connected peers.
@@ -879,10 +945,20 @@ fn relays_collation_protocol_messages() {
 		let peer_b = PeerId::random();
 
 		network_handle
-			.connect_peer(peer_a.clone(), PeerSet::Validation, ObservedRole::Full)
+			.connect_peer(
+				peer_a.clone(),
+				ValidationVersion::V1,
+				PeerSet::Validation,
+				ObservedRole::Full,
+			)
 			.await;
 		network_handle
-			.connect_peer(peer_b.clone(), PeerSet::Collation, ObservedRole::Full)
+			.connect_peer(
+				peer_b.clone(),
+				ValidationVersion::V1,
+				PeerSet::Collation,
+				ObservedRole::Full,
+			)
 			.await;
 
 		// bridge will inform about all connected peers.
@@ -982,10 +1058,20 @@ fn different_views_on_different_peer_sets() {
 		let peer = PeerId::random();
 
 		network_handle
-			.connect_peer(peer.clone(), PeerSet::Validation, ObservedRole::Full)
+			.connect_peer(
+				peer.clone(),
+				ValidationVersion::V1,
+				PeerSet::Validation,
+				ObservedRole::Full,
+			)
 			.await;
 		network_handle
-			.connect_peer(peer.clone(), PeerSet::Collation, ObservedRole::Full)
+			.connect_peer(
+				peer.clone(),
+				ValidationVersion::V1,
+				PeerSet::Collation,
+				ObservedRole::Full,
+			)
 			.await;
 
 		// bridge will inform about all connected peers.
@@ -1069,7 +1155,12 @@ fn sent_views_include_finalized_number_update() {
 		let peer_a = PeerId::random();
 
 		network_handle
-			.connect_peer(peer_a.clone(), PeerSet::Validation, ObservedRole::Full)
+			.connect_peer(
+				peer_a.clone(),
+				ValidationVersion::V1,
+				PeerSet::Validation,
+				ObservedRole::Full,
+			)
 			.await;
 
 		let hash_a = Hash::repeat_byte(1);
@@ -1114,7 +1205,12 @@ fn view_finalized_number_can_not_go_down() {
 		let peer_a = PeerId::random();
 
 		network_handle
-			.connect_peer(peer_a.clone(), PeerSet::Validation, ObservedRole::Full)
+			.connect_peer(
+				peer_a.clone(),
+				ValidationVersion::V1,
+				PeerSet::Validation,
+				ObservedRole::Full,
+			)
 			.await;
 
 		network_handle
@@ -1198,9 +1294,161 @@ fn our_view_updates_decreasing_order_and_limited_to_max() {
 	});
 }
 
-// TODO [now]: test that vstaging peers are accepted.
+#[test]
+fn network_protocol_versioning_view_update() {
+	let (oracle, handle) = make_sync_oracle(false);
+	test_harness(Box::new(oracle), |test_harness| async move {
+		let TestHarness { mut network_handle, mut virtual_overseer } = test_harness;
 
-// TODO [now]: test that vstaging peers are sent view update wire messages with the
-// vstaging format.
+		let peer_ids: Vec<_> = (0..4).map(|_| PeerId::random()).collect();
+		let peers = [
+			(peer_ids[0], PeerSet::Validation, ValidationVersion::VStaging),
+			(peer_ids[1], PeerSet::Collation, ValidationVersion::V1),
+			(peer_ids[2], PeerSet::Validation, ValidationVersion::V1),
+			(peer_ids[3], PeerSet::Collation, ValidationVersion::VStaging),
+		];
 
-// TODO [now]: check that v2 messages are sent to the correct subsystem.
+		let head = Hash::repeat_byte(1);
+		virtual_overseer
+			.send(FromOrchestra::Signal(OverseerSignal::ActiveLeaves(
+				ActiveLeavesUpdate::start_work(ActivatedLeaf {
+					hash: head,
+					number: 1,
+					status: LeafStatus::Fresh,
+					span: Arc::new(jaeger::Span::Disabled),
+				}),
+			)))
+			.await;
+
+		handle.await_mode_switch().await;
+
+		for &(peer_id, peer_set, version) in &peers {
+			network_handle
+				.connect_peer(peer_id, version, peer_set, ObservedRole::Full)
+				.await;
+		}
+
+		let view = view![head];
+		let actions = network_handle.next_network_actions(4).await;
+
+		for &(peer_id, peer_set, version) in &peers {
+			let wire_msg = match version {
+				ValidationVersion::V1 =>
+					WireMessage::<protocol_v1::ValidationProtocol>::ViewUpdate(view.clone())
+						.encode(),
+				ValidationVersion::VStaging =>
+					WireMessage::<protocol_vstaging::ValidationProtocol>::ViewUpdate(view.clone())
+						.encode(),
+			};
+			assert_network_actions_contains(
+				&actions,
+				&NetworkAction::WriteNotification(peer_id, peer_set, wire_msg),
+			);
+		}
+
+		virtual_overseer
+	});
+}
+
+#[test]
+fn network_protocol_versioning_subsystem_msg() {
+	let (oracle, _handle) = make_sync_oracle(false);
+	test_harness(Box::new(oracle), |test_harness| async move {
+		let TestHarness { mut network_handle, mut virtual_overseer } = test_harness;
+
+		let peer = PeerId::random();
+
+		network_handle
+			.connect_peer(
+				peer.clone(),
+				ValidationVersion::VStaging,
+				PeerSet::Validation,
+				ObservedRole::Full,
+			)
+			.await;
+
+		// bridge will inform about all connected peers.
+		{
+			assert_sends_validation_event_to_all(
+				NetworkBridgeEvent::PeerConnected(
+					peer.clone(),
+					ObservedRole::Full,
+					ValidationVersion::VStaging.into(),
+					None,
+				),
+				&mut virtual_overseer,
+			)
+			.await;
+
+			assert_sends_validation_event_to_all(
+				NetworkBridgeEvent::PeerViewChange(peer.clone(), View::default()),
+				&mut virtual_overseer,
+			)
+			.await;
+		}
+
+		let approval_distribution_message =
+			protocol_vstaging::ApprovalDistributionMessage::Approvals(Vec::new());
+
+		let msg = protocol_vstaging::ValidationProtocol::ApprovalDistribution(
+			approval_distribution_message.clone(),
+		);
+
+		network_handle
+			.peer_message(
+				peer.clone(),
+				PeerSet::Validation,
+				WireMessage::ProtocolMessage(msg.clone()).encode(),
+			)
+			.await;
+
+		assert_matches!(
+			virtual_overseer.recv().await,
+			AllMessages::ApprovalDistribution(
+				ApprovalDistributionMessage::NetworkBridgeUpdate(
+					NetworkBridgeEvent::PeerMessage(p, Versioned::VStaging(m))
+				)
+			) => {
+				assert_eq!(p, peer);
+				assert_eq!(m, approval_distribution_message);
+			}
+		);
+
+		let metadata = protocol_vstaging::StatementMetadata {
+			relay_parent: Hash::zero(),
+			candidate_hash: CandidateHash::default(),
+			signed_by: ValidatorIndex(0),
+			signature: sp_core::crypto::UncheckedFrom::unchecked_from([1u8; 64]),
+		};
+		let statement_distribution_message =
+			protocol_vstaging::StatementDistributionMessage::LargeStatement(metadata);
+		let msg = protocol_vstaging::ValidationProtocol::StatementDistribution(
+			statement_distribution_message.clone(),
+		);
+
+		network_handle
+			.peer_message(
+				peer.clone(),
+				PeerSet::Validation,
+				WireMessage::ProtocolMessage(msg.clone()).encode(),
+			)
+			.await;
+
+		assert_matches!(
+			virtual_overseer.recv().await,
+			AllMessages::StatementDistribution(
+				StatementDistributionMessage::NetworkBridgeUpdate(
+					NetworkBridgeEvent::PeerMessage(p, Versioned::VStaging(m))
+				)
+			) => {
+				assert_eq!(p, peer);
+				assert_eq!(m, statement_distribution_message);
+			}
+		);
+
+		// No more messages.
+		assert_matches!(futures::poll!(virtual_overseer.recv().boxed()), Poll::Pending);
+
+		virtual_overseer
+	});
+}

--- a/node/network/bridge/src/tx/mod.rs
+++ b/node/network/bridge/src/tx/mod.rs
@@ -20,7 +20,7 @@ use super::*;
 use polkadot_node_network_protocol::{
 	peer_set::{CollationVersion, PeerSet, PeerSetProtocolNames, ValidationVersion},
 	request_response::ReqProtocolNames,
-	v1 as protocol_v1, PeerId, Versioned,
+	v1 as protocol_v1, vstaging as protocol_vstaging, PeerId, Versioned,
 };
 
 use polkadot_node_subsystem::{
@@ -183,6 +183,13 @@ where
 					WireMessage::ProtocolMessage(msg),
 					&metrics,
 				),
+				Versioned::VStaging(msg) => send_validation_message_vstaging(
+					&mut network_service,
+					peers,
+					peerset_protocol_names,
+					WireMessage::ProtocolMessage(msg),
+					&metrics,
+				),
 			}
 		},
 		NetworkBridgeTxMessage::SendValidationMessages(msgs) => {
@@ -195,6 +202,13 @@ where
 			for (peers, msg) in msgs {
 				match msg {
 					Versioned::V1(msg) => send_validation_message_v1(
+						&mut network_service,
+						peers,
+						peerset_protocol_names,
+						WireMessage::ProtocolMessage(msg),
+						&metrics,
+					),
+					Versioned::VStaging(msg) => send_validation_message_vstaging(
 						&mut network_service,
 						peers,
 						peerset_protocol_names,
@@ -219,6 +233,13 @@ where
 					WireMessage::ProtocolMessage(msg),
 					&metrics,
 				),
+				Versioned::VStaging(msg) => send_collation_message_vstaging(
+					&mut network_service,
+					peers,
+					peerset_protocol_names,
+					WireMessage::ProtocolMessage(msg),
+					&metrics,
+				),
 			}
 		},
 		NetworkBridgeTxMessage::SendCollationMessages(msgs) => {
@@ -231,6 +252,13 @@ where
 			for (peers, msg) in msgs {
 				match msg {
 					Versioned::V1(msg) => send_collation_message_v1(
+						&mut network_service,
+						peers,
+						peerset_protocol_names,
+						WireMessage::ProtocolMessage(msg),
+						&metrics,
+					),
+					Versioned::VStaging(msg) => send_collation_message_vstaging(
 						&mut network_service,
 						peers,
 						peerset_protocol_names,
@@ -362,6 +390,42 @@ fn send_collation_message_v1(
 		peers,
 		PeerSet::Collation,
 		CollationVersion::V1.into(),
+		protocol_names,
+		message,
+		metrics,
+	);
+}
+
+fn send_validation_message_vstaging(
+	net: &mut impl Network,
+	peers: Vec<PeerId>,
+	protocol_names: &PeerSetProtocolNames,
+	message: WireMessage<protocol_vstaging::ValidationProtocol>,
+	metrics: &Metrics,
+) {
+	send_message(
+		net,
+		peers,
+		PeerSet::Validation,
+		ValidationVersion::VStaging.into(),
+		protocol_names,
+		message,
+		metrics,
+	);
+}
+
+fn send_collation_message_vstaging(
+	net: &mut impl Network,
+	peers: Vec<PeerId>,
+	protocol_names: &PeerSetProtocolNames,
+	message: WireMessage<protocol_vstaging::CollationProtocol>,
+	metrics: &Metrics,
+) {
+	send_message(
+		net,
+		peers,
+		PeerSet::Collation,
+		CollationVersion::VStaging.into(),
 		protocol_names,
 		message,
 		metrics,

--- a/node/network/bridge/src/tx/tests.rs
+++ b/node/network/bridge/src/tx/tests.rs
@@ -321,3 +321,5 @@ fn send_messages_to_peers() {
 		virtual_overseer
 	});
 }
+
+// TODO [now]: check that `send_validation_message_vstaging` and `send_collation_message_vstaging` work correctly.

--- a/node/network/bridge/src/tx/tests.rs
+++ b/node/network/bridge/src/tx/tests.rs
@@ -124,8 +124,7 @@ impl Network for TestNetwork {
 	}
 
 	fn disconnect_peer(&self, who: PeerId, protocol: ProtocolName) {
-		let (peer_set, version) = self.peerset_protocol_names.try_get_protocol(&protocol).unwrap();
-		assert_eq!(version, peer_set.get_main_version());
+		let (peer_set, _) = self.peerset_protocol_names.try_get_protocol(&protocol).unwrap();
 
 		self.action_tx
 			.lock()
@@ -134,8 +133,7 @@ impl Network for TestNetwork {
 	}
 
 	fn write_notification(&self, who: PeerId, protocol: ProtocolName, message: Vec<u8>) {
-		let (peer_set, version) = self.peerset_protocol_names.try_get_protocol(&protocol).unwrap();
-		assert_eq!(version, peer_set.get_main_version());
+		let (peer_set, _) = self.peerset_protocol_names.try_get_protocol(&protocol).unwrap();
 
 		self.action_tx
 			.lock()
@@ -167,10 +165,17 @@ impl TestNetworkHandle {
 		self.action_rx.next().await.expect("subsystem concluded early")
 	}
 
-	async fn connect_peer(&mut self, peer: PeerId, peer_set: PeerSet, role: ObservedRole) {
+	async fn connect_peer(
+		&mut self,
+		peer: PeerId,
+		protocol_version: ValidationVersion,
+		peer_set: PeerSet,
+		role: ObservedRole,
+	) {
+		let protocol_version = ProtocolVersion::from(protocol_version);
 		self.send_network_event(NetworkEvent::NotificationStreamOpened {
 			remote: peer,
-			protocol: self.peerset_protocol_names.get_main_name(peer_set),
+			protocol: self.peerset_protocol_names.get_name(peer_set, protocol_version),
 			negotiated_fallback: None,
 			role: role.into(),
 		})
@@ -235,7 +240,12 @@ fn send_messages_to_peers() {
 		let peer = PeerId::random();
 
 		network_handle
-			.connect_peer(peer.clone(), PeerSet::Validation, ObservedRole::Full)
+			.connect_peer(
+				peer.clone(),
+				ValidationVersion::V1,
+				PeerSet::Validation,
+				ObservedRole::Full,
+			)
 			.timeout(TIMEOUT)
 			.await
 			.expect("Timeout does not occur");
@@ -244,7 +254,12 @@ fn send_messages_to_peers() {
 		// so the single item sink has to be free explicitly
 
 		network_handle
-			.connect_peer(peer.clone(), PeerSet::Collation, ObservedRole::Full)
+			.connect_peer(
+				peer.clone(),
+				ValidationVersion::V1,
+				PeerSet::Collation,
+				ObservedRole::Full,
+			)
 			.timeout(TIMEOUT)
 			.await
 			.expect("Timeout does not occur");
@@ -322,4 +337,106 @@ fn send_messages_to_peers() {
 	});
 }
 
-// TODO [now]: check that `send_validation_message_vstaging` and `send_collation_message_vstaging` work correctly.
+#[test]
+fn network_protocol_versioning_send() {
+	test_harness(|test_harness| async move {
+		let TestHarness { mut network_handle, mut virtual_overseer } = test_harness;
+
+		let peer_ids: Vec<_> = (0..4).map(|_| PeerId::random()).collect();
+		let peers = [
+			(peer_ids[0], PeerSet::Validation, ValidationVersion::VStaging),
+			(peer_ids[1], PeerSet::Collation, ValidationVersion::V1),
+			(peer_ids[2], PeerSet::Validation, ValidationVersion::V1),
+			(peer_ids[3], PeerSet::Collation, ValidationVersion::VStaging),
+		];
+
+		for &(peer_id, peer_set, version) in &peers {
+			network_handle
+				.connect_peer(peer_id, version, peer_set, ObservedRole::Full)
+				.timeout(TIMEOUT)
+				.await
+				.expect("Timeout does not occur");
+		}
+
+		// send a validation protocol message.
+
+		{
+			let approval_distribution_message =
+				protocol_vstaging::ApprovalDistributionMessage::Approvals(Vec::new());
+
+			let msg = protocol_vstaging::ValidationProtocol::ApprovalDistribution(
+				approval_distribution_message.clone(),
+			);
+
+			// Note that bridge doesn't ensure neither peer's protocol version
+			// or peer set match the message.
+			let receivers = vec![peer_ids[0], peer_ids[3]];
+			virtual_overseer
+				.send(FromOrchestra::Communication {
+					msg: NetworkBridgeTxMessage::SendValidationMessage(
+						receivers.clone(),
+						Versioned::VStaging(msg.clone()),
+					),
+				})
+				.timeout(TIMEOUT)
+				.await
+				.expect("Timeout does not occur");
+
+			for peer in &receivers {
+				assert_eq!(
+					network_handle
+						.next_network_action()
+						.timeout(TIMEOUT)
+						.await
+						.expect("Timeout does not occur"),
+					NetworkAction::WriteNotification(
+						*peer,
+						PeerSet::Validation,
+						WireMessage::ProtocolMessage(msg.clone()).encode(),
+					)
+				);
+			}
+		}
+
+		// send a collation protocol message.
+
+		{
+			let collator_protocol_message = protocol_vstaging::CollatorProtocolMessage::Declare(
+				Sr25519Keyring::Alice.public().into(),
+				0_u32.into(),
+				dummy_collator_signature(),
+			);
+
+			let msg = protocol_vstaging::CollationProtocol::CollatorProtocol(
+				collator_protocol_message.clone(),
+			);
+
+			let receivers = vec![peer_ids[1], peer_ids[2]];
+
+			virtual_overseer
+				.send(FromOrchestra::Communication {
+					msg: NetworkBridgeTxMessage::SendCollationMessages(vec![(
+						receivers.clone(),
+						Versioned::VStaging(msg.clone()),
+					)]),
+				})
+				.await;
+
+			for peer in &receivers {
+				assert_eq!(
+					network_handle
+						.next_network_action()
+						.timeout(TIMEOUT)
+						.await
+						.expect("Timeout does not occur"),
+					NetworkAction::WriteNotification(
+						*peer,
+						PeerSet::Collation,
+						WireMessage::ProtocolMessage(msg.clone()).encode(),
+					)
+				);
+			}
+		}
+		virtual_overseer
+	});
+}

--- a/node/network/collator-protocol/src/collator_side/mod.rs
+++ b/node/network/collator-protocol/src/collator_side/mod.rs
@@ -27,7 +27,7 @@ use sp_core::Pair;
 
 use polkadot_node_network_protocol::{
 	self as net_protocol,
-	peer_set::{PeerSet, CollationVersion, ProtocolVersion},
+	peer_set::{CollationVersion, PeerSet, ProtocolVersion},
 	request_response::{
 		incoming::{self, OutgoingResponse},
 		v1::{self as request_v1, CollationFetchingRequest, CollationFetchingResponse},

--- a/node/network/collator-protocol/src/collator_side/mod.rs
+++ b/node/network/collator-protocol/src/collator_side/mod.rs
@@ -550,7 +550,7 @@ async fn declare_v1<Context>(ctx: &mut Context, state: &mut State, peer: PeerId)
 }
 
 /// Issue a `Declare` collation message to the given `peer` on protocol version
-/// vstaging
+/// `staging`.
 #[overseer::contextbounds(CollatorProtocol, prefix = self::overseer)]
 async fn declare_vstaging<Context>(ctx: &mut Context, state: &mut State, peer: PeerId) {
 	let declare_signature_payload =

--- a/node/network/collator-protocol/src/collator_side/mod.rs
+++ b/node/network/collator-protocol/src/collator_side/mod.rs
@@ -27,13 +27,14 @@ use sp_core::Pair;
 
 use polkadot_node_network_protocol::{
 	self as net_protocol,
-	peer_set::PeerSet,
+	peer_set::{PeerSet, CollationVersion, ProtocolVersion},
 	request_response::{
 		incoming::{self, OutgoingResponse},
 		v1::{self as request_v1, CollationFetchingRequest, CollationFetchingResponse},
 		IncomingRequest, IncomingRequestReceiver,
 	},
-	v1 as protocol_v1, OurView, PeerId, UnifiedReputationChange as Rep, Versioned, View,
+	v1 as protocol_v1, vstaging as protocol_vstaging, OurView, PeerId,
+	UnifiedReputationChange as Rep, Versioned, View,
 };
 use polkadot_node_primitives::{CollationSecondedSignal, PoV, Statement};
 use polkadot_node_subsystem::{
@@ -272,6 +273,11 @@ struct WaitingCollationFetches {
 type ActiveCollationFetches =
 	FuturesUnordered<Pin<Box<dyn Future<Output = (Hash, PeerId)> + Send + 'static>>>;
 
+struct PeerData {
+	view: View,
+	version: ProtocolVersion,
+}
+
 struct State {
 	/// Our network peer id.
 	local_peer_id: PeerId,
@@ -285,7 +291,7 @@ struct State {
 
 	/// Track all active peers and their views
 	/// to determine what is relevant to them.
-	peer_views: HashMap<PeerId, View>,
+	peer_data: HashMap<PeerId, PeerData>,
 
 	/// Our own view.
 	view: OurView,
@@ -332,7 +338,7 @@ impl State {
 			collator_pair,
 			metrics,
 			collating_on: Default::default(),
-			peer_views: Default::default(),
+			peer_data: Default::default(),
 			view: Default::default(),
 			span_per_relay_parent: Default::default(),
 			collations: Default::default(),
@@ -344,12 +350,13 @@ impl State {
 		}
 	}
 
-	/// Get all peers which have the given relay parent in their view.
-	fn peers_interested_in_leaf(&self, relay_parent: &Hash) -> Vec<PeerId> {
-		self.peer_views
+	/// Get all peers which have the given relay parent in their view along
+	/// with their protocol version.
+	fn peers_interested_in_leaf(&self, relay_parent: &Hash) -> Vec<(PeerId, ProtocolVersion)> {
+		self.peer_data
 			.iter()
-			.filter(|(_, v)| v.contains(relay_parent))
-			.map(|(peer, _)| *peer)
+			.filter(|(_, data)| data.view.contains(relay_parent))
+			.map(|(peer, data)| (*peer, data.version))
 			.collect()
 	}
 }
@@ -451,8 +458,8 @@ async fn distribute_collation<Context>(
 
 	let interested = state.peers_interested_in_leaf(&relay_parent);
 	// Make sure already connected peers get collations:
-	for peer_id in interested {
-		advertise_collation(ctx, state, relay_parent, peer_id).await;
+	for (peer_id, version) in interested {
+		advertise_collation(ctx, state, relay_parent, peer_id, version).await;
 	}
 
 	Ok(())
@@ -521,9 +528,10 @@ async fn determine_our_validators<Context>(
 	Ok(current_validators)
 }
 
-/// Issue a `Declare` collation message to the given `peer`.
+/// Issue a `Declare` collation message to the given `peer` on protocol version
+/// v1.
 #[overseer::contextbounds(CollatorProtocol, prefix = self::overseer)]
-async fn declare<Context>(ctx: &mut Context, state: &mut State, peer: PeerId) {
+async fn declare_v1<Context>(ctx: &mut Context, state: &mut State, peer: PeerId) {
 	let declare_signature_payload = protocol_v1::declare_signature_payload(&state.local_peer_id);
 
 	if let Some(para_id) = state.collating_on {
@@ -536,6 +544,30 @@ async fn declare<Context>(ctx: &mut Context, state: &mut State, peer: PeerId) {
 		ctx.send_message(NetworkBridgeTxMessage::SendCollationMessage(
 			vec![peer],
 			Versioned::V1(protocol_v1::CollationProtocol::CollatorProtocol(wire_message)),
+		))
+		.await;
+	}
+}
+
+/// Issue a `Declare` collation message to the given `peer` on protocol version
+/// vstaging
+#[overseer::contextbounds(CollatorProtocol, prefix = self::overseer)]
+async fn declare_vstaging<Context>(ctx: &mut Context, state: &mut State, peer: PeerId) {
+	let declare_signature_payload =
+		protocol_vstaging::declare_signature_payload(&state.local_peer_id);
+
+	if let Some(para_id) = state.collating_on {
+		let wire_message = protocol_vstaging::CollatorProtocolMessage::Declare(
+			state.collator_pair.public(),
+			para_id,
+			state.collator_pair.sign(&declare_signature_payload),
+		);
+
+		ctx.send_message(NetworkBridgeTxMessage::SendCollationMessage(
+			vec![peer],
+			Versioned::VStaging(protocol_vstaging::CollationProtocol::CollatorProtocol(
+				wire_message,
+			)),
 		))
 		.await;
 	}
@@ -569,6 +601,7 @@ async fn advertise_collation<Context>(
 	state: &mut State,
 	relay_parent: Hash,
 	peer: PeerId,
+	version: ProtocolVersion,
 ) {
 	let should_advertise = state
 		.our_validators_groups
@@ -606,13 +639,26 @@ async fn advertise_collation<Context>(
 		},
 	}
 
-	let wire_message = protocol_v1::CollatorProtocolMessage::AdvertiseCollation(relay_parent);
+	if version == CollationVersion::V1.into() {
+		let wire_message = protocol_v1::CollatorProtocolMessage::AdvertiseCollation(relay_parent);
 
-	ctx.send_message(NetworkBridgeTxMessage::SendCollationMessage(
-		vec![peer.clone()],
-		Versioned::V1(protocol_v1::CollationProtocol::CollatorProtocol(wire_message)),
-	))
-	.await;
+		ctx.send_message(NetworkBridgeTxMessage::SendCollationMessage(
+			vec![peer.clone()],
+			Versioned::V1(protocol_v1::CollationProtocol::CollatorProtocol(wire_message)),
+		))
+		.await;
+	} else if version == CollationVersion::VStaging.into() {
+		let wire_message =
+			protocol_vstaging::CollatorProtocolMessage::AdvertiseCollation(relay_parent);
+
+		ctx.send_message(NetworkBridgeTxMessage::SendCollationMessage(
+			vec![peer.clone()],
+			Versioned::VStaging(protocol_vstaging::CollationProtocol::CollatorProtocol(
+				wire_message,
+			)),
+		))
+		.await;
+	}
 
 	if let Some(validators) = state.our_validators_groups.get_mut(&relay_parent) {
 		validators.advertised_to_peer(&state.peer_ids, &peer);
@@ -738,12 +784,11 @@ async fn handle_incoming_peer_message<Context>(
 	runtime: &mut RuntimeInfo,
 	state: &mut State,
 	origin: PeerId,
-	msg: protocol_v1::CollatorProtocolMessage,
+	msg: net_protocol::CollatorProtocolMessage,
 ) -> Result<()> {
-	use protocol_v1::CollatorProtocolMessage::*;
-
 	match msg {
-		Declare(_, _, _) => {
+		Versioned::V1(protocol_v1::CollatorProtocolMessage::Declare(_, _, _)) |
+		Versioned::VStaging(protocol_vstaging::CollatorProtocolMessage::Declare(_, _, _)) => {
 			gum::trace!(
 				target: LOG_TARGET,
 				?origin,
@@ -754,7 +799,8 @@ async fn handle_incoming_peer_message<Context>(
 			ctx.send_message(NetworkBridgeTxMessage::DisconnectPeer(origin, PeerSet::Collation))
 				.await;
 		},
-		AdvertiseCollation(_) => {
+		Versioned::V1(protocol_v1::CollatorProtocolMessage::AdvertiseCollation(_)) |
+		Versioned::VStaging(protocol_vstaging::CollatorProtocolMessage::AdvertiseCollation(_)) => {
 			gum::trace!(
 				target: LOG_TARGET,
 				?origin,
@@ -771,7 +817,14 @@ async fn handle_incoming_peer_message<Context>(
 			ctx.send_message(NetworkBridgeTxMessage::DisconnectPeer(origin, PeerSet::Collation))
 				.await;
 		},
-		CollationSeconded(relay_parent, statement) => {
+		Versioned::V1(protocol_v1::CollatorProtocolMessage::CollationSeconded(
+			relay_parent,
+			statement,
+		)) |
+		Versioned::VStaging(protocol_vstaging::CollatorProtocolMessage::CollationSeconded(
+			relay_parent,
+			statement,
+		)) =>
 			if !matches!(statement.unchecked_payload(), Statement::Seconded(_)) {
 				gum::warn!(
 					target: LOG_TARGET,
@@ -804,8 +857,7 @@ async fn handle_incoming_peer_message<Context>(
 						"received an unexpected `CollationSeconded`: unknown statement",
 					);
 				}
-			}
-		},
+			},
 	}
 
 	Ok(())
@@ -892,14 +944,23 @@ async fn handle_peer_view_change<Context>(
 	peer_id: PeerId,
 	view: View,
 ) {
-	let current = state.peer_views.entry(peer_id.clone()).or_default();
+	let (added, version) = {
+		let peer_data = match state.peer_data.get_mut(&peer_id) {
+			Some(pd) => pd,
+			None => return,
+		};
 
-	let added: Vec<Hash> = view.difference(&*current).cloned().collect();
+		let current = &mut peer_data.view;
 
-	*current = view;
+		let added: Vec<Hash> = view.difference(&*current).cloned().collect();
+
+		*current = view;
+
+		(added, peer_data.version)
+	};
 
 	for added in added.into_iter() {
-		advertise_collation(ctx, state, added, peer_id.clone()).await;
+		advertise_collation(ctx, state, added, peer_id.clone(), version).await;
 	}
 }
 
@@ -914,7 +975,7 @@ async fn handle_network_msg<Context>(
 	use NetworkBridgeEvent::*;
 
 	match bridge_message {
-		PeerConnected(peer_id, observed_role, _, maybe_authority) => {
+		PeerConnected(peer_id, observed_role, version, maybe_authority) => {
 			// If it is possible that a disconnected validator would attempt a reconnect
 			// it should be handled here.
 			gum::trace!(target: LOG_TARGET, ?peer_id, ?observed_role, "Peer connected");
@@ -926,8 +987,13 @@ async fn handle_network_msg<Context>(
 					"Connected to requested validator"
 				);
 				state.peer_ids.insert(peer_id, authority_ids);
+				state.peer_data.insert(peer_id, PeerData { view: View::default(), version });
 
-				declare(ctx, state, peer_id).await;
+				if version == CollationVersion::V1.into() {
+					declare_v1(ctx, state, peer_id).await;
+				} else if version == CollationVersion::VStaging.into() {
+					declare_vstaging(ctx, state, peer_id).await;
+				}
 			}
 		},
 		PeerViewChange(peer_id, view) => {
@@ -936,14 +1002,14 @@ async fn handle_network_msg<Context>(
 		},
 		PeerDisconnected(peer_id) => {
 			gum::trace!(target: LOG_TARGET, ?peer_id, "Peer disconnected");
-			state.peer_views.remove(&peer_id);
+			state.peer_data.remove(&peer_id);
 			state.peer_ids.remove(&peer_id);
 		},
 		OurViewChange(view) => {
 			gum::trace!(target: LOG_TARGET, ?view, "Own view change");
 			handle_our_view_change(state, view).await?;
 		},
-		PeerMessage(remote, Versioned::V1(msg)) => {
+		PeerMessage(remote, msg) => {
 			handle_incoming_peer_message(ctx, runtime, state, remote, msg).await?;
 		},
 		NewGossipTopology { .. } => {

--- a/node/network/collator-protocol/src/collator_side/mod.rs
+++ b/node/network/collator-protocol/src/collator_side/mod.rs
@@ -946,9 +946,7 @@ async fn handle_network_msg<Context>(
 		PeerMessage(remote, Versioned::V1(msg)) => {
 			handle_incoming_peer_message(ctx, runtime, state, remote, msg).await?;
 		},
-		PeerMessage(_, Versioned::VStaging(msg)) => {
-			
-		},
+		PeerMessage(_, Versioned::VStaging(msg)) => {},
 		NewGossipTopology { .. } => {
 			// impossible!
 		},

--- a/node/network/collator-protocol/src/collator_side/tests.rs
+++ b/node/network/collator-protocol/src/collator_side/tests.rs
@@ -987,5 +987,3 @@ where
 		test_harness
 	});
 }
-
-// TODO [now]: vstaging tests

--- a/node/network/collator-protocol/src/collator_side/tests.rs
+++ b/node/network/collator-protocol/src/collator_side/tests.rs
@@ -987,3 +987,5 @@ where
 		test_harness
 	});
 }
+
+// TODO [now]: vstaging tests

--- a/node/network/collator-protocol/src/validator_side/mod.rs
+++ b/node/network/collator-protocol/src/validator_side/mod.rs
@@ -1451,7 +1451,7 @@ async fn handle_collation_fetched_result<Context>(
 			ctx.send_message(CandidateBackingMessage::Second(
 				relay_parent.clone(),
 				candidate_receipt,
-				unimplemented!(), // TODO [now]
+				pvd,
 				pov,
 			))
 			.await;

--- a/node/network/collator-protocol/src/validator_side/mod.rs
+++ b/node/network/collator-protocol/src/validator_side/mod.rs
@@ -1084,9 +1084,7 @@ async fn handle_network_msg<Context>(
 		PeerMessage(remote, Versioned::V1(msg)) => {
 			process_incoming_peer_message(ctx, state, remote, msg).await;
 		},
-		PeerMessage(_, Versioned::VStaging(msg)) => {
-			
-		},
+		PeerMessage(_, Versioned::VStaging(msg)) => {},
 	}
 
 	Ok(())

--- a/node/network/collator-protocol/src/validator_side/mod.rs
+++ b/node/network/collator-protocol/src/validator_side/mod.rs
@@ -34,15 +34,14 @@ use sp_keystore::SyncCryptoStorePtr;
 
 use polkadot_node_network_protocol::{
 	self as net_protocol,
-	peer_set::{CollationVersion, PeerSet, ProtocolVersion},
+	peer_set::PeerSet,
 	request_response as req_res,
 	request_response::{
 		outgoing::{Recipient, RequestError},
 		v1::{CollationFetchingRequest, CollationFetchingResponse},
 		OutgoingRequest, Requests,
 	},
-	v1 as protocol_v1, vstaging as protocol_vstaging, OurView, PeerId,
-	UnifiedReputationChange as Rep, Versioned, View,
+	v1 as protocol_v1, OurView, PeerId, UnifiedReputationChange as Rep, Versioned, View,
 };
 use polkadot_node_primitives::{PoV, SignedFullStatement};
 use polkadot_node_subsystem::{
@@ -248,12 +247,11 @@ enum AdvertisementError {
 struct PeerData {
 	view: View,
 	state: PeerState,
-	version: ProtocolVersion,
 }
 
 impl PeerData {
-	fn new(view: View, version: ProtocolVersion) -> Self {
-		PeerData { view, state: PeerState::Connected(Instant::now()), version }
+	fn new(view: View) -> Self {
+		PeerData { view, state: PeerState::Connected(Instant::now()) }
 	}
 
 	/// Update the view, clearing all advertisements that are no longer in the
@@ -345,6 +343,12 @@ impl PeerData {
 			PeerState::Collating(ref state) =>
 				state.last_active.elapsed() >= policy.inactive_collator,
 		}
+	}
+}
+
+impl Default for PeerData {
+	fn default() -> Self {
+		PeerData::new(Default::default())
 	}
 }
 
@@ -705,33 +709,17 @@ async fn note_good_collation(
 async fn notify_collation_seconded(
 	sender: &mut impl overseer::CollatorProtocolSenderTrait,
 	peer_id: PeerId,
-	peer_version: ProtocolVersion,
 	relay_parent: Hash,
 	statement: SignedFullStatement,
 ) {
-	if peer_version == CollationVersion::V1.into() {
-		let wire_message =
-			protocol_v1::CollatorProtocolMessage::CollationSeconded(relay_parent, statement.into());
-		sender
-			.send_message(NetworkBridgeTxMessage::SendCollationMessage(
-				vec![peer_id],
-				Versioned::V1(protocol_v1::CollationProtocol::CollatorProtocol(wire_message)),
-			))
-			.await;
-	} else if peer_version == CollationVersion::VStaging.into() {
-		let wire_message = protocol_vstaging::CollatorProtocolMessage::CollationSeconded(
-			relay_parent,
-			statement.into(),
-		);
-		sender
-			.send_message(NetworkBridgeTxMessage::SendCollationMessage(
-				vec![peer_id],
-				Versioned::VStaging(protocol_vstaging::CollationProtocol::CollatorProtocol(
-					wire_message,
-				)),
-			))
-			.await;
-	}
+	let wire_message =
+		protocol_v1::CollatorProtocolMessage::CollationSeconded(relay_parent, statement.into());
+	sender
+		.send_message(NetworkBridgeTxMessage::SendCollationMessage(
+			vec![peer_id],
+			Versioned::V1(protocol_v1::CollationProtocol::CollatorProtocol(wire_message)),
+		))
+		.await;
 
 	modify_reputation(sender, peer_id, BENEFIT_NOTIFY_GOOD).await;
 }
@@ -739,13 +727,8 @@ async fn notify_collation_seconded(
 /// A peer's view has changed. A number of things should be done:
 ///  - Ongoing collation requests have to be canceled.
 ///  - Advertisements by this peer that are no longer relevant have to be removed.
-///
-/// This requires that the peer has an entry in the peer-data map.
 async fn handle_peer_view_change(state: &mut State, peer_id: PeerId, view: View) -> Result<()> {
-	let peer_data = match state.peer_data.get_mut(&peer_id) {
-		None => return Ok(()),
-		Some(pd) => pd,
-	};
+	let peer_data = state.peer_data.entry(peer_id.clone()).or_default();
 
 	peer_data.update_view(view);
 	state
@@ -833,20 +816,12 @@ async fn process_incoming_peer_message<Context>(
 	ctx: &mut Context,
 	state: &mut State,
 	origin: PeerId,
-	msg: net_protocol::CollatorProtocolMessage,
+	msg: protocol_v1::CollatorProtocolMessage,
 ) {
+	use protocol_v1::CollatorProtocolMessage::*;
 	use sp_runtime::traits::AppVerify;
 	match msg {
-		Versioned::V1(protocol_v1::CollatorProtocolMessage::Declare(
-			collator_id,
-			para_id,
-			signature,
-		)) |
-		Versioned::VStaging(protocol_vstaging::CollatorProtocolMessage::Declare(
-			collator_id,
-			para_id,
-			signature,
-		)) => {
+		Declare(collator_id, para_id, signature) => {
 			if collator_peer_id(&state.peer_data, &collator_id).is_some() {
 				modify_reputation(ctx.sender(), origin, COST_UNEXPECTED_MESSAGE).await;
 				return
@@ -912,10 +887,7 @@ async fn process_incoming_peer_message<Context>(
 				disconnect_peer(ctx.sender(), origin).await;
 			}
 		},
-		Versioned::V1(protocol_v1::CollatorProtocolMessage::AdvertiseCollation(relay_parent)) |
-		Versioned::VStaging(protocol_vstaging::CollatorProtocolMessage::AdvertiseCollation(
-			relay_parent,
-		)) => {
+		AdvertiseCollation(relay_parent) => {
 			let _span = state
 				.span_per_relay_parent
 				.get(&relay_parent)
@@ -1003,11 +975,7 @@ async fn process_incoming_peer_message<Context>(
 				},
 			}
 		},
-		Versioned::V1(protocol_v1::CollatorProtocolMessage::CollationSeconded(_, _)) |
-		Versioned::VStaging(protocol_vstaging::CollatorProtocolMessage::CollationSeconded(
-			_,
-			_,
-		)) => {
+		CollationSeconded(_, _) => {
 			gum::warn!(
 				target: LOG_TARGET,
 				peer_id = ?origin,
@@ -1096,11 +1064,8 @@ async fn handle_network_msg<Context>(
 	use NetworkBridgeEvent::*;
 
 	match bridge_message {
-		PeerConnected(peer_id, _role, version, _) => {
-			state
-				.peer_data
-				.entry(peer_id)
-				.or_insert_with(|| PeerData::new(View::default(), version));
+		PeerConnected(peer_id, _role, _version, _) => {
+			state.peer_data.entry(peer_id).or_default();
 			state.metrics.note_collator_peer_count(state.peer_data.len());
 		},
 		PeerDisconnected(peer_id) => {
@@ -1116,8 +1081,11 @@ async fn handle_network_msg<Context>(
 		OurViewChange(view) => {
 			handle_our_view_change(ctx, state, keystore, view).await?;
 		},
-		PeerMessage(remote, msg) => {
+		PeerMessage(remote, Versioned::V1(msg)) => {
 			process_incoming_peer_message(ctx, state, remote, msg).await;
+		},
+		PeerMessage(_, Versioned::VStaging(msg)) => {
+			
 		},
 	}
 
@@ -1167,16 +1135,7 @@ async fn process_msg<Context>(
 				let (collator_id, pending_collation) = collation_event;
 				let PendingCollation { relay_parent, peer_id, .. } = pending_collation;
 				note_good_collation(ctx.sender(), &state.peer_data, collator_id).await;
-				if let Some(pd) = state.peer_data.get(&peer_id) {
-					notify_collation_seconded(
-						ctx.sender(),
-						peer_id,
-						pd.version,
-						relay_parent,
-						stmt,
-					)
-					.await;
-				}
+				notify_collation_seconded(ctx.sender(), peer_id, relay_parent, stmt).await;
 
 				if let Some(collations) = state.collations_per_relay_parent.get_mut(&parent) {
 					collations.status = CollationStatus::Seconded;

--- a/node/network/collator-protocol/src/validator_side/mod.rs
+++ b/node/network/collator-protocol/src/validator_side/mod.rs
@@ -34,14 +34,15 @@ use sp_keystore::SyncCryptoStorePtr;
 
 use polkadot_node_network_protocol::{
 	self as net_protocol,
-	peer_set::PeerSet,
+	peer_set::{CollationVersion, PeerSet, ProtocolVersion},
 	request_response as req_res,
 	request_response::{
 		outgoing::{Recipient, RequestError},
 		v1::{CollationFetchingRequest, CollationFetchingResponse},
 		OutgoingRequest, Requests,
 	},
-	v1 as protocol_v1, OurView, PeerId, UnifiedReputationChange as Rep, Versioned, View,
+	v1 as protocol_v1, vstaging as protocol_vstaging, OurView, PeerId,
+	UnifiedReputationChange as Rep, Versioned, View,
 };
 use polkadot_node_primitives::{PoV, SignedFullStatement};
 use polkadot_node_subsystem::{
@@ -247,11 +248,12 @@ enum AdvertisementError {
 struct PeerData {
 	view: View,
 	state: PeerState,
+	version: ProtocolVersion,
 }
 
 impl PeerData {
-	fn new(view: View) -> Self {
-		PeerData { view, state: PeerState::Connected(Instant::now()) }
+	fn new(view: View, version: ProtocolVersion) -> Self {
+		PeerData { view, state: PeerState::Connected(Instant::now()), version }
 	}
 
 	/// Update the view, clearing all advertisements that are no longer in the
@@ -343,12 +345,6 @@ impl PeerData {
 			PeerState::Collating(ref state) =>
 				state.last_active.elapsed() >= policy.inactive_collator,
 		}
-	}
-}
-
-impl Default for PeerData {
-	fn default() -> Self {
-		PeerData::new(Default::default())
 	}
 }
 
@@ -709,17 +705,33 @@ async fn note_good_collation(
 async fn notify_collation_seconded(
 	sender: &mut impl overseer::CollatorProtocolSenderTrait,
 	peer_id: PeerId,
+	peer_version: ProtocolVersion,
 	relay_parent: Hash,
 	statement: SignedFullStatement,
 ) {
-	let wire_message =
-		protocol_v1::CollatorProtocolMessage::CollationSeconded(relay_parent, statement.into());
-	sender
-		.send_message(NetworkBridgeTxMessage::SendCollationMessage(
-			vec![peer_id],
-			Versioned::V1(protocol_v1::CollationProtocol::CollatorProtocol(wire_message)),
-		))
-		.await;
+	if peer_version == CollationVersion::V1.into() {
+		let wire_message =
+			protocol_v1::CollatorProtocolMessage::CollationSeconded(relay_parent, statement.into());
+		sender
+			.send_message(NetworkBridgeTxMessage::SendCollationMessage(
+				vec![peer_id],
+				Versioned::V1(protocol_v1::CollationProtocol::CollatorProtocol(wire_message)),
+			))
+			.await;
+	} else if peer_version == CollationVersion::VStaging.into() {
+		let wire_message = protocol_vstaging::CollatorProtocolMessage::CollationSeconded(
+			relay_parent,
+			statement.into(),
+		);
+		sender
+			.send_message(NetworkBridgeTxMessage::SendCollationMessage(
+				vec![peer_id],
+				Versioned::VStaging(protocol_vstaging::CollationProtocol::CollatorProtocol(
+					wire_message,
+				)),
+			))
+			.await;
+	}
 
 	modify_reputation(sender, peer_id, BENEFIT_NOTIFY_GOOD).await;
 }
@@ -727,8 +739,13 @@ async fn notify_collation_seconded(
 /// A peer's view has changed. A number of things should be done:
 ///  - Ongoing collation requests have to be canceled.
 ///  - Advertisements by this peer that are no longer relevant have to be removed.
+///
+/// This requires that the peer has an entry in the peer-data map.
 async fn handle_peer_view_change(state: &mut State, peer_id: PeerId, view: View) -> Result<()> {
-	let peer_data = state.peer_data.entry(peer_id.clone()).or_default();
+	let peer_data = match state.peer_data.get_mut(&peer_id) {
+		None => return Ok(()),
+		Some(pd) => pd,
+	};
 
 	peer_data.update_view(view);
 	state
@@ -816,12 +833,20 @@ async fn process_incoming_peer_message<Context>(
 	ctx: &mut Context,
 	state: &mut State,
 	origin: PeerId,
-	msg: protocol_v1::CollatorProtocolMessage,
+	msg: net_protocol::CollatorProtocolMessage,
 ) {
-	use protocol_v1::CollatorProtocolMessage::*;
 	use sp_runtime::traits::AppVerify;
 	match msg {
-		Declare(collator_id, para_id, signature) => {
+		Versioned::V1(protocol_v1::CollatorProtocolMessage::Declare(
+			collator_id,
+			para_id,
+			signature,
+		)) |
+		Versioned::VStaging(protocol_vstaging::CollatorProtocolMessage::Declare(
+			collator_id,
+			para_id,
+			signature,
+		)) => {
 			if collator_peer_id(&state.peer_data, &collator_id).is_some() {
 				modify_reputation(ctx.sender(), origin, COST_UNEXPECTED_MESSAGE).await;
 				return
@@ -887,7 +912,10 @@ async fn process_incoming_peer_message<Context>(
 				disconnect_peer(ctx.sender(), origin).await;
 			}
 		},
-		AdvertiseCollation(relay_parent) => {
+		Versioned::V1(protocol_v1::CollatorProtocolMessage::AdvertiseCollation(relay_parent)) |
+		Versioned::VStaging(protocol_vstaging::CollatorProtocolMessage::AdvertiseCollation(
+			relay_parent,
+		)) => {
 			let _span = state
 				.span_per_relay_parent
 				.get(&relay_parent)
@@ -975,7 +1003,11 @@ async fn process_incoming_peer_message<Context>(
 				},
 			}
 		},
-		CollationSeconded(_, _) => {
+		Versioned::V1(protocol_v1::CollatorProtocolMessage::CollationSeconded(_, _)) |
+		Versioned::VStaging(protocol_vstaging::CollatorProtocolMessage::CollationSeconded(
+			_,
+			_,
+		)) => {
 			gum::warn!(
 				target: LOG_TARGET,
 				peer_id = ?origin,
@@ -1064,8 +1096,11 @@ async fn handle_network_msg<Context>(
 	use NetworkBridgeEvent::*;
 
 	match bridge_message {
-		PeerConnected(peer_id, _role, _version, _) => {
-			state.peer_data.entry(peer_id).or_default();
+		PeerConnected(peer_id, _role, version, _) => {
+			state
+				.peer_data
+				.entry(peer_id)
+				.or_insert_with(|| PeerData::new(View::default(), version));
 			state.metrics.note_collator_peer_count(state.peer_data.len());
 		},
 		PeerDisconnected(peer_id) => {
@@ -1081,7 +1116,7 @@ async fn handle_network_msg<Context>(
 		OurViewChange(view) => {
 			handle_our_view_change(ctx, state, keystore, view).await?;
 		},
-		PeerMessage(remote, Versioned::V1(msg)) => {
+		PeerMessage(remote, msg) => {
 			process_incoming_peer_message(ctx, state, remote, msg).await;
 		},
 	}
@@ -1132,7 +1167,16 @@ async fn process_msg<Context>(
 				let (collator_id, pending_collation) = collation_event;
 				let PendingCollation { relay_parent, peer_id, .. } = pending_collation;
 				note_good_collation(ctx.sender(), &state.peer_data, collator_id).await;
-				notify_collation_seconded(ctx.sender(), peer_id, relay_parent, stmt).await;
+				if let Some(pd) = state.peer_data.get(&peer_id) {
+					notify_collation_seconded(
+						ctx.sender(),
+						peer_id,
+						pd.version,
+						relay_parent,
+						stmt,
+					)
+					.await;
+				}
 
 				if let Some(collations) = state.collations_per_relay_parent.get_mut(&parent) {
 					collations.status = CollationStatus::Seconded;
@@ -1407,7 +1451,7 @@ async fn handle_collation_fetched_result<Context>(
 			ctx.send_message(CandidateBackingMessage::Second(
 				relay_parent.clone(),
 				candidate_receipt,
-				pvd,
+				unimplemented!(), // TODO [now]
 				pov,
 			))
 			.await;

--- a/node/network/gossip-support/src/lib.rs
+++ b/node/network/gossip-support/src/lib.rs
@@ -402,8 +402,12 @@ where
 			NetworkBridgeEvent::OurViewChange(_) => {},
 			NetworkBridgeEvent::PeerViewChange(_, _) => {},
 			NetworkBridgeEvent::NewGossipTopology { .. } => {},
-			NetworkBridgeEvent::PeerMessage(_, Versioned::V1(v)) => {
-				match v {};
+			NetworkBridgeEvent::PeerMessage(_, message) => {
+				// match void -> LLVM unreachable
+				match message {
+					Versioned::V1(m) => match m {},
+					Versioned::VStaging(m) => match m {},
+				}
 			},
 		}
 	}

--- a/node/network/protocol/Cargo.toml
+++ b/node/network/protocol/Cargo.toml
@@ -24,3 +24,6 @@ gum = { package = "tracing-gum", path = "../../gum" }
 
 [dev-dependencies]
 rand_chacha = "0.3.1"
+
+[features]
+network-protocol-staging = []

--- a/node/network/protocol/src/lib.rs
+++ b/node/network/protocol/src/lib.rs
@@ -269,7 +269,8 @@ impl<V1: Clone, VStaging: Clone> Versioned<&'_ V1, &'_ VStaging> {
 }
 
 /// All supported versions of the validation protocol message.
-pub type VersionedValidationProtocol = Versioned<v1::ValidationProtocol, vstaging::ValidationProtocol>;
+pub type VersionedValidationProtocol =
+	Versioned<v1::ValidationProtocol, vstaging::ValidationProtocol>;
 
 impl From<v1::ValidationProtocol> for VersionedValidationProtocol {
 	fn from(v1: v1::ValidationProtocol) -> Self {
@@ -340,7 +341,8 @@ macro_rules! impl_versioned_try_from {
 				#[allow(unreachable_patterns)] // when there is only one variant
 				match x {
 					Versioned::V1($v1_pat) => Ok(Versioned::V1($v1_out.clone())),
-					Versioned::VStaging($vstaging_pat) => Ok(Versioned::VStaging($vstaging_out.clone())),
+					Versioned::VStaging($vstaging_pat) =>
+						Ok(Versioned::VStaging($vstaging_out.clone())),
 					_ => Err(crate::WrongVariant),
 				}
 			}
@@ -349,7 +351,8 @@ macro_rules! impl_versioned_try_from {
 }
 
 /// Version-annotated messages used by the bitfield distribution subsystem.
-pub type BitfieldDistributionMessage = Versioned<v1::BitfieldDistributionMessage, vstaging::BitfieldDistributionMessage>;
+pub type BitfieldDistributionMessage =
+	Versioned<v1::BitfieldDistributionMessage, vstaging::BitfieldDistributionMessage>;
 impl_versioned_full_protocol_from!(
 	BitfieldDistributionMessage,
 	VersionedValidationProtocol,
@@ -363,7 +366,8 @@ impl_versioned_try_from!(
 );
 
 /// Version-annotated messages used by the statement distribution subsystem.
-pub type StatementDistributionMessage = Versioned<v1::StatementDistributionMessage, vstaging::StatementDistributionMessage>;
+pub type StatementDistributionMessage =
+	Versioned<v1::StatementDistributionMessage, vstaging::StatementDistributionMessage>;
 impl_versioned_full_protocol_from!(
 	StatementDistributionMessage,
 	VersionedValidationProtocol,
@@ -377,7 +381,8 @@ impl_versioned_try_from!(
 );
 
 /// Version-annotated messages used by the approval distribution subsystem.
-pub type ApprovalDistributionMessage = Versioned<v1::ApprovalDistributionMessage, vstaging::ApprovalDistributionMessage>;
+pub type ApprovalDistributionMessage =
+	Versioned<v1::ApprovalDistributionMessage, vstaging::ApprovalDistributionMessage>;
 impl_versioned_full_protocol_from!(
 	ApprovalDistributionMessage,
 	VersionedValidationProtocol,
@@ -392,7 +397,8 @@ impl_versioned_try_from!(
 );
 
 /// Version-annotated messages used by the gossip-support subsystem (this is void).
-pub type GossipSupportNetworkMessage = Versioned<v1::GossipSupportNetworkMessage, vstaging::GossipSupportNetworkMessage>;
+pub type GossipSupportNetworkMessage =
+	Versioned<v1::GossipSupportNetworkMessage, vstaging::GossipSupportNetworkMessage>;
 // This is a void enum placeholder, so never gets sent over the wire.
 impl TryFrom<VersionedValidationProtocol> for GossipSupportNetworkMessage {
 	type Error = WrongVariant;
@@ -409,7 +415,8 @@ impl<'a> TryFrom<&'a VersionedValidationProtocol> for GossipSupportNetworkMessag
 }
 
 /// Version-annotated messages used by the bitfield distribution subsystem.
-pub type CollatorProtocolMessage = Versioned<v1::CollatorProtocolMessage, vstaging::CollatorProtocolMessage>;
+pub type CollatorProtocolMessage =
+	Versioned<v1::CollatorProtocolMessage, vstaging::CollatorProtocolMessage>;
 impl_versioned_full_protocol_from!(
 	CollatorProtocolMessage,
 	VersionedCollationProtocol,

--- a/node/network/protocol/src/lib.rs
+++ b/node/network/protocol/src/lib.rs
@@ -251,22 +251,25 @@ impl View {
 
 /// A protocol-versioned type.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Versioned<V1> {
+pub enum Versioned<V1, VStaging> {
 	/// V1 type.
 	V1(V1),
+	/// VStaging type.
+	VStaging(VStaging),
 }
 
-impl<V1: Clone> Versioned<&'_ V1> {
+impl<V1: Clone, VStaging: Clone> Versioned<&'_ V1, &'_ VStaging> {
 	/// Convert to a fully-owned version of the message.
-	pub fn clone_inner(&self) -> Versioned<V1> {
+	pub fn clone_inner(&self) -> Versioned<V1, VStaging> {
 		match *self {
 			Versioned::V1(inner) => Versioned::V1(inner.clone()),
+			Versioned::VStaging(inner) => Versioned::VStaging(inner.clone()),
 		}
 	}
 }
 
 /// All supported versions of the validation protocol message.
-pub type VersionedValidationProtocol = Versioned<v1::ValidationProtocol>;
+pub type VersionedValidationProtocol = Versioned<v1::ValidationProtocol, vstaging::ValidationProtocol>;
 
 impl From<v1::ValidationProtocol> for VersionedValidationProtocol {
 	fn from(v1: v1::ValidationProtocol) -> Self {
@@ -274,12 +277,24 @@ impl From<v1::ValidationProtocol> for VersionedValidationProtocol {
 	}
 }
 
+impl From<vstaging::ValidationProtocol> for VersionedValidationProtocol {
+	fn from(vstaging: vstaging::ValidationProtocol) -> Self {
+		VersionedValidationProtocol::VStaging(vstaging)
+	}
+}
+
 /// All supported versions of the collation protocol message.
-pub type VersionedCollationProtocol = Versioned<v1::CollationProtocol>;
+pub type VersionedCollationProtocol = Versioned<v1::CollationProtocol, vstaging::CollationProtocol>;
 
 impl From<v1::CollationProtocol> for VersionedCollationProtocol {
 	fn from(v1: v1::CollationProtocol) -> Self {
 		VersionedCollationProtocol::V1(v1)
+	}
+}
+
+impl From<vstaging::CollationProtocol> for VersionedCollationProtocol {
+	fn from(vstaging: vstaging::CollationProtocol) -> Self {
+		VersionedCollationProtocol::VStaging(vstaging)
 	}
 }
 
@@ -289,6 +304,7 @@ macro_rules! impl_versioned_full_protocol_from {
 			fn from(versioned_from: $from) -> $out {
 				match versioned_from {
 					Versioned::V1(x) => Versioned::V1(x.into()),
+					Versioned::VStaging(x) => Versioned::VStaging(x.into()),
 				}
 			}
 		}
@@ -298,7 +314,12 @@ macro_rules! impl_versioned_full_protocol_from {
 /// Implement `TryFrom` for one versioned enum variant into the inner type.
 /// `$m_ty::$variant(inner) -> Ok(inner)`
 macro_rules! impl_versioned_try_from {
-	($from:ty, $out:ty, $v1_pat:pat => $v1_out:expr) => {
+	(
+		$from:ty,
+		$out:ty,
+		$v1_pat:pat => $v1_out:expr,
+		$vstaging_pat:pat => $vstaging_out:expr
+	) => {
 		impl TryFrom<$from> for $out {
 			type Error = crate::WrongVariant;
 
@@ -306,6 +327,7 @@ macro_rules! impl_versioned_try_from {
 				#[allow(unreachable_patterns)] // when there is only one variant
 				match x {
 					Versioned::V1($v1_pat) => Ok(Versioned::V1($v1_out)),
+					Versioned::VStaging($vstaging_pat) => Ok(Versioned::VStaging($vstaging_out)),
 					_ => Err(crate::WrongVariant),
 				}
 			}
@@ -318,6 +340,7 @@ macro_rules! impl_versioned_try_from {
 				#[allow(unreachable_patterns)] // when there is only one variant
 				match x {
 					Versioned::V1($v1_pat) => Ok(Versioned::V1($v1_out.clone())),
+					Versioned::VStaging($vstaging_pat) => Ok(Versioned::VStaging($vstaging_out.clone())),
 					_ => Err(crate::WrongVariant),
 				}
 			}
@@ -326,7 +349,7 @@ macro_rules! impl_versioned_try_from {
 }
 
 /// Version-annotated messages used by the bitfield distribution subsystem.
-pub type BitfieldDistributionMessage = Versioned<v1::BitfieldDistributionMessage>;
+pub type BitfieldDistributionMessage = Versioned<v1::BitfieldDistributionMessage, vstaging::BitfieldDistributionMessage>;
 impl_versioned_full_protocol_from!(
 	BitfieldDistributionMessage,
 	VersionedValidationProtocol,
@@ -335,11 +358,12 @@ impl_versioned_full_protocol_from!(
 impl_versioned_try_from!(
 	VersionedValidationProtocol,
 	BitfieldDistributionMessage,
-	v1::ValidationProtocol::BitfieldDistribution(x) => x
+	v1::ValidationProtocol::BitfieldDistribution(x) => x,
+	vstaging::ValidationProtocol::BitfieldDistribution(x) => x
 );
 
 /// Version-annotated messages used by the statement distribution subsystem.
-pub type StatementDistributionMessage = Versioned<v1::StatementDistributionMessage>;
+pub type StatementDistributionMessage = Versioned<v1::StatementDistributionMessage, vstaging::StatementDistributionMessage>;
 impl_versioned_full_protocol_from!(
 	StatementDistributionMessage,
 	VersionedValidationProtocol,
@@ -348,11 +372,12 @@ impl_versioned_full_protocol_from!(
 impl_versioned_try_from!(
 	VersionedValidationProtocol,
 	StatementDistributionMessage,
-	v1::ValidationProtocol::StatementDistribution(x) => x
+	v1::ValidationProtocol::StatementDistribution(x) => x,
+	vstaging::ValidationProtocol::StatementDistribution(x) => x
 );
 
 /// Version-annotated messages used by the approval distribution subsystem.
-pub type ApprovalDistributionMessage = Versioned<v1::ApprovalDistributionMessage>;
+pub type ApprovalDistributionMessage = Versioned<v1::ApprovalDistributionMessage, vstaging::ApprovalDistributionMessage>;
 impl_versioned_full_protocol_from!(
 	ApprovalDistributionMessage,
 	VersionedValidationProtocol,
@@ -361,11 +386,13 @@ impl_versioned_full_protocol_from!(
 impl_versioned_try_from!(
 	VersionedValidationProtocol,
 	ApprovalDistributionMessage,
-	v1::ValidationProtocol::ApprovalDistribution(x) => x
+	v1::ValidationProtocol::ApprovalDistribution(x) => x,
+	vstaging::ValidationProtocol::ApprovalDistribution(x) => x
+
 );
 
 /// Version-annotated messages used by the gossip-support subsystem (this is void).
-pub type GossipSupportNetworkMessage = Versioned<v1::GossipSupportNetworkMessage>;
+pub type GossipSupportNetworkMessage = Versioned<v1::GossipSupportNetworkMessage, vstaging::GossipSupportNetworkMessage>;
 // This is a void enum placeholder, so never gets sent over the wire.
 impl TryFrom<VersionedValidationProtocol> for GossipSupportNetworkMessage {
 	type Error = WrongVariant;
@@ -382,7 +409,7 @@ impl<'a> TryFrom<&'a VersionedValidationProtocol> for GossipSupportNetworkMessag
 }
 
 /// Version-annotated messages used by the bitfield distribution subsystem.
-pub type CollatorProtocolMessage = Versioned<v1::CollatorProtocolMessage>;
+pub type CollatorProtocolMessage = Versioned<v1::CollatorProtocolMessage, vstaging::CollatorProtocolMessage>;
 impl_versioned_full_protocol_from!(
 	CollatorProtocolMessage,
 	VersionedCollationProtocol,
@@ -391,7 +418,8 @@ impl_versioned_full_protocol_from!(
 impl_versioned_try_from!(
 	VersionedCollationProtocol,
 	CollatorProtocolMessage,
-	v1::CollationProtocol::CollatorProtocol(x) => x
+	v1::CollationProtocol::CollatorProtocol(x) => x,
+	vstaging::CollationProtocol::CollatorProtocol(x) => x
 );
 
 /// v1 notification protocol types.
@@ -399,6 +427,164 @@ pub mod v1 {
 	use parity_scale_codec::{Decode, Encode};
 
 	use polkadot_primitives::v2::{
+		CandidateHash, CandidateIndex, CollatorId, CollatorSignature, CompactStatement, Hash,
+		Id as ParaId, UncheckedSignedAvailabilityBitfield, ValidatorIndex, ValidatorSignature,
+	};
+
+	use polkadot_node_primitives::{
+		approval::{IndirectAssignmentCert, IndirectSignedApprovalVote},
+		UncheckedSignedFullStatement,
+	};
+
+	/// Network messages used by the bitfield distribution subsystem.
+	#[derive(Debug, Clone, Encode, Decode, PartialEq, Eq)]
+	pub enum BitfieldDistributionMessage {
+		/// A signed availability bitfield for a given relay-parent hash.
+		#[codec(index = 0)]
+		Bitfield(Hash, UncheckedSignedAvailabilityBitfield),
+	}
+
+	/// Network messages used by the statement distribution subsystem.
+	#[derive(Debug, Clone, Encode, Decode, PartialEq, Eq)]
+	pub enum StatementDistributionMessage {
+		/// A signed full statement under a given relay-parent.
+		#[codec(index = 0)]
+		Statement(Hash, UncheckedSignedFullStatement),
+		/// Seconded statement with large payload (e.g. containing a runtime upgrade).
+		///
+		/// We only gossip the hash in that case, actual payloads can be fetched from sending node
+		/// via request/response.
+		#[codec(index = 1)]
+		LargeStatement(StatementMetadata),
+	}
+
+	/// Data that makes a statement unique.
+	#[derive(Debug, Clone, Encode, Decode, PartialEq, Eq, Hash)]
+	pub struct StatementMetadata {
+		/// Relay parent this statement is relevant under.
+		pub relay_parent: Hash,
+		/// Hash of the candidate that got validated.
+		pub candidate_hash: CandidateHash,
+		/// Validator that attested the validity.
+		pub signed_by: ValidatorIndex,
+		/// Signature of seconding validator.
+		pub signature: ValidatorSignature,
+	}
+
+	impl StatementDistributionMessage {
+		/// Get fingerprint describing the contained statement uniquely.
+		pub fn get_fingerprint(&self) -> (CompactStatement, ValidatorIndex) {
+			match self {
+				Self::Statement(_, statement) => (
+					statement.unchecked_payload().to_compact(),
+					statement.unchecked_validator_index(),
+				),
+				Self::LargeStatement(meta) =>
+					(CompactStatement::Seconded(meta.candidate_hash), meta.signed_by),
+			}
+		}
+
+		/// Get the signature from the statement.
+		pub fn get_signature(&self) -> ValidatorSignature {
+			match self {
+				Self::Statement(_, statement) => statement.unchecked_signature().clone(),
+				Self::LargeStatement(metadata) => metadata.signature.clone(),
+			}
+		}
+
+		/// Get contained relay parent.
+		pub fn get_relay_parent(&self) -> Hash {
+			match self {
+				Self::Statement(r, _) => *r,
+				Self::LargeStatement(meta) => meta.relay_parent,
+			}
+		}
+
+		/// Whether this message contains a large statement.
+		pub fn is_large_statement(&self) -> bool {
+			if let Self::LargeStatement(_) = self {
+				true
+			} else {
+				false
+			}
+		}
+	}
+
+	/// Network messages used by the approval distribution subsystem.
+	#[derive(Debug, Clone, Encode, Decode, PartialEq, Eq)]
+	pub enum ApprovalDistributionMessage {
+		/// Assignments for candidates in recent, unfinalized blocks.
+		///
+		/// Actually checking the assignment may yield a different result.
+		#[codec(index = 0)]
+		Assignments(Vec<(IndirectAssignmentCert, CandidateIndex)>),
+		/// Approvals for candidates in some recent, unfinalized block.
+		#[codec(index = 1)]
+		Approvals(Vec<IndirectSignedApprovalVote>),
+	}
+
+	/// Dummy network message type, so we will receive connect/disconnect events.
+	#[derive(Debug, Clone, PartialEq, Eq)]
+	pub enum GossipSupportNetworkMessage {}
+
+	/// Network messages used by the collator protocol subsystem
+	#[derive(Debug, Clone, Encode, Decode, PartialEq, Eq)]
+	pub enum CollatorProtocolMessage {
+		/// Declare the intent to advertise collations under a collator ID, attaching a
+		/// signature of the `PeerId` of the node using the given collator ID key.
+		#[codec(index = 0)]
+		Declare(CollatorId, ParaId, CollatorSignature),
+		/// Advertise a collation to a validator. Can only be sent once the peer has
+		/// declared that they are a collator with given ID.
+		#[codec(index = 1)]
+		AdvertiseCollation(Hash),
+		/// A collation sent to a validator was seconded.
+		#[codec(index = 4)]
+		CollationSeconded(Hash, UncheckedSignedFullStatement),
+	}
+
+	/// All network messages on the validation peer-set.
+	#[derive(Debug, Clone, Encode, Decode, PartialEq, Eq, derive_more::From)]
+	pub enum ValidationProtocol {
+		/// Bitfield distribution messages
+		#[codec(index = 1)]
+		#[from]
+		BitfieldDistribution(BitfieldDistributionMessage),
+		/// Statement distribution messages
+		#[codec(index = 3)]
+		#[from]
+		StatementDistribution(StatementDistributionMessage),
+		/// Approval distribution messages
+		#[codec(index = 4)]
+		#[from]
+		ApprovalDistribution(ApprovalDistributionMessage),
+	}
+
+	/// All network messages on the collation peer-set.
+	#[derive(Debug, Clone, Encode, Decode, PartialEq, Eq, derive_more::From)]
+	pub enum CollationProtocol {
+		/// Collator protocol messages
+		#[codec(index = 0)]
+		#[from]
+		CollatorProtocol(CollatorProtocolMessage),
+	}
+
+	/// Get the payload that should be signed and included in a `Declare` message.
+	///
+	/// The payload is the local peer id of the node, which serves to prove that it
+	/// controls the collator key it is declaring an intention to collate under.
+	pub fn declare_signature_payload(peer_id: &sc_network::PeerId) -> Vec<u8> {
+		let mut payload = peer_id.to_bytes();
+		payload.extend_from_slice(b"COLL");
+		payload
+	}
+}
+
+/// vstaging network protocol types.
+pub mod vstaging {
+	use parity_scale_codec::{Decode, Encode};
+
+	use polkadot_primitives::vstaging::{
 		CandidateHash, CandidateIndex, CollatorId, CollatorSignature, CompactStatement, Hash,
 		Id as ParaId, UncheckedSignedAvailabilityBitfield, ValidatorIndex, ValidatorSignature,
 	};

--- a/node/network/protocol/src/peer_set.rs
+++ b/node/network/protocol/src/peer_set.rs
@@ -75,8 +75,6 @@ impl PeerSet {
 		let fallback_names = PeerSetProtocolNames::get_fallback_names(self);
 		let max_notification_size = self.get_max_notification_size(is_authority);
 
-		// TODO [now] if a feature flag is set, use the vstaging
-		// protocol version as default.
 		match self {
 			PeerSet::Validation => NonDefaultSetConfig {
 				notifications_protocol: protocol,
@@ -117,9 +115,16 @@ impl PeerSet {
 	/// Networking layer relies on `get_main_version()` being the version
 	/// of the main protocol name reported by [`PeerSetProtocolNames::get_main_name()`].
 	pub fn get_main_version(self) -> ProtocolVersion {
+		#[cfg(not(feature = "network-protocol-staging"))]
 		match self {
 			PeerSet::Validation => ValidationVersion::V1.into(),
 			PeerSet::Collation => CollationVersion::V1.into(),
+		}
+
+		#[cfg(feature = "network-protocol-staging")]
+		match self {
+			PeerSet::Validation => ValidationVersion::VStaging.into(),
+			PeerSet::Collation => CollationVersion::VStaging.into(),
 		}
 	}
 

--- a/node/network/protocol/src/peer_set.rs
+++ b/node/network/protocol/src/peer_set.rs
@@ -233,7 +233,6 @@ pub enum CollationVersion {
 	VStaging = 2,
 }
 
-
 /// Marker indicating the version is unknown.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct UnknownVersion;
@@ -243,7 +242,9 @@ impl TryFrom<ProtocolVersion> for ValidationVersion {
 
 	fn try_from(p: ProtocolVersion) -> Result<Self, UnknownVersion> {
 		for v in Self::iter() {
-			if v as u32 == p.0 { return Ok(v) }
+			if v as u32 == p.0 {
+				return Ok(v)
+			}
 		}
 
 		Err(UnknownVersion)
@@ -255,7 +256,9 @@ impl TryFrom<ProtocolVersion> for CollationVersion {
 
 	fn try_from(p: ProtocolVersion) -> Result<Self, UnknownVersion> {
 		for v in Self::iter() {
-			if v as u32 == p.0 { return Ok(v) }
+			if v as u32 == p.0 {
+				return Ok(v)
+			}
 		}
 
 		Err(UnknownVersion)

--- a/node/network/statement-distribution/src/lib.rs
+++ b/node/network/statement-distribution/src/lib.rs
@@ -31,6 +31,7 @@ use polkadot_node_network_protocol::{
 	peer_set::{IsAuthority, PeerSet},
 	request_response::{v1 as request_v1, IncomingRequestReceiver},
 	v1::{self as protocol_v1, StatementMetadata},
+	vstaging as protocol_vstaging,
 	IfDisconnected, PeerId, UnifiedReputationChange as Rep, Versioned, View,
 };
 use polkadot_node_primitives::{
@@ -607,7 +608,7 @@ struct FetchingInfo {
 	///
 	/// We use an `IndexMap` here to preserve the ordering of peers sending us messages. This is
 	/// desirable because we reward first sending peers with reputation.
-	available_peers: IndexMap<PeerId, Vec<protocol_v1::StatementDistributionMessage>>,
+	available_peers: IndexMap<PeerId, Vec<net_protocol::StatementDistributionMessage>>,
 	/// Peers left to try in case the background task needs it.
 	peers_to_try: Vec<PeerId>,
 	/// Sender for sending fresh peers to the fetching task in case of failure.
@@ -1249,11 +1250,11 @@ async fn retrieve_statement_from_message<'a, Context>(
 
 					let is_new_peer = match info.available_peers.entry(peer) {
 						IEntry::Occupied(mut occupied) => {
-							occupied.get_mut().push(message);
+							occupied.get_mut().push(Versioned::V1(message));
 							false
 						},
 						IEntry::Vacant(vacant) => {
-							vacant.insert(vec![message]);
+							vacant.insert(vec![Versioned::V1(message)]);
 							true
 						},
 					};
@@ -1331,7 +1332,7 @@ async fn launch_request<Context>(
 	}
 	let available_peers = {
 		let mut m = IndexMap::new();
-		m.insert(peer, vec![protocol_v1::StatementDistributionMessage::LargeStatement(meta)]);
+		m.insert(peer, vec![Versioned::V1(protocol_v1::StatementDistributionMessage::LargeStatement(meta))]);
 		m
 	};
 	Some(LargeStatementStatus::Fetching(FetchingInfo {
@@ -1351,7 +1352,7 @@ async fn handle_incoming_message_and_circulate<'a, Context, R>(
 	active_heads: &'a mut HashMap<Hash, ActiveHeadData>,
 	recent_outdated_heads: &RecentOutdatedHeads,
 	ctx: &mut Context,
-	message: protocol_v1::StatementDistributionMessage,
+	message: net_protocol::StatementDistributionMessage,
 	req_sender: &mpsc::Sender<RequesterMessage>,
 	metrics: &Metrics,
 	runtime: &mut RuntimeInfo,
@@ -1384,7 +1385,7 @@ async fn handle_incoming_message_and_circulate<'a, Context, R>(
 		// statement before a `Seconded` statement. `Seconded` statements are the only ones
 		// that require dependents. Thus, if this is a `Seconded` statement for a candidate we
 		// were not aware of before, we cannot have any dependent statements from the candidate.
-		let _ = metrics.time_network_bridge_update_v1("circulate_statement");
+		let _ = metrics.time_network_bridge_update("circulate_statement");
 
 		let session_index = runtime.get_session_index_for_child(ctx.sender(), relay_parent).await;
 		let topology = match session_index {
@@ -1430,12 +1431,19 @@ async fn handle_incoming_message<'a, Context>(
 	active_heads: &'a mut HashMap<Hash, ActiveHeadData>,
 	recent_outdated_heads: &RecentOutdatedHeads,
 	ctx: &mut Context,
-	message: protocol_v1::StatementDistributionMessage,
+	message: net_protocol::StatementDistributionMessage,
 	req_sender: &mpsc::Sender<RequesterMessage>,
 	metrics: &Metrics,
 ) -> Option<(Hash, StoredStatement<'a>)> {
+	let _ = metrics.time_network_bridge_update("handle_incoming_message");
+
+	// TODO [now] handle vstaging messages
+	let message = match message {
+		Versioned::V1(m) => m,
+		Versioned::VStaging(_) => unimplemented!(),
+	};
+
 	let relay_parent = message.get_relay_parent();
-	let _ = metrics.time_network_bridge_update_v1("handle_incoming_message");
 
 	let active_head = match active_heads.get_mut(&relay_parent) {
 		Some(h) => h,
@@ -1648,8 +1656,11 @@ async fn handle_incoming_message<'a, Context>(
 
 			// When we receive a new message from a peer, we forward it to the
 			// candidate backing subsystem.
-			ctx.send_message(CandidateBackingMessage::Statement(relay_parent, statement_with_pvd))
-				.await;
+			ctx.send_message(CandidateBackingMessage::Statement(
+				relay_parent,
+				unimplemented!(), // TODO [now]: fixme
+			))
+			.await;
 
 			Some((relay_parent, statement))
 		},
@@ -1742,7 +1753,7 @@ async fn handle_network_update<Context, R>(
 			}
 		},
 		NetworkBridgeEvent::NewGossipTopology(topology) => {
-			let _ = metrics.time_network_bridge_update_v1("new_gossip_topology");
+			let _ = metrics.time_network_bridge_update("new_gossip_topology");
 
 			let new_session_index = topology.session;
 			let new_topology: SessionGridTopology = topology.into();
@@ -1766,7 +1777,7 @@ async fn handle_network_update<Context, R>(
 				}
 			}
 		},
-		NetworkBridgeEvent::PeerMessage(peer, Versioned::V1(message)) => {
+		NetworkBridgeEvent::PeerMessage(peer, message) => {
 			handle_incoming_message_and_circulate(
 				peer,
 				topology_storage,
@@ -1783,7 +1794,7 @@ async fn handle_network_update<Context, R>(
 			.await;
 		},
 		NetworkBridgeEvent::PeerViewChange(peer, view) => {
-			let _ = metrics.time_network_bridge_update_v1("peer_view_change");
+			let _ = metrics.time_network_bridge_update("peer_view_change");
 			gum::trace!(target: LOG_TARGET, ?peer, ?view, "Peer view change");
 			match peers.get_mut(&peer) {
 				Some(data) =>

--- a/node/network/statement-distribution/src/lib.rs
+++ b/node/network/statement-distribution/src/lib.rs
@@ -31,8 +31,8 @@ use polkadot_node_network_protocol::{
 	peer_set::{IsAuthority, PeerSet},
 	request_response::{v1 as request_v1, IncomingRequestReceiver},
 	v1::{self as protocol_v1, StatementMetadata},
-	vstaging as protocol_vstaging,
-	IfDisconnected, PeerId, UnifiedReputationChange as Rep, Versioned, View,
+	vstaging as protocol_vstaging, IfDisconnected, PeerId, UnifiedReputationChange as Rep,
+	Versioned, View,
 };
 use polkadot_node_primitives::{
 	SignedFullStatement, Statement, StatementWithPVD, UncheckedSignedFullStatement,
@@ -1332,7 +1332,10 @@ async fn launch_request<Context>(
 	}
 	let available_peers = {
 		let mut m = IndexMap::new();
-		m.insert(peer, vec![Versioned::V1(protocol_v1::StatementDistributionMessage::LargeStatement(meta))]);
+		m.insert(
+			peer,
+			vec![Versioned::V1(protocol_v1::StatementDistributionMessage::LargeStatement(meta))],
+		);
 		m
 	};
 	Some(LargeStatementStatus::Fetching(FetchingInfo {

--- a/node/network/statement-distribution/src/metrics.rs
+++ b/node/network/statement-distribution/src/metrics.rs
@@ -81,10 +81,7 @@ impl Metrics {
 		message_type: &'static str,
 	) -> Option<metrics::prometheus::prometheus::HistogramTimer> {
 		self.0.as_ref().map(|metrics| {
-			metrics
-				.network_bridge_update
-				.with_label_values(&[message_type])
-				.start_timer()
+			metrics.network_bridge_update.with_label_values(&[message_type]).start_timer()
 		})
 	}
 

--- a/node/network/statement-distribution/src/metrics.rs
+++ b/node/network/statement-distribution/src/metrics.rs
@@ -27,7 +27,7 @@ struct MetricsInner {
 	received_responses: prometheus::CounterVec<prometheus::U64>,
 	active_leaves_update: prometheus::Histogram,
 	share: prometheus::Histogram,
-	network_bridge_update_v1: prometheus::HistogramVec,
+	network_bridge_update: prometheus::HistogramVec,
 	statements_unexpected: prometheus::CounterVec<prometheus::U64>,
 	created_message_size: prometheus::Gauge<prometheus::U64>,
 }
@@ -75,14 +75,14 @@ impl Metrics {
 		self.0.as_ref().map(|metrics| metrics.share.start_timer())
 	}
 
-	/// Provide a timer for `network_bridge_update_v1` which observes on drop.
-	pub fn time_network_bridge_update_v1(
+	/// Provide a timer for `network_bridge_update` which observes on drop.
+	pub fn time_network_bridge_update(
 		&self,
 		message_type: &'static str,
 	) -> Option<metrics::prometheus::prometheus::HistogramTimer> {
 		self.0.as_ref().map(|metrics| {
 			metrics
-				.network_bridge_update_v1
+				.network_bridge_update
 				.with_label_values(&[message_type])
 				.start_timer()
 		})
@@ -166,11 +166,11 @@ impl metrics::Metrics for Metrics {
 				)?,
 				registry,
 			)?,
-			network_bridge_update_v1: prometheus::register(
+			network_bridge_update: prometheus::register(
 				prometheus::HistogramVec::new(
 					prometheus::HistogramOpts::new(
-						"polkadot_parachain_statement_distribution_network_bridge_update_v1",
-						"Time spent within `statement_distribution::network_bridge_update_v1`",
+						"polkadot_parachain_statement_distribution_network_bridge_update",
+						"Time spent within `statement_distribution::network_bridge_update`",
 					)
 					.buckets(HISTOGRAM_LATENCY_BUCKETS.into()),
 					&["message_type"],


### PR DESCRIPTION
This is the networking portion of the code extracted from #5618 and rebased onto the latest version of the feature branch. These changes are a common base for #5055 and #5740 

This is targeted to the feature branch and has a number of issues - mainly, that the code as presented doesn't actually function. This will be patched by future PRs, e.g. new versions of #5618 and #5740 + other PRs for writing tests given in TODOs.