### PR TITLE
some tests to avoid regressions in xcm ancestry inversion

### DIFF
--- a/xcm/src/v2/multilocation.rs
+++ b/xcm/src/v2/multilocation.rs
@@ -951,9 +951,8 @@ mod tests {
 		let reserve_ancestry: MultiLocation = (Parachain(1000)).into();
 		let destination = MultiLocation::new(1, X1(Parachain(2000)));
 		inverted.reanchor(&destination, &reserve_ancestry).unwrap();
-		let expected: MultiLocation =
-			(Parent, Parachain(1000), PalletInstance(50), GeneralIndex(1984)).into();
-		assert_eq!(inverted, expected);
+
+		assert_eq!(inverted, input);
 	}
 
 	#[test]

--- a/xcm/src/v2/multilocation.rs
+++ b/xcm/src/v2/multilocation.rs
@@ -884,7 +884,7 @@ impl TryFrom<MultiLocation> for Junctions {
 #[cfg(test)]
 mod tests {
 	use super::{Ancestor, AncestorThen, Junctions::*, MultiLocation, Parent, ParentThen};
-	use crate::opaque::v2::{Junction::*, NetworkId::*};
+	use crate::opaque::v2::{Junction, Junction::*, NetworkId::*};
 	use parity_scale_codec::{Decode, Encode};
 
 	#[test]
@@ -899,6 +899,60 @@ mod tests {
 		let target = (Parent, Parent, PalletInstance(69), GeneralIndex(2)).into();
 		let expected = (Parent, Parent, PalletInstance(42), GeneralIndex(1)).into();
 		let inverted = ancestry.inverted(&target).unwrap();
+		assert_eq!(inverted, expected);
+	}
+
+	fn account20() -> Junction {
+		AccountKey20 { network: Any, key: Default::default() }
+	}
+
+	fn account32() -> Junction {
+		AccountId32 { network: Any, id: Default::default() }
+	}
+
+	#[test]
+	fn inverter_works_in_tree() {
+		let ancestry: MultiLocation = X3(Parachain(1), account20(), account20()).into();
+		let target = MultiLocation::new(3, X2(Parachain(2), account32()));
+		let inverted = ancestry.inverted(&target).unwrap();
+		let expected = MultiLocation::new(2, X3(Parachain(1), account20(), account20()));
+		assert_eq!(inverted, expected);
+	}
+
+	#[test]
+	fn inverter_uses_ancestry_as_inverted_location() {
+		let ancestry: MultiLocation = X2(account20(), account20()).into();
+		let target = MultiLocation::grandparent();
+		let inverted = ancestry.inverted(&target).unwrap();
+		let expected = X2(account20(), account20()).into();
+		assert_eq!(inverted, expected);
+	}
+
+	#[test]
+	fn inverter_errors_when_location_is_too_large() {
+		let ancestry: MultiLocation = Here.into();
+		let target = MultiLocation { parents: 99, interior: X1(Parachain(88)) };
+		let inverted = ancestry.inverted(&target);
+		assert_eq!(inverted, Err(()));
+	}
+
+	#[test]
+	fn fixed_point() {
+		let non_reserve_ancestry: MultiLocation = (Parachain(2000)).into();
+
+		let input =
+			MultiLocation::new(1, X3(Parachain(1000), PalletInstance(50), GeneralIndex(1984)));
+		let destination = MultiLocation::new(1, X1(Parachain(1000)));
+		let mut inverted = input.clone();
+		inverted.reanchor(&destination, &non_reserve_ancestry).unwrap();
+		let expected: MultiLocation = X2(PalletInstance(50), GeneralIndex(1984)).into();
+		assert_eq!(inverted, expected);
+
+		let reserve_ancestry: MultiLocation = (Parachain(1000)).into();
+		let destination = MultiLocation::new(1, X1(Parachain(2000)));
+		inverted.reanchor(&destination, &reserve_ancestry).unwrap();
+		let expected: MultiLocation =
+			(Parent, Parachain(1000), PalletInstance(50), GeneralIndex(1984)).into();
 		assert_eq!(inverted, expected);
 	}
 


### PR DESCRIPTION
1. ported some tests from conversion to multilocation
2. added tests which proves that transferring to and from leads to same location 
3. may be useful to test before merge of https://github.com/paritytech/polkadot/pull/6301