### PR TITLE
kusama: allow root to cancel/kill referendums

### DIFF
--- a/runtime/kusama/src/governance/mod.rs
+++ b/runtime/kusama/src/governance/mod.rs
@@ -82,8 +82,8 @@ impl pallet_referenda::Config for Runtime {
 	type Scheduler = Scheduler;
 	type Currency = Balances;
 	type SubmitOrigin = frame_system::EnsureSigned<AccountId>;
-	type CancelOrigin = ReferendumCanceller;
-	type KillOrigin = ReferendumKiller;
+	type CancelOrigin = EitherOf<EnsureRoot<AccountId>, ReferendumCanceller>,
+	type KillOrigin = EitherOf<EnsureRoot<AccountId>, ReferendumKiller>,
 	type Slash = Treasury;
 	type Votes = pallet_conviction_voting::VotesOf<Runtime>;
 	type Tally = pallet_conviction_voting::TallyOf<Runtime>;

--- a/runtime/kusama/src/governance/mod.rs
+++ b/runtime/kusama/src/governance/mod.rs
@@ -82,8 +82,8 @@ impl pallet_referenda::Config for Runtime {
 	type Scheduler = Scheduler;
 	type Currency = Balances;
 	type SubmitOrigin = frame_system::EnsureSigned<AccountId>;
-	type CancelOrigin = EitherOf<EnsureRoot<AccountId>, ReferendumCanceller>,
-	type KillOrigin = EitherOf<EnsureRoot<AccountId>, ReferendumKiller>,
+	type CancelOrigin = EitherOf<EnsureRoot<AccountId>, ReferendumCanceller>;
+	type KillOrigin = EitherOf<EnsureRoot<AccountId>, ReferendumKiller>;
 	type Slash = Treasury;
 	type Votes = pallet_conviction_voting::VotesOf<Runtime>;
 	type Tally = pallet_conviction_voting::TallyOf<Runtime>;


### PR DESCRIPTION
This PR changes the origins for killing and cancelling OpenGov referendums to include the Root origin.