### PR TITLE
Update wococo runtime

### DIFF
--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -128,9 +128,9 @@ impl SubstrateCli for Cli {
 			"wococo-dev" => Box::new(service::chain_spec::wococo_development_config()?),
 			#[cfg(feature = "rococo-native")]
 			"wococo-local" => Box::new(service::chain_spec::wococo_local_testnet_config()?),
-			#[cfg(not(feature = "rococo-native"))]
+			#[cfg(not(feature = "westend-native"))]
 			name if name.starts_with("wococo-") =>
-				Err(format!("`{}` only supported with `rococo-native` feature enabled.", name))?,
+				Err(format!("`{}` only supported with `westend-native` feature enabled.", name))?,
 			#[cfg(feature = "rococo-native")]
 			"versi-dev" => Box::new(service::chain_spec::versi_development_config()?),
 			#[cfg(feature = "rococo-native")]
@@ -148,15 +148,14 @@ impl SubstrateCli for Cli {
 
 				// When `force_*` is given or the file name starts with the name of one of the known chains,
 				// we use the chain spec for the specific chain.
-				if self.run.force_rococo ||
-					chain_spec.is_rococo() ||
-					chain_spec.is_wococo() ||
-					chain_spec.is_versi()
-				{
+				if self.run.force_rococo || chain_spec.is_rococo() || chain_spec.is_versi() {
 					Box::new(service::RococoChainSpec::from_json_file(path)?)
 				} else if self.run.force_kusama || chain_spec.is_kusama() {
 					Box::new(service::KusamaChainSpec::from_json_file(path)?)
-				} else if self.run.force_westend || chain_spec.is_westend() {
+				} else if self.run.force_westend ||
+					chain_spec.is_westend() ||
+					chain_spec.is_wococo()
+				{
 					Box::new(service::WestendChainSpec::from_json_file(path)?)
 				} else {
 					chain_spec
@@ -172,12 +171,12 @@ impl SubstrateCli for Cli {
 		}
 
 		#[cfg(feature = "westend-native")]
-		if spec.is_westend() {
+		if spec.is_westend() || spec.is_wococo() {
 			return &service::westend_runtime::VERSION
 		}
 
 		#[cfg(feature = "rococo-native")]
-		if spec.is_rococo() || spec.is_wococo() || spec.is_versi() {
+		if spec.is_rococo() || spec.is_versi() {
 			return &service::rococo_runtime::VERSION
 		}
 

--- a/node/service/src/chain_spec.rs
+++ b/node/service/src/chain_spec.rs
@@ -1781,20 +1781,16 @@ pub fn versi_development_config() -> Result<RococoChainSpec, String> {
 }
 
 /// Wococo development config (single validator Alice)
-#[cfg(feature = "rococo-native")]
-pub fn wococo_development_config() -> Result<RococoChainSpec, String> {
+#[cfg(feature = "westend-native")]
+pub fn wococo_development_config() -> Result<WestendChainSpec, String> {
 	const WOCOCO_DEV_PROTOCOL_ID: &str = "woco";
-	let wasm_binary = rococo::WASM_BINARY.ok_or("Wococo development wasm not available")?;
+	let wasm_binary = westend::WASM_BINARY.ok_or("Wococo development wasm not available")?;
 
-	Ok(RococoChainSpec::from_genesis(
+	Ok(WestendChainSpec::from_genesis(
 		"Development",
 		"wococo_dev",
 		ChainType::Development,
-		move || RococoGenesisExt {
-			runtime_genesis_config: rococo_development_config_genesis(wasm_binary),
-			// Use 1 minute session length.
-			session_length_in_blocks: Some(10),
-		},
+		move || westend_development_config_genesis(wasm_binary),
 		vec![],
 		None,
 		Some(WOCOCO_DEV_PROTOCOL_ID),
@@ -1933,16 +1929,16 @@ pub fn rococo_local_testnet_config() -> Result<RococoChainSpec, String> {
 	))
 }
 
-/// Wococo is a temporary testnet that uses almost the same runtime as rococo.
-#[cfg(feature = "rococo-native")]
-fn wococo_local_testnet_genesis(wasm_binary: &[u8]) -> rococo_runtime::GenesisConfig {
-	rococo_testnet_genesis(
+/// Wococo is a temporary testnet that uses almost the same runtime as westend.
+#[cfg(feature = "westend-native")]
+fn wococo_local_testnet_genesis(wasm_binary: &[u8]) -> westend::GenesisConfig {
+	westend_testnet_genesis(
 		wasm_binary,
 		vec![
-			get_authority_keys_from_seed("Alice"),
-			get_authority_keys_from_seed("Bob"),
-			get_authority_keys_from_seed("Charlie"),
-			get_authority_keys_from_seed("Dave"),
+			get_authority_keys_from_seed_no_beefy("Alice"),
+			get_authority_keys_from_seed_no_beefy("Bob"),
+			get_authority_keys_from_seed_no_beefy("Charlie"),
+			get_authority_keys_from_seed_no_beefy("Dave"),
 		],
 		get_account_id_from_seed::<sr25519::Public>("Alice"),
 		None,
@@ -1950,19 +1946,15 @@ fn wococo_local_testnet_genesis(wasm_binary: &[u8]) -> rococo_runtime::GenesisCo
 }
 
 /// Wococo local testnet config (multivalidator Alice + Bob + Charlie + Dave)
-#[cfg(feature = "rococo-native")]
-pub fn wococo_local_testnet_config() -> Result<RococoChainSpec, String> {
-	let wasm_binary = rococo::WASM_BINARY.ok_or("Wococo development wasm not available")?;
+#[cfg(feature = "westend-native")]
+pub fn wococo_local_testnet_config() -> Result<WestendChainSpec, String> {
+	let wasm_binary = westend::WASM_BINARY.ok_or("Wococo development wasm not available")?;
 
-	Ok(RococoChainSpec::from_genesis(
+	Ok(WestendChainSpec::from_genesis(
 		"Wococo Local Testnet",
 		"wococo_local_testnet",
 		ChainType::Local,
-		move || RococoGenesisExt {
-			runtime_genesis_config: wococo_local_testnet_genesis(wasm_binary),
-			// Use 1 minute session length.
-			session_length_in_blocks: Some(10),
-		},
+		move || wococo_local_testnet_genesis(wasm_binary),
 		vec![],
 		None,
 		Some(DEFAULT_PROTOCOL_ID),

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -1327,10 +1327,7 @@ pub fn new_chain_ops(
 	let telemetry_worker_handle = None;
 
 	#[cfg(feature = "rococo-native")]
-	if config.chain_spec.is_rococo() ||
-		config.chain_spec.is_wococo() ||
-		config.chain_spec.is_versi()
-	{
+	if config.chain_spec.is_rococo() || config.chain_spec.is_versi() {
 		return chain_ops!(config, jaeger_agent, telemetry_worker_handle; rococo_runtime, RococoExecutorDispatch, Rococo)
 	}
 
@@ -1340,7 +1337,7 @@ pub fn new_chain_ops(
 	}
 
 	#[cfg(feature = "westend-native")]
-	if config.chain_spec.is_westend() {
+	if config.chain_spec.is_westend() || config.chain_spec.is_wococo() {
 		return chain_ops!(config, jaeger_agent, telemetry_worker_handle; westend_runtime, WestendExecutorDispatch, Westend)
 	}
 
@@ -1375,10 +1372,7 @@ pub fn build_full(
 	hwbench: Option<sc_sysinfo::HwBench>,
 ) -> Result<NewFull<Client>, Error> {
 	#[cfg(feature = "rococo-native")]
-	if config.chain_spec.is_rococo() ||
-		config.chain_spec.is_wococo() ||
-		config.chain_spec.is_versi()
-	{
+	if config.chain_spec.is_rococo() || config.chain_spec.is_versi() {
 		return new_full::<rococo_runtime::RuntimeApi, RococoExecutorDispatch, _>(
 			config,
 			is_collator,
@@ -1416,7 +1410,7 @@ pub fn build_full(
 	}
 
 	#[cfg(feature = "westend-native")]
-	if config.chain_spec.is_westend() {
+	if config.chain_spec.is_westend() || config.chain_spec.is_wococo() {
 		return new_full::<westend_runtime::RuntimeApi, WestendExecutorDispatch, _>(
 			config,
 			is_collator,


### PR DESCRIPTION
We would very much like to have an experimental testnet based on the Westend runtime for certain use cases both internal (disputes scaling) or external (connecting third party validators to testnets). We already have a Wococo testnet which sees little us. 

This PR will replace Rococo runtime by Westend in  Wococo. 