### PR TITLE
backing: introduce seconding check request

### DIFF
--- a/node/core/backing/src/lib.rs
+++ b/node/core/backing/src/lib.rs
@@ -1264,6 +1264,11 @@ async fn handle_seconding_check_message<Context>(
 		)
 		.await;
 
+		// If seconding sanity check doesn't pass now, fetching collation
+		// is pointless as it will also fail once candidate validation concludes.
+		// However, the response may happen to be empty: this means that the
+		// parent node-candidate has not been seconded yet. This is OK,
+		// the request will be kept in memory.
 		match result {
 			SecondingAllowed::No => {
 				let _ = tx.send(false);

--- a/node/core/backing/src/lib.rs
+++ b/node/core/backing/src/lib.rs
@@ -994,12 +994,22 @@ async fn handle_active_leaves_update<Context>(
 
 					match result {
 						SecondingAllowed::No => {
-							// unreachable: the request wasn't rejected previously
-							// when received, it's not expected to have any possible
-							// membership in known fragment trees. Once there appears
-							// at least one, request is removed from the memory.
-							// Thus, we couldn't have seconded candidate with the same
-							// fragment tree membership prior to this activation.
+							// This branch is unreachable for both known leaves and
+							// an activated one:
+							// 1. The request wasn't rejected previously when received.
+							// Therefore, there was no conflicting entry in known active leaves.
+							//
+							// 2. If a validator learned about new backed candidate which made
+							// a fragment tree membership clear, the request would've already left the memory.
+							// Hence, no conflicting entry exists in known active leaves at the
+							// moment of new activation.
+							//
+							// 3. A single new leaf is imported, which **may** make fragment tree membership clear.
+							// Prospective parachains only learns about new candidates from backing, this leaf
+							// cannot introduce conflicting entry ((2) still holds).
+							//
+							// 4. Either it has a possible membership in the fragment tree (respond with true)
+							// or it does not (membership is empty and precondition at (2) holds).
 						},
 						SecondingAllowed::Yes(membership) =>
 							if membership.iter().any(|(_, m)| !m.is_empty()) {

--- a/node/core/backing/src/tests/mod.rs
+++ b/node/core/backing/src/tests/mod.rs
@@ -212,7 +212,7 @@ impl TestCandidateBuilder {
 				erasure_root: self.erasure_root,
 				collator: dummy_collator(),
 				signature: dummy_collator_signature(),
-				para_head: dummy_hash(),
+				para_head: self.head_data.hash(),
 				validation_code_hash: ValidationCode(self.validation_code).hash(),
 				persisted_validation_data_hash: self.persisted_validation_data_hash,
 			},

--- a/node/core/prospective-parachains/src/lib.rs
+++ b/node/core/prospective-parachains/src/lib.rs
@@ -42,7 +42,7 @@ use polkadot_node_subsystem::{
 use polkadot_node_subsystem_util::inclusion_emulator::staging::{Constraints, RelayChainBlockInfo};
 use polkadot_primitives::vstaging::{
 	BlockNumber, CandidateHash, CommittedCandidateReceipt, CoreState, Hash, Id as ParaId,
-	PersistedValidationData,
+	PersistedValidationData, MAX_CANDIDATE_DEPTH,
 };
 
 use crate::{
@@ -55,16 +55,8 @@ mod fragment_tree;
 
 const LOG_TARGET: &str = "parachain::prospective-parachains";
 
-// The maximum depth the subsystem will allow. 'depth' is defined as the
-// amount of blocks between the para head in a relay-chain block's state
-// and a candidate with a particular relay-parent.
-//
-// This value is chosen mostly for reasons of resource-limitation.
-// Without it, a malicious validator group could create arbitrarily long,
-// useless prospective parachains and DoS honest nodes.
-const MAX_DEPTH: usize = 4;
-
 // The maximum ancestry we support.
+// TODO: fetch from the Runtime (https://github.com/paritytech/polkadot/issues/6163).
 const MAX_ANCESTRY: usize = 5;
 
 struct RelayBlockViewData {
@@ -215,7 +207,7 @@ async fn handle_active_leaves_update<Context>(
 				para,
 				block_info.clone(),
 				constraints,
-				MAX_DEPTH,
+				MAX_CANDIDATE_DEPTH,
 				ancestry.iter().cloned(),
 			)
 			.expect("ancestors are provided in reverse order and correctly; qed");

--- a/node/core/prospective-parachains/src/lib.rs
+++ b/node/core/prospective-parachains/src/lib.rs
@@ -31,6 +31,7 @@ use std::collections::{HashMap, HashSet};
 
 use futures::{channel::oneshot, prelude::*};
 
+use polkadot_node_primitives::MAX_CANDIDATE_DEPTH;
 use polkadot_node_subsystem::{
 	messages::{
 		ChainApiMessage, FragmentTreeMembership, HypotheticalDepthRequest,
@@ -42,7 +43,7 @@ use polkadot_node_subsystem::{
 use polkadot_node_subsystem_util::inclusion_emulator::staging::{Constraints, RelayChainBlockInfo};
 use polkadot_primitives::vstaging::{
 	BlockNumber, CandidateHash, CommittedCandidateReceipt, CoreState, Hash, Id as ParaId,
-	PersistedValidationData, MAX_CANDIDATE_DEPTH,
+	PersistedValidationData,
 };
 
 use crate::{

--- a/node/network/collator-protocol/src/collator_side/mod.rs
+++ b/node/network/collator-protocol/src/collator_side/mod.rs
@@ -36,7 +36,7 @@ use polkadot_node_network_protocol::{
 	v1 as protocol_v1, vstaging as protocol_vstaging, OurView, PeerId,
 	UnifiedReputationChange as Rep, Versioned, View,
 };
-use polkadot_node_primitives::{CollationSecondedSignal, PoV, Statement};
+use polkadot_node_primitives::{CollationSecondedSignal, PoV, Statement, MAX_CANDIDATE_DEPTH};
 use polkadot_node_subsystem::{
 	jaeger,
 	messages::{
@@ -54,9 +54,7 @@ use polkadot_primitives::v2::{
 	GroupIndex, Hash, Id as ParaId, SessionIndex,
 };
 
-use super::{
-	prospective_parachains_mode, ProspectiveParachainsMode, LOG_TARGET, MAX_CANDIDATE_DEPTH,
-};
+use super::{prospective_parachains_mode, ProspectiveParachainsMode, LOG_TARGET};
 use crate::{
 	error::{log_error, Error, FatalError, Result},
 	modify_reputation,

--- a/node/network/collator-protocol/src/lib.rs
+++ b/node/network/collator-protocol/src/lib.rs
@@ -49,15 +49,6 @@ mod validator_side;
 
 const LOG_TARGET: &'static str = "parachain::collator-protocol";
 
-/// The maximum depth a candidate can occupy for any relay parent.
-/// 'depth' is defined as the amount of blocks between the para
-/// head in a relay-chain block's state and a candidate with a
-/// particular relay-parent.
-///
-/// This value is only used for limiting the number of candidates
-/// we accept and distribute per relay parent.
-const MAX_CANDIDATE_DEPTH: usize = 4;
-
 /// A collator eviction policy - how fast to evict collators which are inactive.
 #[derive(Debug, Clone, Copy)]
 pub struct CollatorEvictionPolicy {

--- a/node/network/collator-protocol/src/validator_side/collation.rs
+++ b/node/network/collator-protocol/src/validator_side/collation.rs
@@ -31,12 +31,12 @@ use futures::channel::oneshot;
 use std::collections::VecDeque;
 
 use polkadot_node_network_protocol::PeerId;
-use polkadot_node_primitives::PoV;
+use polkadot_node_primitives::{PoV, MAX_CANDIDATE_DEPTH};
 use polkadot_primitives::v2::{
 	CandidateHash, CandidateReceipt, CollatorId, Hash, Id as ParaId, PersistedValidationData,
 };
 
-use crate::{error::SecondingError, ProspectiveParachainsMode, LOG_TARGET, MAX_CANDIDATE_DEPTH};
+use crate::{error::SecondingError, ProspectiveParachainsMode, LOG_TARGET};
 
 /// Candidate supplied with a para head it's built on top of.
 #[derive(Debug, Copy, Clone, Hash, Eq, PartialEq)]

--- a/node/network/collator-protocol/src/validator_side/mod.rs
+++ b/node/network/collator-protocol/src/validator_side/mod.rs
@@ -977,13 +977,12 @@ where
 			None
 		},
 		(ProspectiveParachainsMode::Enabled, Some((candidate_hash, parent_head_data_hash))) =>
-			SecondingCheckRequest {
+			Some(SecondingCheckRequest {
 				candidate_para_id: collator_para_id,
 				candidate_relay_parent: relay_parent,
 				candidate_hash,
 				parent_head_data_hash,
-			}
-			.into(),
+			}),
 		_ => return Err(AdvertisementError::ProtocolMismatch),
 	};
 
@@ -1522,7 +1521,7 @@ pub(crate) async fn run<Context>(
 					Some(response) => response,
 					None => {
 						// Most likely the parent went out of view.
-						gum::debug!(
+						gum::trace!(
 							target: LOG_TARGET,
 							relay_parent = ?request.candidate_relay_parent,
 							candidate_hash = ?request.candidate_hash,

--- a/node/network/collator-protocol/src/validator_side/mod.rs
+++ b/node/network/collator-protocol/src/validator_side/mod.rs
@@ -44,7 +44,7 @@ use polkadot_node_network_protocol::{
 	v1 as protocol_v1, vstaging as protocol_vstaging, OurView, PeerId,
 	UnifiedReputationChange as Rep, Versioned, View,
 };
-use polkadot_node_primitives::{PoV, SignedFullStatement, Statement};
+use polkadot_node_primitives::{PoV, SignedFullStatement, Statement, MAX_CANDIDATE_DEPTH};
 use polkadot_node_subsystem::{
 	jaeger,
 	messages::{
@@ -65,7 +65,7 @@ use crate::error::{Error, FetchError, Result, SecondingError};
 
 use super::{
 	modify_reputation, prospective_parachains_mode, tick_stream, ProspectiveParachainsMode,
-	LOG_TARGET, MAX_CANDIDATE_DEPTH,
+	LOG_TARGET,
 };
 
 mod collation;

--- a/node/network/collator-protocol/src/validator_side/mod.rs
+++ b/node/network/collator-protocol/src/validator_side/mod.rs
@@ -1005,6 +1005,7 @@ where
 	if let Some(request) = seconding_check_request {
 		let collator_id = collator_id.clone();
 		let (tx, rx) = oneshot::channel();
+		// Don't request collation until the check resolves.
 		sender
 			.send_message(CandidateBackingMessage::AdvertisementSecondingCheck { request, tx })
 			.await;
@@ -1019,7 +1020,6 @@ where
 			}
 			.boxed(),
 		);
-	// Don't request collation until the check resolves.
 	} else {
 		let result = enqueue_collation(
 			sender,

--- a/node/network/collator-protocol/src/validator_side/tests/mod.rs
+++ b/node/network/collator-protocol/src/validator_side/tests/mod.rs
@@ -20,7 +20,7 @@ use futures::{executor, future, Future};
 use sp_core::{crypto::Pair, Encode};
 use sp_keyring::Sr25519Keyring;
 use sp_keystore::{testing::KeyStore as TestKeyStore, SyncCryptoStore};
-use std::{iter, sync::Arc, task::Poll, time::Duration};
+use std::{iter, sync::Arc, time::Duration};
 
 use polkadot_node_network_protocol::{
 	our_view,
@@ -752,7 +752,7 @@ fn fetch_one_collation_at_a_time() {
 		test_helpers::Yield::new().await;
 
 		// Second collation is not requested since there's already seconded one.
-		assert_matches!(futures::poll!(virtual_overseer.recv().boxed()), Poll::Pending);
+		assert_matches!(virtual_overseer.recv().now_or_never(), None);
 
 		virtual_overseer
 	})

--- a/node/network/collator-protocol/src/validator_side/tests/prospective_parachains.rs
+++ b/node/network/collator-protocol/src/validator_side/tests/prospective_parachains.rs
@@ -272,7 +272,7 @@ fn v1_advertisement_rejected() {
 
 		// Not reported.
 		test_helpers::Yield::new().await;
-		assert_matches!(futures::poll!(virtual_overseer.recv().boxed()), Poll::Pending);
+		assert_matches!(virtual_overseer.recv().now_or_never(), None);
 
 		virtual_overseer
 	});
@@ -528,7 +528,7 @@ fn second_multiple_candidates_per_relay_parent() {
 		.await;
 
 		test_helpers::Yield::new().await;
-		assert_matches!(futures::poll!(virtual_overseer.recv().boxed()), Poll::Pending);
+		assert_matches!(virtual_overseer.recv().now_or_never(), None);
 
 		virtual_overseer
 	});
@@ -661,8 +661,6 @@ fn seconding_check_failed() {
 		update_view(&mut virtual_overseer, &test_state, vec![(head_b, head_b_num)], 1).await;
 
 		let peer_a = PeerId::random();
-
-		// Accept both collators from the implicit view.
 		connect_and_declare_collator(
 			&mut virtual_overseer,
 			peer_a,
@@ -697,7 +695,7 @@ fn seconding_check_failed() {
 
 		// Collation request is discarded.
 		test_helpers::Yield::new().await;
-		assert_matches!(futures::poll!(virtual_overseer.recv().boxed()), Poll::Pending);
+		assert_matches!(virtual_overseer.recv().now_or_never(), None);
 
 		virtual_overseer
 	});
@@ -721,8 +719,6 @@ fn advertisement_spam_protection() {
 		update_view(&mut virtual_overseer, &test_state, vec![(head_b, head_b_num)], 1).await;
 
 		let peer_a = PeerId::random();
-
-		// Accept both collators from the implicit view.
 		connect_and_declare_collator(
 			&mut virtual_overseer,
 			peer_a,

--- a/node/primitives/src/lib.rs
+++ b/node/primitives/src/lib.rs
@@ -51,6 +51,17 @@ pub use disputes::{
 	ValidDisputeVote, ACTIVE_DURATION_SECS,
 };
 
+/// The maximum depth of a parachain candidate. 'depth' is defined as the
+/// amount of blocks between the para head in a relay-chain block's state
+/// and a candidate with a particular relay-parent. When async backing is
+/// disabled, the only possible depth is 0 and this constant should be ignored.
+///
+/// This value is chosen mostly for reasons of resource-limitation.
+/// Without it, a malicious validator group could create arbitrarily long,
+/// useless prospective parachains and DoS honest nodes.
+// TODO: fetch from the Runtime (https://github.com/paritytech/polkadot/issues/6163).
+pub const MAX_CANDIDATE_DEPTH: usize = 4;
+
 // For a 16-ary Merkle Prefix Trie, we can expect at most 16 32-byte hashes per node
 // plus some overhead:
 // header 1 + bitmap 2 + max partial_key 8 + children 16 * (32 + len 1) + value 32 + value len 1

--- a/node/subsystem-types/src/messages.rs
+++ b/node/subsystem-types/src/messages.rs
@@ -100,7 +100,7 @@ pub enum CandidateBackingMessage {
 		/// Response sender. The receiving side should not be blocked on
 		/// since it can take up some time until the candidate is ready
 		/// to be seconded, if ever. Rather works as a subscribe-notify channel.
-		sender: oneshot::Sender<bool>,
+		tx: oneshot::Sender<bool>,
 	},
 	/// Note that the Candidate Backing subsystem should second the given candidate in the context of the
 	/// given relay-parent (ref. by hash). This candidate must be validated.

--- a/node/subsystem-types/src/messages.rs
+++ b/node/subsystem-types/src/messages.rs
@@ -61,12 +61,6 @@ use std::{
 pub mod network_bridge_event;
 pub use network_bridge_event::NetworkBridgeEvent;
 
-/// Subsystem messages where each message is always bound to a relay parent.
-pub trait BoundToRelayParent {
-	/// Returns the relay parent this message is bound to.
-	fn relay_parent(&self) -> Hash;
-}
-
 /// A request to the candidate backing subsystem to check whether
 /// it's correct to fetch and start seconding a candidate.
 #[derive(Debug, Copy, Clone)]
@@ -108,17 +102,6 @@ pub enum CandidateBackingMessage {
 	/// Note a validator's statement about a particular candidate.
 	/// Agreements are simply tallied until a quorum is reached.
 	Statement(Hash, SignedFullStatementWithPVD),
-}
-
-impl BoundToRelayParent for CandidateBackingMessage {
-	fn relay_parent(&self) -> Hash {
-		match self {
-			Self::GetBackedCandidates(hash, _, _) => *hash,
-			Self::AdvertisementSecondingCheck { request, .. } => request.candidate_relay_parent,
-			Self::Second(hash, _, _, _) => *hash,
-			Self::Statement(hash, _) => *hash,
-		}
-	}
 }
 
 /// Blanket error for validation failing for internal reasons.
@@ -254,12 +237,6 @@ pub enum CollatorProtocolMessage {
 impl Default for CollatorProtocolMessage {
 	fn default() -> Self {
 		Self::CollateOn(Default::default())
-	}
-}
-
-impl BoundToRelayParent for CollatorProtocolMessage {
-	fn relay_parent(&self) -> Hash {
-		Default::default()
 	}
 }
 
@@ -517,12 +494,6 @@ impl BitfieldDistributionMessage {
 /// Currently non-instantiable.
 #[derive(Debug)]
 pub enum BitfieldSigningMessage {}
-
-impl BoundToRelayParent for BitfieldSigningMessage {
-	fn relay_parent(&self) -> Hash {
-		match *self {}
-	}
-}
 
 /// Availability store subsystem message.
 #[derive(Debug)]
@@ -821,15 +792,6 @@ pub enum ProvisionerMessage {
 	RequestInherentData(Hash, oneshot::Sender<ProvisionerInherentData>),
 	/// This data should become part of a relay chain block
 	ProvisionableData(Hash, ProvisionableData),
-}
-
-impl BoundToRelayParent for ProvisionerMessage {
-	fn relay_parent(&self) -> Hash {
-		match self {
-			Self::RequestInherentData(hash, _) => *hash,
-			Self::ProvisionableData(hash, _) => *hash,
-		}
-	}
 }
 
 /// Message to the Collation Generation subsystem.

--- a/node/subsystem-types/src/messages.rs
+++ b/node/subsystem-types/src/messages.rs
@@ -62,7 +62,7 @@ pub mod network_bridge_event;
 pub use network_bridge_event::NetworkBridgeEvent;
 
 /// A request to the candidate backing subsystem to check whether
-/// it's correct to fetch and start seconding a candidate.
+/// there exists vacant membership in some fragment tree.
 #[derive(Debug, Copy, Clone)]
 pub struct SecondingCheckRequest {
 	/// Para id of the candidate.
@@ -87,7 +87,10 @@ pub enum CandidateBackingMessage {
 	/// seconded candidate.
 	///
 	/// Returns false immediately if there exists an already-occupied depth in some fragment
-	/// tree for this candidate. Otherwise, notifies back when the parent node is seconded.
+	/// tree for this candidate. Otherwise, notifies back if the parent node is seconded.
+	///
+	/// The sender will be dropped with no response if candidate relay parent leaves the implicit
+	/// view or async backing is disabled.
 	AdvertisementSecondingCheck {
 		/// Request parameters.
 		request: SecondingCheckRequest,

--- a/node/subsystem-types/src/messages.rs
+++ b/node/subsystem-types/src/messages.rs
@@ -114,7 +114,7 @@ impl BoundToRelayParent for CandidateBackingMessage {
 	fn relay_parent(&self) -> Hash {
 		match self {
 			Self::GetBackedCandidates(hash, _, _) => *hash,
-			Self::SecondingCheck { request, .. } => request.candidate_relay_parent,
+			Self::AdvertisementSecondingCheck { request, .. } => request.candidate_relay_parent,
 			Self::Second(hash, _, _, _) => *hash,
 			Self::Statement(hash, _) => *hash,
 		}


### PR DESCRIPTION
Fixes https://github.com/paritytech/polkadot/issues/5923

Note that collators remove validators from the reserved peerset within 6 seconds after advertising a collation and update it at least once every 12 seconds.
We may want to increase some of these timeouts cause of this PR.