### PR TITLE
staking miner: CLI make request and connection timeout configurable

### DIFF
--- a/utils/staking-miner/src/opts.rs
+++ b/utils/staking-miner/src/opts.rs
@@ -327,8 +327,9 @@ mod test_super {
 			"10",
 			"--connection-timeout",
 			"9",
-			"info"
-		]).unwrap();
+			"info",
+		])
+		.unwrap();
 
 		assert_eq!(
 			opt,

--- a/utils/staking-miner/src/opts.rs
+++ b/utils/staking-miner/src/opts.rs
@@ -27,6 +27,14 @@ pub(crate) struct Opt {
 	#[clap(long, short, default_value = DEFAULT_URI, env = "URI", global = true)]
 	pub uri: String,
 
+	/// WS connection timeout in number of seconds.
+	#[clap(long, parse(try_from_str), default_value_t = 60)]
+	pub connection_timeout: usize,
+
+	/// WS request timeout in number of seconds.
+	#[clap(long, parse(try_from_str), default_value_t = 60 * 10)]
+	pub request_timeout: usize,
+
 	#[clap(subcommand)]
 	pub command: Command,
 }
@@ -223,6 +231,8 @@ mod test_super {
 			opt,
 			Opt {
 				uri: "hi".to_string(),
+				connection_timeout: 60,
+				request_timeout: 10 * 60,
 				command: Command::Monitor(MonitorConfig {
 					seed_or_path: "//Alice".to_string(),
 					listen: "head".to_string(),
@@ -251,6 +261,8 @@ mod test_super {
 			opt,
 			Opt {
 				uri: "hi".to_string(),
+				connection_timeout: 60,
+				request_timeout: 10 * 60,
 				command: Command::DryRun(DryRunConfig {
 					seed_or_path: "//Alice".to_string(),
 					at: None,
@@ -279,6 +291,8 @@ mod test_super {
 			opt,
 			Opt {
 				uri: "hi".to_string(),
+				connection_timeout: 60,
+				request_timeout: 10 * 60,
 				command: Command::EmergencySolution(EmergencySolutionConfig {
 					take: Some(99),
 					at: None,
@@ -294,7 +308,36 @@ mod test_super {
 
 		assert_eq!(
 			opt,
-			Opt { uri: "hi".to_string(), command: Command::Info(InfoOpts { json: false }) }
+			Opt {
+				uri: "hi".to_string(),
+				connection_timeout: 60,
+				request_timeout: 10 * 60,
+				command: Command::Info(InfoOpts { json: false })
+			}
+		);
+	}
+
+	#[test]
+	fn cli_request_conn_timeout_works() {
+		let opt = Opt::try_parse_from([
+			env!("CARGO_PKG_NAME"),
+			"--uri",
+			"hi",
+			"--request-timeout",
+			"10",
+			"--connection-timeout",
+			"9",
+			"info"
+		]).unwrap();
+
+		assert_eq!(
+			opt,
+			Opt {
+				uri: "hi".to_string(),
+				connection_timeout: 9,
+				request_timeout: 10,
+				command: Command::Info(InfoOpts { json: false })
+			}
 		);
 	}
 

--- a/utils/staking-miner/src/rpc.rs
+++ b/utils/staking-miner/src/rpc.rs
@@ -27,9 +27,6 @@ use sp_core::{storage::StorageKey, Bytes};
 use sp_version::RuntimeVersion;
 use std::{future::Future, time::Duration};
 
-const MAX_CONNECTION_DURATION: Duration = Duration::from_secs(20);
-const MAX_REQUEST_DURATION: Duration = Duration::from_secs(60);
-
 #[derive(frame_support::DebugNoBound, thiserror::Error)]
 pub(crate) enum RpcHelperError {
 	JsonRpsee(#[from] jsonrpsee::core::Error),
@@ -125,11 +122,15 @@ impl SharedRpcClient {
 	}
 
 	/// Create a new shared JSON-RPC web-socket client.
-	pub(crate) async fn new(uri: &str) -> Result<Self, RpcError> {
+	pub(crate) async fn new(
+		uri: &str,
+		connection_timeout: Duration,
+		request_timeout: Duration,
+	) -> Result<Self, RpcError> {
 		let client = WsClientBuilder::default()
-			.connection_timeout(MAX_CONNECTION_DURATION)
+			.connection_timeout(connection_timeout)
 			.max_request_body_size(u32::MAX)
-			.request_timeout(MAX_REQUEST_DURATION)
+			.request_timeout(request_timeout)
 			.build(uri)
 			.await?;
 		Ok(Self(Arc::new(client)))


### PR DESCRIPTION
Make it possible to configure the `connection timeout` and `request timeout` via CLI flags.