### PR TITLE
[DNM] `approval-distribution`: process assignments and votes in parallel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5951,6 +5951,7 @@ version = "0.9.31"
 dependencies = [
  "assert_matches",
  "env_logger 0.9.0",
+ "fatality",
  "futures",
  "log",
  "polkadot-node-network-protocol",

--- a/node/network/approval-distribution/Cargo.toml
+++ b/node/network/approval-distribution/Cargo.toml
@@ -11,6 +11,7 @@ polkadot-node-subsystem = { path = "../../subsystem" }
 polkadot-node-subsystem-util = { path = "../../subsystem-util" }
 polkadot-primitives = { path = "../../../primitives" }
 rand = "0.8"
+fatality = "0.0.6"
 
 futures = "0.3.21"
 gum = { package = "tracing-gum", path = "../../gum" }

--- a/node/network/approval-distribution/src/error.rs
+++ b/node/network/approval-distribution/src/error.rs
@@ -17,9 +17,6 @@
 
 //! Error handling related code and Error/Result definitions.
 
-use crate::LOG_TARGET;
-use fatality::Nested;
-
 #[allow(missing_docs)]
 #[fatality::fatality(splitable)]
 pub enum Error {
@@ -27,20 +24,4 @@ pub enum Error {
 	PendingCheckCanceled,
 }
 
-pub type Result<T> = std::result::Result<T, Error>;
-
 pub type JfyiResult<T> = std::result::Result<T, JfyiError>;
-
-/// Utility for eating top level errors and log them.
-///
-/// We basically always want to try and continue on error. This utility function is meant to
-/// consume top-level errors by simply logging them.
-pub fn log_error(result: Result<()>) -> std::result::Result<(), FatalError> {
-	match result.into_nested()? {
-		Err(error @ JfyiError::PendingCheckCanceled) => {
-			gum::debug!(target: LOG_TARGET, error = ?error);
-			Ok(())
-		},
-		Ok(()) => Ok(()),
-	}
-}

--- a/node/network/approval-distribution/src/error.rs
+++ b/node/network/approval-distribution/src/error.rs
@@ -1,0 +1,46 @@
+// Copyright 2022 Parity Technologies (UK) Ltd.
+// This file is part of Polkadot.
+
+// Polkadot is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Polkadot is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+//! Error handling related code and Error/Result definitions.
+
+use crate::LOG_TARGET;
+use fatality::Nested;
+
+#[allow(missing_docs)]
+#[fatality::fatality(splitable)]
+pub enum Error {
+	#[error("Approval voting check canceled.")]
+	PendingCheckCanceled,
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+pub type JfyiResult<T> = std::result::Result<T, JfyiError>;
+
+/// Utility for eating top level errors and log them.
+///
+/// We basically always want to try and continue on error. This utility function is meant to
+/// consume top-level errors by simply logging them.
+pub fn log_error(result: Result<()>) -> std::result::Result<(), FatalError> {
+	match result.into_nested()? {
+		Err(error @ JfyiError::PendingCheckCanceled) => {
+			gum::debug!(target: LOG_TARGET, error = ?error);
+			Ok(())
+		},
+		Ok(()) => Ok(()),
+	}
+}

--- a/node/network/approval-distribution/src/lib.rs
+++ b/node/network/approval-distribution/src/lib.rs
@@ -966,10 +966,14 @@ impl State {
 		let message_subject = MessageSubject(block_hash, claimed_candidate_index, validator_index);
 		let message_kind = MessageKind::Assignment;
 
-		let entry = self
-			.blocks
-			.get_mut(&block_hash)
-			.expect("completion routine is executed only if block exists; qed");
+		let entry = self.blocks.get_mut(&block_hash);
+
+		if entry.is_none() {
+			// Block got finalized, bail out
+			return
+		}
+
+		let entry = entry.expect("Entry is Some, we just checked above; qed");
 
 		gum::trace!(
 			target: LOG_TARGET,
@@ -1284,10 +1288,14 @@ impl State {
 		let message_subject = MessageSubject(block_hash, candidate_index, validator_index);
 		let message_kind = MessageKind::Approval;
 
-		let entry = self
-			.blocks
-			.get_mut(&block_hash)
-			.expect("completion routine is executed only if block exists; qed");
+		let entry = self.blocks.get_mut(&block_hash);
+
+		if entry.is_none() {
+			// Block got finalized, bail out
+			return
+		}
+
+		let entry = entry.expect("Entry is Some, we just checked above; qed");
 
 		gum::trace!(
 			target: LOG_TARGET,

--- a/node/network/approval-distribution/src/lib.rs
+++ b/node/network/approval-distribution/src/lib.rs
@@ -1353,21 +1353,16 @@ impl State {
 						required_routing
 					},
 					Some(MessageState {
-						approval_state: ApprovalState::Approved(cert, signature),
-						required_routing,
-						local,
-						random_routing,
+						approval_state: ApprovalState::Approved(_cert, _signature),
+						required_routing: _,
+						local: _,
+						random_routing: _,
 					}) => {
 						// Approval has already been imported and distributed earlier, but it was from a different peer.
 						// No need to distribute it again.
 						// A `FuturesOrdered` also does the trick here, but if we do more parallelization in approval voting
 						// this case still might still need to be addressed as the ordering is screwed.
 						RequiredRouting::None
-					},
-					Some(_) => {
-						unreachable!(
-							"we only insert it after the metadata, checked the metadata above; qed"
-						);
 					},
 					None => {
 						// this would indicate a bug in approval-voting

--- a/node/network/approval-distribution/src/tests.rs
+++ b/node/network/approval-distribution/src/tests.rs
@@ -419,7 +419,6 @@ fn spam_attack_results_in_negative_reputation_change() {
 
 		for i in 0..candidates_count {
 			expect_reputation_change(overseer, peer, COST_UNEXPECTED_MESSAGE).await;
-
 			assert_matches!(
 				overseer_recv(overseer).await,
 				AllMessages::ApprovalVoting(ApprovalVotingMessage::CheckAndImportAssignment(
@@ -432,7 +431,9 @@ fn spam_attack_results_in_negative_reputation_change() {
 					tx.send(AssignmentCheckResult::Accepted).unwrap();
 				}
 			);
+		}
 
+		for _ in 0..candidates_count {
 			expect_reputation_change(overseer, peer, BENEFIT_VALID_MESSAGE_FIRST).await;
 		}
 


### PR DESCRIPTION
While figuring out which are our current performance bottlenecks, we identified `approval-distribution` as being the strongest one, see https://github.com/paritytech/polkadot/issues/5962.

This PR attempts to improve the performance of the subsystem, such that we clear up the bounded queue faster resulting in `approval-voting` never blocking when sending messages.  This is done by processing messages from different peers in parallel. The expectation is that this change will also drive the CPU usage higher as we expect both subsystems to churn through messages faster than before.

This is currently a draft to see how things improve at scale, but it will need some polishing, as well as spam protection rework.