### PR TITLE
backing: don't send backed candidate to provisioner if async backing is enabled

### DIFF
--- a/node/core/backing/src/lib.rs
+++ b/node/core/backing/src/lib.rs
@@ -1525,18 +1525,18 @@ async fn import_statement<Context>(
 						candidate_hash,
 					))
 					.await;
+				} else {
+					// The provisioner waits on candidate-backing, which means
+					// that we need to send unbounded messages to avoid cycles.
+					//
+					// Backed candidates are bounded by the number of validators,
+					// parachains, and the block production rate of the relay chain.
+					let message = ProvisionerMessage::ProvisionableData(
+						rp_state.parent,
+						ProvisionableData::BackedCandidate(backed.receipt()),
+					);
+					ctx.send_unbounded_message(message);
 				}
-
-				// The provisioner waits on candidate-backing, which means
-				// that we need to send unbounded messages to avoid cycles.
-				//
-				// Backed candidates are bounded by the number of validators,
-				// parachains, and the block production rate of the relay chain.
-				let message = ProvisionerMessage::ProvisionableData(
-					rp_state.parent,
-					ProvisionableData::BackedCandidate(backed.receipt()),
-				);
-				ctx.send_unbounded_message(message);
 			}
 		}
 	}

--- a/node/core/backing/src/tests/prospective_parachains.rs
+++ b/node/core/backing/src/tests/prospective_parachains.rs
@@ -1046,18 +1046,6 @@ fn backing_works() {
 
 		assert_matches!(
 			virtual_overseer.recv().await,
-			AllMessages::Provisioner(
-				ProvisionerMessage::ProvisionableData(
-					_,
-					ProvisionableData::BackedCandidate(candidate_receipt)
-				)
-			) => {
-				assert_eq!(candidate_receipt, candidate_a.to_plain());
-			}
-		);
-
-		assert_matches!(
-			virtual_overseer.recv().await,
 			AllMessages::StatementDistribution(
 				StatementDistributionMessage::Share(hash, _stmt)
 			) => {
@@ -1267,7 +1255,6 @@ fn concurrent_dependent_candidates() {
 				AllMessages::ProspectiveParachains(
 					ProspectiveParachainsMessage::CandidateBacked(..),
 				) => {},
-				AllMessages::Provisioner(ProvisionerMessage::ProvisionableData(..)) => {},
 				AllMessages::StatementDistribution(StatementDistributionMessage::Share(
 					_,
 					statement,


### PR DESCRIPTION
The provisioner will discard it anyways and collect it from prospective parachains