### PR TITLE
Remove `parity-util-mem` from `runtime-api` cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4028,15 +4028,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "memory-lru"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce95ae042940bad7e312857b929ee3d11b8f799a80cb7b9c7ec5125516906395"
-dependencies = [
- "lru",
-]
-
-[[package]]
 name = "memory_units"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6531,8 +6522,7 @@ name = "polkadot-node-core-runtime-api"
 version = "0.9.31"
 dependencies = [
  "futures",
- "memory-lru",
- "parity-util-mem",
+ "lru",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-test-helpers",

--- a/node/core/runtime-api/Cargo.toml
+++ b/node/core/runtime-api/Cargo.toml
@@ -7,8 +7,7 @@ edition = "2021"
 [dependencies]
 futures = "0.3.21"
 gum = { package = "tracing-gum", path = "../../gum" }
-memory-lru = "0.1.1"
-parity-util-mem = { version = "0.12.0", default-features = false }
+lru = "0.8"
 
 sp-consensus-babe = { git = "https://github.com/paritytech/substrate", branch = "master" }
 

--- a/node/core/runtime-api/src/cache.rs
+++ b/node/core/runtime-api/src/cache.rs
@@ -14,10 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::collections::btree_map::BTreeMap;
+use std::{collections::btree_map::BTreeMap, num::NonZeroUsize};
 
-use memory_lru::{MemoryLruCache, ResidentSize};
-use parity_util_mem::{MallocSizeOf, MallocSizeOfExt};
+use lru::LruCache;
 use sp_consensus_babe::Epoch;
 
 use polkadot_primitives::v2::{
@@ -28,126 +27,91 @@ use polkadot_primitives::v2::{
 	ValidationCodeHash, ValidatorId, ValidatorIndex, ValidatorSignature,
 };
 
-const AUTHORITIES_CACHE_SIZE: usize = 128 * 1024;
-const VALIDATORS_CACHE_SIZE: usize = 64 * 1024;
-const VALIDATOR_GROUPS_CACHE_SIZE: usize = 64 * 1024;
-const AVAILABILITY_CORES_CACHE_SIZE: usize = 64 * 1024;
-const PERSISTED_VALIDATION_DATA_CACHE_SIZE: usize = 64 * 1024;
-const ASSUMED_VALIDATION_DATA_CACHE_SIZE: usize = 64 * 1024;
-const CHECK_VALIDATION_OUTPUTS_CACHE_SIZE: usize = 64 * 1024;
-const SESSION_INDEX_FOR_CHILD_CACHE_SIZE: usize = 64 * 1024;
-const VALIDATION_CODE_CACHE_SIZE: usize = 10 * 1024 * 1024;
-const CANDIDATE_PENDING_AVAILABILITY_CACHE_SIZE: usize = 64 * 1024;
-const CANDIDATE_EVENTS_CACHE_SIZE: usize = 64 * 1024;
-const SESSION_INFO_CACHE_SIZE: usize = 64 * 1024;
-const DMQ_CONTENTS_CACHE_SIZE: usize = 64 * 1024;
-const INBOUND_HRMP_CHANNELS_CACHE_SIZE: usize = 64 * 1024;
-const CURRENT_BABE_EPOCH_CACHE_SIZE: usize = 64 * 1024;
-const ON_CHAIN_VOTES_CACHE_SIZE: usize = 3 * 1024;
-const PVFS_REQUIRE_PRECHECK_SIZE: usize = 1024;
-const VALIDATION_CODE_HASH_CACHE_SIZE: usize = 64 * 1024;
-const VERSION_CACHE_SIZE: usize = 4 * 1024;
-const DISPUTES_CACHE_SIZE: usize = 64 * 1024;
-
-struct ResidentSizeOf<T>(T);
-
-impl<T: MallocSizeOf> ResidentSize for ResidentSizeOf<T> {
-	fn resident_size(&self) -> usize {
-		std::mem::size_of::<Self>() + self.0.malloc_size_of()
-	}
-}
-
-struct DoesNotAllocate<T>(T);
-
-impl<T> ResidentSize for DoesNotAllocate<T> {
-	fn resident_size(&self) -> usize {
-		std::mem::size_of::<Self>()
-	}
-}
-
-// this is an ugly workaround for `AuthorityDiscoveryId`
-// not implementing `MallocSizeOf`
-struct VecOfDoesNotAllocate<T>(Vec<T>);
-
-impl<T> ResidentSize for VecOfDoesNotAllocate<T> {
-	fn resident_size(&self) -> usize {
-		std::mem::size_of::<T>() * self.0.capacity()
-	}
-}
+const AUTHORITIES_CACHE_CAP: Option<NonZeroUsize> = NonZeroUsize::new(1024);
+const VALIDATORS_CACHE_CAP: Option<NonZeroUsize> = NonZeroUsize::new(1024);
+const VALIDATOR_GROUPS_CACHE_CAP: Option<NonZeroUsize> = NonZeroUsize::new(1024);
+const AVAILABILITY_CORES_CACHE_CAP: Option<NonZeroUsize> = NonZeroUsize::new(1024);
+const PERSISTED_VALIDATION_DATA_CACHE_CAP: Option<NonZeroUsize> = NonZeroUsize::new(1024);
+const ASSUMED_VALIDATION_DATA_CACHE_CAP: Option<NonZeroUsize> = NonZeroUsize::new(1024);
+const CHECK_VALIDATION_OUTPUTS_CACHE_CAP: Option<NonZeroUsize> = NonZeroUsize::new(1024);
+const SESSION_INDEX_FOR_CHILD_CACHE_CAP: Option<NonZeroUsize> = NonZeroUsize::new(1024);
+const VALIDATION_CODE_CACHE_CAP: Option<NonZeroUsize> = NonZeroUsize::new(1024);
+const CANDIDATE_PENDING_AVAILABILITY_CACHE_CAP: Option<NonZeroUsize> = NonZeroUsize::new(1024);
+const CANDIDATE_EVENTS_CACHE_CAP: Option<NonZeroUsize> = NonZeroUsize::new(1024);
+const SESSION_INFO_CACHE_CAP: Option<NonZeroUsize> = NonZeroUsize::new(128);
+const DMQ_CONTENTS_CACHE_CAP: Option<NonZeroUsize> = NonZeroUsize::new(1024);
+const INBOUND_HRMP_CHANNELS_CACHE_CAP: Option<NonZeroUsize> = NonZeroUsize::new(1024);
+const CURRENT_BABE_EPOCH_CACHE_CAP: Option<NonZeroUsize> = NonZeroUsize::new(1024);
+const ON_CHAIN_VOTES_CACHE_CAP: Option<NonZeroUsize> = NonZeroUsize::new(1024);
+const PVFS_REQUIRE_PRECHECK_CAP: Option<NonZeroUsize> = NonZeroUsize::new(1024);
+const VALIDATION_CODE_HASH_CACHE_CAP: Option<NonZeroUsize> = NonZeroUsize::new(1024);
+const VERSION_CACHE_CAP: Option<NonZeroUsize> = NonZeroUsize::new(1024);
+const DISPUTES_CACHE_CAP: Option<NonZeroUsize> = NonZeroUsize::new(1024);
 
 pub(crate) struct RequestResultCache {
-	authorities: MemoryLruCache<Hash, VecOfDoesNotAllocate<AuthorityDiscoveryId>>,
-	validators: MemoryLruCache<Hash, ResidentSizeOf<Vec<ValidatorId>>>,
-	validator_groups:
-		MemoryLruCache<Hash, ResidentSizeOf<(Vec<Vec<ValidatorIndex>>, GroupRotationInfo)>>,
-	availability_cores: MemoryLruCache<Hash, ResidentSizeOf<Vec<CoreState>>>,
-	persisted_validation_data: MemoryLruCache<
-		(Hash, ParaId, OccupiedCoreAssumption),
-		ResidentSizeOf<Option<PersistedValidationData>>,
-	>,
-	assumed_validation_data: MemoryLruCache<
-		(ParaId, Hash),
-		ResidentSizeOf<Option<(PersistedValidationData, ValidationCodeHash)>>,
-	>,
-	check_validation_outputs:
-		MemoryLruCache<(Hash, ParaId, CandidateCommitments), ResidentSizeOf<bool>>,
-	session_index_for_child: MemoryLruCache<Hash, ResidentSizeOf<SessionIndex>>,
-	validation_code: MemoryLruCache<
-		(Hash, ParaId, OccupiedCoreAssumption),
-		ResidentSizeOf<Option<ValidationCode>>,
-	>,
-	validation_code_by_hash:
-		MemoryLruCache<ValidationCodeHash, ResidentSizeOf<Option<ValidationCode>>>,
-	candidate_pending_availability:
-		MemoryLruCache<(Hash, ParaId), ResidentSizeOf<Option<CommittedCandidateReceipt>>>,
-	candidate_events: MemoryLruCache<Hash, ResidentSizeOf<Vec<CandidateEvent>>>,
-	session_info: MemoryLruCache<SessionIndex, ResidentSizeOf<SessionInfo>>,
-	dmq_contents:
-		MemoryLruCache<(Hash, ParaId), ResidentSizeOf<Vec<InboundDownwardMessage<BlockNumber>>>>,
-	inbound_hrmp_channels_contents: MemoryLruCache<
-		(Hash, ParaId),
-		ResidentSizeOf<BTreeMap<ParaId, Vec<InboundHrmpMessage<BlockNumber>>>>,
-	>,
-	current_babe_epoch: MemoryLruCache<Hash, DoesNotAllocate<Epoch>>,
-	on_chain_votes: MemoryLruCache<Hash, ResidentSizeOf<Option<ScrapedOnChainVotes>>>,
-	pvfs_require_precheck: MemoryLruCache<Hash, ResidentSizeOf<Vec<ValidationCodeHash>>>,
-	validation_code_hash: MemoryLruCache<
-		(Hash, ParaId, OccupiedCoreAssumption),
-		ResidentSizeOf<Option<ValidationCodeHash>>,
-	>,
-	version: MemoryLruCache<Hash, ResidentSizeOf<u32>>,
-	disputes: MemoryLruCache<
-		Hash,
-		ResidentSizeOf<Vec<(SessionIndex, CandidateHash, DisputeState<BlockNumber>)>>,
-	>,
+	authorities: LruCache<Hash, Vec<AuthorityDiscoveryId>>,
+	validators: LruCache<Hash, Vec<ValidatorId>>,
+	validator_groups: LruCache<Hash, (Vec<Vec<ValidatorIndex>>, GroupRotationInfo)>,
+	availability_cores: LruCache<Hash, Vec<CoreState>>,
+	persisted_validation_data:
+		LruCache<(Hash, ParaId, OccupiedCoreAssumption), Option<PersistedValidationData>>,
+	assumed_validation_data:
+		LruCache<(ParaId, Hash), Option<(PersistedValidationData, ValidationCodeHash)>>,
+	check_validation_outputs: LruCache<(Hash, ParaId, CandidateCommitments), bool>,
+	session_index_for_child: LruCache<Hash, SessionIndex>,
+	validation_code: LruCache<(Hash, ParaId, OccupiedCoreAssumption), Option<ValidationCode>>,
+	validation_code_by_hash: LruCache<ValidationCodeHash, Option<ValidationCode>>,
+	candidate_pending_availability: LruCache<(Hash, ParaId), Option<CommittedCandidateReceipt>>,
+	candidate_events: LruCache<Hash, Vec<CandidateEvent>>,
+	session_info: LruCache<SessionIndex, SessionInfo>,
+	dmq_contents: LruCache<(Hash, ParaId), Vec<InboundDownwardMessage<BlockNumber>>>,
+	inbound_hrmp_channels_contents:
+		LruCache<(Hash, ParaId), BTreeMap<ParaId, Vec<InboundHrmpMessage<BlockNumber>>>>,
+	current_babe_epoch: LruCache<Hash, Epoch>,
+	on_chain_votes: LruCache<Hash, Option<ScrapedOnChainVotes>>,
+	pvfs_require_precheck: LruCache<Hash, Vec<ValidationCodeHash>>,
+	validation_code_hash:
+		LruCache<(Hash, ParaId, OccupiedCoreAssumption), Option<ValidationCodeHash>>,
+	version: LruCache<Hash, u32>,
+	disputes: LruCache<Hash, Vec<(SessionIndex, CandidateHash, DisputeState<BlockNumber>)>>,
 }
 
 impl Default for RequestResultCache {
 	fn default() -> Self {
 		Self {
-			authorities: MemoryLruCache::new(AUTHORITIES_CACHE_SIZE),
-			validators: MemoryLruCache::new(VALIDATORS_CACHE_SIZE),
-			validator_groups: MemoryLruCache::new(VALIDATOR_GROUPS_CACHE_SIZE),
-			availability_cores: MemoryLruCache::new(AVAILABILITY_CORES_CACHE_SIZE),
-			persisted_validation_data: MemoryLruCache::new(PERSISTED_VALIDATION_DATA_CACHE_SIZE),
-			assumed_validation_data: MemoryLruCache::new(ASSUMED_VALIDATION_DATA_CACHE_SIZE),
-			check_validation_outputs: MemoryLruCache::new(CHECK_VALIDATION_OUTPUTS_CACHE_SIZE),
-			session_index_for_child: MemoryLruCache::new(SESSION_INDEX_FOR_CHILD_CACHE_SIZE),
-			validation_code: MemoryLruCache::new(VALIDATION_CODE_CACHE_SIZE),
-			validation_code_by_hash: MemoryLruCache::new(VALIDATION_CODE_CACHE_SIZE),
-			candidate_pending_availability: MemoryLruCache::new(
-				CANDIDATE_PENDING_AVAILABILITY_CACHE_SIZE,
+			authorities: LruCache::new(AUTHORITIES_CACHE_CAP.expect("!= 0; qed")),
+			validators: LruCache::new(VALIDATORS_CACHE_CAP.expect("!= 0; qed")),
+			validator_groups: LruCache::new(VALIDATOR_GROUPS_CACHE_CAP.expect("!= 0; qed")),
+			availability_cores: LruCache::new(AVAILABILITY_CORES_CACHE_CAP.expect("!= 0; qed")),
+			persisted_validation_data: LruCache::new(
+				PERSISTED_VALIDATION_DATA_CACHE_CAP.expect("!= 0; qed"),
 			),
-			candidate_events: MemoryLruCache::new(CANDIDATE_EVENTS_CACHE_SIZE),
-			session_info: MemoryLruCache::new(SESSION_INFO_CACHE_SIZE),
-			dmq_contents: MemoryLruCache::new(DMQ_CONTENTS_CACHE_SIZE),
-			inbound_hrmp_channels_contents: MemoryLruCache::new(INBOUND_HRMP_CHANNELS_CACHE_SIZE),
-			current_babe_epoch: MemoryLruCache::new(CURRENT_BABE_EPOCH_CACHE_SIZE),
-			on_chain_votes: MemoryLruCache::new(ON_CHAIN_VOTES_CACHE_SIZE),
-			pvfs_require_precheck: MemoryLruCache::new(PVFS_REQUIRE_PRECHECK_SIZE),
-			validation_code_hash: MemoryLruCache::new(VALIDATION_CODE_HASH_CACHE_SIZE),
-			version: MemoryLruCache::new(VERSION_CACHE_SIZE),
-			disputes: MemoryLruCache::new(DISPUTES_CACHE_SIZE),
+			assumed_validation_data: LruCache::new(
+				ASSUMED_VALIDATION_DATA_CACHE_CAP.expect("!= 0; qed"),
+			),
+			check_validation_outputs: LruCache::new(
+				CHECK_VALIDATION_OUTPUTS_CACHE_CAP.expect("!= 0; qed"),
+			),
+			session_index_for_child: LruCache::new(
+				SESSION_INDEX_FOR_CHILD_CACHE_CAP.expect("!= 0; qed"),
+			),
+			validation_code: LruCache::new(VALIDATION_CODE_CACHE_CAP.expect("!= 0; qed")),
+			validation_code_by_hash: LruCache::new(VALIDATION_CODE_CACHE_CAP.expect("!= 0; qed")),
+			candidate_pending_availability: LruCache::new(
+				CANDIDATE_PENDING_AVAILABILITY_CACHE_CAP.expect("!= 0; qed"),
+			),
+			candidate_events: LruCache::new(CANDIDATE_EVENTS_CACHE_CAP.expect("!= 0; qed")),
+			session_info: LruCache::new(SESSION_INFO_CACHE_CAP.expect("!= 0; qed")),
+			dmq_contents: LruCache::new(DMQ_CONTENTS_CACHE_CAP.expect("!= 0; qed")),
+			inbound_hrmp_channels_contents: LruCache::new(
+				INBOUND_HRMP_CHANNELS_CACHE_CAP.expect("!= 0; qed"),
+			),
+			current_babe_epoch: LruCache::new(CURRENT_BABE_EPOCH_CACHE_CAP.expect("!= 0; qed")),
+			on_chain_votes: LruCache::new(ON_CHAIN_VOTES_CACHE_CAP.expect("!= 0; qed")),
+			pvfs_require_precheck: LruCache::new(PVFS_REQUIRE_PRECHECK_CAP.expect("!= 0; qed")),
+			validation_code_hash: LruCache::new(VALIDATION_CODE_HASH_CACHE_CAP.expect("!= 0; qed")),
+			version: LruCache::new(VERSION_CACHE_CAP.expect("!= 0; qed")),
+			disputes: LruCache::new(DISPUTES_CACHE_CAP.expect("!= 0; qed")),
 		}
 	}
 }
@@ -157,7 +121,7 @@ impl RequestResultCache {
 		&mut self,
 		relay_parent: &Hash,
 	) -> Option<&Vec<AuthorityDiscoveryId>> {
-		self.authorities.get(relay_parent).map(|v| &v.0)
+		self.authorities.get(relay_parent)
 	}
 
 	pub(crate) fn cache_authorities(
@@ -165,22 +129,22 @@ impl RequestResultCache {
 		relay_parent: Hash,
 		authorities: Vec<AuthorityDiscoveryId>,
 	) {
-		self.authorities.insert(relay_parent, VecOfDoesNotAllocate(authorities));
+		self.authorities.put(relay_parent, authorities);
 	}
 
 	pub(crate) fn validators(&mut self, relay_parent: &Hash) -> Option<&Vec<ValidatorId>> {
-		self.validators.get(relay_parent).map(|v| &v.0)
+		self.validators.get(relay_parent)
 	}
 
 	pub(crate) fn cache_validators(&mut self, relay_parent: Hash, validators: Vec<ValidatorId>) {
-		self.validators.insert(relay_parent, ResidentSizeOf(validators));
+		self.validators.put(relay_parent, validators);
 	}
 
 	pub(crate) fn validator_groups(
 		&mut self,
 		relay_parent: &Hash,
 	) -> Option<&(Vec<Vec<ValidatorIndex>>, GroupRotationInfo)> {
-		self.validator_groups.get(relay_parent).map(|v| &v.0)
+		self.validator_groups.get(relay_parent)
 	}
 
 	pub(crate) fn cache_validator_groups(
@@ -188,22 +152,22 @@ impl RequestResultCache {
 		relay_parent: Hash,
 		groups: (Vec<Vec<ValidatorIndex>>, GroupRotationInfo),
 	) {
-		self.validator_groups.insert(relay_parent, ResidentSizeOf(groups));
+		self.validator_groups.put(relay_parent, groups);
 	}
 
 	pub(crate) fn availability_cores(&mut self, relay_parent: &Hash) -> Option<&Vec<CoreState>> {
-		self.availability_cores.get(relay_parent).map(|v| &v.0)
+		self.availability_cores.get(relay_parent)
 	}
 
 	pub(crate) fn cache_availability_cores(&mut self, relay_parent: Hash, cores: Vec<CoreState>) {
-		self.availability_cores.insert(relay_parent, ResidentSizeOf(cores));
+		self.availability_cores.put(relay_parent, cores);
 	}
 
 	pub(crate) fn persisted_validation_data(
 		&mut self,
 		key: (Hash, ParaId, OccupiedCoreAssumption),
 	) -> Option<&Option<PersistedValidationData>> {
-		self.persisted_validation_data.get(&key).map(|v| &v.0)
+		self.persisted_validation_data.get(&key)
 	}
 
 	pub(crate) fn cache_persisted_validation_data(
@@ -211,14 +175,14 @@ impl RequestResultCache {
 		key: (Hash, ParaId, OccupiedCoreAssumption),
 		data: Option<PersistedValidationData>,
 	) {
-		self.persisted_validation_data.insert(key, ResidentSizeOf(data));
+		self.persisted_validation_data.put(key, data);
 	}
 
 	pub(crate) fn assumed_validation_data(
 		&mut self,
 		key: (Hash, ParaId, Hash),
 	) -> Option<&Option<(PersistedValidationData, ValidationCodeHash)>> {
-		self.assumed_validation_data.get(&(key.1, key.2)).map(|v| &v.0)
+		self.assumed_validation_data.get(&(key.1, key.2))
 	}
 
 	pub(crate) fn cache_assumed_validation_data(
@@ -226,14 +190,14 @@ impl RequestResultCache {
 		key: (ParaId, Hash),
 		data: Option<(PersistedValidationData, ValidationCodeHash)>,
 	) {
-		self.assumed_validation_data.insert(key, ResidentSizeOf(data));
+		self.assumed_validation_data.put(key, data);
 	}
 
 	pub(crate) fn check_validation_outputs(
 		&mut self,
 		key: (Hash, ParaId, CandidateCommitments),
 	) -> Option<&bool> {
-		self.check_validation_outputs.get(&key).map(|v| &v.0)
+		self.check_validation_outputs.get(&key)
 	}
 
 	pub(crate) fn cache_check_validation_outputs(
@@ -241,11 +205,11 @@ impl RequestResultCache {
 		key: (Hash, ParaId, CandidateCommitments),
 		value: bool,
 	) {
-		self.check_validation_outputs.insert(key, ResidentSizeOf(value));
+		self.check_validation_outputs.put(key, value);
 	}
 
 	pub(crate) fn session_index_for_child(&mut self, relay_parent: &Hash) -> Option<&SessionIndex> {
-		self.session_index_for_child.get(relay_parent).map(|v| &v.0)
+		self.session_index_for_child.get(relay_parent)
 	}
 
 	pub(crate) fn cache_session_index_for_child(
@@ -253,14 +217,14 @@ impl RequestResultCache {
 		relay_parent: Hash,
 		index: SessionIndex,
 	) {
-		self.session_index_for_child.insert(relay_parent, ResidentSizeOf(index));
+		self.session_index_for_child.put(relay_parent, index);
 	}
 
 	pub(crate) fn validation_code(
 		&mut self,
 		key: (Hash, ParaId, OccupiedCoreAssumption),
 	) -> Option<&Option<ValidationCode>> {
-		self.validation_code.get(&key).map(|v| &v.0)
+		self.validation_code.get(&key)
 	}
 
 	pub(crate) fn cache_validation_code(
@@ -268,7 +232,7 @@ impl RequestResultCache {
 		key: (Hash, ParaId, OccupiedCoreAssumption),
 		value: Option<ValidationCode>,
 	) {
-		self.validation_code.insert(key, ResidentSizeOf(value));
+		self.validation_code.put(key, value);
 	}
 
 	// the actual key is `ValidationCodeHash` (`Hash` is ignored),
@@ -277,7 +241,7 @@ impl RequestResultCache {
 		&mut self,
 		key: (Hash, ValidationCodeHash),
 	) -> Option<&Option<ValidationCode>> {
-		self.validation_code_by_hash.get(&key.1).map(|v| &v.0)
+		self.validation_code_by_hash.get(&key.1)
 	}
 
 	pub(crate) fn cache_validation_code_by_hash(
@@ -285,14 +249,14 @@ impl RequestResultCache {
 		key: ValidationCodeHash,
 		value: Option<ValidationCode>,
 	) {
-		self.validation_code_by_hash.insert(key, ResidentSizeOf(value));
+		self.validation_code_by_hash.put(key, value);
 	}
 
 	pub(crate) fn candidate_pending_availability(
 		&mut self,
 		key: (Hash, ParaId),
 	) -> Option<&Option<CommittedCandidateReceipt>> {
-		self.candidate_pending_availability.get(&key).map(|v| &v.0)
+		self.candidate_pending_availability.get(&key)
 	}
 
 	pub(crate) fn cache_candidate_pending_availability(
@@ -300,11 +264,11 @@ impl RequestResultCache {
 		key: (Hash, ParaId),
 		value: Option<CommittedCandidateReceipt>,
 	) {
-		self.candidate_pending_availability.insert(key, ResidentSizeOf(value));
+		self.candidate_pending_availability.put(key, value);
 	}
 
 	pub(crate) fn candidate_events(&mut self, relay_parent: &Hash) -> Option<&Vec<CandidateEvent>> {
-		self.candidate_events.get(relay_parent).map(|v| &v.0)
+		self.candidate_events.get(relay_parent)
 	}
 
 	pub(crate) fn cache_candidate_events(
@@ -312,22 +276,22 @@ impl RequestResultCache {
 		relay_parent: Hash,
 		events: Vec<CandidateEvent>,
 	) {
-		self.candidate_events.insert(relay_parent, ResidentSizeOf(events));
+		self.candidate_events.put(relay_parent, events);
 	}
 
 	pub(crate) fn session_info(&mut self, key: SessionIndex) -> Option<&SessionInfo> {
-		self.session_info.get(&key).map(|v| &v.0)
+		self.session_info.get(&key)
 	}
 
 	pub(crate) fn cache_session_info(&mut self, key: SessionIndex, value: SessionInfo) {
-		self.session_info.insert(key, ResidentSizeOf(value));
+		self.session_info.put(key, value);
 	}
 
 	pub(crate) fn dmq_contents(
 		&mut self,
 		key: (Hash, ParaId),
 	) -> Option<&Vec<InboundDownwardMessage<BlockNumber>>> {
-		self.dmq_contents.get(&key).map(|v| &v.0)
+		self.dmq_contents.get(&key)
 	}
 
 	pub(crate) fn cache_dmq_contents(
@@ -335,14 +299,14 @@ impl RequestResultCache {
 		key: (Hash, ParaId),
 		value: Vec<InboundDownwardMessage<BlockNumber>>,
 	) {
-		self.dmq_contents.insert(key, ResidentSizeOf(value));
+		self.dmq_contents.put(key, value);
 	}
 
 	pub(crate) fn inbound_hrmp_channels_contents(
 		&mut self,
 		key: (Hash, ParaId),
 	) -> Option<&BTreeMap<ParaId, Vec<InboundHrmpMessage<BlockNumber>>>> {
-		self.inbound_hrmp_channels_contents.get(&key).map(|v| &v.0)
+		self.inbound_hrmp_channels_contents.get(&key)
 	}
 
 	pub(crate) fn cache_inbound_hrmp_channel_contents(
@@ -350,22 +314,22 @@ impl RequestResultCache {
 		key: (Hash, ParaId),
 		value: BTreeMap<ParaId, Vec<InboundHrmpMessage<BlockNumber>>>,
 	) {
-		self.inbound_hrmp_channels_contents.insert(key, ResidentSizeOf(value));
+		self.inbound_hrmp_channels_contents.put(key, value);
 	}
 
 	pub(crate) fn current_babe_epoch(&mut self, relay_parent: &Hash) -> Option<&Epoch> {
-		self.current_babe_epoch.get(relay_parent).map(|v| &v.0)
+		self.current_babe_epoch.get(relay_parent)
 	}
 
 	pub(crate) fn cache_current_babe_epoch(&mut self, relay_parent: Hash, epoch: Epoch) {
-		self.current_babe_epoch.insert(relay_parent, DoesNotAllocate(epoch));
+		self.current_babe_epoch.put(relay_parent, epoch);
 	}
 
 	pub(crate) fn on_chain_votes(
 		&mut self,
 		relay_parent: &Hash,
 	) -> Option<&Option<ScrapedOnChainVotes>> {
-		self.on_chain_votes.get(relay_parent).map(|v| &v.0)
+		self.on_chain_votes.get(relay_parent)
 	}
 
 	pub(crate) fn cache_on_chain_votes(
@@ -373,14 +337,14 @@ impl RequestResultCache {
 		relay_parent: Hash,
 		scraped: Option<ScrapedOnChainVotes>,
 	) {
-		self.on_chain_votes.insert(relay_parent, ResidentSizeOf(scraped));
+		self.on_chain_votes.put(relay_parent, scraped);
 	}
 
 	pub(crate) fn pvfs_require_precheck(
 		&mut self,
 		relay_parent: &Hash,
 	) -> Option<&Vec<ValidationCodeHash>> {
-		self.pvfs_require_precheck.get(relay_parent).map(|v| &v.0)
+		self.pvfs_require_precheck.get(relay_parent)
 	}
 
 	pub(crate) fn cache_pvfs_require_precheck(
@@ -388,14 +352,14 @@ impl RequestResultCache {
 		relay_parent: Hash,
 		pvfs: Vec<ValidationCodeHash>,
 	) {
-		self.pvfs_require_precheck.insert(relay_parent, ResidentSizeOf(pvfs))
+		self.pvfs_require_precheck.put(relay_parent, pvfs);
 	}
 
 	pub(crate) fn validation_code_hash(
 		&mut self,
 		key: (Hash, ParaId, OccupiedCoreAssumption),
 	) -> Option<&Option<ValidationCodeHash>> {
-		self.validation_code_hash.get(&key).map(|v| &v.0)
+		self.validation_code_hash.get(&key)
 	}
 
 	pub(crate) fn cache_validation_code_hash(
@@ -403,22 +367,22 @@ impl RequestResultCache {
 		key: (Hash, ParaId, OccupiedCoreAssumption),
 		value: Option<ValidationCodeHash>,
 	) {
-		self.validation_code_hash.insert(key, ResidentSizeOf(value));
+		self.validation_code_hash.put(key, value);
 	}
 
 	pub(crate) fn version(&mut self, relay_parent: &Hash) -> Option<&u32> {
-		self.version.get(&relay_parent).map(|v| &v.0)
+		self.version.get(relay_parent)
 	}
 
 	pub(crate) fn cache_version(&mut self, key: Hash, value: u32) {
-		self.version.insert(key, ResidentSizeOf(value));
+		self.version.put(key, value);
 	}
 
 	pub(crate) fn disputes(
 		&mut self,
 		relay_parent: &Hash,
 	) -> Option<&Vec<(SessionIndex, CandidateHash, DisputeState<BlockNumber>)>> {
-		self.disputes.get(relay_parent).map(|v| &v.0)
+		self.disputes.get(relay_parent)
 	}
 
 	pub(crate) fn cache_disputes(
@@ -426,7 +390,7 @@ impl RequestResultCache {
 		relay_parent: Hash,
 		value: Vec<(SessionIndex, CandidateHash, DisputeState<BlockNumber>)>,
 	) {
-		self.disputes.insert(relay_parent, ResidentSizeOf(value));
+		self.disputes.put(relay_parent, value);
 	}
 }
 


### PR DESCRIPTION
## Overview

See title.

## Related Issues

https://github.com/paritytech/substrate/issues/12658