### PR TITLE
Make sure errors get logged

### DIFF
--- a/node/overseer/src/lib.rs
+++ b/node/overseer/src/lib.rs
@@ -711,7 +711,15 @@ where
 	}
 
 	/// Run the `Overseer`.
-	pub async fn run(mut self) -> SubsystemResult<()> {
+	///
+	/// Logging any errors.
+	pub async fn run(self) {
+		if let Err(err) = self.run_inner().await {
+			gum::error!(target: LOG_TARGET, ?err, "Overseer exited with error");
+		}
+	}
+
+	async fn run_inner(mut self) -> SubsystemResult<()> {
 		let metrics = self.metrics.clone();
 		spawn_metronome_metrics(&mut self, metrics)?;
 

--- a/node/overseer/src/tests.rs
+++ b/node/overseer/src/tests.rs
@@ -241,7 +241,7 @@ fn overseer_metrics_work() {
 				.unwrap();
 
 		let mut handle = Handle::new(handle);
-		let overseer_fut = overseer.run().fuse();
+		let overseer_fut = overseer.run_inner().fuse();
 
 		pin_mut!(overseer_fut);
 
@@ -302,7 +302,7 @@ fn overseer_ends_on_subsystem_exit() {
 			.build()
 			.unwrap();
 
-		overseer.run().await.unwrap();
+		overseer.run_inner().await.unwrap();
 	})
 }
 
@@ -400,7 +400,7 @@ fn overseer_start_stop_works() {
 			.unwrap();
 		let mut handle = Handle::new(handle);
 
-		let overseer_fut = overseer.run().fuse();
+		let overseer_fut = overseer.run_inner().fuse();
 		pin_mut!(overseer_fut);
 
 		let mut ss5_results = Vec::new();
@@ -499,7 +499,7 @@ fn overseer_finalize_works() {
 			.unwrap();
 		let mut handle = Handle::new(handle);
 
-		let overseer_fut = overseer.run().fuse();
+		let overseer_fut = overseer.run_inner().fuse();
 		pin_mut!(overseer_fut);
 
 		let mut ss5_results = Vec::new();
@@ -595,7 +595,7 @@ fn overseer_finalize_leaf_preserves_it() {
 			.unwrap();
 		let mut handle = Handle::new(handle);
 
-		let overseer_fut = overseer.run().fuse();
+		let overseer_fut = overseer.run_inner().fuse();
 		pin_mut!(overseer_fut);
 
 		let mut ss5_results = Vec::new();
@@ -684,7 +684,7 @@ fn do_not_send_empty_leaves_update_on_block_finalization() {
 
 		let mut handle = Handle::new(handle);
 
-		let overseer_fut = overseer.run().fuse();
+		let overseer_fut = overseer.run_inner().fuse();
 		pin_mut!(overseer_fut);
 
 		let mut ss5_results = Vec::new();
@@ -947,7 +947,7 @@ fn overseer_all_subsystems_receive_signals_and_messages() {
 				.unwrap();
 
 		let mut handle = Handle::new(handle);
-		let overseer_fut = overseer.run().fuse();
+		let overseer_fut = overseer.run_inner().fuse();
 
 		pin_mut!(overseer_fut);
 

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -1112,8 +1112,8 @@ where
 					pin_mut!(forward);
 
 					select! {
-						_ = forward => (),
-						_ = overseer_fut => (),
+						() = forward => (),
+						() = overseer_fut => (),
 						complete => (),
 					}
 				}),


### PR DESCRIPTION
instead of silently dropped.