### PR TITLE
Fix fuzzing builds xcm-fuzz and erasure-coding fuzzer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2750,13 +2750,14 @@ dependencies = [
 
 [[package]]
 name = "honggfuzz"
-version = "0.5.54"
+version = "0.5.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bea09577d948a98a5f59b7c891e274c4fb35ad52f67782b3d0cb53b9c05301f1"
+checksum = "848e9c511092e0daa0a35a63e8e6e475a3e8f870741448b9f6028d69b142f18e"
 dependencies = [
  "arbitrary",
  "lazy_static",
- "memmap",
+ "memmap2 0.5.0",
+ "rustc_version",
 ]
 
 [[package]]
@@ -4183,16 +4184,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "480b5a5de855d11ff13195950bdc8b98b5e942ef47afc447f6615cdcc4e15d80"
 dependencies = [
  "rustix",
-]
-
-[[package]]
-name = "memmap"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
-dependencies = [
- "libc",
- "winapi",
 ]
 
 [[package]]

--- a/erasure-coding/fuzzer/Cargo.toml
+++ b/erasure-coding/fuzzer/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 [dependencies]
 polkadot-erasure-coding = { path = ".." }
 honggfuzz = "0.5"
+polkadot-primitives = { path = "../../primitives" }
 primitives = { package = "polkadot-node-primitives", path = "../../node/primitives/" }
 
 [[bin]]

--- a/erasure-coding/fuzzer/src/round_trip.rs
+++ b/erasure-coding/fuzzer/src/round_trip.rs
@@ -2,6 +2,7 @@ use polkadot_erasure_coding::*;
 use primitives::{AvailableData, BlockData, PoV};
 use std::sync::Arc;
 use honggfuzz::fuzz;
+use polkadot_primitives::v2::PersistedValidationData;
 
 
 fn main() {

--- a/xcm/xcm-simulator/fuzzer/Cargo.toml
+++ b/xcm/xcm-simulator/fuzzer/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0" }
-honggfuzz = "0.5.54"
+honggfuzz = "0.5.55"
 scale-info = { version = "2.1.2", features = ["derive"] }
 
 frame-system = { git = "https://github.com/paritytech/substrate", branch = "master" }

--- a/xcm/xcm-simulator/fuzzer/src/fuzz.rs
+++ b/xcm/xcm-simulator/fuzzer/src/fuzz.rs
@@ -27,6 +27,7 @@ use xcm::{latest::prelude::*, MAX_XCM_DECODE_DEPTH};
 
 pub const ALICE: sp_runtime::AccountId32 = sp_runtime::AccountId32::new([0u8; 32]);
 pub const INITIAL_BALANCE: u128 = 1_000_000_000;
+use honggfuzz::fuzz;
 
 decl_test_parachain! {
 	pub struct ParaA {

--- a/xcm/xcm-simulator/fuzzer/src/fuzz.rs
+++ b/xcm/xcm-simulator/fuzzer/src/fuzz.rs
@@ -27,7 +27,6 @@ use xcm::{latest::prelude::*, MAX_XCM_DECODE_DEPTH};
 
 pub const ALICE: sp_runtime::AccountId32 = sp_runtime::AccountId32::new([0u8; 32]);
 pub const INITIAL_BALANCE: u128 = 1_000_000_000;
-use honggfuzz::fuzz;
 
 decl_test_parachain! {
 	pub struct ParaA {
@@ -123,7 +122,7 @@ fn main() {
 	#[cfg(fuzzing)]
 	{
 		loop {
-			fuzz!(|data: &[u8]| {
+			honggfuzz::fuzz!(|data: &[u8]| {
 				run_one_input(data);
 			});
 		}


### PR DESCRIPTION
include polkadot-primitives in erasure-coding to build fuzzer..
Change honggfuzz to 0.5.55 from 0.5.54 for a straightforward build and include honggfuzz in fuzz.rs