### PR TITLE
Log `UnknownBlock` errors from runtime

### DIFF
--- a/node/collation-generation/src/lib.rs
+++ b/node/collation-generation/src/lib.rs
@@ -431,6 +431,7 @@ async fn obtain_current_validation_code_hash(
 			}
 		},
 		Err(e @ RuntimeApiError::Execution { .. }) => Err(e.into()),
+		Err(e @ RuntimeApiError::UnknownBlock { .. }) => Err(e.into()),
 	}
 }
 

--- a/node/core/provisioner/src/disputes/prioritized_selection/mod.rs
+++ b/node/core/provisioner/src/disputes/prioritized_selection/mod.rs
@@ -477,6 +477,8 @@ where
 					GetOnchainDisputesError::Execution(e, relay_parent),
 				RuntimeApiError::NotSupported { .. } =>
 					GetOnchainDisputesError::NotSupported(e, relay_parent),
+				RuntimeApiError::UnknownBlock { .. } =>
+					GetOnchainDisputesError::UnknownBlock(e, relay_parent),
 			})
 		})
 		.map(|v| v.into_iter().map(|e| ((e.0, e.1), e.2)).collect())

--- a/node/core/provisioner/src/disputes/prioritized_selection/mod.rs
+++ b/node/core/provisioner/src/disputes/prioritized_selection/mod.rs
@@ -128,6 +128,15 @@ where
 			);
 			HashMap::new()
 		},
+		Err(GetOnchainDisputesError::UnknownBlock(runtime_api_err, parent_hash)) => {
+			gum::warn!(
+				target: LOG_TARGET,
+				?runtime_api_err,
+				?parent_hash,
+				"Trying to fetch onchain disputes for unknown block.",
+			);
+			HashMap::new()
+		},
 	};
 
 	let recent_disputes = request_disputes(sender).await;

--- a/node/core/provisioner/src/error.rs
+++ b/node/core/provisioner/src/error.rs
@@ -90,6 +90,9 @@ pub enum GetOnchainDisputesError {
 
 	#[error("runtime doesn't support RuntimeApiRequest::Disputes for parent {1}")]
 	NotSupported(#[source] RuntimeApiError, Hash),
+
+	#[error("runtime api is called on unknown block {1}")]
+	UnknownBlock(#[source] RuntimeApiError, Hash),
 }
 
 pub fn log_error(result: Result<()>) -> std::result::Result<(), FatalError> {

--- a/node/core/provisioner/src/lib.rs
+++ b/node/core/provisioner/src/lib.rs
@@ -739,6 +739,14 @@ async fn has_required_runtime(
 			);
 			false
 		},
+		Result::Ok(Err(RuntimeApiError::UnknownBlock { .. })) => {
+			gum::trace!(
+				target: LOG_TARGET,
+				?relay_parent,
+				"UnknownBlock error while fetching ParachainHost runtime api version"
+			);
+			false
+		},
 		Result::Err(_) => {
 			gum::trace!(
 				target: LOG_TARGET,

--- a/node/core/pvf-checker/src/lib.rs
+++ b/node/core/pvf-checker/src/lib.rs
@@ -518,7 +518,7 @@ async fn sign_and_submit_pvf_check_statement(
 				target: LOG_TARGET,
 				?relay_parent,
 				?validation_code_hash,
-				"error occured during submitting a vote: {:?}",
+				"error occurred during submitting a vote: {:?}",
 				e,
 			);
 		},

--- a/node/core/pvf-checker/src/runtime_api.rs
+++ b/node/core/pvf-checker/src/runtime_api.rs
@@ -70,6 +70,7 @@ pub(crate) enum RuntimeRequestError {
 	NotSupported,
 	ApiError,
 	CommunicationError,
+	UnknownBlock,
 }
 
 pub(crate) async fn runtime_api_request<T>(
@@ -102,6 +103,7 @@ pub(crate) async fn runtime_api_request<T>(
 						RuntimeRequestError::ApiError
 					},
 					NotSupported { .. } => RuntimeRequestError::NotSupported,
+					UnknownBlock { .. } => RuntimeRequestError::UnknownBlock,
 				}
 			})
 		})

--- a/node/subsystem-types/src/errors.rs
+++ b/node/subsystem-types/src/errors.rs
@@ -39,6 +39,16 @@ pub enum RuntimeApiError {
 		/// The runtime API being called
 		runtime_api_name: &'static str,
 	},
+
+	/// The runtime API request can't be executed because the block at which the execution must
+	/// happen doesn't exist. This usually happens when the block is already pruned.
+	#[error(
+		"The runtime API {runtime_api_name} was called for an unknown (already pruned?) block"
+	)]
+	UnknownBlock {
+		/// The runtime API being called
+		runtime_api_name: &'static str,
+	},
 }
 
 /// A description of an error causing the chain API request to be unservable.

--- a/node/subsystem-types/src/lib.rs
+++ b/node/subsystem-types/src/lib.rs
@@ -31,7 +31,7 @@ pub mod errors;
 pub mod messages;
 
 mod runtime_client;
-pub use runtime_client::RuntimeApiSubsystemClient;
+pub use runtime_client::{ApiError, RuntimeApiSubsystemClient};
 
 pub use jaeger::*;
 pub use polkadot_node_jaeger as jaeger;

--- a/node/subsystem-types/src/runtime_client.rs
+++ b/node/subsystem-types/src/runtime_client.rs
@@ -22,11 +22,12 @@ use polkadot_primitives::{
 	PvfCheckStatement, ScrapedOnChainVotes, SessionIndex, SessionInfo, ValidationCode,
 	ValidationCodeHash, ValidatorId, ValidatorIndex, ValidatorSignature,
 };
-use sp_api::{ApiError, ApiExt, ProvideRuntimeApi};
+use sp_api::{ApiExt, ProvideRuntimeApi};
 use sp_authority_discovery::AuthorityDiscoveryApi;
 use sp_consensus_babe::{BabeApi, Epoch};
 use std::collections::BTreeMap;
 
+pub use sp_api::ApiError;
 /// Exposes all runtime calls that are used by the runtime API subsystem.
 #[async_trait]
 pub trait RuntimeApiSubsystemClient {


### PR DESCRIPTION
This PR is building upon https://github.com/paritytech/substrate/pull/12707 and is related to https://github.com/paritytech/polkadot/issues/5885

# The problem

All runtime calls first check the runtime version before issuing the actual runtime api call. If a call is made for a block which is pruned (e.g. because a better fork was finalized), the runtime api version can't be checked and `NotSupported` error is returned. This is misleading because the problem is different. The call IS supported but it can't be executed at a pruned block.

# How this is solved

This PR adds explicit logging for `UnknownBlock` runtime errors so that it is clear why the runtime call is failing. Furthermore `UnknownBlock` variant is added to `RuntimeApiError` enum in `node/subsystem-types/src/errors.rs`. This allows any subsystem to handle such errors in its own way.

# What this PR doesn't do

The PR doesn't fix the root cause (prevent executing logic on pruned blocks). 

# Sample logs

E.g. for `{node=~"versi-validator-f.*"} |~ "UnknownBlock|discarded"`:

![image](https://user-images.githubusercontent.com/610755/215712037-0883d950-dda7-449b-b8fd-45e68b6ea134.png)
