### PR TITLE
refactor grid topology to expose more info to subsystems

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6134,6 +6134,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "sp-application-crypto",
+ "sp-authority-discovery",
  "sp-core",
  "sp-keyring",
  "sp-keystore",

--- a/node/network/approval-distribution/src/lib.rs
+++ b/node/network/approval-distribution/src/lib.rs
@@ -343,9 +343,13 @@ impl State {
 				})
 			},
 			NetworkBridgeEvent::NewGossipTopology(topology) => {
-				let session = topology.session;
-				self.handle_new_session_topology(ctx, session, SessionGridTopology::from(topology))
-					.await;
+				self.handle_new_session_topology(
+					ctx,
+					topology.session,
+					topology.topology,
+					topology.local_index,
+				)
+				.await;
 			},
 			NetworkBridgeEvent::PeerViewChange(peer_id, view) => {
 				self.handle_peer_view_change(ctx, metrics, peer_id, view, rng).await;
@@ -500,8 +504,14 @@ impl State {
 		ctx: &mut Context,
 		session: SessionIndex,
 		topology: SessionGridTopology,
+		local_index: Option<ValidatorIndex>,
 	) {
-		self.topologies.insert_topology(session, topology);
+		if local_index.is_none() {
+			// this subsystem only matters to validators.
+			return
+		}
+
+		self.topologies.insert_topology(session, topology, local_index);
 		let topology = self.topologies.get_topology(session).expect("just inserted above; qed");
 
 		adjust_required_routing_and_propagate(
@@ -511,7 +521,9 @@ impl State {
 			|block_entry| block_entry.session == session,
 			|required_routing, local, validator_index| {
 				if *required_routing == RequiredRouting::PendingTopology {
-					*required_routing = topology.required_routing_by_index(*validator_index, local);
+					*required_routing = topology
+						.local_grid_neighbors()
+						.required_routing_by_index(*validator_index, local);
 				}
 			},
 		)
@@ -861,7 +873,7 @@ impl State {
 		let local = source == MessageSource::Local;
 
 		let required_routing = topology.map_or(RequiredRouting::PendingTopology, |t| {
-			t.required_routing_by_index(validator_index, local)
+			t.local_grid_neighbors().required_routing_by_index(validator_index, local)
 		});
 
 		let message_state = match entry.candidates.get_mut(claimed_candidate_index as usize) {
@@ -902,7 +914,10 @@ impl State {
 				return false
 			}
 
-			if let Some(true) = topology.as_ref().map(|t| t.route_to_peer(required_routing, peer)) {
+			if let Some(true) = topology
+				.as_ref()
+				.map(|t| t.local_grid_neighbors().route_to_peer(required_routing, peer))
+			{
 				return true
 			}
 
@@ -1169,7 +1184,8 @@ impl State {
 			//      the assignment to all aware peers in the required routing _except_ the original
 			//      source of the assignment. Hence the `in_topology_check`.
 			//   3. Any randomly selected peers have been sent the assignment already.
-			let in_topology = topology.map_or(false, |t| t.route_to_peer(required_routing, peer));
+			let in_topology = topology
+				.map_or(false, |t| t.local_grid_neighbors().route_to_peer(required_routing, peer));
 			in_topology || knowledge.sent.contains(message_subject, MessageKind::Assignment)
 		};
 
@@ -1301,9 +1317,9 @@ impl State {
 						let required_routing = message_state.required_routing;
 						let rng = &mut *rng;
 						let mut peer_filter = move |peer_id| {
-							let in_topology = topology
-								.as_ref()
-								.map_or(false, |t| t.route_to_peer(required_routing, peer_id));
+							let in_topology = topology.as_ref().map_or(false, |t| {
+								t.local_grid_neighbors().route_to_peer(required_routing, peer_id)
+							});
 							in_topology || {
 								let route_random = random_routing.sample(total_peers, rng);
 								if route_random {
@@ -1564,7 +1580,10 @@ async fn adjust_required_routing_and_propagate<Context, BlockFilter, RoutingModi
 				});
 
 			for (peer, peer_knowledge) in &mut block_entry.known_by {
-				if !topology.route_to_peer(message_state.required_routing, peer) {
+				if !topology
+					.local_grid_neighbors()
+					.route_to_peer(message_state.required_routing, peer)
+				{
 					continue
 				}
 

--- a/node/network/bitfield-distribution/Cargo.toml
+++ b/node/network/bitfield-distribution/Cargo.toml
@@ -18,6 +18,7 @@ polkadot-node-subsystem-test-helpers = { path = "../../subsystem-test-helpers" }
 bitvec = { version = "1.0.0", default-features = false, features = ["alloc"] }
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sp-application-crypto = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-authority-discovery = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sp-keystore = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "master" }
 maplit = "1.0.2"

--- a/node/network/bridge/src/rx/mod.rs
+++ b/node/network/bridge/src/rx/mod.rs
@@ -495,10 +495,7 @@ where
 	let mut peers = Vec::with_capacity(neighbors.len());
 	for (discovery_id, validator_index) in neighbors {
 		let addr = get_peer_id_by_authority_id(ads, discovery_id.clone()).await;
-
-		if let Some(peer_id) = addr {
-			peers.push(TopologyPeerInfo { peer_ids: vec![peer_id], validator_index, discovery_id });
-		}
+		peers.push(TopologyPeerInfo { peer_ids: addr.into_iter().collect(), validator_index, discovery_id });
 	}
 
 	peers

--- a/node/network/bridge/src/rx/mod.rs
+++ b/node/network/bridge/src/rx/mod.rs
@@ -495,7 +495,11 @@ where
 	let mut peers = Vec::with_capacity(neighbors.len());
 	for (discovery_id, validator_index) in neighbors {
 		let addr = get_peer_id_by_authority_id(ads, discovery_id.clone()).await;
-		peers.push(TopologyPeerInfo { peer_ids: addr.into_iter().collect(), validator_index, discovery_id });
+		peers.push(TopologyPeerInfo {
+			peer_ids: addr.into_iter().collect(),
+			validator_index,
+			discovery_id,
+		});
 	}
 
 	peers

--- a/node/network/bridge/src/rx/mod.rs
+++ b/node/network/bridge/src/rx/mod.rs
@@ -27,6 +27,7 @@ use sp_consensus::SyncOracle;
 
 use polkadot_node_network_protocol::{
 	self as net_protocol,
+	grid_topology::{SessionGridTopology, TopologyPeerInfo},
 	peer_set::{
 		CollationVersion, PeerSet, PeerSetProtocolNames, PerPeerSet, ProtocolVersion,
 		ValidationVersion,
@@ -37,10 +38,9 @@ use polkadot_node_network_protocol::{
 use polkadot_node_subsystem::{
 	errors::SubsystemError,
 	messages::{
-		network_bridge_event::{NewGossipTopology, TopologyPeerInfo},
-		ApprovalDistributionMessage, BitfieldDistributionMessage, CollatorProtocolMessage,
-		GossipSupportMessage, NetworkBridgeEvent, NetworkBridgeRxMessage,
-		StatementDistributionMessage,
+		network_bridge_event::NewGossipTopology, ApprovalDistributionMessage,
+		BitfieldDistributionMessage, CollatorProtocolMessage, GossipSupportMessage,
+		NetworkBridgeEvent, NetworkBridgeRxMessage, StatementDistributionMessage,
 	},
 	overseer, ActivatedLeaf, ActiveLeavesUpdate, FromOrchestra, OverseerSignal, SpawnedSubsystem,
 };
@@ -127,28 +127,6 @@ where
 			.boxed();
 		SpawnedSubsystem { name: "network-bridge-subsystem", future }
 	}
-}
-
-async fn update_gossip_peers_1d<AD, N>(
-	ads: &mut AD,
-	neighbors: N,
-) -> HashMap<AuthorityDiscoveryId, TopologyPeerInfo>
-where
-	AD: validator_discovery::AuthorityDiscovery,
-	N: IntoIterator<Item = (AuthorityDiscoveryId, ValidatorIndex)>,
-	N::IntoIter: std::iter::ExactSizeIterator,
-{
-	let neighbors = neighbors.into_iter();
-	let mut peers = HashMap::with_capacity(neighbors.len());
-	for (authority, validator_index) in neighbors {
-		let addr = get_peer_id_by_authority_id(ads, authority.clone()).await;
-
-		if let Some(peer_id) = addr {
-			peers.insert(authority, TopologyPeerInfo { peer_ids: vec![peer_id], validator_index });
-		}
-	}
-
-	peers
 }
 
 async fn handle_network_messages<AD>(
@@ -507,6 +485,25 @@ where
 	}
 }
 
+async fn flesh_out_topology_peers<AD, N>(ads: &mut AD, neighbors: N) -> Vec<TopologyPeerInfo>
+where
+	AD: validator_discovery::AuthorityDiscovery,
+	N: IntoIterator<Item = (AuthorityDiscoveryId, ValidatorIndex)>,
+	N::IntoIter: std::iter::ExactSizeIterator,
+{
+	let neighbors = neighbors.into_iter();
+	let mut peers = Vec::with_capacity(neighbors.len());
+	for (discovery_id, validator_index) in neighbors {
+		let addr = get_peer_id_by_authority_id(ads, discovery_id.clone()).await;
+
+		if let Some(peer_id) = addr {
+			peers.push(TopologyPeerInfo { peer_ids: vec![peer_id], validator_index, discovery_id });
+		}
+	}
+
+	peers
+}
+
 #[overseer::contextbounds(NetworkBridgeRx, prefix = self::overseer)]
 async fn run_incoming_orchestra_signals<Context, N, AD>(
 	mut ctx: Context,
@@ -532,29 +529,28 @@ where
 				msg:
 					NetworkBridgeRxMessage::NewGossipTopology {
 						session,
-						our_neighbors_x,
-						our_neighbors_y,
+						local_index,
+						canonical_shuffling,
+						shuffled_indices,
 					},
 			} => {
 				gum::debug!(
 					target: LOG_TARGET,
 					action = "NewGossipTopology",
-					neighbors_x = our_neighbors_x.len(),
-					neighbors_y = our_neighbors_y.len(),
+					?session,
+					?local_index,
 					"Gossip topology has changed",
 				);
 
-				let gossip_peers_x =
-					update_gossip_peers_1d(&mut authority_discovery_service, our_neighbors_x).await;
-
-				let gossip_peers_y =
-					update_gossip_peers_1d(&mut authority_discovery_service, our_neighbors_y).await;
+				let topology_peers =
+					flesh_out_topology_peers(&mut authority_discovery_service, canonical_shuffling)
+						.await;
 
 				dispatch_validation_event_to_all_unbounded(
 					NetworkBridgeEvent::NewGossipTopology(NewGossipTopology {
 						session,
-						our_neighbors_x: gossip_peers_x,
-						our_neighbors_y: gossip_peers_y,
+						topology: SessionGridTopology::new(shuffled_indices, topology_peers),
+						local_index,
 					}),
 					ctx.sender(),
 				);

--- a/node/network/gossip-support/src/lib.rs
+++ b/node/network/gossip-support/src/lib.rs
@@ -525,71 +525,35 @@ async fn update_gossip_topology(
 		sp_core::blake2_256(&subject)
 	};
 
-	// shuffle the indices
-	let mut rng: ChaCha20Rng = SeedableRng::from_seed(random_seed);
-	let len = authorities.len();
-	let mut indices: Vec<usize> = (0..len).collect();
-	indices.shuffle(&mut rng);
-	let our_shuffled_position = indices
-		.iter()
-		.position(|i| *i == our_index)
-		.expect("our_index < len; indices contains it; qed");
+	// shuffle the validators and create the index mapping
+	let (shuffled_indices, canonical_shuffling) = {
+		let mut rng: ChaCha20Rng = SeedableRng::from_seed(random_seed);
+		let len = authorities.len();
+		let mut shuffled_indices = vec![0; len];
+		let mut canonical_shuffling: Vec<_> = authorities
+			.iter()
+			.enumerate()
+			.map(|(i, a)| (a.clone(), ValidatorIndex(i as _)))
+			.collect();
 
-	let neighbors = matrix_neighbors(our_shuffled_position, len);
-	let row_neighbors = neighbors
-		.row_neighbors
-		.map(|i| indices[i])
-		.map(|i| (authorities[i].clone(), ValidatorIndex::from(i as u32)))
-		.collect();
+		canonical_shuffling.shuffle(&mut rng);
+		for (i, (_, validator_index)) in canonical_shuffling.iter().enumerate() {
+			shuffled_indices[validator_index.0 as usize] = i;
+		}
 
-	let column_neighbors = neighbors
-		.column_neighbors
-		.map(|i| indices[i])
-		.map(|i| (authorities[i].clone(), ValidatorIndex::from(i as u32)))
-		.collect();
+		(shuffled_indices, canonical_shuffling)
+	};
 
 	sender
 		.send_message(NetworkBridgeRxMessage::NewGossipTopology {
 			session: session_index,
-			our_neighbors_x: row_neighbors,
-			our_neighbors_y: column_neighbors,
+			local_index: Some(ValidatorIndex(our_index as _)),
+			canonical_shuffling,
+			shuffled_indices,
 		})
 		.await;
 
 	Ok(())
-}
-
-struct MatrixNeighbors<R, C> {
-	row_neighbors: R,
-	column_neighbors: C,
-}
-
-/// Compute our row and column neighbors in a matrix
-fn matrix_neighbors(
-	our_index: usize,
-	len: usize,
-) -> MatrixNeighbors<impl Iterator<Item = usize>, impl Iterator<Item = usize>> {
-	assert!(our_index < len, "our_index is computed using `enumerate`; qed");
-
-	// e.g. for size 11 the matrix would be
-	//
-	// 0  1  2
-	// 3  4  5
-	// 6  7  8
-	// 9 10
-	//
-	// and for index 10, the neighbors would be 1, 4, 7, 9
-
-	let sqrt = (len as f64).sqrt() as usize;
-	let our_row = our_index / sqrt;
-	let our_column = our_index % sqrt;
-	let row_neighbors = our_row * sqrt..std::cmp::min(our_row * sqrt + sqrt, len);
-	let column_neighbors = (our_column..len).step_by(sqrt);
-
-	MatrixNeighbors {
-		row_neighbors: row_neighbors.filter(move |i| *i != our_index),
-		column_neighbors: column_neighbors.filter(move |i| *i != our_index),
-	}
 }
 
 #[overseer::subsystem(GossipSupport, error = SubsystemError, prefix = self::overseer)]

--- a/node/network/protocol/src/grid_topology.rs
+++ b/node/network/protocol/src/grid_topology.rs
@@ -30,7 +30,7 @@
 //!
 
 use crate::PeerId;
-use polkadot_primitives::v2::{SessionIndex, ValidatorIndex};
+use polkadot_primitives::v2::{AuthorityDiscoveryId, SessionIndex, ValidatorIndex};
 use rand::{CryptoRng, Rng};
 use std::{
 	collections::{hash_map, HashMap, HashSet},
@@ -48,9 +48,102 @@ pub const DEFAULT_RANDOM_SAMPLE_RATE: usize = crate::MIN_GOSSIP_PEERS;
 /// The number of peers to randomly propagate messages to.
 pub const DEFAULT_RANDOM_CIRCULATION: usize = 4;
 
-/// Topology representation
-#[derive(Default, Clone, Debug)]
+/// Information about a peer in the gossip topology for a session.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TopologyPeerInfo {
+	/// The validator's known peer IDs.
+	pub peer_ids: Vec<PeerId>,
+	/// The index of the validator in the discovery keys of the corresponding
+	/// `SessionInfo`. This can extend _beyond_ the set of active parachain validators.
+	pub validator_index: ValidatorIndex,
+	/// The authority discovery public key of the validator in the corresponding
+	/// `SessionInfo`.
+	pub discovery_id: AuthorityDiscoveryId,
+}
+
+/// Topology representation for a session.
+#[derive(Default, Clone, Debug, PartialEq)]
 pub struct SessionGridTopology {
+	/// An array mapping validator indices to their indices in the
+	/// shuffling itself. This has the same size as the number of validators
+	/// in the session.
+	shuffled_indices: Vec<usize>,
+	/// The canonical shuffling of validators for the session.
+	canonical_shuffling: Vec<TopologyPeerInfo>,
+}
+
+impl SessionGridTopology {
+	/// Create a new session grid topology.
+	pub fn new(shuffled_indices: Vec<usize>, canonical_shuffling: Vec<TopologyPeerInfo>) -> Self {
+		SessionGridTopology { shuffled_indices, canonical_shuffling }
+	}
+
+	/// Produces the outgoing routing logic for a particular peer.
+	///
+	/// This fails if the validator index is out of bounds.
+	pub fn compute_grid_neighbors_for(&self, v: ValidatorIndex) -> Option<GridNeighbors> {
+		let shuffled_val_index = *self.shuffled_indices.get(v.0 as usize)?;
+		let neighbors = matrix_neighbors(shuffled_val_index, self.shuffled_indices.len())?;
+
+		let mut grid_subset = GridNeighbors::empty();
+		for r_n in neighbors.row_neighbors {
+			let n = &self.canonical_shuffling[r_n];
+			grid_subset.validator_indices_x.insert(n.validator_index);
+			for p in &n.peer_ids {
+				grid_subset.peers_x.insert(p.clone());
+			}
+		}
+
+		for c_n in neighbors.column_neighbors {
+			let n = &self.canonical_shuffling[c_n];
+			grid_subset.validator_indices_y.insert(n.validator_index);
+			for p in &n.peer_ids {
+				grid_subset.peers_y.insert(p.clone());
+			}
+		}
+
+		Some(grid_subset)
+	}
+}
+
+struct MatrixNeighbors<R, C> {
+	row_neighbors: R,
+	column_neighbors: C,
+}
+
+/// Compute our row and column neighbors in a matrix
+fn matrix_neighbors(
+	val_index: usize,
+	len: usize,
+) -> Option<MatrixNeighbors<impl Iterator<Item = usize>, impl Iterator<Item = usize>>> {
+	if val_index >= len {
+		return None
+	}
+
+	// e.g. for size 11 the matrix would be
+	//
+	// 0  1  2
+	// 3  4  5
+	// 6  7  8
+	// 9 10
+	//
+	// and for index 10, the neighbors would be 1, 4, 7, 9
+
+	let sqrt = (len as f64).sqrt() as usize;
+	let our_row = val_index / sqrt;
+	let our_column = val_index % sqrt;
+	let row_neighbors = our_row * sqrt..std::cmp::min(our_row * sqrt + sqrt, len);
+	let column_neighbors = (our_column..len).step_by(sqrt);
+
+	Some(MatrixNeighbors {
+		row_neighbors: row_neighbors.filter(move |i| *i != val_index),
+		column_neighbors: column_neighbors.filter(move |i| *i != val_index),
+	})
+}
+
+/// Information about the grid neighbors for a particular node in the topology.
+#[derive(Debug, Clone, PartialEq)]
+pub struct GridNeighbors {
 	/// Represent peers in the X axis
 	pub peers_x: HashSet<PeerId>,
 	/// Represent validators in the X axis
@@ -61,7 +154,18 @@ pub struct SessionGridTopology {
 	pub validator_indices_y: HashSet<ValidatorIndex>,
 }
 
-impl SessionGridTopology {
+impl GridNeighbors {
+	/// Utility function for creating an empty set of grid neighbors.
+	/// Useful for testing.
+	pub fn empty() -> Self {
+		GridNeighbors {
+			peers_x: HashSet::new(),
+			validator_indices_x: HashSet::new(),
+			peers_y: HashSet::new(),
+			validator_indices_y: HashSet::new(),
+		}
+	}
+
 	/// Given the originator of a message as a validator index, indicates the part of the topology
 	/// we're meant to send the message to.
 	pub fn required_routing_by_index(
@@ -123,7 +227,7 @@ impl SessionGridTopology {
 	}
 
 	/// Returns the difference between this and the `other` topology as a vector of peers
-	pub fn peers_diff(&self, other: &SessionGridTopology) -> Vec<PeerId> {
+	pub fn peers_diff(&self, other: &Self) -> Vec<PeerId> {
 		self.peers_x
 			.iter()
 			.chain(self.peers_y.iter())
@@ -138,15 +242,39 @@ impl SessionGridTopology {
 	}
 }
 
+/// An entry tracking a session grid topology and some memoized local neighbors.
+#[derive(Debug)]
+pub struct SessionGridTopologyEntry {
+	topology: SessionGridTopology,
+	local_neighbors: GridNeighbors,
+}
+
+impl SessionGridTopologyEntry {
+	/// Access the local grid neighbors.
+	pub fn local_grid_neighbors(&self) -> &GridNeighbors {
+		&self.local_neighbors
+	}
+
+	/// Access the local grid neighbors mutably.
+	pub fn local_grid_neighbors_mut(&mut self) -> &mut GridNeighbors {
+		&mut self.local_neighbors
+	}
+
+	/// Access the underlying topology.
+	pub fn get(&self) -> &SessionGridTopology {
+		&self.topology
+	}
+}
+
 /// A set of topologies indexed by session
 #[derive(Default)]
 pub struct SessionGridTopologies {
-	inner: HashMap<SessionIndex, (Option<SessionGridTopology>, usize)>,
+	inner: HashMap<SessionIndex, (Option<SessionGridTopologyEntry>, usize)>,
 }
 
 impl SessionGridTopologies {
 	/// Returns a topology for the specific session index
-	pub fn get_topology(&self, session: SessionIndex) -> Option<&SessionGridTopology> {
+	pub fn get_topology(&self, session: SessionIndex) -> Option<&SessionGridTopologyEntry> {
 		self.inner.get(&session).and_then(|val| val.0.as_ref())
 	}
 
@@ -166,63 +294,112 @@ impl SessionGridTopologies {
 	}
 
 	/// Insert a new topology, no-op if already present.
-	pub fn insert_topology(&mut self, session: SessionIndex, topology: SessionGridTopology) {
+	pub fn insert_topology(
+		&mut self,
+		session: SessionIndex,
+		topology: SessionGridTopology,
+		local_index: Option<ValidatorIndex>,
+	) {
 		let entry = self.inner.entry(session).or_insert((None, 0));
 		if entry.0.is_none() {
-			entry.0 = Some(topology);
+			let local_neighbors = local_index
+				.and_then(|l| topology.compute_grid_neighbors_for(l))
+				.unwrap_or_else(GridNeighbors::empty);
+
+			entry.0 = Some(SessionGridTopologyEntry { topology, local_neighbors });
 		}
 	}
 }
 
 /// A simple storage for a topology and the corresponding session index
-#[derive(Default, Debug)]
-pub struct GridTopologySessionBound {
-	topology: SessionGridTopology,
+#[derive(Debug)]
+struct GridTopologySessionBound {
+	entry: SessionGridTopologyEntry,
 	session_index: SessionIndex,
 }
 
 /// A storage for the current and maybe previous topology
-#[derive(Default, Debug)]
+#[derive(Debug)]
 pub struct SessionBoundGridTopologyStorage {
 	current_topology: GridTopologySessionBound,
 	prev_topology: Option<GridTopologySessionBound>,
+}
+
+impl Default for SessionBoundGridTopologyStorage {
+	fn default() -> Self {
+		// having this struct be `Default` is objectively stupid
+		// but used in a few places
+		SessionBoundGridTopologyStorage {
+			current_topology: GridTopologySessionBound {
+				// session 0 is valid so we should use the upper bound
+				// as the default instead of the lower bound.
+				session_index: SessionIndex::max_value(),
+				entry: SessionGridTopologyEntry {
+					topology: SessionGridTopology {
+						shuffled_indices: Vec::new(),
+						canonical_shuffling: Vec::new(),
+					},
+					local_neighbors: GridNeighbors::empty(),
+				},
+			},
+			prev_topology: None,
+		}
+	}
 }
 
 impl SessionBoundGridTopologyStorage {
 	/// Return a grid topology based on the session index:
 	/// If we need a previous session and it is registered in the storage, then return that session.
 	/// Otherwise, return a current session to have some grid topology in any case
-	pub fn get_topology_or_fallback(&self, idx: SessionIndex) -> &SessionGridTopology {
-		self.get_topology(idx).unwrap_or(&self.current_topology.topology)
+	pub fn get_topology_or_fallback(&self, idx: SessionIndex) -> &SessionGridTopologyEntry {
+		self.get_topology(idx).unwrap_or(&self.current_topology.entry)
 	}
 
 	/// Return the grid topology for the specific session index, if no such a session is stored
 	/// returns `None`.
-	pub fn get_topology(&self, idx: SessionIndex) -> Option<&SessionGridTopology> {
+	pub fn get_topology(&self, idx: SessionIndex) -> Option<&SessionGridTopologyEntry> {
 		if let Some(prev_topology) = &self.prev_topology {
 			if idx == prev_topology.session_index {
-				return Some(&prev_topology.topology)
+				return Some(&prev_topology.entry)
 			}
 		}
 		if self.current_topology.session_index == idx {
-			return Some(&self.current_topology.topology)
+			return Some(&self.current_topology.entry)
 		}
 
 		None
 	}
 
 	/// Update the current topology preserving the previous one
-	pub fn update_topology(&mut self, session_index: SessionIndex, topology: SessionGridTopology) {
+	pub fn update_topology(
+		&mut self,
+		session_index: SessionIndex,
+		topology: SessionGridTopology,
+		local_index: Option<ValidatorIndex>,
+	) {
+		let local_neighbors = local_index
+			.and_then(|l| topology.compute_grid_neighbors_for(l))
+			.unwrap_or_else(GridNeighbors::empty);
+
 		let old_current = std::mem::replace(
 			&mut self.current_topology,
-			GridTopologySessionBound { topology, session_index },
+			GridTopologySessionBound {
+				entry: SessionGridTopologyEntry { topology, local_neighbors },
+				session_index,
+			},
 		);
 		self.prev_topology.replace(old_current);
 	}
 
 	/// Returns a current grid topology
-	pub fn get_current_topology(&self) -> &SessionGridTopology {
-		&self.current_topology.topology
+	pub fn get_current_topology(&self) -> &SessionGridTopologyEntry {
+		&self.current_topology.entry
+	}
+
+	/// Access the current grid topology mutably. Dangerous and intended
+	/// to be used in tests.
+	pub fn get_current_topology_mut(&mut self) -> &mut SessionGridTopologyEntry {
+		&mut self.current_topology.entry
 	}
 }
 
@@ -364,5 +541,28 @@ mod tests {
 
 		let mut random_routing = RandomRouting { target: 10, sent: 0, sample_rate: 10 };
 		assert_eq!(run_random_routing(&mut random_routing, &mut rng, 10, 100), 10);
+	}
+
+	#[test]
+	fn test_matrix_neighbors() {
+		for (our_index, len, expected_row, expected_column) in vec![
+			(0usize, 1usize, vec![], vec![]),
+			(1, 2, vec![], vec![0usize]),
+			(0, 9, vec![1, 2], vec![3, 6]),
+			(9, 10, vec![], vec![0, 3, 6]),
+			(10, 11, vec![9], vec![1, 4, 7]),
+			(7, 11, vec![6, 8], vec![1, 4, 10]),
+		]
+		.into_iter()
+		{
+			let matrix = matrix_neighbors(our_index, len);
+			let mut row_result: Vec<_> = matrix.row_neighbors.collect();
+			let mut column_result: Vec<_> = matrix.column_neighbors.collect();
+			row_result.sort();
+			column_result.sort();
+
+			assert_eq!(row_result, expected_row);
+			assert_eq!(column_result, expected_column);
+		}
 	}
 }

--- a/node/network/protocol/src/grid_topology.rs
+++ b/node/network/protocol/src/grid_topology.rs
@@ -111,7 +111,7 @@ struct MatrixNeighbors<R, C> {
 	column_neighbors: C,
 }
 
-/// Compute our row and column neighbors in a matrix
+/// Compute the row and column neighbors of `val_index` in a matrix
 fn matrix_neighbors(
 	val_index: usize,
 	len: usize,

--- a/node/network/protocol/src/grid_topology.rs
+++ b/node/network/protocol/src/grid_topology.rs
@@ -80,7 +80,7 @@ impl SessionGridTopology {
 
 	/// Produces the outgoing routing logic for a particular peer.
 	///
-	/// This fails if the validator index is out of bounds.
+	/// Returns `None` if the validator index is out of bounds.
 	pub fn compute_grid_neighbors_for(&self, v: ValidatorIndex) -> Option<GridNeighbors> {
 		let shuffled_val_index = *self.shuffled_indices.get(v.0 as usize)?;
 		let neighbors = matrix_neighbors(shuffled_val_index, self.shuffled_indices.len())?;

--- a/node/network/protocol/src/grid_topology.rs
+++ b/node/network/protocol/src/grid_topology.rs
@@ -242,7 +242,7 @@ impl GridNeighbors {
 	}
 }
 
-/// An entry tracking a session grid topology and some memoized local neighbors.
+/// An entry tracking a session grid topology and some cached local neighbors.
 #[derive(Debug)]
 pub struct SessionGridTopologyEntry {
 	topology: SessionGridTopology,

--- a/node/network/protocol/src/grid_topology.rs
+++ b/node/network/protocol/src/grid_topology.rs
@@ -555,7 +555,7 @@ mod tests {
 		]
 		.into_iter()
 		{
-			let matrix = matrix_neighbors(our_index, len);
+			let matrix = matrix_neighbors(our_index, len).unwrap();
 			let mut row_result: Vec<_> = matrix.row_neighbors.collect();
 			let mut column_result: Vec<_> = matrix.column_neighbors.collect();
 			row_result.sort();

--- a/node/network/protocol/src/grid_topology.rs
+++ b/node/network/protocol/src/grid_topology.rs
@@ -82,7 +82,9 @@ impl SessionGridTopology {
 	///
 	/// Returns `None` if the validator index is out of bounds.
 	pub fn compute_grid_neighbors_for(&self, v: ValidatorIndex) -> Option<GridNeighbors> {
+		if self.shuffled_indices.len() != self.canonical_shuffling.len() { return None }
 		let shuffled_val_index = *self.shuffled_indices.get(v.0 as usize)?;
+
 		let neighbors = matrix_neighbors(shuffled_val_index, self.shuffled_indices.len())?;
 
 		let mut grid_subset = GridNeighbors::empty();

--- a/node/network/protocol/src/grid_topology.rs
+++ b/node/network/protocol/src/grid_topology.rs
@@ -82,7 +82,9 @@ impl SessionGridTopology {
 	///
 	/// Returns `None` if the validator index is out of bounds.
 	pub fn compute_grid_neighbors_for(&self, v: ValidatorIndex) -> Option<GridNeighbors> {
-		if self.shuffled_indices.len() != self.canonical_shuffling.len() { return None }
+		if self.shuffled_indices.len() != self.canonical_shuffling.len() {
+			return None
+		}
 		let shuffled_val_index = *self.shuffled_indices.get(v.0 as usize)?;
 
 		let neighbors = matrix_neighbors(shuffled_val_index, self.shuffled_indices.len())?;

--- a/node/network/statement-distribution/src/lib.rs
+++ b/node/network/statement-distribution/src/lib.rs
@@ -27,7 +27,7 @@ use parity_scale_codec::Encode;
 
 use polkadot_node_network_protocol::{
 	self as net_protocol,
-	grid_topology::{RequiredRouting, SessionBoundGridTopologyStorage, SessionGridTopology},
+	grid_topology::{GridNeighbors, RequiredRouting, SessionBoundGridTopologyStorage},
 	peer_set::{IsAuthority, PeerSet},
 	request_response::{v1 as request_v1, IncomingRequestReceiver},
 	v1::{self as protocol_v1, StatementMetadata},
@@ -910,7 +910,10 @@ async fn circulate_statement_and_dependents<Context>(
 		.with_candidate(statement.payload().candidate_hash())
 		.with_stage(jaeger::Stage::StatementDistribution);
 
-	let topology = topology_store.get_topology_or_fallback(active_head.session_index);
+	let topology = topology_store
+		.get_topology_or_fallback(active_head.session_index)
+		.local_grid_neighbors();
+
 	// First circulate the statement directly to all peers needing it.
 	// The borrow of `active_head` needs to encompass only this (Rust) statement.
 	let outputs: Option<(CandidateHash, Vec<PeerId>)> = {
@@ -1009,7 +1012,7 @@ fn is_statement_large(statement: &SignedFullStatement) -> (bool, Option<usize>) 
 #[overseer::contextbounds(StatementDistribution, prefix=self::overseer)]
 async fn circulate_statement<'a, Context>(
 	required_routing: RequiredRouting,
-	topology: &SessionGridTopology,
+	topology: &GridNeighbors,
 	peers: &mut HashMap<PeerId, PeerData>,
 	ctx: &mut Context,
 	relay_parent: Hash,
@@ -1352,7 +1355,8 @@ async fn handle_incoming_message_and_circulate<'a, Context, R>(
 
 		let session_index = runtime.get_session_index_for_child(ctx.sender(), relay_parent).await;
 		let topology = match session_index {
-			Ok(session_index) => topology_storage.get_topology_or_fallback(session_index),
+			Ok(session_index) =>
+				topology_storage.get_topology_or_fallback(session_index).local_grid_neighbors(),
 			Err(e) => {
 				gum::debug!(
 					target: LOG_TARGET,
@@ -1361,7 +1365,7 @@ async fn handle_incoming_message_and_circulate<'a, Context, R>(
 					e
 				);
 
-				topology_storage.get_current_topology()
+				topology_storage.get_current_topology().local_grid_neighbors()
 			},
 		};
 		let required_routing =
@@ -1588,7 +1592,7 @@ async fn handle_incoming_message<'a, Context>(
 #[overseer::contextbounds(StatementDistribution, prefix=self::overseer)]
 async fn update_peer_view_and_maybe_send_unlocked<Context, R>(
 	peer: PeerId,
-	topology: &SessionGridTopology,
+	topology: &GridNeighbors,
 	peer_data: &mut PeerData,
 	ctx: &mut Context,
 	active_heads: &HashMap<Hash, ActiveHeadData>,
@@ -1673,16 +1677,22 @@ async fn handle_network_update<Context, R>(
 			let _ = metrics.time_network_bridge_update_v1("new_gossip_topology");
 
 			let new_session_index = topology.session;
-			let new_topology: SessionGridTopology = topology.into();
-			let old_topology = topology_storage.get_current_topology();
-			let newly_added = new_topology.peers_diff(old_topology);
-			topology_storage.update_topology(new_session_index, new_topology);
+			let new_topology = topology.topology;
+			let old_topology =
+				topology_storage.get_current_topology().local_grid_neighbors().clone();
+			topology_storage.update_topology(new_session_index, new_topology, topology.local_index);
+
+			let newly_added = topology_storage
+				.get_current_topology()
+				.local_grid_neighbors()
+				.peers_diff(&old_topology);
+
 			for peer in newly_added {
 				if let Some(data) = peers.get_mut(&peer) {
 					let view = std::mem::take(&mut data.view);
 					update_peer_view_and_maybe_send_unlocked(
 						peer,
-						topology_storage.get_current_topology(),
+						topology_storage.get_current_topology().local_grid_neighbors(),
 						data,
 						ctx,
 						&*active_heads,
@@ -1717,7 +1727,7 @@ async fn handle_network_update<Context, R>(
 				Some(data) =>
 					update_peer_view_and_maybe_send_unlocked(
 						peer,
-						topology_storage.get_current_topology(),
+						topology_storage.get_current_topology().local_grid_neighbors(),
 						data,
 						ctx,
 						&*active_heads,

--- a/node/network/statement-distribution/src/tests.rs
+++ b/node/network/statement-distribution/src/tests.rs
@@ -20,6 +20,7 @@ use futures::executor::{self, block_on};
 use futures_timer::Delay;
 use parity_scale_codec::{Decode, Encode};
 use polkadot_node_network_protocol::{
+	grid_topology::{SessionGridTopology, TopologyPeerInfo},
 	peer_set::ValidationVersion,
 	request_response::{
 		v1::{StatementFetchingRequest, StatementFetchingResponse},
@@ -509,7 +510,7 @@ fn peer_view_update_sends_messages() {
 	let peer = PeerId::random();
 
 	executor::block_on(async move {
-		let mut topology: SessionGridTopology = Default::default();
+		let mut topology = GridNeighbors::empty();
 		topology.peers_x = HashSet::from_iter(vec![peer.clone()].into_iter());
 		update_peer_view_and_maybe_send_unlocked(
 			peer.clone(),
@@ -639,7 +640,7 @@ fn circulated_statement_goes_to_all_peers_with_view() {
 		};
 		let statement = StoredStatement { comparator: &comparator, statement: &statement };
 
-		let mut topology: SessionGridTopology = Default::default();
+		let mut topology = GridNeighbors::empty();
 		topology.peers_x =
 			HashSet::from_iter(vec![peer_a.clone(), peer_b.clone(), peer_c.clone()].into_iter());
 		let needs_dependents = circulate_statement(
@@ -2019,42 +2020,77 @@ fn handle_multiple_seconded_statements() {
 				.await;
 		}
 
-		// Explicitly add all `lucky` peers to the gossip peers to ensure that neither `peerA` not `peerB`
-		// receive statements
+		// Set up a topology which puts peers a & b in a column together.
 		let gossip_topology = {
-			let mut t = network_bridge_event::NewGossipTopology {
-				session: 1,
-				our_neighbors_x: HashMap::new(),
-				our_neighbors_y: HashMap::new(),
-			};
+			// create a lucky_peers+1 * lucky_peers+1 grid topology where we are at index 2, sharing
+			// a row with peer_a (0) and peer_b (1) and a column with all the lucky peers.
+			// the rest is filled with junk.
+			// This is an absolute garbage hack depending on quirks of the implementation
+			// and not on sound architecture.
 
-			// Create a topology to ensure that we send messages not to `peer_a`/`peer_b`
-			for (i, peer) in lucky_peers.iter().enumerate() {
-				let authority_id = AuthorityPair::generate().0.public();
-				t.our_neighbors_y.insert(
-					authority_id,
-					network_bridge_event::TopologyPeerInfo {
-						peer_ids: vec![peer.clone()],
-						validator_index: (i as u32 + 2_u32).into(),
-					},
-				);
+			let n_lucky = lucky_peers.len();
+			let dim = n_lucky + 1;
+			let grid_size = dim * dim;
+			let topology_peer_info: Vec<_> = (0..grid_size)
+				.map(|i| {
+					if i == 0 {
+						TopologyPeerInfo {
+							peer_ids: vec![peer_a.clone()],
+							validator_index: ValidatorIndex(0),
+							discovery_id: AuthorityPair::generate().0.public(),
+						}
+					} else if i == 1 {
+						TopologyPeerInfo {
+							peer_ids: vec![peer_b.clone()],
+							validator_index: ValidatorIndex(1),
+							discovery_id: AuthorityPair::generate().0.public(),
+						}
+					} else if i == 2 {
+						TopologyPeerInfo {
+							peer_ids: vec![],
+							validator_index: ValidatorIndex(2),
+							discovery_id: AuthorityPair::generate().0.public(),
+						}
+					} else if (i - 2) % dim == 0 {
+						let lucky_index = ((i - 2) / dim) - 1;
+						TopologyPeerInfo {
+							peer_ids: vec![lucky_peers[lucky_index].clone()],
+							validator_index: ValidatorIndex(i as _),
+							discovery_id: AuthorityPair::generate().0.public(),
+						}
+					} else {
+						TopologyPeerInfo {
+							peer_ids: vec![PeerId::random()],
+							validator_index: ValidatorIndex(i as _),
+							discovery_id: AuthorityPair::generate().0.public(),
+						}
+					}
+				})
+				.collect();
+
+			// also a hack: this is only required to be accurate for
+			// the validator indices we compute grid neighbors for.
+			let mut shuffled_indices = vec![0; grid_size];
+			shuffled_indices[2] = 2;
+
+			// Some sanity checking to make sure this hack is set up correctly.
+			let topology = SessionGridTopology::new(shuffled_indices, topology_peer_info);
+			let grid_neighbors = topology.compute_grid_neighbors_for(ValidatorIndex(2)).unwrap();
+			assert_eq!(grid_neighbors.peers_x.len(), 25);
+			assert!(grid_neighbors.peers_x.contains(&peer_a));
+			assert!(grid_neighbors.peers_x.contains(&peer_b));
+			assert!(!grid_neighbors.peers_y.contains(&peer_b));
+			assert!(!grid_neighbors.route_to_peer(RequiredRouting::GridY, &peer_b));
+			assert_eq!(grid_neighbors.peers_y.len(), lucky_peers.len());
+			for lucky in &lucky_peers {
+				assert!(grid_neighbors.peers_y.contains(lucky));
 			}
-			t.our_neighbors_x.insert(
-				AuthorityPair::generate().0.public(),
-				network_bridge_event::TopologyPeerInfo {
-					peer_ids: vec![peer_a.clone()],
-					validator_index: 0_u32.into(),
-				},
-			);
-			t.our_neighbors_x.insert(
-				AuthorityPair::generate().0.public(),
-				network_bridge_event::TopologyPeerInfo {
-					peer_ids: vec![peer_b.clone()],
-					validator_index: 1_u32.into(),
-				},
-			);
 
-			t
+			network_bridge_event::NewGossipTopology {
+				session: 1,
+				topology,
+				local_index: Some(ValidatorIndex(2)),
+			}
 		};
 
 		handle

--- a/node/overseer/src/tests.rs
+++ b/node/overseer/src/tests.rs
@@ -873,8 +873,9 @@ fn test_network_bridge_tx_msg() -> NetworkBridgeTxMessage {
 fn test_network_bridge_rx_msg() -> NetworkBridgeRxMessage {
 	NetworkBridgeRxMessage::NewGossipTopology {
 		session: SessionIndex::from(0_u32),
-		our_neighbors_x: HashMap::new(),
-		our_neighbors_y: HashMap::new(),
+		local_index: None,
+		canonical_shuffling: Vec::new(),
+		shuffled_indices: Vec::new(),
 	}
 }
 

--- a/node/subsystem-types/src/messages.rs
+++ b/node/subsystem-types/src/messages.rs
@@ -328,18 +328,13 @@ pub enum NetworkBridgeRxMessage {
 	NewGossipTopology {
 		/// The session info this gossip topology is concerned with.
 		session: SessionIndex,
-		/// Ids of our neighbors in the X dimensions of the new gossip topology,
-		/// along with their validator indices within the session.
-		///
-		/// We're not necessarily connected to all of them, but we should
-		/// try to be.
-		our_neighbors_x: HashMap<AuthorityDiscoveryId, ValidatorIndex>,
-		/// Ids of our neighbors in the X dimensions of the new gossip topology,
-		/// along with their validator indices within the session.
-		///
-		/// We're not necessarily connected to all of them, but we should
-		/// try to be.
-		our_neighbors_y: HashMap<AuthorityDiscoveryId, ValidatorIndex>,
+		/// Our validator index in the session, if any.
+		local_index: Option<ValidatorIndex>,
+		/// The canonical shuffling of validators for the session.
+		canonical_shuffling: Vec<(AuthorityDiscoveryId, ValidatorIndex)>,
+		/// The reverse mapping of `canonical_shuffling`: from validator index
+		/// to the index in `canonical_shuffling`
+		shuffled_indices: Vec<usize>,
 	},
 }
 

--- a/node/subsystem-types/src/messages/network_bridge_event.rs
+++ b/node/subsystem-types/src/messages/network_bridge_event.rs
@@ -14,10 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::{
-	collections::{HashMap, HashSet},
-	convert::TryFrom,
-};
+use std::{collections::HashSet, convert::TryFrom};
 
 pub use sc_network::{PeerId, ReputationChange};
 
@@ -27,25 +24,15 @@ use polkadot_node_network_protocol::{
 };
 use polkadot_primitives::v2::{AuthorityDiscoveryId, SessionIndex, ValidatorIndex};
 
-/// Information about a peer in the gossip topology for a session.
-#[derive(Debug, Clone, PartialEq)]
-pub struct TopologyPeerInfo {
-	/// The validator's known peer IDs.
-	pub peer_ids: Vec<PeerId>,
-	/// The index of the validator in the discovery keys of the corresponding
-	/// `SessionInfo`. This can extend _beyond_ the set of active parachain validators.
-	pub validator_index: ValidatorIndex,
-}
-
 /// A struct indicating new gossip topology.
 #[derive(Debug, Clone, PartialEq)]
 pub struct NewGossipTopology {
 	/// The session index this topology corresponds to.
 	pub session: SessionIndex,
-	/// Neighbors in the 'X' dimension of the grid.
-	pub our_neighbors_x: HashMap<AuthorityDiscoveryId, TopologyPeerInfo>,
-	/// Neighbors in the 'Y' dimension of the grid.
-	pub our_neighbors_y: HashMap<AuthorityDiscoveryId, TopologyPeerInfo>,
+	/// The topology itself.
+	pub topology: SessionGridTopology,
+	/// The local validator index, if any.
+	pub local_index: Option<ValidatorIndex>,
 }
 
 /// Events from network.
@@ -120,21 +107,5 @@ impl<M> NetworkBridgeEvent<M> {
 			NetworkBridgeEvent::OurViewChange(ref view) =>
 				NetworkBridgeEvent::OurViewChange(view.clone()),
 		})
-	}
-}
-
-impl From<NewGossipTopology> for SessionGridTopology {
-	fn from(topology: NewGossipTopology) -> Self {
-		let peers_x =
-			topology.our_neighbors_x.values().flat_map(|p| &p.peer_ids).cloned().collect();
-		let peers_y =
-			topology.our_neighbors_y.values().flat_map(|p| &p.peer_ids).cloned().collect();
-
-		let validator_indices_x =
-			topology.our_neighbors_x.values().map(|p| p.validator_index.clone()).collect();
-		let validator_indices_y =
-			topology.our_neighbors_y.values().map(|p| p.validator_index.clone()).collect();
-
-		SessionGridTopology { peers_x, peers_y, validator_indices_x, validator_indices_y }
 	}
 }

--- a/roadmap/implementers-guide/src/types/network.md
+++ b/roadmap/implementers-guide/src/types/network.md
@@ -145,10 +145,19 @@ These updates are posted from the [Network Bridge Subsystem](../node/utility/net
 struct NewGossipTopology {
 	/// The session index this topology corresponds to.
 	session: SessionIndex,
-	/// Neighbors in the 'X' dimension of the grid.
-	our_neighbors_x: HashMap<AuthorityDiscoveryId, TopologyPeerInfo>,
-	/// Neighbors in the 'Y' dimension of the grid.
-	our_neighbors_y: HashMap<AuthorityDiscoveryId, TopologyPeerInfo>,
+	/// The topology itself.
+	topology: SessionGridTopology,
+	/// The local validator index, if any.
+	local_index: Option<ValidatorIndex>,
+}
+
+struct SessionGridTopology {
+	/// An array mapping validator indices to their indices in the
+	/// shuffling itself. This has the same size as the number of validators
+	/// in the session.
+	shuffled_indices: Vec<usize>,
+	/// The canonical shuffling of validators for the session.
+	canonical_shuffling: Vec<TopologyPeerInfo>,
 }
 
 struct TopologyPeerInfo {
@@ -157,6 +166,9 @@ struct TopologyPeerInfo {
 	/// The index of the validator in the discovery keys of the corresponding
 	/// `SessionInfo`. This can extend _beyond_ the set of active parachain validators.
 	validator_index: ValidatorIndex,
+	/// The authority discovery public key of the validator in the corresponding
+	/// `SessionInfo`.
+	discovery_id: AuthorityDiscoveryId,
 }
 
 enum NetworkBridgeEvent<M> {

--- a/roadmap/implementers-guide/src/types/overseer-protocol.md
+++ b/roadmap/implementers-guide/src/types/overseer-protocol.md
@@ -555,14 +555,15 @@ enum NetworkBridgeMessage {
     /// Inform the distribution subsystems about the new
     /// gossip network topology formed.
     NewGossipTopology {
-        /// The session this topology corresponds to.
-        session: SessionIndex,
-        /// Ids of our neighbors in the X dimension of the new gossip topology.
-        /// We're not necessarily connected to all of them, but we should try to be.
-        our_neighbors_x: HashSet<AuthorityDiscoveryId>,
-        /// Ids of our neighbors in the Y dimension of the new gossip topology.
-        /// We're not necessarily connected to all of them, but we should try to be.
-        our_neighbors_y: HashSet<AuthorityDiscoveryId>,
+		/// The session info this gossip topology is concerned with.
+		session: SessionIndex,
+		/// Our validator index in the session, if any.
+		local_index: Option<ValidatorIndex>,
+		/// The canonical shuffling of validators for the session.
+		canonical_shuffling: Vec<(AuthorityDiscoveryId, ValidatorIndex)>,
+		/// The reverse mapping of `canonical_shuffling`: from validator index
+		/// to the index in `canonical_shuffling`
+		shuffled_indices: Vec<usize>,
     }
 }
 ```


### PR DESCRIPTION
This is split off from #5999 . It reduces the scope of the `gossip-support` subsystem to only fetch and shuffle the authorities in a canonical way and transmit that to other networking subsystems. The actual shuffling mechanism has not been changed and therefore these changes are fully backwards compatible. 

The determination of the local node's X and Y dimension neighbors is now handled by the subsystems themselves with some common utilities exposed in the `grid_topology` module. This is necessary for implementing more complex networking subsystems that leverage the topology by examining not only the local node's neighbors but knowing the neighbors of other validators. In #5999 this will be used to determine which messages other peers are allowed to send us, and similar techniques may be used in hardening other subsystems which use the topology as well.