### PR TITLE
Let the PVF host kill the worker on timeout

### DIFF
--- a/node/core/pvf/src/execute/worker.rs
+++ b/node/core/pvf/src/execute/worker.rs
@@ -74,6 +74,8 @@ pub enum Outcome {
 
 /// Given the idle token of a worker and parameters of work, communicates with the worker and
 /// returns the outcome.
+///
+/// NOTE: Returning the `HardTimeout` or `IoErr` errors will trigger the child process being killed.
 pub async fn start_work(
 	worker: IdleWorker,
 	artifact: ArtifactPathId,
@@ -148,7 +150,7 @@ pub async fn start_work(
 				target: LOG_TARGET,
 				worker_pid = %pid,
 				validation_code_hash = ?artifact.id.code_hash,
-				"execution worker exceeded alloted time for execution",
+				"execution worker exceeded allotted time for execution",
 			);
 			// TODO: This case is not really a hard timeout as the timeout here in the host is
 			// lenient. Should fix this as part of

--- a/node/core/pvf/src/host.rs
+++ b/node/core/pvf/src/host.rs
@@ -390,7 +390,8 @@ async fn run(
 			from_prepare_queue = from_prepare_queue_rx.next() => {
 				let from_queue = break_if_fatal!(from_prepare_queue.ok_or(Fatal));
 
-				// Note that preparation always succeeds.
+				// Note that unless the worker dies, the preparation outcome is always reported as
+				// concluded.
 				//
 				// That's because the error conditions are written into the artifact and will be
 				// reported at the time of the execution. It potentially, but not necessarily, can

--- a/node/core/pvf/src/host.rs
+++ b/node/core/pvf/src/host.rs
@@ -390,8 +390,7 @@ async fn run(
 			from_prepare_queue = from_prepare_queue_rx.next() => {
 				let from_queue = break_if_fatal!(from_prepare_queue.ok_or(Fatal));
 
-				// Note that unless the worker dies, the preparation outcome is always reported as
-				// concluded.
+				// Note that the preparation outcome is always reported as concluded.
 				//
 				// That's because the error conditions are written into the artifact and will be
 				// reported at the time of the execution. It potentially, but not necessarily, can

--- a/node/core/pvf/src/prepare/pool.rs
+++ b/node/core/pvf/src/prepare/pool.rs
@@ -299,7 +299,8 @@ fn handle_mux(
 					let data = match spawned.get_mut(worker) {
 						None => {
 							// Perhaps the worker was killed meanwhile and the result is no longer
-							// relevant.
+							// relevant. We already send `Rip` when purging if we detect that the
+							// worker is dead.
 							return Ok(())
 						},
 						Some(data) => data,
@@ -321,6 +322,7 @@ fn handle_mux(
 
 					Ok(())
 				},
+				// Sending `rip: true` triggers killing the worker.
 				Outcome::DidNotMakeIt => {
 					if attempt_retire(metrics, spawned, worker) {
 						reply(
@@ -335,6 +337,7 @@ fn handle_mux(
 
 					Ok(())
 				},
+				// Sending `rip: true` triggers killing the worker.
 				Outcome::TimedOut => {
 					if attempt_retire(metrics, spawned, worker) {
 						reply(

--- a/node/core/pvf/src/prepare/pool.rs
+++ b/node/core/pvf/src/prepare/pool.rs
@@ -294,6 +294,8 @@ fn handle_mux(
 			Ok(())
 		},
 		PoolEvent::StartWork(worker, outcome) => {
+			// If we receive any outcome other than `Concluded`, we attempt to kill the worker
+			// process.
 			match outcome {
 				Outcome::Concluded { worker: idle, result } => {
 					let data = match spawned.get_mut(worker) {
@@ -322,7 +324,6 @@ fn handle_mux(
 
 					Ok(())
 				},
-				// Sending `rip: true` triggers killing the worker.
 				Outcome::DidNotMakeIt => {
 					if attempt_retire(metrics, spawned, worker) {
 						reply(
@@ -337,7 +338,6 @@ fn handle_mux(
 
 					Ok(())
 				},
-				// Sending `rip: true` triggers killing the worker.
 				Outcome::TimedOut => {
 					if attempt_retire(metrics, spawned, worker) {
 						reply(

--- a/node/core/pvf/src/prepare/worker.rs
+++ b/node/core/pvf/src/prepare/worker.rs
@@ -167,8 +167,8 @@ pub async fn start_work(
 
 /// Handles the case where we successfully received response bytes on the host from the child.
 ///
-/// NOTE: Here we know the artifact exists, but is still located in a temporary file. If we error, the temporary
-/// artifact will be cleared by `with_tmp_file`.
+/// NOTE: Here we know the artifact exists, but is still located in a temporary file which will be
+/// cleared by `with_tmp_file`.
 async fn handle_response_bytes(
 	response_bytes: Vec<u8>,
 	pid: u32,

--- a/node/core/pvf/src/prepare/worker.rs
+++ b/node/core/pvf/src/prepare/worker.rs
@@ -78,6 +78,9 @@ enum Selected {
 
 /// Given the idle token of a worker and parameters of work, communicates with the worker and
 /// returns the outcome.
+///
+/// NOTE: Returning the `TimedOut` or `DidNotMakeIt` errors will trigger the child process being
+/// killed.
 pub async fn start_work(
 	worker: IdleWorker,
 	code: Arc<Vec<u8>>,
@@ -149,6 +152,7 @@ pub async fn start_work(
 			},
 		};
 
+		// NOTE: A `TimedOut` or `DidNotMakeIt` error triggers the child process being killed.
 		match selected {
 			// Timed out on the child. This should already be logged by the child.
 			Selected::Done(Err(PrepareError::TimedOut)) => Outcome::TimedOut,
@@ -162,6 +166,9 @@ pub async fn start_work(
 }
 
 /// Handles the case where we successfully received response bytes on the host from the child.
+///
+/// NOTE: Here we know the artifact exists, but is still located in a temporary file. If we error, the temporary
+/// artifact will be cleared by `with_tmp_file`.
 async fn handle_response_bytes(
 	response_bytes: Vec<u8>,
 	pid: u32,
@@ -201,9 +208,6 @@ async fn handle_response_bytes(
 		);
 
 		// Return a timeout error.
-		//
-		// NOTE: The artifact exists, but is located in a temporary file which
-		// will be cleared by `with_tmp_file`.
 		return Selected::Deadline
 	}
 

--- a/node/core/pvf/src/worker_common.rs
+++ b/node/core/pvf/src/worker_common.rs
@@ -199,10 +199,8 @@ where
 }
 
 /// Loop that runs in the CPU time monitor thread on prepare and execute jobs. Continuously wakes up
-/// from sleeping and then either sleeps for the remaining CPU time, or kills the process if we
-/// exceed the CPU timeout.
-///
-/// NOTE: Killed processes are detected and cleaned up in `purge_dead`.
+/// from sleeping and then either sleeps for the remaining CPU time, or sends back a timeout error
+/// if we exceed the CPU timeout.
 ///
 /// NOTE: If the job completes and this thread is still sleeping, it will continue sleeping in the
 /// background. When it wakes, it will see that the flag has been set and return.

--- a/node/core/pvf/src/worker_common.rs
+++ b/node/core/pvf/src/worker_common.rs
@@ -258,6 +258,8 @@ pub async fn cpu_time_monitor_loop(
 					err
 				);
 			}
+
+			return
 		}
 
 		// Sleep for the remaining CPU time, plus a bit to account for overhead. Note that the sleep


### PR DESCRIPTION
# PULL REQUEST

## Overview

After the recent [CPU timeout change](https://github.com/paritytech/polkadot/issues/4217), we were killing the PVF worker process on
the worker-side if the process timed out. However, this had an issue where the
worker would be killed by `purge_dead` and a `Rip` event sent out, and the
`TimedOut` error from the worker would be dropped.

This interfered with the [logic](https://github.com/paritytech/polkadot/blob/master/node/core/pvf/src/host.rs#L775) for retrying after preparation failures after a delay.
(Actually, the host will even try to spin up another worker to try to process
the timing-out prepare job again, which is pretty bad.)

This PR changes the flow so that the child worker just sends back `TimedOut`
without killing the process. The host will kill the worker if it detects
`TimedOut`, whether the worker was execution or preparation, while properly
bubbling up the error.

## Related Issue

Found while investigating https://github.com/paritytech/polkadot/issues/3754.