### PR TITLE
update deprecated alias `--all`

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ cargo build # Builds all native code
 You can run the tests if you like:
 
 ```bash
-cargo test --all --release
+cargo test --workspace --release
 ```
 
 You can start a development chain with:


### PR DESCRIPTION
`--all` is a deprecated alias for `--workspace` (https://doc.rust-lang.org/cargo/commands/cargo-test.html)