### PR TITLE
Issue 4804: Notify chain selection of concluded disputes directly

### DIFF
--- a/node/core/chain-selection/src/lib.rs
+++ b/node/core/chain-selection/src/lib.rs
@@ -687,7 +687,7 @@ fn handle_approved_block(backend: &mut impl Backend, approved_block: Hash) -> Re
 // the dispute coordinator has notified chain selection 
 fn handle_revert_blocks(
 	backend: &impl Backend,
-	blocks_to_revert: HashSet<(BlockNumber, Hash)>,
+	blocks_to_revert: Vec<(BlockNumber, Hash)>,
 ) -> Result<Vec<BackendWriteOp>, Error> {
 	let mut overlay = OverlayedBackend::new(backend);
 	for (block_number, block_hash) in blocks_to_revert {

--- a/node/core/chain-selection/src/lib.rs
+++ b/node/core/chain-selection/src/lib.rs
@@ -34,6 +34,7 @@ use std::{
 	sync::Arc,
 	time::{Duration, SystemTime, UNIX_EPOCH},
 };
+use std::collections::BTreeMap;
 
 use crate::backend::{Backend, BackendWriteOp, OverlayedBackend};
 
@@ -328,13 +329,14 @@ pub struct Config {
 pub struct ChainSelectionSubsystem {
 	config: Config,
 	db: Arc<dyn Database>,
+	blocks_including_candidates: BTreeMap<CandidateHash, BlockNumber>,
 }
 
 impl ChainSelectionSubsystem {
 	/// Create a new instance of the subsystem with the given config
 	/// and key-value store.
 	pub fn new(config: Config, db: Arc<dyn Database>) -> Self {
-		ChainSelectionSubsystem { config, db }
+		ChainSelectionSubsystem { config, db, blocks_including_candidates: BTreeMap::new() }
 	}
 
 	/// Revert to the block corresponding to the specified `hash`.
@@ -442,6 +444,9 @@ where
 
 							backend.write(write_ops)?;
 						}
+
+						// Update blocks including candidates based on candidate included events
+						process_included_events(sender, block_number, block_hash)
 					}
 					FromOrchestra::Signal(OverseerSignal::BlockFinalized(h, n)) => {
 						handle_finalized_block(backend, h, n)?
@@ -684,8 +689,9 @@ fn handle_approved_block(backend: &mut impl Backend, approved_block: Hash) -> Re
 
 // A dispute has concluded against a candidate. Here we apply the reverted status to
 // all blocks on chains containing that candidate.
-fn handle_concluded_dispute_reversions(hash: CandidateHash) {
+fn handle_concluded_dispute_reversions(hash: CandidateHash) -> Result<(), Error> {
 
+	Ok(())
 }
 
 fn detect_stagnant(

--- a/node/core/chain-selection/src/lib.rs
+++ b/node/core/chain-selection/src/lib.rs
@@ -683,7 +683,8 @@ fn handle_approved_block(backend: &mut impl Backend, approved_block: Hash) -> Re
 }
 
 // Here we revert a provided group of blocks. The most common cause for this is that
-// the dispute coordinator has notified chain selection 
+// the dispute coordinator has notified chain selection of a dispute which concluded
+// against a candidate.
 fn handle_revert_blocks(
 	backend: &impl Backend,
 	blocks_to_revert: Vec<(BlockNumber, Hash)>,

--- a/node/core/chain-selection/src/lib.rs
+++ b/node/core/chain-selection/src/lib.rs
@@ -16,7 +16,6 @@
 
 //! Implements the Chain Selection Subsystem.
 
-use gum::CandidateHash;
 use polkadot_node_primitives::BlockWeight;
 use polkadot_node_subsystem::{
 	errors::ChainApiError,
@@ -468,7 +467,7 @@ where
 							let _ = tx.send(best_containing);
 						}
 						ChainSelectionMessage::DisputeConcludedAgainst(block_number, block_hash) => {
-							handle_concluded_dispute_reversions(block_number, block_hash)?
+							handle_concluded_dispute_reversions(backend, block_number, block_hash)?
 						}
 					}
 				}
@@ -684,8 +683,13 @@ fn handle_approved_block(backend: &mut impl Backend, approved_block: Hash) -> Re
 
 // A dispute has concluded against a candidate. Here we apply the reverted status to
 // all blocks on chains containing that candidate.
-fn handle_concluded_dispute_reversions(block_number: u32, block_hash: Hash) -> Result<(), Error> {
-
+fn handle_concluded_dispute_reversions(
+	backend: &mut impl Backend, 
+	block_number: u32, 
+	block_hash: Hash
+) -> Result<(), Error> {
+	let mut overlay = OverlayedBackend::new(backend);
+	tree::apply_single_reversion(&mut overlay, block_hash, block_number)?;
 	Ok(())
 }
 

--- a/node/core/chain-selection/src/lib.rs
+++ b/node/core/chain-selection/src/lib.rs
@@ -684,9 +684,9 @@ fn handle_approved_block(backend: &mut impl Backend, approved_block: Hash) -> Re
 // A dispute has concluded against a candidate. Here we revert the block containing
 // that candidate and mark its descendants as non-viable
 fn handle_concluded_dispute_reversions(
-	backend: &mut impl Backend, 
-	block_number: u32, 
-	block_hash: Hash
+	backend: &mut impl Backend,
+	block_number: u32,
+	block_hash: Hash,
 ) -> Result<(), Error> {
 	let mut overlay = OverlayedBackend::new(backend);
 	tree::apply_single_reversion(&mut overlay, block_hash, block_number)?;

--- a/node/core/chain-selection/src/lib.rs
+++ b/node/core/chain-selection/src/lib.rs
@@ -333,7 +333,7 @@ impl ChainSelectionSubsystem {
 	/// Create a new instance of the subsystem with the given config
 	/// and key-value store.
 	pub fn new(config: Config, db: Arc<dyn Database>) -> Self {
-		ChainSelectionSubsystem { config, db, }
+		ChainSelectionSubsystem { config, db }
 	}
 
 	/// Revert to the block corresponding to the specified `hash`.
@@ -681,8 +681,8 @@ fn handle_approved_block(backend: &mut impl Backend, approved_block: Hash) -> Re
 	backend.write(ops)
 }
 
-// A dispute has concluded against a candidate. Here we apply the reverted status to
-// all blocks on chains containing that candidate.
+// A dispute has concluded against a candidate. Here we revert the block containing
+// that candidate and mark its descendants as non-viable
 fn handle_concluded_dispute_reversions(
 	backend: &mut impl Backend, 
 	block_number: u32, 

--- a/node/core/chain-selection/src/lib.rs
+++ b/node/core/chain-selection/src/lib.rs
@@ -32,7 +32,6 @@ use parity_scale_codec::Error as CodecError;
 use std::{
 	sync::Arc,
 	time::{Duration, SystemTime, UNIX_EPOCH},
-	collections::HashSet,
 };
 
 use crate::backend::{Backend, BackendWriteOp, OverlayedBackend};

--- a/node/core/chain-selection/src/lib.rs
+++ b/node/core/chain-selection/src/lib.rs
@@ -16,6 +16,7 @@
 
 //! Implements the Chain Selection Subsystem.
 
+use gum::CandidateHash;
 use polkadot_node_primitives::BlockWeight;
 use polkadot_node_subsystem::{
 	errors::ChainApiError,
@@ -466,6 +467,9 @@ where
 
 							let _ = tx.send(best_containing);
 						}
+						ChainSelectionMessage::DisputeConcludedAgainst(hash) => {
+							handle_concluded_dispute_reversions(hash)?
+						}
 					}
 				}
 			}
@@ -676,6 +680,12 @@ fn handle_approved_block(backend: &mut impl Backend, approved_block: Hash) -> Re
 	};
 
 	backend.write(ops)
+}
+
+// A dispute has concluded against a candidate. Here we apply the reverted status to
+// all blocks on chains containing that candidate.
+fn handle_concluded_dispute_reversions(hash: CandidateHash) {
+
 }
 
 fn detect_stagnant(

--- a/node/core/chain-selection/src/lib.rs
+++ b/node/core/chain-selection/src/lib.rs
@@ -467,7 +467,7 @@ where
 							let _ = tx.send(best_containing);
 						}
 						ChainSelectionMessage::DisputeConcludedAgainst(block_number, block_hash) => {
-							handle_concluded_dispute_reversions(backend, block_number, block_hash)?
+							handle_concluded_dispute_reversion(backend, block_number, block_hash)?
 						}
 					}
 				}
@@ -683,7 +683,7 @@ fn handle_approved_block(backend: &mut impl Backend, approved_block: Hash) -> Re
 
 // A dispute has concluded against a candidate. Here we revert the block containing
 // that candidate and mark its descendants as non-viable
-fn handle_concluded_dispute_reversions(
+fn handle_concluded_dispute_reversion(
 	backend: &mut impl Backend,
 	block_number: u32,
 	block_hash: Hash,

--- a/node/core/chain-selection/src/tests.rs
+++ b/node/core/chain-selection/src/tests.rs
@@ -2041,7 +2041,7 @@ fn revert_blocks_message_triggers_proper_reversion() {
 		let block_1_hash = backend.load_blocks_by_number(1).unwrap().get(0).unwrap().clone();
 		let block_2_hash = backend.load_blocks_by_number(2).unwrap().get(0).unwrap().clone();
 
-		// Sending dispute concluded against message
+		// Sending revert blocks message
 		let (_, write_rx) = backend.await_next_write();
 		virtual_overseer
 			.send(FromOrchestra::Communication {

--- a/node/core/chain-selection/src/tests.rs
+++ b/node/core/chain-selection/src/tests.rs
@@ -2045,7 +2045,7 @@ fn dispute_concluded_against_message_triggers_proper_reversion() {
 		let (_, write_rx) = backend.await_next_write();
 		virtual_overseer
 			.send(FromOrchestra::Communication {
-				msg: ChainSelectionMessage::DisputeConcludedAgainst(2, block_2_hash),
+				msg: ChainSelectionMessage::RevertBlocks(Vec::from({(2, block_2_hash)})),
 			})
 			.await;
 
@@ -2103,10 +2103,7 @@ fn dispute_reversion_against_finalized_is_ignored() {
 		// Sending dispute conculded against message
 		virtual_overseer
 			.send(FromOrchestra::Communication {
-				msg: ChainSelectionMessage::DisputeConcludedAgainst(
-					finalized_number,
-					finalized_hash,
-				),
+				msg: ChainSelectionMessage::RevertBlocks(Vec::from({(finalized_number, finalized_hash)})),
 			})
 			.await;
 

--- a/node/core/chain-selection/src/tests.rs
+++ b/node/core/chain-selection/src/tests.rs
@@ -2103,7 +2103,10 @@ fn dispute_reversion_against_finalized_is_ignored() {
 		// Sending dispute conculded against message
 		virtual_overseer
 			.send(FromOrchestra::Communication {
-				msg: ChainSelectionMessage::DisputeConcludedAgainst(finalized_number, finalized_hash),
+				msg: ChainSelectionMessage::DisputeConcludedAgainst(
+					finalized_number,
+					finalized_hash,
+				),
 			})
 			.await;
 

--- a/node/core/chain-selection/src/tests.rs
+++ b/node/core/chain-selection/src/tests.rs
@@ -2041,7 +2041,7 @@ fn revert_blocks_message_triggers_proper_reversion() {
 		let block_1_hash = backend.load_blocks_by_number(1).unwrap().get(0).unwrap().clone();
 		let block_2_hash = backend.load_blocks_by_number(2).unwrap().get(0).unwrap().clone();
 
-		// Sending dispute conculded against message
+		// Sending dispute concluded against message
 		let (_, write_rx) = backend.await_next_write();
 		virtual_overseer
 			.send(FromOrchestra::Communication {
@@ -2052,7 +2052,7 @@ fn revert_blocks_message_triggers_proper_reversion() {
 		write_rx.await.unwrap();
 
 		// Checking results:
-		// Block 2 should be explicitely reverted
+		// Block 2 should be explicitly reverted
 		assert_eq!(
 			backend
 				.load_block_entry(&block_2_hash)
@@ -2100,7 +2100,7 @@ fn revert_blocks_against_finalized_is_ignored() {
 		// Checking mini chain
 		assert_backend_contains(&backend, built_chain.iter().map(|&(ref h, _)| h));
 
-		// Sending dispute conculded against message
+		// Sending dispute concluded against message
 		virtual_overseer
 			.send(FromOrchestra::Communication {
 				msg: ChainSelectionMessage::RevertBlocks(Vec::from([(

--- a/node/core/chain-selection/src/tests.rs
+++ b/node/core/chain-selection/src/tests.rs
@@ -2048,7 +2048,7 @@ fn dispute_concluded_against_message_triggers_proper_reversion() {
 				msg: ChainSelectionMessage::DisputeConcludedAgainst(2, block_2_hash),
 			})
 			.await;
-		
+
 		write_rx.await.unwrap();
 
 		// Checking results:

--- a/node/core/chain-selection/src/tests.rs
+++ b/node/core/chain-selection/src/tests.rs
@@ -2016,7 +2016,7 @@ fn stagnant_makes_childless_parent_leaf() {
 }
 
 #[test]
-fn dispute_concluded_against_message_triggers_proper_reversion() {
+fn revert_blocks_message_triggers_proper_reversion() {
 	test_harness(|backend, _, mut virtual_overseer| async move {
 		// Building mini chain with 1 finalized block and 3 unfinalized blocks
 		let finalized_number = 0;
@@ -2045,7 +2045,7 @@ fn dispute_concluded_against_message_triggers_proper_reversion() {
 		let (_, write_rx) = backend.await_next_write();
 		virtual_overseer
 			.send(FromOrchestra::Communication {
-				msg: ChainSelectionMessage::RevertBlocks(Vec::from({(2, block_2_hash)})),
+				msg: ChainSelectionMessage::RevertBlocks(Vec::from([(2, block_2_hash)])),
 			})
 			.await;
 
@@ -2080,7 +2080,7 @@ fn dispute_concluded_against_message_triggers_proper_reversion() {
 }
 
 #[test]
-fn dispute_reversion_against_finalized_is_ignored() {
+fn revert_blocks_against_finalized_is_ignored() {
 	test_harness(|backend, _, mut virtual_overseer| async move {
 		// Building mini chain with 1 finalized block and 3 unfinalized blocks
 		let finalized_number = 0;
@@ -2103,7 +2103,7 @@ fn dispute_reversion_against_finalized_is_ignored() {
 		// Sending dispute conculded against message
 		virtual_overseer
 			.send(FromOrchestra::Communication {
-				msg: ChainSelectionMessage::RevertBlocks(Vec::from({(finalized_number, finalized_hash)})),
+				msg: ChainSelectionMessage::RevertBlocks(Vec::from([(finalized_number, finalized_hash)])),
 			})
 			.await;
 

--- a/node/core/chain-selection/src/tests.rs
+++ b/node/core/chain-selection/src/tests.rs
@@ -2103,7 +2103,10 @@ fn revert_blocks_against_finalized_is_ignored() {
 		// Sending dispute conculded against message
 		virtual_overseer
 			.send(FromOrchestra::Communication {
-				msg: ChainSelectionMessage::RevertBlocks(Vec::from([(finalized_number, finalized_hash)])),
+				msg: ChainSelectionMessage::RevertBlocks(Vec::from([(
+					finalized_number,
+					finalized_hash,
+				)])),
 			})
 			.await;
 

--- a/node/core/chain-selection/src/tree.rs
+++ b/node/core/chain-selection/src/tree.rs
@@ -420,7 +420,7 @@ fn revert_single_block_entry_if_present(
 				revert_target = revert_number,
 				?maybe_reporting_hash,
 				?maybe_reporting_number,
-				"The reversion of an unfinalized block has been called for.",
+				"Unfinalized block reverted due to a bad parachain block.",
 			);
 
 			block_entry.viability.explicitly_reverted = true;

--- a/node/core/chain-selection/src/tree.rs
+++ b/node/core/chain-selection/src/tree.rs
@@ -393,7 +393,7 @@ fn apply_ancestor_reversions(
 	Ok(())
 }
 
-/// Marks a single block as explicitly reverted. Then propegates viability updates
+/// Marks a single block as explicitly reverted, then propagates viability updates
 /// to all its children. This is triggered when the disputes subsystem signals that
 /// a dispute has concluded against a candidate.
 pub(crate) fn apply_single_reversion(

--- a/node/core/chain-selection/src/tree.rs
+++ b/node/core/chain-selection/src/tree.rs
@@ -176,6 +176,7 @@ fn propagate_viability_update(
 				*viability_pivots.entry(new_entry.parent_hash).or_insert(0) += 1;
 			}
 		}
+		
 		backend.write_block_entry(new_entry);
 
 		tree_frontier

--- a/node/core/chain-selection/src/tree.rs
+++ b/node/core/chain-selection/src/tree.rs
@@ -400,35 +400,34 @@ fn apply_ancestor_reversions(
 pub(crate) fn apply_single_reversion(
 	backend: &mut OverlayedBackend<impl Backend>,
 	revert_hash: Hash,
-	revert_number: BlockNumber
+	revert_number: BlockNumber,
 ) -> Result<(), Error> {
-	let mut entry_to_revert = 
-		match backend.load_block_entry(&revert_hash)? {
-			None => {
-				gum::warn!(
-					target: LOG_TARGET,
-					?revert_hash,
-					// We keep parent block numbers in the disputes subsystem just
-					// for this log
-					revert_target = revert_number,
-					"The hammer has dropped. \
+	let mut entry_to_revert = match backend.load_block_entry(&revert_hash)? {
+		None => {
+			gum::warn!(
+				target: LOG_TARGET,
+				?revert_hash,
+				// We keep parent block numbers in the disputes subsystem just
+				// for this log
+				revert_target = revert_number,
+				"The hammer has dropped. \
 				A dispute has concluded against a finalized block. \
 				Please inform an adult.",
-				);
+			);
 
-				return Ok(());
-			},
-			Some(entry_to_revert) => {
-				gum::info!(
-					target: LOG_TARGET,
-					?revert_hash,
-					revert_target = revert_number,
-					"A dispute has concluded against a block, causing it to be reverted.",
-				);
+			return Ok(())
+		},
+		Some(entry_to_revert) => {
+			gum::info!(
+				target: LOG_TARGET,
+				?revert_hash,
+				revert_target = revert_number,
+				"A dispute has concluded against a block, causing it to be reverted.",
+			);
 
-				entry_to_revert
-			},
-		};
+			entry_to_revert
+		},
+	};
 	entry_to_revert.viability.explicitly_reverted = true;
 	// Marks children of reverted block as non-viable
 	propagate_viability_update(backend, entry_to_revert)?;

--- a/node/core/chain-selection/src/tree.rs
+++ b/node/core/chain-selection/src/tree.rs
@@ -420,7 +420,7 @@ fn revert_single_block_entry_if_present(
 				revert_target = revert_number,
 				?maybe_reporting_hash,
 				?maybe_reporting_number,
-				"The reversion of a block including an invalid parachain block candidate has been called for.",
+				"The reversion of an unfinalized block has been called for.",
 			);
 
 			block_entry.viability.explicitly_reverted = true;

--- a/node/core/chain-selection/src/tree.rs
+++ b/node/core/chain-selection/src/tree.rs
@@ -346,8 +346,8 @@ fn add_block(
 	Ok(())
 }
 
-// Assuming that a block is already imported, accepts the number of the block
-// as well as a list of reversions triggered by the block in ascending order.
+/// Assuming that a block is already imported, accepts the number of the block
+/// as well as a list of reversions triggered by the block in ascending order.
 fn apply_ancestor_reversions(
 	backend: &mut OverlayedBackend<impl Backend>,
 	block_hash: Hash,

--- a/node/core/chain-selection/src/tree.rs
+++ b/node/core/chain-selection/src/tree.rs
@@ -176,7 +176,6 @@ fn propagate_viability_update(
 				*viability_pivots.entry(new_entry.parent_hash).or_insert(0) += 1;
 			}
 		}
-
 		backend.write_block_entry(new_entry);
 
 		tree_frontier

--- a/node/core/dispute-coordinator/src/initialized.rs
+++ b/node/core/dispute-coordinator/src/initialized.rs
@@ -1036,7 +1036,7 @@ impl Initialized {
 				ctx.send_message(ChainSelectionMessage::RevertBlocks(blocks_to_revert.clone()))
 					.await;
 			} else {
-				gum::trace!(
+				gum::debug!(
 					target: LOG_TARGET,
 					?candidate_hash,
 					?session,

--- a/node/core/dispute-coordinator/src/initialized.rs
+++ b/node/core/dispute-coordinator/src/initialized.rs
@@ -31,8 +31,8 @@ use polkadot_node_primitives::{
 };
 use polkadot_node_subsystem::{
 	messages::{
-		ApprovalVotingMessage, BlockDescription, DisputeCoordinatorMessage,
-		DisputeDistributionMessage, ImportStatementsResult, ChainSelectionMessage,
+		ApprovalVotingMessage, BlockDescription, ChainSelectionMessage, DisputeCoordinatorMessage,
+		DisputeDistributionMessage, ImportStatementsResult,
 	},
 	overseer, ActivatedLeaf, ActiveLeavesUpdate, FromOrchestra, OverseerSignal,
 };
@@ -1031,14 +1031,12 @@ impl Initialized {
 		// will need to mark the candidate's relay parent as reverted.
 		if import_result.is_freshly_concluded_against() {
 			if let Some(info) = self.scraper.get_included_candidate_info(candidate_hash) {
-				ctx.send_message(
-					ChainSelectionMessage::DisputeConcludedAgainst(
-						info.block_number,
-						info.block_hash,
-					))
-					.await;
-			}
-			else {
+				ctx.send_message(ChainSelectionMessage::DisputeConcludedAgainst(
+					info.block_number,
+					info.block_hash,
+				))
+				.await;
+			} else {
 				gum::error!(
 					target: LOG_TARGET,
 					?candidate_hash,

--- a/node/core/dispute-coordinator/src/initialized.rs
+++ b/node/core/dispute-coordinator/src/initialized.rs
@@ -1032,8 +1032,7 @@ impl Initialized {
 		if import_result.is_freshly_concluded_against() {
 			let blocks_including = self.scraper.get_blocks_including_candidate(&candidate_hash);
 			if blocks_including.len() > 0 {
-				ctx.send_message(ChainSelectionMessage::RevertBlocks(blocks_including))
-					.await;
+				ctx.send_message(ChainSelectionMessage::RevertBlocks(blocks_including)).await;
 			} else {
 				gum::debug!(
 					target: LOG_TARGET,

--- a/node/core/dispute-coordinator/src/initialized.rs
+++ b/node/core/dispute-coordinator/src/initialized.rs
@@ -1020,8 +1020,23 @@ impl Initialized {
 
 		// Notify ChainSelection if a dispute has concluded against a candidate
 		if import_result.is_freshly_concluded_against() {
-			ctx.send_message(ChainSelectionMessage::DisputeConcludedAgainst(candidate_hash))
-				.await;
+			let possible_info = self.scraper.get_included_candidate_info(candidate_hash);
+			if let Some(info) = possible_info {
+				ctx.send_message(
+					ChainSelectionMessage::DisputeConcludedAgainst(
+						info.block_number,
+						info.block_hash,
+					))
+					.await;
+			}
+			else {
+				gum::error!(
+					target: LOG_TARGET,
+					?candidate_hash,
+					?session,
+					"Could not find parent block info for concluded candidate!"
+				);
+			}
 		}
 
 		// Update metrics:

--- a/node/core/dispute-coordinator/src/initialized.rs
+++ b/node/core/dispute-coordinator/src/initialized.rs
@@ -1031,7 +1031,7 @@ impl Initialized {
 		// will need to mark the candidate's relay parent as reverted.
 		if import_result.is_freshly_concluded_against() {
 			if let Some(blocks_to_revert) =
-				self.scraper.get_blocks_including_candidate(candidate_hash)
+				self.scraper.get_blocks_including_candidate(&candidate_hash)
 			{
 				ctx.send_message(ChainSelectionMessage::RevertBlocks(blocks_to_revert.clone()))
 					.await;

--- a/node/core/dispute-coordinator/src/initialized.rs
+++ b/node/core/dispute-coordinator/src/initialized.rs
@@ -1027,10 +1027,10 @@ impl Initialized {
 			}
 		}
 
-		// Notify ChainSelection if a dispute has concluded against a candidate
+		// Notify ChainSelection if a dispute has concluded against a candidate. ChainSelection
+		// will need to mark the candidate's relay parent as reverted.
 		if import_result.is_freshly_concluded_against() {
-			let possible_info = self.scraper.get_included_candidate_info(candidate_hash);
-			if let Some(info) = possible_info {
+			if let Some(info) = self.scraper.get_included_candidate_info(candidate_hash) {
 				ctx.send_message(
 					ChainSelectionMessage::DisputeConcludedAgainst(
 						info.block_number,

--- a/node/core/dispute-coordinator/src/initialized.rs
+++ b/node/core/dispute-coordinator/src/initialized.rs
@@ -1030,12 +1030,11 @@ impl Initialized {
 		// Notify ChainSelection if a dispute has concluded against a candidate. ChainSelection
 		// will need to mark the candidate's relay parent as reverted.
 		if import_result.is_freshly_concluded_against() {
-			if let Some(info) = self.scraper.get_included_candidate_info(candidate_hash) {
-				ctx.send_message(ChainSelectionMessage::DisputeConcludedAgainst(
-					info.block_number,
-					info.block_hash,
-				))
-				.await;
+			if let Some(blocks_to_revert) =
+				self.scraper.get_blocks_including_candidate(candidate_hash)
+			{
+				ctx.send_message(ChainSelectionMessage::RevertBlocks(blocks_to_revert.clone()))
+					.await;
 			} else {
 				gum::error!(
 					target: LOG_TARGET,

--- a/node/core/dispute-coordinator/src/initialized.rs
+++ b/node/core/dispute-coordinator/src/initialized.rs
@@ -1030,10 +1030,9 @@ impl Initialized {
 		// Notify ChainSelection if a dispute has concluded against a candidate. ChainSelection
 		// will need to mark the candidate's relay parent as reverted.
 		if import_result.is_freshly_concluded_against() {
-			if let Some(blocks_to_revert) =
-				self.scraper.get_blocks_including_candidate(&candidate_hash)
-			{
-				ctx.send_message(ChainSelectionMessage::RevertBlocks(blocks_to_revert.clone()))
+			let blocks_including = self.scraper.get_blocks_including_candidate(&candidate_hash);
+			if blocks_including.len() > 0 {
+				ctx.send_message(ChainSelectionMessage::RevertBlocks(blocks_including))
 					.await;
 			} else {
 				gum::debug!(

--- a/node/core/dispute-coordinator/src/initialized.rs
+++ b/node/core/dispute-coordinator/src/initialized.rs
@@ -32,7 +32,7 @@ use polkadot_node_primitives::{
 use polkadot_node_subsystem::{
 	messages::{
 		ApprovalVotingMessage, BlockDescription, DisputeCoordinatorMessage,
-		DisputeDistributionMessage, ImportStatementsResult,
+		DisputeDistributionMessage, ImportStatementsResult, ChainSelectionMessage,
 	},
 	overseer, ActivatedLeaf, ActiveLeavesUpdate, FromOrchestra, OverseerSignal,
 };
@@ -1016,6 +1016,12 @@ impl Initialized {
 				);
 				overlay_db.write_recent_disputes(recent_disputes);
 			}
+		}
+
+		// Notify ChainSelection if a dispute has concluded against a candidate
+		if import_result.is_freshly_concluded_against() {
+			ctx.send_message(ChainSelectionMessage::DisputeConcludedAgainst(candidate_hash))
+				.await;
 		}
 
 		// Update metrics:

--- a/node/core/dispute-coordinator/src/initialized.rs
+++ b/node/core/dispute-coordinator/src/initialized.rs
@@ -1036,11 +1036,11 @@ impl Initialized {
 				ctx.send_message(ChainSelectionMessage::RevertBlocks(blocks_to_revert.clone()))
 					.await;
 			} else {
-				gum::error!(
+				gum::trace!(
 					target: LOG_TARGET,
 					?candidate_hash,
 					?session,
-					"Could not find parent block info for concluded candidate!"
+					"Could not find an including block for candidate against which a dispute has concluded."
 				);
 			}
 		}

--- a/node/core/dispute-coordinator/src/scraping/candidates.rs
+++ b/node/core/dispute-coordinator/src/scraping/candidates.rs
@@ -10,7 +10,7 @@ struct RefCountedCandidates {
 	candidates: HashMap<CandidateHash, CandidateInfo>,
 }
 
-// If a dispute is concluded against this candidate, then the ChainSelection 
+// If a dispute is concluded against this candidate, then the ChainSelection
 // subsystem needs block number and block hash to mark the relay parent as reverted.
 pub struct CandidateInfo {
 	count: usize,
@@ -131,7 +131,7 @@ impl ScrapedCandidates {
 	}
 
 	// Gets candidate info, importantly containing relay parent block number and
-	// block hash. These are needed for relay block reversions based on concluded 
+	// block hash. These are needed for relay block reversions based on concluded
 	// disputes.
 	pub fn get_candidate_info(&mut self, candidate: CandidateHash) -> Option<&CandidateInfo> {
 		self.candidates.candidates.get(&candidate)
@@ -143,7 +143,7 @@ impl ScrapedCandidates {
 		block_hash: Hash,
 		candidate_hash: CandidateHash,
 	) {
-		self.candidates.insert( block_number, block_hash, candidate_hash);
+		self.candidates.insert(block_number, block_hash, candidate_hash);
 		self.candidates_by_block_number
 			.entry(block_number)
 			.or_default()

--- a/node/core/dispute-coordinator/src/scraping/candidates.rs
+++ b/node/core/dispute-coordinator/src/scraping/candidates.rs
@@ -102,15 +102,18 @@ impl ScrapedCandidates {
 	}
 
 	// Removes all candidates up to a given height. The candidates at the block height are NOT removed.
-	pub fn remove_up_to_height(&mut self, height: &BlockNumber) {
+	pub fn remove_up_to_height(&mut self, height: &BlockNumber) -> HashSet<CandidateHash> {
+		let mut candidates_modified: HashSet<CandidateHash> = HashSet::new();
 		let not_stale = self.candidates_by_block_number.split_off(&height);
 		let stale = std::mem::take(&mut self.candidates_by_block_number);
 		self.candidates_by_block_number = not_stale;
 		for candidates in stale.values() {
 			for c in candidates {
 				self.candidates.remove(c);
+				candidates_modified.insert(c.clone());
 			}
 		}
+		candidates_modified
 	}
 
 	pub fn insert(&mut self, block_number: BlockNumber, candidate_hash: CandidateHash) {

--- a/node/core/dispute-coordinator/src/scraping/candidates.rs
+++ b/node/core/dispute-coordinator/src/scraping/candidates.rs
@@ -117,11 +117,7 @@ impl ScrapedCandidates {
 		unique_candidates
 	}
 
-	pub fn insert(
-		&mut self,
-		block_number: BlockNumber,
-		candidate_hash: CandidateHash
-	) {
+	pub fn insert(&mut self, block_number: BlockNumber, candidate_hash: CandidateHash) {
 		self.candidates.insert(candidate_hash);
 		self.candidates_by_block_number
 			.entry(block_number)
@@ -140,7 +136,6 @@ impl ScrapedCandidates {
 mod scraped_candidates_tests {
 	use super::*;
 	use polkadot_primitives::v2::{BlakeTwo256, HashT};
-	use test_helpers::dummy_hash;
 
 	#[test]
 	fn stale_candidates_are_removed() {

--- a/node/core/dispute-coordinator/src/scraping/candidates.rs
+++ b/node/core/dispute-coordinator/src/scraping/candidates.rs
@@ -27,9 +27,9 @@ impl RefCountedCandidates {
 	// If `CandidateHash` already exists in the `HashMap` its reference count is increased.
 	pub fn insert(
 		&mut self,
+		candidate: CandidateHash,
 		block_number: BlockNumber,
 		block_hash: Hash,
-		candidate: CandidateHash,
 	) {
 		self.candidates
 			.entry(candidate)
@@ -70,11 +70,11 @@ mod ref_counted_candidates_tests {
 		let zero = CandidateHash(BlakeTwo256::hash(&vec![0]));
 		let one = CandidateHash(BlakeTwo256::hash(&vec![1]));
 		// add two separate candidates
-		container.insert(0, dummy_hash(), zero); // refcount == 1
-		container.insert(0, dummy_hash(), one);
+		container.insert(zero, 0, dummy_hash()); // refcount == 1
+		container.insert(one, 0, dummy_hash());
 
 		// and increase the reference count for the first
-		container.insert(0, dummy_hash(), zero); // refcount == 2
+		container.insert(zero, 0, dummy_hash()); // refcount == 2
 
 		assert!(container.contains(&zero));
 		assert!(container.contains(&one));
@@ -143,7 +143,7 @@ impl ScrapedCandidates {
 		block_hash: Hash,
 		candidate_hash: CandidateHash,
 	) {
-		self.candidates.insert(block_number, block_hash, candidate_hash);
+		self.candidates.insert(candidate_hash, block_number, block_hash);
 		self.candidates_by_block_number
 			.entry(block_number)
 			.or_default()

--- a/node/core/dispute-coordinator/src/scraping/candidates.rs
+++ b/node/core/dispute-coordinator/src/scraping/candidates.rs
@@ -102,19 +102,15 @@ impl ScrapedCandidates {
 	}
 
 	// Removes all candidates up to a given height. The candidates at the block height are NOT removed.
-	pub fn remove_up_to_height(&mut self, height: &BlockNumber) -> HashSet<CandidateHash> {
-		let mut unique_candidates: HashSet<CandidateHash> = HashSet::new();
+	pub fn remove_up_to_height(&mut self, height: &BlockNumber) {
 		let not_stale = self.candidates_by_block_number.split_off(&height);
 		let stale = std::mem::take(&mut self.candidates_by_block_number);
 		self.candidates_by_block_number = not_stale;
 		for candidates in stale.values() {
 			for c in candidates {
 				self.candidates.remove(c);
-				unique_candidates.insert(c.clone());
 			}
 		}
-
-		unique_candidates
 	}
 
 	pub fn insert(&mut self, block_number: BlockNumber, candidate_hash: CandidateHash) {

--- a/node/core/dispute-coordinator/src/scraping/candidates.rs
+++ b/node/core/dispute-coordinator/src/scraping/candidates.rs
@@ -13,7 +13,7 @@ struct RefCountedCandidates {
 // If a dispute is concluded against this candidate, then the ChainSelection
 // subsystem needs block number and block hash to mark the relay parent as reverted.
 pub struct CandidateInfo {
-	count: usize,
+	ref_count: usize,
 	pub block_number: BlockNumber,
 	pub block_hash: Hash,
 }
@@ -33,8 +33,8 @@ impl RefCountedCandidates {
 	) {
 		self.candidates
 			.entry(candidate)
-			.or_insert(CandidateInfo { count: 0, block_number, block_hash })
-			.count += 1;
+			.or_insert(CandidateInfo { ref_count: 0, block_number, block_hash })
+			.ref_count += 1;
 	}
 
 	// If a `CandidateHash` with reference count equals to 1 is about to be removed - the
@@ -43,9 +43,9 @@ impl RefCountedCandidates {
 	// reference count is decreased and the candidate remains in the container.
 	pub fn remove(&mut self, candidate: &CandidateHash) {
 		match self.candidates.get_mut(candidate) {
-			Some(v) if v.count > 1 => v.count -= 1,
+			Some(v) if v.ref_count > 1 => v.ref_count -= 1,
 			Some(v) => {
-				assert!(v.count == 1);
+				assert!(v.ref_count == 1);
 				self.candidates.remove(candidate);
 			},
 			None => {},

--- a/node/core/dispute-coordinator/src/scraping/candidates.rs
+++ b/node/core/dispute-coordinator/src/scraping/candidates.rs
@@ -139,9 +139,9 @@ impl ScrapedCandidates {
 
 	pub fn insert(
 		&mut self,
+		candidate_hash: CandidateHash,
 		block_number: BlockNumber,
 		block_hash: Hash,
-		candidate_hash: CandidateHash,
 	) {
 		self.candidates.insert(candidate_hash, block_number, block_hash);
 		self.candidates_by_block_number
@@ -167,7 +167,7 @@ mod scraped_candidates_tests {
 	fn stale_candidates_are_removed() {
 		let mut candidates = ScrapedCandidates::new();
 		let target = CandidateHash(BlakeTwo256::hash(&vec![1, 2, 3]));
-		candidates.insert(1, dummy_hash(), target);
+		candidates.insert(target, 1, dummy_hash());
 
 		assert!(candidates.contains(&target));
 

--- a/node/core/dispute-coordinator/src/scraping/candidates.rs
+++ b/node/core/dispute-coordinator/src/scraping/candidates.rs
@@ -10,6 +10,8 @@ struct RefCountedCandidates {
 	candidates: HashMap<CandidateHash, CandidateInfo>,
 }
 
+// If a dispute is concluded against this candidate, then the ChainSelection 
+// subsystem needs block number and block hash to mark the relay parent as reverted.
 pub struct CandidateInfo {
 	count: usize,
 	pub block_number: BlockNumber,
@@ -128,6 +130,9 @@ impl ScrapedCandidates {
 		}
 	}
 
+	// Gets candidate info, importantly containing relay parent block number and
+	// block hash. These are needed for relay block reversions based on concluded 
+	// disputes.
 	pub fn get_candidate_info(&mut self, candidate: CandidateHash) -> Option<&CandidateInfo> {
 		self.candidates.candidates.get(&candidate)
 	}

--- a/node/core/dispute-coordinator/src/scraping/candidates.rs
+++ b/node/core/dispute-coordinator/src/scraping/candidates.rs
@@ -110,7 +110,7 @@ impl ScrapedCandidates {
 		for candidates in stale.values() {
 			for c in candidates {
 				self.candidates.remove(c);
-				candidates_modified.insert(c.clone());
+				candidates_modified.insert(*c);
 			}
 		}
 		candidates_modified

--- a/node/core/dispute-coordinator/src/scraping/mod.rs
+++ b/node/core/dispute-coordinator/src/scraping/mod.rs
@@ -71,7 +71,7 @@ impl ScrapedUpdates {
 
 /// A structure meant to facilitate chain reversions in the event of a dispute
 /// concluding against a candidate. Each candidate hash maps to a vector of block
-/// numbers and hashes for all blocks which included the candidate. The entries
+/// number + hash pairs for all blocks which included the candidate. The entries
 /// in each vector are ordered by decreasing parent block number to facilitate
 /// minimal cost pruning.
 pub struct InclusionsPerCandidate {

--- a/node/core/dispute-coordinator/src/scraping/mod.rs
+++ b/node/core/dispute-coordinator/src/scraping/mod.rs
@@ -75,7 +75,7 @@ impl ScrapedUpdates {
 ///
 /// Scrapes unfinalized chain in order to collect information from blocks. Chain scraping
 /// during disputes enables critical spam prevention. It does so by updating two important
-/// criteria determining whether a vote sent during dispute distribution is potential 
+/// criteria determining whether a vote sent during dispute distribution is potential
 /// spam. Namely, whether the candidate being voted on is backed or included.
 ///
 /// Concretely:

--- a/node/core/dispute-coordinator/src/scraping/mod.rs
+++ b/node/core/dispute-coordinator/src/scraping/mod.rs
@@ -70,10 +70,8 @@ impl ScrapedUpdates {
 }
 
 /// A structure meant to facilitate chain reversions in the event of a dispute
-/// concluding against a candidate. Each candidate hash maps to a vector of block
-/// number + hash pairs for all blocks which included the candidate. The entries
-/// in each vector are ordered by decreasing parent block number to facilitate
-/// minimal cost pruning.
+/// concluding against a candidate. Each candidate hash maps to a number of 
+/// block heights, which in turn map to vectors of blocks at those heights. 
 pub struct Inclusions {
 	inclusions_inner: BTreeMap<CandidateHash, BTreeMap<BlockNumber, Vec<Hash>>>,
 }
@@ -83,8 +81,8 @@ impl Inclusions {
 		Self { inclusions_inner: BTreeMap::new() }
 	}
 
-	// Insert parent block into vector for the candidate hash it is including,
-	// maintaining ordering by decreasing parent block number.
+	// Add parent block to the vector which has CandidateHash as an outer key and 
+	// BlockNumber as an inner key
 	pub fn insert(
 		&mut self,
 		candidate_hash: CandidateHash,

--- a/node/core/dispute-coordinator/src/scraping/mod.rs
+++ b/node/core/dispute-coordinator/src/scraping/mod.rs
@@ -237,7 +237,7 @@ impl ChainScraper {
 						?block_number,
 						"Processing included event"
 					);
-					self.included_candidates.insert(block_number, block_hash, candidate_hash);
+					self.included_candidates.insert(candidate_hash, block_number, block_hash);
 					included_receipts.push(receipt);
 				},
 				CandidateEvent::CandidateBacked(receipt, _, _, _) => {
@@ -248,7 +248,7 @@ impl ChainScraper {
 						?block_number,
 						"Processing backed event"
 					);
-					self.backed_candidates.insert(block_number, block_hash, candidate_hash);
+					self.backed_candidates.insert(candidate_hash, block_number, block_hash);
 				},
 				_ => {
 					// skip the rest

--- a/node/core/dispute-coordinator/src/scraping/mod.rs
+++ b/node/core/dispute-coordinator/src/scraping/mod.rs
@@ -105,6 +105,7 @@ impl Inclusions {
 
 	pub fn remove_up_to_height(&mut self, height: &BlockNumber) {
 		for blocks_including in self.inclusions_inner.values_mut() {
+            // Returns everything after the given key, including the key. This works because the blocks are sorted in ascending order.
 			*blocks_including = blocks_including.split_off(height);
 		}
 		self.inclusions_inner.retain(|_, blocks_including| blocks_including.keys().len() > 0);

--- a/node/core/dispute-coordinator/src/scraping/mod.rs
+++ b/node/core/dispute-coordinator/src/scraping/mod.rs
@@ -234,7 +234,7 @@ impl ChainScraper {
 						?block_number,
 						"Processing included event"
 					);
-					self.included_candidates.insert(block_number, candidate_hash);
+					self.included_candidates.insert(block_number, block_hash, candidate_hash);
 					included_receipts.push(receipt);
 				},
 				CandidateEvent::CandidateBacked(receipt, _, _, _) => {

--- a/node/core/dispute-coordinator/src/scraping/mod.rs
+++ b/node/core/dispute-coordinator/src/scraping/mod.rs
@@ -109,7 +109,7 @@ impl Inclusions {
 		for blocks_including in self.inclusions_inner.values_mut() {
 			*blocks_including = blocks_including.split_off(height);
 		}
-		self.inclusions_inner.retain(|_, including_blocks| including_blocks.keys().len() > 0);
+		self.inclusions_inner.retain(|_, blocks_including| blocks_including.keys().len() > 0);
 	}
 
 	pub fn get(&mut self, candidate: &CandidateHash) -> Vec<(BlockNumber, Hash)> {

--- a/node/core/dispute-coordinator/src/scraping/mod.rs
+++ b/node/core/dispute-coordinator/src/scraping/mod.rs
@@ -34,6 +34,8 @@ use crate::{
 	LOG_TARGET,
 };
 
+use self::candidates::CandidateInfo;
+
 #[cfg(test)]
 mod tests;
 
@@ -207,7 +209,7 @@ impl ChainScraper {
 						?block_number,
 						"Processing included event"
 					);
-					self.included_candidates.insert(block_number, candidate_hash);
+					self.included_candidates.insert(block_number, block_hash, candidate_hash);
 				},
 				CandidateEvent::CandidateBacked(receipt, _, _, _) => {
 					let candidate_hash = receipt.hash();
@@ -217,7 +219,7 @@ impl ChainScraper {
 						?block_number,
 						"Processing backed event"
 					);
-					self.backed_candidates.insert(block_number, candidate_hash);
+					self.backed_candidates.insert(block_number, block_hash, candidate_hash);
 				},
 				_ => {
 					// skip the rest
@@ -291,6 +293,13 @@ impl ChainScraper {
 			}
 		}
 		return Ok(ancestors)
+	}
+
+	pub fn get_included_candidate_info(
+		&mut self,
+		candidate: CandidateHash,
+	) -> Option<&CandidateInfo> {
+		self.included_candidates.get_candidate_info(candidate)
 	}
 }
 

--- a/node/core/dispute-coordinator/src/scraping/mod.rs
+++ b/node/core/dispute-coordinator/src/scraping/mod.rs
@@ -73,7 +73,10 @@ impl ScrapedUpdates {
 
 /// Chain scraper
 ///
-/// Scrapes unfinalized chain in order to collect information from blocks.
+/// Scrapes unfinalized chain in order to collect information from blocks. Chain scraping
+/// during disputes enables critical spam prevention. It does so by updating two important
+/// criteria determining whether a vote sent during dispute distribution is potential 
+/// spam. Namely, whether the candidate being voted on is backed or included.
 ///
 /// Concretely:
 ///

--- a/node/core/dispute-coordinator/src/scraping/mod.rs
+++ b/node/core/dispute-coordinator/src/scraping/mod.rs
@@ -208,16 +208,12 @@ impl ChainScraper {
 			Some(key_to_prune) => {
 				self.backed_candidates.remove_up_to_height(&key_to_prune);
 				let candidates_pruned = self.included_candidates.remove_up_to_height(&key_to_prune);
-				// Removing entries from inclusions per candidate referring to blocks before 
+				// Removing entries from inclusions per candidate referring to blocks before
 				// key_to_prune
 				for candidate_hash in candidates_pruned {
 					self.inclusions_per_candidate.entry(candidate_hash).and_modify(|inclusions| {
-						*inclusions = inclusions
-							.clone()
-							.into_iter()
-							.filter(|inclusion| inclusion.0 >= key_to_prune)
-							.collect::<HashSet<(BlockNumber, Hash)>>();
-					}); 
+						inclusions.retain(|inclusion| inclusion.0 >= key_to_prune);
+					});
 					if let Some(inclusions) = self.inclusions_per_candidate.get(&candidate_hash) {
 						if inclusions.is_empty() {
 							self.inclusions_per_candidate.remove(&candidate_hash);

--- a/node/core/dispute-coordinator/src/scraping/tests.rs
+++ b/node/core/dispute-coordinator/src/scraping/tests.rs
@@ -620,10 +620,10 @@ fn inclusions_per_candidate_properly_adds_and_prunes() {
 		// the candidate is included are recorded
 		assert_eq!(
 			scraper.get_blocks_including_candidate(&candidate.hash()),
-			Some(&Vec::from([
-				(TEST_TARGET_BLOCK_NUMBER_2, get_block_number_hash(TEST_TARGET_BLOCK_NUMBER_2)),
-				(TEST_TARGET_BLOCK_NUMBER, get_block_number_hash(TEST_TARGET_BLOCK_NUMBER))
-			]))
+			Vec::from([
+				(TEST_TARGET_BLOCK_NUMBER, get_block_number_hash(TEST_TARGET_BLOCK_NUMBER)),
+				(TEST_TARGET_BLOCK_NUMBER_2, get_block_number_hash(TEST_TARGET_BLOCK_NUMBER_2))
+			])
 		);
 
 		// After `DISPUTE_CANDIDATE_LIFETIME_AFTER_FINALIZATION` blocks the earlier inclusion should be removed
@@ -634,10 +634,10 @@ fn inclusions_per_candidate_properly_adds_and_prunes() {
 		// The later inclusion should still be present, as we haven't exceeded its lifetime
 		assert_eq!(
 			scraper.get_blocks_including_candidate(&candidate.hash()),
-			Some(&Vec::from([(
+			Vec::from([(
 				TEST_TARGET_BLOCK_NUMBER_2,
 				get_block_number_hash(TEST_TARGET_BLOCK_NUMBER_2)
-			)]))
+			)])
 		);
 
 		finalized_block_number =
@@ -645,6 +645,6 @@ fn inclusions_per_candidate_properly_adds_and_prunes() {
 		process_finalized_block(&mut scraper, &finalized_block_number);
 
 		// Now both inclusions have exceeded their lifetimes after finalization and should be purged
-		assert_eq!(scraper.get_blocks_including_candidate(&candidate.hash()), None);
+		assert!(scraper.get_blocks_including_candidate(&candidate.hash()).len() == 0);
 	});
 }

--- a/node/core/dispute-coordinator/src/scraping/tests.rs
+++ b/node/core/dispute-coordinator/src/scraping/tests.rs
@@ -578,3 +578,73 @@ fn scraper_handles_the_same_candidate_incuded_in_two_different_block_heights() {
 		assert!(!scraper.is_candidate_included(&magic_candidate.hash()));
 	});
 }
+
+#[test]
+fn inclusions_per_candidate_properly_adds_and_prunes() {
+	const TEST_TARGET_BLOCK_NUMBER: BlockNumber = 2;
+	const TEST_TARGET_BLOCK_NUMBER_2: BlockNumber = 3;
+
+	// How many blocks should we skip before sending a leaf update.
+	const BLOCKS_TO_SKIP: usize = 4;
+
+	futures::executor::block_on(async {
+		let (state, mut virtual_overseer) = TestState::new().await;
+
+		let TestState { mut chain, mut scraper, mut ctx } = state;
+
+		// 1 because `TestState` starts at leaf 1.
+		let next_update = (1..BLOCKS_TO_SKIP).map(|_| next_leaf(&mut chain)).last().unwrap();
+
+		let mut finalized_block_number = 1;
+		let expected_ancestry_len = BLOCKS_TO_SKIP - finalized_block_number as usize;
+		let overseer_fut = overseer_process_active_leaves_update(
+			&mut virtual_overseer,
+			&chain,
+			finalized_block_number,
+			expected_ancestry_len,
+			|block_num| {
+				if block_num == TEST_TARGET_BLOCK_NUMBER || block_num == TEST_TARGET_BLOCK_NUMBER_2
+				{
+					get_backed_and_included_candidate_events(TEST_TARGET_BLOCK_NUMBER)
+				} else {
+					vec![]
+				}
+			},
+		);
+		join(process_active_leaves_update(ctx.sender(), &mut scraper, next_update), overseer_fut)
+			.await;
+
+		let candidate = make_candidate_receipt(get_block_number_hash(TEST_TARGET_BLOCK_NUMBER));
+
+		// We included the same candidate at two different block heights. So both blocks in which
+		// the candidate is included are recorded
+		assert_eq!(
+			scraper.get_blocks_including_candidate(&candidate.hash()),
+			Some(&Vec::from([
+				(TEST_TARGET_BLOCK_NUMBER_2, get_block_number_hash(TEST_TARGET_BLOCK_NUMBER_2)),
+				(TEST_TARGET_BLOCK_NUMBER, get_block_number_hash(TEST_TARGET_BLOCK_NUMBER))
+			]))
+		);
+
+		// After `DISPUTE_CANDIDATE_LIFETIME_AFTER_FINALIZATION` blocks the earlier inclusion should be removed
+		finalized_block_number =
+			TEST_TARGET_BLOCK_NUMBER + DISPUTE_CANDIDATE_LIFETIME_AFTER_FINALIZATION;
+		process_finalized_block(&mut scraper, &finalized_block_number);
+
+		// The later inclusion should still be present, as we haven't exceeded its lifetime
+		assert_eq!(
+			scraper.get_blocks_including_candidate(&candidate.hash()),
+			Some(&Vec::from([(
+				TEST_TARGET_BLOCK_NUMBER_2,
+				get_block_number_hash(TEST_TARGET_BLOCK_NUMBER_2)
+			)]))
+		);
+
+		finalized_block_number =
+			TEST_TARGET_BLOCK_NUMBER_2 + DISPUTE_CANDIDATE_LIFETIME_AFTER_FINALIZATION;
+		process_finalized_block(&mut scraper, &finalized_block_number);
+
+		// Now both inclusions have exceeded their lifetimes after finalization and should be purged
+		assert_eq!(scraper.get_blocks_including_candidate(&candidate.hash()), None);
+	});
+}

--- a/node/core/dispute-coordinator/src/tests.rs
+++ b/node/core/dispute-coordinator/src/tests.rs
@@ -3444,8 +3444,6 @@ fn informs_chain_selection_when_dispute_concluded_against() {
 			handle_approval_vote_request(&mut virtual_overseer, &candidate_hash, HashMap::new())
 				.await;
 
-			test_state.clock.set(ACTIVE_DURATION_SECS + 1);
-
 			assert_matches!(
 				virtual_overseer.recv().await,
 				AllMessages::ChainSelection(

--- a/node/core/dispute-coordinator/src/tests.rs
+++ b/node/core/dispute-coordinator/src/tests.rs
@@ -3394,7 +3394,6 @@ fn informs_chain_selection_when_dispute_concluded_against() {
 				)
 				.await;
 
-			// Concluding dispute
 			let supermajority_threshold =
 				polkadot_primitives::v2::supermajority_threshold(test_state.validators.len());
 

--- a/node/core/dispute-coordinator/src/tests.rs
+++ b/node/core/dispute-coordinator/src/tests.rs
@@ -3342,7 +3342,7 @@ fn participation_requests_reprioritized_for_newly_included() {
 // the chain selection subsystem. Then chain selection can revert the relay parent of
 // the disputed candidate and mark all descendants as non-viable. This direct
 // notification saves time compared to letting chain selection learn about a dispute
-// conclusion from on chain sources.
+// conclusion from an on chain revert log.
 #[test]
 fn informs_chain_selection_when_dispute_concluded_against() {
 	test_harness(|mut test_state, mut virtual_overseer| {
@@ -3447,12 +3447,12 @@ fn informs_chain_selection_when_dispute_concluded_against() {
 			assert_matches!(
 				virtual_overseer.recv().await,
 				AllMessages::ChainSelection(
-					ChainSelectionMessage::DisputeConcludedAgainst(block_number, block_hash)
+					ChainSelectionMessage::RevertBlocks(block_number, block_hash)
 				) => {
 					assert_eq!(block_number, parent_number);
 					assert_eq!(block_hash, parent_hash);
 				},
-				"Overseer did not receive `ChainSelectionMessage::DisputeConcludedAgainst` message"
+				"Overseer did not receive `ChainSelectionMessage::RevertBlocks` message"
 			);
 
 			// Wrap up

--- a/node/core/dispute-coordinator/src/tests.rs
+++ b/node/core/dispute-coordinator/src/tests.rs
@@ -36,7 +36,7 @@ use polkadot_node_primitives::{
 };
 use polkadot_node_subsystem::{
 	messages::{
-		ApprovalVotingMessage, ChainApiMessage, DisputeCoordinatorMessage,
+		ApprovalVotingMessage, ChainApiMessage, ChainSelectionMessage, DisputeCoordinatorMessage,
 		DisputeDistributionMessage, ImportStatementsResult,
 	},
 	overseer::FromOrchestra,
@@ -3344,6 +3344,137 @@ fn participation_requests_reprioritized_for_newly_included() {
 
 			// Wrap up
 			virtual_overseer.send(FromOrchestra::Signal(OverseerSignal::Conclude)).await;
+
+			test_state
+		})
+	});
+}
+
+// When a dispute has concluded against a parachain block candidate we want to notify
+// the chain selection subsystem. Then chain selection can revert the relay parent of
+// the disputed candidate and mark all descendants as non-viable. This direct
+// notification saves time compared to letting chain selection learn about a dispute
+// conclusion from on chain sources.
+#[test]
+fn informs_chain_selection_when_dispute_concluded_against() {
+	test_harness(|mut test_state, mut virtual_overseer| {
+		Box::pin(async move {
+			let session = 1;
+
+			test_state.handle_resume_sync(&mut virtual_overseer, session).await;
+
+			let candidate_receipt = make_invalid_candidate_receipt();
+			let parent_number = 1;
+
+			let candidate_hash = candidate_receipt.hash();
+
+			// Copied from activate_leaf_at_session to give access to parent_hash
+			let block_header = Header {
+				parent_hash: test_state.last_block,
+				number: parent_number,
+				digest: dummy_digest(),
+				state_root: dummy_hash(),
+				extrinsics_root: dummy_hash(),
+			};
+			let parent_hash = block_header.hash();
+
+			test_state
+				.activate_leaf_at_session(
+					&mut virtual_overseer,
+					session,
+					parent_number,
+					vec![make_candidate_included_event(candidate_receipt.clone())],
+				)
+				.await;
+
+			let supermajority_threshold =
+				polkadot_primitives::v2::supermajority_threshold(test_state.validators.len());
+
+			let (valid_vote, invalid_vote) = generate_opposing_votes_pair(
+				&test_state,
+				ValidatorIndex(2),
+				ValidatorIndex(1),
+				candidate_hash,
+				session,
+				VoteType::Explicit,
+			)
+			.await;
+
+			let (pending_confirmation, confirmation_rx) = oneshot::channel();
+			virtual_overseer
+				.send(FromOrchestra::Communication {
+					msg: DisputeCoordinatorMessage::ImportStatements {
+						candidate_receipt: candidate_receipt.clone(),
+						session,
+						statements: vec![
+							(valid_vote, ValidatorIndex(2)),
+							(invalid_vote, ValidatorIndex(1)),
+						],
+						pending_confirmation: Some(pending_confirmation),
+					},
+				})
+				.await;
+			handle_approval_vote_request(&mut virtual_overseer, &candidate_hash, HashMap::new())
+				.await;
+			assert_matches!(confirmation_rx.await.unwrap(),
+				ImportStatementsResult::ValidImport => {}
+			);
+
+			// Use a different expected commitments hash to ensure the candidate validation returns invalid.
+			participation_with_distribution(
+				&mut virtual_overseer,
+				&candidate_hash,
+				CandidateCommitments::default().hash(),
+			)
+			.await;
+
+			let mut statements = Vec::new();
+			// minus 2, because of local vote and one previously imported invalid vote.
+			for i in (0_u32..supermajority_threshold as u32 - 2).map(|i| i + 3) {
+				let vote = test_state
+					.issue_explicit_statement_with_index(
+						ValidatorIndex(i),
+						candidate_hash,
+						session,
+						false,
+					)
+					.await;
+
+				statements.push((vote, ValidatorIndex(i as _)));
+			}
+
+			virtual_overseer
+				.send(FromOrchestra::Communication {
+					msg: DisputeCoordinatorMessage::ImportStatements {
+						candidate_receipt: candidate_receipt.clone(),
+						session,
+						statements,
+						pending_confirmation: None,
+					},
+				})
+				.await;
+			handle_approval_vote_request(&mut virtual_overseer, &candidate_hash, HashMap::new())
+				.await;
+
+			test_state.clock.set(ACTIVE_DURATION_SECS + 1);
+
+			assert_matches!(
+				virtual_overseer.recv().await,
+				AllMessages::ChainSelection(
+					ChainSelectionMessage::DisputeConcludedAgainst(block_number, block_hash)
+				) => {
+					assert_eq!(block_number, parent_number);
+					assert_eq!(block_hash, parent_hash);
+				},
+				"Overseer did not receive `ChainSelectionMessage::DisputeConcludedAgainst` message"
+			);
+
+			// Wrap up
+			virtual_overseer.send(FromOrchestra::Signal(OverseerSignal::Conclude)).await;
+			assert_matches!(
+				virtual_overseer.try_recv().await,
+				None => {}
+			);
 
 			test_state
 		})

--- a/node/overseer/src/lib.rs
+++ b/node/overseer/src/lib.rs
@@ -593,6 +593,7 @@ pub struct Overseer<SupportsParachains> {
 		ApprovalVotingMessage,
 		AvailabilityStoreMessage,
 		AvailabilityRecoveryMessage,
+		ChainSelectionMessage,
 	])]
 	dispute_coordinator: DisputeCoordinator,
 

--- a/node/subsystem-types/src/messages.rs
+++ b/node/subsystem-types/src/messages.rs
@@ -520,7 +520,7 @@ pub enum ChainSelectionMessage {
 	BestLeafContaining(Hash, oneshot::Sender<Option<Hash>>),
 	/// The passed blocks must be marked as reverted, and their children must be marked
 	/// as non-viable.
-	RevertBlocks(HashSet<(BlockNumber, Hash)>),
+	RevertBlocks(Vec<(BlockNumber, Hash)>),
 }
 
 /// A sender for the result of a runtime API request.

--- a/node/subsystem-types/src/messages.rs
+++ b/node/subsystem-types/src/messages.rs
@@ -592,7 +592,9 @@ pub enum ChainSelectionMessage {
 	/// Request the best leaf containing the given block in its ancestry. Return `None` if
 	/// there is no such leaf.
 	BestLeafContaining(Hash, oneshot::Sender<Option<Hash>>),
-	/// Apply reverted status to blocks in chains containing the disputed candidate.
+	/// Passed block number and hash are for the relay parent of the disputed candidate.
+	/// The parent must be marked as reverted, and its children must be marked as 
+	/// non-viable.
 	DisputeConcludedAgainst(BlockNumber, Hash),
 }
 

--- a/node/subsystem-types/src/messages.rs
+++ b/node/subsystem-types/src/messages.rs
@@ -518,10 +518,9 @@ pub enum ChainSelectionMessage {
 	/// Request the best leaf containing the given block in its ancestry. Return `None` if
 	/// there is no such leaf.
 	BestLeafContaining(Hash, oneshot::Sender<Option<Hash>>),
-	/// Passed block number and hash are for the relay parent of the disputed candidate.
-	/// The parent must be marked as reverted, and its children must be marked as
-	/// non-viable.
-	DisputeConcludedAgainst(BlockNumber, Hash),
+	/// The passed blocks must be marked as reverted, and their children must be marked
+	/// as non-viable.
+	RevertBlocks(HashSet<(BlockNumber, Hash)>),
 }
 
 /// A sender for the result of a runtime API request.

--- a/node/subsystem-types/src/messages.rs
+++ b/node/subsystem-types/src/messages.rs
@@ -593,7 +593,7 @@ pub enum ChainSelectionMessage {
 	/// there is no such leaf.
 	BestLeafContaining(Hash, oneshot::Sender<Option<Hash>>),
 	/// Apply reverted status to blocks in chains containing the disputed candidate.
-	DisputeConcludedAgainst(Hash),
+	DisputeConcludedAgainst(CandidateHash),
 }
 
 impl ChainSelectionMessage {

--- a/node/subsystem-types/src/messages.rs
+++ b/node/subsystem-types/src/messages.rs
@@ -593,7 +593,7 @@ pub enum ChainSelectionMessage {
 	/// there is no such leaf.
 	BestLeafContaining(Hash, oneshot::Sender<Option<Hash>>),
 	/// Apply reverted status to blocks in chains containing the disputed candidate.
-	DisputeConcludedAgainst(CandidateHash),
+	DisputeConcludedAgainst(BlockNumber, Hash),
 }
 
 impl ChainSelectionMessage {
@@ -606,7 +606,7 @@ impl ChainSelectionMessage {
 			ChainSelectionMessage::Approved(_) => None,
 			ChainSelectionMessage::Leaves(_) => None,
 			ChainSelectionMessage::BestLeafContaining(..) => None,
-			ChainSelectionMessage::DisputeConcludedAgainst(_) => None,
+			ChainSelectionMessage::DisputeConcludedAgainst(..) => None,
 		}
 	}
 }

--- a/node/subsystem-types/src/messages.rs
+++ b/node/subsystem-types/src/messages.rs
@@ -593,7 +593,7 @@ pub enum ChainSelectionMessage {
 	/// there is no such leaf.
 	BestLeafContaining(Hash, oneshot::Sender<Option<Hash>>),
 	/// Passed block number and hash are for the relay parent of the disputed candidate.
-	/// The parent must be marked as reverted, and its children must be marked as 
+	/// The parent must be marked as reverted, and its children must be marked as
 	/// non-viable.
 	DisputeConcludedAgainst(BlockNumber, Hash),
 }

--- a/node/subsystem-types/src/messages.rs
+++ b/node/subsystem-types/src/messages.rs
@@ -592,6 +592,8 @@ pub enum ChainSelectionMessage {
 	/// Request the best leaf containing the given block in its ancestry. Return `None` if
 	/// there is no such leaf.
 	BestLeafContaining(Hash, oneshot::Sender<Option<Hash>>),
+	/// Apply reverted status to blocks in chains containing the disputed candidate.
+	DisputeConcludedAgainst(Hash),
 }
 
 impl ChainSelectionMessage {
@@ -604,6 +606,7 @@ impl ChainSelectionMessage {
 			ChainSelectionMessage::Approved(_) => None,
 			ChainSelectionMessage::Leaves(_) => None,
 			ChainSelectionMessage::BestLeafContaining(..) => None,
+			ChainSelectionMessage::DisputeConcludedAgainst(_) => None,
 		}
 	}
 }

--- a/roadmap/implementers-guide/src/node/disputes/dispute-coordinator.md
+++ b/roadmap/implementers-guide/src/node/disputes/dispute-coordinator.md
@@ -9,7 +9,11 @@ In particular the dispute-coordinator is responsible for:
 
 - Ensuring that the node is able to raise a dispute in case an invalid candidate
   is found during approval checking.
-- Ensuring approval votes will be recorded.
+- Ensuring that backing and approval votes will be recorded on chain. With these 
+  votes on chain we can be certain that appropriate targets for slashing will be
+  available for concluded disputes. Also, scraping these votes during a dispute
+  is necessary for critical spam prevention measures.
+- Ensuring backing votes will never get overridden by explicit votes.
 - Coordinating actual participation in a dispute, ensuring that the node
   participates in any justified dispute in a way that ensures resolution of
   disputes on the network even in the case of many disputes raised (flood/DoS
@@ -17,15 +21,13 @@ In particular the dispute-coordinator is responsible for:
 - Ensuring disputes resolve, even for candidates on abandoned forks as much as
   reasonably possible, to rule out "free tries" and thus guarantee our gambler's
   ruin property.
-- Provide an API for chain selection, so we can prevent finalization of any
+- Providing an API for chain selection, so we can prevent finalization of any
   chain which has included candidates for which a dispute is either ongoing or
   concluded invalid and avoid building on chains with an included invalid
   candidate.
-- Provide an API for retrieving (resolved) disputes, including all votes, both
+- Providing an API for retrieving (resolved) disputes, including all votes, both
   implicit (approval, backing) and explicit dispute votes. So validators can get
   rewarded/slashed accordingly.
-- Ensure backing votes are recorded and will never get overridden by explicit
-  votes.
 
 ## Ensuring That Disputes Can Be Raised
 

--- a/roadmap/implementers-guide/src/node/utility/chain-selection.md
+++ b/roadmap/implementers-guide/src/node/utility/chain-selection.md
@@ -8,6 +8,7 @@ This subsystem needs to update its information on the unfinalized chain:
   * On every leaf-activated signal
   * On every block-finalized signal
   * On every `ChainSelectionMessage::Approve`
+  * On every `ChainSelectionMessage::DisputeConcludedAgainst`
   * Periodically, to detect stagnation.
 
 Simple implementations of these updates do `O(n_unfinalized_blocks)` disk operations. If the amount of unfinalized blocks is relatively small, the updates should not take very much time. However, in cases where there are hundreds or thousands of unfinalized blocks the naive implementations of these update algorithms would have to be replaced with more sophisticated versions.
@@ -28,6 +29,10 @@ Update the approval status of the referenced block. If the block was stagnant an
 
 If the required block is unknown or not viable, then return `None`.
 Iterate over all leaves, returning the first leaf containing the required block in its chain, and `None` otherwise.
+
+### `ChainSelectionMessage::DisputeConcludedAgainst`
+This message indicates that a dispute has concluded against a parachain block candidate. The message passes along the block number and hash of the disputed candidate's relay parent. The relay parent will be marked as reverted, and its descendants will be marked as non-viable.
+
 
 ### Periodically
 

--- a/roadmap/implementers-guide/src/node/utility/chain-selection.md
+++ b/roadmap/implementers-guide/src/node/utility/chain-selection.md
@@ -8,7 +8,7 @@ This subsystem needs to update its information on the unfinalized chain:
   * On every leaf-activated signal
   * On every block-finalized signal
   * On every `ChainSelectionMessage::Approve`
-  * On every `ChainSelectionMessage::DisputeConcludedAgainst`
+  * On every `ChainSelectionMessage::RevertBlocks`
   * Periodically, to detect stagnation.
 
 Simple implementations of these updates do `O(n_unfinalized_blocks)` disk operations. If the amount of unfinalized blocks is relatively small, the updates should not take very much time. However, in cases where there are hundreds or thousands of unfinalized blocks the naive implementations of these update algorithms would have to be replaced with more sophisticated versions.
@@ -33,7 +33,7 @@ Gets all leaves of the chain, i.e. block hashes that are suitable to build upon 
 
 If the required block is unknown or not viable, then return `None`. Iterate over all leaves in order of descending weight, returning the first leaf containing the required block in its chain, and `None` otherwise.
 
-### `ChainSelectionMessage::DisputeConcludedAgainst`
+### `ChainSelectionMessage::RevertBlocks`
 This message indicates that a dispute has concluded against a parachain block candidate. The message passes along the block number and hash of the disputed candidate's relay parent. The relay parent will be marked as reverted, and its descendants will be marked as non-viable.
 
 

--- a/roadmap/implementers-guide/src/node/utility/chain-selection.md
+++ b/roadmap/implementers-guide/src/node/utility/chain-selection.md
@@ -34,7 +34,7 @@ Gets all leaves of the chain, i.e. block hashes that are suitable to build upon 
 If the required block is unknown or not viable, then return `None`. Iterate over all leaves in order of descending weight, returning the first leaf containing the required block in its chain, and `None` otherwise.
 
 ### `ChainSelectionMessage::RevertBlocks`
-This message indicates that a dispute has concluded against a parachain block candidate. The message passes along the block number and hash of the disputed candidate's relay parent. The relay parent will be marked as reverted, and its descendants will be marked as non-viable.
+This message indicates that a dispute has concluded against a parachain block candidate. The message passes along a vector containing the block number and block hash of each block where the disputed candidate was included. The passed blocks will be marked as reverted, and their descendants will be marked as non-viable.
 
 
 ### Periodically


### PR DESCRIPTION
Would like feedback on my current design, which leans heavily on the disputes chain scraper for block number and block hash to revert.

Left to do:
- Documentation changes called for by issue
- Testing (Some guidance on necessary tests to write would be nice)