### PR TITLE
Add prospective parachains subsystem tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6536,9 +6536,12 @@ dependencies = [
  "parity-scale-codec 2.3.1",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
+ "polkadot-node-subsystem-test-helpers",
+ "polkadot-node-subsystem-types",
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
  "polkadot-primitives-test-helpers",
+ "sp-core",
  "thiserror",
  "tracing-gum",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6541,7 +6541,11 @@ dependencies = [
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
  "polkadot-primitives-test-helpers",
+ "sc-keystore",
+ "sp-application-crypto",
  "sp-core",
+ "sp-keyring",
+ "sp-keystore",
  "thiserror",
  "tracing-gum",
 ]

--- a/node/core/backing/src/lib.rs
+++ b/node/core/backing/src/lib.rs
@@ -878,15 +878,13 @@ async fn handle_active_leaves_update<Context>(
 			}
 
 			let mut seconded_at_depth = HashMap::new();
-			for response in membership_answers.next().await {
+			if let Some(response) = membership_answers.next().await {
 				match response {
 					Err(oneshot::Canceled) => {
 						gum::warn!(
 							target: LOG_TARGET,
 							"Prospective parachains subsystem unreachable for membership request",
 						);
-
-						continue
 					},
 					Ok((para_id, candidate_hash, membership)) => {
 						// This request gives membership in all fragment trees. We have some

--- a/node/core/backing/src/tests/prospective_parachains.rs
+++ b/node/core/backing/src/tests/prospective_parachains.rs
@@ -306,7 +306,6 @@ fn seconding_sanity_check_allowed() {
 		const LEAF_A_ANCESTRY_LEN: BlockNumber = 3;
 		let para_id = test_state.chain_ids[0];
 
-		let leaf_b_hash = Hash::from_low_u64_be(128);
 		// `a` is grandparent of `b`.
 		let leaf_a_hash = Hash::from_low_u64_be(130);
 		let leaf_a_parent = get_parent_hash(leaf_a_hash);
@@ -322,6 +321,7 @@ fn seconding_sanity_check_allowed() {
 		const LEAF_B_BLOCK_NUMBER: BlockNumber = LEAF_A_BLOCK_NUMBER + 2;
 		const LEAF_B_ANCESTRY_LEN: BlockNumber = 4;
 
+		let leaf_b_hash = Hash::from_low_u64_be(128);
 		let activated = ActivatedLeaf {
 			hash: leaf_b_hash,
 			number: LEAF_B_BLOCK_NUMBER,

--- a/node/core/dispute-coordinator/src/scraping/tests.rs
+++ b/node/core/dispute-coordinator/src/scraping/tests.rs
@@ -134,8 +134,7 @@ fn make_candidate_receipt(relay_parent: Hash) -> CandidateReceipt {
 		para_head: zeros,
 		validation_code_hash: zeros.into(),
 	};
-	let candidate = CandidateReceipt { descriptor, commitments_hash: zeros };
-	candidate
+	CandidateReceipt { descriptor, commitments_hash: zeros }
 }
 
 /// Get a dummy `ActivatedLeaf` for a given block number.

--- a/node/core/prospective-parachains/Cargo.toml
+++ b/node/core/prospective-parachains/Cargo.toml
@@ -19,7 +19,10 @@ polkadot-node-subsystem-util = { path = "../../subsystem-util" }
 
 [dev-dependencies]
 assert_matches = "1"
+polkadot-node-subsystem-test-helpers = { path = "../../subsystem-test-helpers" }
+polkadot-node-subsystem-types = { path = "../../subsystem-types" }
 polkadot-primitives-test-helpers = { path = "../../../primitives/test-helpers" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
 
 [features]
 # If not enabled, the dispute coordinator will do nothing.

--- a/node/core/prospective-parachains/Cargo.toml
+++ b/node/core/prospective-parachains/Cargo.toml
@@ -23,6 +23,10 @@ polkadot-node-subsystem-test-helpers = { path = "../../subsystem-test-helpers" }
 polkadot-node-subsystem-types = { path = "../../subsystem-types" }
 polkadot-primitives-test-helpers = { path = "../../../primitives/test-helpers" }
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-keystore = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-application-crypto = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-keystore = { git = "https://github.com/paritytech/substrate", branch = "master" }
 
 [features]
 # If not enabled, the dispute coordinator will do nothing.

--- a/node/core/prospective-parachains/src/fragment_tree.rs
+++ b/node/core/prospective-parachains/src/fragment_tree.rs
@@ -913,16 +913,19 @@ mod tests {
 		);
 
 		let candidate_hash = candidate.hash();
+		let output_head_hash = candidate.commitments.head_data.hash();
 		let parent_head_hash = pvd.parent_head.hash();
 
 		storage.add_candidate(candidate, pvd).unwrap();
 		storage.retain(|_| true);
 		assert!(storage.contains(&candidate_hash));
 		assert_eq!(storage.iter_para_children(&parent_head_hash).count(), 1);
+		assert!(storage.head_data_by_hash(&output_head_hash).is_some());
 
 		storage.retain(|_| false);
 		assert!(!storage.contains(&candidate_hash));
 		assert_eq!(storage.iter_para_children(&parent_head_hash).count(), 0);
+		assert!(storage.head_data_by_hash(&output_head_hash).is_none());
 	}
 
 	#[test]

--- a/node/core/prospective-parachains/src/fragment_tree.rs
+++ b/node/core/prospective-parachains/src/fragment_tree.rs
@@ -197,6 +197,7 @@ enum CandidateState {
 	Backed,
 }
 
+#[derive(Debug)]
 struct CandidateEntry {
 	candidate_hash: CandidateHash,
 	relay_parent: Hash,

--- a/node/core/prospective-parachains/src/fragment_tree.rs
+++ b/node/core/prospective-parachains/src/fragment_tree.rs
@@ -184,6 +184,11 @@ impl CandidateStorage {
 	fn get(&'_ self, candidate_hash: &CandidateHash) -> Option<&'_ CandidateEntry> {
 		self.by_candidate_hash.get(candidate_hash)
 	}
+
+	#[cfg(test)]
+	pub fn len(&self) -> (usize, usize) {
+		(self.by_parent_head.len(), self.by_candidate_hash.len())
+	}
 }
 
 /// The state of a candidate.

--- a/node/core/prospective-parachains/src/lib.rs
+++ b/node/core/prospective-parachains/src/lib.rs
@@ -640,7 +640,7 @@ async fn fetch_ancestry<Context>(
 	let hashes = rx.map_err(JfyiError::ChainApiRequestCanceled).await??;
 	let mut block_info = Vec::with_capacity(hashes.len());
 	for hash in hashes {
-		match fetch_block_info(ctx, relay_hash).await? {
+		match fetch_block_info(ctx, hash).await? {
 			None => {
 				gum::warn!(
 					target: LOG_TARGET,

--- a/node/core/prospective-parachains/src/lib.rs
+++ b/node/core/prospective-parachains/src/lib.rs
@@ -55,6 +55,8 @@ use crate::{
 
 mod error;
 mod fragment_tree;
+#[cfg(test)]
+mod tests;
 
 const LOG_TARGET: &str = "parachain::prospective-parachains";
 

--- a/node/core/prospective-parachains/src/tests.rs
+++ b/node/core/prospective-parachains/src/tests.rs
@@ -1171,15 +1171,15 @@ fn check_pvd_query() {
 		)
 		.await;
 
-		// TODO: Get pvd of candidate B before adding it.
-		// get_pvd(
-		// 	&mut virtual_overseer,
-		// 	1.into(),
-		// 	leaf_a.hash,
-		// 	HeadData(vec![1]),
-		// 	Some(pvd_b.clone()),
-		// )
-		// .await;
+		// Get pvd of candidate B before adding it.
+		get_pvd(
+			&mut virtual_overseer,
+			1.into(),
+			leaf_a.hash,
+			HeadData(vec![1]),
+			Some(pvd_b.clone()),
+		)
+		.await;
 
 		// Add candidate B.
 		second_candidate(&mut virtual_overseer, candidate_b, pvd_b.clone(), response_b.clone())
@@ -1195,15 +1195,15 @@ fn check_pvd_query() {
 		)
 		.await;
 
-		// TODO: Get pvd of candidate C before adding it.
-		// get_pvd(
-		// 	&mut virtual_overseer,
-		// 	1.into(),
-		// 	leaf_a.hash,
-		// 	HeadData(vec![2]),
-		// 	Some(pvd_c.clone()),
-		// )
-		// .await;
+		// Get pvd of candidate C before adding it.
+		get_pvd(
+			&mut virtual_overseer,
+			1.into(),
+			leaf_a.hash,
+			HeadData(vec![2]),
+			Some(pvd_c.clone()),
+		)
+		.await;
 
 		// Add candidate C.
 		second_candidate(&mut virtual_overseer, candidate_c, pvd_c.clone(), response_c.clone())

--- a/node/core/prospective-parachains/src/tests.rs
+++ b/node/core/prospective-parachains/src/tests.rs
@@ -1025,7 +1025,6 @@ fn check_depth_query() {
 			candidate_hash_a,
 			1.into(),
 			HeadData(vec![1, 2, 3]),
-			// TODO: When would these be different?
 			leaf_a.hash,
 			leaf_a.hash,
 			vec![0],

--- a/node/core/prospective-parachains/src/tests.rs
+++ b/node/core/prospective-parachains/src/tests.rs
@@ -1,101 +1,282 @@
 use super::*;
+use ::polkadot_primitives_test_helpers::dummy_hash;
 use assert_matches::assert_matches;
 use futures::executor;
-use polkadot_node_subsystem::messages::{
-	AllMessages, ProspectiveParachainsMessage, ProspectiveValidationDataRequest,
+use polkadot_node_subsystem::{
+	errors::RuntimeApiError,
+	messages::{AllMessages, ProspectiveParachainsMessage, ProspectiveValidationDataRequest},
 };
 use polkadot_node_subsystem_test_helpers as test_helpers;
 use polkadot_node_subsystem_types::{jaeger, ActivatedLeaf, LeafStatus};
-use polkadot_primitives::vstaging as vstaging_primitives;
+use polkadot_primitives::{
+	v2::{
+		CandidateDescriptor, GroupRotationInfo, HeadData, PersistedValidationData, ScheduledCore,
+		SessionIndex, SigningContext, ValidatorId, ValidatorIndex,
+	},
+	vstaging as vstaging_primitives,
+};
+use sp_application_crypto::AppKey;
 use sp_core::testing::TaskExecutor;
+use sp_keyring::Sr25519Keyring;
+use sp_keystore::{CryptoStore, SyncCryptoStore, SyncCryptoStorePtr};
 use std::sync::Arc;
 
 const ASYNC_BACKING_PARAMETERS: vstaging_primitives::AsyncBackingParameters =
 	vstaging_primitives::AsyncBackingParameters { max_candidate_depth: 4, allowed_ancestry_len: 3 };
 
-#[test]
-fn correctly_updates_leaves() {
-	let first_block_hash = [1; 32].into();
-	let second_block_hash = [2; 32].into();
-	let third_block_hash = [3; 32].into();
+const ASYNC_BACKING_DISABLED_ERROR: RuntimeApiError =
+	RuntimeApiError::NotSupported { runtime_api_name: "test-runtime" };
 
-	let pool = TaskExecutor::new();
-	let (mut ctx, mut ctx_handle) =
-		test_helpers::make_subsystem_context::<ProspectiveParachainsMessage, _>(pool.clone());
+type VirtualOverseer = test_helpers::TestSubsystemContextHandle<ProspectiveParachainsMessage>;
+
+fn validator_pubkeys(val_ids: &[Sr25519Keyring]) -> Vec<ValidatorId> {
+	val_ids.iter().map(|v| v.public().into()).collect()
+}
+
+struct TestState {
+	chain_ids: Vec<ParaId>,
+	keystore: SyncCryptoStorePtr,
+	validators: Vec<Sr25519Keyring>,
+	validator_public: Vec<ValidatorId>,
+	validation_data: PersistedValidationData,
+	validator_groups: (Vec<Vec<ValidatorIndex>>, GroupRotationInfo),
+	availability_cores: Vec<CoreState>,
+	head_data: HashMap<ParaId, HeadData>,
+	signing_context: SigningContext,
+	relay_parent: Hash,
+}
+
+impl TestState {
+	fn session(&self) -> SessionIndex {
+		self.signing_context.session_index
+	}
+}
+
+impl Default for TestState {
+	fn default() -> Self {
+		let chain_a = ParaId::from(1);
+		let chain_b = ParaId::from(2);
+
+		let chain_ids = vec![chain_a, chain_b];
+
+		let validators = vec![
+			Sr25519Keyring::Alice,
+			Sr25519Keyring::Bob,
+			Sr25519Keyring::Charlie,
+			Sr25519Keyring::Dave,
+			Sr25519Keyring::Ferdie,
+			Sr25519Keyring::One,
+		];
+
+		let keystore = Arc::new(sc_keystore::LocalKeystore::in_memory());
+		// Make sure `Alice` key is in the keystore, so this mocked node will be a parachain validator.
+		SyncCryptoStore::sr25519_generate_new(
+			&*keystore,
+			ValidatorId::ID,
+			Some(&validators[0].to_seed()),
+		)
+		.expect("Insert key into keystore");
+
+		let validator_public = validator_pubkeys(&validators);
+
+		let validator_groups = vec![vec![2, 0, 3, 5], vec![1]]
+			.into_iter()
+			.map(|g| g.into_iter().map(ValidatorIndex).collect())
+			.collect();
+		let group_rotation_info =
+			GroupRotationInfo { session_start_block: 0, group_rotation_frequency: 100, now: 1 };
+
+		let availability_cores = vec![
+			CoreState::Scheduled(ScheduledCore { para_id: chain_a, collator: None }),
+			CoreState::Scheduled(ScheduledCore { para_id: chain_b, collator: None }),
+		];
+
+		let mut head_data = HashMap::new();
+		head_data.insert(chain_a, HeadData(vec![4, 5, 6]));
+		head_data.insert(chain_b, HeadData(vec![5, 6, 7]));
+
+		let relay_parent = Hash::repeat_byte(5);
+
+		let signing_context = SigningContext { session_index: 1, parent_hash: relay_parent };
+
+		let validation_data = PersistedValidationData {
+			parent_head: HeadData(vec![7, 8, 9]),
+			relay_parent_number: 0_u32.into(),
+			max_pov_size: 1024,
+			relay_parent_storage_root: dummy_hash(),
+		};
+
+		Self {
+			chain_ids,
+			keystore,
+			validators,
+			validator_public,
+			validator_groups: (validator_groups, group_rotation_info),
+			availability_cores,
+			head_data,
+			validation_data,
+			signing_context,
+			relay_parent,
+		}
+	}
+}
+
+fn test_harness<T: Future<Output = VirtualOverseer>>(
+	test: impl FnOnce(VirtualOverseer) -> T,
+) -> View {
+	let pool = sp_core::testing::TaskExecutor::new();
+
+	let (mut context, virtual_overseer) = test_helpers::make_subsystem_context(pool.clone());
 
 	let mut view = View::new();
-
-	let check_fut = async move {
-		// Activate a leaf.
-		let activated = ActivatedLeaf {
-			hash: first_block_hash,
-			number: 1,
-			span: Arc::new(jaeger::Span::Disabled),
-			status: LeafStatus::Fresh,
-		};
-		let update = ActiveLeavesUpdate::start_work(activated);
-		handle_active_leaves_update(&mut ctx, &mut view, update).await.unwrap();
-
-		// Activate another leaf.
-		let activated = ActivatedLeaf {
-			hash: second_block_hash,
-			number: 2,
-			span: Arc::new(jaeger::Span::Disabled),
-			status: LeafStatus::Fresh,
-		};
-		let update = ActiveLeavesUpdate::start_work(activated);
-		handle_active_leaves_update(&mut ctx, &mut view, update.clone()).await.unwrap();
-
-		// Try activating a duplicate leaf.
-		handle_active_leaves_update(&mut ctx, &mut view, update).await.unwrap();
-
-		// Pass in an empty update.
-		let update = ActiveLeavesUpdate::default();
-		handle_active_leaves_update(&mut ctx, &mut view, update).await.unwrap();
-
-		// Activate a leaf and remove one at the same time.
-		let activated = ActivatedLeaf {
-			hash: third_block_hash,
-			number: 3,
-			span: Arc::new(jaeger::Span::Disabled),
-			status: LeafStatus::Fresh,
-		};
-		let update = ActiveLeavesUpdate {
-			activated: Some(activated),
-			deactivated: [second_block_hash][..].into(),
-		};
-		handle_active_leaves_update(&mut ctx, &mut view, update).await.unwrap();
-
-		// TODO: Check tree contents.
-		assert_eq!(view.active_leaves.len(), 2);
-
-		// Remove all remaining leaves.
-		let update = ActiveLeavesUpdate {
-			deactivated: [first_block_hash, third_block_hash][..].into(),
-			..Default::default()
-		};
-		handle_active_leaves_update(&mut ctx, &mut view, update).await.unwrap();
-
-		// Check final tree contents.
-		assert!(view.active_leaves.is_empty() && view.candidate_storage.is_empty());
-	};
-
-	let test_fut = async move {
-		assert_matches!(
-			ctx_handle.recv().await,
-			AllMessages::RuntimeApi(
-				RuntimeApiMessage::Request(parent, RuntimeApiRequest::StagingAsyncBackingParameters(tx))
-			) if parent == first_block_hash => {
-				tx.send(Ok(ASYNC_BACKING_PARAMETERS)).unwrap();
+	let subsystem = async move {
+		loop {
+			match run_iteration(&mut context, &mut view).await {
+				Ok(()) => break,
+				Err(e) => panic!("{:?}", e),
 			}
-		);
+		}
 
-		// TODO: Fill this out.
-
-		let message = ctx_handle.recv().await;
-		println!("{:?}", message);
+		view
 	};
 
-	let test_fut = future::join(test_fut, check_fut);
-	executor::block_on(test_fut);
+	let test_fut = test(virtual_overseer);
+
+	futures::pin_mut!(test_fut);
+	futures::pin_mut!(subsystem);
+	let (_, view) = futures::executor::block_on(future::join(
+		async move {
+			let mut virtual_overseer = test_fut.await;
+			virtual_overseer.send(FromOrchestra::Signal(OverseerSignal::Conclude)).await;
+		},
+		subsystem,
+	));
+
+	view
 }
+
+async fn test_startup_async_backing_disabled(
+	virtual_overseer: &mut VirtualOverseer,
+	test_state: &TestState,
+) {
+	// Start work on some new parent.
+	virtual_overseer
+		.send(FromOrchestra::Signal(OverseerSignal::ActiveLeaves(ActiveLeavesUpdate::start_work(
+			ActivatedLeaf {
+				hash: test_state.relay_parent,
+				number: 1,
+				status: LeafStatus::Fresh,
+				span: Arc::new(jaeger::Span::Disabled),
+			},
+		))))
+		.await;
+
+	assert_matches!(
+		virtual_overseer.recv().await,
+		AllMessages::RuntimeApi(
+			RuntimeApiMessage::Request(parent, RuntimeApiRequest::StagingAsyncBackingParameters(tx))
+		) if parent == test_state.relay_parent => {
+			tx.send(Err(ASYNC_BACKING_DISABLED_ERROR)).unwrap();
+		}
+	);
+}
+
+#[test]
+fn should_do_no_work_if_async_backing_disabled_for_leaf() {
+	let test_state = TestState::default();
+	let view = test_harness(|mut virtual_overseer| async move {
+		test_startup_async_backing_disabled(&mut virtual_overseer, &test_state).await;
+
+		virtual_overseer
+	});
+
+	assert!(view.active_leaves.is_empty());
+	assert!(view.candidate_storage.is_empty());
+}
+
+// #[test]
+// fn correctly_updates_leaves() {
+// 	let first_block_hash = [1; 32].into();
+// 	let second_block_hash = [2; 32].into();
+// 	let third_block_hash = [3; 32].into();
+
+// 	let pool = TaskExecutor::new();
+// 	let (mut ctx, mut ctx_handle) =
+// 		test_helpers::make_subsystem_context::<ProspectiveParachainsMessage, _>(pool.clone());
+
+// 	let mut view = View::new();
+
+// 	let check_fut = async move {
+// 		// Activate a leaf.
+// 		let activated = ActivatedLeaf {
+// 			hash: first_block_hash,
+// 			number: 1,
+// 			span: Arc::new(jaeger::Span::Disabled),
+// 			status: LeafStatus::Fresh,
+// 		};
+// 		let update = ActiveLeavesUpdate::start_work(activated);
+// 		handle_active_leaves_update(&mut ctx, &mut view, update).await.unwrap();
+
+// 		// Activate another leaf.
+// 		let activated = ActivatedLeaf {
+// 			hash: second_block_hash,
+// 			number: 2,
+// 			span: Arc::new(jaeger::Span::Disabled),
+// 			status: LeafStatus::Fresh,
+// 		};
+// 		let update = ActiveLeavesUpdate::start_work(activated);
+// 		handle_active_leaves_update(&mut ctx, &mut view, update.clone()).await.unwrap();
+
+// 		// Try activating a duplicate leaf.
+// 		handle_active_leaves_update(&mut ctx, &mut view, update).await.unwrap();
+
+// 		// Pass in an empty update.
+// 		let update = ActiveLeavesUpdate::default();
+// 		handle_active_leaves_update(&mut ctx, &mut view, update).await.unwrap();
+
+// 		// Activate a leaf and remove one at the same time.
+// 		let activated = ActivatedLeaf {
+// 			hash: third_block_hash,
+// 			number: 3,
+// 			span: Arc::new(jaeger::Span::Disabled),
+// 			status: LeafStatus::Fresh,
+// 		};
+// 		let update = ActiveLeavesUpdate {
+// 			activated: Some(activated),
+// 			deactivated: [second_block_hash][..].into(),
+// 		};
+// 		handle_active_leaves_update(&mut ctx, &mut view, update).await.unwrap();
+
+// 		// TODO: Check tree contents.
+// 		assert_eq!(view.active_leaves.len(), 2);
+
+// 		// Remove all remaining leaves.
+// 		let update = ActiveLeavesUpdate {
+// 			deactivated: [first_block_hash, third_block_hash][..].into(),
+// 			..Default::default()
+// 		};
+// 		handle_active_leaves_update(&mut ctx, &mut view, update).await.unwrap();
+
+// 		// Check final tree contents.
+// 		assert!(view.active_leaves.is_empty() && view.candidate_storage.is_empty());
+// 	};
+
+// 	let test_fut = async move {
+// 		assert_matches!(
+// 			ctx_handle.recv().await,
+// 			AllMessages::RuntimeApi(
+// 				RuntimeApiMessage::Request(parent, RuntimeApiRequest::StagingAsyncBackingParameters(tx))
+// 			) if parent == first_block_hash => {
+// 				tx.send(Ok(ASYNC_BACKING_PARAMETERS)).unwrap();
+// 			}
+// 		);
+
+// 		// TODO: Fill this out.
+
+// 		let message = ctx_handle.recv().await;
+// 		println!("{:?}", message);
+// 	};
+
+// 	let test_fut = future::join(test_fut, check_fut);
+// 	executor::block_on(test_fut);
+// }

--- a/node/core/prospective-parachains/src/tests.rs
+++ b/node/core/prospective-parachains/src/tests.rs
@@ -82,12 +82,13 @@ fn dummy_pvd(parent_head: HeadData, relay_parent_number: u32) -> PersistedValida
 fn make_candidate(
 	leaf: &TestLeaf,
 	para_id: ParaId,
+	parent_head: HeadData,
+	head_data: HeadData,
 	validation_code_hash: ValidationCodeHash,
 ) -> (CommittedCandidateReceipt, PersistedValidationData) {
-	let PerParaData { min_relay_parent: _, required_parent } = leaf.para_data(para_id);
-	let pvd = dummy_pvd(required_parent.clone(), leaf.number);
+	let pvd = dummy_pvd(parent_head, leaf.number);
 	let commitments = CandidateCommitments {
-		head_data: required_parent.clone(),
+		head_data,
 		horizontal_messages: Vec::new(),
 		upward_messages: Vec::new(),
 		new_validation_code: None,
@@ -533,32 +534,48 @@ fn send_candidates_and_check_if_found() {
 		activate_leaf(&mut virtual_overseer, &leaf_c, &test_state).await;
 
 		// Candidate A1
-		let (candidate_a1, pvd_a1) =
-			make_candidate(&leaf_a, 1.into(), test_state.validation_code_hash);
+		let (candidate_a1, pvd_a1) = make_candidate(
+			&leaf_a,
+			1.into(),
+			HeadData(vec![1, 2, 3]),
+			HeadData(vec![1]),
+			test_state.validation_code_hash,
+		);
 		let candidate_hash_a1 = candidate_a1.hash();
-		// TODO: Is this correct?
-		let response_a1 = vec![(leaf_a.hash, vec![0, 1, 2, 3, 4])];
+		let response_a1 = vec![(leaf_a.hash, vec![0])];
 
 		// Candidate A2
-		let (candidate_a2, pvd_a2) =
-			make_candidate(&leaf_a, 2.into(), test_state.validation_code_hash);
+		let (candidate_a2, pvd_a2) = make_candidate(
+			&leaf_a,
+			2.into(),
+			HeadData(vec![2, 3, 4]),
+			HeadData(vec![2]),
+			test_state.validation_code_hash,
+		);
 		let candidate_hash_a2 = candidate_a2.hash();
-		// TODO: Is this correct?
-		let response_a2 = vec![(leaf_a.hash, vec![0, 1, 2, 3, 4])];
+		let response_a2 = vec![(leaf_a.hash, vec![0])];
 
 		// Candidate B
-		let (candidate_b, pvd_b) =
-			make_candidate(&leaf_b, 1.into(), test_state.validation_code_hash);
+		let (candidate_b, pvd_b) = make_candidate(
+			&leaf_b,
+			1.into(),
+			HeadData(vec![3, 4, 5]),
+			HeadData(vec![3]),
+			test_state.validation_code_hash,
+		);
 		let candidate_hash_b = candidate_b.hash();
-		// TODO: Is this correct?
-		let response_b = vec![(leaf_b.hash, vec![0, 1, 2, 3, 4])];
+		let response_b = vec![(leaf_b.hash, vec![0])];
 
 		// Candidate C
-		let (candidate_c, pvd_c) =
-			make_candidate(&leaf_c, 2.into(), test_state.validation_code_hash);
+		let (candidate_c, pvd_c) = make_candidate(
+			&leaf_c,
+			2.into(),
+			HeadData(vec![6, 7, 8]),
+			HeadData(vec![4]),
+			test_state.validation_code_hash,
+		);
 		let candidate_hash_c = candidate_c.hash();
-		// TODO: Is this correct?
-		let response_c = vec![(leaf_c.hash, vec![0, 1, 2, 3, 4])];
+		let response_c = vec![(leaf_c.hash, vec![0])];
 
 		// Second candidates.
 		second_candidate(&mut virtual_overseer, candidate_a1, pvd_a1, response_a1.clone()).await;
@@ -627,32 +644,48 @@ fn check_candidate_parent_leaving_view() {
 		activate_leaf(&mut virtual_overseer, &leaf_c, &test_state).await;
 
 		// Candidate A1
-		let (candidate_a1, pvd_a1) =
-			make_candidate(&leaf_a, 1.into(), test_state.validation_code_hash);
+		let (candidate_a1, pvd_a1) = make_candidate(
+			&leaf_a,
+			1.into(),
+			HeadData(vec![1, 2, 3]),
+			HeadData(vec![1]),
+			test_state.validation_code_hash,
+		);
 		let candidate_hash_a1 = candidate_a1.hash();
-		// TODO: Is this correct?
-		let response_a1 = vec![(leaf_a.hash, vec![0, 1, 2, 3, 4])];
+		let response_a1 = vec![(leaf_a.hash, vec![0])];
 
 		// Candidate A2
-		let (candidate_a2, pvd_a2) =
-			make_candidate(&leaf_a, 2.into(), test_state.validation_code_hash);
+		let (candidate_a2, pvd_a2) = make_candidate(
+			&leaf_a,
+			2.into(),
+			HeadData(vec![2, 3, 4]),
+			HeadData(vec![2]),
+			test_state.validation_code_hash,
+		);
 		let candidate_hash_a2 = candidate_a2.hash();
-		// TODO: Is this correct?
-		let response_a2 = vec![(leaf_a.hash, vec![0, 1, 2, 3, 4])];
+		let response_a2 = vec![(leaf_a.hash, vec![0])];
 
 		// Candidate B
-		let (candidate_b, pvd_b) =
-			make_candidate(&leaf_b, 1.into(), test_state.validation_code_hash);
+		let (candidate_b, pvd_b) = make_candidate(
+			&leaf_b,
+			1.into(),
+			HeadData(vec![3, 4, 5]),
+			HeadData(vec![3]),
+			test_state.validation_code_hash,
+		);
 		let candidate_hash_b = candidate_b.hash();
-		// TODO: Is this correct?
-		let response_b = vec![(leaf_b.hash, vec![0, 1, 2, 3, 4])];
+		let response_b = vec![(leaf_b.hash, vec![0])];
 
 		// Candidate C
-		let (candidate_c, pvd_c) =
-			make_candidate(&leaf_c, 2.into(), test_state.validation_code_hash);
+		let (candidate_c, pvd_c) = make_candidate(
+			&leaf_c,
+			2.into(),
+			HeadData(vec![6, 7, 8]),
+			HeadData(vec![4]),
+			test_state.validation_code_hash,
+		);
 		let candidate_hash_c = candidate_c.hash();
-		// TODO: Is this correct?
-		let response_c = vec![(leaf_c.hash, vec![0, 1, 2, 3, 4])];
+		let response_c = vec![(leaf_c.hash, vec![0])];
 
 		// Second candidates.
 		second_candidate(&mut virtual_overseer, candidate_a1, pvd_a1, response_a1.clone()).await;
@@ -734,7 +767,13 @@ fn check_candidate_on_multiple_forks() {
 		activate_leaf(&mut virtual_overseer, &leaf_c, &test_state).await;
 
 		// Candidate
-		let (candidate, pvd) = make_candidate(&leaf_a, 1.into(), test_state.validation_code_hash);
+		let (candidate, pvd) = make_candidate(
+			&leaf_a,
+			1.into(),
+			HeadData(vec![1, 2, 3]),
+			HeadData(vec![1]),
+			test_state.validation_code_hash,
+		);
 		let candidate_hash = candidate.hash();
 		// TODO: Is this correct?
 		let response = vec![(leaf_a.hash, vec![0, 1, 2, 3, 4])];
@@ -788,20 +827,28 @@ fn check_backable_query() {
 		activate_leaf(&mut virtual_overseer, &leaf_a, &test_state).await;
 
 		// Candidate A
-		let (candidate_a, pvd_a) =
-			make_candidate(&leaf_a, 1.into(), test_state.validation_code_hash);
+		let (candidate_a, pvd_a) = make_candidate(
+			&leaf_a,
+			1.into(),
+			HeadData(vec![1, 2, 3]),
+			HeadData(vec![1]),
+			test_state.validation_code_hash,
+		);
 		let candidate_hash_a = candidate_a.hash();
-		// TODO: Is this correct?
-		let response_a = vec![(leaf_a.hash, vec![0, 1, 2, 3, 4])];
+		let response_a = vec![(leaf_a.hash, vec![0])];
 
 		// Candidate B
-		let (mut candidate_b, pvd_b) =
-			make_candidate(&leaf_a, 1.into(), test_state.validation_code_hash);
+		let (mut candidate_b, pvd_b) = make_candidate(
+			&leaf_a,
+			1.into(),
+			HeadData(vec![1]),
+			HeadData(vec![2]),
+			test_state.validation_code_hash,
+		);
 		// Set a field to make this candidate unique.
 		candidate_b.descriptor.para_head = Hash::from_low_u64_le(1000);
 		let candidate_hash_b = candidate_b.hash();
-		// TODO: Is this correct?
-		let response_b = vec![(leaf_a.hash, vec![0, 1, 2, 3, 4])];
+		let response_b = vec![(leaf_a.hash, vec![1])];
 
 		// Second candidates.
 		second_candidate(

--- a/node/core/prospective-parachains/src/tests.rs
+++ b/node/core/prospective-parachains/src/tests.rs
@@ -1,0 +1,101 @@
+use super::*;
+use assert_matches::assert_matches;
+use futures::executor;
+use polkadot_node_subsystem::messages::{
+	AllMessages, ProspectiveParachainsMessage, ProspectiveValidationDataRequest,
+};
+use polkadot_node_subsystem_test_helpers as test_helpers;
+use polkadot_node_subsystem_types::{jaeger, ActivatedLeaf, LeafStatus};
+use polkadot_primitives::vstaging as vstaging_primitives;
+use sp_core::testing::TaskExecutor;
+use std::sync::Arc;
+
+const ASYNC_BACKING_PARAMETERS: vstaging_primitives::AsyncBackingParameters =
+	vstaging_primitives::AsyncBackingParameters { max_candidate_depth: 4, allowed_ancestry_len: 3 };
+
+#[test]
+fn correctly_updates_leaves() {
+	let first_block_hash = [1; 32].into();
+	let second_block_hash = [2; 32].into();
+	let third_block_hash = [3; 32].into();
+
+	let pool = TaskExecutor::new();
+	let (mut ctx, mut ctx_handle) =
+		test_helpers::make_subsystem_context::<ProspectiveParachainsMessage, _>(pool.clone());
+
+	let mut view = View::new();
+
+	let check_fut = async move {
+		// Activate a leaf.
+		let activated = ActivatedLeaf {
+			hash: first_block_hash,
+			number: 1,
+			span: Arc::new(jaeger::Span::Disabled),
+			status: LeafStatus::Fresh,
+		};
+		let update = ActiveLeavesUpdate::start_work(activated);
+		handle_active_leaves_update(&mut ctx, &mut view, update).await.unwrap();
+
+		// Activate another leaf.
+		let activated = ActivatedLeaf {
+			hash: second_block_hash,
+			number: 2,
+			span: Arc::new(jaeger::Span::Disabled),
+			status: LeafStatus::Fresh,
+		};
+		let update = ActiveLeavesUpdate::start_work(activated);
+		handle_active_leaves_update(&mut ctx, &mut view, update.clone()).await.unwrap();
+
+		// Try activating a duplicate leaf.
+		handle_active_leaves_update(&mut ctx, &mut view, update).await.unwrap();
+
+		// Pass in an empty update.
+		let update = ActiveLeavesUpdate::default();
+		handle_active_leaves_update(&mut ctx, &mut view, update).await.unwrap();
+
+		// Activate a leaf and remove one at the same time.
+		let activated = ActivatedLeaf {
+			hash: third_block_hash,
+			number: 3,
+			span: Arc::new(jaeger::Span::Disabled),
+			status: LeafStatus::Fresh,
+		};
+		let update = ActiveLeavesUpdate {
+			activated: Some(activated),
+			deactivated: [second_block_hash][..].into(),
+		};
+		handle_active_leaves_update(&mut ctx, &mut view, update).await.unwrap();
+
+		// TODO: Check tree contents.
+		assert_eq!(view.active_leaves.len(), 2);
+
+		// Remove all remaining leaves.
+		let update = ActiveLeavesUpdate {
+			deactivated: [first_block_hash, third_block_hash][..].into(),
+			..Default::default()
+		};
+		handle_active_leaves_update(&mut ctx, &mut view, update).await.unwrap();
+
+		// Check final tree contents.
+		assert!(view.active_leaves.is_empty() && view.candidate_storage.is_empty());
+	};
+
+	let test_fut = async move {
+		assert_matches!(
+			ctx_handle.recv().await,
+			AllMessages::RuntimeApi(
+				RuntimeApiMessage::Request(parent, RuntimeApiRequest::StagingAsyncBackingParameters(tx))
+			) if parent == first_block_hash => {
+				tx.send(Ok(ASYNC_BACKING_PARAMETERS)).unwrap();
+			}
+		);
+
+		// TODO: Fill this out.
+
+		let message = ctx_handle.recv().await;
+		println!("{:?}", message);
+	};
+
+	let test_fut = future::join(test_fut, check_fut);
+	executor::block_on(test_fut);
+}

--- a/node/network/collator-protocol/src/validator_side/tests/prospective_parachains.rs
+++ b/node/network/collator-protocol/src/validator_side/tests/prospective_parachains.rs
@@ -423,7 +423,6 @@ fn second_multiple_candidates_per_relay_parent() {
 		for i in 0..(ASYNC_BACKING_PARAMETERS.max_candidate_depth + 1) {
 			let mut candidate = dummy_candidate_receipt_bad_sig(head_c, Some(Default::default()));
 			candidate.descriptor.para_id = test_state.chain_ids[0];
-			candidate.descriptor.relay_parent = head_c;
 			candidate.descriptor.persisted_validation_data_hash = dummy_pvd().hash();
 			let commitments = CandidateCommitments {
 				head_data: HeadData(vec![i as u8]),
@@ -579,7 +578,6 @@ fn fetched_collation_sanity_check() {
 
 		let mut candidate = dummy_candidate_receipt_bad_sig(head_c, Some(Default::default()));
 		candidate.descriptor.para_id = test_state.chain_ids[0];
-		candidate.descriptor.relay_parent = head_c;
 		let commitments = CandidateCommitments {
 			head_data: HeadData(vec![1, 2, 3]),
 			horizontal_messages: Vec::new(),

--- a/node/service/Cargo.toml
+++ b/node/service/Cargo.toml
@@ -159,7 +159,7 @@ full-node = [
 	"polkadot-node-core-chain-api",
 	"polkadot-node-core-chain-selection",
 	"polkadot-node-core-dispute-coordinator",
-    "polkadot-node-core-prospective-parachains",
+	"polkadot-node-core-prospective-parachains",
 	"polkadot-node-core-provisioner",
 	"polkadot-node-core-runtime-api",
 	"polkadot-statement-distribution",

--- a/node/subsystem-util/src/inclusion_emulator/staging.rs
+++ b/node/subsystem-util/src/inclusion_emulator/staging.rs
@@ -64,9 +64,8 @@
 //! A fragment tree is a mental model for thinking about a forking series of predictions
 //! about a single parachain. There may be one or more fragment trees per parachain.
 //!
-//! In expectation, most parachains will have a plausibly-unique authorship method
-//! which means that they should really be much closer to fragment-chains, maybe
-//! maybe with an occasional fork.
+//! In expectation, most parachains will have a plausibly-unique authorship method which means that
+//! they should really be much closer to fragment-chains, maybe with an occasional fork.
 //!
 //! Avoiding fragment-tree blowup is beyond the scope of this module.
 //!
@@ -99,7 +98,7 @@
 //! As predictions fade into the past, new ones should be stacked on top.
 //!
 //! Every new relay-chain block is an opportunity to make a new prediction about the future.
-//! higher-level logic should select the leaves of the fragment-trees to build upon or whether
+//! Higher-level logic should select the leaves of the fragment-trees to build upon or whether
 //! to create a new fragment-tree.
 //!
 //! ### Code Upgrades


### PR DESCRIPTION
# PULL REQUEST

## Overview

Some of the basic tests implemented:

- [X] Test if it does 0 work if async backing is disabled for this leaf.
- [X] After activation send some candidates, check if they're found.
- [X] Check if the candidate won't be found once its relay parent leaves the view.
- [X] Introduce a candidate to multiple forks, see how the membership is returned.
- [X] Test basic usage of queries.

I tested basic scenarios, but if we want, we can expand on these in a follow-up. Is there anything specific we still want to test? Perhaps more complex scenarios e.g. longer depths, crazier forks, candidates appearing in a tree more than once, etc. 

## Relevant Issues

Closes https://github.com/paritytech/polkadot/issues/6186