### PR TITLE
Handle substrate-node-template and substrate-parachain-template

### DIFF
--- a/scripts/ci/gitlab/pipeline/publish.yml
+++ b/scripts/ci/gitlab/pipeline/publish.yml
@@ -215,24 +215,37 @@ publish-rustdoc:
   after_script:
     - rm -rf .git/ ./*
 
-# Ref: https://github.com/paritytech/opstooling/issues/111
-update-node-template:
+.update-substrate-template-repository:
   stage:                           publish
   extends:                         .kubernetes-env
   variables:
-    GIT_STRATEGY:          none
+    GIT_STRATEGY:                  none
   rules:
     # The template is only updated for FINAL releases
     # i.e. the rule should not cover RC or patch releases
-    - if: $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+$/           # e.g. v1.0
-    - if: $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+$/    # e.g. v1.0.0
+    - if: $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+$/                     # e.g. v1.0
+    - if: $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+$/             # e.g. v1.0.0
   script:
     - git clone --depth=1 --branch="$PIPELINE_SCRIPTS_TAG" https://github.com/paritytech/pipeline-scripts
     - export POLKADOT_BRANCH="polkadot-v$CI_COMMIT_TAG"
     - git clone --depth=1 --branch="$POLKADOT_BRANCH" https://github.com/paritytech/substrate
     - cd substrate
     - ../pipeline-scripts/update_substrate_template.sh
-      --repo-name "substrate-node-template"
-      --template-path "bin/node-template"
+      --repo-name "$TARGET_REPOSITORY"
+      --template-path "$TEMPLATE_PATH"
       --github-api-token "$GITHUB_TOKEN"
       --polkadot-branch "$POLKADOT_BRANCH"
+
+# Ref: https://github.com/paritytech/opstooling/issues/111
+update-node-template:
+  extends:                         .update-substrate-template-repository
+  variables:
+    TARGET_REPOSITORY:             substrate-node-template
+    TEMPLATE_PATH:                 bin/node-template
+
+# Ref: https://github.com/paritytech/opstooling/issues/111
+update-parachain-template:
+  extends:                         .update-substrate-template-repository
+  variables:
+    TARGET_REPOSITORY:             substrate-parachain-template
+    TEMPLATE_PATH:                 parachain-template


### PR DESCRIPTION
Follow-up to https://github.com/paritytech/polkadot/pull/6522 to include `substrate-parachain-template` in addition to `substrate-node-template`, as requested by https://github.com/paritytech/release-engineering/issues/142.

close https://github.com/paritytech/release-engineering/issues/142