### PR TITLE
paras: adjust weights for root dispatchables 

### DIFF
--- a/runtime/kusama/src/weights/runtime_parachains_paras.rs
+++ b/runtime/kusama/src/weights/runtime_parachains_paras.rs
@@ -176,4 +176,7 @@ impl<T: frame_system::Config> runtime_parachains::paras::WeightInfo for WeightIn
 			.saturating_add(T::DbWeight::get().reads(5 as u64))
 			.saturating_add(T::DbWeight::get().writes(304 as u64))
 	}
+	fn force_schedule_code_upgrade_pvf_checking_enabled(_c: u32) -> Weight {
+		Weight::MAX
+	}
 }

--- a/runtime/parachains/src/paras/benchmarking.rs
+++ b/runtime/parachains/src/paras/benchmarking.rs
@@ -23,7 +23,7 @@ use sp_runtime::traits::{One, Saturating};
 
 mod pvf_check;
 
-use self::pvf_check::{VoteCause, VoteOutcome};
+use self::pvf_check::{enable_pvf_checking, VoteCause, VoteOutcome};
 
 // 2 ^ 10, because binary search time complexity is O(log(2, n)) and n = 1024 gives us a big and
 // round number.
@@ -104,6 +104,18 @@ benchmarks! {
 		let new_code = ValidationCode(vec![0; c as usize]);
 		let para_id = ParaId::from(c as u32);
 		let block = T::BlockNumber::from(c);
+		generate_disordered_upgrades::<T>();
+	}: _(RawOrigin::Root, para_id, new_code, block)
+	verify {
+		assert_last_event::<T>(Event::CodeUpgradeScheduled(para_id).into());
+	}
+	force_schedule_code_upgrade_pvf_checking_enabled {
+		let c in 1 .. MAX_CODE_SIZE;
+		let new_code = ValidationCode(vec![0; c as usize]);
+		let para_id = ParaId::from(c as u32);
+		let block = T::BlockNumber::from(c);
+
+		enable_pvf_checking::<T>();
 		generate_disordered_upgrades::<T>();
 	}: _(RawOrigin::Root, para_id, new_code, block)
 	verify {

--- a/runtime/parachains/src/paras/benchmarking/pvf_check.rs
+++ b/runtime/parachains/src/paras/benchmarking/pvf_check.rs
@@ -32,6 +32,13 @@ fn old_validation_code() -> ValidationCode {
 	ValidationCode(vec![1])
 }
 
+/// Enables pvf-checking in the configuration pallet.
+pub fn enable_pvf_checking<T: Config>() {
+	let mut config = configuration::Pallet::<T>::config();
+	config.pvf_checking_enabled = true;
+	configuration::Pallet::<T>::force_set_active_config(config);
+}
+
 /// Prepares the PVF check statement and the validator signature to pass into
 /// `include_pvf_check_statement` during benchmarking phase.
 ///
@@ -109,9 +116,7 @@ where
 		.collect::<Vec<_>>();
 
 	// 1. Make sure PVF pre-checking is enabled in the config.
-	let mut config = configuration::Pallet::<T>::config();
-	config.pvf_checking_enabled = true;
-	configuration::Pallet::<T>::force_set_active_config(config.clone());
+	enable_pvf_checking::<T>();
 
 	// 2. initialize a new session with deterministic validator set.
 	ParasShared::<T>::set_active_validators_ascending(validators.clone());
@@ -122,7 +127,7 @@ where
 ///
 /// The subject of the vote (i.e. validation code) and the cause (upgrade/onboarding) is specified
 /// by the test setup.
-fn initialize_pvf_active_vote<T>(vote_cause: VoteCause)
+pub fn initialize_pvf_active_vote<T>(vote_cause: VoteCause)
 where
 	T: Config + shared::Config,
 {

--- a/runtime/polkadot/src/weights/runtime_parachains_paras.rs
+++ b/runtime/polkadot/src/weights/runtime_parachains_paras.rs
@@ -182,4 +182,7 @@ impl<T: frame_system::Config> runtime_parachains::paras::WeightInfo for WeightIn
 			.saturating_add(T::DbWeight::get().reads(6 as u64))
 			.saturating_add(T::DbWeight::get().writes(304 as u64))
 	}
+	fn force_schedule_code_upgrade_pvf_checking_enabled(_c: u32) -> Weight {
+		Weight::MAX
+	}
 }

--- a/runtime/rococo/src/weights/runtime_parachains_paras.rs
+++ b/runtime/rococo/src/weights/runtime_parachains_paras.rs
@@ -182,4 +182,7 @@ impl<T: frame_system::Config> runtime_parachains::paras::WeightInfo for WeightIn
 			.saturating_add(T::DbWeight::get().reads(6 as u64))
 			.saturating_add(T::DbWeight::get().writes(304 as u64))
 	}
+	fn force_schedule_code_upgrade_pvf_checking_enabled(_c: u32) -> Weight {
+		Weight::MAX
+	}
 }

--- a/runtime/westend/src/weights/runtime_parachains_paras.rs
+++ b/runtime/westend/src/weights/runtime_parachains_paras.rs
@@ -176,4 +176,7 @@ impl<T: frame_system::Config> runtime_parachains::paras::WeightInfo for WeightIn
 			.saturating_add(T::DbWeight::get().reads(5 as u64))
 			.saturating_add(T::DbWeight::get().writes(304 as u64))
 	}
+	fn force_schedule_code_upgrade_pvf_checking_enabled(_c: u32) -> Weight {
+		Weight::MAX
+	}
 }


### PR DESCRIPTION
`force_schedule_code_upgrade` can kick off a pvf-check which should be taken into account. This one is simple.

There's also `add_trusted_validation_code`, it's weight cannot be computed ahead of dispatch: an edge case is when there're a lot of paras having the same code hash they want to upgrade to and this code undergoes a prechecking.

In order to know how many paras are doing it, it's necessary to access a chain state (`PvfActiveVoteMap`).
It's of course not crucial because pvf check always concludes or times out at worst.
One simple possible approach is to require some generous weight for the call and then compute it in flight, refunding the rest. Given it may only be used by root or governance, should be fine.