### PR TITLE
Increase BlockHashCount parameter

### DIFF
--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -75,7 +75,7 @@ const_assert!(NORMAL_DISPATCH_RATIO.deconstruct() >= AVERAGE_ON_INITIALIZE_RATIO
 
 // Common constants used in all runtimes.
 parameter_types! {
-	pub const BlockHashCount: BlockNumber = 2400;
+	pub const BlockHashCount: BlockNumber = 4096;
 	/// The portion of the `NORMAL_DISPATCH_RATIO` that we adjust the fees with. Blocks filled less
 	/// than this will decrease the weight and more will increase.
 	pub const TargetBlockFullness: Perquintill = Perquintill::from_percent(25);


### PR DESCRIPTION
The work here involves increasing the `BlockHashCount` from `2400` to `4096`.

### **Reasons**

This change uses the same reasoning from a previous PR #1086 that increased the `BlockHashCount` initially. As it turns out, it would have been good to have the parameter set to a greater limit in the first place. Coinbase is running into expiration issues when signing certain transactions. The extra buffer that would be added by this increase would prevent less failures of broadcasting transactions. Specifically, we could set the `eraPeriod` to a much later time, so the node would be able to look back further when looking for a block index, which would allow us to have a transaction sit around longer waiting to be signed.

As mentioned in the previous PR, immortals are still not an option due to their potential to replay attacks.

### **Impact**

This is where I could use the help of some experienced parity developers to help test this appropriately. From previous discussions with @joepetrowski , it was mentioned that with the `4096` value, it would land on the 3rd level of the trie which _should_ be doable in terms of performance. I'm hoping that this could be verified. 
