### PR TITLE
XCM ClaimAssets weight

### DIFF
--- a/xcm/pallet-xcm/src/lib.rs
+++ b/xcm/pallet-xcm/src/lib.rs
@@ -1315,25 +1315,27 @@ pub mod pallet {
 			origin: &MultiLocation,
 			ticket: &MultiLocation,
 			assets: &MultiAssets,
-		) -> bool {
+		) -> (u64, bool) {
 			let mut versioned = VersionedMultiAssets::from(assets.clone());
 			match (ticket.parents, &ticket.interior) {
 				(0, X1(GeneralIndex(i))) =>
 					versioned = match versioned.into_version(*i as u32) {
 						Ok(v) => v,
-						Err(()) => return false,
+						Err(()) => return (0, false),
 					},
 				(0, Here) => (),
-				_ => return false,
+				_ => return (0, false),
 			};
 			let hash = BlakeTwo256::hash_of(&(origin, versioned.clone()));
 			match AssetTraps::<T>::get(hash) {
-				0 => return false,
+				0 => return (0, false),
 				1 => AssetTraps::<T>::remove(hash),
 				n => AssetTraps::<T>::insert(hash, n - 1),
 			}
 			Self::deposit_event(Event::AssetsClaimed(hash, origin.clone(), versioned));
-			return true
+
+			// TODO #3735: Put the real weight in there.
+			return (0, true)
 		}
 	}
 

--- a/xcm/xcm-builder/src/test_utils.rs
+++ b/xcm/xcm-builder/src/test_utils.rs
@@ -67,17 +67,21 @@ impl DropAssets for TestAssetTrap {
 }
 
 impl ClaimAssets for TestAssetTrap {
-	fn claim_assets(origin: &MultiLocation, ticket: &MultiLocation, what: &MultiAssets) -> bool {
+	fn claim_assets(
+		origin: &MultiLocation,
+		ticket: &MultiLocation,
+		what: &MultiAssets,
+	) -> (Weight, bool) {
 		let mut t: Vec<(MultiLocation, MultiAssets)> = TrappedAssets::get();
 		if let (0, X1(GeneralIndex(i))) = (ticket.parents, &ticket.interior) {
 			if let Some((l, a)) = t.get(*i as usize) {
 				if l == origin && a == what {
 					t.swap_remove(*i as usize);
 					TrappedAssets::set(t);
-					return true
+					return (0, true)
 				}
 			}
 		}
-		false
+		(0, false)
 	}
 }

--- a/xcm/xcm-executor/src/lib.rs
+++ b/xcm/xcm-executor/src/lib.rs
@@ -483,11 +483,12 @@ impl<Config: config::Config> XcmExecutor<Config> {
 			},
 			ClaimAsset { assets, ticket } => {
 				let origin = self.origin.as_ref().ok_or(XcmError::BadOrigin)?;
-				let ok = Config::AssetClaims::claim_assets(origin, &ticket, &assets);
+				let (weight, ok) = Config::AssetClaims::claim_assets(origin, &ticket, &assets);
 				ensure!(ok, XcmError::UnknownClaim);
 				for asset in assets.drain().into_iter() {
 					self.holding.subsume(asset);
 				}
+				self.total_surplus.saturating_accrue(weight);
 				Ok(())
 			},
 			Trap(code) => Err(XcmError::Trap(code)),

--- a/xcm/xcm-executor/src/traits/drop_assets.rs
+++ b/xcm/xcm-executor/src/traits/drop_assets.rs
@@ -62,19 +62,25 @@ impl<D: DropAssets, O: Contains<MultiLocation>> DropAssets for FilterOrigin<D, O
 
 /// Define any handlers for the `AssetClaim` instruction.
 pub trait ClaimAssets {
-	/// Claim any assets available to `origin` and return them in a single `Assets` value, together
-	/// with the weight used by this operation.
-	fn claim_assets(origin: &MultiLocation, ticket: &MultiLocation, what: &MultiAssets) -> bool;
+	/// Claim any assets available to `origin`.
+	/// Return true if the claim is successful, together with the weight used by this operation.
+	fn claim_assets(
+		origin: &MultiLocation,
+		ticket: &MultiLocation,
+		what: &MultiAssets,
+	) -> (Weight, bool);
 }
 
 #[impl_trait_for_tuples::impl_for_tuples(30)]
 impl ClaimAssets for Tuple {
-	fn claim_assets(origin: &MultiLocation, ticket: &MultiLocation, what: &MultiAssets) -> bool {
+	fn claim_assets(
+		origin: &MultiLocation,
+		ticket: &MultiLocation,
+		what: &MultiAssets,
+	) -> (Weight, bool) {
 		for_tuples!( #(
-			if Tuple::claim_assets(origin, ticket, what) {
-				return true;
-			}
+			return Tuple::claim_assets(origin, ticket, what);
 		)* );
-		false
+		(0, false)
 	}
 }


### PR DESCRIPTION
Current implementation of `claim_asset` API doesn't take weights into consideration, even though Gavin's original comment signaled that intention.

https://github.com/paritytech/polkadot/blob/a779892f8ee2a072ac9676d7949ac4539f630ecd/xcm/xcm-executor/src/traits/drop_assets.rs#L63-L68

This PR aims to improve the API such that `claim_asset` returns a `(Weight, bool)` tuple.

Ties back to https://github.com/paritytech/polkadot/issues/3735 as a TODO