### PR TITLE
Companion for substrate##12915: Reset mmr storage

### DIFF
--- a/runtime/rococo/Cargo.toml
+++ b/runtime/rococo/Cargo.toml
@@ -229,6 +229,7 @@ try-runtime = [
 	"pallet-im-online/try-runtime",
 	"pallet-indices/try-runtime",
 	"pallet-membership/try-runtime",
+	"pallet-mmr/try-runtime",
 	"pallet-multisig/try-runtime",
 	"pallet-offences/try-runtime",
 	"pallet-preimage/try-runtime",

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -1456,7 +1456,9 @@ pub type Executive = frame_executive::Executive<
 	frame_system::ChainContext<Runtime>,
 	Runtime,
 	AllPalletsWithSystem,
-	(),
+	(
+		pallet_mmr::migrations::v1::MigrateToV1<Runtime>,
+	),
 >;
 /// The payload being signed in transactions.
 pub type SignedPayload = generic::SignedPayload<RuntimeCall, SignedExtra>;


### PR DESCRIPTION
Resets mmr storage on rococo via runtime upgrade state migration.

Companion for https://github.com/paritytech/substrate/pull/12915