### PR TITLE
Prevent `dispute-coordinator` from doing any work before the initial node sync is complete.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6926,6 +6926,7 @@ dependencies = [
  "polkadot-primitives-test-helpers",
  "sc-keystore",
  "sp-application-crypto",
+ "sp-consensus",
  "sp-core",
  "sp-keyring",
  "sp-keystore",

--- a/node/core/dispute-coordinator/Cargo.toml
+++ b/node/core/dispute-coordinator/Cargo.toml
@@ -19,7 +19,7 @@ polkadot-node-subsystem = { path = "../../subsystem" }
 polkadot-node-subsystem-util = { path = "../../subsystem-util" }
 
 sc-keystore = { git = "https://github.com/paritytech/substrate", branch = "master" }
-
+sp-consensus = { git = "https://github.com/paritytech/substrate", branch = "master" }
 
 [dev-dependencies]
 kvdb-memorydb = "0.13.0"

--- a/node/core/dispute-coordinator/src/initialized.rs
+++ b/node/core/dispute-coordinator/src/initialized.rs
@@ -93,7 +93,8 @@ impl Initialized {
 		spam_slots: SpamSlots,
 		scraper: ChainScraper,
 	) -> Self {
-		let DisputeCoordinatorSubsystem { config: _, store: _, keystore, metrics } = subsystem;
+		let DisputeCoordinatorSubsystem { config: _, store: _, keystore, metrics, sync_oracle: _ } =
+			subsystem;
 
 		let (participation_sender, participation_receiver) = mpsc::channel(1);
 		let participation = Participation::new(participation_sender);
@@ -1235,7 +1236,7 @@ enum MuxedMessage {
 impl MuxedMessage {
 	async fn receive<Context>(
 		ctx: &mut Context,
-		from_sender: &mut participation::WorkerMessageReceiver,
+		from_sender: &mut WorkerMessageReceiver,
 	) -> FatalResult<Self> {
 		// We are only fusing here to make `select` happy, in reality we will quit if the stream
 		// ends.

--- a/node/service/src/overseer.rs
+++ b/node/service/src/overseer.rs
@@ -300,6 +300,7 @@ where
 			dispute_coordinator_config,
 			keystore.clone(),
 			Metrics::register(registry)?,
+			Box::new(network_service.clone()),
 		))
 		.dispute_distribution(DisputeDistributionSubsystem::new(
 			keystore.clone(),


### PR DESCRIPTION
On the first `ActiveLeavesUpdate` the subsystem queries the runtime to obtain `RollingSessionWindow`. This often leads to errors because the first leaf update generated by overseer is either the genesis block (when the local database is empty) or the last seen block before the node was stopped. This often leads to `NotSupported` errors when querying the runtime api.

The mitigation is to pass a `SyncOracle` instance when constructing `dispute coordinator` and don't do any work until the full sync is complete.

Related to https://github.com/paritytech/polkadot/issues/5885