### PR TITLE
lingua.dic is not managed by CI team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,3 +2,5 @@
 /.github/ @paritytech/ci @chevdor
 /scripts/ci/ @paritytech/ci @chevdor
 /.gitlab-ci.yml @paritytech/ci
+# lingua.dic is not managed by CI team
+/scripts/ci/gitlab/lingua.dic


### PR DESCRIPTION
Check syntax here: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file.

The motivation is that every time we need to teach hunspell a new word, we don't want to block the PR on an approval from a CI team. Example: #6139.