### PR TITLE
Bump blake2 from 0.10.2 to 0.10.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -559,9 +559,9 @@ dependencies = [
 
 [[package]]
 name = "blake2"
-version = "0.10.2"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b94ba84325db59637ffc528bbe8c7f86c02c57cff5c0e2b9b00f9a851f42f309"
+checksum = "b9cf849ee05b2ee5fba5e36f97ff8ec2533916700fc0758d40d92136a42f3388"
 dependencies = [
  "digest 0.10.3",
 ]


### PR DESCRIPTION
Companion for https://github.com/paritytech/substrate/pull/12266