### PR TITLE
Fix XCM transact bench

### DIFF
--- a/xcm/pallet-xcm-benchmarks/src/generic/benchmarking.rs
+++ b/xcm/pallet-xcm-benchmarks/src/generic/benchmarking.rs
@@ -100,8 +100,6 @@ benchmarks! {
 			call: double_encoded_noop_call,
 		};
 		let xcm = Xcm(vec![instruction]);
-
-		let num_events = frame_system::Pallet::<T>::events().len();
 	}: {
 		executor.bench_process(xcm)?;
 	} verify {


### PR DESCRIPTION
Dont call `events` in the genesis since https://github.com/paritytech/substrate/pull/13217 makes it abort.