### PR TITLE
[DNM] Allow to benchmark HRMP messages from the undying collator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11235,6 +11235,7 @@ dependencies = [
  "dlmalloc",
  "log",
  "parity-scale-codec",
+ "polkadot-core-primitives",
  "polkadot-parachain",
  "sp-io",
  "sp-std",
@@ -11246,12 +11247,14 @@ dependencies = [
 name = "test-parachain-undying-collator"
 version = "0.9.29"
 dependencies = [
+ "async-trait",
  "clap",
  "futures",
  "futures-timer",
  "log",
  "parity-scale-codec",
  "polkadot-cli",
+ "polkadot-client",
  "polkadot-node-core-pvf",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
@@ -11261,6 +11264,7 @@ dependencies = [
  "polkadot-test-service",
  "sc-cli",
  "sc-service",
+ "sp-api",
  "sp-core",
  "sp-keyring",
  "substrate-test-utils",

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -302,7 +302,7 @@ pub fn open_database(db_source: &DatabaseSource) -> Result<Arc<dyn Database>, Er
 			path.parent().ok_or(Error::DatabasePathRequired)?.into(),
 			parachains_db::CacheSizes::default(),
 		)?,
-		DatabaseSource::Auto { paritydb_path, rocksdb_path, .. } =>
+		DatabaseSource::Auto { paritydb_path, rocksdb_path, .. } => {
 			if paritydb_path.is_dir() && paritydb_path.exists() {
 				parachains_db::open_creating_paritydb(
 					paritydb_path.parent().ok_or(Error::DatabasePathRequired)?.into(),
@@ -313,7 +313,8 @@ pub fn open_database(db_source: &DatabaseSource) -> Result<Arc<dyn Database>, Er
 					rocksdb_path.clone(),
 					parachains_db::CacheSizes::default(),
 				)?
-			},
+			}
+		},
 		DatabaseSource::Custom { .. } => {
 			unimplemented!("No polkadot subsystem db for custom source.");
 		},
@@ -695,9 +696,9 @@ where
 
 			// Only consider leaves that are in maximum an uncle of the best block.
 			if number < best_block.number().saturating_sub(1) {
-				return None
+				return None;
 			} else if hash == best_block.hash() {
-				return None
+				return None;
 			};
 
 			let parent_hash = client.header(&BlockId::Hash(hash)).ok()??.parent_hash;
@@ -763,9 +764,9 @@ where
 	let backoff_authoring_blocks = {
 		let mut backoff = sc_consensus_slots::BackoffAuthoringOnFinalizedHeadLagging::default();
 
-		if config.chain_spec.is_rococo() ||
-			config.chain_spec.is_wococo() ||
-			config.chain_spec.is_versi()
+		if config.chain_spec.is_rococo()
+			|| config.chain_spec.is_wococo()
+			|| config.chain_spec.is_versi()
 		{
 			// it's a testnet that's in flux, finality has stalled sometimes due
 			// to operational issues and it's annoying to slow down block
@@ -777,10 +778,10 @@ where
 	};
 
 	// If not on a known test network, warn the user that BEEFY is still experimental.
-	if enable_beefy &&
-		!config.chain_spec.is_rococo() &&
-		!config.chain_spec.is_wococo() &&
-		!config.chain_spec.is_versi()
+	if enable_beefy
+		&& !config.chain_spec.is_rococo()
+		&& !config.chain_spec.is_wococo()
+		&& !config.chain_spec.is_versi()
 	{
 		gum::warn!("BEEFY is still experimental, usage on a production network is discouraged.");
 	}
@@ -1202,10 +1203,10 @@ where
 	// Reduce grandpa load on Kusama and test networks. This will slow down finality by
 	// approximately one slot duration, but will reduce load. We would like to see the impact on
 	// Kusama, see: https://github.com/paritytech/polkadot/issues/5464
-	let gossip_duration = if chain_spec.is_versi() ||
-		chain_spec.is_wococo() ||
-		chain_spec.is_rococo() ||
-		chain_spec.is_kusama()
+	let gossip_duration = if chain_spec.is_versi()
+		|| chain_spec.is_wococo()
+		|| chain_spec.is_rococo()
+		|| chain_spec.is_kusama()
 	{
 		Duration::from_millis(2000)
 	} else {
@@ -1328,26 +1329,26 @@ pub fn new_chain_ops(
 	let telemetry_worker_handle = None;
 
 	#[cfg(feature = "rococo-native")]
-	if config.chain_spec.is_rococo() ||
-		config.chain_spec.is_wococo() ||
-		config.chain_spec.is_versi()
+	if config.chain_spec.is_rococo()
+		|| config.chain_spec.is_wococo()
+		|| config.chain_spec.is_versi()
 	{
-		return chain_ops!(config, jaeger_agent, telemetry_worker_handle; rococo_runtime, RococoExecutorDispatch, Rococo)
+		return chain_ops!(config, jaeger_agent, telemetry_worker_handle; rococo_runtime, RococoExecutorDispatch, Rococo);
 	}
 
 	#[cfg(feature = "kusama-native")]
 	if config.chain_spec.is_kusama() {
-		return chain_ops!(config, jaeger_agent, telemetry_worker_handle; kusama_runtime, KusamaExecutorDispatch, Kusama)
+		return chain_ops!(config, jaeger_agent, telemetry_worker_handle; kusama_runtime, KusamaExecutorDispatch, Kusama);
 	}
 
 	#[cfg(feature = "westend-native")]
 	if config.chain_spec.is_westend() {
-		return chain_ops!(config, jaeger_agent, telemetry_worker_handle; westend_runtime, WestendExecutorDispatch, Westend)
+		return chain_ops!(config, jaeger_agent, telemetry_worker_handle; westend_runtime, WestendExecutorDispatch, Westend);
 	}
 
 	#[cfg(feature = "polkadot-native")]
 	{
-		return chain_ops!(config, jaeger_agent, telemetry_worker_handle; polkadot_runtime, PolkadotExecutorDispatch, Polkadot)
+		return chain_ops!(config, jaeger_agent, telemetry_worker_handle; polkadot_runtime, PolkadotExecutorDispatch, Polkadot);
 	}
 	#[cfg(not(feature = "polkadot-native"))]
 	Err(Error::NoRuntime)
@@ -1376,9 +1377,9 @@ pub fn build_full(
 	hwbench: Option<sc_sysinfo::HwBench>,
 ) -> Result<NewFull<Client>, Error> {
 	#[cfg(feature = "rococo-native")]
-	if config.chain_spec.is_rococo() ||
-		config.chain_spec.is_wococo() ||
-		config.chain_spec.is_versi()
+	if config.chain_spec.is_rococo()
+		|| config.chain_spec.is_wococo()
+		|| config.chain_spec.is_versi()
 	{
 		return new_full::<rococo_runtime::RuntimeApi, RococoExecutorDispatch, _>(
 			config,
@@ -1394,7 +1395,7 @@ pub fn build_full(
 			malus_finality_delay,
 			hwbench,
 		)
-		.map(|full| full.with_client(Client::Rococo))
+		.map(|full| full.with_client(Client::Rococo));
 	}
 
 	#[cfg(feature = "kusama-native")]
@@ -1413,7 +1414,7 @@ pub fn build_full(
 			malus_finality_delay,
 			hwbench,
 		)
-		.map(|full| full.with_client(Client::Kusama))
+		.map(|full| full.with_client(Client::Kusama));
 	}
 
 	#[cfg(feature = "westend-native")]
@@ -1432,7 +1433,7 @@ pub fn build_full(
 			malus_finality_delay,
 			hwbench,
 		)
-		.map(|full| full.with_client(Client::Westend))
+		.map(|full| full.with_client(Client::Westend));
 	}
 
 	#[cfg(feature = "polkadot-native")]
@@ -1454,7 +1455,7 @@ pub fn build_full(
 			malus_finality_delay,
 			hwbench,
 		)
-		.map(|full| full.with_client(Client::Polkadot))
+		.map(|full| full.with_client(Client::Polkadot));
 	}
 
 	#[cfg(not(feature = "polkadot-native"))]
@@ -1479,7 +1480,7 @@ pub fn revert_backend(
 	let revertible = blocks.min(best_number - finalized);
 
 	if revertible == 0 {
-		return Ok(())
+		return Ok(());
 	}
 
 	let number = best_number - revertible;

--- a/parachain/test-parachains/undying/Cargo.toml
+++ b/parachain/test-parachains/undying/Cargo.toml
@@ -8,6 +8,7 @@ build = "build.rs"
 
 [dependencies]
 parachain = { package = "polkadot-parachain", path = "../../", default-features = false, features = [ "wasm-api" ] }
+polkadot-core-primitives = { path = "../../../core-primitives", default-features = false }
 parity-scale-codec = { version = "3.1.5", default-features = false, features = ["derive"] }
 sp-std = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 tiny-keccak = { version = "2.0.2", features = ["keccak"] }

--- a/parachain/test-parachains/undying/collator/Cargo.toml
+++ b/parachain/test-parachains/undying/collator/Cargo.toml
@@ -14,6 +14,7 @@ name = "undying_collator_puppet_worker"
 path = "bin/puppet_worker.rs"
 
 [dependencies]
+async-trait = "0.1.57"
 parity-scale-codec = { version = "3.1.5", default-features = false, features = ["derive"] }
 clap = { version = "3.1", features = ["derive"] }
 futures = "0.3.19"
@@ -26,10 +27,12 @@ polkadot-cli = { path = "../../../../cli" }
 polkadot-service = { path = "../../../../node/service", features = ["rococo-native"] }
 polkadot-node-primitives = { path = "../../../../node/primitives" }
 polkadot-node-subsystem = { path = "../../../../node/subsystem" }
+polkadot-client = { path = "../../../../node/client" }
 
 sc-cli = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sc-service = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "master" }
 
 # This one is tricky. Even though it is not used directly by the collator, we still need it for the
 # `puppet_worker` binary, which is required for the integration test. However, this shouldn't be

--- a/parachain/test-parachains/undying/collator/src/cli.rs
+++ b/parachain/test-parachains/undying/collator/src/cli.rs
@@ -18,6 +18,7 @@
 
 use clap::Parser;
 use sc_cli::{RuntimeVersion, SubstrateCli};
+use test_parachain_undying::HrmpChannelConfiguration;
 
 /// Sub-commands supported by the collator.
 #[derive(Debug, Parser)]
@@ -30,6 +31,9 @@ pub enum Subcommand {
 	#[clap(name = "export-genesis-wasm")]
 	ExportGenesisWasm(ExportGenesisWasmCommand),
 }
+
+//#[derive(Debug, Parser)]
+//pub struct HrmpCliParams(pub(crate) HrmpChannelConfiguration);
 
 /// Command for exporting the genesis state of the parachain
 #[derive(Debug, Parser)]
@@ -46,6 +50,10 @@ pub struct ExportGenesisStateCommand {
 	/// we compute per block.
 	#[clap(long, default_value = "1")]
 	pub pvf_complexity: u32,
+
+	/// Configuration of the hrmp channels
+	#[clap(long)]
+	pub hrmp_params: Vec<HrmpChannelConfiguration>,
 }
 
 /// Command for exporting the genesis wasm file.
@@ -71,6 +79,10 @@ pub struct RunCmd {
 	/// we compute per block.
 	#[clap(long, default_value = "1")]
 	pub pvf_complexity: u32,
+
+	/// Configuration of the hrmp channels
+	#[clap(long)]
+	pub hrmp_params: Vec<HrmpChannelConfiguration>,
 }
 
 #[allow(missing_docs)]

--- a/parachain/test-parachains/undying/collator/src/lib.rs
+++ b/parachain/test-parachains/undying/collator/src/lib.rs
@@ -23,7 +23,7 @@ use polkadot_node_primitives::{
 	maybe_compress_pov, Collation, CollationResult, CollationSecondedSignal, CollatorFn,
 	MaybeCompressedPoV, PoV, Statement,
 };
-use polkadot_primitives::v2::{CollatorId, CollatorPair, Hash};
+use polkadot_primitives::v2::{CollatorId, CollatorPair, Hash, OutboundHrmpMessage};
 use sp_core::Pair;
 use std::{
 	collections::HashMap,
@@ -33,7 +33,12 @@ use std::{
 	},
 	time::Duration,
 };
-use test_parachain_undying::{execute, hash_state, BlockData, GraveyardState, HeadData};
+use test_parachain_undying::{
+	execute, hash_state, BlockData, GraveyardState, HeadData, HrmpChannelConfiguration,
+};
+
+pub mod relay_chain;
+use relay_chain::RelayChainInterface;
 
 /// Default PoV size which also drives state size.
 const DEFAULT_POV_SIZE: usize = 1000;
@@ -45,7 +50,8 @@ fn calculate_head_and_state_for_number(
 	number: u64,
 	graveyard_size: usize,
 	pvf_complexity: u32,
-) -> (HeadData, GraveyardState) {
+	hrmp_channels: Vec<HrmpChannelConfiguration>,
+) -> (HeadData, GraveyardState, Vec<OutboundHrmpMessage<ParaId>>) {
 	let index = 0u64;
 	let mut graveyard = vec![0u8; graveyard_size * graveyard_size];
 	let zombies = 0;
@@ -59,16 +65,23 @@ fn calculate_head_and_state_for_number(
 	let mut state = GraveyardState { index, graveyard, zombies, seal };
 	let mut head =
 		HeadData { number: 0, parent_hash: Hash::default().into(), post_state: hash_state(&state) };
+	let mut messages: Vec<OutboundHrmpMessage<ParaId>> = Vec::new();
 
 	while head.number < number {
-		let block = BlockData { state, tombstones: 1_000, iterations: pvf_complexity };
-		let (new_head, new_state) =
+		let block = BlockData {
+			state,
+			tombstones: 1_000,
+			iterations: pvf_complexity,
+			hrmp_channels: hrmp_channels.clone(),
+		};
+		let (new_head, new_state, new_messages) =
 			execute(head.hash(), head.clone(), block).expect("Produces valid block");
 		head = new_head;
 		state = new_state;
+		messages = new_messages;
 	}
 
-	(head, state)
+	(head, state, messages)
 }
 
 /// The state of the undying parachain.
@@ -89,11 +102,17 @@ struct State {
 	/// TODO: Implement a static state, and use `ballast` to inflate the PoV size. This way
 	/// we can just discard the `ballast` before processing the block.
 	graveyard_size: usize,
+	/// Configuration of the HRMP channels to be sent/received
+	hrmp_channels: Vec<HrmpChannelConfiguration>,
 }
 
 impl State {
 	/// Init the genesis state.
-	fn genesis(graveyard_size: usize, pvf_complexity: u32) -> Self {
+	fn genesis(
+		graveyard_size: usize,
+		pvf_complexity: u32,
+		hrmp_channels: Vec<HrmpChannelConfiguration>,
+	) -> Self {
 		let index = 0u64;
 		let mut graveyard = vec![0u8; graveyard_size * graveyard_size];
 		let zombies = 0;
@@ -116,13 +135,17 @@ impl State {
 			best_block: 0,
 			pvf_complexity,
 			graveyard_size,
+			hrmp_channels,
 		}
 	}
 
 	/// Advance the state and produce a new block based on the given `parent_head`.
 	///
-	/// Returns the new [`BlockData`] and the new [`HeadData`].
-	fn advance(&mut self, parent_head: HeadData) -> (BlockData, HeadData) {
+	/// Returns the new [`BlockData`] and the new [`HeadData`] along with a set of [`OutboundHrmpMessage`].
+	fn advance(
+		&mut self,
+		parent_head: HeadData,
+	) -> (BlockData, HeadData, Vec<OutboundHrmpMessage<ParaId>>) {
 		self.best_block = parent_head.number;
 
 		let state = if let Some(head_data) = self.number_to_head.get(&self.best_block) {
@@ -131,22 +154,29 @@ impl State {
 					parent_head.number,
 					self.graveyard_size,
 					self.pvf_complexity,
+					self.hrmp_channels.clone(),
 				)
 				.1
 			})
 		} else {
-			let (_, state) = calculate_head_and_state_for_number(
+			let (_, state, _) = calculate_head_and_state_for_number(
 				parent_head.number,
 				self.graveyard_size,
 				self.pvf_complexity,
+				self.hrmp_channels.clone(),
 			);
 			state
 		};
 
 		// Start with prev state and transaction to execute (place 1000 tombstones).
-		let block = BlockData { state, tombstones: 1000, iterations: self.pvf_complexity };
+		let block = BlockData {
+			state,
+			tombstones: 1000,
+			iterations: self.pvf_complexity,
+			hrmp_channels: self.hrmp_channels.clone(),
+		};
 
-		let (new_head, new_state) =
+		let (new_head, new_state, messages) =
 			execute(parent_head.hash(), parent_head, block.clone()).expect("Produces valid block");
 
 		let new_head_arc = Arc::new(new_head.clone());
@@ -154,7 +184,7 @@ impl State {
 		self.head_to_state.insert(new_head_arc.clone(), new_state);
 		self.number_to_head.insert(new_head.number, new_head_arc);
 
-		(block, new_head)
+		(block, new_head, messages)
 	}
 }
 
@@ -167,14 +197,18 @@ pub struct Collator {
 
 impl Default for Collator {
 	fn default() -> Self {
-		Self::new(DEFAULT_POV_SIZE, DEFAULT_PVF_COMPLEXITY)
+		Self::new(DEFAULT_POV_SIZE, DEFAULT_PVF_COMPLEXITY, Vec::new())
 	}
 }
 
 impl Collator {
 	/// Create a new collator instance with the state initialized from genesis and `pov_size`
 	/// parameter. The same parameter needs to be passed when exporting the genesis state.
-	pub fn new(pov_size: usize, pvf_complexity: u32) -> Self {
+	pub fn new(
+		pov_size: usize,
+		pvf_complexity: u32,
+		hrmp_channels: Vec<HrmpChannelConfiguration>,
+	) -> Self {
 		let graveyard_size = ((pov_size / std::mem::size_of::<u8>()) as f64).sqrt().ceil() as usize;
 
 		log::info!(
@@ -187,7 +221,11 @@ impl Collator {
 		log::info!("PVF time complexity: {}", pvf_complexity);
 
 		Self {
-			state: Arc::new(Mutex::new(State::genesis(graveyard_size, pvf_complexity))),
+			state: Arc::new(Mutex::new(State::genesis(
+				graveyard_size,
+				pvf_complexity,
+				hrmp_channels,
+			))),
 			key: CollatorPair::generate().0,
 			seconded_collations: Arc::new(AtomicU32::new(0)),
 		}
@@ -225,6 +263,7 @@ impl Collator {
 	pub fn create_collation_function(
 		&self,
 		spawner: impl SpawnNamed + Clone + 'static,
+		relay_chain_interface: Arc<dyn RelayChainInterface>,
 	) -> CollatorFn {
 		use futures::FutureExt as _;
 
@@ -235,7 +274,7 @@ impl Collator {
 			let parent = HeadData::decode(&mut &validation_data.parent_head.0[..])
 				.expect("Decodes parent head");
 
-			let (block_data, head_data) = state.lock().unwrap().advance(parent);
+			let (block_data, head_data, messages) = state.lock().unwrap().advance(parent);
 
 			log::info!(
 				"created a new collation on relay-parent({}): {:?}",
@@ -248,7 +287,7 @@ impl Collator {
 
 			let collation = Collation {
 				upward_messages: Vec::new(),
-				horizontal_messages: Vec::new(),
+				horizontal_messages: messages,
 				new_validation_code: None,
 				head_data: head_data.encode().into(),
 				proof_of_validity: MaybeCompressedPoV::Raw(pov.clone()),
@@ -302,7 +341,7 @@ impl Collator {
 			let current_block = self.state.lock().unwrap().best_block;
 
 			if start_block + blocks <= current_block {
-				return
+				return;
 			}
 		}
 	}
@@ -317,12 +356,13 @@ impl Collator {
 			Delay::new(Duration::from_secs(1)).await;
 
 			if seconded <= seconded_collations.load(Ordering::Relaxed) {
-				return
+				return;
 			}
 		}
 	}
 }
 
+use polkadot_service::ParaId;
 use sp_core::traits::SpawnNamed;
 
 #[cfg(test)]
@@ -335,7 +375,7 @@ mod tests {
 	#[test]
 	fn collator_works() {
 		let spawner = sp_core::testing::TaskExecutor::new();
-		let collator = Collator::new(1_000, 1);
+		let collator = Collator::new(1_000, 1, Vec::new());
 		let collation_function = collator.create_collation_function(spawner);
 
 		for i in 0..5 {
@@ -389,17 +429,17 @@ mod tests {
 
 	#[test]
 	fn advance_to_state_when_parent_head_is_missing() {
-		let collator = Collator::new(1_000, 1);
+		let collator = Collator::new(1_000, 1, Vec::new());
 		let graveyard_size = collator.state.lock().unwrap().graveyard_size;
 
-		let mut head = calculate_head_and_state_for_number(10, graveyard_size, 1).0;
+		let mut head = calculate_head_and_state_for_number(10, graveyard_size, 1, Vec::new()).0;
 
 		for i in 1..10 {
 			head = collator.state.lock().unwrap().advance(head).1;
 			assert_eq!(10 + i, head.number);
 		}
 
-		let collator = Collator::new(1_000, 1);
+		let collator = Collator::new(1_000, 1, Vec::new());
 		let mut second_head = collator
 			.state
 			.lock()

--- a/parachain/test-parachains/undying/collator/src/main.rs
+++ b/parachain/test-parachains/undying/collator/src/main.rs
@@ -20,9 +20,10 @@ use polkadot_cli::{Error, Result};
 use polkadot_node_primitives::CollationGenerationConfig;
 use polkadot_node_subsystem::messages::{CollationGenerationMessage, CollatorProtocolMessage};
 use polkadot_primitives::v2::Id as ParaId;
+
 use sc_cli::{Error as SubstrateCliError, SubstrateCli};
 use sp_core::hexdisplay::HexDisplay;
-use test_parachain_undying_collator::Collator;
+use test_parachain_undying_collator::{relay_chain::RelayChainInterfaceBuilder, Collator};
 
 mod cli;
 use cli::Cli;
@@ -34,7 +35,8 @@ fn main() -> Result<()> {
 		Some(cli::Subcommand::ExportGenesisState(params)) => {
 			// `pov_size` and `pvf_complexity` need to match the ones that we start the collator
 			// with.
-			let collator = Collator::new(params.pov_size, params.pvf_complexity);
+			let collator =
+				Collator::new(params.pov_size, params.pvf_complexity, params.hrmp_params);
 			println!("0x{:?}", HexDisplay::from(&collator.genesis_head()));
 
 			Ok::<_, Error>(())
@@ -54,7 +56,8 @@ fn main() -> Result<()> {
 			})?;
 
 			runner.run_node_until_exit(|config| async move {
-				let collator = Collator::new(cli.run.pov_size, cli.run.pvf_complexity);
+				let collator =
+					Collator::new(cli.run.pov_size, cli.run.pvf_complexity, cli.run.hrmp_params);
 
 				let full_node = polkadot_service::build_full(
 					config,
@@ -85,10 +88,14 @@ fn main() -> Result<()> {
 				log::info!("Genesis state: {}", genesis_head_hex);
 				log::info!("Validation code: {}", validation_code_hex);
 
+				let relay_chain_interface =
+					RelayChainInterfaceBuilder { polkadot_client: full_node.client }.build();
 				let config = CollationGenerationConfig {
 					key: collator.collator_key(),
-					collator: collator
-						.create_collation_function(full_node.task_manager.spawn_handle()),
+					collator: collator.create_collation_function(
+						full_node.task_manager.spawn_handle(),
+						relay_chain_interface,
+					),
 					para_id,
 				};
 				overseer_handle

--- a/parachain/test-parachains/undying/collator/src/relay_chain.rs
+++ b/parachain/test-parachains/undying/collator/src/relay_chain.rs
@@ -1,0 +1,112 @@
+// Copyright 2022 Parity Technologies (UK) Ltd.
+// This file is part of Polkadot.
+
+// Polkadot is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Polkadot is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Collator for the `Undying` test parachain.
+//! Relay chain interface module
+
+use async_trait::async_trait;
+use polkadot_client::{ClientHandle, ExecuteWithClient};
+use polkadot_primitives::{
+	runtime_api::ParachainHost,
+	v2::{Block, BlockId, Hash, InboundDownwardMessage, InboundHrmpMessage},
+};
+use polkadot_service::{AuxStore, ParaId};
+use sp_api::{ApiError, ProvideRuntimeApi};
+
+use std::{collections::BTreeMap, sync::Arc};
+
+#[async_trait]
+pub trait RelayChainInterface: Send + Sync {
+	/// Returns the whole contents of the downward message queue for the parachain we are collating
+	/// for.
+	///
+	/// Returns `None` in case of an error.
+	async fn retrieve_dmq_contents(
+		&self,
+		para_id: ParaId,
+		relay_parent: Hash,
+	) -> Result<Vec<InboundDownwardMessage>, ApiError>;
+
+	/// Returns channels contents for each inbound HRMP channel addressed to the parachain we are
+	/// collating for.
+	///
+	/// Empty channels are also included.
+	async fn retrieve_all_inbound_hrmp_channel_contents(
+		&self,
+		para_id: ParaId,
+		relay_parent: Hash,
+	) -> Result<BTreeMap<ParaId, Vec<InboundHrmpMessage>>, ApiError>;
+}
+
+pub struct RelayChainInProcessInterface<Client> {
+	full_client: Arc<Client>,
+}
+
+impl<Client: Send + Sync> RelayChainInProcessInterface<Client> {
+	/// Create a new instance of [`RelayChainInProcessInterface`]
+	pub fn new(full_client: Arc<Client>) -> Self {
+		Self { full_client }
+	}
+}
+
+#[async_trait]
+impl<Client> RelayChainInterface for RelayChainInProcessInterface<Client>
+where
+	Client: ProvideRuntimeApi<Block> + Sync + Send + 'static,
+	Client::Api: ParachainHost<Block>,
+{
+	async fn retrieve_dmq_contents(
+		&self,
+		para_id: ParaId,
+		relay_parent: Hash,
+	) -> Result<Vec<InboundDownwardMessage>, ApiError> {
+		self.full_client
+			.runtime_api()
+			.dmq_contents(&BlockId::Hash(relay_parent), para_id)
+	}
+
+	async fn retrieve_all_inbound_hrmp_channel_contents(
+		&self,
+		para_id: ParaId,
+		relay_parent: Hash,
+	) -> Result<BTreeMap<ParaId, Vec<InboundHrmpMessage>>, ApiError> {
+		self.full_client
+			.runtime_api()
+			.inbound_hrmp_channels_contents(&BlockId::Hash(relay_parent), para_id)
+	}
+}
+
+pub struct RelayChainInterfaceBuilder {
+	pub polkadot_client: polkadot_client::Client,
+}
+
+impl RelayChainInterfaceBuilder {
+	pub fn build(self) -> Arc<dyn RelayChainInterface> {
+		self.polkadot_client.clone().execute_with(self)
+	}
+}
+
+impl ExecuteWithClient for RelayChainInterfaceBuilder {
+	type Output = Arc<dyn RelayChainInterface>;
+
+	fn execute_with_client<Client, Api, Backend>(self, client: Arc<Client>) -> Self::Output
+	where
+		Client: ProvideRuntimeApi<Block> + AuxStore + 'static + Sync + Send,
+		Client::Api: ParachainHost<Block>,
+	{
+		Arc::new(RelayChainInProcessInterface::new(client))
+	}
+}

--- a/parachain/test-parachains/undying/src/wasm_validation.rs
+++ b/parachain/test-parachains/undying/src/wasm_validation.rs
@@ -31,14 +31,14 @@ pub extern "C" fn validate_block(params: *const u8, len: usize) -> u64 {
 
 	let parent_hash = crate::keccak256(&params.parent_head.0[..]);
 
-	let (new_head, _) =
+	let (new_head, _, hrmp_messages) =
 		crate::execute(parent_hash, parent_head, block_data).expect("Executes block");
 
 	parachain::write_result(&ValidationResult {
 		head_data: GenericHeadData(new_head.encode()),
 		new_validation_code: None,
 		upward_messages: sp_std::vec::Vec::new(),
-		horizontal_messages: sp_std::vec::Vec::new(),
+		horizontal_messages: hrmp_messages,
 		processed_downward_messages: 0,
 		hrmp_watermark: params.relay_parent_number,
 	})


### PR DESCRIPTION
## Work description

We want to test HRMP/DMP/UMP (and XCM in perspective) during our zombienet automated tests. Hence, it might be a good idea to have an ability to generate and process such messages within our test collators.

## Tasks list

- [ ] Pass RuntimeApi to the collator function
- [ ] Support HRMP channels configuration
- [ ] Move HRMP messages into collator state
- [ ] Support messages within wasm_validation
- [ ] Think about useful payload
- [ ] Probably add UMP/DMP messages processing as well