### PR TITLE
Increase max rewardable nominators

### DIFF
--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -573,7 +573,7 @@ parameter_types! {
 	pub const BondingDuration: sp_staking::EraIndex = 28;
 	// 27 eras in which slashes can be cancelled (slightly less than 7 days).
 	pub const SlashDeferDuration: sp_staking::EraIndex = 27;
-	pub const MaxNominatorRewardedPerValidator: u32 = 256;
+	pub const MaxNominatorRewardedPerValidator: u32 = 512;
 	pub const OffendingValidatorsThreshold: Perbill = Perbill::from_percent(17);
 	// 24
 	pub const MaxNominations: u32 = <NposCompactSolution24 as NposSolution>::LIMIT as u32;

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -525,7 +525,7 @@ parameter_types! {
 	pub const BondingDuration: sp_staking::EraIndex = 28;
 	pub const SlashDeferDuration: sp_staking::EraIndex = 27;
 	pub const RewardCurve: &'static PiecewiseLinear<'static> = &REWARD_CURVE;
-	pub const MaxNominatorRewardedPerValidator: u32 = 256;
+	pub const MaxNominatorRewardedPerValidator: u32 = 512;
 	pub const OffendingValidatorsThreshold: Perbill = Perbill::from_percent(17);
 	// 16
 	pub const MaxNominations: u32 = <NposCompactSolution16 as frame_election_provider_support::NposSolution>::LIMIT as u32;


### PR DESCRIPTION
With the recent release of nomination pools, I suggest increasing this number as well to take a big leap toward reducing the number of "inactive" nominators. Historically, we have introduced this parameter mainly to control the weight of the `payout_staker` transaction, but it was never intended for it to remain here for long. 

With the new config, we get: 

```
a full payout takes 0.10 of the block weight [196012912000 / 2000000000000]
```

This is a prelude to https://github.com/paritytech/substrate/pull/11935 which might take a while to complete, in which we aim to eradicate the notion of oversubscribed validators altogether, for the sake of simplicity, and have one fixed cap on maximum number of backers per validators.