### PR TITLE
Make some fixes to logging in PVF subsystem

### DIFF
--- a/node/core/pvf/src/execute/queue.rs
+++ b/node/core/pvf/src/execute/queue.rs
@@ -244,12 +244,12 @@ fn handle_job_finish(
 	};
 
 	queue.metrics.execute_finished();
-	gum::trace!(
+	gum::debug!(
 		target: LOG_TARGET,
 		validation_code_hash = ?artifact_id.code_hash,
+		?worker,
 		worker_rip = idle_worker.is_none(),
-		?result,
-		"job finished.",
+		"execute worker concluded",
 	);
 
 	// First we send the result. It may fail due the other end of the channel being dropped, that's

--- a/node/core/pvf/src/execute/queue.rs
+++ b/node/core/pvf/src/execute/queue.rs
@@ -244,7 +244,7 @@ fn handle_job_finish(
 	};
 
 	queue.metrics.execute_finished();
-	gum::debug!(
+	gum::trace!(
 		target: LOG_TARGET,
 		validation_code_hash = ?artifact_id.code_hash,
 		worker_rip = idle_worker.is_none(),

--- a/node/core/pvf/src/executor_intf.rs
+++ b/node/core/pvf/src/executor_intf.rs
@@ -129,7 +129,7 @@ impl Executor {
 		// 2. It cannot and does not limit the stack space consumed by Rust code.
 		//
 		//    Meaning that if the wasm code leaves no stack space for Rust code, then the Rust code
-		//    and that will abort the process as well.
+		//    will abort and that will abort the process as well.
 		//
 		// Typically on Linux the main thread gets the stack size specified by the `ulimit` and
 		// typically it's configured to 8 MiB. Rust's spawned threads are 2 MiB. OTOH, the


### PR DESCRIPTION
# PULL REQUEST

## Overview

Tackled some simpler issues relating to logging in the PVF subsystem.

I made the trace log for execute worker conclusion match the one for prepare worker conclusion. Trace log for conclusion of prepare job:

```rs
gum::debug!(
	target: LOG_TARGET,
	validation_code_hash = ?artifact_id.code_hash,
	?worker,
	?rip,
	"prepare worker concluded",
);
```

## Issues Closed

Closes #3599
Closes #4216