### PR TITLE
gossip-support: disconnect when we're no longer in other's reserved set

### DIFF
--- a/node/network/gossip-support/src/lib.rs
+++ b/node/network/gossip-support/src/lib.rs
@@ -249,11 +249,14 @@ where
 					let mut connections = authorities_past_present_future(sender, leaf).await?;
 
 					// Remove all of our locally controlled validator indices so we don't connect to ourself.
-					// If we control none of them, don't issue connection requests - we're outside
-					// of the 'clique' of recent validators.
-					if remove_all_controlled(&self.keystore, &mut connections).await != 0 {
-						self.issue_connection_request(sender, connections).await;
-					}
+					let connections = if remove_all_controlled(&self.keystore, &mut connections).await != 0 {
+						connections
+					} else {
+						// If we control none of them, issue an empty connection request
+						// to clean up all connections.
+						Vec::new()
+					};
+					self.issue_connection_request(sender, connections).await;
 				}
 
 				if is_new_session {
@@ -353,7 +356,7 @@ where
 
 		// issue another request for the same session
 		// if at least a third of the authorities were not resolved.
-		if 3 * failures >= num {
+		if num != 0 && 3 * failures >= num {
 			let timestamp = Instant::now();
 			match self.failure_start {
 				None => self.failure_start = Some(timestamp),

--- a/node/network/gossip-support/src/lib.rs
+++ b/node/network/gossip-support/src/lib.rs
@@ -249,13 +249,14 @@ where
 					let mut connections = authorities_past_present_future(sender, leaf).await?;
 
 					// Remove all of our locally controlled validator indices so we don't connect to ourself.
-					let connections = if remove_all_controlled(&self.keystore, &mut connections).await != 0 {
-						connections
-					} else {
-						// If we control none of them, issue an empty connection request
-						// to clean up all connections.
-						Vec::new()
-					};
+					let connections =
+						if remove_all_controlled(&self.keystore, &mut connections).await != 0 {
+							connections
+						} else {
+							// If we control none of them, issue an empty connection request
+							// to clean up all connections.
+							Vec::new()
+						};
 					self.issue_connection_request(sender, connections).await;
 				}
 


### PR DESCRIPTION
Closes #6008.

Not sure if this is the desired behavious, but it's definitely unexpected for validators. See https://github.com/paritytech/polkadot/issues/6008#issuecomment-1250840027.