### PR TITLE
CI: Remove the excessive variable declaration

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,8 +37,6 @@ variables:
   DOCKER_OS:                       "debian:stretch"
   ARCH:                            "x86_64"
   ZOMBIENET_IMAGE:                 "docker.io/paritytech/zombienet:v1.2.78"
-  PIPELINE_SCRIPTS_TAG:            "v0.4"
-
 default:
   cache:                           {}
   retry:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,6 +37,7 @@ variables:
   DOCKER_OS:                       "debian:stretch"
   ARCH:                            "x86_64"
   ZOMBIENET_IMAGE:                 "docker.io/paritytech/zombienet:v1.2.78"
+
 default:
   cache:                           {}
   retry:


### PR DESCRIPTION
The `PIPELINE_SCRIPTS_TAG` variable is already defined on the project level and has higher precedence so this declaration is unnecessary and misguiding.