### PR TITLE
Enable treasury.spend by Root origin for Polkadot network before Gov2

### DIFF
--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -833,6 +833,7 @@ parameter_types! {
 	pub const MaxKeys: u32 = 10_000;
 	pub const MaxPeerInHeartbeats: u32 = 10_000;
 	pub const MaxPeerDataEncodingSize: u32 = 1_000;
+	pub const RootSpendOriginMaxAmount: Balance = Balance::MAX;
 }
 
 type ApproveOrigin = EitherOfDiverse<
@@ -856,7 +857,7 @@ impl pallet_treasury::Config for Runtime {
 	type SpendFunds = Bounties;
 	type MaxApprovals = MaxApprovals;
 	type WeightInfo = weights::pallet_treasury::WeightInfo<Runtime>;
-	type SpendOrigin = EnsureRoot<AccountId>;
+	type SpendOrigin = frame_system::EnsureRootWithSuccess<AccountId, RootSpendOriginMaxAmount>;
 }
 
 parameter_types! {

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -856,7 +856,7 @@ impl pallet_treasury::Config for Runtime {
 	type SpendFunds = Bounties;
 	type MaxApprovals = MaxApprovals;
 	type WeightInfo = weights::pallet_treasury::WeightInfo<Runtime>;
-	type SpendOrigin = frame_support::traits::NeverEnsureOrigin<Balance>;
+	type SpendOrigin = EnsureRoot<AccountId>;
 }
 
 parameter_types! {


### PR DESCRIPTION
This allows the chain to call treasury.spend by Root.

For some public-benefit treasury proposals, it may be the case that it's not feasible for anyone to pay the proposal deposit. With this PR one can table these as referendums for the slower route. Useful for, for example, [upstream open source treasury proposals](https://pacna.org/dot-support-os/).

This does not change any security properties of the chain because the Root can do everything anyway.