### PR TITLE
Remove executed runtime migrations (nompools MigrateToV3, InitiateNominationPools)

### DIFF
--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -1455,7 +1455,6 @@ pub type Executive = frame_executive::Executive<
 	Runtime,
 	AllPalletsWithSystem,
 	(
-		pallet_nomination_pools::migration::v3::MigrateToV3<Runtime>,
 		pallet_staking::migrations::v11::MigrateToV11<
 			Runtime,
 			VoterList,

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -1537,8 +1537,6 @@ pub type Executive = frame_executive::Executive<
 	Runtime,
 	AllPalletsWithSystem,
 	(
-		InitiateNominationPools,
-		pallet_nomination_pools::migration::v3::MigrateToV3<Runtime>,
 		pallet_staking::migrations::v11::MigrateToV11<
 			Runtime,
 			VoterList,

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -1200,7 +1200,6 @@ pub type Executive = frame_executive::Executive<
 			VoterList,
 			StakingMigrationV11OldPallet,
 		>,
-		pallet_nomination_pools::migration::v3::MigrateToV3<Runtime>,
 		pallet_staking::migrations::v12::MigrateToV12<Runtime>,
 	),
 >;


### PR DESCRIPTION
The migrations that are dropped here are present in runtimes 9290/9291 and can thus be cleaned up