### PR TITLE
XCM: Add HRMP to SafeCallFilter

### DIFF
--- a/runtime/kusama/src/xcm_config.rs
+++ b/runtime/kusama/src/xcm_config.rs
@@ -326,6 +326,7 @@ impl Contains<RuntimeCall> for SafeCallFilter {
 				pallet_nomination_pools::Call::update_roles { .. } |
 				pallet_nomination_pools::Call::chill { .. },
 			) |
+			RuntimeCall::Hrmp(..) |
 			RuntimeCall::XcmPallet(pallet_xcm::Call::limited_reserve_transfer_assets {
 				..
 			}) => true,

--- a/runtime/kusama/src/xcm_config.rs
+++ b/runtime/kusama/src/xcm_config.rs
@@ -26,7 +26,7 @@ use frame_support::{
 	traits::{Contains, Everything, Nothing},
 	weights::Weight,
 };
-use runtime_common::{xcm_sender, ToAuthor};
+use runtime_common::{paras_registrar, xcm_sender, ToAuthor};
 use sp_core::ConstU32;
 use xcm::latest::prelude::*;
 use xcm_builder::{
@@ -327,6 +327,13 @@ impl Contains<RuntimeCall> for SafeCallFilter {
 				pallet_nomination_pools::Call::chill { .. },
 			) |
 			RuntimeCall::Hrmp(..) |
+			RuntimeCall::Registrar(
+				paras_registrar::Call::deregister { .. } |
+				paras_registrar::Call::swap { .. } |
+				paras_registrar::Call::remove_lock { .. } |
+				paras_registrar::Call::reserve { .. } |
+				paras_registrar::Call::add_lock { .. },
+			) |
 			RuntimeCall::XcmPallet(pallet_xcm::Call::limited_reserve_transfer_assets {
 				..
 			}) => true,

--- a/runtime/polkadot/src/xcm_config.rs
+++ b/runtime/polkadot/src/xcm_config.rs
@@ -25,7 +25,7 @@ use frame_support::{
 	traits::{Contains, Everything, Nothing},
 	weights::Weight,
 };
-use runtime_common::{xcm_sender, ToAuthor};
+use runtime_common::{paras_registrar, xcm_sender, ToAuthor};
 use sp_core::ConstU32;
 use xcm::latest::prelude::*;
 use xcm_builder::{
@@ -291,6 +291,13 @@ impl Contains<RuntimeCall> for SafeCallFilter {
 				pallet_nomination_pools::Call::chill { .. },
 			) |
 			RuntimeCall::Hrmp(..) |
+			RuntimeCall::Registrar(
+				paras_registrar::Call::deregister { .. } |
+				paras_registrar::Call::swap { .. } |
+				paras_registrar::Call::remove_lock { .. } |
+				paras_registrar::Call::reserve { .. } |
+				paras_registrar::Call::add_lock { .. },
+			) |
 			RuntimeCall::XcmPallet(pallet_xcm::Call::limited_reserve_transfer_assets {
 				..
 			}) => true,

--- a/runtime/polkadot/src/xcm_config.rs
+++ b/runtime/polkadot/src/xcm_config.rs
@@ -290,6 +290,7 @@ impl Contains<RuntimeCall> for SafeCallFilter {
 				pallet_nomination_pools::Call::update_roles { .. } |
 				pallet_nomination_pools::Call::chill { .. },
 			) |
+			RuntimeCall::Hrmp(..) |
 			RuntimeCall::XcmPallet(pallet_xcm::Call::limited_reserve_transfer_assets {
 				..
 			}) => true,

--- a/runtime/rococo/src/xcm_config.rs
+++ b/runtime/rococo/src/xcm_config.rs
@@ -261,6 +261,7 @@ impl Contains<RuntimeCall> for SafeCallFilter {
 				pallet_bounties::Call::close_bounty { .. },
 			) |
 			RuntimeCall::ChildBounties(..) |
+			RuntimeCall::Hrmp(..) |
 			RuntimeCall::XcmPallet(pallet_xcm::Call::limited_reserve_transfer_assets {
 				..
 			}) => true,

--- a/runtime/rococo/src/xcm_config.rs
+++ b/runtime/rococo/src/xcm_config.rs
@@ -25,7 +25,7 @@ use frame_support::{
 	traits::{Contains, Everything, Nothing},
 	weights::Weight,
 };
-use runtime_common::{xcm_sender, ToAuthor};
+use runtime_common::{paras_registrar, xcm_sender, ToAuthor};
 use sp_core::ConstU32;
 use xcm::latest::prelude::*;
 use xcm_builder::{
@@ -262,6 +262,13 @@ impl Contains<RuntimeCall> for SafeCallFilter {
 			) |
 			RuntimeCall::ChildBounties(..) |
 			RuntimeCall::Hrmp(..) |
+			RuntimeCall::Registrar(
+				paras_registrar::Call::deregister { .. } |
+				paras_registrar::Call::swap { .. } |
+				paras_registrar::Call::remove_lock { .. } |
+				paras_registrar::Call::reserve { .. } |
+				paras_registrar::Call::add_lock { .. },
+			) |
 			RuntimeCall::XcmPallet(pallet_xcm::Call::limited_reserve_transfer_assets {
 				..
 			}) => true,

--- a/runtime/westend/src/xcm_config.rs
+++ b/runtime/westend/src/xcm_config.rs
@@ -24,7 +24,7 @@ use frame_support::{
 	parameter_types,
 	traits::{Contains, Everything, Nothing},
 };
-use runtime_common::{xcm_sender, ToAuthor};
+use runtime_common::{paras_registrar, xcm_sender, ToAuthor};
 use sp_core::ConstU32;
 use xcm::latest::prelude::*;
 use xcm_builder::{
@@ -202,6 +202,13 @@ impl Contains<RuntimeCall> for SafeCallFilter {
 				pallet_nomination_pools::Call::chill { .. },
 			) |
 			RuntimeCall::Hrmp(..) |
+			RuntimeCall::Registrar(
+				paras_registrar::Call::deregister { .. } |
+				paras_registrar::Call::swap { .. } |
+				paras_registrar::Call::remove_lock { .. } |
+				paras_registrar::Call::reserve { .. } |
+				paras_registrar::Call::add_lock { .. },
+			) |
 			RuntimeCall::XcmPallet(pallet_xcm::Call::limited_reserve_transfer_assets {
 				..
 			}) => true,

--- a/runtime/westend/src/xcm_config.rs
+++ b/runtime/westend/src/xcm_config.rs
@@ -201,6 +201,7 @@ impl Contains<RuntimeCall> for SafeCallFilter {
 				pallet_nomination_pools::Call::update_roles { .. } |
 				pallet_nomination_pools::Call::chill { .. },
 			) |
+			RuntimeCall::Hrmp(..) |
 			RuntimeCall::XcmPallet(pallet_xcm::Call::limited_reserve_transfer_assets {
 				..
 			}) => true,


### PR DESCRIPTION
Resolves #6602.

Allows HRMP and several `paras_registrar` dispatchable calls originating from an XCM `Transact` instruction to pass through the filter and be executed on the relay chains.