### PR TITLE
CI: fix runtime-migration label detection

### DIFF
--- a/scripts/ci/gitlab/pipeline/check.yml
+++ b/scripts/ci/gitlab/pipeline/check.yml
@@ -62,10 +62,10 @@ check-try-runtime:
     - |
       export has_runtimemigration_label=$(curl -sS -H "Accept: application/vnd.github+json" \
         -H "Authorization: token $GITHUB_PR_TOKEN" \
-        https://api.github.com/repos/paritytech/polkadot/issues/$CI_COMMIT_REF_NAME/labels | grep "E1" | wc -l)
+        https://api.github.com/repos/paritytech/polkadot/issues/$CI_COMMIT_REF_NAME/labels | grep "E0-runtime_migration" | wc -l)
     - |
       if [[ $has_runtimemigration_label != 0 ]]; then
-        echo "Found label runtimemigration. Running tests"
+        echo "Found label runtime_migration. Running tests"
         export RUST_LOG=remote-ext=debug,runtime=debug
         echo "---------- Running try-runtime for ${NETWORK} ----------"
         time cargo build --release -p "$NETWORK"-runtime
@@ -75,7 +75,7 @@ check-try-runtime:
             --chain=${NETWORK}-dev \
             on-runtime-upgrade live --uri wss://${NETWORK}-try-runtime-node.parity-chains.parity.io:443
       else
-        echo "runtimemigration label not found. Skipping"
+        echo "runtime_migration label not found. Skipping"
       fi
 
 check-runtime-migration-polkadot:


### PR DESCRIPTION
Looks like the label renamed from `E1` to `E0`.