### PR TITLE
Ensure for a configurable origin in XCM (#6442)

### DIFF
--- a/runtime/kusama/src/xcm_config.rs
+++ b/runtime/kusama/src/xcm_config.rs
@@ -21,6 +21,7 @@ use super::{
 	RuntimeCall, RuntimeEvent, RuntimeOrigin, StakingAdmin, WeightToFee, XcmPallet,
 };
 use frame_support::{match_types, parameter_types, traits::Everything};
+use frame_system::EnsureRoot;
 use runtime_common::{xcm_sender, ToAuthor};
 use xcm::latest::prelude::*;
 use xcm_builder::{
@@ -219,4 +220,5 @@ impl pallet_xcm::Config for Runtime {
 	type RuntimeCall = RuntimeCall;
 	const VERSION_DISCOVERY_QUEUE_SIZE: u32 = 100;
 	type AdvertisedXcmVersion = pallet_xcm::CurrentXcmVersion;
+	type AdminOrigin = EnsureRoot<AccountId>;
 }

--- a/runtime/polkadot/src/xcm_config.rs
+++ b/runtime/polkadot/src/xcm_config.rs
@@ -24,6 +24,7 @@ use frame_support::{
 	match_types, parameter_types,
 	traits::{Everything, Nothing},
 };
+use frame_system::EnsureRoot;
 use runtime_common::{xcm_sender, ToAuthor};
 use xcm::latest::prelude::*;
 use xcm_builder::{
@@ -193,4 +194,5 @@ impl pallet_xcm::Config for Runtime {
 	type RuntimeCall = RuntimeCall;
 	const VERSION_DISCOVERY_QUEUE_SIZE: u32 = 100;
 	type AdvertisedXcmVersion = AdvertisedXcmVersion;
+	type AdminOrigin = EnsureRoot<AccountId>;
 }

--- a/runtime/rococo/src/xcm_config.rs
+++ b/runtime/rococo/src/xcm_config.rs
@@ -21,6 +21,7 @@ use super::{
 	RuntimeEvent, RuntimeOrigin, WeightToFee, XcmPallet,
 };
 use frame_support::{match_types, parameter_types, traits::Everything};
+use frame_system::EnsureRoot;
 use runtime_common::{xcm_sender, ToAuthor};
 use xcm::latest::prelude::*;
 use xcm_builder::{
@@ -209,4 +210,5 @@ impl pallet_xcm::Config for Runtime {
 	type RuntimeCall = RuntimeCall;
 	const VERSION_DISCOVERY_QUEUE_SIZE: u32 = 100;
 	type AdvertisedXcmVersion = pallet_xcm::CurrentXcmVersion;
+	type AdminOrigin = EnsureRoot<AccountId>;
 }

--- a/runtime/test-runtime/src/lib.rs
+++ b/runtime/test-runtime/src/lib.rs
@@ -40,6 +40,7 @@ use frame_support::{
 	construct_runtime, parameter_types,
 	traits::{Everything, KeyOwnerProofSystem, WithdrawReasons},
 };
+use frame_system::EnsureRoot;
 use pallet_grandpa::{fg_primitives, AuthorityId as GrandpaId};
 use pallet_session::historical as session_historical;
 use pallet_transaction_payment::{FeeDetails, RuntimeDispatchInfo};
@@ -564,6 +565,7 @@ impl pallet_xcm::Config for Runtime {
 	type RuntimeCall = RuntimeCall;
 	const VERSION_DISCOVERY_QUEUE_SIZE: u32 = 100;
 	type AdvertisedXcmVersion = pallet_xcm::CurrentXcmVersion;
+	type AdminOrigin = EnsureRoot<AccountId>;
 }
 
 impl parachains_hrmp::Config for Runtime {

--- a/runtime/westend/src/xcm_config.rs
+++ b/runtime/westend/src/xcm_config.rs
@@ -24,6 +24,7 @@ use frame_support::{
 	parameter_types,
 	traits::{Everything, Nothing},
 };
+use frame_system::EnsureRoot;
 use runtime_common::{xcm_sender, ToAuthor};
 use xcm::latest::prelude::*;
 use xcm_builder::{
@@ -143,4 +144,5 @@ impl pallet_xcm::Config for Runtime {
 	type RuntimeCall = RuntimeCall;
 	const VERSION_DISCOVERY_QUEUE_SIZE: u32 = 100;
 	type AdvertisedXcmVersion = pallet_xcm::CurrentXcmVersion;
+	type AdminOrigin = EnsureRoot<AccountId>;
 }

--- a/xcm/pallet-xcm/src/lib.rs
+++ b/xcm/pallet-xcm/src/lib.rs
@@ -126,6 +126,9 @@ pub mod pallet {
 		/// The latest supported version that we advertise. Generally just set it to
 		/// `pallet_xcm::CurrentXcmVersion`.
 		type AdvertisedXcmVersion: Get<XcmVersion>;
+
+		/// The configurable origin to use with Gov2
+		type AdminOrigin: EnsureOrigin<<Self as SysConfig>::RuntimeOrigin>;
 	}
 
 	/// The maximum number of distinct assets allowed to be transferred in a single helper extrinsic.
@@ -613,7 +616,7 @@ pub mod pallet {
 			location: Box<MultiLocation>,
 			xcm_version: XcmVersion,
 		) -> DispatchResult {
-			ensure_root(origin)?;
+			T::AdminOrigin::ensure_origin(origin)?;
 			let location = *location;
 			SupportedVersion::<T>::insert(
 				XCM_VERSION,
@@ -635,7 +638,7 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			maybe_xcm_version: Option<XcmVersion>,
 		) -> DispatchResult {
-			ensure_root(origin)?;
+			T::AdminOrigin::ensure_origin(origin)?;
 			SafeXcmVersion::<T>::set(maybe_xcm_version);
 			Ok(())
 		}
@@ -650,7 +653,7 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			location: Box<VersionedMultiLocation>,
 		) -> DispatchResult {
-			ensure_root(origin)?;
+			T::AdminOrigin::ensure_origin(origin)?;
 			let location: MultiLocation =
 				(*location).try_into().map_err(|()| Error::<T>::BadLocation)?;
 			Self::request_version_notify(location).map_err(|e| {
@@ -674,7 +677,7 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			location: Box<VersionedMultiLocation>,
 		) -> DispatchResult {
-			ensure_root(origin)?;
+			T::AdminOrigin::ensure_origin(origin)?;
 			let location: MultiLocation =
 				(*location).try_into().map_err(|()| Error::<T>::BadLocation)?;
 			Self::unrequest_version_notify(location).map_err(|e| {

--- a/xcm/pallet-xcm/src/mock.rs
+++ b/xcm/pallet-xcm/src/mock.rs
@@ -15,6 +15,7 @@
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
 use frame_support::{construct_runtime, parameter_types, traits::Everything};
+use frame_system::EnsureRoot;
 use polkadot_parachain::primitives::Id as ParaId;
 use polkadot_runtime_parachains::origin;
 use sp_core::H256;
@@ -291,6 +292,7 @@ impl pallet_xcm::Config for Test {
 	type RuntimeCall = RuntimeCall;
 	const VERSION_DISCOVERY_QUEUE_SIZE: u32 = 100;
 	type AdvertisedXcmVersion = AdvertisedXcmVersion;
+	type AdminOrigin = EnsureRoot<AccountId>;
 }
 
 impl origin::Config for Test {}

--- a/xcm/xcm-builder/tests/mock/mod.rs
+++ b/xcm/xcm-builder/tests/mock/mod.rs
@@ -18,6 +18,7 @@ use frame_support::{
 	construct_runtime, parameter_types,
 	traits::{Everything, Nothing},
 };
+use frame_system::EnsureRoot;
 use sp_core::H256;
 use sp_runtime::{testing::Header, traits::IdentityLookup, AccountId32};
 use sp_std::cell::RefCell;
@@ -194,6 +195,7 @@ impl pallet_xcm::Config for Runtime {
 	type RuntimeOrigin = RuntimeOrigin;
 	const VERSION_DISCOVERY_QUEUE_SIZE: u32 = 100;
 	type AdvertisedXcmVersion = pallet_xcm::CurrentXcmVersion;
+	type AdminOrigin = EnsureRoot<AccountId>;
 }
 
 impl origin::Config for Runtime {}

--- a/xcm/xcm-simulator/example/src/parachain.rs
+++ b/xcm/xcm-simulator/example/src/parachain.rs
@@ -22,6 +22,7 @@ use frame_support::{
 	traits::{Everything, Nothing},
 	weights::{constants::WEIGHT_REF_TIME_PER_SECOND, Weight},
 };
+use frame_system::EnsureRoot;
 use sp_core::H256;
 use sp_runtime::{
 	testing::Header,
@@ -315,6 +316,7 @@ impl pallet_xcm::Config for Runtime {
 	type RuntimeCall = RuntimeCall;
 	const VERSION_DISCOVERY_QUEUE_SIZE: u32 = 100;
 	type AdvertisedXcmVersion = pallet_xcm::CurrentXcmVersion;
+	type AdminOrigin = EnsureRoot<AccountId>;
 }
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;

--- a/xcm/xcm-simulator/example/src/relay_chain.rs
+++ b/xcm/xcm-simulator/example/src/relay_chain.rs
@@ -20,6 +20,7 @@ use frame_support::{
 	construct_runtime, parameter_types,
 	traits::{Everything, Nothing},
 };
+use frame_system::EnsureRoot;
 use sp_core::H256;
 use sp_runtime::{testing::Header, traits::IdentityLookup, AccountId32};
 
@@ -158,6 +159,7 @@ impl pallet_xcm::Config for Runtime {
 	type RuntimeCall = RuntimeCall;
 	const VERSION_DISCOVERY_QUEUE_SIZE: u32 = 100;
 	type AdvertisedXcmVersion = pallet_xcm::CurrentXcmVersion;
+	type AdminOrigin = EnsureRoot<AccountId>;
 }
 
 parameter_types! {

--- a/xcm/xcm-simulator/fuzzer/src/parachain.rs
+++ b/xcm/xcm-simulator/fuzzer/src/parachain.rs
@@ -22,6 +22,7 @@ use frame_support::{
 	traits::{Everything, Nothing},
 	weights::{constants::WEIGHT_REF_TIME_PER_SECOND, Weight},
 };
+use frame_system::EnsureRoot;
 use sp_core::H256;
 use sp_runtime::{
 	testing::Header,
@@ -315,6 +316,7 @@ impl pallet_xcm::Config for Runtime {
 	type RuntimeCall = RuntimeCall;
 	const VERSION_DISCOVERY_QUEUE_SIZE: u32 = 100;
 	type AdvertisedXcmVersion = pallet_xcm::CurrentXcmVersion;
+	type AdminOrigin = EnsureRoot<AccountId>;
 }
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;

--- a/xcm/xcm-simulator/fuzzer/src/relay_chain.rs
+++ b/xcm/xcm-simulator/fuzzer/src/relay_chain.rs
@@ -20,6 +20,7 @@ use frame_support::{
 	construct_runtime, parameter_types,
 	traits::{Everything, Nothing},
 };
+use frame_system::EnsureRoot;
 use sp_core::H256;
 use sp_runtime::{testing::Header, traits::IdentityLookup, AccountId32};
 
@@ -158,6 +159,7 @@ impl pallet_xcm::Config for Runtime {
 	type RuntimeCall = RuntimeCall;
 	const VERSION_DISCOVERY_QUEUE_SIZE: u32 = 100;
 	type AdvertisedXcmVersion = pallet_xcm::CurrentXcmVersion;
+	type AdminOrigin = EnsureRoot<AccountId>;
 }
 
 parameter_types! {


### PR DESCRIPTION
PR to address the issue: Ensure extrinsics in the XCM pallet check for a configurable origin #6442;
This commit:
1. Adds new associated type, `AdminOrigin`, bounded by `EnsureOrigin` trait in XCM-pallet config 
2. Replaces `ensure_root()` with `ensure_origin()`. 
3. Uses `EnsureRoot<AccountId>` in all implementations of XCM pallet to preserve the current behavior until Gov2 specific origins are implemented.

The changes pass tests xcm-pallet and runtime.
