### PR TITLE
Use explicit call indices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,7 +410,7 @@ dependencies = [
 [[package]]
 name = "beefy-gadget"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -447,7 +447,7 @@ dependencies = [
 [[package]]
 name = "beefy-gadget-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "beefy-gadget",
  "futures",
@@ -467,7 +467,7 @@ dependencies = [
 [[package]]
 name = "beefy-merkle-tree"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "sp-api",
  "sp-beefy",
@@ -1990,7 +1990,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "fork-tree"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -2014,7 +2014,7 @@ checksum = "85dcb89d2b10c5f6133de2efd8c11959ce9dbb46a2f7a4cab208c4eeda6ce1ab"
 [[package]]
 name = "frame-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2037,7 +2037,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "Inflector",
  "array-bytes",
@@ -2089,7 +2089,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2100,7 +2100,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -2117,7 +2117,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2146,7 +2146,7 @@ dependencies = [
 [[package]]
 name = "frame-remote-externalities"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "env_logger 0.9.0",
  "futures",
@@ -2165,7 +2165,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "bitflags",
  "frame-metadata",
@@ -2197,7 +2197,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -2211,7 +2211,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -2223,7 +2223,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2233,7 +2233,7 @@ dependencies = [
 [[package]]
 name = "frame-support-test"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "frame-support",
  "frame-support-test-pallet",
@@ -2256,7 +2256,7 @@ dependencies = [
 [[package]]
 name = "frame-support-test-pallet"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2267,7 +2267,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "frame-support",
  "log",
@@ -2285,7 +2285,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2300,7 +2300,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -2309,7 +2309,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -2480,7 +2480,7 @@ dependencies = [
 [[package]]
 name = "generate-bags"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "chrono",
  "frame-election-provider-support",
@@ -4072,7 +4072,7 @@ dependencies = [
 [[package]]
 name = "mmr-gadget"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "futures",
  "log",
@@ -4092,7 +4092,7 @@ dependencies = [
 [[package]]
 name = "mmr-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "anyhow",
  "jsonrpsee",
@@ -4597,7 +4597,7 @@ checksum = "20448fd678ec04e6ea15bbe0476874af65e98a01515d667aa49f1434dc44ebf4"
 [[package]]
 name = "pallet-assets"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4612,7 +4612,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4628,7 +4628,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4643,7 +4643,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4667,7 +4667,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -4687,7 +4687,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list-remote-tests"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "frame-election-provider-support",
  "frame-remote-externalities",
@@ -4706,7 +4706,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4721,7 +4721,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4737,7 +4737,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "array-bytes",
  "beefy-merkle-tree",
@@ -4760,7 +4760,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4778,7 +4778,7 @@ dependencies = [
 [[package]]
 name = "pallet-child-bounties"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4797,7 +4797,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4814,7 +4814,7 @@ dependencies = [
 [[package]]
 name = "pallet-conviction-voting"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -4831,7 +4831,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4849,7 +4849,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -4873,7 +4873,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -4886,7 +4886,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "5.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4904,7 +4904,7 @@ dependencies = [
 [[package]]
 name = "pallet-fast-unstake"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -4922,7 +4922,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4945,7 +4945,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -4961,7 +4961,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4981,7 +4981,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4998,7 +4998,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5015,7 +5015,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5032,7 +5032,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5048,7 +5048,7 @@ dependencies = [
 [[package]]
 name = "pallet-nis"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5064,7 +5064,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5081,7 +5081,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5101,7 +5101,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
 version = "1.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -5111,7 +5111,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5128,7 +5128,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5151,7 +5151,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5168,7 +5168,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5183,7 +5183,7 @@ dependencies = [
 [[package]]
 name = "pallet-ranked-collective"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5201,7 +5201,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5216,7 +5216,7 @@ dependencies = [
 [[package]]
 name = "pallet-referenda"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -5235,7 +5235,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5252,7 +5252,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5273,7 +5273,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5289,7 +5289,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5303,7 +5303,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5326,7 +5326,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -5337,7 +5337,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -5346,7 +5346,7 @@ dependencies = [
 [[package]]
 name = "pallet-state-trie-migration"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5363,7 +5363,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5377,7 +5377,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5395,7 +5395,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5414,7 +5414,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5430,7 +5430,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -5446,7 +5446,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -5458,7 +5458,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5475,7 +5475,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5491,7 +5491,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5506,7 +5506,7 @@ dependencies = [
 [[package]]
 name = "pallet-whitelist"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8279,7 +8279,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "4.1.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "log",
  "sp-core",
@@ -8290,7 +8290,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "async-trait",
  "futures",
@@ -8317,7 +8317,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "futures",
  "futures-timer",
@@ -8340,7 +8340,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -8356,7 +8356,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "impl-trait-for-tuples",
  "memmap2",
@@ -8373,7 +8373,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -8384,7 +8384,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "array-bytes",
  "chrono",
@@ -8424,7 +8424,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "fnv",
  "futures",
@@ -8452,7 +8452,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -8477,7 +8477,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "async-trait",
  "futures",
@@ -8502,7 +8502,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -8543,7 +8543,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -8565,7 +8565,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -8578,7 +8578,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "async-trait",
  "futures",
@@ -8602,7 +8602,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "lru",
  "parity-scale-codec",
@@ -8626,7 +8626,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "sc-allocator",
  "sp-maybe-compressed-blob",
@@ -8639,7 +8639,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "log",
  "sc-allocator",
@@ -8652,7 +8652,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "cfg-if",
  "libc",
@@ -8669,7 +8669,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "ahash",
  "array-bytes",
@@ -8710,7 +8710,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "finality-grandpa",
  "futures",
@@ -8731,7 +8731,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "ansi_term",
  "futures",
@@ -8747,7 +8747,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -8762,7 +8762,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -8809,7 +8809,7 @@ dependencies = [
 [[package]]
 name = "sc-network-bitswap"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "cid",
  "futures",
@@ -8829,7 +8829,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "async-trait",
  "bitflags",
@@ -8855,7 +8855,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "ahash",
  "futures",
@@ -8873,7 +8873,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "array-bytes",
  "futures",
@@ -8894,7 +8894,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -8926,7 +8926,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "array-bytes",
  "futures",
@@ -8945,7 +8945,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "array-bytes",
  "bytes",
@@ -8975,7 +8975,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "futures",
  "libp2p",
@@ -8988,7 +8988,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -8997,7 +8997,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "futures",
  "hash-db",
@@ -9027,7 +9027,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -9050,7 +9050,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "futures",
  "http",
@@ -9066,7 +9066,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "futures",
  "hex",
@@ -9085,7 +9085,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "async-trait",
  "directories",
@@ -9155,7 +9155,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -9167,7 +9167,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -9186,7 +9186,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "6.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "futures",
  "libc",
@@ -9205,7 +9205,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "chrono",
  "futures",
@@ -9223,7 +9223,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "ansi_term",
  "atty",
@@ -9254,7 +9254,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -9265,7 +9265,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "async-trait",
  "futures",
@@ -9291,7 +9291,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "async-trait",
  "futures",
@@ -9305,7 +9305,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "futures",
  "futures-timer",
@@ -9787,7 +9787,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "hash-db",
  "log",
@@ -9805,7 +9805,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "blake2",
  "proc-macro-crate",
@@ -9817,7 +9817,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9830,7 +9830,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -9845,7 +9845,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9858,7 +9858,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -9870,7 +9870,7 @@ dependencies = [
 [[package]]
 name = "sp-beefy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9887,7 +9887,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -9899,7 +9899,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "futures",
  "log",
@@ -9917,7 +9917,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "async-trait",
  "futures",
@@ -9936,7 +9936,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "async-trait",
  "merlin",
@@ -9959,7 +9959,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9973,7 +9973,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9986,7 +9986,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "array-bytes",
  "base58",
@@ -10031,7 +10031,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "blake2",
  "byteorder",
@@ -10045,7 +10045,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10056,7 +10056,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.1",
@@ -10065,7 +10065,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10075,7 +10075,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.13.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -10086,7 +10086,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -10104,7 +10104,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -10118,7 +10118,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "bytes",
  "ed25519-dalek",
@@ -10145,7 +10145,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -10156,7 +10156,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.13.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "async-trait",
  "futures",
@@ -10173,7 +10173,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "4.1.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "thiserror",
  "zstd",
@@ -10182,7 +10182,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "ckb-merkle-mountain-range",
  "log",
@@ -10200,7 +10200,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10214,7 +10214,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -10224,7 +10224,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -10234,7 +10234,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -10244,7 +10244,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -10266,7 +10266,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -10284,7 +10284,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -10296,7 +10296,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10310,7 +10310,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10322,7 +10322,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.13.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "hash-db",
  "log",
@@ -10344,12 +10344,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 
 [[package]]
 name = "sp-storage"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -10362,7 +10362,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "async-trait",
  "futures-timer",
@@ -10378,7 +10378,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "parity-scale-codec",
  "sp-std",
@@ -10390,7 +10390,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -10399,7 +10399,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "async-trait",
  "log",
@@ -10415,7 +10415,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "ahash",
  "hash-db",
@@ -10438,7 +10438,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -10455,7 +10455,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -10466,7 +10466,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "impl-trait-for-tuples",
  "log",
@@ -10479,7 +10479,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -10694,7 +10694,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "platforms",
 ]
@@ -10702,7 +10702,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures",
@@ -10723,7 +10723,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "futures-util",
  "hyper",
@@ -10736,7 +10736,7 @@ dependencies = [
 [[package]]
 name = "substrate-rpc-client"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "async-trait",
  "jsonrpsee",
@@ -10749,7 +10749,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-trie-migration-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "jsonrpsee",
  "log",
@@ -10770,7 +10770,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -10796,7 +10796,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-utils"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "futures",
  "substrate-test-utils-derive",
@@ -10806,7 +10806,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-utils-derive"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -10817,7 +10817,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "5.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "ansi_term",
  "build-helper",
@@ -11564,7 +11564,7 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 [[package]]
 name = "try-runtime-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#cd2fdcf85eb96c53ce2a5d418d4338eb92f5d4f5"
+source = "git+https://github.com/paritytech/substrate?branch=master#5d3624c7fb7648d6f3170007790e95e726d84f35"
 dependencies = [
  "clap",
  "frame-remote-externalities",

--- a/runtime/common/src/assigned_slots.rs
+++ b/runtime/common/src/assigned_slots.rs
@@ -200,6 +200,7 @@ pub mod pallet {
 	impl<T: Config> Pallet<T> {
 		// TODO: Benchmark this
 		/// Assign a permanent parachain slot and immediately create a lease for it.
+		#[pallet::call_index(0)]
 		#[pallet::weight(((MAXIMUM_BLOCK_WEIGHT / 10) as Weight, DispatchClass::Operational))]
 		pub fn assign_perm_parachain_slot(origin: OriginFor<T>, id: ParaId) -> DispatchResult {
 			T::AssignSlotOrigin::ensure_origin(origin)?;
@@ -258,6 +259,7 @@ pub mod pallet {
 		/// Assign a temporary parachain slot. The function tries to create a lease for it
 		/// immediately if `SlotLeasePeriodStart::Current` is specified, and if the number
 		/// of currently active temporary slots is below `MaxTemporarySlotPerLeasePeriod`.
+		#[pallet::call_index(1)]
 		#[pallet::weight(((MAXIMUM_BLOCK_WEIGHT / 10) as Weight, DispatchClass::Operational))]
 		pub fn assign_temp_parachain_slot(
 			origin: OriginFor<T>,
@@ -341,6 +343,7 @@ pub mod pallet {
 
 		// TODO: Benchmark this
 		/// Unassign a permanent or temporary parachain slot
+		#[pallet::call_index(2)]
 		#[pallet::weight(((MAXIMUM_BLOCK_WEIGHT / 10) as Weight, DispatchClass::Operational))]
 		pub fn unassign_parachain_slot(origin: OriginFor<T>, id: ParaId) -> DispatchResult {
 			T::AssignSlotOrigin::ensure_origin(origin.clone())?;

--- a/runtime/common/src/auctions.rs
+++ b/runtime/common/src/auctions.rs
@@ -253,6 +253,7 @@ pub mod pallet {
 		/// This can only happen when there isn't already an auction in progress and may only be
 		/// called by the root origin. Accepts the `duration` of this auction and the
 		/// `lease_period_index` of the initial lease period of the four that are to be auctioned.
+		#[pallet::call_index(0)]
 		#[pallet::weight((T::WeightInfo::new_auction(), DispatchClass::Operational))]
 		pub fn new_auction(
 			origin: OriginFor<T>,
@@ -279,6 +280,7 @@ pub mod pallet {
 		/// absolute lease period index value, not an auction-specific offset.
 		/// - `amount` is the amount to bid to be held as deposit for the parachain should the
 		/// bid win. This amount is held throughout the range.
+		#[pallet::call_index(1)]
 		#[pallet::weight(T::WeightInfo::bid())]
 		pub fn bid(
 			origin: OriginFor<T>,
@@ -296,6 +298,7 @@ pub mod pallet {
 		/// Cancel an in-progress auction.
 		///
 		/// Can only be called by Root origin.
+		#[pallet::call_index(2)]
 		#[pallet::weight(T::WeightInfo::cancel_auction())]
 		pub fn cancel_auction(origin: OriginFor<T>) -> DispatchResult {
 			ensure_root(origin)?;

--- a/runtime/common/src/claims.rs
+++ b/runtime/common/src/claims.rs
@@ -305,6 +305,7 @@ pub mod pallet {
 		///
 		/// Total Complexity: O(1)
 		/// </weight>
+		#[pallet::call_index(0)]
 		#[pallet::weight(T::WeightInfo::claim())]
 		pub fn claim(
 			origin: OriginFor<T>,
@@ -337,6 +338,7 @@ pub mod pallet {
 		///
 		/// Total Complexity: O(1)
 		/// </weight>
+		#[pallet::call_index(1)]
 		#[pallet::weight(T::WeightInfo::mint_claim())]
 		pub fn mint_claim(
 			origin: OriginFor<T>,
@@ -384,6 +386,7 @@ pub mod pallet {
 		///
 		/// Total Complexity: O(1)
 		/// </weight>
+		#[pallet::call_index(2)]
 		#[pallet::weight(T::WeightInfo::claim_attest())]
 		pub fn claim_attest(
 			origin: OriginFor<T>,
@@ -420,6 +423,7 @@ pub mod pallet {
 		///
 		/// Total Complexity: O(1)
 		/// </weight>
+		#[pallet::call_index(3)]
 		#[pallet::weight((
 			T::WeightInfo::attest(),
 			DispatchClass::Normal,
@@ -436,6 +440,7 @@ pub mod pallet {
 			Ok(())
 		}
 
+		#[pallet::call_index(4)]
 		#[pallet::weight(T::WeightInfo::move_claim())]
 		pub fn move_claim(
 			origin: OriginFor<T>,

--- a/runtime/common/src/crowdloan/mod.rs
+++ b/runtime/common/src/crowdloan/mod.rs
@@ -372,6 +372,7 @@ pub mod pallet {
 		///
 		/// This applies a lock to your parachain configuration, ensuring that it cannot be changed
 		/// by the parachain manager.
+		#[pallet::call_index(0)]
 		#[pallet::weight(T::WeightInfo::create())]
 		pub fn create(
 			origin: OriginFor<T>,
@@ -449,6 +450,7 @@ pub mod pallet {
 
 		/// Contribute to a crowd sale. This will transfer some balance over to fund a parachain
 		/// slot. It will be withdrawable when the crowdloan has ended and the funds are unused.
+		#[pallet::call_index(1)]
 		#[pallet::weight(T::WeightInfo::contribute())]
 		pub fn contribute(
 			origin: OriginFor<T>,
@@ -477,6 +479,7 @@ pub mod pallet {
 		///
 		/// - `who`: The account whose contribution should be withdrawn.
 		/// - `index`: The parachain to whose crowdloan the contribution was made.
+		#[pallet::call_index(2)]
 		#[pallet::weight(T::WeightInfo::withdraw())]
 		pub fn withdraw(
 			origin: OriginFor<T>,
@@ -510,6 +513,7 @@ pub mod pallet {
 		/// times to fully refund all users. We will refund `RemoveKeysLimit` users at a time.
 		///
 		/// Origin must be signed, but can come from anyone.
+		#[pallet::call_index(3)]
 		#[pallet::weight(T::WeightInfo::refund(T::RemoveKeysLimit::get()))]
 		pub fn refund(
 			origin: OriginFor<T>,
@@ -555,6 +559,7 @@ pub mod pallet {
 		}
 
 		/// Remove a fund after the retirement period has ended and all funds have been returned.
+		#[pallet::call_index(4)]
 		#[pallet::weight(T::WeightInfo::dissolve())]
 		pub fn dissolve(origin: OriginFor<T>, #[pallet::compact] index: ParaId) -> DispatchResult {
 			let who = ensure_signed(origin)?;
@@ -582,6 +587,7 @@ pub mod pallet {
 		/// Edit the configuration for an in-progress crowdloan.
 		///
 		/// Can only be called by Root origin.
+		#[pallet::call_index(5)]
 		#[pallet::weight(T::WeightInfo::edit())]
 		pub fn edit(
 			origin: OriginFor<T>,
@@ -619,6 +625,7 @@ pub mod pallet {
 		/// Add an optional memo to an existing crowdloan contribution.
 		///
 		/// Origin must be Signed, and the user must have contributed to the crowdloan.
+		#[pallet::call_index(6)]
 		#[pallet::weight(T::WeightInfo::add_memo())]
 		pub fn add_memo(origin: OriginFor<T>, index: ParaId, memo: Vec<u8>) -> DispatchResult {
 			let who = ensure_signed(origin)?;
@@ -637,6 +644,7 @@ pub mod pallet {
 		/// Poke the fund into `NewRaise`
 		///
 		/// Origin must be Signed, and the fund has non-zero raise.
+		#[pallet::call_index(7)]
 		#[pallet::weight(T::WeightInfo::poke())]
 		pub fn poke(origin: OriginFor<T>, index: ParaId) -> DispatchResult {
 			ensure_signed(origin)?;
@@ -650,6 +658,7 @@ pub mod pallet {
 
 		/// Contribute your entire balance to a crowd sale. This will transfer the entire balance of a user over to fund a parachain
 		/// slot. It will be withdrawable when the crowdloan has ended and the funds are unused.
+		#[pallet::call_index(8)]
 		#[pallet::weight(T::WeightInfo::contribute())]
 		pub fn contribute_all(
 			origin: OriginFor<T>,

--- a/runtime/common/src/paras_registrar.rs
+++ b/runtime/common/src/paras_registrar.rs
@@ -228,6 +228,7 @@ pub mod pallet {
 		///
 		/// ## Events
 		/// The `Registered` event is emitted in case of success.
+		#[pallet::call_index(0)]
 		#[pallet::weight(<T as Config>::WeightInfo::register())]
 		pub fn register(
 			origin: OriginFor<T>,
@@ -246,6 +247,7 @@ pub mod pallet {
 		///
 		/// The deposit taken can be specified for this registration. Any `ParaId`
 		/// can be registered, including sub-1000 IDs which are System Parachains.
+		#[pallet::call_index(1)]
 		#[pallet::weight(<T as Config>::WeightInfo::force_register())]
 		pub fn force_register(
 			origin: OriginFor<T>,
@@ -262,6 +264,7 @@ pub mod pallet {
 		/// Deregister a Para Id, freeing all data and returning any deposit.
 		///
 		/// The caller must be Root, the `para` owner, or the `para` itself. The para must be a parathread.
+		#[pallet::call_index(2)]
 		#[pallet::weight(<T as Config>::WeightInfo::deregister())]
 		pub fn deregister(origin: OriginFor<T>, id: ParaId) -> DispatchResult {
 			Self::ensure_root_para_or_owner(origin, id)?;
@@ -279,6 +282,7 @@ pub mod pallet {
 		/// `ParaId` to be a long-term identifier of a notional "parachain". However, their
 		/// scheduling info (i.e. whether they're a parathread or parachain), auction information
 		/// and the auction deposit are switched.
+		#[pallet::call_index(3)]
 		#[pallet::weight(<T as Config>::WeightInfo::swap())]
 		pub fn swap(origin: OriginFor<T>, id: ParaId, other: ParaId) -> DispatchResult {
 			Self::ensure_root_para_or_owner(origin, id)?;
@@ -328,6 +332,7 @@ pub mod pallet {
 		/// previously locked para to deregister or swap a para without using governance.
 		///
 		/// Can only be called by the Root origin or the parachain.
+		#[pallet::call_index(4)]
 		#[pallet::weight(T::DbWeight::get().reads_writes(1, 1))]
 		pub fn remove_lock(origin: OriginFor<T>, para: ParaId) -> DispatchResult {
 			Self::ensure_root_or_para(origin, para)?;
@@ -349,6 +354,7 @@ pub mod pallet {
 		///
 		/// ## Events
 		/// The `Reserved` event is emitted in case of success, which provides the ID reserved for use.
+		#[pallet::call_index(5)]
 		#[pallet::weight(<T as Config>::WeightInfo::reserve())]
 		pub fn reserve(origin: OriginFor<T>) -> DispatchResult {
 			let who = ensure_signed(origin)?;
@@ -362,6 +368,7 @@ pub mod pallet {
 		/// para to deregister or swap a para.
 		///
 		/// Can be called by Root, the parachain, or the parachain manager if the parachain is unlocked.
+		#[pallet::call_index(6)]
 		#[pallet::weight(T::DbWeight::get().reads_writes(1, 1))]
 		pub fn add_lock(origin: OriginFor<T>, para: ParaId) -> DispatchResult {
 			Self::ensure_root_para_or_owner(origin, para)?;
@@ -372,6 +379,7 @@ pub mod pallet {
 		/// Schedule a parachain upgrade.
 		///
 		/// Can be called by Root, the parachain, or the parachain manager if the parachain is unlocked.
+		#[pallet::call_index(7)]
 		#[pallet::weight(<T as Config>::WeightInfo::schedule_code_upgrade(new_code.0.len() as u32))]
 		pub fn schedule_code_upgrade(
 			origin: OriginFor<T>,
@@ -386,6 +394,7 @@ pub mod pallet {
 		/// Set the parachain's current head.
 		///
 		/// Can be called by Root, the parachain, or the parachain manager if the parachain is unlocked.
+		#[pallet::call_index(8)]
 		#[pallet::weight(<T as Config>::WeightInfo::set_current_head(new_head.0.len() as u32))]
 		pub fn set_current_head(
 			origin: OriginFor<T>,

--- a/runtime/common/src/paras_sudo_wrapper.rs
+++ b/runtime/common/src/paras_sudo_wrapper.rs
@@ -70,6 +70,7 @@ pub mod pallet {
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
 		/// Schedule a para to be initialized at the start of the next session.
+		#[pallet::call_index(0)]
 		#[pallet::weight((1_000, DispatchClass::Operational))]
 		pub fn sudo_schedule_para_initialize(
 			origin: OriginFor<T>,
@@ -83,6 +84,7 @@ pub mod pallet {
 		}
 
 		/// Schedule a para to be cleaned up at the start of the next session.
+		#[pallet::call_index(1)]
 		#[pallet::weight((1_000, DispatchClass::Operational))]
 		pub fn sudo_schedule_para_cleanup(origin: OriginFor<T>, id: ParaId) -> DispatchResult {
 			ensure_root(origin)?;
@@ -92,6 +94,7 @@ pub mod pallet {
 		}
 
 		/// Upgrade a parathread to a parachain
+		#[pallet::call_index(2)]
 		#[pallet::weight((1_000, DispatchClass::Operational))]
 		pub fn sudo_schedule_parathread_upgrade(
 			origin: OriginFor<T>,
@@ -109,6 +112,7 @@ pub mod pallet {
 		}
 
 		/// Downgrade a parachain to a parathread
+		#[pallet::call_index(3)]
 		#[pallet::weight((1_000, DispatchClass::Operational))]
 		pub fn sudo_schedule_parachain_downgrade(
 			origin: OriginFor<T>,
@@ -129,6 +133,7 @@ pub mod pallet {
 		///
 		/// The given parachain should exist and the payload should not exceed the preconfigured size
 		/// `config.max_downward_message_size`.
+		#[pallet::call_index(4)]
 		#[pallet::weight((1_000, DispatchClass::Operational))]
 		pub fn sudo_queue_downward_xcm(
 			origin: OriginFor<T>,
@@ -149,6 +154,7 @@ pub mod pallet {
 		///
 		/// This is equivalent to sending an `Hrmp::hrmp_init_open_channel` extrinsic followed by
 		/// `Hrmp::hrmp_accept_open_channel`.
+		#[pallet::call_index(5)]
 		#[pallet::weight((1_000, DispatchClass::Operational))]
 		pub fn sudo_establish_hrmp_channel(
 			origin: OriginFor<T>,

--- a/runtime/common/src/purchase.rs
+++ b/runtime/common/src/purchase.rs
@@ -195,6 +195,7 @@ pub mod pallet {
 		/// We check that the account does not exist at this stage.
 		///
 		/// Origin must match the `ValidityOrigin`.
+		#[pallet::call_index(0)]
 		#[pallet::weight(Weight::from_ref_time(200_000_000) + T::DbWeight::get().reads_writes(4, 1))]
 		pub fn create_account(
 			origin: OriginFor<T>,
@@ -232,6 +233,7 @@ pub mod pallet {
 		/// We check that the account exists at this stage, but has not completed the process.
 		///
 		/// Origin must match the `ValidityOrigin`.
+		#[pallet::call_index(1)]
 		#[pallet::weight(T::DbWeight::get().reads_writes(1, 1))]
 		pub fn update_validity_status(
 			origin: OriginFor<T>,
@@ -260,6 +262,7 @@ pub mod pallet {
 		/// We check that the account is valid for a balance transfer at this point.
 		///
 		/// Origin must match the `ValidityOrigin`.
+		#[pallet::call_index(2)]
 		#[pallet::weight(T::DbWeight::get().reads_writes(2, 1))]
 		pub fn update_balance(
 			origin: OriginFor<T>,
@@ -297,6 +300,7 @@ pub mod pallet {
 		///
 		/// Origin must match the configured `PaymentAccount` (if it is not configured then this
 		/// will always fail with `BadOrigin`).
+		#[pallet::call_index(3)]
 		#[pallet::weight(T::DbWeight::get().reads_writes(4, 2))]
 		pub fn payout(origin: OriginFor<T>, who: T::AccountId) -> DispatchResult {
 			// Payments must be made directly by the `PaymentAccount`.
@@ -366,6 +370,7 @@ pub mod pallet {
 		/// Set the account that will be used to payout users in the DOT purchase process.
 		///
 		/// Origin must match the `ConfigurationOrigin`
+		#[pallet::call_index(4)]
 		#[pallet::weight(T::DbWeight::get().writes(1))]
 		pub fn set_payment_account(origin: OriginFor<T>, who: T::AccountId) -> DispatchResult {
 			T::ConfigurationOrigin::ensure_origin(origin)?;
@@ -378,6 +383,7 @@ pub mod pallet {
 		/// Set the statement that must be signed for a user to participate on the DOT sale.
 		///
 		/// Origin must match the `ConfigurationOrigin`
+		#[pallet::call_index(5)]
 		#[pallet::weight(T::DbWeight::get().writes(1))]
 		pub fn set_statement(origin: OriginFor<T>, statement: Vec<u8>) -> DispatchResult {
 			T::ConfigurationOrigin::ensure_origin(origin)?;
@@ -394,6 +400,7 @@ pub mod pallet {
 		/// Set the block where locked DOTs will become unlocked.
 		///
 		/// Origin must match the `ConfigurationOrigin`
+		#[pallet::call_index(6)]
 		#[pallet::weight(T::DbWeight::get().writes(1))]
 		pub fn set_unlock_block(
 			origin: OriginFor<T>,

--- a/runtime/common/src/slots/mod.rs
+++ b/runtime/common/src/slots/mod.rs
@@ -165,6 +165,7 @@ pub mod pallet {
 		/// independently of any other on-chain mechanism to use it.
 		///
 		/// The dispatch origin for this call must match `T::ForceOrigin`.
+		#[pallet::call_index(0)]
 		#[pallet::weight(T::WeightInfo::force_lease())]
 		pub fn force_lease(
 			origin: OriginFor<T>,
@@ -183,6 +184,7 @@ pub mod pallet {
 		/// Clear all leases for a Para Id, refunding any deposits back to the original owners.
 		///
 		/// The dispatch origin for this call must match `T::ForceOrigin`.
+		#[pallet::call_index(1)]
 		#[pallet::weight(T::WeightInfo::clear_all_leases())]
 		pub fn clear_all_leases(origin: OriginFor<T>, para: ParaId) -> DispatchResult {
 			T::ForceOrigin::ensure_origin(origin)?;
@@ -205,6 +207,7 @@ pub mod pallet {
 		/// let them onboard from here.
 		///
 		/// Origin must be signed, but can be called by anyone.
+		#[pallet::call_index(2)]
 		#[pallet::weight(T::WeightInfo::trigger_onboard())]
 		pub fn trigger_onboard(origin: OriginFor<T>, para: ParaId) -> DispatchResult {
 			let _ = ensure_signed(origin)?;

--- a/runtime/parachains/src/configuration.rs
+++ b/runtime/parachains/src/configuration.rs
@@ -521,6 +521,7 @@ pub mod pallet {
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
 		/// Set the validation upgrade cooldown.
+		#[pallet::call_index(0)]
 		#[pallet::weight((
 			T::WeightInfo::set_config_with_block_number(),
 			DispatchClass::Operational,
@@ -536,6 +537,7 @@ pub mod pallet {
 		}
 
 		/// Set the validation upgrade delay.
+		#[pallet::call_index(1)]
 		#[pallet::weight((
 			T::WeightInfo::set_config_with_block_number(),
 			DispatchClass::Operational,
@@ -551,6 +553,7 @@ pub mod pallet {
 		}
 
 		/// Set the acceptance period for an included candidate.
+		#[pallet::call_index(2)]
 		#[pallet::weight((
 			T::WeightInfo::set_config_with_block_number(),
 			DispatchClass::Operational,
@@ -566,6 +569,7 @@ pub mod pallet {
 		}
 
 		/// Set the max validation code size for incoming upgrades.
+		#[pallet::call_index(3)]
 		#[pallet::weight((
 			T::WeightInfo::set_config_with_u32(),
 			DispatchClass::Operational,
@@ -578,6 +582,7 @@ pub mod pallet {
 		}
 
 		/// Set the max POV block size for incoming upgrades.
+		#[pallet::call_index(4)]
 		#[pallet::weight((
 			T::WeightInfo::set_config_with_u32(),
 			DispatchClass::Operational,
@@ -590,6 +595,7 @@ pub mod pallet {
 		}
 
 		/// Set the max head data size for paras.
+		#[pallet::call_index(5)]
 		#[pallet::weight((
 			T::WeightInfo::set_config_with_u32(),
 			DispatchClass::Operational,
@@ -602,6 +608,7 @@ pub mod pallet {
 		}
 
 		/// Set the number of parathread execution cores.
+		#[pallet::call_index(6)]
 		#[pallet::weight((
 			T::WeightInfo::set_config_with_u32(),
 			DispatchClass::Operational,
@@ -614,6 +621,7 @@ pub mod pallet {
 		}
 
 		/// Set the number of retries for a particular parathread.
+		#[pallet::call_index(7)]
 		#[pallet::weight((
 			T::WeightInfo::set_config_with_u32(),
 			DispatchClass::Operational,
@@ -626,6 +634,7 @@ pub mod pallet {
 		}
 
 		/// Set the parachain validator-group rotation frequency
+		#[pallet::call_index(8)]
 		#[pallet::weight((
 			T::WeightInfo::set_config_with_block_number(),
 			DispatchClass::Operational,
@@ -641,6 +650,7 @@ pub mod pallet {
 		}
 
 		/// Set the availability period for parachains.
+		#[pallet::call_index(9)]
 		#[pallet::weight((
 			T::WeightInfo::set_config_with_block_number(),
 			DispatchClass::Operational,
@@ -656,6 +666,7 @@ pub mod pallet {
 		}
 
 		/// Set the availability period for parathreads.
+		#[pallet::call_index(10)]
 		#[pallet::weight((
 			T::WeightInfo::set_config_with_block_number(),
 			DispatchClass::Operational,
@@ -671,6 +682,7 @@ pub mod pallet {
 		}
 
 		/// Set the scheduling lookahead, in expected number of blocks at peak throughput.
+		#[pallet::call_index(11)]
 		#[pallet::weight((
 			T::WeightInfo::set_config_with_u32(),
 			DispatchClass::Operational,
@@ -683,6 +695,7 @@ pub mod pallet {
 		}
 
 		/// Set the maximum number of validators to assign to any core.
+		#[pallet::call_index(12)]
 		#[pallet::weight((
 			T::WeightInfo::set_config_with_option_u32(),
 			DispatchClass::Operational,
@@ -698,6 +711,7 @@ pub mod pallet {
 		}
 
 		/// Set the maximum number of validators to use in parachain consensus.
+		#[pallet::call_index(13)]
 		#[pallet::weight((
 			T::WeightInfo::set_config_with_option_u32(),
 			DispatchClass::Operational,
@@ -710,6 +724,7 @@ pub mod pallet {
 		}
 
 		/// Set the dispute period, in number of sessions to keep for disputes.
+		#[pallet::call_index(14)]
 		#[pallet::weight((
 			T::WeightInfo::set_config_with_u32(),
 			DispatchClass::Operational,
@@ -722,6 +737,7 @@ pub mod pallet {
 		}
 
 		/// Set the dispute post conclusion acceptance period.
+		#[pallet::call_index(15)]
 		#[pallet::weight((
 			T::WeightInfo::set_config_with_block_number(),
 			DispatchClass::Operational,
@@ -737,6 +753,7 @@ pub mod pallet {
 		}
 
 		/// Set the maximum number of dispute spam slots.
+		#[pallet::call_index(16)]
 		#[pallet::weight((
 			T::WeightInfo::set_config_with_u32(),
 			DispatchClass::Operational,
@@ -749,6 +766,7 @@ pub mod pallet {
 		}
 
 		/// Set the dispute conclusion by time out period.
+		#[pallet::call_index(17)]
 		#[pallet::weight((
 			T::WeightInfo::set_config_with_block_number(),
 			DispatchClass::Operational,
@@ -765,6 +783,7 @@ pub mod pallet {
 
 		/// Set the no show slots, in number of number of consensus slots.
 		/// Must be at least 1.
+		#[pallet::call_index(18)]
 		#[pallet::weight((
 			T::WeightInfo::set_config_with_u32(),
 			DispatchClass::Operational,
@@ -777,6 +796,7 @@ pub mod pallet {
 		}
 
 		/// Set the total number of delay tranches.
+		#[pallet::call_index(19)]
 		#[pallet::weight((
 			T::WeightInfo::set_config_with_u32(),
 			DispatchClass::Operational,
@@ -789,6 +809,7 @@ pub mod pallet {
 		}
 
 		/// Set the zeroth delay tranche width.
+		#[pallet::call_index(20)]
 		#[pallet::weight((
 			T::WeightInfo::set_config_with_u32(),
 			DispatchClass::Operational,
@@ -801,6 +822,7 @@ pub mod pallet {
 		}
 
 		/// Set the number of validators needed to approve a block.
+		#[pallet::call_index(21)]
 		#[pallet::weight((
 			T::WeightInfo::set_config_with_u32(),
 			DispatchClass::Operational,
@@ -813,6 +835,7 @@ pub mod pallet {
 		}
 
 		/// Set the number of samples to do of the `RelayVRFModulo` approval assignment criterion.
+		#[pallet::call_index(22)]
 		#[pallet::weight((
 			T::WeightInfo::set_config_with_u32(),
 			DispatchClass::Operational,
@@ -825,6 +848,7 @@ pub mod pallet {
 		}
 
 		/// Sets the maximum items that can present in a upward dispatch queue at once.
+		#[pallet::call_index(23)]
 		#[pallet::weight((
 			T::WeightInfo::set_config_with_u32(),
 			DispatchClass::Operational,
@@ -837,6 +861,7 @@ pub mod pallet {
 		}
 
 		/// Sets the maximum total size of items that can present in a upward dispatch queue at once.
+		#[pallet::call_index(24)]
 		#[pallet::weight((
 			T::WeightInfo::set_config_with_u32(),
 			DispatchClass::Operational,
@@ -849,6 +874,7 @@ pub mod pallet {
 		}
 
 		/// Set the critical downward message size.
+		#[pallet::call_index(25)]
 		#[pallet::weight((
 			T::WeightInfo::set_config_with_u32(),
 			DispatchClass::Operational,
@@ -861,6 +887,7 @@ pub mod pallet {
 		}
 
 		/// Sets the soft limit for the phase of dispatching dispatchable upward messages.
+		#[pallet::call_index(26)]
 		#[pallet::weight((
 			T::WeightInfo::set_config_with_weight(),
 			DispatchClass::Operational,
@@ -873,6 +900,7 @@ pub mod pallet {
 		}
 
 		/// Sets the maximum size of an upward message that can be sent by a candidate.
+		#[pallet::call_index(27)]
 		#[pallet::weight((
 			T::WeightInfo::set_config_with_u32(),
 			DispatchClass::Operational,
@@ -885,6 +913,7 @@ pub mod pallet {
 		}
 
 		/// Sets the maximum number of messages that a candidate can contain.
+		#[pallet::call_index(28)]
 		#[pallet::weight((
 			T::WeightInfo::set_config_with_u32(),
 			DispatchClass::Operational,
@@ -900,6 +929,7 @@ pub mod pallet {
 		}
 
 		/// Sets the number of sessions after which an HRMP open channel request expires.
+		#[pallet::call_index(29)]
 		#[pallet::weight((
 			T::WeightInfo::set_hrmp_open_request_ttl(),
 			DispatchClass::Operational,
@@ -911,6 +941,7 @@ pub mod pallet {
 		}
 
 		/// Sets the amount of funds that the sender should provide for opening an HRMP channel.
+		#[pallet::call_index(30)]
 		#[pallet::weight((
 			T::WeightInfo::set_config_with_balance(),
 			DispatchClass::Operational,
@@ -924,6 +955,7 @@ pub mod pallet {
 
 		/// Sets the amount of funds that the recipient should provide for accepting opening an HRMP
 		/// channel.
+		#[pallet::call_index(31)]
 		#[pallet::weight((
 			T::WeightInfo::set_config_with_balance(),
 			DispatchClass::Operational,
@@ -936,6 +968,7 @@ pub mod pallet {
 		}
 
 		/// Sets the maximum number of messages allowed in an HRMP channel at once.
+		#[pallet::call_index(32)]
 		#[pallet::weight((
 			T::WeightInfo::set_config_with_u32(),
 			DispatchClass::Operational,
@@ -948,6 +981,7 @@ pub mod pallet {
 		}
 
 		/// Sets the maximum total size of messages in bytes allowed in an HRMP channel at once.
+		#[pallet::call_index(33)]
 		#[pallet::weight((
 			T::WeightInfo::set_config_with_u32(),
 			DispatchClass::Operational,
@@ -960,6 +994,7 @@ pub mod pallet {
 		}
 
 		/// Sets the maximum number of inbound HRMP channels a parachain is allowed to accept.
+		#[pallet::call_index(34)]
 		#[pallet::weight((
 			T::WeightInfo::set_config_with_u32(),
 			DispatchClass::Operational,
@@ -975,6 +1010,7 @@ pub mod pallet {
 		}
 
 		/// Sets the maximum number of inbound HRMP channels a parathread is allowed to accept.
+		#[pallet::call_index(35)]
 		#[pallet::weight((
 			T::WeightInfo::set_config_with_u32(),
 			DispatchClass::Operational,
@@ -990,6 +1026,7 @@ pub mod pallet {
 		}
 
 		/// Sets the maximum size of a message that could ever be put into an HRMP channel.
+		#[pallet::call_index(36)]
 		#[pallet::weight((
 			T::WeightInfo::set_config_with_u32(),
 			DispatchClass::Operational,
@@ -1002,6 +1039,7 @@ pub mod pallet {
 		}
 
 		/// Sets the maximum number of outbound HRMP channels a parachain is allowed to open.
+		#[pallet::call_index(37)]
 		#[pallet::weight((
 			T::WeightInfo::set_config_with_u32(),
 			DispatchClass::Operational,
@@ -1017,6 +1055,7 @@ pub mod pallet {
 		}
 
 		/// Sets the maximum number of outbound HRMP channels a parathread is allowed to open.
+		#[pallet::call_index(38)]
 		#[pallet::weight((
 			T::WeightInfo::set_config_with_u32(),
 			DispatchClass::Operational,
@@ -1032,6 +1071,7 @@ pub mod pallet {
 		}
 
 		/// Sets the maximum number of outbound HRMP messages can be sent by a candidate.
+		#[pallet::call_index(39)]
 		#[pallet::weight((
 			T::WeightInfo::set_config_with_u32(),
 			DispatchClass::Operational,
@@ -1047,6 +1087,7 @@ pub mod pallet {
 		}
 
 		/// Sets the maximum amount of weight any individual upward message may consume.
+		#[pallet::call_index(40)]
 		#[pallet::weight((
 			T::WeightInfo::set_config_with_weight(),
 			DispatchClass::Operational,
@@ -1059,6 +1100,7 @@ pub mod pallet {
 		}
 
 		/// Enable or disable PVF pre-checking. Consult the field documentation prior executing.
+		#[pallet::call_index(41)]
 		#[pallet::weight((
 			// Using u32 here is a little bit of cheating, but that should be fine.
 			T::WeightInfo::set_config_with_u32(),
@@ -1072,6 +1114,7 @@ pub mod pallet {
 		}
 
 		/// Set the number of session changes after which a PVF pre-checking voting is rejected.
+		#[pallet::call_index(42)]
 		#[pallet::weight((
 			T::WeightInfo::set_config_with_u32(),
 			DispatchClass::Operational,
@@ -1087,6 +1130,7 @@ pub mod pallet {
 		/// upgrade taking place.
 		///
 		/// See the field documentation for information and constraints for the new value.
+		#[pallet::call_index(43)]
 		#[pallet::weight((
 			T::WeightInfo::set_config_with_block_number(),
 			DispatchClass::Operational,
@@ -1103,6 +1147,7 @@ pub mod pallet {
 
 		/// Setting this to true will disable consistency checks for the configuration setters.
 		/// Use with caution.
+		#[pallet::call_index(44)]
 		#[pallet::weight((
 			T::DbWeight::get().writes(1),
 			DispatchClass::Operational,

--- a/runtime/parachains/src/disputes.rs
+++ b/runtime/parachains/src/disputes.rs
@@ -525,6 +525,7 @@ pub mod pallet {
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
+		#[pallet::call_index(0)]
 		#[pallet::weight(<T as Config>::WeightInfo::force_unfreeze())]
 		pub fn force_unfreeze(origin: OriginFor<T>) -> DispatchResult {
 			ensure_root(origin)?;

--- a/runtime/parachains/src/disputes/slashing.rs
+++ b/runtime/parachains/src/disputes/slashing.rs
@@ -475,6 +475,7 @@ pub mod pallet {
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
+		#[pallet::call_index(0)]
 		#[pallet::weight(<T as Config>::WeightInfo::report_dispute_lost(
 			key_owner_proof.validator_count()
 		))]

--- a/runtime/parachains/src/hrmp.rs
+++ b/runtime/parachains/src/hrmp.rs
@@ -465,6 +465,7 @@ pub mod pallet {
 		///
 		/// The channel can be opened only after the recipient confirms it and only on a session
 		/// change.
+		#[pallet::call_index(0)]
 		#[pallet::weight(<T as Config>::WeightInfo::hrmp_init_open_channel())]
 		pub fn hrmp_init_open_channel(
 			origin: OriginFor<T>,
@@ -491,6 +492,7 @@ pub mod pallet {
 		/// Accept a pending open channel request from the given sender.
 		///
 		/// The channel will be opened only on the next session boundary.
+		#[pallet::call_index(1)]
 		#[pallet::weight(<T as Config>::WeightInfo::hrmp_accept_open_channel())]
 		pub fn hrmp_accept_open_channel(origin: OriginFor<T>, sender: ParaId) -> DispatchResult {
 			let origin = ensure_parachain(<T as Config>::RuntimeOrigin::from(origin))?;
@@ -503,6 +505,7 @@ pub mod pallet {
 		/// recipient in the channel being closed.
 		///
 		/// The closure can only happen on a session change.
+		#[pallet::call_index(2)]
 		#[pallet::weight(<T as Config>::WeightInfo::hrmp_close_channel())]
 		pub fn hrmp_close_channel(
 			origin: OriginFor<T>,
@@ -521,6 +524,7 @@ pub mod pallet {
 		/// Origin must be Root.
 		///
 		/// Number of inbound and outbound channels for `para` must be provided as witness data of weighing.
+		#[pallet::call_index(3)]
 		#[pallet::weight(<T as Config>::WeightInfo::force_clean_hrmp(*_inbound, *_outbound))]
 		pub fn force_clean_hrmp(
 			origin: OriginFor<T>,
@@ -539,6 +543,7 @@ pub mod pallet {
 		/// function process all of those requests immediately.
 		///
 		/// Total number of opening channels must be provided as witness data of weighing.
+		#[pallet::call_index(4)]
 		#[pallet::weight(<T as Config>::WeightInfo::force_process_hrmp_open(*_channels))]
 		pub fn force_process_hrmp_open(origin: OriginFor<T>, _channels: u32) -> DispatchResult {
 			ensure_root(origin)?;
@@ -553,6 +558,7 @@ pub mod pallet {
 		/// function process all of those requests immediately.
 		///
 		/// Total number of closing channels must be provided as witness data of weighing.
+		#[pallet::call_index(5)]
 		#[pallet::weight(<T as Config>::WeightInfo::force_process_hrmp_close(*_channels))]
 		pub fn force_process_hrmp_close(origin: OriginFor<T>, _channels: u32) -> DispatchResult {
 			ensure_root(origin)?;
@@ -568,6 +574,7 @@ pub mod pallet {
 		///
 		/// Total number of open requests (i.e. `HrmpOpenChannelRequestsList`) must be provided as
 		/// witness data.
+		#[pallet::call_index(6)]
 		#[pallet::weight(<T as Config>::WeightInfo::hrmp_cancel_open_request(*open_requests))]
 		pub fn hrmp_cancel_open_request(
 			origin: OriginFor<T>,
@@ -591,6 +598,7 @@ pub mod pallet {
 		///
 		/// Expected use is when one of the `ParaId`s involved in the channel is governed by the
 		/// Relay Chain, e.g. a common good parachain.
+		#[pallet::call_index(7)]
 		#[pallet::weight(<T as Config>::WeightInfo::force_open_hrmp_channel())]
 		pub fn force_open_hrmp_channel(
 			origin: OriginFor<T>,

--- a/runtime/parachains/src/initializer.rs
+++ b/runtime/parachains/src/initializer.rs
@@ -210,6 +210,7 @@ pub mod pallet {
 		/// Issue a signal to the consensus engine to forcibly act as though all parachain
 		/// blocks in all relay chain blocks up to and including the given number in the current
 		/// chain are valid and should be finalized.
+		#[pallet::call_index(0)]
 		#[pallet::weight((
 			<T as Config>::WeightInfo::force_approve(
 				frame_system::Pallet::<T>::digest().logs.len() as u32,

--- a/runtime/parachains/src/paras/mod.rs
+++ b/runtime/parachains/src/paras/mod.rs
@@ -788,6 +788,7 @@ pub mod pallet {
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
 		/// Set the storage for the parachain validation code immediately.
+		#[pallet::call_index(0)]
 		#[pallet::weight(<T as Config>::WeightInfo::force_set_current_code(new_code.0.len() as u32))]
 		pub fn force_set_current_code(
 			origin: OriginFor<T>,
@@ -815,6 +816,7 @@ pub mod pallet {
 		}
 
 		/// Set the storage for the current parachain head data immediately.
+		#[pallet::call_index(1)]
 		#[pallet::weight(<T as Config>::WeightInfo::force_set_current_head(new_head.0.len() as u32))]
 		pub fn force_set_current_head(
 			origin: OriginFor<T>,
@@ -827,6 +829,7 @@ pub mod pallet {
 		}
 
 		/// Schedule an upgrade as if it was scheduled in the given relay parent block.
+		#[pallet::call_index(2)]
 		#[pallet::weight(<T as Config>::WeightInfo::force_schedule_code_upgrade(new_code.0.len() as u32))]
 		pub fn force_schedule_code_upgrade(
 			origin: OriginFor<T>,
@@ -842,6 +845,7 @@ pub mod pallet {
 		}
 
 		/// Note a new block head for para within the context of the current block.
+		#[pallet::call_index(3)]
 		#[pallet::weight(<T as Config>::WeightInfo::force_note_new_head(new_head.0.len() as u32))]
 		pub fn force_note_new_head(
 			origin: OriginFor<T>,
@@ -858,6 +862,7 @@ pub mod pallet {
 		/// Put a parachain directly into the next session's action queue.
 		/// We can't queue it any sooner than this without going into the
 		/// initializer...
+		#[pallet::call_index(4)]
 		#[pallet::weight(<T as Config>::WeightInfo::force_queue_action())]
 		pub fn force_queue_action(origin: OriginFor<T>, para: ParaId) -> DispatchResult {
 			ensure_root(origin)?;
@@ -884,6 +889,7 @@ pub mod pallet {
 		///
 		/// This function is mainly meant to be used for upgrading parachains that do not follow
 		/// the go-ahead signal while the PVF pre-checking feature is enabled.
+		#[pallet::call_index(5)]
 		#[pallet::weight(<T as Config>::WeightInfo::add_trusted_validation_code(validation_code.0.len() as u32))]
 		pub fn add_trusted_validation_code(
 			origin: OriginFor<T>,
@@ -932,6 +938,7 @@ pub mod pallet {
 		/// This is better than removing the storage directly, because it will not remove the code
 		/// that was suddenly got used by some parachain while this dispatchable was pending
 		/// dispatching.
+		#[pallet::call_index(6)]
 		#[pallet::weight(<T as Config>::WeightInfo::poke_unused_validation_code())]
 		pub fn poke_unused_validation_code(
 			origin: OriginFor<T>,
@@ -946,6 +953,7 @@ pub mod pallet {
 
 		/// Includes a statement for a PVF pre-checking vote. Potentially, finalizes the vote and
 		/// enacts the results if that was the last vote before achieving the supermajority.
+		#[pallet::call_index(7)]
 		#[pallet::weight(
 			<T as Config>::WeightInfo::include_pvf_check_statement_finalize_upgrade_accept()
 				.max(<T as Config>::WeightInfo::include_pvf_check_statement_finalize_upgrade_reject())

--- a/runtime/parachains/src/paras_inherent/mod.rs
+++ b/runtime/parachains/src/paras_inherent/mod.rs
@@ -277,6 +277,7 @@ pub mod pallet {
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
 		/// Enter the paras inherent. This will process bitfields and backed candidates.
+		#[pallet::call_index(0)]
 		#[pallet::weight((
 			paras_inherent_total_weight::<T>(
 				data.backed_candidates.as_slice(),

--- a/runtime/parachains/src/ump.rs
+++ b/runtime/parachains/src/ump.rs
@@ -349,6 +349,7 @@ pub mod pallet {
 		///
 		/// Events:
 		/// - `OverweightServiced`: On success.
+		#[pallet::call_index(0)]
 		#[pallet::weight(weight_limit.saturating_add(<T as Config>::WeightInfo::service_overweight()))]
 		pub fn service_overweight(
 			origin: OriginFor<T>,

--- a/runtime/rococo/src/validator_manager.rs
+++ b/runtime/rococo/src/validator_manager.rs
@@ -66,6 +66,7 @@ pub mod pallet {
 		/// Add new validators to the set.
 		///
 		/// The new validators will be active from current session + 2.
+		#[pallet::call_index(0)]
 		#[pallet::weight(100_000)]
 		pub fn register_validators(
 			origin: OriginFor<T>,
@@ -82,6 +83,7 @@ pub mod pallet {
 		/// Remove validators from the set.
 		///
 		/// The removed validators will be deactivated from current session + 2.
+		#[pallet::call_index(1)]
 		#[pallet::weight(100_000)]
 		pub fn deregister_validators(
 			origin: OriginFor<T>,

--- a/runtime/test-runtime/src/lib.rs
+++ b/runtime/test-runtime/src/lib.rs
@@ -621,6 +621,7 @@ pub mod pallet_test_notifier {
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
+		#[pallet::call_index(0)]
 		#[pallet::weight(1_000_000)]
 		pub fn prepare_new_query(origin: OriginFor<T>) -> DispatchResult {
 			let who = ensure_signed(origin)?;
@@ -635,6 +636,7 @@ pub mod pallet_test_notifier {
 			Ok(())
 		}
 
+		#[pallet::call_index(1)]
 		#[pallet::weight(1_000_000)]
 		pub fn prepare_new_notify_query(origin: OriginFor<T>) -> DispatchResult {
 			let who = ensure_signed(origin)?;
@@ -652,6 +654,7 @@ pub mod pallet_test_notifier {
 			Ok(())
 		}
 
+		#[pallet::call_index(2)]
 		#[pallet::weight(1_000_000)]
 		pub fn notification_received(
 			origin: OriginFor<T>,

--- a/xcm/pallet-xcm/src/lib.rs
+++ b/xcm/pallet-xcm/src/lib.rs
@@ -458,6 +458,7 @@ pub mod pallet {
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
+		#[pallet::call_index(0)]
 		#[pallet::weight(100_000_000)]
 		pub fn send(
 			origin: OriginFor<T>,
@@ -493,6 +494,7 @@ pub mod pallet {
 		///   `dest` side. May not be empty.
 		/// - `fee_asset_item`: The index into `assets` of the item which should be used to pay
 		///   fees.
+		#[pallet::call_index(1)]
 		#[pallet::weight({
 			let maybe_assets: Result<MultiAssets, ()> = (*assets.clone()).try_into();
 			let maybe_dest: Result<MultiLocation, ()> = (*dest.clone()).try_into();
@@ -534,6 +536,7 @@ pub mod pallet {
 		///   `dest` side.
 		/// - `fee_asset_item`: The index into `assets` of the item which should be used to pay
 		///   fees.
+		#[pallet::call_index(2)]
 		#[pallet::weight({
 			match ((*assets.clone()).try_into(), (*dest.clone()).try_into()) {
 				(Ok(assets), Ok(dest)) => {
@@ -574,6 +577,7 @@ pub mod pallet {
 		///
 		/// NOTE: A successful return to this does *not* imply that the `msg` was executed successfully
 		/// to completion; only that *some* of it was executed.
+		#[pallet::call_index(3)]
 		#[pallet::weight(Weight::from_ref_time(max_weight.saturating_add(100_000_000u64)))]
 		pub fn execute(
 			origin: OriginFor<T>,
@@ -602,6 +606,7 @@ pub mod pallet {
 		/// - `origin`: Must be Root.
 		/// - `location`: The destination that is being described.
 		/// - `xcm_version`: The latest version of XCM that `location` supports.
+		#[pallet::call_index(4)]
 		#[pallet::weight(100_000_000u64)]
 		pub fn force_xcm_version(
 			origin: OriginFor<T>,
@@ -624,6 +629,7 @@ pub mod pallet {
 		///
 		/// - `origin`: Must be Root.
 		/// - `maybe_xcm_version`: The default XCM encoding version, or `None` to disable.
+		#[pallet::call_index(5)]
 		#[pallet::weight(100_000_000u64)]
 		pub fn force_default_xcm_version(
 			origin: OriginFor<T>,
@@ -638,6 +644,7 @@ pub mod pallet {
 		///
 		/// - `origin`: Must be Root.
 		/// - `location`: The location to which we should subscribe for XCM version notifications.
+		#[pallet::call_index(6)]
 		#[pallet::weight(100_000_000u64)]
 		pub fn force_subscribe_version_notify(
 			origin: OriginFor<T>,
@@ -661,6 +668,7 @@ pub mod pallet {
 		/// - `origin`: Must be Root.
 		/// - `location`: The location to which we are currently subscribed for XCM version
 		///   notifications which we no longer desire.
+		#[pallet::call_index(7)]
 		#[pallet::weight(100_000_000u64)]
 		pub fn force_unsubscribe_version_notify(
 			origin: OriginFor<T>,
@@ -696,6 +704,7 @@ pub mod pallet {
 		/// - `fee_asset_item`: The index into `assets` of the item which should be used to pay
 		///   fees.
 		/// - `weight_limit`: The remote-side weight limit, if any, for the XCM fee purchase.
+		#[pallet::call_index(8)]
 		#[pallet::weight({
 			match ((*assets.clone()).try_into(), (*dest.clone()).try_into()) {
 				(Ok(assets), Ok(dest)) => {
@@ -743,6 +752,7 @@ pub mod pallet {
 		/// - `fee_asset_item`: The index into `assets` of the item which should be used to pay
 		///   fees.
 		/// - `weight_limit`: The remote-side weight limit, if any, for the XCM fee purchase.
+		#[pallet::call_index(9)]
 		#[pallet::weight({
 			let maybe_assets: Result<MultiAssets, ()> = (*assets.clone()).try_into();
 			let maybe_dest: Result<MultiLocation, ()> = (*dest.clone()).try_into();

--- a/xcm/pallet-xcm/src/mock.rs
+++ b/xcm/pallet-xcm/src/mock.rs
@@ -73,6 +73,7 @@ pub mod pallet_test_notifier {
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
+		#[pallet::call_index(0)]
 		#[pallet::weight(1_000_000)]
 		pub fn prepare_new_query(origin: OriginFor<T>) -> DispatchResult {
 			let who = ensure_signed(origin)?;
@@ -87,6 +88,7 @@ pub mod pallet_test_notifier {
 			Ok(())
 		}
 
+		#[pallet::call_index(1)]
 		#[pallet::weight(1_000_000)]
 		pub fn prepare_new_notify_query(origin: OriginFor<T>) -> DispatchResult {
 			let who = ensure_signed(origin)?;
@@ -104,6 +106,7 @@ pub mod pallet_test_notifier {
 			Ok(())
 		}
 
+		#[pallet::call_index(2)]
 		#[pallet::weight(1_000_000)]
 		pub fn notification_received(
 			origin: OriginFor<T>,


### PR DESCRIPTION
Use explicit call indices on all pallets. Same as in https://github.com/paritytech/substrate/pull/12891.  
The completeness of this can be verified by the absence of warnings since https://github.com/paritytech/substrate/pull/12894.