### PR TITLE
Demote warning

### DIFF
--- a/node/core/provisioner/src/lib.rs
+++ b/node/core/provisioner/src/lib.rs
@@ -271,7 +271,15 @@ async fn send_inherent_data_bg<Context>(
 
 		match send_result.await {
 			Err(err) => {
-				gum::warn!(target: LOG_TARGET, err = ?err, "failed to assemble or send inherent data");
+				if let Error::CanceledBackedCandidates(_) = err {
+					gum::debug!(
+						target: LOG_TARGET,
+						err = ?err,
+						"Failed to assemble or send inherent data - block got likely obsoleted already."
+					);
+				} else {
+					gum::warn!(target: LOG_TARGET, err = ?err, "failed to assemble or send inherent data");
+				}
 				metrics.on_inherent_data_request(Err(()));
 			},
 			Ok(()) => {


### PR DESCRIPTION
This can happen under heavy load - no value in warning here.

Scenario this happens:

- New slot
- We get asked about what fork to build on
- We start building (create inherent gets called)
- We learn about a better fork (but Babe does not care as it already has a fork)
- 6 seconds passed - New slot
- Babe asks about what for to build on - we answer with the best block we learned about 6 seconds ago (slightly after we got asked the last time)
- We start building (on that old block)
- Milliseconds later we learn about a new block (the one from the slot we are actually in now)
- We kick the old leaf -> create inherent fails

Full discussion: https://github.com/paritytech/substrate/issues/12375