### PR TITLE
Update tests for Rust 1.64

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,7 +32,7 @@ variables:
   GIT_STRATEGY:                    fetch
   GIT_DEPTH:                       100
   CI_SERVER_NAME:                  "GitLab CI"
-  CI_IMAGE:                        "paritytech/ci-linux:production"
+  CI_IMAGE:                        "paritytech/ci-linux:staging"
   DOCKER_OS:                       "debian:stretch"
   ARCH:                            "x86_64"
   ZOMBIENET_IMAGE:                 "docker.io/paritytech/zombienet:v1.2.67"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,7 +32,7 @@ variables:
   GIT_STRATEGY:                    fetch
   GIT_DEPTH:                       100
   CI_SERVER_NAME:                  "GitLab CI"
-  CI_IMAGE:                        "paritytech/ci-linux:staging"
+  CI_IMAGE:                        "paritytech/ci-linux:production"
   DOCKER_OS:                       "debian:stretch"
   ARCH:                            "x86_64"
   ZOMBIENET_IMAGE:                 "docker.io/paritytech/zombienet:v1.2.67"

--- a/node/gum/src/tests.rs
+++ b/node/gum/src/tests.rs
@@ -14,9 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
+#![allow(named_arguments_used_positionally)]
+
 use super::*;
 pub use polkadot_primitives::v2::{CandidateHash, Hash};
-#![allow(named_arguments_used_positionally)]
 
 #[derive(Default, Debug)]
 struct Y {

--- a/node/gum/src/tests.rs
+++ b/node/gum/src/tests.rs
@@ -14,8 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
-#![allow(named_arguments_used_positionally)]
-
 use super::*;
 pub use polkadot_primitives::v2::{CandidateHash, Hash};
 
@@ -34,7 +32,7 @@ fn plain() {
 fn wo_alias() {
 	let a: i32 = 7;
 	error!(target: "foo",
-		"Something something {}, {:?}, or maybe {}",
+		"Something something {}, {b:?}, or maybe {c}",
 		a,
 		b = Y::default(),
 		c = a

--- a/node/gum/src/tests.rs
+++ b/node/gum/src/tests.rs
@@ -16,6 +16,7 @@
 
 use super::*;
 pub use polkadot_primitives::v2::{CandidateHash, Hash};
+#![allow(named_arguments_used_positionally)]
 
 #[derive(Default, Debug)]
 struct Y {


### PR DESCRIPTION
Check that Rust 1.64 doesn't break anything too far. Relates to https://github.com/paritytech/substrate/pull/12440.