### PR TITLE
Retry failed PVF prepare jobs

### DIFF
--- a/node/core/pvf/src/artifacts.rs
+++ b/node/core/pvf/src/artifacts.rs
@@ -103,10 +103,22 @@ pub enum ArtifactState {
 		last_time_needed: SystemTime,
 	},
 	/// A task to prepare this artifact is scheduled.
-	Preparing { waiting_for_response: Vec<PrepareResultSender> },
+	Preparing {
+		/// List of result senders that are waiting for a response.
+		waiting_for_response: Vec<PrepareResultSender>,
+		/// The number of times this artifact has failed to prepare.
+		num_failures: u32,
+	},
 	/// The code couldn't be compiled due to an error. Such artifacts
 	/// never reach the executor and stay in the host's memory.
-	FailedToProcess(PrepareError),
+	FailedToProcess {
+		/// Keep track of the last time that processing this artifact failed.
+		last_time_failed: SystemTime,
+		/// The number of times this artifact has failed to prepare.
+		num_failures: u32,
+		/// The prepare error.
+		error: PrepareError,
+	},
 }
 
 /// A container of all known artifact ids and their states.
@@ -150,7 +162,7 @@ impl Artifacts {
 		// See the precondition.
 		always!(self
 			.artifacts
-			.insert(artifact_id, ArtifactState::Preparing { waiting_for_response })
+			.insert(artifact_id, ArtifactState::Preparing { waiting_for_response, num_failures: 0 })
 			.is_none());
 	}
 

--- a/node/core/pvf/src/artifacts.rs
+++ b/node/core/pvf/src/artifacts.rs
@@ -116,7 +116,7 @@ pub enum ArtifactState {
 		last_time_failed: SystemTime,
 		/// The number of times this artifact has failed to prepare.
 		num_failures: u32,
-		/// The prepare error.
+		/// The last error encountered for preparation.
 		error: PrepareError,
 	},
 }


### PR DESCRIPTION
# PULL REQUEST

## Overview

- Keep track of the time of failure and the number of failures.
- If we get a request to prepare a PVF, retry if:
  - Enough time has elapsed since a failure, and
  - The number of failures is not greater than `NUM_PREPARE_RETRIES`

### TODO

- [x] How to test this?

## Issues closed

Closes #4288