### PR TITLE
[orchestra] fix: require the initialization with `F: FnOnce` to be `Send`

### DIFF
--- a/node/orchestra/examples/solo.rs
+++ b/node/orchestra/examples/solo.rs
@@ -46,24 +46,31 @@ impl<Context> Fortified {
 	}
 }
 
+async fn setup() {
+	let builder = Solo::builder();
+
+	let builder = builder.goblin_tower(Fortified::default());
+
+	let builder = builder.spawner(DummySpawner);
+	let (orchestra, _handle): (Solo<_>, _) = builder.build().unwrap();
+
+	let orchestra_fut = orchestra
+		.running_subsystems
+		.into_future()
+		.timeout(std::time::Duration::from_millis(300))
+		.fuse();
+
+	pin_mut!(orchestra_fut);
+
+	orchestra_fut.await;
+}
+
+fn assert_t_impl_trait_send<T: Send>(_: &T) {}
+
 fn main() {
 	use futures::{executor, pin_mut};
 
-	executor::block_on(async move {
-		let (orchestra, _handle): (Solo<_>, _) = Solo::builder()
-			.goblin_tower(Fortified::default())
-			.spawner(DummySpawner)
-			.build()
-			.unwrap();
-
-		let orchestra_fut = orchestra
-			.running_subsystems
-			.into_future()
-			.timeout(std::time::Duration::from_millis(300))
-			.fuse();
-
-		pin_mut!(orchestra_fut);
-
-		orchestra_fut.await
-	});
+	let x = setup();
+	assert_t_impl_trait_send(&x);
+	executor::block_on(x);
 }

--- a/node/orchestra/examples/solo.rs
+++ b/node/orchestra/examples/solo.rs
@@ -60,7 +60,7 @@ async fn setup() {
 		.timeout(std::time::Duration::from_millis(300))
 		.fuse();
 
-	pin_mut!(orchestra_fut);
+	futures::pin_mut!(orchestra_fut);
 
 	orchestra_fut.await;
 }
@@ -68,9 +68,7 @@ async fn setup() {
 fn assert_t_impl_trait_send<T: Send>(_: &T) {}
 
 fn main() {
-	use futures::{executor, pin_mut};
-
 	let x = setup();
 	assert_t_impl_trait_send(&x);
-	executor::block_on(x);
+	futures::executor::block_on(x);
 }

--- a/node/orchestra/proc-macro/src/impl_builder.rs
+++ b/node/orchestra/proc-macro/src/impl_builder.rs
@@ -172,7 +172,7 @@ pub(crate) fn impl_builder(info: &OrchestraInfo) -> proc_macro2::TokenStream {
 					pub fn #field_name_with<'a, F>(self, subsystem_init_fn: F ) ->
 						#builder <InitStateSpawner, #( #post_setter_state_generics, )* #( #baggage_passthrough_state_generics, )*>
 					where
-						F: 'static + FnOnce(#handle) ->
+						F: 'static + Send + FnOnce(#handle) ->
 							::std::result::Result<#field_type, #error_ty>,
 					{
 						let boxed_func = Init::<#field_type>::Fn(
@@ -206,7 +206,7 @@ pub(crate) fn impl_builder(info: &OrchestraInfo) -> proc_macro2::TokenStream {
 						-> #builder <InitStateSpawner, #( #post_replace_state_generics, )* #( #baggage_passthrough_state_generics, )*>
 					where
 						#field_type: 'static,
-						F: 'static + FnOnce(#field_type) -> NEW,
+						F: 'static + Send + FnOnce(#field_type) -> NEW,
 						NEW: #support_crate ::Subsystem<#subsystem_ctx_name< #subsystem_consumes >, #error_ty>,
 					{
 						let replacement: Init<NEW> = match self.#field_name {
@@ -333,7 +333,7 @@ pub(crate) fn impl_builder(info: &OrchestraInfo) -> proc_macro2::TokenStream {
 
 	let mut ts = quote! {
 		/// Convenience alias.
-		type SubsystemInitFn<T> = Box<dyn FnOnce(#handle) -> ::std::result::Result<T, #error_ty> >;
+		type SubsystemInitFn<T> = Box<dyn FnOnce(#handle) -> ::std::result::Result<T, #error_ty> + Send + 'static>;
 
 		/// Type for the initialized field of the orchestra builder
 		pub enum Init<T> {


### PR DESCRIPTION
If creating intermediate variables of the builder type within a future, rustc will complain about the future not being send, while the thing itself isn't even using the closure based field initialization. Adding an additional bound, resolves this and pushes the error message "closer" to the user, and to the public interface boundary of the generated code.

CC @sandreim 

Polkadot address: 1TmDZDCaYhbE3Uip8n6GxBbfFYpikxppTp18qJFboSKPY1U