### PR TITLE
Separate preparation timeouts for PVF prechecking and execution

### DIFF
--- a/node/core/pvf/src/host.rs
+++ b/node/core/pvf/src/host.rs
@@ -61,8 +61,9 @@ pub struct ValidationHost {
 }
 
 impl ValidationHost {
-	/// Precheck PVF with the given code, i.e. verify that it compiles within a reasonable time limit.
-	/// This will prepare the PVF. The result of preparation will be sent to the provided result sender.
+	/// Precheck PVF with the given code, i.e. verify that it compiles within a reasonable time
+	/// limit. This will prepare the PVF. The result of preparation will be sent to the provided
+	/// result sender.
 	///
 	/// This is async to accommodate the possibility of back-pressure. In the vast majority of
 	/// situations this function should return immediately.

--- a/node/core/pvf/src/host.rs
+++ b/node/core/pvf/src/host.rs
@@ -41,12 +41,12 @@ use std::{
 /// The time period after which the precheck preparation worker is considered unresponsive and will
 /// be killed.
 // NOTE: If you change this make sure to fix the buckets of `pvf_preparation_time` metric.
-const PRECHECK_COMPILATION_TIMEOUT: Duration = Duration::from_secs(60);
+pub const PRECHECK_COMPILATION_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// The time period after which the execute preparation worker is considered unresponsive and will
 /// be killed.
 // NOTE: If you change this make sure to fix the buckets of `pvf_preparation_time` metric.
-const EXECUTE_COMPILATION_TIMEOUT: Duration = Duration::from_secs(180);
+pub const EXECUTE_COMPILATION_TIMEOUT: Duration = Duration::from_secs(180);
 
 /// An alias to not spell the type for the oneshot sender for the PVF execution result.
 pub(crate) type ResultSender = oneshot::Sender<Result<ValidationResult, ValidationError>>;

--- a/node/core/pvf/src/metrics.rs
+++ b/node/core/pvf/src/metrics.rs
@@ -155,7 +155,8 @@ impl metrics::Metrics for Metrics {
 						"Time spent in preparing PVF artifacts in seconds",
 					)
 					.buckets(vec![
-						// This is synchronized with COMPILATION_TIMEOUT=60s constant found in
+						// This is synchronized with the PRECHECK_COMPILATION_TIMEOUT=60s
+						// and EXECUTE_COMPILATION_TIMEOUT=180s constants found in
 						// src/prepare/worker.rs
 						0.1,
 						0.5,
@@ -166,6 +167,7 @@ impl metrics::Metrics for Metrics {
 						20.0,
 						30.0,
 						60.0,
+						180.0,
 					]),
 				)?,
 				registry,

--- a/node/core/pvf/src/prepare/pool.rs
+++ b/node/core/pvf/src/prepare/pool.rs
@@ -61,7 +61,12 @@ pub enum ToPool {
 	///
 	/// In either case, the worker is considered busy and no further `StartWork` messages should be
 	/// sent until either `Concluded` or `Rip` message is received.
-	StartWork { worker: Worker, code: Arc<Vec<u8>>, artifact_path: PathBuf },
+	StartWork {
+		worker: Worker,
+		code: Arc<Vec<u8>>,
+		artifact_path: PathBuf,
+		compilation_timeout: Duration,
+	},
 }
 
 /// A message sent from pool to its client.
@@ -205,7 +210,7 @@ fn handle_to_pool(
 			metrics.prepare_worker().on_begin_spawn();
 			mux.push(spawn_worker_task(program_path.to_owned(), spawn_timeout).boxed());
 		},
-		ToPool::StartWork { worker, code, artifact_path } => {
+		ToPool::StartWork { worker, code, artifact_path, compilation_timeout } => {
 			if let Some(data) = spawned.get_mut(worker) {
 				if let Some(idle) = data.idle.take() {
 					let preparation_timer = metrics.time_preparation();
@@ -216,6 +221,7 @@ fn handle_to_pool(
 							code,
 							cache_path.to_owned(),
 							artifact_path,
+							compilation_timeout,
 							preparation_timer,
 						)
 						.boxed(),
@@ -263,9 +269,11 @@ async fn start_work_task<Timer>(
 	code: Arc<Vec<u8>>,
 	cache_path: PathBuf,
 	artifact_path: PathBuf,
+	compilation_timeout: Duration,
 	_preparation_timer: Option<Timer>,
 ) -> PoolEvent {
-	let outcome = worker::start_work(idle, code, &cache_path, artifact_path).await;
+	let outcome =
+		worker::start_work(idle, code, &cache_path, artifact_path, compilation_timeout).await;
 	PoolEvent::StartWork(worker, outcome)
 }
 

--- a/node/core/pvf/src/prepare/queue.rs
+++ b/node/core/pvf/src/prepare/queue.rs
@@ -91,7 +91,7 @@ impl WorkerData {
 }
 
 /// A queue structured like this is prone to starving, however, we don't care that much since we expect
-///  there is going to be a limited number of critical jobs and we don't really care if background starve.
+/// there is going to be a limited number of critical jobs and we don't really care if background starve.
 #[derive(Default)]
 struct Unscheduled {
 	normal: VecDeque<Job>,
@@ -225,7 +225,7 @@ async fn handle_enqueue(queue: &mut Queue, priority: Priority, pvf: Pvf) -> Resu
 		"second Enqueue sent for a known artifact"
 	) {
 		// This function is called in response to a `Enqueue` message;
-		// Precondtion for `Enqueue` is that it is sent only once for a PVF;
+		// Precondition for `Enqueue` is that it is sent only once for a PVF;
 		// Thus this should always be `false`;
 		// qed.
 		gum::warn!(

--- a/node/core/pvf/src/prepare/worker.rs
+++ b/node/core/pvf/src/prepare/worker.rs
@@ -72,7 +72,6 @@ pub async fn start_work(
 	gum::debug!(
 		target: LOG_TARGET,
 		worker_pid = %pid,
-		?compilation_timeout,
 		"starting prepare for {}",
 		artifact_path.display(),
 	);

--- a/node/core/pvf/src/prepare/worker.rs
+++ b/node/core/pvf/src/prepare/worker.rs
@@ -72,6 +72,7 @@ pub async fn start_work(
 	gum::debug!(
 		target: LOG_TARGET,
 		worker_pid = %pid,
+		?compilation_timeout,
 		"starting prepare for {}",
 		artifact_path.display(),
 	);

--- a/roadmap/implementers-guide/src/pvf-prechecking.md
+++ b/roadmap/implementers-guide/src/pvf-prechecking.md
@@ -1,6 +1,6 @@
 # PVF Pre-checking Overview
 
-> ⚠️ This discusses a mechanism that is currently not under-development. Follow the progress under [#3211].
+> ⚠️ This discusses a mechanism that is currently under-development. Follow the progress under [#3211].
 
 ## Motivation
 

--- a/roadmap/implementers-guide/src/pvf-prechecking.md
+++ b/roadmap/implementers-guide/src/pvf-prechecking.md
@@ -2,11 +2,33 @@
 
 > ⚠️ This discusses a mechanism that is currently under-development. Follow the progress under [#3211].
 
+## Terms
+
+This functionality involves several processes which may be potentially
+confusing:
+
+- **Prechecking:** This is the process of initially checking the PVF when it is
+  first added. We attempt *preparation* of the PVF and make sure it succeeds
+  within a given timeout.
+- **Execution:** This actually executes the PVF. The node may not have the
+  artifact from prechecking, in which case this process also includes a
+  *preparation* job. The timeout for preparation here is more lenient than when
+  prechecking.
+- **Preparation:** This is the process of preparing the WASM blob and includes
+  both *prevalidation* and *compilation*. As prevalidation is pretty minimal
+  right now, preparation mostly consists of compilation. Note that *prechecking*
+  just consists of preparation, whereas *execution* will also prepare the PVF if
+  the artifact is not already found.
+- **Prevalidation:** Right now this just tries to deserialize the binary with
+  parity-wasm. It is a part of *preparation*.
+- **Compilation:** This is the process of compiling a PVF from wasm code to
+  machine code. It is a part of *preparation*.
+
 ## Motivation
 
 Parachains' and parathreads' validation function is described by a wasm module that we refer to as a PVF. Since it's a wasm module the typical way of executing it is to compile it to machine code. Typically an optimizing compiler consists of algorithms that are able to optimize the resulting machine code heavily. However, while those algorithms perform quite well for a typical wasm code produced by standard toolchains (e.g. rustc/LLVM), those algorithms can be abused to consume a lot of resources. Moreover, since those algorithms are rather complex there is a lot of room for a bug that can crash the compiler.
 
-If compilation of a Parachain Validation Function (PVF) takes too long or uses too much memory, this can leave a node in limbo as to whether a candidate of that parachain is valid or not. 
+If compilation of a Parachain Validation Function (PVF) takes too long or uses too much memory, this can leave a node in limbo as to whether a candidate of that parachain is valid or not.
 
 The amount of time that a PVF takes to compile is a subjective resource limit and as such PVFs may be maliciously crafted so that there is e.g. a 50/50 split of validators which can and cannot compile and execute the PVF.
 

--- a/scripts/ci/gitlab/lingua.dic
+++ b/scripts/ci/gitlab/lingua.dic
@@ -204,6 +204,7 @@ PoV/MS
 PoW/MS
 PR
 precheck
+prechecking
 preconfigured
 preimage/MS
 preopen

--- a/zombienet_tests/functional/0001-parachains-pvf.zndsl
+++ b/zombienet_tests/functional/0001-parachains-pvf.zndsl
@@ -64,14 +64,14 @@ one: reports histogram polkadot_pvf_preparation_time has at least 1 samples in b
 two: reports histogram polkadot_pvf_preparation_time has at least 1 samples in buckets ["0.1", "0.5", "1", "2", "3", "10"] within 10 seconds
 
 # Check all buckets >= 20.             
-alice: reports histogram polkadot_pvf_preparation_time has 0 samples in buckets ["20", "30", "60", "+Inf"] within 10 seconds
-bob: reports histogram polkadot_pvf_preparation_time has 0 samples in buckets ["20", "30", "60", "+Inf"] within 10 seconds
-charlie: reports histogram polkadot_pvf_preparation_time has 0 samples in buckets ["20", "30", "60", "+Inf"] within 10 seconds
-dave: reports histogram polkadot_pvf_preparation_time has 0 samples in buckets ["20", "30", "60", "+Inf"] within 10 seconds
-ferdie: reports histogram polkadot_pvf_preparation_time has 0 samples in buckets ["20", "30", "60", "+Inf"] within 10 seconds
-eve: reports histogram polkadot_pvf_preparation_time has 0 samples in buckets ["20", "30", "60", "+Inf"] within 10 seconds
-one: reports histogram polkadot_pvf_preparation_time has 0 samples in buckets ["20", "30", "60", "+Inf"] within 10 seconds
-two: reports histogram polkadot_pvf_preparation_time has 0 samples in buckets ["20", "30", "60", "+Inf"] within 10 seconds
+alice: reports histogram polkadot_pvf_preparation_time has 0 samples in buckets ["20", "30", "60", "180", "+Inf"] within 10 seconds
+bob: reports histogram polkadot_pvf_preparation_time has 0 samples in buckets ["20", "30", "60", "180", "+Inf"] within 10 seconds
+charlie: reports histogram polkadot_pvf_preparation_time has 0 samples in buckets ["20", "30", "60", "180", "+Inf"] within 10 seconds
+dave: reports histogram polkadot_pvf_preparation_time has 0 samples in buckets ["20", "30", "60", "180", "+Inf"] within 10 seconds
+ferdie: reports histogram polkadot_pvf_preparation_time has 0 samples in buckets ["20", "30", "60", "180", "+Inf"] within 10 seconds
+eve: reports histogram polkadot_pvf_preparation_time has 0 samples in buckets ["20", "30", "60", "180", "+Inf"] within 10 seconds
+one: reports histogram polkadot_pvf_preparation_time has 0 samples in buckets ["20", "30", "60", "180", "+Inf"] within 10 seconds
+two: reports histogram polkadot_pvf_preparation_time has 0 samples in buckets ["20", "30", "60", "180", "+Inf"] within 10 seconds
 
 # Check execution time.
 # There are two different timeout conditions: BACKING_EXECUTION_TIMEOUT(2s) and


### PR DESCRIPTION
# PULL REQUEST

## Overview

Per the linked issue, we make the required changes so that preparation for
execution is more lenient (by a factor of 3) than preparation for prechecking.

We [add a compilation_timeout parameter for PVF preparation job](https://github.com/paritytech/polkadot/commit/ee0abe26cc1b81c961ee1b78925d64795c305bd6) 
and also split the `COMPILATION_TIMEOUT` constant into two new consts.

### Todo

- [ ] ~~What kind of tests should be added?~~