### PR TITLE
Kusama: approve/reject treasury prop by treasurer

### DIFF
--- a/runtime/kusama/src/governance/mod.rs
+++ b/runtime/kusama/src/governance/mod.rs
@@ -30,7 +30,7 @@ mod origins;
 pub use origins::{
 	pallet_custom_origins, AuctionAdmin, Fellows, FellowshipAdmin, FellowshipExperts,
 	FellowshipInitiates, FellowshipMasters, GeneralAdmin, LeaseAdmin, ReferendumCanceller,
-	ReferendumKiller, Spender, StakingAdmin, WhitelistedCaller,
+	ReferendumKiller, Spender, StakingAdmin, Treasurer, WhitelistedCaller,
 };
 mod tracks;
 pub use tracks::TracksInfo;

--- a/runtime/kusama/src/governance/origins.rs
+++ b/runtime/kusama/src/governance/origins.rs
@@ -120,6 +120,7 @@ pub mod pallet_custom_origins {
 	}
 	decl_unit_ensures!(
 		StakingAdmin,
+		Treasurer,
 		FellowshipAdmin,
 		GeneralAdmin,
 		AuctionAdmin,

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -106,7 +106,7 @@ pub mod xcm_config;
 pub mod governance;
 use governance::{
 	old::CouncilCollective, pallet_custom_origins, AuctionAdmin, GeneralAdmin, LeaseAdmin,
-	StakingAdmin, TreasurySpender,
+	StakingAdmin, Treasurer, TreasurySpender,
 };
 
 #[cfg(test)]
@@ -633,8 +633,8 @@ parameter_types! {
 impl pallet_treasury::Config for Runtime {
 	type PalletId = TreasuryPalletId;
 	type Currency = Balances;
-	type ApproveOrigin = EnsureRoot<AccountId>;
-	type RejectOrigin = EnsureRoot<AccountId>;
+	type ApproveOrigin = EitherOfDiverse<EnsureRoot<AccountId>, Treasurer>;
+	type RejectOrigin = EitherOfDiverse<EnsureRoot<AccountId>, Treasurer>;
 	type RuntimeEvent = RuntimeEvent;
 	type OnSlash = Treasury;
 	type ProposalBond = ProposalBond;


### PR DESCRIPTION
In the PR the Treasurer origin included as the treasury approve/reject/close origin. 

New pallet_treasury::spend call is supposed to be used for new treasury proposals submitted via Gov v2.
But to speed the process and approve/reject/close the proposals submitted before with pallet_treasury::propose_spend call we want to utilize the `treasurer` track of the public referenda.