### PR TITLE
minor: ig: Fix description of execution retry delay

### DIFF
--- a/roadmap/implementers-guide/src/node/utility/candidate-validation.md
+++ b/roadmap/implementers-guide/src/node/utility/candidate-validation.md
@@ -67,7 +67,7 @@ or time out). We will only retry preparation if another request comes in after
 resolved. We will retry up to 5 times.
 
 If the actual **execution** of the artifact fails, we will retry once if it was
-an ambiguous error after a 1 second delay, to allow any potential transient
+an ambiguous error after a brief delay, to allow any potential transient
 conditions to clear.
 
 #### Preparation timeouts


### PR DESCRIPTION
The delay is 3s and not 1s. I removed the reference to a specific number of seconds as it may be too specific for a high-level description.

Follow-up from https://github.com/paritytech/polkadot/pull/6293#pullrequestreview-1186211030. Note the delay is [already 3s](https://github.com/paritytech/polkadot/blob/m-cat%2Fig-fix-retry-delay/node/core/candidate-validation/src/lib.rs#L65), it was just the description that was wrong.