### PR TITLE
Rework `RuntimeInfo` to support mock implementation for tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6612,6 +6612,7 @@ dependencies = [
  "polkadot-node-subsystem-util",
  "polkadot-overseer",
  "polkadot-primitives",
+ "polkadot-primitives-test-helpers",
  "sc-keystore",
  "sp-application-crypto",
  "sp-core",

--- a/node/core/backing/src/lib.rs
+++ b/node/core/backing/src/lib.rs
@@ -121,7 +121,7 @@ impl ValidatedCandidateCommand {
 }
 
 /// The candidate backing subsystem.
-pub struct CandidateBackingSubsystem<RuntimeInfo> {
+pub struct CandidateBackingSubsystem<RuntimeInfo: RuntimeInfoProvider> {
 	runtime: RuntimeInfo,
 	keystore: SyncCryptoStorePtr,
 	metrics: Metrics,

--- a/node/core/backing/src/lib.rs
+++ b/node/core/backing/src/lib.rs
@@ -121,7 +121,7 @@ impl ValidatedCandidateCommand {
 }
 
 /// The candidate backing subsystem.
-pub struct CandidateBackingSubsystem<RuntimeInfo: RuntimeInfoProvider> {
+pub struct CandidateBackingSubsystem<RuntimeInfo> {
 	runtime: RuntimeInfo,
 	keystore: SyncCryptoStorePtr,
 	metrics: Metrics,

--- a/node/core/backing/src/tests.rs
+++ b/node/core/backing/src/tests.rs
@@ -30,7 +30,6 @@ use polkadot_node_subsystem::{
 	ActivatedLeaf, ActiveLeavesUpdate, FromOrchestra, LeafStatus, OverseerSignal,
 };
 use polkadot_node_subsystem_test_helpers as test_helpers;
-use polkadot_node_subsystem_util::runtime::RuntimeInfo;
 use polkadot_primitives::v3::{
 	CandidateDescriptor, CollatorId, GroupRotationInfo, HeadData, PersistedValidationData,
 	ScheduledCore,
@@ -152,8 +151,8 @@ fn test_harness<T: Future<Output = VirtualOverseer>>(
 	let (context, virtual_overseer) = test_helpers::make_subsystem_context(pool.clone());
 
 	let subsystem = async move {
-		let mut runtime = RuntimeInfo::new(Some(keystore.clone()));
-		if let Err(e) = super::run(context, &mut runtime, keystore, Metrics(None)).await {
+		let runtime = test_helpers::TestRuntimeInfo::new(Some(keystore.clone()));
+		if let Err(e) = super::run(context, runtime, keystore, Metrics(None)).await {
 			panic!("{:?}", e);
 		}
 	};

--- a/node/core/candidate-validation/src/lib.rs
+++ b/node/core/candidate-validation/src/lib.rs
@@ -663,7 +663,8 @@ trait ValidationBackend {
 
 			// Encode the params again when re-trying. We expect the retry case to be relatively
 			// rare, and we want to avoid unconditionally cloning data.
-			validation_result = self.validate_candidate(pvf_with_params, timeout, params.encode()).await;
+			validation_result =
+				self.validate_candidate(pvf_with_params, timeout, params.encode()).await;
 		}
 
 		validation_result

--- a/node/core/pvf-checker/src/lib.rs
+++ b/node/core/pvf-checker/src/lib.rs
@@ -26,7 +26,7 @@ use polkadot_node_subsystem::{
 	overseer, ActiveLeavesUpdate, FromOrchestra, OverseerSignal, SpawnedSubsystem, SubsystemError,
 	SubsystemResult, SubsystemSender,
 };
-use polkadot_node_subsystem_util::runtime::RuntimeInfo;
+use polkadot_node_subsystem_util::runtime::{RuntimeInfo, RuntimeInfoProvider};
 use polkadot_primitives::{
 	v3::{
 		BlockNumber, Hash, PvfCheckStatement, SessionIndex, ValidationCodeHash, ValidatorId,

--- a/node/core/pvf-checker/src/tests.rs
+++ b/node/core/pvf-checker/src/tests.rs
@@ -25,7 +25,7 @@ use polkadot_node_subsystem::{
 	ActivatedLeaf, ActiveLeavesUpdate, FromOrchestra, LeafStatus, OverseerSignal, RuntimeApiError,
 };
 use polkadot_node_subsystem_test_helpers::{make_subsystem_context, TestSubsystemContextHandle};
-use polkadot_node_subsystem_util::runtime::RuntimeInfo;
+use polkadot_node_subsystem_util::runtime::{RuntimeInfo, RuntimeInfoProvider};
 use polkadot_primitives::v3::{
 	BlockNumber, Hash, Header, PvfCheckStatement, SessionIndex, ValidationCode, ValidationCodeHash,
 	ValidatorId,

--- a/node/network/availability-distribution/src/lib.rs
+++ b/node/network/availability-distribution/src/lib.rs
@@ -28,7 +28,7 @@ use polkadot_node_subsystem::{
 mod error;
 use error::{log_error, FatalError, Result};
 
-use polkadot_node_subsystem_util::runtime::RuntimeInfo;
+use polkadot_node_subsystem_util::runtime::{RuntimeInfo, RuntimeInfoProvider};
 
 /// `Requester` taking care of requesting chunks for candidates pending availability.
 mod requester;

--- a/node/network/availability-distribution/src/pov_requester/mod.rs
+++ b/node/network/availability-distribution/src/pov_requester/mod.rs
@@ -29,7 +29,7 @@ use polkadot_node_subsystem::{
 	messages::{IfDisconnected, NetworkBridgeTxMessage},
 	overseer,
 };
-use polkadot_node_subsystem_util::runtime::RuntimeInfo;
+use polkadot_node_subsystem_util::runtime::{RuntimeInfo, RuntimeInfoProvider};
 use polkadot_primitives::v3::{
 	AuthorityDiscoveryId, CandidateHash, Hash, Id as ParaId, ValidatorIndex,
 };

--- a/node/network/availability-distribution/src/requester/mod.rs
+++ b/node/network/availability-distribution/src/requester/mod.rs
@@ -36,7 +36,7 @@ use polkadot_node_subsystem::{
 	messages::{ChainApiMessage, RuntimeApiMessage},
 	overseer, ActivatedLeaf, ActiveLeavesUpdate, LeafStatus,
 };
-use polkadot_node_subsystem_util::runtime::{get_occupied_cores, RuntimeInfo};
+use polkadot_node_subsystem_util::runtime::{get_occupied_cores, RuntimeInfo, RuntimeInfoProvider};
 use polkadot_primitives::v3::{CandidateHash, Hash, OccupiedCore, SessionIndex};
 
 use super::{FatalError, Metrics, Result, LOG_TARGET};

--- a/node/network/availability-distribution/src/requester/session_cache.rs
+++ b/node/network/availability-distribution/src/requester/session_cache.rs
@@ -20,7 +20,7 @@ use lru::LruCache;
 use rand::{seq::SliceRandom, thread_rng};
 
 use polkadot_node_subsystem::overseer;
-use polkadot_node_subsystem_util::runtime::RuntimeInfo;
+use polkadot_node_subsystem_util::runtime::{RuntimeInfo, RuntimeInfoProvider};
 use polkadot_primitives::v3::{
 	AuthorityDiscoveryId, GroupIndex, Hash, SessionIndex, ValidatorIndex,
 };

--- a/node/network/availability-distribution/src/requester/tests.rs
+++ b/node/network/availability-distribution/src/requester/tests.rs
@@ -20,7 +20,7 @@ use futures::FutureExt;
 
 use polkadot_node_network_protocol::jaeger;
 use polkadot_node_primitives::{BlockData, ErasureChunk, PoV};
-use polkadot_node_subsystem_util::runtime::RuntimeInfo;
+use polkadot_node_subsystem_util::runtime::{RuntimeInfo, RuntimeInfoProvider};
 use polkadot_primitives::v3::{
 	BlockNumber, CoreState, GroupIndex, Hash, Id as ParaId, ScheduledCore, SessionIndex,
 	SessionInfo,

--- a/node/network/collator-protocol/src/collator_side/mod.rs
+++ b/node/network/collator-protocol/src/collator_side/mod.rs
@@ -44,7 +44,7 @@ use polkadot_node_subsystem::{
 	overseer, FromOrchestra, OverseerSignal, PerLeafSpan,
 };
 use polkadot_node_subsystem_util::{
-	runtime::{get_availability_cores, get_group_rotation_info, RuntimeInfo},
+	runtime::{get_availability_cores, get_group_rotation_info, RuntimeInfo, RuntimeInfoProvider},
 	TimeoutExt,
 };
 use polkadot_primitives::v3::{

--- a/node/network/dispute-distribution/src/lib.rs
+++ b/node/network/dispute-distribution/src/lib.rs
@@ -37,7 +37,7 @@ use polkadot_node_subsystem::{
 	messages::DisputeDistributionMessage, overseer, FromOrchestra, OverseerSignal,
 	SpawnedSubsystem, SubsystemError,
 };
-use polkadot_node_subsystem_util::{runtime, runtime::RuntimeInfo};
+use polkadot_node_subsystem_util::runtime::{self, RuntimeInfo, RuntimeInfoProvider};
 
 /// ## The sender [`DisputeSender`]
 ///

--- a/node/network/dispute-distribution/src/receiver/mod.rs
+++ b/node/network/dispute-distribution/src/receiver/mod.rs
@@ -44,7 +44,7 @@ use polkadot_node_subsystem::{
 	messages::{DisputeCoordinatorMessage, ImportStatementsResult},
 	overseer,
 };
-use polkadot_node_subsystem_util::{runtime, runtime::RuntimeInfo};
+use polkadot_node_subsystem_util::runtime::{self, RuntimeInfo, RuntimeInfoProvider};
 
 use crate::{
 	metrics::{FAILED, SUCCEEDED},

--- a/node/network/dispute-distribution/src/sender/mod.rs
+++ b/node/network/dispute-distribution/src/sender/mod.rs
@@ -32,7 +32,7 @@ use indexmap::{map::Entry, IndexMap};
 use polkadot_node_network_protocol::request_response::v1::DisputeRequest;
 use polkadot_node_primitives::{CandidateVotes, DisputeMessage, SignedDisputeStatement};
 use polkadot_node_subsystem::{messages::DisputeCoordinatorMessage, overseer, ActiveLeavesUpdate};
-use polkadot_node_subsystem_util::runtime::RuntimeInfo;
+use polkadot_node_subsystem_util::runtime::{RuntimeInfo, RuntimeInfoProvider};
 use polkadot_primitives::v3::{CandidateHash, DisputeStatement, Hash, SessionIndex};
 
 /// For each ongoing dispute we have a `SendTask` which takes care of it.

--- a/node/network/dispute-distribution/src/sender/send_task.rs
+++ b/node/network/dispute-distribution/src/sender/send_task.rs
@@ -27,7 +27,10 @@ use polkadot_node_network_protocol::{
 	IfDisconnected,
 };
 use polkadot_node_subsystem::{messages::NetworkBridgeTxMessage, overseer};
-use polkadot_node_subsystem_util::{metrics, runtime::RuntimeInfo};
+use polkadot_node_subsystem_util::{
+	metrics,
+	runtime::{RuntimeInfo, RuntimeInfoProvider},
+};
 use polkadot_primitives::v3::{
 	AuthorityDiscoveryId, CandidateHash, Hash, SessionIndex, ValidatorIndex,
 };

--- a/node/network/statement-distribution/src/lib.rs
+++ b/node/network/statement-distribution/src/lib.rs
@@ -58,7 +58,7 @@ use futures::{
 };
 use indexmap::{map::Entry as IEntry, IndexMap};
 use sp_keystore::SyncCryptoStorePtr;
-use util::runtime::RuntimeInfo;
+use util::runtime::{RuntimeInfo, RuntimeInfoProvider};
 
 use std::collections::{hash_map::Entry, HashMap, HashSet, VecDeque};
 

--- a/node/service/src/overseer.rs
+++ b/node/service/src/overseer.rs
@@ -71,7 +71,10 @@ pub use polkadot_node_core_dispute_coordinator::DisputeCoordinatorSubsystem;
 pub use polkadot_node_core_provisioner::ProvisionerSubsystem;
 pub use polkadot_node_core_pvf_checker::PvfCheckerSubsystem;
 pub use polkadot_node_core_runtime_api::RuntimeApiSubsystem;
-use polkadot_node_subsystem_util::rand::{self, SeedableRng};
+use polkadot_node_subsystem_util::{
+	rand::{self, SeedableRng},
+	runtime::RuntimeInfo,
+};
 pub use polkadot_statement_distribution::StatementDistributionSubsystem;
 
 /// Arguments passed for overseer construction.
@@ -162,7 +165,7 @@ pub fn prepared_overseer_builder<Spawner, RuntimeClient>(
 		Arc<RuntimeClient>,
 		CandidateValidationSubsystem,
 		PvfCheckerSubsystem,
-		CandidateBackingSubsystem,
+		CandidateBackingSubsystem<RuntimeInfo>,
 		StatementDistributionSubsystem<rand::rngs::StdRng>,
 		AvailabilityDistributionSubsystem,
 		AvailabilityRecoverySubsystem,

--- a/node/subsystem-test-helpers/Cargo.toml
+++ b/node/subsystem-test-helpers/Cargo.toml
@@ -12,6 +12,7 @@ parking_lot = "0.12.0"
 polkadot-node-subsystem = { path = "../subsystem" }
 polkadot-node-subsystem-util = { path = "../subsystem-util" }
 polkadot-primitives = { path = "../../primitives" }
+polkadot-primitives-test-helpers = { path = "../../primitives/test-helpers" }
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sp-keystore = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sc-keystore = { git = "https://github.com/paritytech/substrate", branch = "master" }

--- a/node/subsystem-util/src/rolling_session_window.rs
+++ b/node/subsystem-util/src/rolling_session_window.rs
@@ -595,6 +595,7 @@ mod tests {
 	};
 	use polkadot_node_subsystem_test_helpers::make_subsystem_context;
 	use polkadot_primitives::v3::Header;
+	use polkadot_primitives_test_helpers::dummy_session_info;
 	use sp_core::testing::TaskExecutor;
 
 	const SESSION_DATA_COL: u32 = 0;
@@ -606,25 +607,6 @@ mod tests {
 		let db = DbAdapter::new(db, &[]);
 		let db: Arc<dyn Database> = Arc::new(db);
 		DatabaseParams { db, db_column: SESSION_DATA_COL }
-	}
-
-	fn dummy_session_info(index: SessionIndex) -> SessionInfo {
-		SessionInfo {
-			executor_params: Default::default(),
-			validators: Default::default(),
-			discovery_keys: Vec::new(),
-			assignment_keys: Vec::new(),
-			validator_groups: Default::default(),
-			n_cores: index as _,
-			zeroth_delay_tranche_width: index as _,
-			relay_vrf_modulo_samples: index as _,
-			n_delay_tranches: index as _,
-			no_show_slots: index as _,
-			needed_approvals: index as _,
-			active_validator_indices: Vec::new(),
-			dispute_period: 6,
-			random_seed: [0u8; 32],
-		}
 	}
 
 	fn cache_session_info_test(

--- a/node/subsystem-util/src/runtime/error.rs
+++ b/node/subsystem-util/src/runtime/error.rs
@@ -40,6 +40,7 @@ pub enum Error {
 	NoSuchSession(SessionIndex),
 }
 
+/// `RuntimeInfoProvider` result
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// Receive a response from a runtime request and convert errors.

--- a/node/subsystem-util/src/runtime/mod.rs
+++ b/node/subsystem-util/src/runtime/mod.rs
@@ -38,8 +38,10 @@ use crate::{
 	request_validator_groups,
 };
 
+use async_trait::async_trait;
+
 /// Errors that can happen on runtime fetches.
-mod error;
+pub mod error;
 
 use error::{recv_runtime, Result};
 pub use error::{Error, FatalError, JfyiError};
@@ -100,14 +102,78 @@ impl Default for Config {
 	}
 }
 
-impl RuntimeInfo {
+/// Runtime information provider
+#[async_trait]
+pub trait RuntimeInfoProvider {
 	/// Create a new `RuntimeInfo` for convenient runtime fetches.
-	pub fn new(keystore: Option<SyncCryptoStorePtr>) -> Self {
+	fn new(keystore: Option<SyncCryptoStorePtr>) -> Self
+	where
+		Self: Sized;
+
+	/// Create with more elaborate configuration options.
+	fn new_with_config(cfg: Config) -> Self
+	where
+		Self: Sized;
+
+	/// Returns the session index expected at any child of the `parent` block.
+	/// This does not return the session index for the `parent` block.
+	async fn get_session_index_for_child<Sender>(
+		&mut self,
+		sender: &mut Sender,
+		parent: Hash,
+	) -> Result<SessionIndex>
+	where
+		Sender: SubsystemSender<RuntimeApiMessage>;
+
+	/// Get `ExtendedSessionInfo` by relay parent hash.
+	async fn get_session_info<Sender>(
+		&mut self,
+		sender: &mut Sender,
+		relay_parent: Hash,
+	) -> Result<&ExtendedSessionInfo>
+	where
+		Sender: SubsystemSender<RuntimeApiMessage>,
+	{
+		let session_index = self.get_session_index_for_child(sender, relay_parent).await?;
+
+		self.get_session_info_by_index(sender, relay_parent, session_index).await
+	}
+
+	/// Get `ExtendedSessionInfo` by session index.
+	///
+	/// `request_session_info` still requires the parent to be passed in, so we take the parent
+	/// in addition to the `SessionIndex`.
+	async fn get_session_info_by_index<'a, Sender>(
+		&'a mut self,
+		sender: &mut Sender,
+		parent: Hash,
+		session_index: SessionIndex,
+	) -> Result<&'a ExtendedSessionInfo>
+	where
+		Sender: SubsystemSender<RuntimeApiMessage>;
+
+	/// Convenience function for checking the signature of something signed.
+	async fn check_signature<Sender, Payload, RealPayload>(
+		&mut self,
+		sender: &mut Sender,
+		relay_parent: Hash,
+		signed: UncheckedSigned<Payload, RealPayload>,
+	) -> Result<
+		std::result::Result<Signed<Payload, RealPayload>, UncheckedSigned<Payload, RealPayload>>,
+	>
+	where
+		Sender: SubsystemSender<RuntimeApiMessage>,
+		Payload: EncodeAs<RealPayload> + Clone + Send,
+		RealPayload: Encode + Clone + Send;
+}
+
+#[async_trait]
+impl RuntimeInfoProvider for RuntimeInfo {
+	fn new(keystore: Option<SyncCryptoStorePtr>) -> Self {
 		Self::new_with_config(Config { keystore, ..Default::default() })
 	}
 
-	/// Create with more elaborate configuration options.
-	pub fn new_with_config(cfg: Config) -> Self {
+	fn new_with_config(cfg: Config) -> Self {
 		Self {
 			session_index_cache: LruCache::new(
 				cfg.session_cache_lru_size
@@ -118,9 +184,7 @@ impl RuntimeInfo {
 		}
 	}
 
-	/// Returns the session index expected at any child of the `parent` block.
-	/// This does not return the session index for the `parent` block.
-	pub async fn get_session_index_for_child<Sender>(
+	async fn get_session_index_for_child<Sender>(
 		&mut self,
 		sender: &mut Sender,
 		parent: Hash,
@@ -139,25 +203,7 @@ impl RuntimeInfo {
 		}
 	}
 
-	/// Get `ExtendedSessionInfo` by relay parent hash.
-	pub async fn get_session_info<'a, Sender>(
-		&'a mut self,
-		sender: &mut Sender,
-		relay_parent: Hash,
-	) -> Result<&'a ExtendedSessionInfo>
-	where
-		Sender: SubsystemSender<RuntimeApiMessage>,
-	{
-		let session_index = self.get_session_index_for_child(sender, relay_parent).await?;
-
-		self.get_session_info_by_index(sender, relay_parent, session_index).await
-	}
-
-	/// Get `ExtendedSessionInfo` by session index.
-	///
-	/// `request_session_info` still requires the parent to be passed in, so we take the parent
-	/// in addition to the `SessionIndex`.
-	pub async fn get_session_info_by_index<'a, Sender>(
+	async fn get_session_info_by_index<'a, Sender>(
 		&'a mut self,
 		sender: &mut Sender,
 		parent: Hash,
@@ -183,8 +229,7 @@ impl RuntimeInfo {
 			.expect("We just put the value there. qed."))
 	}
 
-	/// Convenience function for checking the signature of something signed.
-	pub async fn check_signature<Sender, Payload, RealPayload>(
+	async fn check_signature<Sender, Payload, RealPayload>(
 		&mut self,
 		sender: &mut Sender,
 		relay_parent: Hash,
@@ -194,14 +239,16 @@ impl RuntimeInfo {
 	>
 	where
 		Sender: SubsystemSender<RuntimeApiMessage>,
-		Payload: EncodeAs<RealPayload> + Clone,
-		RealPayload: Encode + Clone,
+		Payload: EncodeAs<RealPayload> + Clone + Send,
+		RealPayload: Encode + Clone + Send,
 	{
 		let session_index = self.get_session_index_for_child(sender, relay_parent).await?;
 		let info = self.get_session_info_by_index(sender, relay_parent, session_index).await?;
 		Ok(check_signature(session_index, &info.session_info, relay_parent, signed))
 	}
+}
 
+impl RuntimeInfo {
 	/// Build `ValidatorInfo` for the current session.
 	///
 	///

--- a/primitives/test-helpers/src/lib.rs
+++ b/primitives/test-helpers/src/lib.rs
@@ -23,8 +23,8 @@
 //! contain randomness based data.
 use polkadot_primitives::v3::{
 	CandidateCommitments, CandidateDescriptor, CandidateReceipt, CollatorId, CollatorSignature,
-	CommittedCandidateReceipt, Hash, HeadData, Id as ParaId, ValidationCode, ValidationCodeHash,
-	ValidatorId,
+	CommittedCandidateReceipt, Hash, HeadData, Id as ParaId, SessionIndex, SessionInfo,
+	ValidationCode, ValidationCodeHash, ValidatorId,
 };
 pub use rand;
 use sp_application_crypto::sr25519;
@@ -119,6 +119,26 @@ pub fn dummy_candidate_descriptor<H: AsRef<[u8]>>(relay_parent: H) -> CandidateD
 		collator,
 	);
 	descriptor
+}
+
+/// Creates a dummy session info.
+pub fn dummy_session_info(index: SessionIndex) -> SessionInfo {
+	SessionInfo {
+		executor_params: Default::default(),
+		validators: Default::default(),
+		discovery_keys: Vec::new(),
+		assignment_keys: Vec::new(),
+		validator_groups: Default::default(),
+		n_cores: index as _,
+		zeroth_delay_tranche_width: index as _,
+		relay_vrf_modulo_samples: index as _,
+		n_delay_tranches: index as _,
+		no_show_slots: index as _,
+		needed_approvals: index as _,
+		active_validator_indices: Vec::new(),
+		dispute_period: 6,
+		random_seed: [0u8; 32],
+	}
 }
 
 /// Create meaningless validation code.


### PR DESCRIPTION
It's a part of #6161 I've singled out to be reviewed separately.

While fixing backing subsys tests, I found that a surprising amount of rework is required to keep tests running and make CI happy. So I put it here not to dissolve it in the main PR code.

Attn: it's a request to merge into the #6161's branch, not into `master`.