### PR TITLE
Fix `polkadot-runtime-constants` std build

### DIFF
--- a/runtime/kusama/constants/Cargo.toml
+++ b/runtime/kusama/constants/Cargo.toml
@@ -17,6 +17,7 @@ sp-core = { git = "https://github.com/paritytech/substrate", default-features = 
 [features]
 default = ["std"]
 std = [
+	"runtime-common/std",
 	"sp-core/std",
 	"sp-runtime/std",
 	"sp-weights/std"

--- a/runtime/kusama/constants/Cargo.toml
+++ b/runtime/kusama/constants/Cargo.toml
@@ -17,6 +17,8 @@ sp-core = { git = "https://github.com/paritytech/substrate", default-features = 
 [features]
 default = ["std"]
 std = [
+	"frame-support/std",
+	"primitives/std",
 	"runtime-common/std",
 	"sp-core/std",
 	"sp-runtime/std",

--- a/runtime/polkadot/constants/Cargo.toml
+++ b/runtime/polkadot/constants/Cargo.toml
@@ -17,6 +17,7 @@ sp-core = { git = "https://github.com/paritytech/substrate", default-features = 
 [features]
 default = ["std"]
 std = [
+	"runtime-common/std",
 	"sp-core/std",
 	"sp-runtime/std",
 	"sp-weights/std"

--- a/runtime/polkadot/constants/Cargo.toml
+++ b/runtime/polkadot/constants/Cargo.toml
@@ -17,6 +17,8 @@ sp-core = { git = "https://github.com/paritytech/substrate", default-features = 
 [features]
 default = ["std"]
 std = [
+	"frame-support/std",
+	"primitives/std",
 	"runtime-common/std",
 	"sp-core/std",
 	"sp-runtime/std",

--- a/runtime/rococo/constants/Cargo.toml
+++ b/runtime/rococo/constants/Cargo.toml
@@ -17,6 +17,7 @@ sp-core = { git = "https://github.com/paritytech/substrate", default-features = 
 [features]
 default = ["std"]
 std = [
+	"runtime-common/std",
 	"sp-core/std",
 	"sp-runtime/std",
 	"sp-weights/std"

--- a/runtime/rococo/constants/Cargo.toml
+++ b/runtime/rococo/constants/Cargo.toml
@@ -17,6 +17,8 @@ sp-core = { git = "https://github.com/paritytech/substrate", default-features = 
 [features]
 default = ["std"]
 std = [
+	"frame-support/std",
+	"primitives/std",
 	"runtime-common/std",
 	"sp-core/std",
 	"sp-runtime/std",

--- a/runtime/westend/constants/Cargo.toml
+++ b/runtime/westend/constants/Cargo.toml
@@ -17,6 +17,7 @@ sp-core = { git = "https://github.com/paritytech/substrate", default-features = 
 [features]
 default = ["std"]
 std = [
+	"runtime-common/std",
 	"sp-core/std",
 	"sp-runtime/std",
 	"sp-weights/std"

--- a/runtime/westend/constants/Cargo.toml
+++ b/runtime/westend/constants/Cargo.toml
@@ -17,6 +17,8 @@ sp-core = { git = "https://github.com/paritytech/substrate", default-features = 
 [features]
 default = ["std"]
 std = [
+	"frame-support/std",
+	"primitives/std",
 	"runtime-common/std",
 	"sp-core/std",
 	"sp-runtime/std",


### PR DESCRIPTION
When I'm running for example `cargo test` on a crate that depends on `polkadot-runtime-constants` I'm getting errors like the following:

```
   --> /home/serban/.cargo/git/checkouts/substrate-f4423eebfa0046a3/87f3fde/primitives/npos-elections/src/reduce.rs:604:21
    |
604 |                     let min_edge = vec![min_voter, min_target];
    |                                    ^^^
    |
    = note: consider importing one of these items:
            codec::alloc::vec
            crate::vec
            scale_info::prelude::vec
            sp_std::vec

error: cannot find macro `vec` in this scope
  --> /home/serban/.cargo/git/checkouts/substrate-f4423eebfa0046a3/87f3fde/primitives/npos-elections/src/phragmms.rs:52:20
   |
52 |     let mut winners = vec![];
   |                       ^^^
   |
   = note: consider importing one of these items:
           codec::alloc::vec
           crate::vec
           scale_info::prelude::vec
           sp_std::vec

```

This seems to fix it.