### PR TITLE
Girazoki xcm runtime api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12908,6 +12908,7 @@ dependencies = [
 name = "xcm-runtime-api"
 version = "0.9.29"
 dependencies = [
+ "derivative",
  "frame-support",
  "frame-system",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3293,6 +3293,7 @@ dependencies = [
  "xcm",
  "xcm-builder",
  "xcm-executor",
+ "xcm-runtime-api",
 ]
 
 [[package]]
@@ -7142,6 +7143,7 @@ dependencies = [
  "xcm",
  "xcm-builder",
  "xcm-executor",
+ "xcm-runtime-api",
 ]
 
 [[package]]
@@ -8443,6 +8445,7 @@ dependencies = [
  "xcm",
  "xcm-builder",
  "xcm-executor",
+ "xcm-runtime-api",
 ]
 
 [[package]]
@@ -12589,6 +12592,7 @@ dependencies = [
  "xcm",
  "xcm-builder",
  "xcm-executor",
+ "xcm-runtime-api",
 ]
 
 [[package]]
@@ -12898,6 +12902,23 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "xcm-runtime-api"
+version = "0.9.29"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-api",
+ "sp-core",
+ "sp-runtime",
+ "sp-std",
+ "xcm",
 ]
 
 [[package]]

--- a/runtime/kusama/Cargo.toml
+++ b/runtime/kusama/Cargo.toml
@@ -101,6 +101,7 @@ primitives = { package = "polkadot-primitives", path = "../../primitives", defau
 xcm = { package = "xcm", path = "../../xcm", default-features = false }
 xcm-executor = { package = "xcm-executor", path = "../../xcm/xcm-executor", default-features = false }
 xcm-builder = { package = "xcm-builder", path = "../../xcm/xcm-builder", default-features = false }
+xcm-runtime-api = { path = "../../xcm/xcm-runtime-api", default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.3.4"
@@ -200,6 +201,7 @@ std = [
 	"xcm-executor/std",
 	"xcm-builder/std",
 	"frame-election-provider-support/std",
+	"xcm-runtime-api/std",
 ]
 runtime-benchmarks = [
 	"runtime-common/runtime-benchmarks",

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -79,7 +79,7 @@ use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
 use static_assertions::const_assert;
 use xcm::{
-	latest::{Error as XcmError, MultiAsset, MultiLocation, Weight as XcmWeight, Xcm},
+	latest::{Error as XcmError, MultiAsset, MultiLocation, Xcm},
 	VersionedMultiLocation, VersionedXcm,
 };
 use xcm_executor::traits::{WeightBounds, WeightTrader};
@@ -1914,17 +1914,16 @@ sp_api::impl_runtime_apis! {
 		}
 	}
 
-	impl xcm_runtime_api::PalletXcmApi<
+	impl xcm_runtime_api::XcmApi<
 		Block,
 		AccountId,
 		RuntimeCall,
 	> for Runtime {
 
-		fn weight_message(message: VersionedXcm<RuntimeCall>) -> xcm_runtime_api::XcmResult<XcmWeight> {
+		fn weight_message(message: VersionedXcm<RuntimeCall>) -> xcm_runtime_api::XcmResult< xcm_runtime_api::VersionedWeight> {
 			let mut message: Xcm<RuntimeCall> = message.try_into().map_err(|_| XcmError::UnhandledXcmVersion)?;
-			<xcm_config::XcmConfig as xcm_executor::Config>::Weigher::weight(& mut message).map_err(|_| XcmError::WeightNotComputable)
+			<xcm_config::XcmConfig as xcm_executor::Config>::Weigher::weight(& mut message).map_err(|_| XcmError::WeightNotComputable).map(|weight| weight.into())
 		}
-
 		fn convert_location(location: VersionedMultiLocation) -> xcm_runtime_api::XcmResult<AccountId> {
 			let location: MultiLocation = location.try_into().map_err(|_| XcmError::UnhandledXcmVersion)?;
 			<xcm_config::SovereignAccountOf as xcm_executor::traits::Convert<
@@ -1932,8 +1931,10 @@ sp_api::impl_runtime_apis! {
 			>>::convert_ref(location).map_err(|_| XcmError::FailedToTransactAsset("AccountIdConversionFailed"))
 		}
 
-		fn calculate_concrete_asset_fee(asset_location: VersionedMultiLocation, weight: XcmWeight) -> xcm_runtime_api::XcmResult<u128>  {
+		fn calculate_concrete_asset_fee(asset_location: VersionedMultiLocation, weight: xcm_runtime_api::VersionedWeight) -> xcm_runtime_api::XcmResult<u128>  {
 			let asset_location: MultiLocation = asset_location.try_into().map_err(|_| XcmError::UnhandledXcmVersion)?;
+			let weight: xcm::latest::Weight = weight.try_into().map_err(|_| XcmError::UnhandledXcmVersion)?;
+
 			// We create a multiasset with max fee
 			let multiasset: MultiAsset = (asset_location, u128::MAX).into();
 			let mut trader = <xcm_config::XcmConfig as xcm_executor::Config>::Trader::new();

--- a/runtime/kusama/src/tests.rs
+++ b/runtime/kusama/src/tests.rs
@@ -24,7 +24,7 @@ use parity_scale_codec::Encode;
 use runtime_common::MinimumMultiplier;
 use separator::Separatable;
 use sp_runtime::FixedPointNumber;
-use xcm_runtime_api::runtime_decl_for_PalletXcmApi::PalletXcmApi;
+use xcm_runtime_api::runtime_decl_for_XcmApi::XcmApi;
 
 #[test]
 fn remove_keys_weight_is_sensible() {
@@ -185,7 +185,7 @@ fn xcm_runtime_api_weight() {
 	]));
 	assert_eq!(
 		Runtime::weight_message(message),
-		Ok(weights::xcm::KusamaXcmWeight::<RuntimeCall>::clear_origin())
+		Ok(weights::xcm::WestendXcmWeight::<RuntimeCall>::clear_origin().into())
 	);
 }
 
@@ -205,7 +205,7 @@ fn xcm_runtime_location_convert() {
 	);
 	assert_eq!(
 		Runtime::convert_location(local_location.clone().into()),
-		Ok(xcm_builder::AccountId32Aliases::<xcm_config::KusamaNetwork, AccountId>::convert_ref(
+		Ok(xcm_builder::AccountId32Aliases::<xcm_config::WestendNetwork, AccountId>::convert_ref(
 			local_location
 		)
 		.unwrap())
@@ -224,7 +224,7 @@ fn xcm_asset() {
 	ext.execute_with(|| {
 		let result = Runtime::calculate_concrete_asset_fee(
 			asset_location.into(),
-			ExtrinsicBaseWeight::get().ref_time(),
+			ExtrinsicBaseWeight::get().ref_time().into(),
 		);
 		assert_eq!(result, Ok(WeightToFee::weight_to_fee(&ExtrinsicBaseWeight::get())));
 	});

--- a/runtime/kusama/src/tests.rs
+++ b/runtime/kusama/src/tests.rs
@@ -24,6 +24,7 @@ use parity_scale_codec::Encode;
 use runtime_common::MinimumMultiplier;
 use separator::Separatable;
 use sp_runtime::FixedPointNumber;
+use xcm_runtime_api::runtime_decl_for_PalletXcmApi::PalletXcmApi;
 
 #[test]
 fn remove_keys_weight_is_sensible() {
@@ -174,4 +175,57 @@ fn era_payout_should_give_sensible_results() {
 #[test]
 fn call_size() {
 	RuntimeCall::assert_size_under(230);
+}
+
+#[test]
+fn xcm_runtime_api_weight() {
+	use xcm::v2::XcmWeightInfo;
+	let message = xcm::VersionedXcm::<RuntimeCall>::V2(xcm::latest::Xcm(vec![
+		xcm::latest::prelude::ClearOrigin,
+	]));
+	assert_eq!(
+		Runtime::weight_message(message),
+		Ok(weights::xcm::KusamaXcmWeight::<RuntimeCall>::clear_origin())
+	);
+}
+
+#[test]
+fn xcm_runtime_location_convert() {
+	use xcm::latest::prelude::*;
+	use xcm_executor::traits::Convert;
+	let para_location = xcm::latest::MultiLocation::new(0, X1(Parachain(1000u32)));
+	assert_eq!(
+		Runtime::convert_location(para_location.clone().into()),
+		Ok(xcm_builder::ChildParachainConvertsVia::<ParaId, AccountId>::convert_ref(para_location)
+			.unwrap())
+	);
+	let local_location = xcm::latest::MultiLocation::new(
+		0,
+		X1(AccountId32 { network: NetworkId::Any, id: [1u8; 32] }),
+	);
+	assert_eq!(
+		Runtime::convert_location(local_location.clone().into()),
+		Ok(xcm_builder::AccountId32Aliases::<xcm_config::KusamaNetwork, AccountId>::convert_ref(
+			local_location
+		)
+		.unwrap())
+	);
+}
+
+#[test]
+fn xcm_asset() {
+	use frame_support::weights::WeightToFee as WeightToFeeT;
+	use xcm::latest::prelude::*;
+	let asset_location: MultiLocation = Here.into();
+	let t = frame_system::GenesisConfig::default()
+		.build_storage::<Runtime>()
+		.expect("Frame system builds valid default genesis config");
+	let mut ext = sp_io::TestExternalities::new(t);
+	ext.execute_with(|| {
+		let result = Runtime::calculate_concrete_asset_fee(
+			asset_location.into(),
+			ExtrinsicBaseWeight::get().ref_time(),
+		);
+		assert_eq!(result, Ok(WeightToFee::weight_to_fee(&ExtrinsicBaseWeight::get())));
+	});
 }

--- a/runtime/polkadot/Cargo.toml
+++ b/runtime/polkadot/Cargo.toml
@@ -75,6 +75,7 @@ pallet-vesting = { git = "https://github.com/paritytech/substrate", branch = "ma
 pallet-utility = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 frame-election-provider-support = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 pallet-xcm = { path = "../../xcm/pallet-xcm", default-features = false }
+xcm-runtime-api = { path = "../../xcm/xcm-runtime-api", default-features = false }
 
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false, optional = true }
 frame-try-runtime = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false, optional = true }
@@ -181,6 +182,7 @@ std = [
 	"xcm/std",
 	"xcm-executor/std",
 	"xcm-builder/std",
+	"xcm-runtime-api/std",
 ]
 runtime-benchmarks = [
 	"runtime-common/runtime-benchmarks",

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -34,6 +34,7 @@ use runtime_parachains::{
 	runtime_api_impl::v2 as parachains_runtime_api_impl, scheduler as parachains_scheduler,
 	session_info as parachains_session_info, shared as parachains_shared, ump as parachains_ump,
 };
+
 use authority_discovery_primitives::AuthorityId as AuthorityDiscoveryId;
 use beefy_primitives::crypto::AuthorityId as BeefyId;
 use frame_election_provider_support::{generate_solution_type, onchain, SequentialPhragmen};

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -78,7 +78,7 @@ use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
 use static_assertions::const_assert;
 use xcm::{
-	latest::{Error as XcmError, MultiAsset, MultiLocation, Weight as XcmWeight, Xcm},
+	latest::{Error as XcmError, MultiAsset, MultiLocation, Xcm},
 	VersionedMultiLocation, VersionedXcm,
 };
 use xcm_executor::traits::{WeightBounds, WeightTrader};
@@ -1996,17 +1996,16 @@ sp_api::impl_runtime_apis! {
 		}
 	}
 
-	impl xcm_runtime_api::PalletXcmApi<
+	impl xcm_runtime_api::XcmApi<
 		Block,
 		AccountId,
 		RuntimeCall,
 	> for Runtime {
 
-		fn weight_message(message: VersionedXcm<RuntimeCall>) -> xcm_runtime_api::XcmResult<XcmWeight> {
+		fn weight_message(message: VersionedXcm<RuntimeCall>) -> xcm_runtime_api::XcmResult< xcm_runtime_api::VersionedWeight> {
 			let mut message: Xcm<RuntimeCall> = message.try_into().map_err(|_| XcmError::UnhandledXcmVersion)?;
-			<xcm_config::XcmConfig as xcm_executor::Config>::Weigher::weight(& mut message).map_err(|_| XcmError::WeightNotComputable)
+			<xcm_config::XcmConfig as xcm_executor::Config>::Weigher::weight(& mut message).map_err(|_| XcmError::WeightNotComputable).map(|weight| weight.into())
 		}
-
 		fn convert_location(location: VersionedMultiLocation) -> xcm_runtime_api::XcmResult<AccountId> {
 			let location: MultiLocation = location.try_into().map_err(|_| XcmError::UnhandledXcmVersion)?;
 			<xcm_config::SovereignAccountOf as xcm_executor::traits::Convert<
@@ -2014,8 +2013,10 @@ sp_api::impl_runtime_apis! {
 			>>::convert_ref(location).map_err(|_| XcmError::FailedToTransactAsset("AccountIdConversionFailed"))
 		}
 
-		fn calculate_concrete_asset_fee(asset_location: VersionedMultiLocation, weight: XcmWeight) -> xcm_runtime_api::XcmResult<u128>  {
+		fn calculate_concrete_asset_fee(asset_location: VersionedMultiLocation, weight: xcm_runtime_api::VersionedWeight) -> xcm_runtime_api::XcmResult<u128>  {
 			let asset_location: MultiLocation = asset_location.try_into().map_err(|_| XcmError::UnhandledXcmVersion)?;
+			let weight: xcm::latest::Weight = weight.try_into().map_err(|_| XcmError::UnhandledXcmVersion)?;
+
 			// We create a multiasset with max fee
 			let multiasset: MultiAsset = (asset_location, u128::MAX).into();
 			let mut trader = <xcm_config::XcmConfig as xcm_executor::Config>::Trader::new();

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -26,6 +26,14 @@ use runtime_common::{
 	prod_or_fast, slots, BlockHashCount, BlockLength, CurrencyToVote, SlowAdjustingFeeUpdate,
 };
 
+use runtime_parachains::{
+	configuration as parachains_configuration, disputes as parachains_disputes,
+	dmp as parachains_dmp, hrmp as parachains_hrmp, inclusion as parachains_inclusion,
+	initializer as parachains_initializer, origin as parachains_origin, paras as parachains_paras,
+	paras_inherent as parachains_paras_inherent, reward_points as parachains_reward_points,
+	runtime_api_impl::v2 as parachains_runtime_api_impl, scheduler as parachains_scheduler,
+	session_info as parachains_session_info, shared as parachains_shared, ump as parachains_ump,
+};
 use authority_discovery_primitives::AuthorityId as AuthorityDiscoveryId;
 use beefy_primitives::crypto::AuthorityId as BeefyId;
 use frame_election_provider_support::{generate_solution_type, onchain, SequentialPhragmen};
@@ -49,14 +57,6 @@ use primitives::v2::{
 	CoreState, GroupRotationInfo, Hash, Id as ParaId, InboundDownwardMessage, InboundHrmpMessage,
 	Moment, Nonce, OccupiedCoreAssumption, PersistedValidationData, ScrapedOnChainVotes,
 	SessionInfo, Signature, ValidationCode, ValidationCodeHash, ValidatorId, ValidatorIndex,
-};
-use runtime_parachains::{
-	configuration as parachains_configuration, disputes as parachains_disputes,
-	dmp as parachains_dmp, hrmp as parachains_hrmp, inclusion as parachains_inclusion,
-	initializer as parachains_initializer, origin as parachains_origin, paras as parachains_paras,
-	paras_inherent as parachains_paras_inherent, reward_points as parachains_reward_points,
-	runtime_api_impl::v2 as parachains_runtime_api_impl, scheduler as parachains_scheduler,
-	session_info as parachains_session_info, shared as parachains_shared, ump as parachains_ump,
 };
 use sp_core::OpaqueMetadata;
 use sp_mmr_primitives as mmr;

--- a/runtime/rococo/Cargo.toml
+++ b/runtime/rococo/Cargo.toml
@@ -87,6 +87,7 @@ polkadot-parachain = { path = "../../parachain", default-features = false }
 xcm = { package = "xcm", path = "../../xcm", default-features = false }
 xcm-executor = { package = "xcm-executor", path = "../../xcm/xcm-executor", default-features = false }
 xcm-builder = { package = "xcm-builder", path = "../../xcm/xcm-builder", default-features = false }
+xcm-runtime-api = { package = "xcm-runtime-api", path = "../../xcm/xcm-runtime-api", default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.3.4"
@@ -172,6 +173,7 @@ std = [
 	"xcm/std",
 	"xcm-executor/std",
 	"xcm-builder/std",
+	"xcm-runtime-api/std",
 ]
 runtime-benchmarks = [
 	"runtime-common/runtime-benchmarks",

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -81,6 +81,11 @@ use sp_staking::SessionIndex;
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
 use static_assertions::const_assert;
+use xcm::{
+	latest::{Error as XcmError, MultiAsset, MultiLocation, Weight as XcmWeight, Xcm},
+	VersionedMultiLocation, VersionedXcm,
+};
+use xcm_executor::traits::{WeightBounds, WeightTrader};
 
 pub use frame_system::Call as SystemCall;
 pub use pallet_balances::Call as BalancesCall;
@@ -1898,6 +1903,38 @@ sp_api::impl_runtime_apis! {
 
 		fn next_authority_set_proof() -> beefy_primitives::mmr::BeefyNextAuthoritySet<Hash> {
 			MmrLeaf::next_authority_set_proof()
+		}
+	}
+
+	impl xcm_runtime_api::PalletXcmApi<
+		Block,
+		AccountId,
+		RuntimeCall,
+	> for Runtime {
+
+		fn weight_message(message: VersionedXcm<RuntimeCall>) -> xcm_runtime_api::XcmResult<XcmWeight> {
+			let mut message: Xcm<RuntimeCall> = message.try_into().map_err(|_| XcmError::UnhandledXcmVersion)?;
+			<xcm_config::XcmConfig as xcm_executor::Config>::Weigher::weight(& mut message).map_err(|_| XcmError::WeightNotComputable)
+		}
+
+		fn convert_location(location: VersionedMultiLocation) -> xcm_runtime_api::XcmResult<AccountId> {
+			let location: MultiLocation = location.try_into().map_err(|_| XcmError::UnhandledXcmVersion)?;
+			<xcm_config::SovereignAccountOf as xcm_executor::traits::Convert<
+				MultiLocation, AccountId
+			>>::convert_ref(location).map_err(|_| XcmError::FailedToTransactAsset("AccountIdConversionFailed"))
+		}
+
+		fn calculate_concrete_asset_fee(asset_location: VersionedMultiLocation, weight: XcmWeight) -> xcm_runtime_api::XcmResult<u128>  {
+			let asset_location: MultiLocation = asset_location.try_into().map_err(|_| XcmError::UnhandledXcmVersion)?;
+			// We create a multiasset with max fee
+			let multiasset: MultiAsset = (asset_location, u128::MAX).into();
+			let mut trader = <xcm_config::XcmConfig as xcm_executor::Config>::Trader::new();
+
+			// we assume max weight can be bought
+			// given the types u64 vs u128, it should be feasible
+			let unused = trader.buy_weight(weight, vec![multiasset.clone()].into())?;
+
+			unused.fungible.get(&multiasset.id).map(|&value| u128::MAX.saturating_sub(value)).ok_or(XcmError::NotHoldingFees)
 		}
 	}
 

--- a/runtime/westend/Cargo.toml
+++ b/runtime/westend/Cargo.toml
@@ -70,6 +70,7 @@ pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "
 pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 pallet-nomination-pools-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+
 pallet-treasury = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 pallet-utility = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 pallet-vesting = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
@@ -93,6 +94,7 @@ runtime-parachains = { package = "polkadot-runtime-parachains", path = "../parac
 xcm = { package = "xcm", path = "../../xcm", default-features = false }
 xcm-executor = { package = "xcm-executor", path = "../../xcm/xcm-executor", default-features = false }
 xcm-builder = { package = "xcm-builder", path = "../../xcm/xcm-builder", default-features = false }
+xcm-runtime-api = { path = "../../xcm/xcm-runtime-api", default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.3.4"
@@ -168,6 +170,7 @@ std = [
 	"sp-runtime/std",
 	"sp-staking/std",
 	"frame-system/std",
+	"xcm-runtime-api/std",
 	"frame-system-rpc-runtime-api/std",
 	"westend-runtime-constants/std",
 	"sp-version/std",

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -75,6 +75,11 @@ use sp_std::{collections::btree_map::BTreeMap, prelude::*};
 #[cfg(any(feature = "std", test))]
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
+use xcm::{
+	latest::{Error as XcmError, MultiAsset, MultiLocation, Weight as XcmWeight, Xcm},
+	VersionedMultiLocation, VersionedXcm,
+};
+use xcm_executor::traits::{WeightBounds, WeightTrader};
 
 pub use frame_system::Call as SystemCall;
 pub use pallet_balances::Call as BalancesCall;
@@ -1646,6 +1651,38 @@ sp_api::impl_runtime_apis! {
 	> for Runtime {
 		fn pending_rewards(member: AccountId) -> Balance {
 			NominationPools::pending_rewards(member).unwrap_or_default()
+		}
+	}
+
+	impl xcm_runtime_api::PalletXcmApi<
+		Block,
+		AccountId,
+		RuntimeCall,
+	> for Runtime {
+
+		fn weight_message(message: VersionedXcm<RuntimeCall>) -> xcm_runtime_api::XcmResult<XcmWeight> {
+			let mut message: Xcm<RuntimeCall> = message.try_into().map_err(|_| XcmError::UnhandledXcmVersion)?;
+			<xcm_config::XcmConfig as xcm_executor::Config>::Weigher::weight(& mut message).map_err(|_| XcmError::WeightNotComputable)
+		}
+
+		fn convert_location(location: VersionedMultiLocation) -> xcm_runtime_api::XcmResult<AccountId> {
+			let location: MultiLocation = location.try_into().map_err(|_| XcmError::UnhandledXcmVersion)?;
+			<xcm_config::LocationConverter as xcm_executor::traits::Convert<
+				MultiLocation, AccountId
+			>>::convert_ref(location).map_err(|_| XcmError::FailedToTransactAsset("AccountIdConversionFailed"))
+		}
+
+		fn calculate_concrete_asset_fee(asset_location: VersionedMultiLocation, weight: XcmWeight) -> xcm_runtime_api::XcmResult<u128>  {
+			let asset_location: MultiLocation = asset_location.try_into().map_err(|_| XcmError::UnhandledXcmVersion)?;
+			// We create a multiasset with max fee
+			let multiasset: MultiAsset = (asset_location, u128::MAX).into();
+			let mut trader = <xcm_config::XcmConfig as xcm_executor::Config>::Trader::new();
+
+			// we assume max weight can be bought
+			// given the types u64 vs u128, it should be feasible
+			let unused = trader.buy_weight(weight, vec![multiasset.clone()].into())?;
+
+			unused.fungible.get(&multiasset.id).map(|&value| u128::MAX.saturating_sub(value)).ok_or(XcmError::NotHoldingFees)
 		}
 	}
 

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -76,7 +76,7 @@ use sp_std::{collections::btree_map::BTreeMap, prelude::*};
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
 use xcm::{
-	latest::{Error as XcmError, MultiAsset, MultiLocation, Weight as XcmWeight, Xcm},
+	latest::{Error as XcmError, MultiAsset, MultiLocation, Xcm},
 	VersionedMultiLocation, VersionedXcm,
 };
 use xcm_executor::traits::{WeightBounds, WeightTrader};
@@ -1654,17 +1654,16 @@ sp_api::impl_runtime_apis! {
 		}
 	}
 
-	impl xcm_runtime_api::PalletXcmApi<
+	impl xcm_runtime_api::XcmApi<
 		Block,
 		AccountId,
 		RuntimeCall,
 	> for Runtime {
 
-		fn weight_message(message: VersionedXcm<RuntimeCall>) -> xcm_runtime_api::XcmResult<XcmWeight> {
+		fn weight_message(message: VersionedXcm<RuntimeCall>) -> xcm_runtime_api::XcmResult< xcm_runtime_api::VersionedWeight> {
 			let mut message: Xcm<RuntimeCall> = message.try_into().map_err(|_| XcmError::UnhandledXcmVersion)?;
-			<xcm_config::XcmConfig as xcm_executor::Config>::Weigher::weight(& mut message).map_err(|_| XcmError::WeightNotComputable)
+			<xcm_config::XcmConfig as xcm_executor::Config>::Weigher::weight(& mut message).map_err(|_| XcmError::WeightNotComputable).map(|weight| weight.into())
 		}
-
 		fn convert_location(location: VersionedMultiLocation) -> xcm_runtime_api::XcmResult<AccountId> {
 			let location: MultiLocation = location.try_into().map_err(|_| XcmError::UnhandledXcmVersion)?;
 			<xcm_config::LocationConverter as xcm_executor::traits::Convert<
@@ -1672,8 +1671,10 @@ sp_api::impl_runtime_apis! {
 			>>::convert_ref(location).map_err(|_| XcmError::FailedToTransactAsset("AccountIdConversionFailed"))
 		}
 
-		fn calculate_concrete_asset_fee(asset_location: VersionedMultiLocation, weight: XcmWeight) -> xcm_runtime_api::XcmResult<u128>  {
+		fn calculate_concrete_asset_fee(asset_location: VersionedMultiLocation, weight: xcm_runtime_api::VersionedWeight) -> xcm_runtime_api::XcmResult<u128>  {
 			let asset_location: MultiLocation = asset_location.try_into().map_err(|_| XcmError::UnhandledXcmVersion)?;
+			let weight: xcm::latest::Weight = weight.try_into().map_err(|_| XcmError::UnhandledXcmVersion)?;
+
 			// We create a multiasset with max fee
 			let multiasset: MultiAsset = (asset_location, u128::MAX).into();
 			let mut trader = <xcm_config::XcmConfig as xcm_executor::Config>::Trader::new();

--- a/runtime/westend/src/tests.rs
+++ b/runtime/westend/src/tests.rs
@@ -18,7 +18,7 @@
 
 use crate::*;
 use xcm::latest::{AssetId::*, Fungibility::*, MultiLocation};
-use xcm_runtime_api::runtime_decl_for_PalletXcmApi::PalletXcmApi;
+use xcm_runtime_api::runtime_decl_for_XcmApi::XcmApi;
 
 #[test]
 fn remove_keys_weight_is_sensible() {
@@ -77,7 +77,7 @@ fn xcm_runtime_api_weight() {
 	]));
 	assert_eq!(
 		Runtime::weight_message(message),
-		Ok(weights::xcm::WestendXcmWeight::<RuntimeCall>::clear_origin())
+		Ok(weights::xcm::WestendXcmWeight::<RuntimeCall>::clear_origin().into())
 	);
 }
 
@@ -116,7 +116,7 @@ fn xcm_asset() {
 	ext.execute_with(|| {
 		let result = Runtime::calculate_concrete_asset_fee(
 			asset_location.into(),
-			ExtrinsicBaseWeight::get().ref_time(),
+			ExtrinsicBaseWeight::get().ref_time().into(),
 		);
 		assert_eq!(result, Ok(WeightToFee::weight_to_fee(&ExtrinsicBaseWeight::get())));
 	});

--- a/xcm/xcm-runtime-api/Cargo.toml
+++ b/xcm/xcm-runtime-api/Cargo.toml
@@ -5,10 +5,12 @@ name = "xcm-runtime-api"
 version = "0.9.29"
 
 [dependencies]
+
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "2.1.2", default-features = false, features = ["derive"] }
 serde = { version = "1.0.137", optional = true, features = ["derive"] }
 log = { version = "0.4.17", default-features = false }
+derivative = {version = "2.2.0", default-features = false, features = [ "use_core" ] }
 
 sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
 sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }

--- a/xcm/xcm-runtime-api/Cargo.toml
+++ b/xcm/xcm-runtime-api/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2021"
+name = "xcm-runtime-api"
+version = "0.9.29"
+
+[dependencies]
+codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.1.2", default-features = false, features = ["derive"] }
+serde = { version = "1.0.137", optional = true, features = ["derive"] }
+log = { version = "0.4.17", default-features = false }
+
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
+sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
+
+xcm = { path = "..", default-features = false }
+
+[features]
+default = ["std"]
+std = [
+	"codec/std",
+	"scale-info/std",
+	"serde",
+	"sp-std/std",
+	"sp-core/std",
+	"sp-runtime/std",
+	"frame-support/std",
+	"frame-system/std",
+	"xcm/std",
+]
+runtime-benchmarks = [
+	"frame-system/runtime-benchmarks"
+]
+try-runtime = ["frame-support/try-runtime"]

--- a/xcm/xcm-runtime-api/src/lib.rs
+++ b/xcm/xcm-runtime-api/src/lib.rs
@@ -1,0 +1,45 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2019-2022 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Runtime API definition for pallet-xcm pallet.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use codec::Codec;
+use sp_runtime::traits::MaybeDisplay;
+use xcm::{
+	latest::{Error as XcmError, Weight},
+	VersionedMultiLocation, VersionedXcm,
+};
+// [`XcmResult`]
+pub type XcmResult<T> = Result<T, XcmError>;
+
+sp_api::decl_runtime_apis! {
+	pub trait PalletXcmApi<AccountId, RuntimeCall> where
+		AccountId: Codec + MaybeDisplay,
+
+	{
+		/// Returns weight of a given message
+		fn weight_message(message: VersionedXcm<RuntimeCall>) -> XcmResult<Weight>;
+
+		/// Returns the location to accountId conversion
+		fn convert_location(location: VersionedMultiLocation) -> XcmResult<AccountId>;
+
+		/// Returns fee charged for an amount of weight in a concrete multiasset
+		fn calculate_concrete_asset_fee(asset_location: VersionedMultiLocation, weight: Weight) -> XcmResult<u128>;
+	}
+}


### PR DESCRIPTION
Adds `xcm-runtime-api ` package which defines a runtime api to retrieve useful runtime-related xcm data. For now the trait contains:

- A function to weight a message `weight_message`
- A function to convert a ML to an account `convert_location`
- A function to calculate the fee to be paid for a certain amount of weight and an asset: `calculate_concrete_asset_fee`

Anticipating changes in Weights in XCM I created a `VersionedWeight` enum so that the API does not break once this change is brought. The other option is to remove this and just simply increment the API version once XCM V3 is merged