### PR TITLE
av-store: write meta for unknown finalized blocks

### DIFF
--- a/node/core/av-store/src/lib.rs
+++ b/node/core/av-store/src/lib.rs
@@ -570,6 +570,14 @@ async fn run_iteration<Context>(
 				FromOrchestra::Signal(OverseerSignal::BlockFinalized(hash, number)) => {
 					let _timer = subsystem.metrics.time_process_block_finalized();
 
+					if !subsystem.known_blocks.is_known(&hash) {
+						// If we haven't processed this block yet,
+						// make sure we write the metadata about the
+						// candidates backed in this finalized block.
+						// Otherwise, we won't be able to store our chunk
+						// for these candidates.
+						process_block_activated(ctx, subsystem, hash).await?;
+					}
 					subsystem.finalized_number = Some(number);
 					subsystem.known_blocks.prune_finalized(number);
 					process_block_finalized(


### PR DESCRIPTION
### Problem

We're observing 
> WARN tokio-runtime-worker parachain::availability-store: Candidate included without being backed?

warnings on Kusama and Versi. They were not expected to happen other than on startup. It seems that the reason for them is that we import finality notification before block import, e.g. https://grafana.parity-mgmt.parity.io/goto/odGJK0c4z?orgId=1
![image](https://user-images.githubusercontent.com/4211399/208112850-aa0fc61e-d730-4f31-b33b-9af9edd8a144.png)

That means if the finalized block contained backed candidates and we haven't seen it as active leaf yet, we won't write the metadata in the db for them, print this warning and won't be able to store our chunk because of missing metadata.

It seems that sometimes block import notifications might be missing, so that's expected. However, I suspect this got worse recently with some disconnection problems (worse block propagation times?): https://grafana.parity-mgmt.parity.io/goto/3m_xK05Vk?orgId=1, which are probably related to #6228. The underlying cause is still unknown.

### Solution

When we see a finalized block notification, we try to process the block first as an active leaf, so we write metadata about the backed and included candidates in it. There's a slight risk of this failing due to pruning since we need to read events. However, I expect that default pruning history should prevent that from happening.

TODO
- [ ] Burn-in on Versi
- [ ] Fix/add tests