### PR TITLE
Make Treasurer origin able to spend any amount

### DIFF
--- a/runtime/kusama/src/governance/origins.rs
+++ b/runtime/kusama/src/governance/origins.rs
@@ -173,6 +173,7 @@ pub mod pallet_custom_origins {
 			SmallSpender = 10 * GRAND,
 			MediumSpender = 100 * GRAND,
 			BigSpender = 1_000 * GRAND,
+			Treasurer = Balance::max_value(),
 		}
 	}
 


### PR DESCRIPTION
The doc comment above `Treasurer` origin says "Origin for spending (any amount of) funds", but the origin is not set anywhere in the Kusama runtime.

The pallet_treasury::Config::SpendOrigin = TreasurySpender = EitherOf<Root, Spender> so I think `Treasurer` origin needs to be added to Spender.

Without this change, I don't see how the `Treasurer` origin/track can do anything.