### PR TITLE
docs: remove references to rpm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,5 @@ runtime/wasm/target/
 .vscode
 polkadot.*
 !polkadot.service
-!.rpm/*
 .DS_Store
 .env

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -208,7 +208,7 @@ pyroscope = ["polkadot-cli/pyroscope"]
 name = "polkadot"
 extended-description = "Implementation of a https://polkadot.network node in Rust based on the Substrate framework."
 section = "misc"
-maintainer = "martin@parity.io"
+maintainer = "security@parity.io"
 license-file = ["LICENSE", "0"]
 # https://www.debian.org/doc/debian-policy/ch-maintainerscripts.html
 maintainer-scripts = "scripts/packaging/deb-maintainer-scripts"
@@ -219,19 +219,6 @@ assets = [
 conf-files = [
 	"/etc/default/polkadot"
 ]
-
-# Configuration for building an .rpm package - for use with `cargo-rpm`
-[package.metadata.rpm]
-package = "polkadot"
-
-[package.metadata.rpm.cargo]
-buildflags = ["--release"]
-
-[package.metadata.rpm.targets]
-polkadot = { path = "/usr/bin/polkadot" }
-
-[package.metadata.rpm.files]
-"../scripts/packaging/polkadot.service" = { path = "/usr/lib/systemd/system/polkadot.service", mode = "644" }
 
 [package.metadata.spellcheck]
 config = "./scripts/ci/gitlab/spellcheck.toml"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ either run the latest binary from our
 [releases](https://github.com/paritytech/polkadot/releases) page, or install
 Polkadot from one of our package repositories.
 
-Installation from the Debian or rpm repositories will create a `systemd`
+Installation from the Debian repository will create a `systemd`
 service that can be used to run a Polkadot node. This is disabled by default,
 and can be started by running `systemctl start polkadot` on demand (use
 `systemctl enable polkadot` to make it auto-start after reboot). By default, it
@@ -46,21 +46,6 @@ apt install parity-keyring
 # Install polkadot
 apt install polkadot
 
-```
-
-### RPM-based (Fedora, CentOS)
-
-Currently supports Fedora 32 and CentOS 8, and derivatives.
-
-```bash
-# Install dnf-plugins-core (This might already be installed)
-dnf install dnf-plugins-core
-# Add the repository and enable it
-dnf config-manager --add-repo https://releases.parity.io/rpm/polkadot.repo
-dnf config-manager --set-enabled polkadot
-# Install polkadot (You may have to confirm the import of the GPG key, which
-# should have the following fingerprint: 9D4B2B6EB8F97156D19669A9FF0812D491B96798)
-dnf install polkadot
 ```
 
 ## Building


### PR DESCRIPTION
we're phasing out publishing of rpm builds due to lack of use and proportionally large maintenance burden, this removes references to the RPMs in the repo