### PR TITLE
approval-voting: remove redundant validation check

### DIFF
--- a/node/core/candidate-validation/src/lib.rs
+++ b/node/core/candidate-validation/src/lib.rs
@@ -467,11 +467,6 @@ where
 	.await;
 
 	if let Ok(ValidationResult::Valid(ref outputs, _)) = validation_result {
-		// If validation produces new commitments we consider the candidate invalid.
-		if candidate_receipt.commitments_hash != outputs.hash() {
-			return Ok(ValidationResult::Invalid(InvalidCandidate::CommitmentsHashMismatch))
-		}
-
 		let (tx, rx) = oneshot::channel();
 		match runtime_api_request(
 			sender,


### PR DESCRIPTION
I was looking at places we could potentially issue disputes but don't log it and came across this check.
Upon further inspection, it seems to be a duplicate of a check in candidate-validation: 
https://github.com/paritytech/polkadot/blob/597b1d213d41e6a54f72d2387b3d671ba4811f7a/node/core/candidate-validation/src/lib.rs#L594-L605

It seemed to be introduced to candidate-validation in #5011. While at it, I've removed another duplicate (unreachable) check in `validate_from_chain_state`.