### PR TITLE
Fix wrong rate limit + add a few logs.

### DIFF
--- a/node/core/approval-voting/src/lib.rs
+++ b/node/core/approval-voting/src/lib.rs
@@ -1327,6 +1327,11 @@ async fn get_approval_signatures_for_candidate<Context>(
 
 	// No need to block subsystem on this (also required to break cycle).
 	// We should not be sending this message frequently - caller must make sure this is bounded.
+	gum::trace!(
+		target: LOG_TARGET,
+		?candidate_hash,
+		"Spawning task for fetching sinatures from approval-distribution"
+	);
 	ctx.spawn("get-approval-signatures", Box::pin(get_approvals))
 }
 

--- a/node/core/dispute-coordinator/src/initialized.rs
+++ b/node/core/dispute-coordinator/src/initialized.rs
@@ -807,7 +807,14 @@ impl Initialized {
 						);
 						intermediate_result
 					},
-					Ok(votes) => intermediate_result.import_approval_votes(&env, votes, now),
+					Ok(votes) => {
+						gum::trace!(
+							target: LOG_TARGET,
+							count = votes.len(),
+							"Successfully received approval votes."
+						);
+						intermediate_result.import_approval_votes(&env, votes, now)
+					},
 				}
 			} else {
 				gum::trace!(

--- a/node/network/dispute-distribution/src/sender/mod.rs
+++ b/node/network/dispute-distribution/src/sender/mod.rs
@@ -389,6 +389,7 @@ impl RateLimit {
 	/// String given as occasion and candidate hash are logged in case the rate limit hit.
 	async fn limit(&mut self, occasion: &'static str, candidate_hash: CandidateHash) {
 		// Wait for rate limit and add some logging:
+		let mut num_wakes: u32 = 0;
 		poll_fn(|cx| {
 			let old_limit = Pin::new(&mut self.limit);
 			match old_limit.poll(cx) {
@@ -397,8 +398,10 @@ impl RateLimit {
 						target: LOG_TARGET,
 						?occasion,
 						?candidate_hash,
+						?num_wakes,
 						"Sending rate limit hit, slowing down requests"
 					);
+					num_wakes += 1;
 					Poll::Pending
 				},
 				Poll::Ready(()) => Poll::Ready(()),

--- a/node/network/dispute-distribution/src/sender/mod.rs
+++ b/node/network/dispute-distribution/src/sender/mod.rs
@@ -195,7 +195,7 @@ impl DisputeSender {
 		// recovered at startup will be relatively "old" anyway and we assume that no more than a
 		// third of the validators will go offline at any point in time anyway.
 		for dispute in unknown_disputes {
-			self.rate_limit.limit("while going through unknown disputes", dispute.1).await;
+			// Rate limiting handled inside `start_send_for_dispute` (calls `start_sender`).
 			self.start_send_for_dispute(ctx, runtime, dispute).await?;
 		}
 		Ok(())


### PR DESCRIPTION
That rate limit was wrong in two ways:

1. It rate limited every unknown dispute, regardless of whether there is a vote from us - hence it would rate limit noops. This is the really bad part, because this means that the subsystem will become slower and slower with more unknown disputes. But if the subystem gets slower, there will be more unknown disputes -> :boom: 
2. It was also completely redundant as `start_send_for_dispute` was rate limited already and not only that it does it properly.

Fix: Remove.

I will see whether some unit test for this makes sense, but that will be a separate PR. For now, let's get the fix in. (It has been tested on Versi and disputes are running super smooth with this fix.) More aggressive testing is still in the works, but so far things are looking good.

Note: Branch name is misleading: The cycle is not yet fixed, this will be a separate PR as well.

Fixes https://github.com/paritytech/polkadot/issues/6412