### PR TITLE
Candidate Validation/PVF: more fidelity of error metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6602,6 +6602,7 @@ dependencies = [
  "derive_more",
  "futures",
  "orchestra",
+ "polkadot-node-core-pvf",
  "polkadot-node-jaeger",
  "polkadot-node-network-protocol",
  "polkadot-node-primitives",

--- a/node/core/backing/src/tests.rs
+++ b/node/core/backing/src/tests.rs
@@ -1192,7 +1192,7 @@ fn backing_works_after_failed_validation() {
 					tx,
 				)
 			) if pov == pov && c.descriptor() == candidate.descriptor() && timeout == BACKING_EXECUTION_TIMEOUT && c.commitments_hash == candidate.commitments.hash() => {
-				tx.send(Err(ValidationFailed("Internal test error".into()))).unwrap();
+				tx.send(Err(ValidationFailed::Other("Internal test error".into()))).unwrap();
 			}
 		);
 

--- a/node/core/candidate-validation/Cargo.toml
+++ b/node/core/candidate-validation/Cargo.toml
@@ -15,13 +15,10 @@ parity-scale-codec = { version = "3.1.5", default-features = false, features = [
 
 polkadot-primitives = { path = "../../../primitives" }
 polkadot-parachain = { path = "../../../parachain" }
+polkadot-node-core-pvf = { path = "../pvf" }
 polkadot-node-primitives = { path = "../../primitives" }
 polkadot-node-subsystem = {path = "../../subsystem" }
 polkadot-node-subsystem-util = { path = "../../subsystem-util" }
-
-# TODO: Do we need this?
-[target.'cfg(not(any(target_os = "android", target_os = "unknown")))'.dependencies]
-polkadot-node-core-pvf = { path = "../pvf" }
 
 [dev-dependencies]
 sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "master" }

--- a/node/core/candidate-validation/Cargo.toml
+++ b/node/core/candidate-validation/Cargo.toml
@@ -19,6 +19,7 @@ polkadot-node-primitives = { path = "../../primitives" }
 polkadot-node-subsystem = {path = "../../subsystem" }
 polkadot-node-subsystem-util = { path = "../../subsystem-util" }
 
+# TODO: Do we need this?
 [target.'cfg(not(any(target_os = "android", target_os = "unknown")))'.dependencies]
 polkadot-node-core-pvf = { path = "../pvf" }
 

--- a/node/core/candidate-validation/src/lib.rs
+++ b/node/core/candidate-validation/src/lib.rs
@@ -562,8 +562,7 @@ async fn validate_candidate_exhaustive(
 
 	match result {
 		// Internal errors.
-		Err(ValidationError::InternalPrepareError(e)) =>
-			Err(ValidationFailed::Prepare(e.to_string())),
+		Err(ValidationError::InternalPrepareError(e)) => Err(ValidationFailed::Prepare(e)),
 		Err(ValidationError::InternalExecuteError(e)) => Err(ValidationFailed::Execute(e)),
 		Err(ValidationError::InternalOtherError(e)) => Err(ValidationFailed::Other(e)),
 

--- a/node/core/candidate-validation/src/lib.rs
+++ b/node/core/candidate-validation/src/lib.rs
@@ -562,9 +562,9 @@ async fn validate_candidate_exhaustive(
 
 	match result {
 		// Internal errors.
-		Err(ValidationError::InternalPrepareError(e)) => Err(ValidationFailed::Prepare(e)),
-		Err(ValidationError::InternalExecuteError(e)) => Err(ValidationFailed::Execute(e)),
-		Err(ValidationError::InternalOtherError(e)) => Err(ValidationFailed::Other(e)),
+		Err(ValidationError::InternalPrepare(e)) => Err(ValidationFailed::Prepare(e)),
+		Err(ValidationError::InternalExecute(e)) => Err(ValidationFailed::Execute(e)),
+		Err(ValidationError::InternalOther(e)) => Err(ValidationFailed::Other(e)),
 
 		// Invalid candidate errors.
 		Err(ValidationError::InvalidCandidate(e)) => match e {
@@ -667,14 +667,14 @@ impl ValidationBackend for ValidationHost {
 
 		let (tx, rx) = oneshot::channel();
 		if let Err(err) = self.execute_pvf(pvf, timeout, encoded_params, priority, tx).await {
-			return Err(ValidationError::InternalOtherError(format!(
+			return Err(ValidationError::InternalOther(format!(
 				"cannot send pvf to the validation host: {:?}",
 				err
 			)))
 		}
 
 		rx.await
-			.map_err(|_| ValidationError::InternalOtherError("validation was cancelled".into()))?
+			.map_err(|_| ValidationError::InternalOther("validation was cancelled".into()))?
 	}
 
 	async fn precheck_pvf(&mut self, pvf: Pvf) -> Result<Duration, PrepareError> {

--- a/node/core/candidate-validation/src/metrics.rs
+++ b/node/core/candidate-validation/src/metrics.rs
@@ -39,8 +39,23 @@ impl Metrics {
 				Ok(ValidationResult::Invalid(_)) => {
 					metrics.validation_requests.with_label_values(&["invalid"]).inc();
 				},
-				Err(_) => {
-					metrics.validation_requests.with_label_values(&["validation failure"]).inc();
+				Err(ValidationFailed::Prepare(_)) => {
+					metrics
+						.validation_requests
+						.with_label_values(&["internal failure (prepare)"])
+						.inc();
+				},
+				Err(ValidationFailed::Execute(_)) => {
+					metrics
+						.validation_requests
+						.with_label_values(&["internal failure (execute)"])
+						.inc();
+				},
+				Err(ValidationFailed::Other(_)) => {
+					metrics
+						.validation_requests
+						.with_label_values(&["internal failure (misc)"])
+						.inc();
 				},
 			}
 		}

--- a/node/core/dispute-coordinator/src/participation/tests.rs
+++ b/node/core/dispute-coordinator/src/participation/tests.rs
@@ -455,7 +455,7 @@ fn cast_invalid_vote_if_validation_fails_or_is_invalid() {
 			AllMessages::CandidateValidation(
 				CandidateValidationMessage::ValidateFromExhaustive(_, _, _, _, timeout, tx)
 			) if timeout == APPROVAL_EXECUTION_TIMEOUT => {
-				tx.send(Ok(ValidationResult::Invalid(InvalidCandidate::Timeout))).unwrap();
+				tx.send(Ok(ValidationResult::Invalid(InvalidCandidate::ExecutionTimeout))).unwrap();
 			},
 			"overseer did not receive candidate validation message",
 		);

--- a/node/core/pvf/src/artifacts.rs
+++ b/node/core/pvf/src/artifacts.rs
@@ -191,7 +191,7 @@ impl Artifacts {
 		let now = SystemTime::now();
 
 		let mut to_remove = vec![];
-		for (k, v) in self.artifacts.iter() {
+		for (k, v) in &self.artifacts {
 			if let ArtifactState::Prepared { last_time_needed, .. } = *v {
 				if now
 					.duration_since(last_time_needed)

--- a/node/core/pvf/src/error.rs
+++ b/node/core/pvf/src/error.rs
@@ -146,12 +146,12 @@ impl From<PrepareError> for ValidationError {
 		// We treat the deterministic errors as `InvalidCandidate`. Should those occur they could
 		// potentially trigger disputes.
 		//
-		// All non-deterministic errors are qualified as `InternalPrepareError`s and will not trigger
+		// All non-deterministic errors are qualified as `InternalPrepare` and will not trigger
 		// disputes.
 		match error {
 			PrepareError::Deterministic(error) =>
 				ValidationError::InvalidCandidate(InvalidCandidate::PrepareError(error)),
-			PrepareError::NonDeterministic(error) => ValidationError::InternalPrepareError(error),
+			PrepareError::NonDeterministic(error) => ValidationError::InternalPrepare(error),
 		}
 	}
 }

--- a/node/core/pvf/src/error.rs
+++ b/node/core/pvf/src/error.rs
@@ -99,11 +99,11 @@ pub enum ValidationError {
 	/// The error was raised because the candidate is invalid.
 	InvalidCandidate(InvalidCandidate),
 	/// This error is raised due to inability to serve the request during preparation.
-	InternalPrepareError(NonDeterministicError),
+	InternalPrepare(NonDeterministicError),
 	/// This error is raised due to inability to serve the request during execution.
-	InternalExecuteError(String),
+	InternalExecute(String),
 	/// This error is raised due to inability to serve the request for some other reason.
-	InternalOtherError(String),
+	InternalOther(String),
 }
 
 /// A description of an error raised during executing a PVF and can be attributed to the combination

--- a/node/core/pvf/src/execute/queue.rs
+++ b/node/core/pvf/src/execute/queue.rs
@@ -235,7 +235,7 @@ fn handle_job_finish(
 			Err(ValidationError::InvalidCandidate(InvalidCandidate::WorkerReportedError(err))),
 		),
 		Outcome::InternalError { err, idle_worker } =>
-			(Some(idle_worker), Err(ValidationError::InternalExecuteError(err))),
+			(Some(idle_worker), Err(ValidationError::InternalExecute(err))),
 		Outcome::HardTimeout =>
 			(None, Err(ValidationError::InvalidCandidate(InvalidCandidate::HardTimeout))),
 		Outcome::IoErr =>

--- a/node/core/pvf/src/execute/queue.rs
+++ b/node/core/pvf/src/execute/queue.rs
@@ -235,7 +235,7 @@ fn handle_job_finish(
 			Err(ValidationError::InvalidCandidate(InvalidCandidate::WorkerReportedError(err))),
 		),
 		Outcome::InternalError { err, idle_worker } =>
-			(Some(idle_worker), Err(ValidationError::InternalError(err))),
+			(Some(idle_worker), Err(ValidationError::InternalExecuteError(err))),
 		Outcome::HardTimeout =>
 			(None, Err(ValidationError::InvalidCandidate(InvalidCandidate::HardTimeout))),
 		Outcome::IoErr =>

--- a/node/core/pvf/src/execute/queue.rs
+++ b/node/core/pvf/src/execute/queue.rs
@@ -149,7 +149,7 @@ impl Queue {
 						break;
 					}
 				}
-				ev = self.mux.select_next_some() => handle_mux(&mut self, ev).await,
+				ev = self.mux.select_next_some() => handle_mux(&mut self, ev),
 			}
 
 			purge_dead(&self.metrics, &mut self.workers).await;
@@ -192,7 +192,7 @@ fn handle_to_queue(queue: &mut Queue, to_queue: ToQueue) {
 	}
 }
 
-async fn handle_mux(queue: &mut Queue, event: QueueEvent) {
+fn handle_mux(queue: &mut Queue, event: QueueEvent) {
 	match event {
 		QueueEvent::Spawn(idle, handle) => {
 			handle_worker_spawned(queue, idle, handle);

--- a/node/core/pvf/src/executor_intf.rs
+++ b/node/core/pvf/src/executor_intf.rs
@@ -40,8 +40,8 @@ use std::{
 // The data section for runtimes are typically rather small and can fit in a single digit number of
 // WASM pages, so let's say an extra 16 pages. Thus let's assume that 32 pages or 2 MiB are used for
 // these needs by default.
-const DEFAULT_HEAP_PAGES_ESTIMATE: u64 = 32;
-const EXTRA_HEAP_PAGES: u64 = 2048;
+const DEFAULT_HEAP_PAGES_ESTIMATE: u32 = 32;
+const EXTRA_HEAP_PAGES: u32 = 2048;
 
 /// The number of bytes devoted for the stack during wasm execution of a PVF.
 const NATIVE_STACK_MAX: u32 = 256 * 1024 * 1024;
@@ -50,7 +50,7 @@ const CONFIG: Config = Config {
 	allow_missing_func_imports: true,
 	cache_path: None,
 	semantics: Semantics {
-		extra_heap_pages: EXTRA_HEAP_PAGES,
+		extra_heap_pages: EXTRA_HEAP_PAGES as u64,
 
 		// NOTE: This is specified in bytes, so we multiply by WASM page size.
 		max_memory_size: Some(((DEFAULT_HEAP_PAGES_ESTIMATE + EXTRA_HEAP_PAGES) * 65536) as usize),

--- a/node/core/pvf/src/host.rs
+++ b/node/core/pvf/src/host.rs
@@ -1235,7 +1235,7 @@ mod tests {
 		assert_matches!(result_rx.now_or_never().unwrap().unwrap(), Err(PrepareError::TimedOut));
 		assert_matches!(
 			result_rx_execute.now_or_never().unwrap().unwrap(),
-			Err(ValidationError::InternalError(_))
+			Err(ValidationError::InternalPrepareError(_))
 		);
 
 		// Reversed case: first send multiple precheck requests, then ask for an execution.

--- a/node/core/pvf/src/host.rs
+++ b/node/core/pvf/src/host.rs
@@ -1241,7 +1241,7 @@ mod tests {
 		);
 		assert_matches!(
 			result_rx_execute.now_or_never().unwrap().unwrap(),
-			Err(ValidationError::InternalPrepareError(_))
+			Err(ValidationError::InternalPrepare(_))
 		);
 
 		// Reversed case: first send multiple precheck requests, then ask for an execution.

--- a/node/core/pvf/src/host.rs
+++ b/node/core/pvf/src/host.rs
@@ -219,7 +219,7 @@ pub fn start(config: Config, metrics: Metrics) -> (ValidationHost, impl Future<O
 
 	let (to_execute_queue_tx, run_execute_queue) = execute::start(
 		metrics,
-		config.execute_worker_program_path.to_owned(),
+		config.execute_worker_program_path.clone(),
 		config.execute_workers_max_num,
 		config.execute_worker_spawn_timeout,
 	);

--- a/node/core/pvf/src/lib.rs
+++ b/node/core/pvf/src/lib.rs
@@ -107,7 +107,10 @@ pub mod testing;
 #[doc(hidden)]
 pub use sp_tracing;
 
-pub use error::{InvalidCandidate, PrepareError, PrepareResult, ValidationError};
+pub use error::{
+	DeterministicError, InvalidCandidate, NonDeterministicError, PrepareError, PrepareResult,
+	ValidationError,
+};
 pub use priority::Priority;
 pub use pvf::Pvf;
 

--- a/node/core/pvf/src/prepare/pool.rs
+++ b/node/core/pvf/src/prepare/pool.rs
@@ -16,7 +16,7 @@
 
 use super::worker::{self, Outcome};
 use crate::{
-	error::{PrepareError, PrepareResult},
+	error::{NonDeterministicError, PrepareError, PrepareResult},
 	metrics::Metrics,
 	worker_common::{IdleWorker, WorkerHandle},
 	LOG_TARGET,
@@ -304,7 +304,9 @@ fn handle_mux(
 					spawned,
 					worker,
 					idle,
-					Err(PrepareError::CreateTmpFileErr(err)),
+					Err(PrepareError::NonDeterministic(NonDeterministicError::CreateTmpFileErr(
+						err,
+					))),
 				),
 				// Return `Concluded`, but do not kill the worker since the error was on the host side.
 				Outcome::RenameTmpFileErr { worker: idle, result: _, err } =>
@@ -313,7 +315,9 @@ fn handle_mux(
 						spawned,
 						worker,
 						idle,
-						Err(PrepareError::RenameTmpFileErr(err)),
+						Err(PrepareError::NonDeterministic(
+							NonDeterministicError::RenameTmpFileErr(err),
+						)),
 					),
 				Outcome::Unreachable => {
 					if attempt_retire(metrics, spawned, worker) {
@@ -329,7 +333,9 @@ fn handle_mux(
 							FromPool::Concluded {
 								worker,
 								rip: true,
-								result: Err(PrepareError::IoErr),
+								result: Err(PrepareError::NonDeterministic(
+									NonDeterministicError::IoErr,
+								)),
 							},
 						)?;
 					}
@@ -343,7 +349,9 @@ fn handle_mux(
 							FromPool::Concluded {
 								worker,
 								rip: true,
-								result: Err(PrepareError::TimedOut),
+								result: Err(PrepareError::NonDeterministic(
+									NonDeterministicError::TimedOut,
+								)),
 							},
 						)?;
 					}

--- a/node/core/pvf/src/prepare/queue.rs
+++ b/node/core/pvf/src/prepare/queue.rs
@@ -492,7 +492,10 @@ pub fn start(
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::{error::PrepareError, host::PRECHECK_PREPARATION_TIMEOUT};
+	use crate::{
+		error::{NonDeterministicError, PrepareError},
+		host::PRECHECK_PREPARATION_TIMEOUT,
+	};
 	use assert_matches::assert_matches;
 	use futures::{future::BoxFuture, FutureExt};
 	use slotmap::SlotMap;
@@ -761,7 +764,7 @@ mod tests {
 		test.send_from_pool(pool::FromPool::Concluded {
 			worker: w1,
 			rip: true,
-			result: Err(PrepareError::IoErr),
+			result: Err(PrepareError::NonDeterministic(NonDeterministicError::IoErr)),
 		});
 		test.poll_ensure_to_pool_is_empty().await;
 	}

--- a/node/core/pvf/src/worker_common.rs
+++ b/node/core/pvf/src/worker_common.rs
@@ -16,7 +16,11 @@
 
 //! Common logic for implementation of worker processes.
 
-use crate::{execute::ExecuteResponse, PrepareError, LOG_TARGET};
+use crate::{
+	error::{NonDeterministicError, PrepareError},
+	execute::ExecuteResponse,
+	LOG_TARGET,
+};
 use async_std::{
 	io,
 	net::Shutdown,
@@ -251,7 +255,8 @@ pub async fn cpu_time_monitor_loop(
 			// handling of this error.
 			let encoded_result = match job_kind {
 				JobKind::Prepare => {
-					let result: Result<(), PrepareError> = Err(PrepareError::TimedOut);
+					let result: Result<(), PrepareError> =
+						Err(PrepareError::NonDeterministic(NonDeterministicError::TimedOut));
 					result.encode()
 				},
 				JobKind::Execute => {

--- a/node/malus/src/variants/common.rs
+++ b/node/malus/src/variants/common.rs
@@ -57,7 +57,7 @@ pub enum FakeCandidateValidationError {
 	/// Failed to execute.`validate_block`. This includes function panicking.
 	ExecutionError,
 	/// Execution timeout.
-	Timeout,
+	ExecutionTimeout,
 	/// Validation input is over the limit.
 	ParamsTooLarge,
 	/// Code size is over the limit.
@@ -86,7 +86,7 @@ impl Into<InvalidCandidate> for FakeCandidateValidationError {
 			FakeCandidateValidationError::ExecutionError =>
 				InvalidCandidate::ExecutionError("Malus".into()),
 			FakeCandidateValidationError::InvalidOutputs => InvalidCandidate::InvalidOutputs,
-			FakeCandidateValidationError::Timeout => InvalidCandidate::Timeout,
+			FakeCandidateValidationError::ExecutionTimeout => InvalidCandidate::ExecutionTimeout,
 			FakeCandidateValidationError::ParamsTooLarge => InvalidCandidate::ParamsTooLarge(666),
 			FakeCandidateValidationError::CodeTooLarge => InvalidCandidate::CodeTooLarge(666),
 			FakeCandidateValidationError::CodeDecompressionFailure =>

--- a/node/primitives/src/lib.rs
+++ b/node/primitives/src/lib.rs
@@ -237,6 +237,9 @@ pub enum InvalidCandidate {
 	ExecutionError(String),
 	/// Validation outputs check doesn't pass.
 	InvalidOutputs,
+	// TODO: Currently unused. Preparation timeouts are treated as non-deterministic, so this can
+	// never be instantiated, whereas execution timeouts are deterministic. Should this
+	// inconsistency be addressed?
 	/// Preparation timeout.
 	PreparationTimeout,
 	/// Execution timeout.

--- a/node/primitives/src/lib.rs
+++ b/node/primitives/src/lib.rs
@@ -227,7 +227,9 @@ pub type UncheckedSignedFullStatement = UncheckedSigned<Statement, CompactStatem
 /// Candidate invalidity details
 #[derive(Debug)]
 pub enum InvalidCandidate {
-	/// Failed to execute.`validate_block`. This includes function panicking.
+	/// Failed to prepare `validate_block`. This includes function panicking.
+	PreparationError(String),
+	/// Failed to execute `validate_block`. This includes function panicking.
 	ExecutionError(String),
 	/// Validation outputs check doesn't pass.
 	InvalidOutputs,

--- a/node/primitives/src/lib.rs
+++ b/node/primitives/src/lib.rs
@@ -227,14 +227,20 @@ pub type UncheckedSignedFullStatement = UncheckedSigned<Statement, CompactStatem
 /// Candidate invalidity details
 #[derive(Debug)]
 pub enum InvalidCandidate {
-	/// Failed to prepare `validate_block`. This includes function panicking.
+	/// Failed to prevalidate.
+	PrevalidationError(String),
+	/// Failed to compile.
+	CompilationError(String),
+	/// Failed to prepare in some other way. This includes function panicking.
 	PreparationError(String),
 	/// Failed to execute `validate_block`. This includes function panicking.
 	ExecutionError(String),
 	/// Validation outputs check doesn't pass.
 	InvalidOutputs,
+	/// Preparation timeout.
+	PreparationTimeout,
 	/// Execution timeout.
-	Timeout,
+	ExecutionTimeout,
 	/// Validation input is over the limit.
 	ParamsTooLarge(u64),
 	/// Code size is over the limit.
@@ -257,6 +263,9 @@ pub enum InvalidCandidate {
 	CodeHashMismatch,
 	/// Validation has generated different candidate commitments.
 	CommitmentsHashMismatch,
+	/// The worker has died during validation of a candidate. See
+	/// [`InvalidCandidate::AmbiguousWorkerDeath`].
+	AmbiguousWorkerDeath,
 }
 
 /// Result of the validation of the candidate.

--- a/node/subsystem-types/Cargo.toml
+++ b/node/subsystem-types/Cargo.toml
@@ -9,6 +9,7 @@ edition.workspace = true
 derive_more = "0.99.17"
 futures = "0.3.21"
 polkadot-primitives = { path = "../../primitives" }
+polkadot-node-core-pvf = { path = "../core/pvf" }
 polkadot-node-primitives = { path = "../primitives" }
 polkadot-node-network-protocol = { path = "../network/protocol" }
 polkadot-statement-table = { path = "../../statement-table" }

--- a/node/subsystem-types/src/messages.rs
+++ b/node/subsystem-types/src/messages.rs
@@ -28,6 +28,7 @@ use thiserror::Error;
 
 pub use sc_network::IfDisconnected;
 
+use polkadot_node_core_pvf::NonDeterministicError;
 use polkadot_node_network_protocol::{
 	self as net_protocol, peer_set::PeerSet, request_response::Requests, PeerId,
 	UnifiedReputationChange,
@@ -93,7 +94,7 @@ impl BoundToRelayParent for CandidateBackingMessage {
 #[error("Validation failed with {0:?}")]
 pub enum ValidationFailed {
 	/// Validation failed due to an internal prepare error.
-	Prepare(String),
+	Prepare(NonDeterministicError),
 	/// Validation failed due to an internal execute error.
 	Execute(String),
 	/// Validation failed due to some other internal error.

--- a/node/subsystem-types/src/messages.rs
+++ b/node/subsystem-types/src/messages.rs
@@ -91,7 +91,14 @@ impl BoundToRelayParent for CandidateBackingMessage {
 /// Blanket error for validation failing for internal reasons.
 #[derive(Debug, Error)]
 #[error("Validation failed with {0:?}")]
-pub struct ValidationFailed(pub String);
+pub enum ValidationFailed {
+	/// Validation failed due to an internal prepare error.
+	Prepare(String),
+	/// Validation failed due to an internal execute error.
+	Execute(String),
+	/// Validation failed due to some other internal error.
+	Other(String),
+}
 
 /// The outcome of the candidate-validation's PVF pre-check request.
 #[derive(Debug, PartialEq)]


### PR DESCRIPTION
# PULL REQUEST

## Overview

Adds some more metrics buckets for the results of candidate validation (i.e. PVF preparation/execution). This was just supposed to be a fun one for me.

I had to add some more error variants along the way. The error being metric'd did not have enough fidelity (having just a single variant for the result of PVF prep/exec, that contained the original error but stringified).

I also split up `PrepareError`. We were handling it differently based on whether it is deterministic. Deterministic variants were already not allowed in certain places, and same for non-deterministic variants, so we might as well enforce this on the type level. This revealed an inconsistency with the way that timeout errors are treated (see TODO).

## Related Issues

Closes https://github.com/paritytech/polkadot/issues/3755