### PR TITLE
BlockId removal: refactor: StorageProvider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,7 +435,7 @@ dependencies = [
 [[package]]
 name = "beefy-gadget"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -472,7 +472,7 @@ dependencies = [
 [[package]]
 name = "beefy-gadget-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "beefy-gadget",
  "beefy-primitives",
@@ -492,7 +492,7 @@ dependencies = [
 [[package]]
 name = "beefy-merkle-tree"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "beefy-primitives",
  "sp-api",
@@ -502,10 +502,11 @@ dependencies = [
 [[package]]
 name = "beefy-primitives"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
+ "serde",
  "sp-api",
  "sp-application-crypto",
  "sp-core",
@@ -1981,7 +1982,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "fork-tree"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -2005,7 +2006,7 @@ checksum = "85dcb89d2b10c5f6133de2efd8c11959ce9dbb46a2f7a4cab208c4eeda6ce1ab"
 [[package]]
 name = "frame-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2028,7 +2029,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "Inflector",
  "array-bytes",
@@ -2079,7 +2080,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2090,7 +2091,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -2106,7 +2107,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2135,7 +2136,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "bitflags",
  "frame-metadata",
@@ -2167,7 +2168,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -2181,7 +2182,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -2193,7 +2194,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2203,7 +2204,7 @@ dependencies = [
 [[package]]
 name = "frame-support-test"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-support",
  "frame-support-test-pallet",
@@ -2226,7 +2227,7 @@ dependencies = [
 [[package]]
 name = "frame-support-test-pallet"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2237,7 +2238,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-support",
  "log",
@@ -2255,7 +2256,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2270,7 +2271,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -2279,7 +2280,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -2450,7 +2451,7 @@ dependencies = [
 [[package]]
 name = "generate-bags"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "chrono",
  "frame-election-provider-support",
@@ -4614,7 +4615,7 @@ checksum = "20448fd678ec04e6ea15bbe0476874af65e98a01515d667aa49f1434dc44ebf4"
 [[package]]
 name = "pallet-assets"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4628,7 +4629,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4644,7 +4645,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4659,7 +4660,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4683,7 +4684,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -4703,7 +4704,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list-remote-tests"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-election-provider-support",
  "frame-support",
@@ -4722,7 +4723,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4737,7 +4738,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "beefy-primitives",
  "frame-support",
@@ -4753,7 +4754,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "array-bytes",
  "beefy-merkle-tree",
@@ -4776,7 +4777,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4794,7 +4795,7 @@ dependencies = [
 [[package]]
 name = "pallet-child-bounties"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4813,7 +4814,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4830,7 +4831,7 @@ dependencies = [
 [[package]]
 name = "pallet-conviction-voting"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -4847,7 +4848,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4865,7 +4866,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -4889,7 +4890,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -4902,7 +4903,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "5.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4920,7 +4921,7 @@ dependencies = [
 [[package]]
 name = "pallet-fast-unstake"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -4941,7 +4942,7 @@ dependencies = [
 [[package]]
 name = "pallet-gilt"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4956,7 +4957,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4979,7 +4980,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -4995,7 +4996,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5015,7 +5016,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5032,7 +5033,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5049,7 +5050,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "ckb-merkle-mountain-range",
  "frame-benchmarking",
@@ -5067,7 +5068,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr-rpc"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -5082,7 +5083,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5098,7 +5099,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5115,7 +5116,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5135,7 +5136,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
 version = "1.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -5145,7 +5146,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5162,7 +5163,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5185,7 +5186,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5202,7 +5203,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5217,7 +5218,7 @@ dependencies = [
 [[package]]
 name = "pallet-ranked-collective"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5235,7 +5236,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5250,7 +5251,7 @@ dependencies = [
 [[package]]
 name = "pallet-referenda"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -5268,7 +5269,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5284,7 +5285,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5305,7 +5306,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5321,7 +5322,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5335,7 +5336,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5358,7 +5359,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -5369,7 +5370,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -5378,7 +5379,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5392,7 +5393,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5410,7 +5411,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5429,7 +5430,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5445,7 +5446,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -5460,7 +5461,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -5471,7 +5472,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5488,7 +5489,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5504,7 +5505,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5519,7 +5520,7 @@ dependencies = [
 [[package]]
 name = "pallet-whitelist"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8002,7 +8003,7 @@ dependencies = [
 [[package]]
 name = "remote-externalities"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "env_logger 0.9.0",
  "jsonrpsee",
@@ -8341,7 +8342,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "4.1.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "log",
  "sp-core",
@@ -8352,7 +8353,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "async-trait",
  "futures",
@@ -8379,7 +8380,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "futures",
  "futures-timer",
@@ -8402,7 +8403,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -8418,7 +8419,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "impl-trait-for-tuples",
  "memmap2 0.5.0",
@@ -8435,7 +8436,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -8446,7 +8447,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "array-bytes",
  "chrono",
@@ -8486,7 +8487,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "fnv",
  "futures",
@@ -8514,7 +8515,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -8539,7 +8540,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "async-trait",
  "futures",
@@ -8563,7 +8564,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -8605,7 +8606,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -8627,7 +8628,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -8640,7 +8641,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "async-trait",
  "futures",
@@ -8664,7 +8665,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "lazy_static",
  "lru 0.7.8",
@@ -8691,7 +8692,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -8707,7 +8708,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -8722,7 +8723,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -8742,7 +8743,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "ahash",
  "array-bytes",
@@ -8783,7 +8784,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "finality-grandpa",
  "futures",
@@ -8804,7 +8805,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "ansi_term",
  "futures",
@@ -8821,7 +8822,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -8836,7 +8837,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -8883,7 +8884,7 @@ dependencies = [
 [[package]]
 name = "sc-network-bitswap"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "cid",
  "futures",
@@ -8903,7 +8904,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "async-trait",
  "bitflags",
@@ -8929,7 +8930,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "ahash",
  "futures",
@@ -8947,7 +8948,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "array-bytes",
  "futures",
@@ -8968,7 +8969,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "array-bytes",
  "fork-tree",
@@ -8998,7 +8999,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "array-bytes",
  "futures",
@@ -9017,7 +9018,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "array-bytes",
  "bytes",
@@ -9047,7 +9048,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "futures",
  "libp2p",
@@ -9060,7 +9061,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -9069,7 +9070,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "futures",
  "hash-db",
@@ -9099,7 +9100,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -9122,7 +9123,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -9135,7 +9136,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "futures",
  "hex",
@@ -9154,7 +9155,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "async-trait",
  "directories",
@@ -9225,7 +9226,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -9239,7 +9240,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -9258,7 +9259,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "6.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "futures",
  "libc",
@@ -9277,7 +9278,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "chrono",
  "futures",
@@ -9295,7 +9296,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "ansi_term",
  "atty",
@@ -9326,7 +9327,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -9337,7 +9338,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "async-trait",
  "futures",
@@ -9364,7 +9365,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "async-trait",
  "futures",
@@ -9378,7 +9379,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "futures",
  "futures-timer",
@@ -9852,7 +9853,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "hash-db",
  "log",
@@ -9870,7 +9871,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "blake2",
  "proc-macro-crate",
@@ -9882,7 +9883,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9895,7 +9896,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -9910,7 +9911,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9923,7 +9924,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -9935,7 +9936,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -9947,7 +9948,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "futures",
  "log",
@@ -9965,7 +9966,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "async-trait",
  "futures",
@@ -9984,7 +9985,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "async-trait",
  "merlin",
@@ -10007,7 +10008,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10021,7 +10022,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10034,7 +10035,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "array-bytes",
  "base58",
@@ -10080,7 +10081,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "blake2",
  "byteorder",
@@ -10094,7 +10095,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10105,7 +10106,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.1",
@@ -10114,7 +10115,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10124,7 +10125,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.12.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -10135,7 +10136,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -10153,7 +10154,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -10167,7 +10168,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "bytes",
  "futures",
@@ -10193,7 +10194,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -10204,7 +10205,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.12.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "async-trait",
  "futures",
@@ -10221,7 +10222,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "4.1.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "thiserror",
  "zstd",
@@ -10230,7 +10231,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -10246,7 +10247,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10260,7 +10261,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -10270,7 +10271,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -10280,7 +10281,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -10290,7 +10291,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -10313,7 +10314,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -10331,7 +10332,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -10343,7 +10344,7 @@ dependencies = [
 [[package]]
 name = "sp-sandbox"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -10357,7 +10358,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10371,7 +10372,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10382,7 +10383,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.12.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "hash-db",
  "log",
@@ -10404,12 +10405,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 
 [[package]]
 name = "sp-storage"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -10422,7 +10423,7 @@ dependencies = [
 [[package]]
 name = "sp-tasks"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "log",
  "sp-core",
@@ -10435,7 +10436,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "async-trait",
  "futures-timer",
@@ -10451,7 +10452,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "parity-scale-codec",
  "sp-std",
@@ -10463,7 +10464,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -10472,7 +10473,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "async-trait",
  "log",
@@ -10488,7 +10489,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "ahash",
  "hash-db",
@@ -10511,7 +10512,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -10528,7 +10529,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -10539,7 +10540,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "impl-trait-for-tuples",
  "log",
@@ -10552,7 +10553,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -10767,7 +10768,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "platforms",
 ]
@@ -10775,7 +10776,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures",
@@ -10796,7 +10797,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "futures-util",
  "hyper",
@@ -10809,7 +10810,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-trie-migration-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "jsonrpsee",
  "log",
@@ -10830,7 +10831,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -10856,7 +10857,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-utils"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "futures",
  "substrate-test-utils-derive",
@@ -10866,7 +10867,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-utils-derive"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -10877,7 +10878,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "5.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "ansi_term",
  "build-helper",
@@ -11584,7 +11585,7 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 [[package]]
 name = "try-runtime-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#e8a4408c53ae2a1a0ef6cb2f7b603887a231c16f"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "clap",
  "frame-try-runtime",

--- a/node/client/src/lib.rs
+++ b/node/client/src/lib.rs
@@ -418,10 +418,7 @@ impl sc_client_api::BlockBackend<Block> for Client {
 	}
 }
 
-impl sc_client_api::StorageProvider<Block, crate::FullBackend> for Client
-where
-	Block: BlockT,
-{
+impl sc_client_api::StorageProvider<Block, crate::FullBackend> for Client {
 	fn storage(
 		&self,
 		hash: &<Block as BlockT>::Hash,

--- a/node/client/src/lib.rs
+++ b/node/client/src/lib.rs
@@ -418,66 +418,69 @@ impl sc_client_api::BlockBackend<Block> for Client {
 	}
 }
 
-impl sc_client_api::StorageProvider<Block, crate::FullBackend> for Client {
+impl sc_client_api::StorageProvider<Block, crate::FullBackend> for Client
+where
+	Block: BlockT,
+{
 	fn storage(
 		&self,
-		id: &BlockId<Block>,
+		hash: &<Block as BlockT>::Hash,
 		key: &StorageKey,
 	) -> sp_blockchain::Result<Option<StorageData>> {
 		with_client! {
 			self,
 			client,
 			{
-				client.storage(id, key)
+				client.storage(hash, key)
 			}
 		}
 	}
 
 	fn storage_keys(
 		&self,
-		id: &BlockId<Block>,
+		hash: &<Block as BlockT>::Hash,
 		key_prefix: &StorageKey,
 	) -> sp_blockchain::Result<Vec<StorageKey>> {
 		with_client! {
 			self,
 			client,
 			{
-				client.storage_keys(id, key_prefix)
+				client.storage_keys(hash, key_prefix)
 			}
 		}
 	}
 
 	fn storage_hash(
 		&self,
-		id: &BlockId<Block>,
+		hash: &<Block as BlockT>::Hash,
 		key: &StorageKey,
 	) -> sp_blockchain::Result<Option<<Block as BlockT>::Hash>> {
 		with_client! {
 			self,
 			client,
 			{
-				client.storage_hash(id, key)
+				client.storage_hash(hash, key)
 			}
 		}
 	}
 
 	fn storage_pairs(
 		&self,
-		id: &BlockId<Block>,
+		hash: &<Block as BlockT>::Hash,
 		key_prefix: &StorageKey,
 	) -> sp_blockchain::Result<Vec<(StorageKey, StorageData)>> {
 		with_client! {
 			self,
 			client,
 			{
-				client.storage_pairs(id, key_prefix)
+				client.storage_pairs(hash, key_prefix)
 			}
 		}
 	}
 
 	fn storage_keys_iter<'a>(
 		&self,
-		id: &BlockId<Block>,
+		hash: &<Block as BlockT>::Hash,
 		prefix: Option<&'a StorageKey>,
 		start_key: Option<&StorageKey>,
 	) -> sp_blockchain::Result<
@@ -487,14 +490,14 @@ impl sc_client_api::StorageProvider<Block, crate::FullBackend> for Client {
 			self,
 			client,
 			{
-				client.storage_keys_iter(id, prefix, start_key)
+				client.storage_keys_iter(hash, prefix, start_key)
 			}
 		}
 	}
 
 	fn child_storage(
 		&self,
-		id: &BlockId<Block>,
+		hash: &<Block as BlockT>::Hash,
 		child_info: &ChildInfo,
 		key: &StorageKey,
 	) -> sp_blockchain::Result<Option<StorageData>> {
@@ -502,14 +505,14 @@ impl sc_client_api::StorageProvider<Block, crate::FullBackend> for Client {
 			self,
 			client,
 			{
-				client.child_storage(id, child_info, key)
+				client.child_storage(hash, child_info, key)
 			}
 		}
 	}
 
 	fn child_storage_keys(
 		&self,
-		id: &BlockId<Block>,
+		hash: &<Block as BlockT>::Hash,
 		child_info: &ChildInfo,
 		key_prefix: &StorageKey,
 	) -> sp_blockchain::Result<Vec<StorageKey>> {
@@ -517,14 +520,14 @@ impl sc_client_api::StorageProvider<Block, crate::FullBackend> for Client {
 			self,
 			client,
 			{
-				client.child_storage_keys(id, child_info, key_prefix)
+				client.child_storage_keys(hash, child_info, key_prefix)
 			}
 		}
 	}
 
 	fn child_storage_keys_iter<'a>(
 		&self,
-		id: &BlockId<Block>,
+		hash: &<Block as BlockT>::Hash,
 		child_info: ChildInfo,
 		prefix: Option<&'a StorageKey>,
 		start_key: Option<&StorageKey>,
@@ -535,14 +538,14 @@ impl sc_client_api::StorageProvider<Block, crate::FullBackend> for Client {
 			self,
 			client,
 			{
-				client.child_storage_keys_iter(id, child_info, prefix, start_key)
+				client.child_storage_keys_iter(hash, child_info, prefix, start_key)
 			}
 		}
 	}
 
 	fn child_storage_hash(
 		&self,
-		id: &BlockId<Block>,
+		hash: &<Block as BlockT>::Hash,
 		child_info: &ChildInfo,
 		key: &StorageKey,
 	) -> sp_blockchain::Result<Option<<Block as BlockT>::Hash>> {
@@ -550,7 +553,7 @@ impl sc_client_api::StorageProvider<Block, crate::FullBackend> for Client {
 			self,
 			client,
 			{
-				client.child_storage_hash(id, child_info, key)
+				client.child_storage_hash(hash, child_info, key)
 			}
 		}
 	}


### PR DESCRIPTION
It changes the arguments of `Backend::StorageProvider` trait from:
block: `BlockId<Block>` to: hash: `&Block::Hash`


Companion for: paritytech/substrate#12510
cumulus companion: paritytech/cumulus#1770
