### PR TITLE
Pipeline with ci image with rust 1.65

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,7 +32,7 @@ variables:
   GIT_STRATEGY:                    fetch
   GIT_DEPTH:                       100
   CI_SERVER_NAME:                  "GitLab CI"
-  CI_IMAGE:                        "paritytech/ci-linux:staging"
+  CI_IMAGE:                        "paritytech/ci-linux:production"
   DOCKER_OS:                       "debian:stretch"
   ARCH:                            "x86_64"
   ZOMBIENET_IMAGE:                 "docker.io/paritytech/zombienet:v1.2.78"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,7 +32,7 @@ variables:
   GIT_STRATEGY:                    fetch
   GIT_DEPTH:                       100
   CI_SERVER_NAME:                  "GitLab CI"
-  CI_IMAGE:                        "paritytech/ci-linux:production"
+  CI_IMAGE:                        "paritytech/ci-linux:staging"
   DOCKER_OS:                       "debian:stretch"
   ARCH:                            "x86_64"
   ZOMBIENET_IMAGE:                 "docker.io/paritytech/zombienet:v1.2.78"

--- a/node/core/runtime-api/src/tests.rs
+++ b/node/core/runtime-api/src/tests.rs
@@ -89,7 +89,7 @@ sp_api::mock_impl_runtime_apis! {
 		}
 
 		fn availability_cores(&self) -> Vec<CoreState> {
-			let _ = self.availability_cores_wait.lock().unwrap();
+			let _lock = self.availability_cores_wait.lock().unwrap();
 			self.availability_cores.clone()
 		}
 


### PR DESCRIPTION
In order to update rust in CI image tests should be fixed.
cc https://github.com/paritytech/ci_cd/issues/653

```bash
error: non-binding let on a synchronization lock
  --> node/core/runtime-api/src/tests.rs:92:8
   |
92 |             let _ = self.availability_cores_wait.lock().unwrap();
   |                 ^   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this binding will immediately drop the value assigned to it
   |                 |
   |                 this lock is not assigned to a binding and is immediately dropped
   |
   = note: `#[deny(let_underscore_lock)]` on by default
help: consider binding to an unused variable to avoid immediately dropping the value
   |
92 |             let _unused = self.availability_cores_wait.lock().unwrap();
   |                 ~~~~~~~
help: consider immediately dropping the value
   |
92 |             drop(self.availability_cores_wait.lock().unwrap());
   |             ~~~~~                                            +
error: could not compile `polkadot-node-core-runtime-api` due to previous error
```