### PR TITLE
crowdloan: Fix migration.

### DIFF
--- a/runtime/common/src/crowdloan/mod.rs
+++ b/runtime/common/src/crowdloan/mod.rs
@@ -184,9 +184,13 @@ pub mod pallet {
 	use frame_support::pallet_prelude::*;
 	use frame_system::{ensure_root, ensure_signed, pallet_prelude::*};
 
+	/// The current storage version.
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
+
 	#[pallet::pallet]
 	#[pallet::generate_store(pub(super) trait Store)]
 	#[pallet::without_storage_info]
+	#[pallet::storage_version(STORAGE_VERSION)]
 	pub struct Pallet<T>(_);
 
 	#[pallet::config]


### PR DESCRIPTION
The migration would not have been run because of the `current_version == 1` check.

Migration was added here: https://github.com/paritytech/polkadot/pull/6372