### PR TITLE
[WIP] ci: update changelog generator logic for new labels

### DIFF
--- a/scripts/ci/changelog/templates/change.md.tera
+++ b/scripts/ci/changelog/templates/change.md.tera
@@ -33,5 +33,10 @@
 {%- set repo = "   " -%}
 {%- endif -%}
 
+{%- if c.meta.T and c.meta.T.value == 6 -%}
+{%- set xcm = " [✉️ XCM]" -%}
+{%- else -%}
+{%- set xcm = "" -%}
+{%- endif -%}
 {{- repo }} {{ audit }}[`#{{c.number}}`]({{c.html_url}}) {{- prio }} - {{ c.title | capitalize | truncate(length=120, end="…") }}{{xcm }}
 {%- endmacro change -%}


### PR DESCRIPTION
Work-in-progress for new label logic in changelogs

This reverts commit 49c9e8aa68f87249fba0370675e7b9543b5d8e56.