### PR TITLE
[ci] fix build-implementers-guide

### DIFF
--- a/scripts/ci/gitlab/pipeline/build.yml
+++ b/scripts/ci/gitlab/pipeline/build.yml
@@ -171,13 +171,11 @@ build-implementers-guide:
   # git depth is set on purpose: https://github.com/paritytech/polkadot/issues/6284
   variables:
     GIT_DEPTH:                     0
+    CI_IMAGE:                      paritytech/mdbook-utils:aec374ea-20221123
   script:
-    - apt-get -y update; apt-get install -y graphviz
-    - cargo install mdbook mdbook-mermaid mdbook-linkcheck mdbook-graphviz mdbook-last-changed
     - mdbook build ./roadmap/implementers-guide
     - mkdir -p artifacts
     - mv roadmap/implementers-guide/book artifacts/
-    # FIXME: remove me after CI image gets nonroot
     - chown -R nonroot:nonroot artifacts/
 
 build-short-benchmark:

--- a/scripts/ci/gitlab/pipeline/build.yml
+++ b/scripts/ci/gitlab/pipeline/build.yml
@@ -171,12 +171,12 @@ build-implementers-guide:
   # git depth is set on purpose: https://github.com/paritytech/polkadot/issues/6284
   variables:
     GIT_DEPTH:                     0
-    CI_IMAGE:                      paritytech/mdbook-utils:aec374ea-20221123
+    CI_IMAGE:                      paritytech/mdbook-utils:e14aae4a-20221123
   script:
     - mdbook build ./roadmap/implementers-guide
     - mkdir -p artifacts
     - mv roadmap/implementers-guide/book artifacts/
-    - chown -R nonroot:nonroot artifacts/
+    - ls -la artifacts/
 
 build-short-benchmark:
   stage:                           build


### PR DESCRIPTION
In the current CI image mdbook-last-changed doesn't work. Created a new image for `build-implementers-guide` job

close https://github.com/paritytech/ci_cd/issues/679
close https://github.com/paritytech/polkadot/issues/6284