### PR TITLE
Pass through `runtime-benchmarks` feature

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -56,7 +56,11 @@ cli = [
 	"polkadot-client",
 	"polkadot-node-core-pvf",
 ]
-runtime-benchmarks = ["service/runtime-benchmarks", "polkadot-node-metrics/runtime-benchmarks"]
+runtime-benchmarks = [
+	"service/runtime-benchmarks",
+	"polkadot-node-metrics/runtime-benchmarks",
+	"polkadot-performance-test?/runtime-benchmarks"
+]
 trie-memory-tracker = ["sp-trie/memory-tracker"]
 full-node = ["service/full-node"]
 try-runtime = ["service/try-runtime"]

--- a/node/test/performance-test/Cargo.toml
+++ b/node/test/performance-test/Cargo.toml
@@ -19,3 +19,6 @@ kusama-runtime = { path = "../../../runtime/kusama" }
 [[bin]]
 name = "gen-ref-constants"
 path = "src/gen_ref_constants.rs"
+
+[features]
+runtime-benchmarks = ["kusama-runtime/runtime-benchmarks"]


### PR DESCRIPTION
As far as I can tell the CI fails [here](https://github.com/paritytech/cumulus/pull/1726) because the `runtime-benchmark` feature is not passed through via `performance-test` into `kusama-runtime`.

cumulus companion: https://github.com/paritytech/cumulus/pull/1726