### PR TITLE
disputes pallet: Filter unconfirmed disputes

### DIFF
--- a/runtime/parachains/src/disputes.rs
+++ b/runtime/parachains/src/disputes.rs
@@ -1041,8 +1041,8 @@ impl<T: Config> Pallet<T> {
 		}
 
 		// Reject disputes containing less votes than needed for confirmation.
-		if summary.state.validators_for.count_ones() + summary.state.validators_against.count_ones() <
-			supermajority_threshold(summary.state.validators_for.len())
+		if (summary.state.validators_for.clone() | &summary.state.validators_against).count_ones() <=
+			byzantine_threshold(summary.state.validators_for.len())
 		{
 			return StatementSetFilter::RemoveAll
 		}
@@ -1211,9 +1211,8 @@ impl<T: Config> Pallet<T> {
 
 		// Reject disputes containing less votes than needed for confirmation.
 		ensure!(
-			summary.state.validators_for.count_ones() +
-				summary.state.validators_against.count_ones() >=
-				supermajority_threshold(summary.state.validators_for.len()),
+			(summary.state.validators_for.clone() | &summary.state.validators_against).count_ones() >
+				byzantine_threshold(summary.state.validators_for.len()),
 			Error::<T>::UnconfirmedDispute,
 		);
 

--- a/runtime/parachains/src/disputes.rs
+++ b/runtime/parachains/src/disputes.rs
@@ -939,6 +939,7 @@ impl<T: Config> Pallet<T> {
 	//
 	// Votes which are duplicate or already known by the chain are filtered out.
 	// The entire set is removed if the dispute is both, ancient and concluded.
+	// Disputes without enough votes to get confirmed are also filtered out.
 	fn filter_dispute_data(
 		set: &DisputeStatementSet,
 		post_conclusion_acceptance_period: <T as frame_system::Config>::BlockNumber,


### PR DESCRIPTION
On dispute import pallet disputes - don't include any disputes with less than required votes for dispute confirmation.

Part of https://github.com/paritytech/polkadot/issues/6331