### PR TITLE
[ZombieNet] fix upgrade node test, use latest as base image

### DIFF
--- a/scripts/ci/gitlab/pipeline/zombienet.yml
+++ b/scripts/ci/gitlab/pipeline/zombienet.yml
@@ -202,8 +202,7 @@ zombienet-tests-misc-upgrade-node:
     - echo "${PARACHAINS_IMAGE_NAME} ${PARACHAINS_IMAGE_TAG}"
     - echo "${GH_DIR}"
     - export DEBUG=zombie,zombie::network-node
-    - BUILD_RELEASE_VERSION="$(cat ./artifacts/BUILD_RELEASE_VERSION)"
-    - export ZOMBIENET_INTEGRATION_TEST_IMAGE="docker.io/parity/polkadot:${BUILD_RELEASE_VERSION}"
+    - export ZOMBIENET_INTEGRATION_TEST_IMAGE="docker.io/parity/polkadot:latest"
     - export COL_IMAGE=${COLLATOR_IMAGE_NAME}:${COLLATOR_IMAGE_TAG}
     - BUILD_LINUX_JOB_ID="$(cat ./artifacts/BUILD_LINUX_JOB_ID)"
     - export POLKADOT_PR_BIN_URL="https://gitlab.parity.io/parity/mirrors/polkadot/-/jobs/${BUILD_LINUX_JOB_ID}/artifacts/raw/artifacts/polkadot"


### PR DESCRIPTION
Fix `zombienet-tests-misc-upgrade-node` to use the `latest` image available in docker hub as base for the upgrade test. This will prevent failures in the test when the version in master is already bumped but not released (as currently with 0.9.31).
Thanks!