### PR TITLE
Run try-runtime hooks in CI

### DIFF
--- a/scripts/ci/gitlab/pipeline/check.yml
+++ b/scripts/ci/gitlab/pipeline/check.yml
@@ -73,7 +73,8 @@ check-try-runtime:
             --runtime ./target/release/wbuild/"$NETWORK"-runtime/target/wasm32-unknown-unknown/release/"$NETWORK"_runtime.wasm \
             -lruntime=debug \
             --chain=${NETWORK}-dev \
-            on-runtime-upgrade live --uri wss://${NETWORK}-try-runtime-node.parity-chains.parity.io:443
+            on-runtime-upgrade --checks live \
+            --uri wss://${NETWORK}-try-runtime-node.parity-chains.parity.io:443
       else
         echo "runtime_migration label not found. Skipping"
       fi


### PR DESCRIPTION
Currently the `pre_` and `post_upgrade` hooks do not run because of new CLI behavious. Enabling the checks again with `--checks`.

TODO: 
- [ ] Verify CI output
- [ ] Remove old migrations, if needed
- [ ] Remove `runtime-migration` label after merge