### PR TITLE
Re-export current primitives in crate root

### DIFF
--- a/erasure-coding/fuzzer/src/round_trip.rs
+++ b/erasure-coding/fuzzer/src/round_trip.rs
@@ -2,7 +2,7 @@ use polkadot_erasure_coding::*;
 use primitives::{AvailableData, BlockData, PoV};
 use std::sync::Arc;
 use honggfuzz::fuzz;
-use polkadot_primitives::v2::PersistedValidationData;
+use polkadot_primitives::PersistedValidationData;
 
 
 fn main() {

--- a/erasure-coding/src/lib.rs
+++ b/erasure-coding/src/lib.rs
@@ -26,7 +26,7 @@
 
 use parity_scale_codec::{Decode, Encode};
 use polkadot_node_primitives::{AvailableData, Proof};
-use polkadot_primitives::v2::{BlakeTwo256, Hash as H256, HashT};
+use polkadot_primitives::{BlakeTwo256, Hash as H256, HashT};
 use sp_core::Blake2Hasher;
 use sp_trie::{
 	trie_types::{TrieDBBuilder, TrieDBMutBuilderV0 as TrieDBMutBuilder},

--- a/node/client/src/benchmarking.rs
+++ b/node/client/src/benchmarking.rs
@@ -16,7 +16,7 @@
 
 //! Code related to benchmarking a [`crate::Client`].
 
-use polkadot_primitives::v2::{AccountId, Balance};
+use polkadot_primitives::{AccountId, Balance};
 use sp_core::{Pair, H256};
 use sp_keyring::Sr25519Keyring;
 use sp_runtime::OpaqueExtrinsic;
@@ -361,14 +361,14 @@ pub fn benchmark_inherent_data(
 	let timestamp = sp_timestamp::InherentDataProvider::new(d.into());
 	futures::executor::block_on(timestamp.provide_inherent_data(&mut inherent_data))?;
 
-	let para_data = polkadot_primitives::v2::InherentData {
+	let para_data = polkadot_primitives::InherentData {
 		bitfields: Vec::new(),
 		backed_candidates: Vec::new(),
 		disputes: Vec::new(),
 		parent_header: header,
 	};
 
-	inherent_data.put_data(polkadot_primitives::v2::PARACHAINS_INHERENT_IDENTIFIER, &para_data)?;
+	inherent_data.put_data(polkadot_primitives::PARACHAINS_INHERENT_IDENTIFIER, &para_data)?;
 
 	Ok(inherent_data)
 }

--- a/node/client/src/lib.rs
+++ b/node/client/src/lib.rs
@@ -20,8 +20,7 @@
 //! There is also the [`Client`] enum that combines all the different clients into one common structure.
 
 use polkadot_primitives::{
-	runtime_api::ParachainHost,
-	v2::{AccountId, Balance, Block, BlockNumber, Hash, Header, Nonce},
+	runtime_api::ParachainHost, AccountId, Balance, Block, BlockNumber, Hash, Header, Nonce,
 };
 use sc_client_api::{AuxStore, Backend as BackendT, BlockchainEvents, KeyIterator, UsageProvider};
 use sc_executor::NativeElseWasmExecutor;

--- a/node/collation-generation/src/lib.rs
+++ b/node/collation-generation/src/lib.rs
@@ -30,7 +30,7 @@ use polkadot_node_subsystem_util::{
 	request_availability_cores, request_persisted_validation_data, request_validation_code,
 	request_validation_code_hash, request_validators,
 };
-use polkadot_primitives::v2::{
+use polkadot_primitives::{
 	collator_signature_payload, CandidateCommitments, CandidateDescriptor, CandidateReceipt,
 	CoreState, Hash, Id as ParaId, OccupiedCoreAssumption, PersistedValidationData,
 	ValidationCodeHash,

--- a/node/collation-generation/src/tests.rs
+++ b/node/collation-generation/src/tests.rs
@@ -32,7 +32,7 @@ mod handle_new_activations {
 	use polkadot_node_subsystem_test_helpers::{
 		subsystem_test_harness, TestSubsystemContextHandle,
 	};
-	use polkadot_primitives::v2::{
+	use polkadot_primitives::{
 		CollatorPair, Id as ParaId, PersistedValidationData, ScheduledCore, ValidationCode,
 	};
 	use std::pin::Pin;

--- a/node/core/approval-voting/src/approval_checking.rs
+++ b/node/core/approval-voting/src/approval_checking.rs
@@ -18,7 +18,7 @@
 
 use bitvec::{order::Lsb0 as BitOrderLsb0, slice::BitSlice};
 use polkadot_node_primitives::approval::DelayTranche;
-use polkadot_primitives::v2::ValidatorIndex;
+use polkadot_primitives::ValidatorIndex;
 
 use crate::{
 	persisted_entries::{ApprovalEntry, CandidateEntry, TrancheEntry},
@@ -460,7 +460,7 @@ mod tests {
 	use crate::{approval_db, BTreeMap};
 	use ::test_helpers::{dummy_candidate_receipt, dummy_hash};
 	use bitvec::{bitvec, order::Lsb0 as BitOrderLsb0, vec::BitVec};
-	use polkadot_primitives::v2::GroupIndex;
+	use polkadot_primitives::GroupIndex;
 
 	#[test]
 	fn pending_is_not_approved() {

--- a/node/core/approval-voting/src/approval_db/v1/mod.rs
+++ b/node/core/approval-voting/src/approval_db/v1/mod.rs
@@ -20,7 +20,7 @@ use parity_scale_codec::{Decode, Encode};
 use polkadot_node_primitives::approval::{AssignmentCert, DelayTranche};
 use polkadot_node_subsystem::{SubsystemError, SubsystemResult};
 use polkadot_node_subsystem_util::database::{DBTransaction, Database};
-use polkadot_primitives::v2::{
+use polkadot_primitives::{
 	BlockNumber, CandidateHash, CandidateReceipt, CoreIndex, GroupIndex, Hash, SessionIndex,
 	ValidatorIndex, ValidatorSignature,
 };

--- a/node/core/approval-voting/src/approval_db/v1/tests.rs
+++ b/node/core/approval-voting/src/approval_db/v1/tests.rs
@@ -22,7 +22,7 @@ use crate::{
 	ops::{add_block_entry, canonicalize, force_approve, NewCandidateInfo},
 };
 use polkadot_node_subsystem_util::database::Database;
-use polkadot_primitives::v2::Id as ParaId;
+use polkadot_primitives::Id as ParaId;
 use std::{collections::HashMap, sync::Arc};
 
 use ::test_helpers::{dummy_candidate_receipt, dummy_candidate_receipt_bad_sig, dummy_hash};

--- a/node/core/approval-voting/src/backend.rs
+++ b/node/core/approval-voting/src/backend.rs
@@ -22,7 +22,7 @@
 //! before any commit to the underlying storage is made.
 
 use polkadot_node_subsystem::SubsystemResult;
-use polkadot_primitives::v2::{BlockNumber, CandidateHash, Hash};
+use polkadot_primitives::{BlockNumber, CandidateHash, Hash};
 
 use std::collections::HashMap;
 

--- a/node/core/approval-voting/src/criteria.rs
+++ b/node/core/approval-voting/src/criteria.rs
@@ -20,7 +20,7 @@ use parity_scale_codec::{Decode, Encode};
 use polkadot_node_primitives::approval::{
 	self as approval_types, AssignmentCert, AssignmentCertKind, DelayTranche, RelayVRFStory,
 };
-use polkadot_primitives::v2::{
+use polkadot_primitives::{
 	AssignmentId, AssignmentPair, CandidateHash, CoreIndex, GroupIndex, IndexedVec, SessionInfo,
 	ValidatorIndex,
 };
@@ -553,7 +553,7 @@ fn is_in_backing_group(
 mod tests {
 	use super::*;
 	use polkadot_node_primitives::approval::{VRFOutput, VRFProof};
-	use polkadot_primitives::v2::{Hash, ASSIGNMENT_KEY_TYPE_ID};
+	use polkadot_primitives::{Hash, ASSIGNMENT_KEY_TYPE_ID};
 	use sp_application_crypto::sr25519;
 	use sp_core::crypto::Pair as PairT;
 	use sp_keyring::sr25519::Keyring as Sr25519Keyring;

--- a/node/core/approval-voting/src/import.rs
+++ b/node/core/approval-voting/src/import.rs
@@ -44,7 +44,7 @@ use polkadot_node_subsystem_util::{
 	determine_new_blocks,
 	rolling_session_window::{RollingSessionWindow, SessionWindowUpdate},
 };
-use polkadot_primitives::v2::{
+use polkadot_primitives::{
 	BlockNumber, CandidateEvent, CandidateHash, CandidateReceipt, ConsensusLog, CoreIndex,
 	GroupIndex, Hash, Header, SessionIndex,
 };
@@ -617,9 +617,7 @@ pub(crate) mod tests {
 	use polkadot_node_subsystem::messages::{AllMessages, ApprovalVotingMessage};
 	use polkadot_node_subsystem_test_helpers::make_subsystem_context;
 	use polkadot_node_subsystem_util::database::Database;
-	use polkadot_primitives::v2::{
-		Id as ParaId, IndexedVec, SessionInfo, ValidatorId, ValidatorIndex,
-	};
+	use polkadot_primitives::{Id as ParaId, IndexedVec, SessionInfo, ValidatorId, ValidatorIndex};
 	pub(crate) use sp_consensus_babe::{
 		digests::{CompatibleDigestItem, PreDigest, SecondaryVRFPreDigest},
 		AllowedSlots, BabeEpochConfiguration, Epoch as BabeEpoch,
@@ -683,21 +681,21 @@ pub(crate) mod tests {
 			_config: &criteria::Config,
 			_leaving_cores: Vec<(
 				CandidateHash,
-				polkadot_primitives::v2::CoreIndex,
-				polkadot_primitives::v2::GroupIndex,
+				polkadot_primitives::CoreIndex,
+				polkadot_primitives::GroupIndex,
 			)>,
-		) -> HashMap<polkadot_primitives::v2::CoreIndex, criteria::OurAssignment> {
+		) -> HashMap<polkadot_primitives::CoreIndex, criteria::OurAssignment> {
 			HashMap::new()
 		}
 
 		fn check_assignment_cert(
 			&self,
-			_claimed_core_index: polkadot_primitives::v2::CoreIndex,
-			_validator_index: polkadot_primitives::v2::ValidatorIndex,
+			_claimed_core_index: polkadot_primitives::CoreIndex,
+			_validator_index: polkadot_primitives::ValidatorIndex,
 			_config: &criteria::Config,
 			_relay_vrf_story: polkadot_node_primitives::approval::RelayVRFStory,
 			_assignment: &polkadot_node_primitives::approval::AssignmentCert,
-			_backing_group: polkadot_primitives::v2::GroupIndex,
+			_backing_group: polkadot_primitives::GroupIndex,
 		) -> Result<polkadot_node_primitives::approval::DelayTranche, criteria::InvalidAssignment> {
 			Ok(0)
 		}

--- a/node/core/approval-voting/src/lib.rs
+++ b/node/core/approval-voting/src/lib.rs
@@ -48,7 +48,7 @@ use polkadot_node_subsystem_util::{
 	},
 	TimeoutExt,
 };
-use polkadot_primitives::v2::{
+use polkadot_primitives::{
 	ApprovalVote, BlockNumber, CandidateHash, CandidateIndex, CandidateReceipt, DisputeStatement,
 	GroupIndex, Hash, SessionIndex, SessionInfo, ValidDisputeStatementKind, ValidatorId,
 	ValidatorIndex, ValidatorPair, ValidatorSignature,

--- a/node/core/approval-voting/src/ops.rs
+++ b/node/core/approval-voting/src/ops.rs
@@ -20,7 +20,7 @@
 use polkadot_node_subsystem::{SubsystemError, SubsystemResult};
 
 use bitvec::order::Lsb0 as BitOrderLsb0;
-use polkadot_primitives::v2::{BlockNumber, CandidateHash, CandidateReceipt, GroupIndex, Hash};
+use polkadot_primitives::{BlockNumber, CandidateHash, CandidateReceipt, GroupIndex, Hash};
 
 use std::collections::{hash_map::Entry, BTreeMap, HashMap};
 

--- a/node/core/approval-voting/src/persisted_entries.rs
+++ b/node/core/approval-voting/src/persisted_entries.rs
@@ -21,7 +21,7 @@
 //! data and logic are intertwined.
 
 use polkadot_node_primitives::approval::{AssignmentCert, DelayTranche, RelayVRFStory};
-use polkadot_primitives::v2::{
+use polkadot_primitives::{
 	BlockNumber, CandidateHash, CandidateReceipt, CoreIndex, GroupIndex, Hash, SessionIndex,
 	ValidatorIndex, ValidatorSignature,
 };

--- a/node/core/approval-voting/src/tests.rs
+++ b/node/core/approval-voting/src/tests.rs
@@ -33,7 +33,7 @@ use polkadot_node_subsystem::{
 use polkadot_node_subsystem_test_helpers as test_helpers;
 use polkadot_node_subsystem_util::TimeoutExt;
 use polkadot_overseer::HeadSupportsParachains;
-use polkadot_primitives::v2::{
+use polkadot_primitives::{
 	CandidateCommitments, CandidateEvent, CoreIndex, GroupIndex, Header, Id as ParaId, IndexedVec,
 	ValidationCode, ValidatorSignature,
 };
@@ -227,7 +227,7 @@ struct MockAssignmentCriteria<Compute, Check>(Compute, Check);
 
 impl<Compute, Check> AssignmentCriteria for MockAssignmentCriteria<Compute, Check>
 where
-	Compute: Fn() -> HashMap<polkadot_primitives::v2::CoreIndex, criteria::OurAssignment>,
+	Compute: Fn() -> HashMap<polkadot_primitives::CoreIndex, criteria::OurAssignment>,
 	Check: Fn(ValidatorIndex) -> Result<DelayTranche, criteria::InvalidAssignment>,
 {
 	fn compute_assignments(
@@ -237,31 +237,28 @@ where
 		_config: &criteria::Config,
 		_leaving_cores: Vec<(
 			CandidateHash,
-			polkadot_primitives::v2::CoreIndex,
-			polkadot_primitives::v2::GroupIndex,
+			polkadot_primitives::CoreIndex,
+			polkadot_primitives::GroupIndex,
 		)>,
-	) -> HashMap<polkadot_primitives::v2::CoreIndex, criteria::OurAssignment> {
+	) -> HashMap<polkadot_primitives::CoreIndex, criteria::OurAssignment> {
 		self.0()
 	}
 
 	fn check_assignment_cert(
 		&self,
-		_claimed_core_index: polkadot_primitives::v2::CoreIndex,
+		_claimed_core_index: polkadot_primitives::CoreIndex,
 		validator_index: ValidatorIndex,
 		_config: &criteria::Config,
 		_relay_vrf_story: polkadot_node_primitives::approval::RelayVRFStory,
 		_assignment: &polkadot_node_primitives::approval::AssignmentCert,
-		_backing_group: polkadot_primitives::v2::GroupIndex,
+		_backing_group: polkadot_primitives::GroupIndex,
 	) -> Result<polkadot_node_primitives::approval::DelayTranche, criteria::InvalidAssignment> {
 		self.1(validator_index)
 	}
 }
 
 impl<F>
-	MockAssignmentCriteria<
-		fn() -> HashMap<polkadot_primitives::v2::CoreIndex, criteria::OurAssignment>,
-		F,
-	>
+	MockAssignmentCriteria<fn() -> HashMap<polkadot_primitives::CoreIndex, criteria::OurAssignment>, F>
 {
 	fn check_only(f: F) -> Self {
 		MockAssignmentCriteria(Default::default, f)
@@ -480,7 +477,7 @@ fn test_harness<T: Future<Output = VirtualOverseer>>(
 
 	let keystore = LocalKeystore::in_memory();
 	let _ = keystore.sr25519_generate_new(
-		polkadot_primitives::v2::PARACHAIN_KEY_TYPE_ID,
+		polkadot_primitives::PARACHAIN_KEY_TYPE_ID,
 		Some(&Sr25519Keyring::Alice.to_seed()),
 	);
 

--- a/node/core/av-store/src/lib.rs
+++ b/node/core/av-store/src/lib.rs
@@ -39,7 +39,7 @@ use polkadot_node_subsystem::{
 	overseer, ActiveLeavesUpdate, FromOrchestra, OverseerSignal, SpawnedSubsystem, SubsystemError,
 };
 use polkadot_node_subsystem_util as util;
-use polkadot_primitives::v2::{
+use polkadot_primitives::{
 	BlockNumber, CandidateEvent, CandidateHash, CandidateReceipt, Hash, Header, ValidatorIndex,
 };
 

--- a/node/core/av-store/src/tests.rs
+++ b/node/core/av-store/src/tests.rs
@@ -30,7 +30,7 @@ use polkadot_node_subsystem::{
 };
 use polkadot_node_subsystem_test_helpers as test_helpers;
 use polkadot_node_subsystem_util::{database::Database, TimeoutExt};
-use polkadot_primitives::v2::{
+use polkadot_primitives::{
 	CandidateHash, CandidateReceipt, CoreIndex, GroupIndex, HeadData, Header,
 	PersistedValidationData, ValidatorId,
 };

--- a/node/core/backing/src/error.rs
+++ b/node/core/backing/src/error.rs
@@ -19,7 +19,7 @@ use futures::channel::{mpsc, oneshot};
 
 use polkadot_node_subsystem::{messages::ValidationFailed, SubsystemError};
 use polkadot_node_subsystem_util::Error as UtilError;
-use polkadot_primitives::v2::BackedCandidate;
+use polkadot_primitives::BackedCandidate;
 
 use crate::LOG_TARGET;
 

--- a/node/core/backing/src/lib.rs
+++ b/node/core/backing/src/lib.rs
@@ -48,7 +48,7 @@ use polkadot_node_subsystem_util::{
 	self as util, request_from_runtime, request_session_index_for_child, request_validator_groups,
 	request_validators, Validator,
 };
-use polkadot_primitives::v2::{
+use polkadot_primitives::{
 	BackedCandidate, CandidateCommitments, CandidateHash, CandidateReceipt, CollatorId,
 	CommittedCandidateReceipt, CoreIndex, CoreState, Hash, Id as ParaId, SigningContext,
 	ValidatorId, ValidatorIndex, ValidatorSignature, ValidityAttestation,
@@ -587,7 +587,7 @@ async fn make_pov_available(
 	n_validators: usize,
 	pov: Arc<PoV>,
 	candidate_hash: CandidateHash,
-	validation_data: polkadot_primitives::v2::PersistedValidationData,
+	validation_data: polkadot_primitives::PersistedValidationData,
 	expected_erasure_root: Hash,
 	span: Option<&jaeger::Span>,
 ) -> Result<Result<(), InvalidErasureRoot>, Error> {

--- a/node/core/backing/src/tests.rs
+++ b/node/core/backing/src/tests.rs
@@ -30,7 +30,7 @@ use polkadot_node_subsystem::{
 	ActivatedLeaf, ActiveLeavesUpdate, FromOrchestra, LeafStatus, OverseerSignal,
 };
 use polkadot_node_subsystem_test_helpers as test_helpers;
-use polkadot_primitives::v2::{
+use polkadot_primitives::{
 	CandidateDescriptor, CollatorId, GroupRotationInfo, HeadData, PersistedValidationData,
 	ScheduledCore,
 };

--- a/node/core/bitfield-signing/src/lib.rs
+++ b/node/core/bitfield-signing/src/lib.rs
@@ -36,7 +36,7 @@ use polkadot_node_subsystem::{
 	SpawnedSubsystem, SubsystemError, SubsystemResult, SubsystemSender,
 };
 use polkadot_node_subsystem_util::{self as util, Validator};
-use polkadot_primitives::v2::{AvailabilityBitfield, CoreState, Hash, ValidatorIndex};
+use polkadot_primitives::{AvailabilityBitfield, CoreState, Hash, ValidatorIndex};
 use sp_keystore::{Error as KeystoreError, SyncCryptoStorePtr};
 use std::{collections::HashMap, iter::FromIterator, time::Duration};
 use wasm_timer::{Delay, Instant};

--- a/node/core/bitfield-signing/src/tests.rs
+++ b/node/core/bitfield-signing/src/tests.rs
@@ -17,7 +17,7 @@
 use super::*;
 use futures::{executor::block_on, pin_mut, StreamExt};
 use polkadot_node_subsystem::messages::AllMessages;
-use polkadot_primitives::v2::{CandidateHash, OccupiedCore};
+use polkadot_primitives::{CandidateHash, OccupiedCore};
 use test_helpers::dummy_candidate_descriptor;
 
 fn occupied_core(para_id: u32, candidate_hash: CandidateHash) -> CoreState {

--- a/node/core/candidate-validation/src/lib.rs
+++ b/node/core/candidate-validation/src/lib.rs
@@ -39,7 +39,7 @@ use polkadot_node_subsystem::{
 	SubsystemSender,
 };
 use polkadot_parachain::primitives::{ValidationParams, ValidationResult as WasmValidationResult};
-use polkadot_primitives::v2::{
+use polkadot_primitives::{
 	CandidateCommitments, CandidateDescriptor, CandidateReceipt, Hash, OccupiedCoreAssumption,
 	PersistedValidationData, ValidationCode, ValidationCodeHash,
 };

--- a/node/core/candidate-validation/src/tests.rs
+++ b/node/core/candidate-validation/src/tests.rs
@@ -22,7 +22,7 @@ use polkadot_node_core_pvf::PrepareError;
 use polkadot_node_subsystem::messages::AllMessages;
 use polkadot_node_subsystem_test_helpers as test_helpers;
 use polkadot_node_subsystem_util::reexports::SubsystemContext;
-use polkadot_primitives::v2::{HeadData, Id as ParaId, UpwardMessage};
+use polkadot_primitives::{HeadData, Id as ParaId, UpwardMessage};
 use sp_core::testing::TaskExecutor;
 use sp_keyring::Sr25519Keyring;
 

--- a/node/core/chain-api/src/lib.rs
+++ b/node/core/chain-api/src/lib.rs
@@ -41,7 +41,7 @@ use polkadot_node_subsystem::{
 	messages::ChainApiMessage, overseer, FromOrchestra, OverseerSignal, SpawnedSubsystem,
 	SubsystemError, SubsystemResult,
 };
-use polkadot_primitives::v2::Block;
+use polkadot_primitives::Block;
 
 mod metrics;
 use self::metrics::Metrics;

--- a/node/core/chain-api/src/tests.rs
+++ b/node/core/chain-api/src/tests.rs
@@ -6,7 +6,7 @@ use std::collections::BTreeMap;
 
 use polkadot_node_primitives::BlockWeight;
 use polkadot_node_subsystem_test_helpers::{make_subsystem_context, TestSubsystemContextHandle};
-use polkadot_primitives::v2::{BlockNumber, Hash, Header};
+use polkadot_primitives::{BlockNumber, Hash, Header};
 use sp_blockchain::Info as BlockInfo;
 use sp_core::testing::TaskExecutor;
 

--- a/node/core/chain-selection/src/backend.rs
+++ b/node/core/chain-selection/src/backend.rs
@@ -21,7 +21,7 @@
 //! [`Backend`], maintaining consistency between queries and temporary writes,
 //! before any commit to the underlying storage is made.
 
-use polkadot_primitives::v2::{BlockNumber, Hash};
+use polkadot_primitives::{BlockNumber, Hash};
 
 use std::collections::HashMap;
 

--- a/node/core/chain-selection/src/db_backend/v1.rs
+++ b/node/core/chain-selection/src/db_backend/v1.rs
@@ -38,7 +38,7 @@ use crate::{
 };
 
 use polkadot_node_primitives::BlockWeight;
-use polkadot_primitives::v2::{BlockNumber, Hash};
+use polkadot_primitives::{BlockNumber, Hash};
 
 use parity_scale_codec::{Decode, Encode};
 use polkadot_node_subsystem_util::database::{DBTransaction, Database};

--- a/node/core/chain-selection/src/lib.rs
+++ b/node/core/chain-selection/src/lib.rs
@@ -24,7 +24,7 @@ use polkadot_node_subsystem::{
 	FromOrchestra, OverseerSignal, SpawnedSubsystem, SubsystemError,
 };
 use polkadot_node_subsystem_util::database::Database;
-use polkadot_primitives::v2::{BlockNumber, ConsensusLog, Hash, Header};
+use polkadot_primitives::{BlockNumber, ConsensusLog, Hash, Header};
 
 use futures::{channel::oneshot, future::Either, prelude::*};
 use parity_scale_codec::Error as CodecError;

--- a/node/core/chain-selection/src/tests.rs
+++ b/node/core/chain-selection/src/tests.rs
@@ -39,7 +39,7 @@ use polkadot_node_subsystem::{
 	jaeger, messages::AllMessages, ActivatedLeaf, ActiveLeavesUpdate, LeafStatus,
 };
 use polkadot_node_subsystem_test_helpers as test_helpers;
-use polkadot_primitives::v2::{BlakeTwo256, ConsensusLog, HashT};
+use polkadot_primitives::{BlakeTwo256, ConsensusLog, HashT};
 
 #[derive(Default)]
 struct TestBackendInner {

--- a/node/core/chain-selection/src/tree.rs
+++ b/node/core/chain-selection/src/tree.rs
@@ -25,7 +25,7 @@
 
 use polkadot_node_primitives::BlockWeight;
 use polkadot_node_subsystem::ChainApiError;
-use polkadot_primitives::v2::{BlockNumber, Hash};
+use polkadot_primitives::{BlockNumber, Hash};
 
 use std::collections::HashMap;
 

--- a/node/core/dispute-coordinator/src/backend.rs
+++ b/node/core/dispute-coordinator/src/backend.rs
@@ -22,7 +22,7 @@
 //! before any commit to the underlying storage is made.
 
 use polkadot_node_subsystem::SubsystemResult;
-use polkadot_primitives::v2::{CandidateHash, SessionIndex};
+use polkadot_primitives::{CandidateHash, SessionIndex};
 
 use std::collections::HashMap;
 

--- a/node/core/dispute-coordinator/src/db/v1.rs
+++ b/node/core/dispute-coordinator/src/db/v1.rs
@@ -19,7 +19,7 @@
 use polkadot_node_primitives::DisputeStatus;
 use polkadot_node_subsystem::{SubsystemError, SubsystemResult};
 use polkadot_node_subsystem_util::database::{DBTransaction, Database};
-use polkadot_primitives::v2::{
+use polkadot_primitives::{
 	CandidateHash, CandidateReceipt, Hash, InvalidDisputeStatementKind, SessionIndex,
 	ValidDisputeStatementKind, ValidatorIndex, ValidatorSignature,
 };
@@ -373,7 +373,7 @@ mod tests {
 	use super::*;
 	use ::test_helpers::{dummy_candidate_receipt, dummy_hash};
 	use polkadot_node_primitives::DISPUTE_WINDOW;
-	use polkadot_primitives::v2::{Hash, Id as ParaId};
+	use polkadot_primitives::{Hash, Id as ParaId};
 
 	fn make_db() -> DbBackend {
 		let db = kvdb_memorydb::create(1);

--- a/node/core/dispute-coordinator/src/import.rs
+++ b/node/core/dispute-coordinator/src/import.rs
@@ -32,7 +32,7 @@ use polkadot_node_primitives::{
 	disputes::ValidCandidateVotes, CandidateVotes, DisputeStatus, SignedDisputeStatement, Timestamp,
 };
 use polkadot_node_subsystem_util::rolling_session_window::RollingSessionWindow;
-use polkadot_primitives::v2::{
+use polkadot_primitives::{
 	CandidateReceipt, DisputeStatement, IndexedVec, SessionIndex, SessionInfo,
 	ValidDisputeStatementKind, ValidatorId, ValidatorIndex, ValidatorPair, ValidatorSignature,
 };
@@ -179,15 +179,14 @@ impl CandidateVoteState<CandidateVotes> {
 
 		let n_validators = env.validators().len();
 
-		let supermajority_threshold =
-			polkadot_primitives::v2::supermajority_threshold(n_validators);
+		let supermajority_threshold = polkadot_primitives::supermajority_threshold(n_validators);
 
 		// We have a dispute, if we have votes on both sides:
 		let is_disputed = !votes.invalid.is_empty() && !votes.valid.raw().is_empty();
 
 		let dispute_status = if is_disputed {
 			let mut status = DisputeStatus::active();
-			let byzantine_threshold = polkadot_primitives::v2::byzantine_threshold(n_validators);
+			let byzantine_threshold = polkadot_primitives::byzantine_threshold(n_validators);
 			let is_confirmed = votes.voted_indices().len() > byzantine_threshold;
 			if is_confirmed {
 				status = status.confirm();

--- a/node/core/dispute-coordinator/src/initialized.rs
+++ b/node/core/dispute-coordinator/src/initialized.rs
@@ -39,7 +39,7 @@ use polkadot_node_subsystem::{
 use polkadot_node_subsystem_util::rolling_session_window::{
 	RollingSessionWindow, SessionWindowUpdate, SessionsUnavailable,
 };
-use polkadot_primitives::v2::{
+use polkadot_primitives::{
 	BlockNumber, CandidateHash, CandidateReceipt, CompactStatement, DisputeStatement,
 	DisputeStatementSet, Hash, ScrapedOnChainVotes, SessionIndex, SessionInfo,
 	ValidDisputeStatementKind, ValidatorId, ValidatorIndex,

--- a/node/core/dispute-coordinator/src/lib.rs
+++ b/node/core/dispute-coordinator/src/lib.rs
@@ -38,7 +38,7 @@ use polkadot_node_subsystem_util::{
 	database::Database,
 	rolling_session_window::{DatabaseParams, RollingSessionWindow},
 };
-use polkadot_primitives::v2::{ScrapedOnChainVotes, ValidatorIndex, ValidatorPair};
+use polkadot_primitives::{ScrapedOnChainVotes, ValidatorIndex, ValidatorPair};
 
 use crate::{
 	error::{FatalResult, JfyiError, Result},

--- a/node/core/dispute-coordinator/src/participation/mod.rs
+++ b/node/core/dispute-coordinator/src/participation/mod.rs
@@ -31,7 +31,7 @@ use polkadot_node_subsystem::{
 	overseer, ActiveLeavesUpdate, RecoveryError,
 };
 use polkadot_node_subsystem_util::runtime::get_validation_code_by_hash;
-use polkadot_primitives::v2::{BlockNumber, CandidateHash, CandidateReceipt, Hash, SessionIndex};
+use polkadot_primitives::{BlockNumber, CandidateHash, CandidateReceipt, Hash, SessionIndex};
 
 use crate::LOG_TARGET;
 

--- a/node/core/dispute-coordinator/src/participation/queues/mod.rs
+++ b/node/core/dispute-coordinator/src/participation/queues/mod.rs
@@ -18,7 +18,7 @@ use std::{cmp::Ordering, collections::BTreeMap};
 
 use futures::channel::oneshot;
 use polkadot_node_subsystem::{messages::ChainApiMessage, overseer};
-use polkadot_primitives::v2::{BlockNumber, CandidateHash, CandidateReceipt, Hash, SessionIndex};
+use polkadot_primitives::{BlockNumber, CandidateHash, CandidateReceipt, Hash, SessionIndex};
 
 use crate::{
 	error::{FatalError, FatalResult, Result},

--- a/node/core/dispute-coordinator/src/participation/queues/tests.rs
+++ b/node/core/dispute-coordinator/src/participation/queues/tests.rs
@@ -17,7 +17,7 @@
 use crate::ParticipationPriority;
 use ::test_helpers::{dummy_candidate_receipt, dummy_hash};
 use assert_matches::assert_matches;
-use polkadot_primitives::v2::{BlockNumber, Hash};
+use polkadot_primitives::{BlockNumber, Hash};
 
 use super::{CandidateComparator, ParticipationRequest, QueueError, Queues};
 

--- a/node/core/dispute-coordinator/src/participation/tests.rs
+++ b/node/core/dispute-coordinator/src/participation/tests.rs
@@ -38,7 +38,7 @@ use polkadot_node_subsystem::{
 use polkadot_node_subsystem_test_helpers::{
 	make_subsystem_context, TestSubsystemContext, TestSubsystemContextHandle,
 };
-use polkadot_primitives::v2::{
+use polkadot_primitives::{
 	BlakeTwo256, CandidateCommitments, HashT, Header, PersistedValidationData, ValidationCode,
 };
 

--- a/node/core/dispute-coordinator/src/scraping/candidates.rs
+++ b/node/core/dispute-coordinator/src/scraping/candidates.rs
@@ -1,4 +1,4 @@
-use polkadot_primitives::v2::{BlockNumber, CandidateHash};
+use polkadot_primitives::{BlockNumber, CandidateHash};
 use std::collections::{BTreeMap, HashMap, HashSet};
 
 /// Keeps `CandidateHash` in reference counted way.
@@ -44,7 +44,7 @@ impl RefCountedCandidates {
 #[cfg(test)]
 mod ref_counted_candidates_tests {
 	use super::*;
-	use polkadot_primitives::v2::{BlakeTwo256, HashT};
+	use polkadot_primitives::{BlakeTwo256, HashT};
 
 	#[test]
 	fn element_is_removed_when_refcount_reaches_zero() {
@@ -131,7 +131,7 @@ impl ScrapedCandidates {
 #[cfg(test)]
 mod scraped_candidates_tests {
 	use super::*;
-	use polkadot_primitives::v2::{BlakeTwo256, HashT};
+	use polkadot_primitives::{BlakeTwo256, HashT};
 
 	#[test]
 	fn stale_candidates_are_removed() {

--- a/node/core/dispute-coordinator/src/scraping/mod.rs
+++ b/node/core/dispute-coordinator/src/scraping/mod.rs
@@ -25,9 +25,7 @@ use polkadot_node_subsystem::{
 	SubsystemSender,
 };
 use polkadot_node_subsystem_util::runtime::{get_candidate_events, get_on_chain_votes};
-use polkadot_primitives::v2::{
-	BlockNumber, CandidateEvent, CandidateHash, Hash, ScrapedOnChainVotes,
-};
+use polkadot_primitives::{BlockNumber, CandidateEvent, CandidateHash, Hash, ScrapedOnChainVotes};
 
 use crate::{
 	error::{FatalError, FatalResult, Result},

--- a/node/core/dispute-coordinator/src/scraping/tests.rs
+++ b/node/core/dispute-coordinator/src/scraping/tests.rs
@@ -36,7 +36,7 @@ use polkadot_node_subsystem_test_helpers::{
 	make_subsystem_context, TestSubsystemContext, TestSubsystemContextHandle, TestSubsystemSender,
 };
 use polkadot_node_subsystem_util::{reexports::SubsystemContext, TimeoutExt};
-use polkadot_primitives::v2::{
+use polkadot_primitives::{
 	BlakeTwo256, BlockNumber, CandidateDescriptor, CandidateEvent, CandidateReceipt, CoreIndex,
 	GroupIndex, Hash, HashT, HeadData, Id as ParaId,
 };

--- a/node/core/dispute-coordinator/src/spam_slots.rs
+++ b/node/core/dispute-coordinator/src/spam_slots.rs
@@ -16,7 +16,7 @@
 
 use std::collections::{BTreeSet, HashMap};
 
-use polkadot_primitives::v2::{CandidateHash, SessionIndex, ValidatorIndex};
+use polkadot_primitives::{CandidateHash, SessionIndex, ValidatorIndex};
 
 use crate::LOG_TARGET;
 

--- a/node/core/dispute-coordinator/src/status.rs
+++ b/node/core/dispute-coordinator/src/status.rs
@@ -15,7 +15,7 @@
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
 use polkadot_node_primitives::{dispute_is_inactive, DisputeStatus, Timestamp};
-use polkadot_primitives::v2::{CandidateHash, SessionIndex};
+use polkadot_primitives::{CandidateHash, SessionIndex};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::LOG_TARGET;

--- a/node/core/dispute-coordinator/src/tests.rs
+++ b/node/core/dispute-coordinator/src/tests.rs
@@ -60,7 +60,7 @@ use polkadot_node_subsystem::{
 use polkadot_node_subsystem_test_helpers::{
 	make_buffered_subsystem_context, TestSubsystemContextHandle,
 };
-use polkadot_primitives::v2::{
+use polkadot_primitives::{
 	ApprovalVote, BlockNumber, CandidateCommitments, CandidateEvent, CandidateHash,
 	CandidateReceipt, CoreIndex, DisputeStatement, GroupIndex, Hash, HeadData, Header, IndexedVec,
 	MultiDisputeStatementSet, ScrapedOnChainVotes, SessionIndex, SessionInfo, SigningContext,
@@ -85,7 +85,7 @@ fn make_keystore(seeds: impl Iterator<Item = String>) -> LocalKeystore {
 
 	for s in seeds {
 		store
-			.sr25519_generate_new(polkadot_primitives::v2::PARACHAIN_KEY_TYPE_ID, Some(&s))
+			.sr25519_generate_new(polkadot_primitives::PARACHAIN_KEY_TYPE_ID, Some(&s))
 			.unwrap();
 	}
 
@@ -1735,7 +1735,7 @@ fn supermajority_valid_dispute_may_be_finalized() {
 				.await;
 
 			let supermajority_threshold =
-				polkadot_primitives::v2::supermajority_threshold(test_state.validators.len());
+				polkadot_primitives::supermajority_threshold(test_state.validators.len());
 
 			let (valid_vote, invalid_vote) = generate_opposing_votes_pair(
 				&test_state,
@@ -1874,7 +1874,7 @@ fn concluded_supermajority_for_non_active_after_time() {
 				.await;
 
 			let supermajority_threshold =
-				polkadot_primitives::v2::supermajority_threshold(test_state.validators.len());
+				polkadot_primitives::supermajority_threshold(test_state.validators.len());
 
 			let (valid_vote, invalid_vote) = generate_opposing_votes_pair(
 				&test_state,
@@ -1991,7 +1991,7 @@ fn concluded_supermajority_against_non_active_after_time() {
 				.await;
 
 			let supermajority_threshold =
-				polkadot_primitives::v2::supermajority_threshold(test_state.validators.len());
+				polkadot_primitives::supermajority_threshold(test_state.validators.len());
 
 			let (valid_vote, invalid_vote) = generate_opposing_votes_pair(
 				&test_state,

--- a/node/core/parachains-inherent/src/lib.rs
+++ b/node/core/parachains-inherent/src/lib.rs
@@ -28,7 +28,7 @@ use futures::{select, FutureExt};
 use polkadot_node_subsystem::{
 	errors::SubsystemError, messages::ProvisionerMessage, overseer::Handle,
 };
-use polkadot_primitives::v2::{Block, Hash, InherentData as ParachainsInherentData};
+use polkadot_primitives::{Block, Hash, InherentData as ParachainsInherentData};
 use std::{sync::Arc, time};
 
 pub(crate) const LOG_TARGET: &str = "parachain::parachains-inherent";
@@ -140,7 +140,7 @@ impl<C: sp_blockchain::HeaderBackend<Block>> sp_inherents::InherentDataProvider
 		.map_err(|e| sp_inherents::Error::Application(Box::new(e)))?;
 
 		dst_inherent_data
-			.put_data(polkadot_primitives::v2::PARACHAINS_INHERENT_IDENTIFIER, &inherent_data)
+			.put_data(polkadot_primitives::PARACHAINS_INHERENT_IDENTIFIER, &inherent_data)
 	}
 
 	async fn try_handle_error(

--- a/node/core/provisioner/src/disputes/mod.rs
+++ b/node/core/provisioner/src/disputes/mod.rs
@@ -25,7 +25,7 @@ use crate::LOG_TARGET;
 use futures::channel::oneshot;
 use polkadot_node_primitives::CandidateVotes;
 use polkadot_node_subsystem::{messages::DisputeCoordinatorMessage, overseer};
-use polkadot_primitives::v2::{CandidateHash, SessionIndex};
+use polkadot_primitives::{CandidateHash, SessionIndex};
 
 /// Request the relevant dispute statements for a set of disputes identified by `CandidateHash` and the `SessionIndex`.
 async fn request_votes(

--- a/node/core/provisioner/src/disputes/prioritized_selection/mod.rs
+++ b/node/core/provisioner/src/disputes/prioritized_selection/mod.rs
@@ -26,7 +26,7 @@ use polkadot_node_subsystem::{
 	messages::{DisputeCoordinatorMessage, RuntimeApiMessage, RuntimeApiRequest},
 	overseer, ActivatedLeaf,
 };
-use polkadot_primitives::v2::{
+use polkadot_primitives::{
 	supermajority_threshold, CandidateHash, DisputeState, DisputeStatement, DisputeStatementSet,
 	Hash, MultiDisputeStatementSet, SessionIndex, ValidatorIndex,
 };

--- a/node/core/provisioner/src/disputes/prioritized_selection/tests.rs
+++ b/node/core/provisioner/src/disputes/prioritized_selection/tests.rs
@@ -25,7 +25,7 @@ use polkadot_node_subsystem::messages::{
 	AllMessages, DisputeCoordinatorMessage, RuntimeApiMessage, RuntimeApiRequest,
 };
 use polkadot_node_subsystem_test_helpers::TestSubsystemSender;
-use polkadot_primitives::v2::{
+use polkadot_primitives::{
 	CandidateHash, DisputeState, InvalidDisputeStatementKind, SessionIndex,
 	ValidDisputeStatementKind, ValidatorSignature,
 };

--- a/node/core/provisioner/src/disputes/random_selection/mod.rs
+++ b/node/core/provisioner/src/disputes/random_selection/mod.rs
@@ -24,7 +24,7 @@
 use crate::{metrics, LOG_TARGET};
 use futures::channel::oneshot;
 use polkadot_node_subsystem::{messages::DisputeCoordinatorMessage, overseer};
-use polkadot_primitives::v2::{
+use polkadot_primitives::{
 	CandidateHash, DisputeStatement, DisputeStatementSet, MultiDisputeStatementSet, SessionIndex,
 };
 use std::collections::HashSet;

--- a/node/core/provisioner/src/error.rs
+++ b/node/core/provisioner/src/error.rs
@@ -19,7 +19,7 @@ use fatality::Nested;
 use futures::channel::{mpsc, oneshot};
 use polkadot_node_subsystem::errors::{ChainApiError, RuntimeApiError, SubsystemError};
 use polkadot_node_subsystem_util as util;
-use polkadot_primitives::v2::Hash;
+use polkadot_primitives::Hash;
 
 pub type FatalResult<T> = std::result::Result<T, FatalError>;
 pub type Result<T> = std::result::Result<T, Error>;

--- a/node/core/provisioner/src/lib.rs
+++ b/node/core/provisioner/src/lib.rs
@@ -37,7 +37,7 @@ use polkadot_node_subsystem::{
 use polkadot_node_subsystem_util::{
 	request_availability_cores, request_persisted_validation_data, TimeoutExt,
 };
-use polkadot_primitives::v2::{
+use polkadot_primitives::{
 	BackedCandidate, BlockNumber, CandidateReceipt, CoreState, Hash, OccupiedCoreAssumption,
 	SignedAvailabilityBitfield, ValidatorIndex,
 };

--- a/node/core/provisioner/src/tests.rs
+++ b/node/core/provisioner/src/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use ::test_helpers::{dummy_candidate_descriptor, dummy_hash};
 use bitvec::bitvec;
-use polkadot_primitives::v2::{OccupiedCore, ScheduledCore};
+use polkadot_primitives::{OccupiedCore, ScheduledCore};
 
 pub fn occupied_core(para_id: u32) -> CoreState {
 	CoreState::Occupied(OccupiedCore {
@@ -41,7 +41,7 @@ pub fn scheduled_core(id: u32) -> ScheduledCore {
 mod select_availability_bitfields {
 	use super::{super::*, default_bitvec, occupied_core};
 	use futures::executor::block_on;
-	use polkadot_primitives::v2::{ScheduledCore, SigningContext, ValidatorId, ValidatorIndex};
+	use polkadot_primitives::{ScheduledCore, SigningContext, ValidatorId, ValidatorIndex};
 	use sp_application_crypto::AppKey;
 	use sp_keystore::{testing::KeyStore, CryptoStore, SyncCryptoStorePtr};
 	use std::sync::Arc;
@@ -234,7 +234,7 @@ mod select_candidates {
 		},
 	};
 	use polkadot_node_subsystem_test_helpers::TestSubsystemSender;
-	use polkadot_primitives::v2::{
+	use polkadot_primitives::{
 		BlockNumber, CandidateCommitments, CommittedCandidateReceipt, PersistedValidationData,
 	};
 

--- a/node/core/pvf-checker/src/interest_view.rs
+++ b/node/core/pvf-checker/src/interest_view.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
-use polkadot_primitives::v2::{Hash, ValidationCodeHash};
+use polkadot_primitives::{Hash, ValidationCodeHash};
 use std::collections::{
 	btree_map::{self, BTreeMap},
 	HashSet,

--- a/node/core/pvf-checker/src/lib.rs
+++ b/node/core/pvf-checker/src/lib.rs
@@ -26,7 +26,7 @@ use polkadot_node_subsystem::{
 	overseer, ActiveLeavesUpdate, FromOrchestra, OverseerSignal, SpawnedSubsystem, SubsystemError,
 	SubsystemResult, SubsystemSender,
 };
-use polkadot_primitives::v2::{
+use polkadot_primitives::{
 	BlockNumber, Hash, PvfCheckStatement, SessionIndex, ValidationCodeHash, ValidatorId,
 	ValidatorIndex,
 };

--- a/node/core/pvf-checker/src/runtime_api.rs
+++ b/node/core/pvf-checker/src/runtime_api.rs
@@ -21,7 +21,7 @@ use polkadot_node_subsystem::{
 	messages::{RuntimeApiMessage, RuntimeApiRequest},
 	SubsystemSender,
 };
-use polkadot_primitives::v2::{
+use polkadot_primitives::{
 	Hash, PvfCheckStatement, SessionIndex, ValidationCodeHash, ValidatorId, ValidatorSignature,
 };
 

--- a/node/core/pvf-checker/src/tests.rs
+++ b/node/core/pvf-checker/src/tests.rs
@@ -25,7 +25,7 @@ use polkadot_node_subsystem::{
 	ActivatedLeaf, ActiveLeavesUpdate, FromOrchestra, LeafStatus, OverseerSignal, RuntimeApiError,
 };
 use polkadot_node_subsystem_test_helpers::{make_subsystem_context, TestSubsystemContextHandle};
-use polkadot_primitives::v2::{
+use polkadot_primitives::{
 	BlockNumber, Hash, Header, PvfCheckStatement, SessionIndex, ValidationCode, ValidationCodeHash,
 	ValidatorId,
 };

--- a/node/core/runtime-api/src/cache.rs
+++ b/node/core/runtime-api/src/cache.rs
@@ -19,7 +19,7 @@ use std::{collections::btree_map::BTreeMap, num::NonZeroUsize};
 use lru::LruCache;
 use sp_consensus_babe::Epoch;
 
-use polkadot_primitives::v2::{
+use polkadot_primitives::{
 	AuthorityDiscoveryId, BlockNumber, CandidateCommitments, CandidateEvent, CandidateHash,
 	CommittedCandidateReceipt, CoreState, DisputeState, GroupRotationInfo, Hash, Id as ParaId,
 	InboundDownwardMessage, InboundHrmpMessage, OccupiedCoreAssumption, PersistedValidationData,

--- a/node/core/runtime-api/src/lib.rs
+++ b/node/core/runtime-api/src/lib.rs
@@ -28,7 +28,7 @@ use polkadot_node_subsystem::{
 	overseer, FromOrchestra, OverseerSignal, SpawnedSubsystem, SubsystemError, SubsystemResult,
 };
 use polkadot_node_subsystem_types::RuntimeApiSubsystemClient;
-use polkadot_primitives::v2::Hash;
+use polkadot_primitives::Hash;
 
 use cache::{RequestResult, RequestResultCache};
 use futures::{channel::oneshot, prelude::*, select, stream::FuturesUnordered};

--- a/node/core/runtime-api/src/tests.rs
+++ b/node/core/runtime-api/src/tests.rs
@@ -21,14 +21,11 @@ use polkadot_node_primitives::{BabeAllowedSlots, BabeEpoch, BabeEpochConfigurati
 use polkadot_node_subsystem::SpawnGlue;
 use polkadot_node_subsystem_test_helpers::make_subsystem_context;
 use polkadot_primitives::{
-	runtime_api::ParachainHost,
-	v2::{
-		AuthorityDiscoveryId, Block, CandidateEvent, CommittedCandidateReceipt, CoreState,
-		GroupRotationInfo, Id as ParaId, InboundDownwardMessage, InboundHrmpMessage,
-		OccupiedCoreAssumption, PersistedValidationData, PvfCheckStatement, ScrapedOnChainVotes,
-		SessionIndex, SessionInfo, ValidationCode, ValidationCodeHash, ValidatorId, ValidatorIndex,
-		ValidatorSignature,
-	},
+	runtime_api::ParachainHost, AuthorityDiscoveryId, Block, CandidateEvent,
+	CommittedCandidateReceipt, CoreState, GroupRotationInfo, Id as ParaId, InboundDownwardMessage,
+	InboundHrmpMessage, OccupiedCoreAssumption, PersistedValidationData, PvfCheckStatement,
+	ScrapedOnChainVotes, SessionIndex, SessionInfo, ValidationCode, ValidationCodeHash,
+	ValidatorId, ValidatorIndex, ValidatorSignature,
 };
 use sp_api::ProvideRuntimeApi;
 use sp_authority_discovery::AuthorityDiscoveryApi;
@@ -115,7 +112,7 @@ sp_api::mock_impl_runtime_apis! {
 		fn check_validation_outputs(
 			&self,
 			para_id: ParaId,
-			_commitments: polkadot_primitives::v2::CandidateCommitments,
+			_commitments: polkadot_primitives::CandidateCommitments,
 		) -> bool {
 			self.validation_outputs_results
 				.get(&para_id)
@@ -223,7 +220,7 @@ sp_api::mock_impl_runtime_apis! {
 		}
 
 		fn submit_report_equivocation_unsigned_extrinsic(
-			_equivocation_proof: sp_consensus_babe::EquivocationProof<polkadot_primitives::v2::Header>,
+			_equivocation_proof: sp_consensus_babe::EquivocationProof<polkadot_primitives::Header>,
 			_key_owner_proof: sp_consensus_babe::OpaqueKeyOwnershipProof,
 		) -> Option<()> {
 			None
@@ -452,7 +449,7 @@ fn requests_check_validation_outputs() {
 	let relay_parent = [1; 32].into();
 	let para_a = ParaId::from(5_u32);
 	let para_b = ParaId::from(6_u32);
-	let commitments = polkadot_primitives::v2::CandidateCommitments::default();
+	let commitments = polkadot_primitives::CandidateCommitments::default();
 	let spawner = sp_core::testing::TaskExecutor::new();
 
 	runtime_api.validation_outputs_results.insert(para_a, false);

--- a/node/gum/src/lib.rs
+++ b/node/gum/src/lib.rs
@@ -27,7 +27,7 @@ pub use tracing::{enabled, event, Level};
 pub use jaeger::hash_to_trace_identifier;
 
 #[doc(hidden)]
-pub use polkadot_primitives::v2::{CandidateHash, Hash};
+pub use polkadot_primitives::{CandidateHash, Hash};
 
 pub use gum_proc_macro::{debug, error, info, trace, warn};
 

--- a/node/gum/src/tests.rs
+++ b/node/gum/src/tests.rs
@@ -15,7 +15,7 @@
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
 use super::*;
-pub use polkadot_primitives::v2::{CandidateHash, Hash};
+pub use polkadot_primitives::{CandidateHash, Hash};
 
 #[derive(Default, Debug)]
 struct Y {

--- a/node/jaeger/src/spans.rs
+++ b/node/jaeger/src/spans.rs
@@ -17,7 +17,7 @@
 //! Polkadot Jaeger span definitions.
 //!
 //! ```rust
-//! # use polkadot_primitives::v2::{CandidateHash, Hash};
+//! # use polkadot_primitives::{CandidateHash, Hash};
 //! # fn main() {
 //! use polkadot_node_jaeger as jaeger;
 //!
@@ -51,7 +51,7 @@
 //! over the course of a function, for this purpose use the non-consuming
 //! `fn` variants, i.e.
 //! ```rust
-//! # use polkadot_primitives::v2::{CandidateHash, Hash};
+//! # use polkadot_primitives::{CandidateHash, Hash};
 //! # fn main() {
 //! # use polkadot_node_jaeger as jaeger;
 //!
@@ -85,9 +85,7 @@
 
 use parity_scale_codec::Encode;
 use polkadot_node_primitives::PoV;
-use polkadot_primitives::v2::{
-	BlakeTwo256, CandidateHash, Hash, HashT, Id as ParaId, ValidatorIndex,
-};
+use polkadot_primitives::{BlakeTwo256, CandidateHash, Hash, HashT, Id as ParaId, ValidatorIndex};
 use sc_network::PeerId;
 
 use std::{fmt, sync::Arc};

--- a/node/malus/src/variants/common.rs
+++ b/node/malus/src/variants/common.rs
@@ -28,7 +28,7 @@ use polkadot_node_subsystem::{
 	overseer,
 };
 
-use polkadot_primitives::v2::{
+use polkadot_primitives::{
 	CandidateCommitments, CandidateDescriptor, CandidateReceipt, PersistedValidationData,
 };
 

--- a/node/malus/src/variants/suggest_garbage_candidate.rs
+++ b/node/malus/src/variants/suggest_garbage_candidate.rs
@@ -33,7 +33,7 @@ use polkadot_cli::{
 };
 use polkadot_node_core_candidate_validation::find_validation_data;
 use polkadot_node_primitives::{AvailableData, BlockData, PoV};
-use polkadot_primitives::v2::CandidateDescriptor;
+use polkadot_primitives::CandidateDescriptor;
 
 use polkadot_node_subsystem_util::request_validators;
 use sp_core::traits::SpawnNamed;
@@ -53,7 +53,7 @@ use crate::{
 // Import extra types relevant to the particular
 // subsystem.
 use polkadot_node_subsystem::{messages::CandidateBackingMessage, SpawnGlue};
-use polkadot_primitives::v2::CandidateReceipt;
+use polkadot_primitives::CandidateReceipt;
 
 use std::sync::Arc;
 
@@ -166,11 +166,11 @@ where
 					};
 
 					let (collator_id, collator_signature) = {
-						use polkadot_primitives::v2::CollatorPair;
+						use polkadot_primitives::CollatorPair;
 						use sp_core::crypto::Pair;
 
 						let collator_pair = CollatorPair::generate().0;
-						let signature_payload = polkadot_primitives::v2::collator_signature_payload(
+						let signature_payload = polkadot_primitives::collator_signature_payload(
 							&relay_parent,
 							&candidate.descriptor().para_id,
 							&validation_data_hash,

--- a/node/metrics/src/runtime/mod.rs
+++ b/node/metrics/src/runtime/mod.rs
@@ -24,7 +24,7 @@
 #![cfg(feature = "runtime-metrics")]
 
 use codec::Decode;
-use primitives::v2::{
+use primitives::{
 	metric_definitions::{CounterDefinition, CounterVecDefinition},
 	RuntimeMetricLabelValues, RuntimeMetricOp, RuntimeMetricUpdate,
 };

--- a/node/metrics/src/runtime/parachain.rs
+++ b/node/metrics/src/runtime/parachain.rs
@@ -18,7 +18,7 @@
 //! All of the metrics have a correspondent runtime metric definition.
 
 use crate::runtime::RuntimeMetricsProvider;
-use primitives::v2::metric_definitions::{
+use primitives::metric_definitions::{
 	PARACHAIN_CREATE_INHERENT_BITFIELDS_SIGNATURE_CHECKS,
 	PARACHAIN_INHERENT_DATA_BITFIELDS_PROCESSED, PARACHAIN_INHERENT_DATA_CANDIDATES_PROCESSED,
 	PARACHAIN_INHERENT_DATA_DISPUTE_SETS_INCLUDED, PARACHAIN_INHERENT_DATA_DISPUTE_SETS_PROCESSED,

--- a/node/metrics/src/tests.rs
+++ b/node/metrics/src/tests.rs
@@ -18,7 +18,7 @@
 
 use hyper::{Client, Uri};
 use polkadot_test_service::{node_config, run_validator_node, test_prometheus_config};
-use primitives::v2::metric_definitions::PARACHAIN_INHERENT_DATA_BITFIELDS_PROCESSED;
+use primitives::metric_definitions::PARACHAIN_INHERENT_DATA_BITFIELDS_PROCESSED;
 use sc_client_api::{execution_extensions::ExecutionStrategies, ExecutionStrategy};
 use sp_keyring::AccountKeyring::*;
 use std::collections::HashMap;

--- a/node/network/approval-distribution/src/lib.rs
+++ b/node/network/approval-distribution/src/lib.rs
@@ -37,7 +37,7 @@ use polkadot_node_subsystem::{
 	},
 	overseer, ActiveLeavesUpdate, FromOrchestra, OverseerSignal, SpawnedSubsystem, SubsystemError,
 };
-use polkadot_primitives::v2::{
+use polkadot_primitives::{
 	BlockNumber, CandidateIndex, Hash, SessionIndex, ValidatorIndex, ValidatorSignature,
 };
 use rand::{CryptoRng, Rng, SeedableRng};

--- a/node/network/approval-distribution/src/tests.rs
+++ b/node/network/approval-distribution/src/tests.rs
@@ -29,7 +29,7 @@ use polkadot_node_primitives::approval::{
 use polkadot_node_subsystem::messages::{network_bridge_event, AllMessages, ApprovalCheckError};
 use polkadot_node_subsystem_test_helpers as test_helpers;
 use polkadot_node_subsystem_util::TimeoutExt as _;
-use polkadot_primitives::v2::{AuthorityDiscoveryId, BlakeTwo256, HashT};
+use polkadot_primitives::{AuthorityDiscoveryId, BlakeTwo256, HashT};
 use polkadot_primitives_test_helpers::dummy_signature;
 use rand::SeedableRng;
 use sp_authority_discovery::AuthorityPair as AuthorityDiscoveryPair;

--- a/node/network/availability-distribution/src/error.rs
+++ b/node/network/availability-distribution/src/error.rs
@@ -19,7 +19,7 @@
 
 use fatality::Nested;
 use polkadot_node_network_protocol::request_response::outgoing::RequestError;
-use polkadot_primitives::v2::SessionIndex;
+use polkadot_primitives::SessionIndex;
 
 use futures::channel::oneshot;
 

--- a/node/network/availability-distribution/src/pov_requester/mod.rs
+++ b/node/network/availability-distribution/src/pov_requester/mod.rs
@@ -30,7 +30,7 @@ use polkadot_node_subsystem::{
 	overseer,
 };
 use polkadot_node_subsystem_util::runtime::RuntimeInfo;
-use polkadot_primitives::v2::{
+use polkadot_primitives::{
 	AuthorityDiscoveryId, CandidateHash, Hash, Id as ParaId, ValidatorIndex,
 };
 
@@ -141,7 +141,7 @@ mod tests {
 		AllMessages, AvailabilityDistributionMessage, RuntimeApiMessage, RuntimeApiRequest,
 	};
 	use polkadot_node_subsystem_test_helpers as test_helpers;
-	use polkadot_primitives::v2::{CandidateHash, Hash, ValidatorIndex};
+	use polkadot_primitives::{CandidateHash, Hash, ValidatorIndex};
 	use test_helpers::mock::make_ferdie_keystore;
 
 	use super::*;

--- a/node/network/availability-distribution/src/requester/fetch_task/mod.rs
+++ b/node/network/availability-distribution/src/requester/fetch_task/mod.rs
@@ -33,7 +33,7 @@ use polkadot_node_subsystem::{
 	messages::{AvailabilityStoreMessage, IfDisconnected, NetworkBridgeTxMessage},
 	overseer,
 };
-use polkadot_primitives::v2::{
+use polkadot_primitives::{
 	AuthorityDiscoveryId, BlakeTwo256, CandidateHash, GroupIndex, Hash, HashT, OccupiedCore,
 	SessionIndex,
 };

--- a/node/network/availability-distribution/src/requester/fetch_task/tests.rs
+++ b/node/network/availability-distribution/src/requester/fetch_task/tests.rs
@@ -31,7 +31,7 @@ use sp_keyring::Sr25519Keyring;
 use polkadot_node_network_protocol::request_response::{v1, Recipient};
 use polkadot_node_primitives::{BlockData, PoV, Proof};
 use polkadot_node_subsystem::messages::AllMessages;
-use polkadot_primitives::v2::{CandidateHash, ValidatorIndex};
+use polkadot_primitives::{CandidateHash, ValidatorIndex};
 
 use super::*;
 use crate::{metrics::Metrics, tests::mock::get_valid_chunk_data};

--- a/node/network/availability-distribution/src/requester/mod.rs
+++ b/node/network/availability-distribution/src/requester/mod.rs
@@ -37,7 +37,7 @@ use polkadot_node_subsystem::{
 	overseer, ActivatedLeaf, ActiveLeavesUpdate, LeafStatus,
 };
 use polkadot_node_subsystem_util::runtime::{get_occupied_cores, RuntimeInfo};
-use polkadot_primitives::v2::{CandidateHash, Hash, OccupiedCore, SessionIndex};
+use polkadot_primitives::{CandidateHash, Hash, OccupiedCore, SessionIndex};
 
 use super::{FatalError, Metrics, Result, LOG_TARGET};
 

--- a/node/network/availability-distribution/src/requester/session_cache.rs
+++ b/node/network/availability-distribution/src/requester/session_cache.rs
@@ -21,9 +21,7 @@ use rand::{seq::SliceRandom, thread_rng};
 
 use polkadot_node_subsystem::overseer;
 use polkadot_node_subsystem_util::runtime::RuntimeInfo;
-use polkadot_primitives::v2::{
-	AuthorityDiscoveryId, GroupIndex, Hash, SessionIndex, ValidatorIndex,
-};
+use polkadot_primitives::{AuthorityDiscoveryId, GroupIndex, Hash, SessionIndex, ValidatorIndex};
 
 use crate::{
 	error::{Error, Result},

--- a/node/network/availability-distribution/src/requester/tests.rs
+++ b/node/network/availability-distribution/src/requester/tests.rs
@@ -21,7 +21,7 @@ use futures::FutureExt;
 use polkadot_node_network_protocol::jaeger;
 use polkadot_node_primitives::{BlockData, ErasureChunk, PoV};
 use polkadot_node_subsystem_util::runtime::RuntimeInfo;
-use polkadot_primitives::v2::{
+use polkadot_primitives::{
 	BlockNumber, CoreState, GroupIndex, Hash, Id as ParaId, ScheduledCore, SessionIndex,
 	SessionInfo,
 };

--- a/node/network/availability-distribution/src/responder.rs
+++ b/node/network/availability-distribution/src/responder.rs
@@ -27,7 +27,7 @@ use polkadot_node_network_protocol::{
 };
 use polkadot_node_primitives::{AvailableData, ErasureChunk};
 use polkadot_node_subsystem::{jaeger, messages::AvailabilityStoreMessage, SubsystemSender};
-use polkadot_primitives::v2::{CandidateHash, ValidatorIndex};
+use polkadot_primitives::{CandidateHash, ValidatorIndex};
 
 use crate::{
 	error::{JfyiError, Result},

--- a/node/network/availability-distribution/src/tests/mock.rs
+++ b/node/network/availability-distribution/src/tests/mock.rs
@@ -22,7 +22,7 @@ use sp_keyring::Sr25519Keyring;
 
 use polkadot_erasure_coding::{branches, obtain_chunks_v1 as obtain_chunks};
 use polkadot_node_primitives::{AvailableData, BlockData, ErasureChunk, PoV, Proof};
-use polkadot_primitives::v2::{
+use polkadot_primitives::{
 	CandidateCommitments, CandidateDescriptor, CandidateHash, CommittedCandidateReceipt,
 	GroupIndex, Hash, HeadData, Id as ParaId, IndexedVec, OccupiedCore, PersistedValidationData,
 	SessionInfo, ValidatorIndex,

--- a/node/network/availability-distribution/src/tests/mod.rs
+++ b/node/network/availability-distribution/src/tests/mod.rs
@@ -19,7 +19,7 @@ use std::collections::HashSet;
 use futures::{executor, future, Future};
 
 use polkadot_node_network_protocol::request_response::{IncomingRequest, ReqProtocolNames};
-use polkadot_primitives::v2::{CoreState, Hash};
+use polkadot_primitives::{CoreState, Hash};
 use sp_keystore::SyncCryptoStorePtr;
 
 use polkadot_node_subsystem_test_helpers as test_helpers;

--- a/node/network/availability-distribution/src/tests/state.rs
+++ b/node/network/availability-distribution/src/tests/state.rs
@@ -47,7 +47,7 @@ use polkadot_node_subsystem::{
 	ActivatedLeaf, ActiveLeavesUpdate, FromOrchestra, LeafStatus, OverseerSignal,
 };
 use polkadot_node_subsystem_test_helpers as test_helpers;
-use polkadot_primitives::v2::{
+use polkadot_primitives::{
 	CandidateHash, CoreState, GroupIndex, Hash, Id as ParaId, ScheduledCore, SessionInfo,
 	ValidatorIndex,
 };

--- a/node/network/availability-recovery/src/lib.rs
+++ b/node/network/availability-recovery/src/lib.rs
@@ -56,7 +56,7 @@ use polkadot_node_subsystem::{
 	SubsystemResult,
 };
 use polkadot_node_subsystem_util::request_session_info;
-use polkadot_primitives::v2::{
+use polkadot_primitives::{
 	AuthorityDiscoveryId, BlakeTwo256, BlockNumber, CandidateHash, CandidateReceipt, GroupIndex,
 	Hash, HashT, IndexedVec, SessionIndex, SessionInfo, ValidatorId, ValidatorIndex,
 };

--- a/node/network/availability-recovery/src/tests.rs
+++ b/node/network/availability-recovery/src/tests.rs
@@ -36,7 +36,7 @@ use polkadot_node_subsystem::{
 };
 use polkadot_node_subsystem_test_helpers::{make_subsystem_context, TestSubsystemContextHandle};
 use polkadot_node_subsystem_util::TimeoutExt;
-use polkadot_primitives::v2::{
+use polkadot_primitives::{
 	AuthorityDiscoveryId, Hash, HeadData, IndexedVec, PersistedValidationData, ValidatorId,
 };
 use polkadot_primitives_test_helpers::{dummy_candidate_receipt, dummy_hash};

--- a/node/network/bitfield-distribution/src/lib.rs
+++ b/node/network/bitfield-distribution/src/lib.rs
@@ -37,7 +37,7 @@ use polkadot_node_subsystem::{
 };
 use polkadot_node_subsystem_util::{self as util};
 
-use polkadot_primitives::v2::{Hash, SignedAvailabilityBitfield, SigningContext, ValidatorId};
+use polkadot_primitives::{Hash, SignedAvailabilityBitfield, SigningContext, ValidatorId};
 use rand::{CryptoRng, Rng, SeedableRng};
 use std::collections::{HashMap, HashSet};
 

--- a/node/network/bitfield-distribution/src/tests.rs
+++ b/node/network/bitfield-distribution/src/tests.rs
@@ -31,7 +31,7 @@ use polkadot_node_subsystem::{
 };
 use polkadot_node_subsystem_test_helpers::make_subsystem_context;
 use polkadot_node_subsystem_util::TimeoutExt;
-use polkadot_primitives::v2::{AvailabilityBitfield, Signed, ValidatorIndex};
+use polkadot_primitives::{AvailabilityBitfield, Signed, ValidatorIndex};
 use rand_chacha::ChaCha12Rng;
 use sp_application_crypto::AppKey;
 use sp_authority_discovery::AuthorityPair as AuthorityDiscoveryPair;

--- a/node/network/bridge/src/network.rs
+++ b/node/network/bridge/src/network.rs
@@ -36,7 +36,7 @@ use polkadot_node_network_protocol::{
 	request_response::{OutgoingRequest, Recipient, ReqProtocolNames, Requests},
 	PeerId, UnifiedReputationChange as Rep,
 };
-use polkadot_primitives::v2::{AuthorityDiscoveryId, Block, Hash};
+use polkadot_primitives::{AuthorityDiscoveryId, Block, Hash};
 
 use crate::validator_discovery::AuthorityDiscovery;
 

--- a/node/network/bridge/src/rx/mod.rs
+++ b/node/network/bridge/src/rx/mod.rs
@@ -45,7 +45,7 @@ use polkadot_node_subsystem::{
 	overseer, ActivatedLeaf, ActiveLeavesUpdate, FromOrchestra, OverseerSignal, SpawnedSubsystem,
 };
 
-use polkadot_primitives::v2::{AuthorityDiscoveryId, BlockNumber, Hash, ValidatorIndex};
+use polkadot_primitives::{AuthorityDiscoveryId, BlockNumber, Hash, ValidatorIndex};
 
 /// Peer set info for network initialization.
 ///

--- a/node/network/bridge/src/rx/tests.rs
+++ b/node/network/bridge/src/rx/tests.rs
@@ -46,7 +46,7 @@ use polkadot_node_subsystem_test_helpers::{
 	SingleItemSink, SingleItemStream, TestSubsystemContextHandle,
 };
 use polkadot_node_subsystem_util::metered;
-use polkadot_primitives::v2::{AuthorityDiscoveryId, Hash};
+use polkadot_primitives::{AuthorityDiscoveryId, Hash};
 
 use sc_network::Multiaddr;
 use sp_keyring::Sr25519Keyring;

--- a/node/network/bridge/src/tx/tests.rs
+++ b/node/network/bridge/src/tx/tests.rs
@@ -32,7 +32,7 @@ use polkadot_node_network_protocol::{
 use polkadot_node_subsystem::{FromOrchestra, OverseerSignal};
 use polkadot_node_subsystem_test_helpers::TestSubsystemContextHandle;
 use polkadot_node_subsystem_util::metered;
-use polkadot_primitives::v2::{AuthorityDiscoveryId, Hash};
+use polkadot_primitives::{AuthorityDiscoveryId, Hash};
 use polkadot_primitives_test_helpers::dummy_collator_signature;
 use sc_network::Multiaddr;
 use sp_keyring::Sr25519Keyring;

--- a/node/network/bridge/src/validator_discovery.rs
+++ b/node/network/bridge/src/validator_discovery.rs
@@ -30,7 +30,7 @@ use polkadot_node_network_protocol::{
 	peer_set::{PeerSet, PeerSetProtocolNames, PerPeerSet},
 	PeerId,
 };
-use polkadot_primitives::v2::AuthorityDiscoveryId;
+use polkadot_primitives::AuthorityDiscoveryId;
 
 const LOG_TARGET: &str = "parachain::validator-discovery";
 
@@ -173,7 +173,7 @@ mod tests {
 		request_response::{outgoing::Requests, ReqProtocolNames},
 		PeerId,
 	};
-	use polkadot_primitives::v2::Hash;
+	use polkadot_primitives::Hash;
 	use sc_network::{Event as NetworkEvent, IfDisconnected, ProtocolName};
 	use sp_keyring::Sr25519Keyring;
 	use std::collections::{HashMap, HashSet};

--- a/node/network/collator-protocol/src/collator_side/mod.rs
+++ b/node/network/collator-protocol/src/collator_side/mod.rs
@@ -47,7 +47,7 @@ use polkadot_node_subsystem_util::{
 	runtime::{get_availability_cores, get_group_rotation_info, RuntimeInfo},
 	TimeoutExt,
 };
-use polkadot_primitives::v2::{
+use polkadot_primitives::{
 	AuthorityDiscoveryId, CandidateHash, CandidateReceipt, CollatorPair, CoreIndex, CoreState,
 	GroupIndex, Hash, Id as ParaId, SessionIndex,
 };

--- a/node/network/collator-protocol/src/collator_side/tests.rs
+++ b/node/network/collator-protocol/src/collator_side/tests.rs
@@ -43,7 +43,7 @@ use polkadot_node_subsystem::{
 };
 use polkadot_node_subsystem_test_helpers as test_helpers;
 use polkadot_node_subsystem_util::TimeoutExt;
-use polkadot_primitives::v2::{
+use polkadot_primitives::{
 	AuthorityDiscoveryId, CollatorPair, GroupIndex, GroupRotationInfo, IndexedVec, ScheduledCore,
 	SessionIndex, SessionInfo, ValidatorId, ValidatorIndex,
 };

--- a/node/network/collator-protocol/src/collator_side/validators_buffer.rs
+++ b/node/network/collator-protocol/src/collator_side/validators_buffer.rs
@@ -37,7 +37,7 @@ use std::{
 
 use bitvec::{bitvec, vec::BitVec};
 
-use polkadot_primitives::v2::{AuthorityDiscoveryId, GroupIndex, Hash, SessionIndex};
+use polkadot_primitives::{AuthorityDiscoveryId, GroupIndex, Hash, SessionIndex};
 
 /// The ring buffer stores at most this many unique validator groups.
 ///

--- a/node/network/collator-protocol/src/lib.rs
+++ b/node/network/collator-protocol/src/lib.rs
@@ -34,7 +34,7 @@ use polkadot_node_network_protocol::{
 	request_response::{v1 as request_v1, IncomingRequestReceiver},
 	PeerId, UnifiedReputationChange as Rep,
 };
-use polkadot_primitives::v2::CollatorPair;
+use polkadot_primitives::CollatorPair;
 
 use polkadot_node_subsystem::{
 	errors::SubsystemError, messages::NetworkBridgeTxMessage, overseer, SpawnedSubsystem,

--- a/node/network/collator-protocol/src/validator_side/mod.rs
+++ b/node/network/collator-protocol/src/validator_side/mod.rs
@@ -53,7 +53,7 @@ use polkadot_node_subsystem::{
 	overseer, FromOrchestra, OverseerSignal, PerLeafSpan, SubsystemSender,
 };
 use polkadot_node_subsystem_util::metrics::{self, prometheus};
-use polkadot_primitives::v2::{CandidateReceipt, CollatorId, Hash, Id as ParaId};
+use polkadot_primitives::{CandidateReceipt, CollatorId, Hash, Id as ParaId};
 
 use crate::error::Result;
 

--- a/node/network/collator-protocol/src/validator_side/tests.rs
+++ b/node/network/collator-protocol/src/validator_side/tests.rs
@@ -32,7 +32,7 @@ use polkadot_node_primitives::BlockData;
 use polkadot_node_subsystem::messages::{AllMessages, RuntimeApiMessage, RuntimeApiRequest};
 use polkadot_node_subsystem_test_helpers as test_helpers;
 use polkadot_node_subsystem_util::TimeoutExt;
-use polkadot_primitives::v2::{
+use polkadot_primitives::{
 	CollatorPair, CoreState, GroupIndex, GroupRotationInfo, OccupiedCore, ScheduledCore,
 	ValidatorId, ValidatorIndex,
 };
@@ -133,7 +133,7 @@ fn test_harness<T: Future<Output = VirtualOverseer>>(test: impl FnOnce(TestHarne
 	let keystore = TestKeyStore::new();
 	keystore
 		.sr25519_generate_new(
-			polkadot_primitives::v2::PARACHAIN_KEY_TYPE_ID,
+			polkadot_primitives::PARACHAIN_KEY_TYPE_ID,
 			Some(&Sr25519Keyring::Alice.to_seed()),
 		)
 		.unwrap();

--- a/node/network/dispute-distribution/src/receiver/batches/batch.rs
+++ b/node/network/dispute-distribution/src/receiver/batches/batch.rs
@@ -22,7 +22,7 @@ use polkadot_node_network_protocol::{
 	PeerId,
 };
 use polkadot_node_primitives::SignedDisputeStatement;
-use polkadot_primitives::v2::{CandidateReceipt, ValidatorIndex};
+use polkadot_primitives::{CandidateReceipt, ValidatorIndex};
 
 use crate::receiver::{BATCH_COLLECTING_INTERVAL, MIN_KEEP_BATCH_ALIVE_VOTES};
 

--- a/node/network/dispute-distribution/src/receiver/batches/mod.rs
+++ b/node/network/dispute-distribution/src/receiver/batches/mod.rs
@@ -22,7 +22,7 @@ use std::{
 use futures::future::pending;
 
 use polkadot_node_network_protocol::request_response::DISPUTE_REQUEST_TIMEOUT;
-use polkadot_primitives::v2::{CandidateHash, CandidateReceipt};
+use polkadot_primitives::{CandidateHash, CandidateReceipt};
 
 use crate::{
 	receiver::batches::{batch::TickResult, waiting_queue::PendingWake},

--- a/node/network/dispute-distribution/src/receiver/error.rs
+++ b/node/network/dispute-distribution/src/receiver/error.rs
@@ -22,7 +22,7 @@ use fatality::Nested;
 use gum::CandidateHash;
 use polkadot_node_network_protocol::{request_response::incoming, PeerId};
 use polkadot_node_subsystem_util::runtime;
-use polkadot_primitives::v2::AuthorityDiscoveryId;
+use polkadot_primitives::AuthorityDiscoveryId;
 
 use crate::LOG_TARGET;
 

--- a/node/network/dispute-distribution/src/receiver/peer_queues.rs
+++ b/node/network/dispute-distribution/src/receiver/peer_queues.rs
@@ -19,7 +19,7 @@ use std::collections::{hash_map::Entry, HashMap, VecDeque};
 use futures::future::pending;
 use futures_timer::Delay;
 use polkadot_node_network_protocol::request_response::{v1::DisputeRequest, IncomingRequest};
-use polkadot_primitives::v2::AuthorityDiscoveryId;
+use polkadot_primitives::AuthorityDiscoveryId;
 
 use crate::RECEIVE_RATE_LIMIT;
 

--- a/node/network/dispute-distribution/src/sender/mod.rs
+++ b/node/network/dispute-distribution/src/sender/mod.rs
@@ -33,7 +33,7 @@ use polkadot_node_network_protocol::request_response::v1::DisputeRequest;
 use polkadot_node_primitives::{CandidateVotes, DisputeMessage, SignedDisputeStatement};
 use polkadot_node_subsystem::{messages::DisputeCoordinatorMessage, overseer, ActiveLeavesUpdate};
 use polkadot_node_subsystem_util::runtime::RuntimeInfo;
-use polkadot_primitives::v2::{CandidateHash, DisputeStatement, Hash, SessionIndex};
+use polkadot_primitives::{CandidateHash, DisputeStatement, Hash, SessionIndex};
 
 /// For each ongoing dispute we have a `SendTask` which takes care of it.
 ///

--- a/node/network/dispute-distribution/src/sender/send_task.rs
+++ b/node/network/dispute-distribution/src/sender/send_task.rs
@@ -28,7 +28,7 @@ use polkadot_node_network_protocol::{
 };
 use polkadot_node_subsystem::{messages::NetworkBridgeTxMessage, overseer};
 use polkadot_node_subsystem_util::{metrics, runtime::RuntimeInfo};
-use polkadot_primitives::v2::{
+use polkadot_primitives::{
 	AuthorityDiscoveryId, CandidateHash, Hash, SessionIndex, ValidatorIndex,
 };
 

--- a/node/network/dispute-distribution/src/tests/mock.rs
+++ b/node/network/dispute-distribution/src/tests/mock.rs
@@ -33,7 +33,7 @@ use sp_keyring::Sr25519Keyring;
 use sp_keystore::{SyncCryptoStore, SyncCryptoStorePtr};
 
 use polkadot_node_primitives::{DisputeMessage, SignedDisputeStatement};
-use polkadot_primitives::v2::{
+use polkadot_primitives::{
 	AuthorityDiscoveryId, CandidateHash, CandidateReceipt, Hash, SessionIndex, SessionInfo,
 	ValidatorId, ValidatorIndex,
 };
@@ -210,7 +210,7 @@ impl MockAuthorityDiscovery {
 impl AuthorityDiscovery for MockAuthorityDiscovery {
 	async fn get_addresses_by_authority_id(
 		&mut self,
-		_authority: polkadot_primitives::v2::AuthorityDiscoveryId,
+		_authority: polkadot_primitives::AuthorityDiscoveryId,
 	) -> Option<HashSet<sc_network::Multiaddr>> {
 		panic!("Not implemented");
 	}
@@ -218,7 +218,7 @@ impl AuthorityDiscovery for MockAuthorityDiscovery {
 	async fn get_authority_ids_by_peer_id(
 		&mut self,
 		peer_id: polkadot_node_network_protocol::PeerId,
-	) -> Option<HashSet<polkadot_primitives::v2::AuthorityDiscoveryId>> {
+	) -> Option<HashSet<polkadot_primitives::AuthorityDiscoveryId>> {
 		for (a, p) in self.peer_ids.iter() {
 			if p == &peer_id {
 				let result =

--- a/node/network/dispute-distribution/src/tests/mod.rs
+++ b/node/network/dispute-distribution/src/tests/mod.rs
@@ -56,7 +56,7 @@ use polkadot_node_subsystem::{
 use polkadot_node_subsystem_test_helpers::{
 	mock::make_ferdie_keystore, subsystem_test_harness, TestSubsystemContextHandle,
 };
-use polkadot_primitives::v2::{
+use polkadot_primitives::{
 	AuthorityDiscoveryId, CandidateHash, CandidateReceipt, Hash, SessionIndex, SessionInfo,
 };
 

--- a/node/network/gossip-support/src/lib.rs
+++ b/node/network/gossip-support/src/lib.rs
@@ -51,9 +51,7 @@ use polkadot_node_subsystem::{
 	overseer, ActiveLeavesUpdate, FromOrchestra, OverseerSignal, SpawnedSubsystem, SubsystemError,
 };
 use polkadot_node_subsystem_util as util;
-use polkadot_primitives::v2::{
-	AuthorityDiscoveryId, Hash, SessionIndex, SessionInfo, ValidatorIndex,
-};
+use polkadot_primitives::{AuthorityDiscoveryId, Hash, SessionIndex, SessionInfo, ValidatorIndex};
 
 #[cfg(test)]
 mod tests;

--- a/node/network/gossip-support/src/tests.rs
+++ b/node/network/gossip-support/src/tests.rs
@@ -37,7 +37,7 @@ use polkadot_node_subsystem::{
 };
 use polkadot_node_subsystem_test_helpers as test_helpers;
 use polkadot_node_subsystem_util::TimeoutExt as _;
-use polkadot_primitives::v2::{GroupIndex, IndexedVec};
+use polkadot_primitives::{GroupIndex, IndexedVec};
 use test_helpers::mock::make_ferdie_keystore;
 
 use super::*;
@@ -121,14 +121,14 @@ impl MockAuthorityDiscovery {
 impl AuthorityDiscovery for MockAuthorityDiscovery {
 	async fn get_addresses_by_authority_id(
 		&mut self,
-		authority: polkadot_primitives::v2::AuthorityDiscoveryId,
+		authority: polkadot_primitives::AuthorityDiscoveryId,
 	) -> Option<HashSet<sc_network::Multiaddr>> {
 		self.addrs.get(&authority).cloned()
 	}
 	async fn get_authority_ids_by_peer_id(
 		&mut self,
 		peer_id: polkadot_node_network_protocol::PeerId,
-	) -> Option<HashSet<polkadot_primitives::v2::AuthorityDiscoveryId>> {
+	) -> Option<HashSet<polkadot_primitives::AuthorityDiscoveryId>> {
 		self.authorities.get(&peer_id).cloned()
 	}
 }

--- a/node/network/protocol/src/authority_discovery.rs
+++ b/node/network/protocol/src/authority_discovery.rs
@@ -22,7 +22,7 @@ use async_trait::async_trait;
 
 use sc_authority_discovery::Service as AuthorityDiscoveryService;
 
-use polkadot_primitives::v2::AuthorityDiscoveryId;
+use polkadot_primitives::AuthorityDiscoveryId;
 use sc_network::{Multiaddr, PeerId};
 
 /// An abstraction over the authority discovery service.

--- a/node/network/protocol/src/grid_topology.rs
+++ b/node/network/protocol/src/grid_topology.rs
@@ -30,7 +30,7 @@
 //!
 
 use crate::PeerId;
-use polkadot_primitives::v2::{AuthorityDiscoveryId, SessionIndex, ValidatorIndex};
+use polkadot_primitives::{AuthorityDiscoveryId, SessionIndex, ValidatorIndex};
 use rand::{CryptoRng, Rng};
 use std::{
 	collections::{hash_map, HashMap, HashSet},

--- a/node/network/protocol/src/lib.rs
+++ b/node/network/protocol/src/lib.rs
@@ -20,7 +20,7 @@
 #![warn(missing_docs)]
 
 use parity_scale_codec::{Decode, Encode};
-use polkadot_primitives::v2::{BlockNumber, Hash};
+use polkadot_primitives::{BlockNumber, Hash};
 use std::{collections::HashMap, fmt};
 
 #[doc(hidden)]
@@ -139,7 +139,7 @@ impl std::ops::Deref for OurView {
 ///
 /// ```
 /// # use polkadot_node_network_protocol::our_view;
-/// # use polkadot_primitives::v2::Hash;
+/// # use polkadot_primitives::Hash;
 /// let our_view = our_view![Hash::repeat_byte(1), Hash::repeat_byte(2)];
 /// ```
 #[macro_export]
@@ -173,7 +173,7 @@ pub struct View {
 ///
 /// ```
 /// # use polkadot_node_network_protocol::view;
-/// # use polkadot_primitives::v2::Hash;
+/// # use polkadot_primitives::Hash;
 /// let view = view![Hash::repeat_byte(1), Hash::repeat_byte(2)];
 /// ```
 #[macro_export]
@@ -398,7 +398,7 @@ impl_versioned_try_from!(
 pub mod v1 {
 	use parity_scale_codec::{Decode, Encode};
 
-	use polkadot_primitives::v2::{
+	use polkadot_primitives::{
 		CandidateHash, CandidateIndex, CollatorId, CollatorSignature, CompactStatement, Hash,
 		Id as ParaId, UncheckedSignedAvailabilityBitfield, ValidatorIndex, ValidatorSignature,
 	};

--- a/node/network/protocol/src/peer_set.rs
+++ b/node/network/protocol/src/peer_set.rs
@@ -17,7 +17,7 @@
 //! All peersets and protocols used for parachains.
 
 use derive_more::Display;
-use polkadot_primitives::v2::Hash;
+use polkadot_primitives::Hash;
 use sc_network_common::{
 	config::{NonDefaultSetConfig, SetConfig},
 	protocol::ProtocolName,

--- a/node/network/protocol/src/request_response/mod.rs
+++ b/node/network/protocol/src/request_response/mod.rs
@@ -35,7 +35,7 @@
 use std::{collections::HashMap, time::Duration, u64};
 
 use futures::channel::mpsc;
-use polkadot_primitives::v2::{MAX_CODE_SIZE, MAX_POV_SIZE};
+use polkadot_primitives::{MAX_CODE_SIZE, MAX_POV_SIZE};
 use strum::{EnumIter, IntoEnumIterator};
 
 pub use sc_network::{config as network, config::RequestResponseConfig, ProtocolName};

--- a/node/network/protocol/src/request_response/outgoing.rs
+++ b/node/network/protocol/src/request_response/outgoing.rs
@@ -21,7 +21,7 @@ use parity_scale_codec::{Decode, Encode, Error as DecodingError};
 use sc_network as network;
 use sc_network::PeerId;
 
-use polkadot_primitives::v2::AuthorityDiscoveryId;
+use polkadot_primitives::AuthorityDiscoveryId;
 
 use super::{v1, IsRequest, Protocol};
 

--- a/node/network/protocol/src/request_response/v1.rs
+++ b/node/network/protocol/src/request_response/v1.rs
@@ -21,7 +21,7 @@ use parity_scale_codec::{Decode, Encode};
 use polkadot_node_primitives::{
 	AvailableData, DisputeMessage, ErasureChunk, PoV, Proof, UncheckedDisputeMessage,
 };
-use polkadot_primitives::v2::{
+use polkadot_primitives::{
 	CandidateHash, CandidateReceipt, CommittedCandidateReceipt, Hash, Id as ParaId, ValidatorIndex,
 };
 

--- a/node/network/statement-distribution/src/error.rs
+++ b/node/network/statement-distribution/src/error.rs
@@ -20,7 +20,7 @@
 use polkadot_node_network_protocol::PeerId;
 use polkadot_node_subsystem::SubsystemError;
 use polkadot_node_subsystem_util::runtime;
-use polkadot_primitives::v2::{CandidateHash, Hash};
+use polkadot_primitives::{CandidateHash, Hash};
 
 use crate::LOG_TARGET;
 

--- a/node/network/statement-distribution/src/lib.rs
+++ b/node/network/statement-distribution/src/lib.rs
@@ -45,7 +45,7 @@ use polkadot_node_subsystem::{
 	overseer, ActiveLeavesUpdate, FromOrchestra, OverseerSignal, PerLeafSpan, SpawnedSubsystem,
 	SubsystemError,
 };
-use polkadot_primitives::v2::{
+use polkadot_primitives::{
 	AuthorityDiscoveryId, CandidateHash, CommittedCandidateReceipt, CompactStatement, Hash,
 	IndexedVec, SignedStatement, SigningContext, UncheckedSignedStatement, ValidatorId,
 	ValidatorIndex, ValidatorSignature,

--- a/node/network/statement-distribution/src/requester.rs
+++ b/node/network/statement-distribution/src/requester.rs
@@ -30,7 +30,7 @@ use polkadot_node_network_protocol::{
 };
 use polkadot_node_subsystem::{Span, Stage};
 use polkadot_node_subsystem_util::TimeoutExt;
-use polkadot_primitives::v2::{CandidateHash, CommittedCandidateReceipt, Hash};
+use polkadot_primitives::{CandidateHash, CommittedCandidateReceipt, Hash};
 
 use crate::{metrics::Metrics, COST_WRONG_HASH, LOG_TARGET};
 

--- a/node/network/statement-distribution/src/responder.rs
+++ b/node/network/statement-distribution/src/responder.rs
@@ -29,7 +29,7 @@ use polkadot_node_network_protocol::{
 	},
 	PeerId, UnifiedReputationChange as Rep,
 };
-use polkadot_primitives::v2::{CandidateHash, CommittedCandidateReceipt, Hash};
+use polkadot_primitives::{CandidateHash, CommittedCandidateReceipt, Hash};
 
 use crate::LOG_TARGET;
 

--- a/node/network/statement-distribution/src/tests.rs
+++ b/node/network/statement-distribution/src/tests.rs
@@ -35,7 +35,7 @@ use polkadot_node_subsystem::{
 	ActivatedLeaf, LeafStatus,
 };
 use polkadot_node_subsystem_test_helpers::mock::make_ferdie_keystore;
-use polkadot_primitives::v2::{
+use polkadot_primitives::{
 	GroupIndex, Hash, Id as ParaId, IndexedVec, SessionInfo, ValidationCode, ValidatorId,
 };
 use polkadot_primitives_test_helpers::{

--- a/node/overseer/examples/minimal-example.rs
+++ b/node/overseer/examples/minimal-example.rs
@@ -32,7 +32,7 @@ use polkadot_overseer::{
 	gen::{FromOrchestra, SpawnedSubsystem},
 	HeadSupportsParachains, SubsystemError,
 };
-use polkadot_primitives::v2::{CandidateReceipt, Hash};
+use polkadot_primitives::{CandidateReceipt, Hash};
 
 struct AlwaysSupportsParachains;
 

--- a/node/overseer/src/lib.rs
+++ b/node/overseer/src/lib.rs
@@ -72,7 +72,7 @@ use futures::{channel::oneshot, future::BoxFuture, select, Future, FutureExt, St
 use lru::LruCache;
 
 use client::{BlockImportNotification, BlockchainEvents, FinalityNotification};
-use polkadot_primitives::v2::{Block, BlockNumber, Hash};
+use polkadot_primitives::{Block, BlockNumber, Hash};
 
 use self::messages::{BitfieldSigningMessage, PvfCheckerMessage};
 use polkadot_node_subsystem_types::messages::{
@@ -370,7 +370,7 @@ pub async fn forward_events<P: BlockchainEvents<Block>>(client: Arc<P>, mut hand
 /// # use std::time::Duration;
 /// # use futures::{executor, pin_mut, select, FutureExt};
 /// # use futures_timer::Delay;
-/// # use polkadot_primitives::v2::Hash;
+/// # use polkadot_primitives::Hash;
 /// # use polkadot_overseer::{
 /// # 	self as overseer,
 /// #   OverseerSignal,

--- a/node/overseer/src/tests.rs
+++ b/node/overseer/src/tests.rs
@@ -29,7 +29,7 @@ use polkadot_node_subsystem_types::{
 	messages::{NetworkBridgeEvent, RuntimeApiRequest},
 	ActivatedLeaf, LeafStatus,
 };
-use polkadot_primitives::v2::{
+use polkadot_primitives::{
 	CandidateHash, CandidateReceipt, CollatorPair, InvalidDisputeStatementKind, SessionIndex,
 	ValidDisputeStatementKind, ValidatorIndex,
 };

--- a/node/primitives/src/approval.rs
+++ b/node/primitives/src/approval.rs
@@ -20,7 +20,7 @@ pub use sp_consensus_babe::Slot;
 pub use sp_consensus_vrf::schnorrkel::{Randomness, VRFOutput, VRFProof};
 
 use parity_scale_codec::{Decode, Encode};
-use polkadot_primitives::v2::{
+use polkadot_primitives::{
 	BlockNumber, CandidateHash, CandidateIndex, CoreIndex, Hash, Header, SessionIndex,
 	ValidatorIndex, ValidatorSignature,
 };

--- a/node/primitives/src/disputes/message.rs
+++ b/node/primitives/src/disputes/message.rs
@@ -24,7 +24,7 @@ use thiserror::Error;
 use parity_scale_codec::{Decode, Encode};
 
 use super::{InvalidDisputeVote, SignedDisputeStatement, ValidDisputeVote};
-use polkadot_primitives::v2::{
+use polkadot_primitives::{
 	CandidateReceipt, DisputeStatement, SessionIndex, SessionInfo, ValidatorIndex,
 };
 

--- a/node/primitives/src/disputes/mod.rs
+++ b/node/primitives/src/disputes/mod.rs
@@ -25,7 +25,7 @@ use sp_application_crypto::AppKey;
 use sp_keystore::{CryptoStore, Error as KeystoreError, SyncCryptoStorePtr};
 
 use super::{Statement, UncheckedSignedFullStatement};
-use polkadot_primitives::v2::{
+use polkadot_primitives::{
 	CandidateHash, CandidateReceipt, DisputeStatement, InvalidDisputeStatementKind, SessionIndex,
 	SigningContext, ValidDisputeStatementKind, ValidatorId, ValidatorIndex, ValidatorSignature,
 };

--- a/node/primitives/src/lib.rs
+++ b/node/primitives/src/lib.rs
@@ -29,7 +29,7 @@ use futures::Future;
 use parity_scale_codec::{Decode, Encode, Error as CodecError, Input};
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 
-use polkadot_primitives::v2::{
+use polkadot_primitives::{
 	BlakeTwo256, BlockNumber, CandidateCommitments, CandidateHash, CollatorPair,
 	CommittedCandidateReceipt, CompactStatement, EncodeAs, Hash, HashT, HeadData, Id as ParaId,
 	OutboundHrmpMessage, PersistedValidationData, SessionIndex, Signed, UncheckedSigned,
@@ -312,7 +312,7 @@ impl MaybeCompressedPoV {
 /// - contains a proof of validity.
 #[derive(Clone, Encode, Decode)]
 #[cfg(not(target_os = "unknown"))]
-pub struct Collation<BlockNumber = polkadot_primitives::v2::BlockNumber> {
+pub struct Collation<BlockNumber = polkadot_primitives::BlockNumber> {
 	/// Messages destined to be interpreted by the Relay chain itself.
 	pub upward_messages: Vec<UpwardMessage>,
 	/// The horizontal messages sent by the parachain.

--- a/node/service/src/chain_spec.rs
+++ b/node/service/src/chain_spec.rs
@@ -25,7 +25,7 @@ use kusama_runtime as kusama;
 use kusama_runtime_constants::currency::UNITS as KSM;
 use pallet_im_online::sr25519::AuthorityId as ImOnlineId;
 use pallet_staking::Forcing;
-use polkadot_primitives::v2::{AccountId, AccountPublic, AssignmentId, ValidatorId};
+use polkadot_primitives::{AccountId, AccountPublic, AssignmentId, ValidatorId};
 #[cfg(feature = "polkadot-native")]
 use polkadot_runtime as polkadot;
 #[cfg(feature = "polkadot-native")]
@@ -67,9 +67,9 @@ const DEFAULT_PROTOCOL_ID: &str = "dot";
 #[serde(rename_all = "camelCase")]
 pub struct Extensions {
 	/// Block numbers with known hashes.
-	pub fork_blocks: sc_client_api::ForkBlocks<polkadot_primitives::v2::Block>,
+	pub fork_blocks: sc_client_api::ForkBlocks<polkadot_primitives::Block>,
 	/// Known bad block hashes.
-	pub bad_blocks: sc_client_api::BadBlocks<polkadot_primitives::v2::Block>,
+	pub bad_blocks: sc_client_api::BadBlocks<polkadot_primitives::Block>,
 	/// The light sync state.
 	///
 	/// This value will be set by the `sync-state rpc` implementation.
@@ -172,10 +172,9 @@ pub fn wococo_config() -> Result<RococoChainSpec, String> {
 	feature = "polkadot-native"
 ))]
 fn default_parachains_host_configuration(
-) -> polkadot_runtime_parachains::configuration::HostConfiguration<
-	polkadot_primitives::v2::BlockNumber,
-> {
-	use polkadot_primitives::v2::{MAX_CODE_SIZE, MAX_POV_SIZE};
+) -> polkadot_runtime_parachains::configuration::HostConfiguration<polkadot_primitives::BlockNumber>
+{
+	use polkadot_primitives::{MAX_CODE_SIZE, MAX_POV_SIZE};
 
 	polkadot_runtime_parachains::configuration::HostConfiguration {
 		validation_upgrade_cooldown: 2u32,
@@ -570,7 +569,7 @@ fn westend_staging_testnet_config_genesis(wasm_binary: &[u8]) -> westend::Genesi
 		},
 		paras: Default::default(),
 		registrar: westend_runtime::RegistrarConfig {
-			next_free_para_id: polkadot_primitives::v2::LOWEST_PUBLIC_ID,
+			next_free_para_id: polkadot_primitives::LOWEST_PUBLIC_ID,
 		},
 		xcm_pallet: Default::default(),
 		nomination_pools: Default::default(),
@@ -1074,7 +1073,7 @@ fn rococo_staging_testnet_config_genesis(wasm_binary: &[u8]) -> rococo_runtime::
 			config: default_parachains_host_configuration(),
 		},
 		registrar: rococo_runtime::RegistrarConfig {
-			next_free_para_id: polkadot_primitives::v2::LOWEST_PUBLIC_ID,
+			next_free_para_id: polkadot_primitives::LOWEST_PUBLIC_ID,
 		},
 		xcm_pallet: Default::default(),
 		nis_counterpart_balances: Default::default(),
@@ -1547,7 +1546,7 @@ pub fn westend_testnet_genesis(
 		},
 		paras: Default::default(),
 		registrar: westend_runtime::RegistrarConfig {
-			next_free_para_id: polkadot_primitives::v2::LOWEST_PUBLIC_ID,
+			next_free_para_id: polkadot_primitives::LOWEST_PUBLIC_ID,
 		},
 		xcm_pallet: Default::default(),
 		nomination_pools: Default::default(),
@@ -1631,7 +1630,7 @@ pub fn rococo_testnet_genesis(
 		},
 		paras: rococo_runtime::ParasConfig { paras: vec![] },
 		registrar: rococo_runtime::RegistrarConfig {
-			next_free_para_id: polkadot_primitives::v2::LOWEST_PUBLIC_ID,
+			next_free_para_id: polkadot_primitives::LOWEST_PUBLIC_ID,
 		},
 		xcm_pallet: Default::default(),
 		nis_counterpart_balances: Default::default(),

--- a/node/service/src/grandpa_support.rs
+++ b/node/service/src/grandpa_support.rs
@@ -23,7 +23,7 @@ use sp_runtime::traits::{Block as BlockT, Header as _, NumberFor};
 use crate::HeaderProvider;
 
 #[cfg(feature = "full-node")]
-use polkadot_primitives::v2::{Block, Hash};
+use polkadot_primitives::{Block, Hash};
 
 /// Returns the block hash of the block at the given `target_number` by walking
 /// backwards from the given `current_header`.

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -101,7 +101,7 @@ pub use polkadot_client::{
 	AbstractClient, Client, ClientHandle, ExecuteWithClient, FullBackend, FullClient,
 	RuntimeApiCollection,
 };
-pub use polkadot_primitives::v2::{Block, BlockId, BlockNumber, CollatorPair, Hash, Id as ParaId};
+pub use polkadot_primitives::{Block, BlockId, BlockNumber, CollatorPair, Hash, Id as ParaId};
 pub use sc_client_api::{Backend, CallExecutor, ExecutionStrategy};
 pub use sc_consensus::{BlockImport, LongestChain};
 use sc_executor::NativeElseWasmExecutor;

--- a/node/service/src/relay_chain_selection.rs
+++ b/node/service/src/relay_chain_selection.rs
@@ -45,9 +45,7 @@ use polkadot_node_subsystem::messages::{
 };
 use polkadot_node_subsystem_util::metrics::{self, prometheus};
 use polkadot_overseer::{AllMessages, Handle};
-use polkadot_primitives::v2::{
-	Block as PolkadotBlock, BlockNumber, Hash, Header as PolkadotHeader,
-};
+use polkadot_primitives::{Block as PolkadotBlock, BlockNumber, Hash, Header as PolkadotHeader};
 use std::sync::Arc;
 
 /// The maximum amount of unfinalized blocks we are willing to allow due to approval checking
@@ -56,7 +54,7 @@ use std::sync::Arc;
 /// This is a safety net that should be removed at some point in the future.
 // In sync with `MAX_HEADS_LOOK_BACK` in `approval-voting`
 // and `MAX_BATCH_SCRAPE_ANCESTORS` in `dispute-coordinator`.
-const MAX_FINALITY_LAG: polkadot_primitives::v2::BlockNumber = PRIMITIVES_MAX_FINALITY_LAG;
+const MAX_FINALITY_LAG: polkadot_primitives::BlockNumber = PRIMITIVES_MAX_FINALITY_LAG;
 
 const LOG_TARGET: &str = "parachain::chain-selection";
 

--- a/node/service/src/tests.rs
+++ b/node/service/src/tests.rs
@@ -40,7 +40,7 @@ use polkadot_node_subsystem::messages::{
 	ApprovalVotingMessage, ChainSelectionMessage, DisputeCoordinatorMessage,
 	HighestApprovedAncestorBlock,
 };
-use polkadot_primitives::v2::{Block, BlockNumber, Hash, Header};
+use polkadot_primitives::{Block, BlockNumber, Hash, Header};
 
 use polkadot_node_subsystem_test_helpers::TestSubsystemSender;
 use polkadot_overseer::{SubsystemContext, SubsystemSender};

--- a/node/subsystem-test-helpers/src/lib.rs
+++ b/node/subsystem-test-helpers/src/lib.rs
@@ -437,7 +437,7 @@ mod tests {
 	use futures::executor::block_on;
 	use polkadot_node_subsystem::messages::CollatorProtocolMessage;
 	use polkadot_overseer::{dummy::dummy_overseer_builder, Handle, HeadSupportsParachains};
-	use polkadot_primitives::v2::Hash;
+	use polkadot_primitives::Hash;
 	use sp_core::traits::SpawnNamed;
 
 	struct AlwaysSupportsParachains;

--- a/node/subsystem-test-helpers/src/mock.rs
+++ b/node/subsystem-test-helpers/src/mock.rs
@@ -21,7 +21,7 @@ use sp_application_crypto::AppKey;
 use sp_keyring::Sr25519Keyring;
 use sp_keystore::{SyncCryptoStore, SyncCryptoStorePtr};
 
-use polkadot_primitives::v2::{AuthorityDiscoveryId, ValidatorId};
+use polkadot_primitives::{AuthorityDiscoveryId, ValidatorId};
 
 /// Get mock keystore with `Ferdie` key.
 pub fn make_ferdie_keystore() -> SyncCryptoStorePtr {

--- a/node/subsystem-types/src/lib.rs
+++ b/node/subsystem-types/src/lib.rs
@@ -24,7 +24,7 @@
 
 use std::{fmt, sync::Arc};
 
-pub use polkadot_primitives::v2::{BlockNumber, Hash};
+pub use polkadot_primitives::{BlockNumber, Hash};
 use smallvec::SmallVec;
 
 pub mod errors;

--- a/node/subsystem-types/src/messages.rs
+++ b/node/subsystem-types/src/messages.rs
@@ -38,7 +38,7 @@ use polkadot_node_primitives::{
 	CollationSecondedSignal, DisputeMessage, DisputeStatus, ErasureChunk, PoV,
 	SignedDisputeStatement, SignedFullStatement, ValidationResult,
 };
-use polkadot_primitives::v2::{
+use polkadot_primitives::{
 	AuthorityDiscoveryId, BackedCandidate, BlockNumber, CandidateEvent, CandidateHash,
 	CandidateIndex, CandidateReceipt, CollatorId, CommittedCandidateReceipt, CoreState,
 	DisputeState, GroupIndex, GroupRotationInfo, Hash, Header as BlockHeader, Id as ParaId,
@@ -642,7 +642,7 @@ pub enum RuntimeApiRequest {
 	/// Sends back `true` if the validation outputs pass all acceptance criteria checks.
 	CheckValidationOutputs(
 		ParaId,
-		polkadot_primitives::v2::CandidateCommitments,
+		polkadot_primitives::CandidateCommitments,
 		RuntimeApiSender<bool>,
 	),
 	/// Get the session index that a child of the block will have.
@@ -672,7 +672,7 @@ pub enum RuntimeApiRequest {
 	/// Get information about the BABE epoch the block was included in.
 	CurrentBabeEpoch(RuntimeApiSender<BabeEpoch>),
 	/// Get all disputes in relation to a relay parent.
-	FetchOnChainVotes(RuntimeApiSender<Option<polkadot_primitives::v2::ScrapedOnChainVotes>>),
+	FetchOnChainVotes(RuntimeApiSender<Option<polkadot_primitives::ScrapedOnChainVotes>>),
 	/// Submits a PVF pre-checking statement into the transaction pool.
 	SubmitPvfCheckStatement(PvfCheckStatement, ValidatorSignature, RuntimeApiSender<()>),
 	/// Returns code hashes of PVFs that require pre-checking by validators in the active set.

--- a/node/subsystem-types/src/messages/network_bridge_event.rs
+++ b/node/subsystem-types/src/messages/network_bridge_event.rs
@@ -22,7 +22,7 @@ use polkadot_node_network_protocol::{
 	grid_topology::SessionGridTopology, peer_set::ProtocolVersion, ObservedRole, OurView, View,
 	WrongVariant,
 };
-use polkadot_primitives::v2::{AuthorityDiscoveryId, SessionIndex, ValidatorIndex};
+use polkadot_primitives::{AuthorityDiscoveryId, SessionIndex, ValidatorIndex};
 
 /// A struct indicating new gossip topology.
 #[derive(Debug, Clone, PartialEq)]

--- a/node/subsystem-types/src/runtime_client.rs
+++ b/node/subsystem-types/src/runtime_client.rs
@@ -16,14 +16,11 @@
 
 use async_trait::async_trait;
 use polkadot_primitives::{
-	runtime_api::ParachainHost,
-	v2::{
-		Block, BlockId, BlockNumber, CandidateCommitments, CandidateEvent, CandidateHash,
-		CommittedCandidateReceipt, CoreState, DisputeState, GroupRotationInfo, Hash, Id,
-		InboundDownwardMessage, InboundHrmpMessage, OccupiedCoreAssumption,
-		PersistedValidationData, PvfCheckStatement, ScrapedOnChainVotes, SessionIndex, SessionInfo,
-		ValidationCode, ValidationCodeHash, ValidatorId, ValidatorIndex, ValidatorSignature,
-	},
+	runtime_api::ParachainHost, Block, BlockId, BlockNumber, CandidateCommitments, CandidateEvent,
+	CandidateHash, CommittedCandidateReceipt, CoreState, DisputeState, GroupRotationInfo, Hash, Id,
+	InboundDownwardMessage, InboundHrmpMessage, OccupiedCoreAssumption, PersistedValidationData,
+	PvfCheckStatement, ScrapedOnChainVotes, SessionIndex, SessionInfo, ValidationCode,
+	ValidationCodeHash, ValidatorId, ValidatorIndex, ValidatorSignature,
 };
 use sp_api::{ApiError, ApiExt, ProvideRuntimeApi};
 use sp_authority_discovery::AuthorityDiscoveryApi;
@@ -157,7 +154,7 @@ pub trait RuntimeApiSubsystemClient {
 		&self,
 		at: Hash,
 		index: SessionIndex,
-	) -> Result<Option<polkadot_primitives::v2::OldV1SessionInfo>, ApiError>;
+	) -> Result<Option<polkadot_primitives::OldV1SessionInfo>, ApiError>;
 
 	/// Submits a PVF pre-checking statement into the transaction pool.
 	///
@@ -370,7 +367,7 @@ where
 		&self,
 		at: Hash,
 		index: SessionIndex,
-	) -> Result<Option<polkadot_primitives::v2::OldV1SessionInfo>, ApiError> {
+	) -> Result<Option<polkadot_primitives::OldV1SessionInfo>, ApiError> {
 		#[allow(deprecated)]
 		self.runtime_api().session_info_before_version_2(&BlockId::Hash(at), index)
 	}

--- a/node/subsystem-util/src/determine_new_blocks.rs
+++ b/node/subsystem-util/src/determine_new_blocks.rs
@@ -18,7 +18,7 @@
 
 use futures::{channel::oneshot, prelude::*};
 use polkadot_node_subsystem::{messages::ChainApiMessage, SubsystemSender};
-use polkadot_primitives::v2::{BlockNumber, Hash, Header};
+use polkadot_primitives::{BlockNumber, Hash, Header};
 
 /// Given a new chain-head hash, this determines the hashes of all new blocks we should track
 /// metadata for, given this head.

--- a/node/subsystem-util/src/lib.rs
+++ b/node/subsystem-util/src/lib.rs
@@ -40,7 +40,7 @@ pub use polkadot_node_metrics::{metrics, Metronome};
 use futures::channel::{mpsc, oneshot};
 use parity_scale_codec::Encode;
 
-use polkadot_primitives::v2::{
+use polkadot_primitives::{
 	AuthorityDiscoveryId, CandidateEvent, CommittedCandidateReceipt, CoreState, EncodeAs,
 	GroupIndex, GroupRotationInfo, Hash, Id as ParaId, OccupiedCoreAssumption,
 	PersistedValidationData, ScrapedOnChainVotes, SessionIndex, SessionInfo, Signed,

--- a/node/subsystem-util/src/rolling_session_window.rs
+++ b/node/subsystem-util/src/rolling_session_window.rs
@@ -24,7 +24,7 @@ use kvdb::{DBKey, DBOp};
 
 use parity_scale_codec::{Decode, Encode};
 pub use polkadot_node_primitives::{new_session_window_size, SessionWindowSize};
-use polkadot_primitives::v2::{BlockNumber, Hash, SessionIndex, SessionInfo};
+use polkadot_primitives::{BlockNumber, Hash, SessionIndex, SessionInfo};
 use std::sync::Arc;
 
 use futures::channel::oneshot;
@@ -594,7 +594,7 @@ mod tests {
 		SubsystemContext,
 	};
 	use polkadot_node_subsystem_test_helpers::make_subsystem_context;
-	use polkadot_primitives::v2::Header;
+	use polkadot_primitives::Header;
 	use sp_core::testing::TaskExecutor;
 
 	const SESSION_DATA_COL: u32 = 0;

--- a/node/subsystem-util/src/runtime/error.rs
+++ b/node/subsystem-util/src/runtime/error.rs
@@ -20,7 +20,7 @@
 use futures::channel::oneshot;
 
 use polkadot_node_subsystem::errors::RuntimeApiError;
-use polkadot_primitives::v2::SessionIndex;
+use polkadot_primitives::SessionIndex;
 
 #[allow(missing_docs)]
 #[fatality::fatality(splitable)]

--- a/node/subsystem-util/src/runtime/mod.rs
+++ b/node/subsystem-util/src/runtime/mod.rs
@@ -26,7 +26,7 @@ use sp_core::crypto::ByteArray;
 use sp_keystore::{CryptoStore, SyncCryptoStorePtr};
 
 use polkadot_node_subsystem::{messages::RuntimeApiMessage, overseer, SubsystemSender};
-use polkadot_primitives::v2::{
+use polkadot_primitives::{
 	CandidateEvent, CoreState, EncodeAs, GroupIndex, GroupRotationInfo, Hash, IndexedVec,
 	OccupiedCore, ScrapedOnChainVotes, SessionIndex, SessionInfo, Signed, SigningContext,
 	UncheckedSigned, ValidationCode, ValidationCodeHash, ValidatorId, ValidatorIndex,

--- a/node/test/client/src/block_builder.rs
+++ b/node/test/client/src/block_builder.rs
@@ -16,7 +16,7 @@
 
 use crate::{Client, FullBackend};
 use parity_scale_codec::{Decode, Encode};
-use polkadot_primitives::v2::{Block, InherentData as ParachainsInherentData};
+use polkadot_primitives::{Block, InherentData as ParachainsInherentData};
 use polkadot_test_runtime::{GetLastTimestamp, UncheckedExtrinsic};
 use sc_block_builder::{BlockBuilder, BlockBuilderProvider};
 use sp_api::ProvideRuntimeApi;
@@ -111,7 +111,7 @@ impl InitPolkadotBlockBuilder for Client {
 
 		inherent_data
 			.put_data(
-				polkadot_primitives::v2::PARACHAINS_INHERENT_IDENTIFIER,
+				polkadot_primitives::PARACHAINS_INHERENT_IDENTIFIER,
 				&parachains_inherent_data,
 			)
 			.expect("Put parachains inherent data");

--- a/node/test/client/src/lib.rs
+++ b/node/test/client/src/lib.rs
@@ -20,7 +20,7 @@
 
 mod block_builder;
 
-use polkadot_primitives::v2::Block;
+use polkadot_primitives::Block;
 use sc_service::client;
 use sp_core::storage::Storage;
 use sp_runtime::BuildStorage;

--- a/node/test/service/src/chain_spec.rs
+++ b/node/test/service/src/chain_spec.rs
@@ -19,7 +19,7 @@
 use babe_primitives::AuthorityId as BabeId;
 use grandpa::AuthorityId as GrandpaId;
 use pallet_staking::Forcing;
-use polkadot_primitives::v2::{AccountId, AssignmentId, ValidatorId, MAX_CODE_SIZE, MAX_POV_SIZE};
+use polkadot_primitives::{AccountId, AssignmentId, ValidatorId, MAX_CODE_SIZE, MAX_POV_SIZE};
 use polkadot_service::chain_spec::{
 	get_account_id_from_seed, get_from_seed, polkadot_chain_spec_properties, Extensions,
 };

--- a/node/test/service/src/lib.rs
+++ b/node/test/service/src/lib.rs
@@ -25,7 +25,7 @@ use futures::future::Future;
 use polkadot_node_primitives::{CollationGenerationConfig, CollatorFn};
 use polkadot_node_subsystem::messages::{CollationGenerationMessage, CollatorProtocolMessage};
 use polkadot_overseer::Handle;
-use polkadot_primitives::v2::{Balance, CollatorPair, HeadData, Id as ParaId, ValidationCode};
+use polkadot_primitives::{Balance, CollatorPair, HeadData, Id as ParaId, ValidationCode};
 use polkadot_runtime_common::BlockHashCount;
 use polkadot_runtime_parachains::paras::{ParaGenesisArgs, ParaKind};
 use polkadot_service::{
@@ -381,7 +381,7 @@ pub fn construct_extrinsic(
 	UncheckedExtrinsic::new_signed(
 		function.clone(),
 		polkadot_test_runtime::Address::Id(caller.public().into()),
-		polkadot_primitives::v2::Signature::Sr25519(signature.clone()),
+		polkadot_primitives::Signature::Sr25519(signature.clone()),
 		extra.clone(),
 	)
 }

--- a/parachain/test-parachains/adder/collator/src/lib.rs
+++ b/parachain/test-parachains/adder/collator/src/lib.rs
@@ -23,7 +23,7 @@ use polkadot_node_primitives::{
 	Collation, CollationResult, CollationSecondedSignal, CollatorFn, MaybeCompressedPoV, PoV,
 	Statement,
 };
-use polkadot_primitives::v2::{CollatorId, CollatorPair};
+use polkadot_primitives::{CollatorId, CollatorPair};
 use sp_core::{traits::SpawnNamed, Pair};
 use std::{
 	collections::HashMap,
@@ -248,7 +248,7 @@ mod tests {
 
 	use futures::executor::block_on;
 	use polkadot_parachain::primitives::{ValidationParams, ValidationResult};
-	use polkadot_primitives::v2::PersistedValidationData;
+	use polkadot_primitives::PersistedValidationData;
 
 	#[test]
 	fn collator_works() {

--- a/parachain/test-parachains/adder/collator/src/main.rs
+++ b/parachain/test-parachains/adder/collator/src/main.rs
@@ -19,7 +19,7 @@
 use polkadot_cli::{Error, Result};
 use polkadot_node_primitives::CollationGenerationConfig;
 use polkadot_node_subsystem::messages::{CollationGenerationMessage, CollatorProtocolMessage};
-use polkadot_primitives::v2::Id as ParaId;
+use polkadot_primitives::Id as ParaId;
 use sc_cli::{Error as SubstrateCliError, SubstrateCli};
 use sp_core::hexdisplay::HexDisplay;
 use test_parachain_adder_collator::Collator;

--- a/parachain/test-parachains/adder/collator/tests/integration.rs
+++ b/parachain/test-parachains/adder/collator/tests/integration.rs
@@ -23,7 +23,7 @@ const PUPPET_EXE: &str = env!("CARGO_BIN_EXE_adder_collator_puppet_worker");
 
 #[substrate_test_utils::test(flavor = "multi_thread")]
 async fn collating_using_adder_collator() {
-	use polkadot_primitives::v2::Id as ParaId;
+	use polkadot_primitives::Id as ParaId;
 	use sp_keyring::AccountKeyring::*;
 
 	let mut builder = sc_cli::LoggerBuilder::new("");

--- a/parachain/test-parachains/undying/collator/src/lib.rs
+++ b/parachain/test-parachains/undying/collator/src/lib.rs
@@ -23,7 +23,7 @@ use polkadot_node_primitives::{
 	maybe_compress_pov, Collation, CollationResult, CollationSecondedSignal, CollatorFn,
 	MaybeCompressedPoV, PoV, Statement,
 };
-use polkadot_primitives::v2::{CollatorId, CollatorPair, Hash};
+use polkadot_primitives::{CollatorId, CollatorPair, Hash};
 use sp_core::Pair;
 use std::{
 	collections::HashMap,
@@ -330,7 +330,7 @@ mod tests {
 	use super::*;
 	use futures::executor::block_on;
 	use polkadot_parachain::primitives::{ValidationParams, ValidationResult};
-	use polkadot_primitives::v2::{Hash, PersistedValidationData};
+	use polkadot_primitives::{Hash, PersistedValidationData};
 
 	#[test]
 	fn collator_works() {

--- a/parachain/test-parachains/undying/collator/src/main.rs
+++ b/parachain/test-parachains/undying/collator/src/main.rs
@@ -19,7 +19,7 @@
 use polkadot_cli::{Error, Result};
 use polkadot_node_primitives::CollationGenerationConfig;
 use polkadot_node_subsystem::messages::{CollationGenerationMessage, CollatorProtocolMessage};
-use polkadot_primitives::v2::Id as ParaId;
+use polkadot_primitives::Id as ParaId;
 use sc_cli::{Error as SubstrateCliError, SubstrateCli};
 use sp_core::hexdisplay::HexDisplay;
 use test_parachain_undying_collator::Collator;

--- a/parachain/test-parachains/undying/collator/tests/integration.rs
+++ b/parachain/test-parachains/undying/collator/tests/integration.rs
@@ -22,7 +22,7 @@ const PUPPET_EXE: &str = env!("CARGO_BIN_EXE_undying_collator_puppet_worker");
 // If this test is failing, make sure to run all tests with the `real-overseer` feature being enabled.
 #[substrate_test_utils::test(flavor = "multi_thread")]
 async fn collating_using_undying_collator() {
-	use polkadot_primitives::v2::Id as ParaId;
+	use polkadot_primitives::Id as ParaId;
 	use sp_keyring::AccountKeyring::*;
 
 	let mut builder = sc_cli::LoggerBuilder::new("");

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -30,3 +30,33 @@ pub mod vstaging;
 // `runtime_api` contains the actual API implementation. It contains stable and
 // unstable functions.
 pub mod runtime_api;
+
+// Current primitives not requiring versioning are exported here.
+// Primitives requiring versioning must not be exported and must be referred by an exact version.
+pub use v2::{
+	byzantine_threshold, check_candidate_backing, collator_signature_payload, metric_definitions,
+	supermajority_threshold, well_known_keys, AbridgedHostConfiguration, AbridgedHrmpChannel,
+	AccountId, AccountIndex, AccountPublic, ApprovalVote, AssignmentId, AuthorityDiscoveryId,
+	AvailabilityBitfield, BackedCandidate, Balance, BlakeTwo256, Block, BlockId, BlockNumber,
+	CandidateCommitments, CandidateDescriptor, CandidateEvent, CandidateHash, CandidateIndex,
+	CandidateReceipt, CheckedDisputeStatementSet, CheckedMultiDisputeStatementSet, CollatorId,
+	CollatorSignature, CommittedCandidateReceipt, CompactStatement, ConsensusLog, CoreIndex,
+	CoreOccupied, CoreState, DisputeState, DisputeStatement, DisputeStatementSet, DownwardMessage,
+	EncodeAs, ExplicitDisputeStatement, GroupIndex, GroupRotationInfo, Hash, HashT, HeadData,
+	Header, HrmpChannelId, Id, InboundDownwardMessage, InboundHrmpMessage, IndexedVec,
+	InherentData, InvalidDisputeStatementKind, Moment, MultiDisputeStatementSet, Nonce,
+	OccupiedCore, OccupiedCoreAssumption, OldV1SessionInfo, OutboundHrmpMessage, ParathreadClaim,
+	ParathreadEntry, PersistedValidationData, PvfCheckStatement, RuntimeMetricLabel,
+	RuntimeMetricLabelValue, RuntimeMetricLabelValues, RuntimeMetricLabels, RuntimeMetricOp,
+	RuntimeMetricUpdate, ScheduledCore, ScrapedOnChainVotes, SessionIndex, SessionInfo, Signature,
+	Signed, SignedAvailabilityBitfield, SignedAvailabilityBitfields, SignedStatement,
+	SigningContext, UncheckedSigned, UncheckedSignedAvailabilityBitfield,
+	UncheckedSignedAvailabilityBitfields, UncheckedSignedStatement, UpgradeGoAhead,
+	UpgradeRestriction, UpwardMessage, ValidDisputeStatementKind, ValidationCode,
+	ValidationCodeHash, ValidatorId, ValidatorIndex, ValidatorSignature, ValidityAttestation,
+	ValidityError, ASSIGNMENT_KEY_TYPE_ID, LOWEST_PUBLIC_ID, MAX_CODE_SIZE, MAX_HEAD_DATA_SIZE,
+	MAX_POV_SIZE, PARACHAINS_INHERENT_IDENTIFIER, PARACHAIN_KEY_TYPE_ID,
+};
+
+#[cfg(feature = "std")]
+pub use v2::{AssignmentPair, CollatorPair, ValidatorPair};

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -50,7 +50,7 @@ pub use v2::{
 	RuntimeMetricLabelValue, RuntimeMetricLabelValues, RuntimeMetricLabels, RuntimeMetricOp,
 	RuntimeMetricUpdate, ScheduledCore, ScrapedOnChainVotes, SessionIndex, SessionInfo, Signature,
 	Signed, SignedAvailabilityBitfield, SignedAvailabilityBitfields, SignedStatement,
-	SigningContext, UncheckedSigned, UncheckedSignedAvailabilityBitfield,
+	SigningContext, Slot, UncheckedSigned, UncheckedSignedAvailabilityBitfield,
 	UncheckedSignedAvailabilityBitfields, UncheckedSignedStatement, UpgradeGoAhead,
 	UpgradeRestriction, UpwardMessage, ValidDisputeStatementKind, ValidationCode,
 	ValidationCodeHash, ValidatorId, ValidatorIndex, ValidatorSignature, ValidityAttestation,

--- a/primitives/src/v2/mod.rs
+++ b/primitives/src/v2/mod.rs
@@ -35,7 +35,7 @@ use sp_arithmetic::traits::{BaseArithmetic, Saturating};
 pub use runtime_primitives::traits::{BlakeTwo256, Hash as HashT};
 
 // Export some core primitives.
-pub use polkadot_core_primitives::v2::{
+pub use polkadot_core_primitives::{
 	AccountId, AccountIndex, AccountPublic, Balance, Block, BlockId, BlockNumber, CandidateHash,
 	ChainId, DownwardMessage, Hash, Header, InboundDownwardMessage, InboundHrmpMessage, Moment,
 	Nonce, OutboundHrmpMessage, Remark, Signature, UncheckedExtrinsic,

--- a/primitives/test-helpers/src/lib.rs
+++ b/primitives/test-helpers/src/lib.rs
@@ -21,7 +21,7 @@
 //!
 //! Note that `dummy_` prefixed values are meant to be fillers, that should not matter, and will
 //! contain randomness based data.
-use polkadot_primitives::v2::{
+use polkadot_primitives::{
 	CandidateCommitments, CandidateDescriptor, CandidateReceipt, CollatorId, CollatorSignature,
 	CommittedCandidateReceipt, Hash, HeadData, Id as ParaId, ValidationCode, ValidationCodeHash,
 	ValidatorId,
@@ -159,7 +159,7 @@ pub fn make_valid_candidate_descriptor<H: AsRef<[u8]>>(
 	collator: Sr25519Keyring,
 ) -> CandidateDescriptor<H> {
 	let validation_code_hash = validation_code_hash.into();
-	let payload = polkadot_primitives::v2::collator_signature_payload::<H>(
+	let payload = polkadot_primitives::collator_signature_payload::<H>(
 		&relay_parent,
 		&para_id,
 		&persisted_validation_data_hash,
@@ -190,7 +190,7 @@ pub fn resign_candidate_descriptor_with_collator<H: AsRef<[u8]>>(
 	collator: Sr25519Keyring,
 ) {
 	descriptor.collator = collator.public().into();
-	let payload = polkadot_primitives::v2::collator_signature_payload::<H>(
+	let payload = polkadot_primitives::collator_signature_payload::<H>(
 		&descriptor.relay_parent,
 		&descriptor.para_id,
 		&descriptor.persisted_validation_data_hash,
@@ -256,6 +256,6 @@ impl rand::RngCore for AlwaysZeroRng {
 	}
 }
 
-pub fn dummy_signature() -> polkadot_primitives::v2::ValidatorSignature {
+pub fn dummy_signature() -> polkadot_primitives::ValidatorSignature {
 	sp_core::crypto::UncheckedFrom::unchecked_from([1u8; 64])
 }

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -21,7 +21,7 @@
 use std::sync::Arc;
 
 use jsonrpsee::RpcModule;
-use polkadot_primitives::v2::{AccountId, Balance, Block, BlockNumber, Hash, Nonce};
+use polkadot_primitives::{AccountId, Balance, Block, BlockNumber, Hash, Nonce};
 use sc_client_api::AuxStore;
 use sc_consensus_babe::{BabeConfiguration, Epoch};
 use sc_finality_grandpa::FinalityProofProvider;

--- a/runtime/common/src/assigned_slots.rs
+++ b/runtime/common/src/assigned_slots.rs
@@ -32,7 +32,7 @@ use frame_support::{pallet_prelude::*, traits::Currency};
 use frame_system::pallet_prelude::*;
 pub use pallet::*;
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
-use primitives::v2::Id as ParaId;
+use primitives::Id as ParaId;
 use runtime_parachains::{
 	configuration,
 	paras::{self},
@@ -549,7 +549,7 @@ mod tests {
 	use frame_support::{assert_noop, assert_ok, parameter_types};
 	use frame_system::EnsureRoot;
 	use pallet_balances;
-	use primitives::v2::{BlockNumber, Header};
+	use primitives::{BlockNumber, Header};
 	use runtime_parachains::{
 		configuration as parachains_configuration, paras as parachains_paras,
 		shared as parachains_shared,

--- a/runtime/common/src/auctions.rs
+++ b/runtime/common/src/auctions.rs
@@ -30,7 +30,7 @@ use frame_support::{
 };
 pub use pallet::*;
 use parity_scale_codec::Decode;
-use primitives::v2::Id as ParaId;
+use primitives::Id as ParaId;
 use sp_runtime::traits::{CheckedSub, One, Saturating, Zero};
 use sp_std::{mem::swap, prelude::*};
 
@@ -684,7 +684,7 @@ mod tests {
 	};
 	use frame_system::{EnsureRoot, EnsureSignedBy};
 	use pallet_balances;
-	use primitives::v2::{BlockNumber, Header, Id as ParaId};
+	use primitives::{BlockNumber, Header, Id as ParaId};
 	use sp_core::H256;
 	use sp_runtime::traits::{BlakeTwo256, IdentityLookup};
 	use std::{cell::RefCell, collections::BTreeMap};

--- a/runtime/common/src/claims.rs
+++ b/runtime/common/src/claims.rs
@@ -23,7 +23,7 @@ use frame_support::{
 };
 pub use pallet::*;
 use parity_scale_codec::{Decode, Encode};
-use primitives::v2::ValidityError;
+use primitives::ValidityError;
 use scale_info::TypeInfo;
 #[cfg(feature = "std")]
 use serde::{self, Deserialize, Deserializer, Serialize, Serializer};

--- a/runtime/common/src/crowdloan/mod.rs
+++ b/runtime/common/src/crowdloan/mod.rs
@@ -70,7 +70,7 @@ use frame_support::{
 };
 pub use pallet::*;
 use parity_scale_codec::{Decode, Encode};
-use primitives::v2::Id as ParaId;
+use primitives::Id as ParaId;
 use scale_info::TypeInfo;
 use sp_runtime::{
 	traits::{
@@ -866,7 +866,7 @@ mod tests {
 		assert_noop, assert_ok, parameter_types,
 		traits::{OnFinalize, OnInitialize},
 	};
-	use primitives::v2::Id as ParaId;
+	use primitives::Id as ParaId;
 	use sp_core::H256;
 	use std::{cell::RefCell, collections::BTreeMap, sync::Arc};
 	// The testing primitives are very useful for avoiding having to work with signatures

--- a/runtime/common/src/impls.rs
+++ b/runtime/common/src/impls.rs
@@ -18,7 +18,7 @@
 
 use crate::NegativeImbalance;
 use frame_support::traits::{Currency, Imbalance, OnUnbalanced};
-use primitives::v2::Balance;
+use primitives::Balance;
 use sp_runtime::Perquintill;
 
 /// Logic for the author to get a portion of fees.
@@ -26,8 +26,8 @@ pub struct ToAuthor<R>(sp_std::marker::PhantomData<R>);
 impl<R> OnUnbalanced<NegativeImbalance<R>> for ToAuthor<R>
 where
 	R: pallet_balances::Config + pallet_authorship::Config,
-	<R as frame_system::Config>::AccountId: From<primitives::v2::AccountId>,
-	<R as frame_system::Config>::AccountId: Into<primitives::v2::AccountId>,
+	<R as frame_system::Config>::AccountId: From<primitives::AccountId>,
+	<R as frame_system::Config>::AccountId: Into<primitives::AccountId>,
 {
 	fn on_nonzero_unbalanced(amount: NegativeImbalance<R>) {
 		if let Some(author) = <pallet_authorship::Pallet<R>>::author() {
@@ -41,8 +41,8 @@ impl<R> OnUnbalanced<NegativeImbalance<R>> for DealWithFees<R>
 where
 	R: pallet_balances::Config + pallet_treasury::Config + pallet_authorship::Config,
 	pallet_treasury::Pallet<R>: OnUnbalanced<NegativeImbalance<R>>,
-	<R as frame_system::Config>::AccountId: From<primitives::v2::AccountId>,
-	<R as frame_system::Config>::AccountId: Into<primitives::v2::AccountId>,
+	<R as frame_system::Config>::AccountId: From<primitives::AccountId>,
+	<R as frame_system::Config>::AccountId: Into<primitives::AccountId>,
 {
 	fn on_unbalanceds<B>(mut fees_then_tips: impl Iterator<Item = NegativeImbalance<R>>) {
 		if let Some(fees) = fees_then_tips.next() {
@@ -105,7 +105,7 @@ mod tests {
 		dispatch::DispatchClass, parameter_types, traits::FindAuthor, weights::Weight, PalletId,
 	};
 	use frame_system::limits;
-	use primitives::v2::AccountId;
+	use primitives::AccountId;
 	use sp_core::H256;
 	use sp_runtime::{
 		testing::Header,

--- a/runtime/common/src/integration_tests.rs
+++ b/runtime/common/src/integration_tests.rs
@@ -31,9 +31,7 @@ use frame_support::{
 use frame_support_test::TestRandomness;
 use frame_system::EnsureRoot;
 use parity_scale_codec::Encode;
-use primitives::v2::{
-	BlockNumber, HeadData, Header, Id as ParaId, ValidationCode, LOWEST_PUBLIC_ID,
-};
+use primitives::{BlockNumber, HeadData, Header, Id as ParaId, ValidationCode, LOWEST_PUBLIC_ID};
 use runtime_parachains::{
 	configuration, origin, paras, shared, Origin as ParaOrigin, ParaLifecycle,
 };

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -43,7 +43,7 @@ use frame_support::{
 	weights::{constants::WEIGHT_REF_TIME_PER_SECOND, Weight},
 };
 use frame_system::limits;
-use primitives::v2::{AssignmentId, Balance, BlockNumber, ValidatorId, MAX_POV_SIZE};
+use primitives::{AssignmentId, Balance, BlockNumber, ValidatorId, MAX_POV_SIZE};
 use sp_runtime::{FixedPointNumber, Perbill, Perquintill};
 use static_assertions::const_assert;
 
@@ -157,7 +157,7 @@ macro_rules! impl_runtime_weights {
 ///
 /// This must only be used as long as the balance type is `u128`.
 pub type CurrencyToVote = frame_support::traits::U128CurrencyToVote;
-static_assertions::assert_eq_size!(primitives::v2::Balance, u128);
+static_assertions::assert_eq_size!(primitives::Balance, u128);
 
 /// A placeholder since there is currently no provided session key handler for parachain validator
 /// keys.

--- a/runtime/common/src/mock.rs
+++ b/runtime/common/src/mock.rs
@@ -22,7 +22,7 @@ use frame_support::{
 	weights::Weight,
 };
 use parity_scale_codec::{Decode, Encode};
-use primitives::v2::{HeadData, Id as ParaId, ValidationCode};
+use primitives::{HeadData, Id as ParaId, ValidationCode};
 use sp_runtime::{traits::SaturatedConversion, Permill};
 use std::{cell::RefCell, collections::HashMap};
 

--- a/runtime/common/src/paras_registrar.rs
+++ b/runtime/common/src/paras_registrar.rs
@@ -24,7 +24,7 @@ use frame_support::{
 	traits::{Currency, Get, ReservableCurrency},
 };
 use frame_system::{self, ensure_root, ensure_signed};
-use primitives::v2::{HeadData, Id as ParaId, ValidationCode, LOWEST_PUBLIC_ID};
+use primitives::{HeadData, Id as ParaId, ValidationCode, LOWEST_PUBLIC_ID};
 use runtime_parachains::{
 	configuration, ensure_parachain,
 	paras::{self, ParaGenesisArgs},
@@ -663,7 +663,7 @@ mod tests {
 	};
 	use frame_system::limits;
 	use pallet_balances::Error as BalancesError;
-	use primitives::v2::{Balance, BlockNumber, Header};
+	use primitives::{Balance, BlockNumber, Header};
 	use runtime_parachains::{configuration, origin, shared};
 	use sp_core::H256;
 	use sp_io::TestExternalities;
@@ -1289,7 +1289,7 @@ mod benchmarking {
 	use crate::traits::Registrar as RegistrarT;
 	use frame_support::assert_ok;
 	use frame_system::RawOrigin;
-	use primitives::v2::{MAX_CODE_SIZE, MAX_HEAD_DATA_SIZE};
+	use primitives::{MAX_CODE_SIZE, MAX_HEAD_DATA_SIZE};
 	use runtime_parachains::{paras, shared, Origin as ParaOrigin};
 	use sp_runtime::traits::Bounded;
 

--- a/runtime/common/src/paras_sudo_wrapper.rs
+++ b/runtime/common/src/paras_sudo_wrapper.rs
@@ -20,7 +20,7 @@ use frame_support::pallet_prelude::*;
 use frame_system::pallet_prelude::*;
 pub use pallet::*;
 use parity_scale_codec::Encode;
-use primitives::v2::Id as ParaId;
+use primitives::Id as ParaId;
 use runtime_parachains::{
 	configuration, dmp, hrmp,
 	paras::{self, ParaGenesisArgs},

--- a/runtime/common/src/slots/mod.rs
+++ b/runtime/common/src/slots/mod.rs
@@ -31,7 +31,7 @@ use frame_support::{
 };
 use frame_system::pallet_prelude::*;
 pub use pallet::*;
-use primitives::v2::Id as ParaId;
+use primitives::Id as ParaId;
 use sp_runtime::traits::{CheckedConversion, CheckedSub, Saturating, Zero};
 use sp_std::prelude::*;
 
@@ -506,7 +506,7 @@ mod tests {
 	use frame_support::{assert_noop, assert_ok, parameter_types};
 	use frame_system::EnsureRoot;
 	use pallet_balances;
-	use primitives::v2::{BlockNumber, Header};
+	use primitives::{BlockNumber, Header};
 	use sp_core::H256;
 	use sp_runtime::traits::{BlakeTwo256, IdentityLookup};
 

--- a/runtime/common/src/traits.rs
+++ b/runtime/common/src/traits.rs
@@ -20,7 +20,7 @@ use frame_support::{
 	dispatch::DispatchResult,
 	traits::{Currency, ReservableCurrency},
 };
-use primitives::v2::{HeadData, Id as ParaId, ValidationCode};
+use primitives::{HeadData, Id as ParaId, ValidationCode};
 use sp_std::vec::*;
 
 /// Parachain registration API.

--- a/runtime/kusama/constants/src/lib.rs
+++ b/runtime/kusama/constants/src/lib.rs
@@ -20,7 +20,7 @@ pub mod weights;
 
 /// Money matters.
 pub mod currency {
-	use primitives::v2::Balance;
+	use primitives::Balance;
 
 	/// The existential deposit.
 	pub const EXISTENTIAL_DEPOSIT: Balance = 1 * CENTS;
@@ -38,7 +38,7 @@ pub mod currency {
 
 /// Time and blocks.
 pub mod time {
-	use primitives::v2::{BlockNumber, Moment};
+	use primitives::{BlockNumber, Moment};
 	use runtime_common::prod_or_fast;
 	pub const MILLISECS_PER_BLOCK: Moment = 6000;
 	pub const SLOT_DURATION: Moment = MILLISECS_PER_BLOCK;
@@ -63,7 +63,7 @@ pub mod fee {
 	use frame_support::weights::{
 		WeightToFeeCoefficient, WeightToFeeCoefficients, WeightToFeePolynomial,
 	};
-	use primitives::v2::Balance;
+	use primitives::Balance;
 	use smallvec::smallvec;
 	pub use sp_runtime::Perbill;
 

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -22,7 +22,7 @@
 
 use pallet_nis::WithMaximumOf;
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
-use primitives::v2::{
+use primitives::{
 	AccountId, AccountIndex, Balance, BlockNumber, CandidateEvent, CommittedCandidateReceipt,
 	CoreState, GroupRotationInfo, Hash, Id as ParaId, InboundDownwardMessage, InboundHrmpMessage,
 	Moment, Nonce, OccupiedCoreAssumption, PersistedValidationData, ScrapedOnChainVotes,
@@ -1324,7 +1324,7 @@ impl pallet_nomination_pools::Config for Runtime {
 construct_runtime! {
 	pub enum Runtime where
 		Block = Block,
-		NodeBlock = primitives::v2::Block,
+		NodeBlock = primitives::Block,
 		UncheckedExtrinsic = UncheckedExtrinsic
 	{
 		// Basic stuff; balances is uncallable initially.
@@ -1661,7 +1661,7 @@ sp_api::impl_runtime_apis! {
 
 		fn check_validation_outputs(
 			para_id: ParaId,
-			outputs: primitives::v2::CandidateCommitments,
+			outputs: primitives::CandidateCommitments,
 		) -> bool {
 			parachains_runtime_api_impl::check_validation_outputs::<Runtime>(para_id, outputs)
 		}
@@ -1713,8 +1713,8 @@ sp_api::impl_runtime_apis! {
 		}
 
 		fn submit_pvf_check_statement(
-			stmt: primitives::v2::PvfCheckStatement,
-			signature: primitives::v2::ValidatorSignature,
+			stmt: primitives::PvfCheckStatement,
+			signature: primitives::ValidatorSignature,
 		) {
 			parachains_runtime_api_impl::submit_pvf_check_statement::<Runtime>(stmt, signature)
 		}

--- a/runtime/metrics/src/with_runtime_metrics.rs
+++ b/runtime/metrics/src/with_runtime_metrics.rs
@@ -23,7 +23,7 @@
 const TRACING_TARGET: &'static str = "metrics";
 
 use parity_scale_codec::Encode;
-use primitives::v2::{
+use primitives::{
 	metric_definitions::{CounterDefinition, CounterVecDefinition},
 	RuntimeMetricLabelValues, RuntimeMetricOp, RuntimeMetricUpdate,
 };

--- a/runtime/metrics/src/without_runtime_metrics.rs
+++ b/runtime/metrics/src/without_runtime_metrics.rs
@@ -18,7 +18,7 @@
 //! provide a dummy implementation for the native runtime to avoid cluttering the runtime code
 //! with `#[cfg(feature = "runtime-metrics")]`.
 
-use primitives::v2::metric_definitions::{CounterDefinition, CounterVecDefinition};
+use primitives::metric_definitions::{CounterDefinition, CounterVecDefinition};
 
 /// A dummy `Counter`.
 pub struct Counter;

--- a/runtime/parachains/src/builder.rs
+++ b/runtime/parachains/src/builder.rs
@@ -22,7 +22,7 @@ use crate::{
 };
 use bitvec::{order::Lsb0 as BitOrderLsb0, vec::BitVec};
 use frame_support::pallet_prelude::*;
-use primitives::v2::{
+use primitives::{
 	collator_signature_payload, AvailabilityBitfield, BackedCandidate, CandidateCommitments,
 	CandidateDescriptor, CandidateHash, CollatorId, CollatorSignature, CommittedCandidateReceipt,
 	CompactStatement, CoreIndex, CoreOccupied, DisputeStatement, DisputeStatementSet, GroupIndex,

--- a/runtime/parachains/src/configuration.rs
+++ b/runtime/parachains/src/configuration.rs
@@ -22,7 +22,7 @@ use crate::shared;
 use frame_support::{pallet_prelude::*, weights::constants::WEIGHT_REF_TIME_PER_MILLIS};
 use frame_system::pallet_prelude::*;
 use parity_scale_codec::{Decode, Encode};
-use primitives::v2::{Balance, SessionIndex, MAX_CODE_SIZE, MAX_HEAD_DATA_SIZE, MAX_POV_SIZE};
+use primitives::{Balance, SessionIndex, MAX_CODE_SIZE, MAX_HEAD_DATA_SIZE, MAX_POV_SIZE};
 use sp_runtime::traits::Zero;
 use sp_std::prelude::*;
 
@@ -1164,7 +1164,7 @@ pub mod pallet {
 		fn integrity_test() {
 			assert_eq!(
 				&ActiveConfig::<T>::hashed_key(),
-				primitives::v2::well_known_keys::ACTIVE_CONFIG,
+				primitives::well_known_keys::ACTIVE_CONFIG,
 				"`well_known_keys::ACTIVE_CONFIG` doesn't match key of `ActiveConfig`! Make sure that the name of the\
 				 configuration pallet is `Configuration` in the runtime!",
 			);

--- a/runtime/parachains/src/configuration/migration.rs
+++ b/runtime/parachains/src/configuration/migration.rs
@@ -34,7 +34,7 @@ pub const STORAGE_VERSION: StorageVersion = StorageVersion::new(3);
 pub mod v3 {
 	use super::*;
 	use frame_support::traits::OnRuntimeUpgrade;
-	use primitives::v2::{Balance, SessionIndex};
+	use primitives::{Balance, SessionIndex};
 
 	// Copied over from configuration.rs @ de9e147695b9f1be8bd44e07861a31e483c8343a and removed
 	// all the comments, and changed the Weight struct to OldWeight
@@ -241,9 +241,8 @@ mod tests {
 		// doesn't need to be read and also leaving it as one line allows to easily copy it.
 		let raw_config = hex_literal::hex!["0000a000005000000a00000000c8000000c800000a0000000a000000100e0000580200000000500000c8000000e87648170000001e00000000000000005039278c0400000000000000000000005039278c0400000000000000000000e8030000009001001e00000000000000009001008070000000000000000000000a0000000a0000000a00000001000000010500000001c8000000060000005802000002000000580200000200000059000000000000001e0000002800000000c817a804000000000200000014000000"];
 
-		let v2 =
-			v3::OldHostConfiguration::<primitives::v2::BlockNumber>::decode(&mut &raw_config[..])
-				.unwrap();
+		let v2 = v3::OldHostConfiguration::<primitives::BlockNumber>::decode(&mut &raw_config[..])
+			.unwrap();
 
 		// We check only a sample of the values here. If we missed any fields or messed up data types
 		// that would skew all the fields coming after.
@@ -267,7 +266,7 @@ mod tests {
 		// We specify only the picked fields and the rest should be provided by the `Default`
 		// implementation. That implementation is copied over between the two types and should work
 		// fine.
-		let v2 = v3::OldHostConfiguration::<primitives::v2::BlockNumber> {
+		let v2 = v3::OldHostConfiguration::<primitives::BlockNumber> {
 			ump_max_individual_weight: OldWeight(0x71616e6f6e0au64),
 			needed_approvals: 69,
 			thread_availability_period: 55,

--- a/runtime/parachains/src/configuration/tests.rs
+++ b/runtime/parachains/src/configuration/tests.rs
@@ -539,7 +539,7 @@ fn verify_externally_accessible() {
 	// This test verifies that the value can be accessed through the well known keys and the
 	// host configuration decodes into the abridged version.
 
-	use primitives::v2::{well_known_keys, AbridgedHostConfiguration};
+	use primitives::{well_known_keys, AbridgedHostConfiguration};
 
 	new_test_ext(Default::default()).execute_with(|| {
 		let ground_truth = HostConfiguration::default();

--- a/runtime/parachains/src/disputes.rs
+++ b/runtime/parachains/src/disputes.rs
@@ -21,7 +21,7 @@ use bitvec::{bitvec, order::Lsb0 as BitOrderLsb0};
 use frame_support::{ensure, traits::Get, weights::Weight};
 use frame_system::pallet_prelude::*;
 use parity_scale_codec::{Decode, Encode};
-use primitives::v2::{
+use primitives::{
 	byzantine_threshold, supermajority_threshold, ApprovalVote, CandidateHash,
 	CheckedDisputeStatementSet, CheckedMultiDisputeStatementSet, CompactStatement, ConsensusLog,
 	DisputeState, DisputeStatement, DisputeStatementSet, ExplicitDisputeStatement,

--- a/runtime/parachains/src/disputes/slashing.rs
+++ b/runtime/parachains/src/disputes/slashing.rs
@@ -51,7 +51,7 @@ use frame_support::{
 };
 
 use parity_scale_codec::{Decode, Encode};
-use primitives::v2::{CandidateHash, SessionIndex, ValidatorId, ValidatorIndex};
+use primitives::{CandidateHash, SessionIndex, ValidatorId, ValidatorIndex};
 use scale_info::TypeInfo;
 use sp_runtime::{
 	traits::Convert,
@@ -488,7 +488,7 @@ pub mod pallet {
 			ensure_none(origin)?;
 
 			// check the membership proof to extract the offender's id
-			let key = (primitives::v2::PARACHAIN_KEY_TYPE_ID, dispute_proof.validator_id.clone());
+			let key = (primitives::PARACHAIN_KEY_TYPE_ID, dispute_proof.validator_id.clone());
 			let offender = T::KeyOwnerProofSystem::check_proof(key, key_owner_proof)
 				.ok_or(Error::<T>::InvalidKeyOwnershipProof)?;
 
@@ -640,7 +640,7 @@ fn is_known_offence<T: Config>(
 	key_owner_proof: &T::KeyOwnerProof,
 ) -> Result<(), TransactionValidityError> {
 	// check the membership proof to extract the offender's id
-	let key = (primitives::v2::PARACHAIN_KEY_TYPE_ID, dispute_proof.validator_id.clone());
+	let key = (primitives::PARACHAIN_KEY_TYPE_ID, dispute_proof.validator_id.clone());
 
 	let offender = T::KeyOwnerProofSystem::check_proof(key, key_owner_proof.clone())
 		.ok_or(InvalidTransaction::BadProof)?;

--- a/runtime/parachains/src/disputes/slashing/benchmarking.rs
+++ b/runtime/parachains/src/disputes/slashing/benchmarking.rs
@@ -21,7 +21,7 @@ use frame_benchmarking::{benchmarks, whitelist_account};
 use frame_support::traits::{OnFinalize, OnInitialize};
 use frame_system::RawOrigin;
 use pallet_staking::testing_utils::create_validators;
-use primitives::v2::{Hash, PARACHAIN_KEY_TYPE_ID};
+use primitives::{Hash, PARACHAIN_KEY_TYPE_ID};
 use sp_runtime::traits::{One, StaticLookup};
 use sp_session::MembershipProof;
 

--- a/runtime/parachains/src/disputes/tests.rs
+++ b/runtime/parachains/src/disputes/tests.rs
@@ -28,7 +28,7 @@ use frame_support::{
 	assert_err, assert_noop, assert_ok,
 	traits::{OnFinalize, OnInitialize},
 };
-use primitives::v2::BlockNumber;
+use primitives::BlockNumber;
 use sp_core::{crypto::CryptoType, Pair};
 
 /// Filtering updates the spam slots, as such update them.

--- a/runtime/parachains/src/dmp.rs
+++ b/runtime/parachains/src/dmp.rs
@@ -19,7 +19,7 @@ use crate::{
 	initializer,
 };
 use frame_support::pallet_prelude::*;
-use primitives::v2::{DownwardMessage, Hash, Id as ParaId, InboundDownwardMessage};
+use primitives::{DownwardMessage, Hash, Id as ParaId, InboundDownwardMessage};
 use sp_runtime::traits::{BlakeTwo256, Hash as HashT, SaturatedConversion};
 use sp_std::{fmt, prelude::*};
 use xcm::latest::SendError;

--- a/runtime/parachains/src/dmp/tests.rs
+++ b/runtime/parachains/src/dmp/tests.rs
@@ -18,7 +18,7 @@ use super::*;
 use crate::mock::{new_test_ext, Configuration, Dmp, MockGenesisConfig, Paras, System};
 use hex_literal::hex;
 use parity_scale_codec::Encode;
-use primitives::v2::BlockNumber;
+use primitives::BlockNumber;
 
 pub(crate) fn run_to_block(to: BlockNumber, new_session: Option<Vec<BlockNumber>>) {
 	while System::block_number() < to {
@@ -184,7 +184,7 @@ fn queue_downward_message_critical() {
 #[test]
 fn verify_dmq_mqc_head_is_externally_accessible() {
 	use hex_literal::hex;
-	use primitives::v2::well_known_keys;
+	use primitives::well_known_keys;
 
 	let a = ParaId::from(2020);
 

--- a/runtime/parachains/src/hrmp.rs
+++ b/runtime/parachains/src/hrmp.rs
@@ -21,7 +21,7 @@ use crate::{
 use frame_support::{pallet_prelude::*, traits::ReservableCurrency};
 use frame_system::pallet_prelude::*;
 use parity_scale_codec::{Decode, Encode};
-use primitives::v2::{
+use primitives::{
 	Balance, Hash, HrmpChannelId, Id as ParaId, InboundHrmpMessage, OutboundHrmpMessage,
 	SessionIndex,
 };

--- a/runtime/parachains/src/hrmp/tests.rs
+++ b/runtime/parachains/src/hrmp/tests.rs
@@ -23,7 +23,7 @@ use crate::{
 	paras::ParaKind,
 };
 use frame_support::{assert_noop, assert_ok, traits::Currency as _};
-use primitives::v2::BlockNumber;
+use primitives::BlockNumber;
 use std::collections::BTreeMap;
 
 fn run_to_block(to: BlockNumber, new_session: Option<Vec<BlockNumber>>) {
@@ -418,7 +418,7 @@ fn check_sent_messages() {
 
 #[test]
 fn verify_externally_accessible() {
-	use primitives::v2::{well_known_keys, AbridgedHrmpChannel};
+	use primitives::{well_known_keys, AbridgedHrmpChannel};
 
 	let para_a = 20.into();
 	let para_b = 21.into();

--- a/runtime/parachains/src/inclusion/mod.rs
+++ b/runtime/parachains/src/inclusion/mod.rs
@@ -27,7 +27,7 @@ use crate::{
 use bitvec::{order::Lsb0 as BitOrderLsb0, vec::BitVec};
 use frame_support::pallet_prelude::*;
 use parity_scale_codec::{Decode, Encode};
-use primitives::v2::{
+use primitives::{
 	AvailabilityBitfield, BackedCandidate, CandidateCommitments, CandidateDescriptor,
 	CandidateHash, CandidateReceipt, CommittedCandidateReceipt, CoreIndex, GroupIndex, Hash,
 	HeadData, Id as ParaId, SigningContext, UncheckedSignedAvailabilityBitfields, ValidatorId,
@@ -574,7 +574,7 @@ impl<T: Config> Pallet<T> {
 
 						// check the signatures in the backing and that it is a majority.
 						{
-							let maybe_amount_validated = primitives::v2::check_candidate_backing(
+							let maybe_amount_validated = primitives::check_candidate_backing(
 								&backed_candidate,
 								&signing_context,
 								group_vals.len(),
@@ -691,7 +691,7 @@ impl<T: Config> Pallet<T> {
 	/// Run the acceptance criteria checks on the given candidate commitments.
 	pub(crate) fn check_validation_outputs_for_runtime_api(
 		para_id: ParaId,
-		validation_outputs: primitives::v2::CandidateCommitments,
+		validation_outputs: primitives::CandidateCommitments,
 	) -> bool {
 		// This function is meant to be called from the runtime APIs against the relay-parent, hence
 		// `relay_parent_number` is equal to `now`.
@@ -1037,11 +1037,11 @@ impl<T: Config> CandidateCheckContext<T> {
 		&self,
 		para_id: ParaId,
 		head_data: &HeadData,
-		new_validation_code: &Option<primitives::v2::ValidationCode>,
+		new_validation_code: &Option<primitives::ValidationCode>,
 		processed_downward_messages: u32,
-		upward_messages: &[primitives::v2::UpwardMessage],
+		upward_messages: &[primitives::UpwardMessage],
 		hrmp_watermark: T::BlockNumber,
-		horizontal_messages: &[primitives::v2::OutboundHrmpMessage<ParaId>],
+		horizontal_messages: &[primitives::OutboundHrmpMessage<ParaId>],
 	) -> Result<(), AcceptanceCheckErr<T::BlockNumber>> {
 		ensure!(
 			head_data.0.len() <= self.config.max_head_data_size as _,

--- a/runtime/parachains/src/inclusion/tests.rs
+++ b/runtime/parachains/src/inclusion/tests.rs
@@ -30,7 +30,7 @@ use assert_matches::assert_matches;
 use frame_support::assert_noop;
 use futures::executor::block_on;
 use keyring::Sr25519Keyring;
-use primitives::v2::{
+use primitives::{
 	BlockNumber, CandidateCommitments, CandidateDescriptor, CollatorId,
 	CompactStatement as Statement, Hash, SignedAvailabilityBitfield, SignedStatement,
 	UncheckedSignedAvailabilityBitfield, ValidationCode, ValidatorId, ValidityAttestation,
@@ -91,7 +91,7 @@ pub(crate) fn collator_sign_candidate(
 ) {
 	candidate.descriptor.collator = collator.public().into();
 
-	let payload = primitives::v2::collator_signature_payload(
+	let payload = primitives::collator_signature_payload(
 		&candidate.descriptor.relay_parent,
 		&candidate.descriptor.para_id,
 		&candidate.descriptor.persisted_validation_data_hash,
@@ -146,7 +146,7 @@ pub(crate) async fn back_candidate(
 	let backed = BackedCandidate { candidate, validity_votes, validator_indices };
 
 	let successfully_backed =
-		primitives::v2::check_candidate_backing(&backed, signing_context, group.len(), |i| {
+		primitives::check_candidate_backing(&backed, signing_context, group.len(), |i| {
 			Some(validators[group[i].0 as usize].public().into())
 		})
 		.ok()

--- a/runtime/parachains/src/initializer.rs
+++ b/runtime/parachains/src/initializer.rs
@@ -30,7 +30,7 @@ use frame_support::{
 };
 use frame_system::limits::BlockWeights;
 use parity_scale_codec::{Decode, Encode};
-use primitives::v2::{BlockNumber, ConsensusLog, SessionIndex, ValidatorId};
+use primitives::{BlockNumber, ConsensusLog, SessionIndex, ValidatorId};
 use scale_info::TypeInfo;
 use sp_std::prelude::*;
 

--- a/runtime/parachains/src/initializer/benchmarking.rs
+++ b/runtime/parachains/src/initializer/benchmarking.rs
@@ -17,7 +17,7 @@
 use super::*;
 use frame_benchmarking::benchmarks;
 use frame_system::RawOrigin;
-use primitives::v2::ConsensusLog;
+use primitives::ConsensusLog;
 use sp_runtime::DigestItem;
 
 // Random large number for the digest

--- a/runtime/parachains/src/initializer/tests.rs
+++ b/runtime/parachains/src/initializer/tests.rs
@@ -18,7 +18,7 @@ use super::*;
 use crate::mock::{
 	new_test_ext, Configuration, Dmp, Initializer, MockGenesisConfig, Paras, SessionInfo, System,
 };
-use primitives::v2::{HeadData, Id as ParaId};
+use primitives::{HeadData, Id as ParaId};
 use test_helpers::dummy_validation_code;
 
 use crate::paras::ParaKind;

--- a/runtime/parachains/src/lib.rs
+++ b/runtime/parachains/src/lib.rs
@@ -50,7 +50,7 @@ mod mock;
 
 pub use origin::{ensure_parachain, Origin};
 pub use paras::ParaLifecycle;
-use primitives::v2::{HeadData, Id as ParaId, ValidationCode};
+use primitives::{HeadData, Id as ParaId, ValidationCode};
 use sp_runtime::DispatchResult;
 
 /// Schedule a para to be initialized at the start of the next session with the given genesis data.
@@ -66,7 +66,7 @@ pub fn schedule_para_initialize<T: paras::Config>(
 /// Schedule a para to be cleaned up at the start of the next session.
 ///
 /// See [`paras::Pallet::schedule_para_cleanup`] for more details.
-pub fn schedule_para_cleanup<T: paras::Config>(id: primitives::v2::Id) -> Result<(), ()> {
+pub fn schedule_para_cleanup<T: paras::Config>(id: primitives::Id) -> Result<(), ()> {
 	<paras::Pallet<T>>::schedule_para_cleanup(id).map_err(|_| ())
 }
 

--- a/runtime/parachains/src/metrics.rs
+++ b/runtime/parachains/src/metrics.rs
@@ -17,7 +17,7 @@
 //! Runtime declaration of the parachain metrics.
 
 use polkadot_runtime_metrics::{Counter, CounterVec};
-use primitives::v2::metric_definitions::{
+use primitives::metric_definitions::{
 	PARACHAIN_CREATE_INHERENT_BITFIELDS_SIGNATURE_CHECKS,
 	PARACHAIN_INHERENT_DATA_BITFIELDS_PROCESSED, PARACHAIN_INHERENT_DATA_CANDIDATES_PROCESSED,
 	PARACHAIN_INHERENT_DATA_DISPUTE_SETS_INCLUDED, PARACHAIN_INHERENT_DATA_DISPUTE_SETS_PROCESSED,

--- a/runtime/parachains/src/mock.rs
+++ b/runtime/parachains/src/mock.rs
@@ -30,7 +30,7 @@ use frame_support::{
 };
 use frame_support_test::TestRandomness;
 use parity_scale_codec::Decode;
-use primitives::v2::{
+use primitives::{
 	AuthorityDiscoveryId, Balance, BlockNumber, CandidateHash, Header, Moment, SessionIndex,
 	UpwardMessage, ValidatorIndex,
 };

--- a/runtime/parachains/src/origin.rs
+++ b/runtime/parachains/src/origin.rs
@@ -16,7 +16,7 @@
 
 //! Declaration of the parachain specific origin and a pallet that hosts it.
 
-use primitives::v2::Id as ParaId;
+use primitives::Id as ParaId;
 use sp_runtime::traits::BadOrigin;
 use sp_std::result;
 

--- a/runtime/parachains/src/paras/benchmarking.rs
+++ b/runtime/parachains/src/paras/benchmarking.rs
@@ -18,7 +18,7 @@ use super::*;
 use crate::configuration::HostConfiguration;
 use frame_benchmarking::benchmarks;
 use frame_system::RawOrigin;
-use primitives::v2::{HeadData, Id as ParaId, ValidationCode, MAX_CODE_SIZE, MAX_HEAD_DATA_SIZE};
+use primitives::{HeadData, Id as ParaId, ValidationCode, MAX_CODE_SIZE, MAX_HEAD_DATA_SIZE};
 use sp_runtime::traits::{One, Saturating};
 
 mod pvf_check;

--- a/runtime/parachains/src/paras/benchmarking/pvf_check.rs
+++ b/runtime/parachains/src/paras/benchmarking/pvf_check.rs
@@ -18,7 +18,7 @@
 
 use crate::{configuration, paras::*, shared::Pallet as ParasShared};
 use frame_system::RawOrigin;
-use primitives::v2::{HeadData, Id as ParaId, ValidationCode, ValidatorId, ValidatorIndex};
+use primitives::{HeadData, Id as ParaId, ValidationCode, ValidatorId, ValidatorIndex};
 use sp_application_crypto::RuntimeAppPublic;
 
 // Constants for the benchmarking
@@ -179,7 +179,7 @@ where
 {
 	let validators = ParasShared::<T>::active_validator_keys();
 
-	let required_votes = primitives::v2::supermajority_threshold(validators.len());
+	let required_votes = primitives::supermajority_threshold(validators.len());
 	(0..required_votes).map(move |validator_index| {
 		let stmt = PvfCheckStatement {
 			accept: vote_outcome == VoteOutcome::Accept,

--- a/runtime/parachains/src/paras/mod.rs
+++ b/runtime/parachains/src/paras/mod.rs
@@ -111,7 +111,7 @@ use bitvec::{order::Lsb0 as BitOrderLsb0, vec::BitVec};
 use frame_support::{pallet_prelude::*, traits::EstimateNextSessionRotation};
 use frame_system::pallet_prelude::*;
 use parity_scale_codec::{Decode, Encode};
-use primitives::v2::{
+use primitives::{
 	ConsensusLog, HeadData, Id as ParaId, PvfCheckStatement, SessionIndex, UpgradeGoAhead,
 	UpgradeRestriction, ValidationCode, ValidationCodeHash, ValidatorSignature,
 };
@@ -452,7 +452,7 @@ impl<BlockNumber> PvfCheckActiveVoteState<BlockNumber> {
 
 	/// Returns `None` if the quorum is not reached, or the direction of the decision.
 	fn quorum(&self, n_validators: usize) -> Option<PvfCheckOutcome> {
-		let q_threshold = primitives::v2::supermajority_threshold(n_validators);
+		let q_threshold = primitives::supermajority_threshold(n_validators);
 		// NOTE: counting the reject votes is deliberately placed first. This is to err on the safe.
 		if self.votes_reject.count_ones() >= q_threshold {
 			Some(PvfCheckOutcome::Rejected)

--- a/runtime/parachains/src/paras/tests.rs
+++ b/runtime/parachains/src/paras/tests.rs
@@ -17,7 +17,7 @@
 use super::*;
 use frame_support::{assert_err, assert_ok, assert_storage_noop};
 use keyring::Sr25519Keyring;
-use primitives::v2::{BlockNumber, ValidatorId, PARACHAIN_KEY_TYPE_ID};
+use primitives::{BlockNumber, ValidatorId, PARACHAIN_KEY_TYPE_ID};
 use sc_keystore::LocalKeystore;
 use sp_keystore::{SyncCryptoStore, SyncCryptoStorePtr};
 use std::sync::Arc;
@@ -114,10 +114,7 @@ fn check_code_is_not_stored(validation_code: &ValidationCode) {
 /// An utility for checking that certain events were deposited.
 struct EventValidator {
 	events: Vec<
-		frame_system::EventRecord<
-			<Test as frame_system::Config>::RuntimeEvent,
-			primitives::v2::Hash,
-		>,
+		frame_system::EventRecord<<Test as frame_system::Config>::RuntimeEvent, primitives::Hash>,
 	>,
 }
 
@@ -1694,7 +1691,7 @@ fn add_trusted_validation_code_enacts_existing_pvf_vote() {
 
 #[test]
 fn verify_upgrade_go_ahead_signal_is_externally_accessible() {
-	use primitives::v2::well_known_keys;
+	use primitives::well_known_keys;
 
 	let a = ParaId::from(2020);
 
@@ -1710,7 +1707,7 @@ fn verify_upgrade_go_ahead_signal_is_externally_accessible() {
 
 #[test]
 fn verify_upgrade_restriction_signal_is_externally_accessible() {
-	use primitives::v2::well_known_keys;
+	use primitives::well_known_keys;
 
 	let a = ParaId::from(2020);
 

--- a/runtime/parachains/src/paras_inherent/mod.rs
+++ b/runtime/parachains/src/paras_inherent/mod.rs
@@ -39,7 +39,7 @@ use frame_support::{
 };
 use frame_system::pallet_prelude::*;
 use pallet_babe::{self, ParentBlockRandomness};
-use primitives::v2::{
+use primitives::{
 	BackedCandidate, CandidateHash, CandidateReceipt, CheckedDisputeStatementSet,
 	CheckedMultiDisputeStatementSet, CoreIndex, DisputeStatementSet,
 	InherentData as ParachainsInherentData, MultiDisputeStatementSet, ScrapedOnChainVotes,

--- a/runtime/parachains/src/paras_inherent/tests.rs
+++ b/runtime/parachains/src/paras_inherent/tests.rs
@@ -139,7 +139,7 @@ mod enter {
 	#[test]
 	fn test_session_is_tracked_in_on_chain_scraping() {
 		use crate::disputes::run_to_block;
-		use primitives::v2::{
+		use primitives::{
 			DisputeStatement, DisputeStatementSet, ExplicitDisputeStatement,
 			InvalidDisputeStatementKind, ValidDisputeStatementKind,
 		};
@@ -859,8 +859,8 @@ mod enter {
 	}
 }
 
-fn default_header() -> primitives::v2::Header {
-	primitives::v2::Header {
+fn default_header() -> primitives::Header {
+	primitives::Header {
 		parent_hash: Default::default(),
 		number: 0,
 		state_root: Default::default(),
@@ -876,7 +876,7 @@ mod sanitizers {
 		back_candidate, collator_sign_candidate, BackingKind, TestCandidateBuilder,
 	};
 	use bitvec::order::Lsb0;
-	use primitives::v2::{
+	use primitives::{
 		AvailabilityBitfield, GroupIndex, Hash, Id as ParaId, SignedAvailabilityBitfield,
 		ValidatorIndex,
 	};
@@ -885,7 +885,7 @@ mod sanitizers {
 	use crate::mock::Test;
 	use futures::executor::block_on;
 	use keyring::Sr25519Keyring;
-	use primitives::v2::PARACHAIN_KEY_TYPE_ID;
+	use primitives::PARACHAIN_KEY_TYPE_ID;
 	use sc_keystore::LocalKeystore;
 	use sp_keystore::{SyncCryptoStore, SyncCryptoStorePtr};
 	use std::sync::Arc;

--- a/runtime/parachains/src/reward_points.rs
+++ b/runtime/parachains/src/reward_points.rs
@@ -23,7 +23,7 @@
 
 use crate::{session_info, shared};
 use frame_support::traits::{Defensive, ValidatorSet};
-use primitives::v2::{SessionIndex, ValidatorIndex};
+use primitives::{SessionIndex, ValidatorIndex};
 use sp_std::collections::btree_set::BTreeSet;
 
 /// The amount of era points given by backing a candidate that is included.

--- a/runtime/parachains/src/runtime_api_impl/v2.rs
+++ b/runtime/parachains/src/runtime_api_impl/v2.rs
@@ -21,7 +21,7 @@ use crate::{
 	configuration, dmp, hrmp, inclusion, initializer, paras, paras_inherent, scheduler,
 	session_info, shared,
 };
-use primitives::v2::{
+use primitives::{
 	AuthorityDiscoveryId, CandidateEvent, CommittedCandidateReceipt, CoreIndex, CoreOccupied,
 	CoreState, GroupIndex, GroupRotationInfo, Hash, Id as ParaId, InboundDownwardMessage,
 	InboundHrmpMessage, OccupiedCore, OccupiedCoreAssumption, PersistedValidationData,
@@ -256,7 +256,7 @@ pub fn assumed_validation_data<T: initializer::Config>(
 /// Implementation for the `check_validation_outputs` function of the runtime API.
 pub fn check_validation_outputs<T: initializer::Config>(
 	para_id: ParaId,
-	outputs: primitives::v2::CandidateCommitments,
+	outputs: primitives::CandidateCommitments,
 ) -> bool {
 	<inclusion::Pallet<T>>::check_validation_outputs_for_runtime_api(para_id, outputs)
 }

--- a/runtime/parachains/src/runtime_api_impl/vstaging.rs
+++ b/runtime/parachains/src/runtime_api_impl/vstaging.rs
@@ -17,7 +17,7 @@
 //! Put implementations of functions from staging APIs here.
 
 use crate::disputes;
-use primitives::v2::{CandidateHash, DisputeState, SessionIndex};
+use primitives::{CandidateHash, DisputeState, SessionIndex};
 use sp_std::prelude::*;
 
 /// Implementation for `get_session_disputes` function from the runtime API

--- a/runtime/parachains/src/scheduler.rs
+++ b/runtime/parachains/src/scheduler.rs
@@ -36,7 +36,7 @@
 //! over time.
 
 use frame_support::pallet_prelude::*;
-use primitives::v2::{
+use primitives::{
 	CollatorId, CoreIndex, CoreOccupied, GroupIndex, GroupRotationInfo, Id as ParaId,
 	ParathreadClaim, ParathreadEntry, ScheduledCore, ValidatorIndex,
 };

--- a/runtime/parachains/src/scheduler/tests.rs
+++ b/runtime/parachains/src/scheduler/tests.rs
@@ -18,7 +18,7 @@ use super::*;
 
 use frame_support::assert_ok;
 use keyring::Sr25519Keyring;
-use primitives::v2::{BlockNumber, CollatorId, SessionIndex, ValidatorId};
+use primitives::{BlockNumber, CollatorId, SessionIndex, ValidatorId};
 
 use crate::{
 	configuration::HostConfiguration,

--- a/runtime/parachains/src/session_info.rs
+++ b/runtime/parachains/src/session_info.rs
@@ -27,7 +27,7 @@ use frame_support::{
 	pallet_prelude::*,
 	traits::{OneSessionHandler, ValidatorSet, ValidatorSetWithIdentification},
 };
-use primitives::v2::{AssignmentId, AuthorityDiscoveryId, SessionIndex, SessionInfo};
+use primitives::{AssignmentId, AuthorityDiscoveryId, SessionIndex, SessionInfo};
 use sp_std::vec::Vec;
 
 pub use pallet::*;

--- a/runtime/parachains/src/session_info/tests.rs
+++ b/runtime/parachains/src/session_info/tests.rs
@@ -25,7 +25,7 @@ use crate::{
 	util::take_active_subset,
 };
 use keyring::Sr25519Keyring;
-use primitives::v2::{BlockNumber, ValidatorId, ValidatorIndex};
+use primitives::{BlockNumber, ValidatorId, ValidatorIndex};
 
 fn run_to_block(
 	to: BlockNumber,

--- a/runtime/parachains/src/shared.rs
+++ b/runtime/parachains/src/shared.rs
@@ -20,7 +20,7 @@
 //! dependent on any of the other pallets.
 
 use frame_support::pallet_prelude::*;
-use primitives::v2::{SessionIndex, ValidatorId, ValidatorIndex};
+use primitives::{SessionIndex, ValidatorId, ValidatorIndex};
 use sp_std::vec::Vec;
 
 use rand::{seq::SliceRandom, SeedableRng};

--- a/runtime/parachains/src/ump.rs
+++ b/runtime/parachains/src/ump.rs
@@ -20,7 +20,7 @@ use crate::{
 };
 use frame_support::{pallet_prelude::*, traits::EnsureOrigin};
 use frame_system::pallet_prelude::*;
-use primitives::v2::{Id as ParaId, UpwardMessage};
+use primitives::{Id as ParaId, UpwardMessage};
 use sp_std::{collections::btree_map::BTreeMap, fmt, marker::PhantomData, mem, prelude::*};
 use xcm::latest::Outcome;
 

--- a/runtime/parachains/src/ump/tests.rs
+++ b/runtime/parachains/src/ump/tests.rs
@@ -269,7 +269,7 @@ fn verify_relay_dispatch_queue_size_is_externally_accessible() {
 	// keys and is decodable into a (u32, u32).
 
 	use parity_scale_codec::Decode as _;
-	use primitives::v2::well_known_keys;
+	use primitives::well_known_keys;
 
 	let a = ParaId::from(228);
 	let msg = vec![1, 2, 3];

--- a/runtime/parachains/src/util.rs
+++ b/runtime/parachains/src/util.rs
@@ -17,7 +17,7 @@
 //! Utilities that don't belong to any particular module but may draw
 //! on all modules.
 
-use primitives::v2::{Id as ParaId, PersistedValidationData, ValidatorIndex};
+use primitives::{Id as ParaId, PersistedValidationData, ValidatorIndex};
 use sp_std::{collections::btree_set::BTreeSet, vec::Vec};
 
 use crate::{configuration, hrmp, paras};
@@ -103,7 +103,7 @@ mod tests {
 	use sp_std::vec::Vec;
 
 	use crate::util::{split_active_subset, take_active_subset};
-	use primitives::v2::ValidatorIndex;
+	use primitives::ValidatorIndex;
 
 	#[test]
 	fn take_active_subset_is_compatible_with_split_active_subset() {

--- a/runtime/polkadot/constants/src/lib.rs
+++ b/runtime/polkadot/constants/src/lib.rs
@@ -22,7 +22,7 @@ pub use self::currency::DOLLARS;
 
 /// Money matters.
 pub mod currency {
-	use primitives::v2::Balance;
+	use primitives::Balance;
 
 	/// The existential deposit.
 	pub const EXISTENTIAL_DEPOSIT: Balance = 100 * CENTS;
@@ -39,7 +39,7 @@ pub mod currency {
 
 /// Time and blocks.
 pub mod time {
-	use primitives::v2::{BlockNumber, Moment};
+	use primitives::{BlockNumber, Moment};
 	use runtime_common::prod_or_fast;
 	pub const MILLISECS_PER_BLOCK: Moment = 6000;
 	pub const SLOT_DURATION: Moment = MILLISECS_PER_BLOCK;
@@ -64,7 +64,7 @@ pub mod fee {
 	use frame_support::weights::{
 		WeightToFeeCoefficient, WeightToFeeCoefficients, WeightToFeePolynomial,
 	};
-	use primitives::v2::Balance;
+	use primitives::Balance;
 	use smallvec::smallvec;
 	pub use sp_runtime::Perbill;
 

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -53,7 +53,7 @@ use pallet_im_online::sr25519::AuthorityId as ImOnlineId;
 use pallet_session::historical as session_historical;
 use pallet_transaction_payment::{FeeDetails, RuntimeDispatchInfo};
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
-use primitives::v2::{
+use primitives::{
 	AccountId, AccountIndex, Balance, BlockNumber, CandidateEvent, CommittedCandidateReceipt,
 	CoreState, GroupRotationInfo, Hash, Id as ParaId, InboundDownwardMessage, InboundHrmpMessage,
 	Moment, Nonce, OccupiedCoreAssumption, PersistedValidationData, ScrapedOnChainVotes,
@@ -1469,7 +1469,7 @@ impl frame_support::traits::OnRuntimeUpgrade for InitiateNominationPools {
 construct_runtime! {
 	pub enum Runtime where
 		Block = Block,
-		NodeBlock = primitives::v2::Block,
+		NodeBlock = primitives::Block,
 		UncheckedExtrinsic = UncheckedExtrinsic
 	{
 		// Basic stuff; balances is uncallable initially.
@@ -1773,7 +1773,7 @@ sp_api::impl_runtime_apis! {
 
 		fn check_validation_outputs(
 			para_id: ParaId,
-			outputs: primitives::v2::CandidateCommitments,
+			outputs: primitives::CandidateCommitments,
 		) -> bool {
 			parachains_runtime_api_impl::check_validation_outputs::<Runtime>(para_id, outputs)
 		}
@@ -1825,8 +1825,8 @@ sp_api::impl_runtime_apis! {
 		}
 
 		fn submit_pvf_check_statement(
-			stmt: primitives::v2::PvfCheckStatement,
-			signature: primitives::v2::ValidatorSignature,
+			stmt: primitives::PvfCheckStatement,
+			signature: primitives::ValidatorSignature,
 		) {
 			parachains_runtime_api_impl::submit_pvf_check_statement::<Runtime>(stmt, signature)
 		}

--- a/runtime/rococo/constants/src/lib.rs
+++ b/runtime/rococo/constants/src/lib.rs
@@ -20,7 +20,7 @@ pub mod weights;
 
 /// Money matters.
 pub mod currency {
-	use primitives::v2::Balance;
+	use primitives::Balance;
 
 	/// The existential deposit.
 	pub const EXISTENTIAL_DEPOSIT: Balance = 1 * CENTS;
@@ -37,7 +37,7 @@ pub mod currency {
 
 /// Time and blocks.
 pub mod time {
-	use primitives::v2::{BlockNumber, Moment};
+	use primitives::{BlockNumber, Moment};
 	use runtime_common::prod_or_fast;
 	pub const MILLISECS_PER_BLOCK: Moment = 6000;
 	pub const SLOT_DURATION: Moment = MILLISECS_PER_BLOCK;
@@ -65,7 +65,7 @@ pub mod fee {
 	use frame_support::weights::{
 		WeightToFeeCoefficient, WeightToFeeCoefficients, WeightToFeePolynomial,
 	};
-	use primitives::v2::Balance;
+	use primitives::Balance;
 	use smallvec::smallvec;
 	pub use sp_runtime::Perbill;
 

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -22,7 +22,7 @@
 
 use pallet_nis::WithMaximumOf;
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
-use primitives::v2::{
+use primitives::{
 	AccountId, AccountIndex, Balance, BlockNumber, CandidateEvent, CandidateHash,
 	CommittedCandidateReceipt, CoreState, DisputeState, GroupRotationInfo, Hash, Id as ParaId,
 	InboundDownwardMessage, InboundHrmpMessage, Moment, Nonce, OccupiedCoreAssumption,
@@ -1330,7 +1330,7 @@ impl pallet_sudo::Config for Runtime {
 construct_runtime! {
 	pub enum Runtime where
 		Block = Block,
-		NodeBlock = primitives::v2::Block,
+		NodeBlock = primitives::Block,
 		UncheckedExtrinsic = UncheckedExtrinsic
 	{
 		// Basic stuff; balances is uncallable initially.
@@ -1665,7 +1665,7 @@ sp_api::impl_runtime_apis! {
 
 		fn check_validation_outputs(
 			para_id: ParaId,
-			outputs: primitives::v2::CandidateCommitments,
+			outputs: primitives::CandidateCommitments,
 		) -> bool {
 			parachains_runtime_api_impl::check_validation_outputs::<Runtime>(para_id, outputs)
 		}
@@ -1717,8 +1717,8 @@ sp_api::impl_runtime_apis! {
 		}
 
 		fn submit_pvf_check_statement(
-			stmt: primitives::v2::PvfCheckStatement,
-			signature: primitives::v2::ValidatorSignature
+			stmt: primitives::PvfCheckStatement,
+			signature: primitives::ValidatorSignature
 		) {
 			parachains_runtime_api_impl::submit_pvf_check_statement::<Runtime>(stmt, signature)
 		}

--- a/runtime/test-runtime/constants/src/lib.rs
+++ b/runtime/test-runtime/constants/src/lib.rs
@@ -20,7 +20,7 @@ pub mod weights;
 
 /// Money matters.
 pub mod currency {
-	use primitives::v2::Balance;
+	use primitives::Balance;
 
 	pub const DOTS: Balance = 1_000_000_000_000;
 	pub const DOLLARS: Balance = DOTS;
@@ -30,7 +30,7 @@ pub mod currency {
 
 /// Time and blocks.
 pub mod time {
-	use primitives::v2::{BlockNumber, Moment};
+	use primitives::{BlockNumber, Moment};
 	// Testnet
 	pub const MILLISECS_PER_BLOCK: Moment = 6000;
 	pub const SLOT_DURATION: Moment = MILLISECS_PER_BLOCK;
@@ -55,7 +55,7 @@ pub mod fee {
 	use frame_support::weights::{
 		WeightToFeeCoefficient, WeightToFeeCoefficients, WeightToFeePolynomial,
 	};
-	use primitives::v2::Balance;
+	use primitives::Balance;
 	use smallvec::smallvec;
 	pub use sp_runtime::Perbill;
 

--- a/runtime/test-runtime/src/lib.rs
+++ b/runtime/test-runtime/src/lib.rs
@@ -44,7 +44,7 @@ use pallet_grandpa::{fg_primitives, AuthorityId as GrandpaId};
 use pallet_session::historical as session_historical;
 use pallet_transaction_payment::{FeeDetails, RuntimeDispatchInfo};
 use polkadot_runtime_parachains::reward_points::RewardValidatorsWithEraPoints;
-use primitives::v2::{
+use primitives::{
 	AccountId, AccountIndex, Balance, BlockNumber, CandidateEvent, CommittedCandidateReceipt,
 	CoreState, GroupRotationInfo, Hash as HashT, Id as ParaId, InboundDownwardMessage,
 	InboundHrmpMessage, Moment, Nonce, OccupiedCoreAssumption, PersistedValidationData,
@@ -670,7 +670,7 @@ pub mod pallet_test_notifier {
 construct_runtime! {
 	pub enum Runtime where
 		Block = Block,
-		NodeBlock = primitives::v2::Block,
+		NodeBlock = primitives::Block,
 		UncheckedExtrinsic = UncheckedExtrinsic
 	{
 		// Basic stuff; balances is uncallable initially.
@@ -856,7 +856,7 @@ sp_api::impl_runtime_apis! {
 
 		fn check_validation_outputs(
 			para_id: ParaId,
-			outputs: primitives::v2::CandidateCommitments,
+			outputs: primitives::CandidateCommitments,
 		) -> bool {
 			runtime_impl::check_validation_outputs::<Runtime>(para_id, outputs)
 		}
@@ -904,8 +904,8 @@ sp_api::impl_runtime_apis! {
 		}
 
 		fn submit_pvf_check_statement(
-			stmt: primitives::v2::PvfCheckStatement,
-			signature: primitives::v2::ValidatorSignature,
+			stmt: primitives::PvfCheckStatement,
+			signature: primitives::ValidatorSignature,
 		) {
 			runtime_impl::submit_pvf_check_statement::<Runtime>(stmt, signature)
 		}

--- a/runtime/westend/constants/src/lib.rs
+++ b/runtime/westend/constants/src/lib.rs
@@ -20,7 +20,7 @@ pub mod weights;
 
 /// Money matters.
 pub mod currency {
-	use primitives::v2::Balance;
+	use primitives::Balance;
 
 	/// The existential deposit.
 	pub const EXISTENTIAL_DEPOSIT: Balance = 1 * CENTS;
@@ -37,7 +37,7 @@ pub mod currency {
 
 /// Time and blocks.
 pub mod time {
-	use primitives::v2::{BlockNumber, Moment};
+	use primitives::{BlockNumber, Moment};
 	use runtime_common::prod_or_fast;
 
 	pub const MILLISECS_PER_BLOCK: Moment = 6000;
@@ -62,7 +62,7 @@ pub mod fee {
 	use frame_support::weights::{
 		WeightToFeeCoefficient, WeightToFeeCoefficients, WeightToFeePolynomial,
 	};
-	use primitives::v2::Balance;
+	use primitives::Balance;
 	use smallvec::smallvec;
 	pub use sp_runtime::Perbill;
 

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -35,7 +35,7 @@ use pallet_im_online::sr25519::AuthorityId as ImOnlineId;
 use pallet_session::historical as session_historical;
 use pallet_transaction_payment::{CurrencyAdapter, FeeDetails, RuntimeDispatchInfo};
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
-use primitives::v2::{
+use primitives::{
 	AccountId, AccountIndex, Balance, BlockNumber, CandidateEvent, CandidateHash,
 	CommittedCandidateReceipt, CoreState, DisputeState, GroupRotationInfo, Hash, Id as ParaId,
 	InboundDownwardMessage, InboundHrmpMessage, Moment, Nonce, OccupiedCoreAssumption,
@@ -1088,7 +1088,7 @@ impl pallet_nomination_pools::Config for Runtime {
 construct_runtime! {
 	pub enum Runtime where
 		Block = Block,
-		NodeBlock = primitives::v2::Block,
+		NodeBlock = primitives::Block,
 		UncheckedExtrinsic = UncheckedExtrinsic
 	{
 		// Basic stuff; balances is uncallable initially.
@@ -1372,7 +1372,7 @@ sp_api::impl_runtime_apis! {
 
 		fn check_validation_outputs(
 			para_id: ParaId,
-			outputs: primitives::v2::CandidateCommitments,
+			outputs: primitives::CandidateCommitments,
 		) -> bool {
 			parachains_runtime_api_impl::check_validation_outputs::<Runtime>(para_id, outputs)
 		}

--- a/statement-table/src/generic.rs
+++ b/statement-table/src/generic.rs
@@ -30,7 +30,7 @@ use std::{
 	hash::Hash,
 };
 
-use primitives::v2::{ValidatorSignature, ValidityAttestation as PrimitiveValidityAttestation};
+use primitives::{ValidatorSignature, ValidityAttestation as PrimitiveValidityAttestation};
 
 use parity_scale_codec::{Decode, Encode};
 

--- a/statement-table/src/lib.rs
+++ b/statement-table/src/lib.rs
@@ -21,7 +21,7 @@ pub use generic::{Context, Table};
 /// Concrete instantiations suitable for v2 primitives.
 pub mod v2 {
 	use crate::generic;
-	use primitives::v2::{
+	use primitives::{
 		CandidateHash, CommittedCandidateReceipt, CompactStatement as PrimitiveStatement, Id,
 		ValidatorIndex, ValidatorSignature,
 	};


### PR DESCRIPTION
Closes #6480 

Current primitives not requiring versioning are re-exported from the `primitives` crate root.

For those who don't want to scroll a lot, all the meaningful changes are in `primitives/src/lib.rs`.

Cumulus companion: paritytech/cumulus#2067