### PR TITLE
validator assignment fixes for backing and collator protocol

### DIFF
--- a/node/core/backing/src/lib.rs
+++ b/node/core/backing/src/lib.rs
@@ -651,7 +651,7 @@ async fn validate_and_make_available(
 
 	let pov = match pov {
 		PoVData::Ready(pov) => pov,
-		PoVData::FetchFromValidator { from_validator, candidate_hash, pov_hash } => {
+		PoVData::FetchFromValidator { from_validator, candidate_hash, pov_hash } =>
 			match request_pov(
 				&mut sender,
 				relay_parent,
@@ -674,8 +674,7 @@ async fn validate_and_make_available(
 				},
 				Err(err) => return Err(err),
 				Ok(pov) => pov,
-			}
-		}
+			},
 	};
 
 	let v = {

--- a/node/core/backing/src/tests/prospective_parachains.rs
+++ b/node/core/backing/src/tests/prospective_parachains.rs
@@ -299,7 +299,7 @@ fn seconding_sanity_check_allowed() {
 	test_harness(test_state.keystore.clone(), |mut virtual_overseer| async move {
 		// Candidate is seconded in a parent of the activated `leaf_a`.
 		const LEAF_A_BLOCK_NUMBER: BlockNumber = 100;
-		const LEAF_A_DEPTH: BlockNumber = 3;
+		const LEAF_A_ANCESTRY_LEN: BlockNumber = 3;
 		let para_id = test_state.chain_ids[0];
 
 		let leaf_b_hash = Hash::from_low_u64_be(128);
@@ -312,11 +312,11 @@ fn seconding_sanity_check_allowed() {
 			status: LeafStatus::Fresh,
 			span: Arc::new(jaeger::Span::Disabled),
 		};
-		let min_relay_parents = vec![(para_id, LEAF_A_BLOCK_NUMBER - LEAF_A_DEPTH)];
+		let min_relay_parents = vec![(para_id, LEAF_A_BLOCK_NUMBER - LEAF_A_ANCESTRY_LEN)];
 		let test_leaf_a = TestLeaf { activated, min_relay_parents };
 
 		const LEAF_B_BLOCK_NUMBER: BlockNumber = LEAF_A_BLOCK_NUMBER + 2;
-		const LEAF_B_DEPTH: BlockNumber = 4;
+		const LEAF_B_ANCESTRY_LEN: BlockNumber = 4;
 
 		let activated = ActivatedLeaf {
 			hash: leaf_b_hash,
@@ -324,7 +324,7 @@ fn seconding_sanity_check_allowed() {
 			status: LeafStatus::Fresh,
 			span: Arc::new(jaeger::Span::Disabled),
 		};
-		let min_relay_parents = vec![(para_id, LEAF_B_BLOCK_NUMBER - LEAF_B_DEPTH)];
+		let min_relay_parents = vec![(para_id, LEAF_B_BLOCK_NUMBER - LEAF_B_ANCESTRY_LEN)];
 		let test_leaf_b = TestLeaf { activated, min_relay_parents };
 
 		activate_leaf(&mut virtual_overseer, test_leaf_a, &test_state, 0).await;
@@ -436,7 +436,7 @@ fn seconding_sanity_check_disallowed() {
 	test_harness(test_state.keystore.clone(), |mut virtual_overseer| async move {
 		// Candidate is seconded in a parent of the activated `leaf_a`.
 		const LEAF_A_BLOCK_NUMBER: BlockNumber = 100;
-		const LEAF_A_DEPTH: BlockNumber = 3;
+		const LEAF_A_ANCESTRY_LEN: BlockNumber = 3;
 		let para_id = test_state.chain_ids[0];
 
 		let leaf_b_hash = Hash::from_low_u64_be(128);
@@ -449,11 +449,11 @@ fn seconding_sanity_check_disallowed() {
 			status: LeafStatus::Fresh,
 			span: Arc::new(jaeger::Span::Disabled),
 		};
-		let min_relay_parents = vec![(para_id, LEAF_A_BLOCK_NUMBER - LEAF_A_DEPTH)];
+		let min_relay_parents = vec![(para_id, LEAF_A_BLOCK_NUMBER - LEAF_A_ANCESTRY_LEN)];
 		let test_leaf_a = TestLeaf { activated, min_relay_parents };
 
 		const LEAF_B_BLOCK_NUMBER: BlockNumber = LEAF_A_BLOCK_NUMBER + 2;
-		const LEAF_B_DEPTH: BlockNumber = 4;
+		const LEAF_B_ANCESTRY_LEN: BlockNumber = 4;
 
 		let activated = ActivatedLeaf {
 			hash: leaf_b_hash,
@@ -461,7 +461,7 @@ fn seconding_sanity_check_disallowed() {
 			status: LeafStatus::Fresh,
 			span: Arc::new(jaeger::Span::Disabled),
 		};
-		let min_relay_parents = vec![(para_id, LEAF_B_BLOCK_NUMBER - LEAF_B_DEPTH)];
+		let min_relay_parents = vec![(para_id, LEAF_B_BLOCK_NUMBER - LEAF_B_ANCESTRY_LEN)];
 		let test_leaf_b = TestLeaf { activated, min_relay_parents };
 
 		activate_leaf(&mut virtual_overseer, test_leaf_a, &test_state, 0).await;
@@ -633,7 +633,7 @@ fn prospective_parachains_reject_candidate() {
 	test_harness(test_state.keystore.clone(), |mut virtual_overseer| async move {
 		// Candidate is seconded in a parent of the activated `leaf_a`.
 		const LEAF_A_BLOCK_NUMBER: BlockNumber = 100;
-		const LEAF_A_DEPTH: BlockNumber = 3;
+		const LEAF_A_ANCESTRY_LEN: BlockNumber = 3;
 		let para_id = test_state.chain_ids[0];
 
 		let leaf_a_hash = Hash::from_low_u64_be(130);
@@ -644,7 +644,7 @@ fn prospective_parachains_reject_candidate() {
 			status: LeafStatus::Fresh,
 			span: Arc::new(jaeger::Span::Disabled),
 		};
-		let min_relay_parents = vec![(para_id, LEAF_A_BLOCK_NUMBER - LEAF_A_DEPTH)];
+		let min_relay_parents = vec![(para_id, LEAF_A_BLOCK_NUMBER - LEAF_A_ANCESTRY_LEN)];
 		let test_leaf_a = TestLeaf { activated, min_relay_parents };
 
 		activate_leaf(&mut virtual_overseer, test_leaf_a, &test_state, 0).await;
@@ -798,7 +798,7 @@ fn second_multiple_candidates_per_relay_parent() {
 	test_harness(test_state.keystore.clone(), |mut virtual_overseer| async move {
 		// Candidate `a` is seconded in a parent of the activated `leaf`.
 		const LEAF_BLOCK_NUMBER: BlockNumber = 100;
-		const LEAF_DEPTH: BlockNumber = 3;
+		const LEAF_ANCESTRY_LEN: BlockNumber = 3;
 		let para_id = test_state.chain_ids[0];
 
 		let leaf_hash = Hash::from_low_u64_be(130);
@@ -810,7 +810,7 @@ fn second_multiple_candidates_per_relay_parent() {
 			status: LeafStatus::Fresh,
 			span: Arc::new(jaeger::Span::Disabled),
 		};
-		let min_relay_parents = vec![(para_id, LEAF_BLOCK_NUMBER - LEAF_DEPTH)];
+		let min_relay_parents = vec![(para_id, LEAF_BLOCK_NUMBER - LEAF_ANCESTRY_LEN)];
 		let test_leaf_a = TestLeaf { activated, min_relay_parents };
 
 		activate_leaf(&mut virtual_overseer, test_leaf_a, &test_state, 0).await;
@@ -922,7 +922,7 @@ fn backing_works() {
 	test_harness(test_state.keystore.clone(), |mut virtual_overseer| async move {
 		// Candidate `a` is seconded in a parent of the activated `leaf`.
 		const LEAF_BLOCK_NUMBER: BlockNumber = 100;
-		const LEAF_DEPTH: BlockNumber = 3;
+		const LEAF_ANCESTRY_LEN: BlockNumber = 3;
 		let para_id = test_state.chain_ids[0];
 
 		let leaf_hash = Hash::from_low_u64_be(130);
@@ -933,7 +933,7 @@ fn backing_works() {
 			status: LeafStatus::Fresh,
 			span: Arc::new(jaeger::Span::Disabled),
 		};
-		let min_relay_parents = vec![(para_id, LEAF_BLOCK_NUMBER - LEAF_DEPTH)];
+		let min_relay_parents = vec![(para_id, LEAF_BLOCK_NUMBER - LEAF_ANCESTRY_LEN)];
 		let test_leaf_a = TestLeaf { activated, min_relay_parents };
 
 		activate_leaf(&mut virtual_overseer, test_leaf_a, &test_state, 0).await;
@@ -1081,7 +1081,7 @@ fn concurrent_dependent_candidates() {
 		// Candidate `a` is seconded in a grandparent of the activated `leaf`,
 		// candidate `b` -- in parent.
 		const LEAF_BLOCK_NUMBER: BlockNumber = 100;
-		const LEAF_DEPTH: BlockNumber = 3;
+		const LEAF_ANCESTRY_LEN: BlockNumber = 3;
 		let para_id = test_state.chain_ids[0];
 
 		let leaf_hash = Hash::from_low_u64_be(130);
@@ -1093,7 +1093,7 @@ fn concurrent_dependent_candidates() {
 			status: LeafStatus::Fresh,
 			span: Arc::new(jaeger::Span::Disabled),
 		};
-		let min_relay_parents = vec![(para_id, LEAF_BLOCK_NUMBER - LEAF_DEPTH)];
+		let min_relay_parents = vec![(para_id, LEAF_BLOCK_NUMBER - LEAF_ANCESTRY_LEN)];
 		let test_leaf_a = TestLeaf { activated, min_relay_parents };
 
 		activate_leaf(&mut virtual_overseer, test_leaf_a, &test_state, 0).await;
@@ -1308,7 +1308,7 @@ fn seconding_sanity_check_occupy_same_depth() {
 	test_harness(test_state.keystore.clone(), |mut virtual_overseer| async move {
 		// Candidate `a` is seconded in a parent of the activated `leaf`.
 		const LEAF_BLOCK_NUMBER: BlockNumber = 100;
-		const LEAF_DEPTH: BlockNumber = 3;
+		const LEAF_ANCESTRY_LEN: BlockNumber = 3;
 
 		let para_id_a = test_state.chain_ids[0];
 		let para_id_b = test_state.chain_ids[1];
@@ -1323,7 +1323,7 @@ fn seconding_sanity_check_occupy_same_depth() {
 			span: Arc::new(jaeger::Span::Disabled),
 		};
 
-		let min_block_number = LEAF_BLOCK_NUMBER - LEAF_DEPTH;
+		let min_block_number = LEAF_BLOCK_NUMBER - LEAF_ANCESTRY_LEN;
 		let min_relay_parents = vec![(para_id_a, min_block_number), (para_id_b, min_block_number)];
 		let test_leaf_a = TestLeaf { activated, min_relay_parents };
 

--- a/node/core/backing/src/tests/prospective_parachains.rs
+++ b/node/core/backing/src/tests/prospective_parachains.rs
@@ -17,7 +17,7 @@
 //! Tests for the backing subsystem with enabled prospective parachains.
 
 use polkadot_node_subsystem::{messages::ChainApiMessage, TimeoutExt};
-use polkadot_primitives::v2::{BlockNumber, Header};
+use polkadot_primitives::v2::{BlockNumber, Header, OccupiedCore};
 
 use super::*;
 
@@ -1429,6 +1429,134 @@ fn seconding_sanity_check_occupy_same_depth() {
 				}
 			);
 		}
+
+		virtual_overseer
+	});
+}
+
+// Test that the subsystem doesn't skip occupied cores assignments.
+#[test]
+fn occupied_core_assignment() {
+	let mut test_state = TestState::default();
+	test_harness(test_state.keystore.clone(), |mut virtual_overseer| async move {
+		// Candidate is seconded in a parent of the activated `leaf_a`.
+		const LEAF_A_BLOCK_NUMBER: BlockNumber = 100;
+		const LEAF_A_ANCESTRY_LEN: BlockNumber = 3;
+		let para_id = test_state.chain_ids[0];
+
+		// Set the core state to occupied.
+		let mut candidate_descriptor = ::test_helpers::dummy_candidate_descriptor(Hash::zero());
+		candidate_descriptor.para_id = para_id;
+		test_state.availability_cores[0] = CoreState::Occupied(OccupiedCore {
+			group_responsible: Default::default(),
+			next_up_on_available: None,
+			occupied_since: 100_u32,
+			time_out_at: 200_u32,
+			next_up_on_time_out: None,
+			availability: Default::default(),
+			candidate_descriptor,
+			candidate_hash: Default::default(),
+		});
+
+		let leaf_a_hash = Hash::from_low_u64_be(130);
+		let leaf_a_parent = get_parent_hash(leaf_a_hash);
+		let activated = ActivatedLeaf {
+			hash: leaf_a_hash,
+			number: LEAF_A_BLOCK_NUMBER,
+			status: LeafStatus::Fresh,
+			span: Arc::new(jaeger::Span::Disabled),
+		};
+		let min_relay_parents = vec![(para_id, LEAF_A_BLOCK_NUMBER - LEAF_A_ANCESTRY_LEN)];
+		let test_leaf_a = TestLeaf { activated, min_relay_parents };
+
+		activate_leaf(&mut virtual_overseer, test_leaf_a, &test_state, 0).await;
+
+		let pov = PoV { block_data: BlockData(vec![42, 43, 44]) };
+		let pvd = dummy_pvd();
+		let validation_code = ValidationCode(vec![1, 2, 3]);
+
+		let expected_head_data = test_state.head_data.get(&para_id).unwrap();
+
+		let pov_hash = pov.hash();
+		let candidate = TestCandidateBuilder {
+			para_id,
+			relay_parent: leaf_a_parent,
+			pov_hash,
+			head_data: expected_head_data.clone(),
+			erasure_root: make_erasure_root(&test_state, pov.clone(), pvd.clone()),
+			persisted_validation_data_hash: pvd.hash(),
+			validation_code: validation_code.0.clone(),
+			..Default::default()
+		}
+		.build();
+
+		let second = CandidateBackingMessage::Second(
+			leaf_a_hash,
+			candidate.to_plain(),
+			pvd.clone(),
+			pov.clone(),
+		);
+
+		virtual_overseer.send(FromOrchestra::Communication { msg: second }).await;
+
+		assert_validate_seconded_candidate(
+			&mut virtual_overseer,
+			leaf_a_parent,
+			&candidate,
+			&pov,
+			&pvd,
+			&validation_code,
+			expected_head_data,
+			false,
+		)
+		.await;
+
+		// `seconding_sanity_check`
+		let expected_request = HypotheticalDepthRequest {
+			candidate_hash: candidate.hash(),
+			candidate_para: para_id,
+			parent_head_data_hash: pvd.parent_head.hash(),
+			candidate_relay_parent: leaf_a_parent,
+			fragment_tree_relay_parent: leaf_a_hash,
+		};
+		assert_hypothetical_depth_requests(
+			&mut virtual_overseer,
+			vec![(expected_request, vec![0, 1, 2, 3])],
+		)
+		.await;
+		// Prospective parachains are notified.
+		assert_matches!(
+			virtual_overseer.recv().await,
+			AllMessages::ProspectiveParachains(
+				ProspectiveParachainsMessage::CandidateSeconded(
+					candidate_para,
+					candidate_receipt,
+					_pvd,
+					tx,
+				),
+			) if candidate_receipt == candidate && candidate_para == para_id && pvd == _pvd => {
+				// Any non-empty response will do.
+				tx.send(vec![(leaf_a_hash, vec![0, 1, 2, 3])]).unwrap();
+			}
+		);
+
+		assert_matches!(
+			virtual_overseer.recv().await,
+			AllMessages::StatementDistribution(
+				StatementDistributionMessage::Share(
+					parent_hash,
+					_signed_statement,
+				)
+			) if parent_hash == leaf_a_parent => {}
+		);
+
+		assert_matches!(
+			virtual_overseer.recv().await,
+			AllMessages::CollatorProtocol(CollatorProtocolMessage::Seconded(hash, statement)) => {
+				assert_eq!(leaf_a_parent, hash);
+				assert_matches!(statement.payload(), Statement::Seconded(_));
+			}
+		);
 
 		virtual_overseer
 	});

--- a/node/network/collator-protocol/src/validator_side/collation.rs
+++ b/node/network/collator-protocol/src/validator_side/collation.rs
@@ -28,7 +28,7 @@
 //!    └─▶Advertised ─▶ Pending ─▶ Fetched ─▶ Validated
 
 use futures::channel::oneshot;
-use std::collections::{HashMap, VecDeque};
+use std::collections::VecDeque;
 
 use polkadot_node_network_protocol::PeerId;
 use polkadot_node_primitives::PoV;
@@ -183,14 +183,14 @@ pub struct Collations {
 	pub fetching_from: Option<(CollatorId, Option<CandidateHash>)>,
 	/// Collation that were advertised to us, but we did not yet fetch.
 	pub waiting_queue: VecDeque<(PendingCollation, CollatorId)>,
-	/// How many collations have been seconded per parachain.
-	pub seconded_count: HashMap<ParaId, usize>,
+	/// How many collations have been seconded.
+	pub seconded_count: usize,
 }
 
 impl Collations {
 	/// Note a seconded collation for a given para.
-	pub(super) fn note_seconded(&mut self, para_id: ParaId) {
-		*self.seconded_count.entry(para_id).or_insert(0) += 1
+	pub(super) fn note_seconded(&mut self) {
+		self.seconded_count += 1
 	}
 
 	/// Returns the next collation to fetch from the `waiting_queue`.
@@ -225,17 +225,12 @@ impl Collations {
 		match self.status {
 			// We don't need to fetch any other collation when we already have seconded one.
 			CollationStatus::Seconded => None,
-			CollationStatus::Waiting => {
-				while let Some(next) = self.waiting_queue.pop_front() {
-					let para_id = next.0.para_id;
-					if !self.is_seconded_limit_reached(relay_parent_mode, para_id) {
-						continue
-					}
-
-					return Some(next)
-				}
-				None
-			},
+			CollationStatus::Waiting =>
+				if !self.is_seconded_limit_reached(relay_parent_mode) {
+					None
+				} else {
+					self.waiting_queue.pop_front()
+				},
 			CollationStatus::WaitingOnValidation | CollationStatus::Fetching =>
 				unreachable!("We have reset the status above!"),
 		}
@@ -245,10 +240,9 @@ impl Collations {
 	pub(super) fn is_seconded_limit_reached(
 		&self,
 		relay_parent_mode: ProspectiveParachainsMode,
-		para_id: ParaId,
 	) -> bool {
 		let seconded_limit =
 			if relay_parent_mode.is_enabled() { MAX_CANDIDATE_DEPTH + 1 } else { 1 };
-		self.seconded_count.get(&para_id).map_or(true, |&num| num < seconded_limit)
+		self.seconded_count < seconded_limit
 	}
 }

--- a/node/network/statement-distribution/src/legacy_v1/mod.rs
+++ b/node/network/statement-distribution/src/legacy_v1/mod.rs
@@ -18,9 +18,7 @@ use parity_scale_codec::Encode;
 
 use polkadot_node_network_protocol::{
 	self as net_protocol,
-	grid_topology::{
-		GridNeighbors, RequiredRouting, SessionBoundGridTopologyStorage,
-	},
+	grid_topology::{GridNeighbors, RequiredRouting, SessionBoundGridTopologyStorage},
 	peer_set::{IsAuthority, PeerSet, ValidationVersion},
 	v1::{self as protocol_v1, StatementMetadata},
 	vstaging as protocol_vstaging, IfDisconnected, PeerId, UnifiedReputationChange as Rep,


### PR DESCRIPTION
1. A follow-up for #5740, collators should connect to the group that was assigned to their **core** in the implicit view, and at any relay parent a group can only be assigned to single para. The logic was broken (as well as the test for it).

2. A small leftover from https://github.com/paritytech/polkadot/pull/5557, we should consider occupied cores too to be aligned with collator protocol and provisioner.

3. misc tests fixes.