### PR TITLE
ci/guide: install mdbook-graphviz

### DIFF
--- a/scripts/ci/gitlab/pipeline/build.yml
+++ b/scripts/ci/gitlab/pipeline/build.yml
@@ -169,6 +169,7 @@ build-implementers-guide:
     - .test-refs
     - .collect-artifacts-short
   script:
+    - apt-get update && apt-get install -y graphviz
     - cargo install mdbook mdbook-mermaid mdbook-linkcheck mdbook-graphviz
     - mdbook build ./roadmap/implementers-guide
     - mkdir -p artifacts

--- a/scripts/ci/gitlab/pipeline/build.yml
+++ b/scripts/ci/gitlab/pipeline/build.yml
@@ -169,7 +169,7 @@ build-implementers-guide:
     - .test-refs
     - .collect-artifacts-short
   script:
-    - apt-get update && apt-get install -y graphviz
+    - apt-get -y update; apt-get install -y graphviz
     - cargo install mdbook mdbook-mermaid mdbook-linkcheck mdbook-graphviz
     - mdbook build ./roadmap/implementers-guide
     - mkdir -p artifacts

--- a/scripts/ci/gitlab/pipeline/build.yml
+++ b/scripts/ci/gitlab/pipeline/build.yml
@@ -169,7 +169,7 @@ build-implementers-guide:
     - .test-refs
     - .collect-artifacts-short
   script:
-    - cargo install mdbook mdbook-mermaid mdbook-linkcheck
+    - cargo install mdbook mdbook-mermaid mdbook-linkcheck mdbook-graphviz
     - mdbook build ./roadmap/implementers-guide
     - mkdir -p artifacts
     - mv roadmap/implementers-guide/book artifacts/


### PR DESCRIPTION
Do we have `graphviz` package install in the builder image?

This PR should fix `dot process` graphs in the implementer's guide not rendering assuming the answer is yes.
Example: https://paritytech.github.io/polkadot/book/node/subsystems-and-jobs.html