### PR TITLE
BuyExecution refund in case of failure

### DIFF
--- a/xcm/xcm-executor/src/lib.rs
+++ b/xcm/xcm-executor/src/lib.rs
@@ -452,8 +452,12 @@ impl<Config: config::Config> XcmExecutor<Config> {
 					// pay for `weight` using up to `fees` of the holding register.
 					let max_fee =
 						self.holding.try_take(fees.into()).map_err(|_| XcmError::NotHoldingFees)?;
-					let unspent = self.trader.buy_weight(weight, max_fee)?;
-					self.holding.subsume_assets(unspent);
+
+					if let Ok(unspent) = self.trader.buy_weight(weight, max_fee.clone()) {
+						self.holding.subsume_assets(unspent);
+					} else {
+						self.holding.subsume_assets(max_fee);
+					}
 				}
 				Ok(())
 			},


### PR DESCRIPTION
In case when `XcmExecutor`'s processing of `BuyExecution` instruction fails at the point of `buy_weight`, the funds used to pay for the execution have already been taken from the holding register.

At the moment, they aren't returned back in the case of failure, causing the funds to simply be burned.
This is a bit unfortunate since it prevents _trapping_ of the funds. 

In a scenario where users loose funds due to an at this point, they cannot make use of `ClaimAsset` instruction to revert the damage.

This PR slightly changes how `BuyExecution` is processed.