### PR TITLE
pvf: Fix missing execution request when retrying preparation

### DIFF
--- a/node/core/pvf/src/host.rs
+++ b/node/core/pvf/src/host.rs
@@ -1465,7 +1465,8 @@ mod tests {
 			execute::ToQueue::Enqueue { result_tx, .. } => result_tx
 		);
 
-		// Send an error for the execution here, just so the result receiver gets something.
+		// Send an error for the execution here, just so we can check the result receiver is still
+		// alive.
 		result_tx_3
 			.send(Err(ValidationError::InvalidCandidate(InvalidCandidate::AmbiguousWorkerDeath)))
 			.unwrap();


### PR DESCRIPTION
# PULL REQUEST

## Overview

See title and related issue.

- [pvf: Fix missing execution request when retrying preparation](https://github.com/paritytech/polkadot/commit/5cdda3b0f7a22c9821630c087802bfb1b931fad1)
- [pvf: Add checks for result sender when retrying preparation in tests](https://github.com/paritytech/polkadot/commit/0e7dad5c0e676de9e0e6e0b2f38a46d8f7682e66)

## Related issue

Closes https://github.com/paritytech/polkadot/issues/6535