### PR TITLE
[ci] Revert cancel-pipeline job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1054,8 +1054,6 @@ short-benchmark-westend:
     PR_NUM:                        "${PR_NUM}"
   trigger:
     project:                       "parity/infrastructure/ci_cd/pipeline-stopper"
-    # remove branch, when pipeline-stopper for polakdot is updated to the same branch
-    branch:                        "as-improve"
 
 cancel-pipeline-test-linux-stable:
   extends:                         .cancel-pipeline-template

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -248,6 +248,7 @@ test-linux-stable:
     # but still want to have debug assertions.
     RUSTFLAGS: "-Cdebug-assertions=y -Dwarnings"
   script:
+    - exit 1
     - time cargo test --workspace --profile testnet --verbose --locked --features=runtime-benchmarks,runtime-metrics
 
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -248,7 +248,6 @@ test-linux-stable:
     # but still want to have debug assertions.
     RUSTFLAGS: "-Cdebug-assertions=y -Dwarnings"
   script:
-    - exit 1
     - time cargo test --workspace --profile testnet --verbose --locked --features=runtime-benchmarks,runtime-metrics
 
 


### PR DESCRIPTION
PR reverts cancel-pipeline job to an old version in order to change it in the future (more info: https://github.com/paritytech/ci_cd/issues/548#issuecomment-1233436898)