### PR TITLE
Fix set-output deprecation

### DIFF
--- a/.github/workflows/release-10_candidate.yml
+++ b/.github/workflows/release-10_candidate.yml
@@ -19,7 +19,7 @@ jobs:
           # Get last rc tag if exists, else set it to {version}-rc1
           version=${GITHUB_REF#refs/heads/release-}
           echo "$version"
-          echo "::set-output name=version::$version"
+          echo "version=$version" >> $GITHUB_OUTPUT
           git tag -l
           last_rc=$(git tag -l "$version-rc*" | sort -V | tail -n 1)
           if [ -n "$last_rc" ]; then
@@ -27,11 +27,11 @@ jobs:
             echo $suffix
             ((suffix++))
             echo $suffix
-            echo "::set-output name=new_tag::$version-rc$suffix"
-            echo "::set-output name=first_rc::false"
+            echo "new_tag=$version-rc$suffix" >> $GITHUB_OUTPUT
+            echo "first_rc=false" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=new_tag::$version-rc1"
-            echo "::set-output name=first_rc::true"
+            echo "new_tag=$version-rc1" >> $GITHUB_OUTPUT
+            echo "first_rc=true" >> $GITHUB_OUTPUT
           fi
       - name: Apply new tag
         uses: tvdias/github-tagger@ed7350546e3e503b5e942dffd65bc8751a95e49d # v0.0.2

--- a/.github/workflows/release-30_publish-draft-release.yml
+++ b/.github/workflows/release-30_publish-draft-release.yml
@@ -17,8 +17,8 @@ jobs:
     steps:
       - id: get-rust-versions
         run: |
-          echo "::set-output name=stable::$(rustc +stable --version)"
-          echo "::set-output name=nightly::$(rustc +nightly --version)"
+          echo "stable=$(rustc +stable --version)" >> $GITHUB_OUTPUT
+          echo "nightly=$(rustc +nightly --version)" >> $GITHUB_OUTPUT
 
   build-runtimes:
     runs-on: ubuntu-latest
@@ -166,7 +166,7 @@ jobs:
           ls "$RUNTIME_DIR/${{ matrix.runtime }}"
           runtime_ver=$(ruby script.rb)
           echo "Found version: >$runtime_ver<"
-          echo "::set-output name=runtime_ver::$runtime_ver"
+          echo "runtime_ver=$runtime_ver" >> $GITHUB_OUTPUT
 
       - name: Upload compressed ${{ matrix.runtime }} wasm
         uses: actions/upload-release-asset@v1


### PR DESCRIPTION
set-output is being deprecated by GH.
More information at https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/