### PR TITLE
Metrics: add PoV size and validation code size in `candidate-validation`

### DIFF
--- a/node/core/candidate-validation/src/lib.rs
+++ b/node/core/candidate-validation/src/lib.rs
@@ -532,6 +532,7 @@ async fn validate_candidate_exhaustive(
 			return Err(ValidationFailed("Code decompression failed".to_string()))
 		},
 	};
+	metrics.observe_code_size(raw_validation_code.len());
 
 	let raw_block_data =
 		match sp_maybe_compressed_blob::decompress(&pov.block_data.0, POV_BOMB_LIMIT) {
@@ -543,6 +544,7 @@ async fn validate_candidate_exhaustive(
 				return Ok(ValidationResult::Invalid(InvalidCandidate::PoVDecompressionFailure))
 			},
 		};
+	metrics.observe_pov_size(raw_block_data.0.len());
 
 	let params = ValidationParams {
 		parent_head: persisted_validation_data.parent_head.clone(),

--- a/node/core/candidate-validation/src/metrics.rs
+++ b/node/core/candidate-validation/src/metrics.rs
@@ -23,6 +23,8 @@ pub(crate) struct MetricsInner {
 	pub(crate) validate_from_chain_state: prometheus::Histogram,
 	pub(crate) validate_from_exhaustive: prometheus::Histogram,
 	pub(crate) validate_candidate_exhaustive: prometheus::Histogram,
+	pub(crate) pov_size: prometheus::Histogram,
+	pub(crate) code_size: prometheus::Histogram,
 }
 
 /// Candidate validation metrics.
@@ -68,6 +70,18 @@ impl Metrics {
 			.as_ref()
 			.map(|metrics| metrics.validate_candidate_exhaustive.start_timer())
 	}
+
+	pub fn observe_code_size(&self, code_size: usize) {
+		if let Some(metrics) = &self.0 {
+			metrics.code_size.observe(code_size as f64);
+		}
+	}
+
+	pub fn observe_pov_size(&self, pov_size: usize) {
+		if let Some(metrics) = &self.0 {
+			metrics.pov_size.observe(pov_size as f64);
+		}
+	}
 }
 
 impl metrics::Metrics for Metrics {
@@ -102,6 +116,32 @@ impl metrics::Metrics for Metrics {
 					"polkadot_parachain_candidate_validation_validate_candidate_exhaustive",
 					"Time spent within `candidate_validation::validate_candidate_exhaustive`",
 				))?,
+				registry,
+			)?,
+			pov_size: prometheus::register(
+				prometheus::Histogram::with_opts(
+					prometheus::HistogramOpts::new(
+						"polkadot_parachain_candidate_validation_pov_size",
+						"The size of the decompressed proof of validity of a candidate",
+					)
+					.buckets(
+						prometheus::exponential_buckets(16384.0, 2.0, 10)
+							.expect("arguments are always valid; qed"),
+					),
+				)?,
+				registry,
+			)?,
+			code_size: prometheus::register(
+				prometheus::Histogram::with_opts(
+					prometheus::HistogramOpts::new(
+						"polkadot_parachain_candidate_validation_code_size",
+						"The size of the decompressed WASM validation blob used for checking a candidate",
+					)
+					.buckets(
+						prometheus::exponential_buckets(16384.0, 2.0, 10)
+							.expect("arguments are always valid; qed"),
+					),
+				)?,
 				registry,
 			)?,
 		};


### PR DESCRIPTION
I think the Histogram buckets are reasonable (16k, 32k, 64k, 128k, 256k, 512k, 1MB, 2MB, 4MB, 8MB) for Kusama settings:
- maxCodeSize: 10,485,760
- maxPovSize: 5,242,880
