### PR TITLE
Add runtime-benchmarks feature to test client and test service

### DIFF
--- a/node/test/client/Cargo.toml
+++ b/node/test/client/Cargo.toml
@@ -31,3 +31,6 @@ sp-state-machine = { git = "https://github.com/paritytech/substrate", branch = "
 [dev-dependencies]
 sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "master" }
 futures = "0.3.21"
+
+[features]
+runtime-benchmarks=["polkadot-test-runtime/runtime-benchmarks"]

--- a/node/test/service/Cargo.toml
+++ b/node/test/service/Cargo.toml
@@ -65,3 +65,4 @@ tokio = { version = "1.24.1", features = ["macros"] }
 
 [features]
 runtime-metrics=["polkadot-test-runtime/runtime-metrics"]
+runtime-benchmarks=["polkadot-test-runtime/runtime-benchmarks"]


### PR DESCRIPTION
paritytech/cumulus#697 CI is failing because the `test-client` and `test-service` crates don't enable runtime-benchmarks on the `test-runtime` crate, and hence we need to add them to their respective Cargo.toml files.