### PR TITLE
Add missing prerequisite in README for implementers guide

### DIFF
--- a/roadmap/implementers-guide/README.md
+++ b/roadmap/implementers-guide/README.md
@@ -12,7 +12,7 @@ sudo apt-get install graphviz # for Ubuntu/Debian
 Then install and build the book:
 
 ```sh
-cargo install mdbook mdbook-linkcheck mdbook-graphviz
+cargo install mdbook mdbook-linkcheck mdbook-graphviz mdbook-mermaid
 mdbook serve roadmap/implementers-guide
 open http://localhost:3000
 ```


### PR DESCRIPTION
NOTE: This is already present in the implementers-guide CI job.