### PR TITLE
Add a `last change` footer to the implementers guide

### DIFF
--- a/roadmap/implementers-guide/README.md
+++ b/roadmap/implementers-guide/README.md
@@ -4,13 +4,14 @@ The implementers' guide is compiled from several source files with [`mdBook`](ht
 
 ## Hosted build
 
-This is avalible at https://paritytech.github.io/polkadot/book/
+This is available [here](https://paritytech.github.io/polkadot/book/).
 
 ## Local build
 
 To view it locally from the repo root:
 
 Ensure graphviz is installed:
+
 ```sh
 brew install graphviz # for macOS
 sudo apt-get install graphviz # for Ubuntu/Debian
@@ -26,4 +27,4 @@ open http://localhost:3000
 
 ## Specification
 
-See also the Polkadot specificaton [hosted](https://spec.polkadot.network/), and it's [source](https://github.com/w3f/polkadot-spec)).
+See also the Polkadot specification [hosted](https://spec.polkadot.network/), and its [source](https://github.com/w3f/polkadot-spec).

--- a/roadmap/implementers-guide/README.md
+++ b/roadmap/implementers-guide/README.md
@@ -19,9 +19,7 @@ sudo apt-get install graphviz # for Ubuntu/Debian
 Then install and build the book:
 
 ```sh
-cargo install mdbook mdbook-linkcheck mdbook-graphviz mdbook-mermaid
-# This plugin is not available on crates.io yet.
-cargo install --git https://github.com/badboy/mdbook-last-changed/ --rev 2448157
+cargo install mdbook mdbook-linkcheck mdbook-graphviz mdbook-mermaid mdbook-last-changed
 mdbook serve roadmap/implementers-guide
 open http://localhost:3000
 ```

--- a/roadmap/implementers-guide/README.md
+++ b/roadmap/implementers-guide/README.md
@@ -20,6 +20,8 @@ Then install and build the book:
 
 ```sh
 cargo install mdbook mdbook-linkcheck mdbook-graphviz mdbook-mermaid
+# This plugin is not available on crates.io yet.
+cargo install --git https://github.com/badboy/mdbook-last-changed/ --rev 2448157
 mdbook serve roadmap/implementers-guide
 open http://localhost:3000
 ```

--- a/roadmap/implementers-guide/book.toml
+++ b/roadmap/implementers-guide/book.toml
@@ -9,8 +9,14 @@ title = "The Polkadot Parachain Host Implementers' Guide"
 command = "mdbook-graphviz"
 [preprocessor.mermaid]
 command = "mdbook-mermaid"
+[preprocessor.last-changed]
+command = "mdbook-last-changed"
+renderer = ["html"]
 
 [output.html]
+additional-css = ["last-changed.css"]
 additional-js = ["mermaid.min.js", "mermaid-init.js"]
+# Repository URL used in the last-changed link.
+git-repository-url = "https://github.com/paritytech/polkadot"
 
 [output.linkcheck]

--- a/roadmap/implementers-guide/last-changed.css
+++ b/roadmap/implementers-guide/last-changed.css
@@ -1,0 +1,7 @@
+footer {
+    font-size: 0.8em;
+    text-align: center;
+    margin-top: 50px;
+    border-top: 1px solid black;
+    padding: 5px 0;
+}

--- a/scripts/ci/gitlab/pipeline/build.yml
+++ b/scripts/ci/gitlab/pipeline/build.yml
@@ -170,9 +170,7 @@ build-implementers-guide:
     - .collect-artifacts-short
   script:
     - apt-get -y update; apt-get install -y graphviz
-    - cargo install mdbook mdbook-mermaid mdbook-linkcheck mdbook-graphviz
-    # This plugin is not available on crates.io yet.
-    - cargo install --git https://github.com/badboy/mdbook-last-changed/ --rev 2448157
+    - cargo install mdbook mdbook-mermaid mdbook-linkcheck mdbook-graphviz mdbook-last-changed
     - mdbook build ./roadmap/implementers-guide
     - mkdir -p artifacts
     - mv roadmap/implementers-guide/book artifacts/

--- a/scripts/ci/gitlab/pipeline/build.yml
+++ b/scripts/ci/gitlab/pipeline/build.yml
@@ -171,6 +171,8 @@ build-implementers-guide:
   script:
     - apt-get -y update; apt-get install -y graphviz
     - cargo install mdbook mdbook-mermaid mdbook-linkcheck mdbook-graphviz
+    # This plugin is not available on crates.io yet.
+    - cargo install --git https://github.com/badboy/mdbook-last-changed/ --rev 2448157
     - mdbook build ./roadmap/implementers-guide
     - mkdir -p artifacts
     - mv roadmap/implementers-guide/book artifacts/


### PR DESCRIPTION
# PULL REQUEST

## Overview

Some of the newcomers were noticing outdated pages in the implementer's guide. This idea came up as a heuristic for how up-to-date an individual page is.

Credit: @alexgparity @eskimor 

## Visual Changes

<img width="1366" alt="Screen Shot 2022-10-30 at 15 21 22" src="https://user-images.githubusercontent.com/6035856/198883678-e14f27bd-47f1-418a-b27f-8b08cbe4eb6b.png">
