### PR TITLE
[zombienet] add nominators

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,7 +32,7 @@ variables:
   CI_IMAGE:                        "paritytech/ci-linux:production"
   DOCKER_OS:                       "debian:stretch"
   ARCH:                            "x86_64"
-  ZOMBIENET_IMAGE:                 "docker.io/paritytech/zombienet:v1.2.68"
+  ZOMBIENET_IMAGE:                 "docker.io/paritytech/zombienet:v1.2.71"
   PIPELINE_SCRIPTS_TAG:            "v0.4"
 
 default:
@@ -835,7 +835,7 @@ zombienet-tests-slashing:
   script:
     - /home/nonroot/zombie-net/scripts/ci/run-test-env-manager.sh
         --github-remote-dir="${GH_DIR}"
-        --concurrency=25
+        --concurrency=30
         --test="0004-slashing.feature"
   allow_failure:                   false
   retry: 2

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -408,8 +408,8 @@ parameter_types! {
 	// 1 hour session, 15 minutes unsigned phase, 8 offchain executions.
 	pub OffchainRepeat: BlockNumber = UnsignedPhase::get() / 8;
 
-	/// We take the top 12500 nominators as electing voters..
-	pub const MaxElectingVoters: u32 = 12_500;
+	/// We take the top 12500/22500 nominators as electing voters..
+	pub const MaxElectingVoters: u32 = prod_or_fast!(12_500, 22_500);
 	/// ... and all of the validators as electable targets. Whilst this is the case, we cannot and
 	/// shall not increase the size of the validator intentions.
 	pub const MaxElectableTargets: u16 = u16::MAX;

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -409,7 +409,7 @@ parameter_types! {
 	pub OffchainRepeat: BlockNumber = UnsignedPhase::get() / 8;
 
 	/// We take the top 12500/22500 nominators as electing voters..
-	pub const MaxElectingVoters: u32 = prod_or_fast!(12_500, 22_500);
+	pub const MaxElectingVoters: u32 = prod_or_fast!(12_500, 25_000);
 	/// ... and all of the validators as electable targets. Whilst this is the case, we cannot and
 	/// shall not increase the size of the validator intentions.
 	pub const MaxElectableTargets: u16 = u16::MAX;

--- a/zombienet_tests/functional/0004-slashing.toml
+++ b/zombienet_tests/functional/0004-slashing.toml
@@ -11,6 +11,7 @@ default_image = "{{ZOMBIENET_INTEGRATION_TEST_IMAGE}}"
 chain = "kusama-local"
 chain_spec_command = "polkadot build-spec --chain kusama-local --disable-default-bootnode"
 default_command = "polkadot"
+random_nominators_count = 25000
 
 [relaychain.default_resources]
 limits = { memory = "8G", cpu = "4" }


### PR DESCRIPTION
Hi @ordian, changes to add nominators:
- bump zombienet.
- change network file to add 25000 nominators.
- set  `MaxElectingVoters` to `22_500` for fast-runtime.

Thanks!
