### PR TITLE
Block `ActiveLeavesUpdate` and `BlockFinalized` events in overseer until major sync is complete

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7280,6 +7280,7 @@ dependencies = [
  "prioritized-metered-channel",
  "sc-client-api",
  "sp-api",
+ "sp-consensus",
  "sp-core",
  "tikv-jemalloc-ctl",
  "tracing-gum",

--- a/node/overseer/Cargo.toml
+++ b/node/overseer/Cargo.toml
@@ -19,6 +19,7 @@ orchestra = "0.0.4"
 gum = { package = "tracing-gum", path = "../gum" }
 lru = "0.9"
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-consensus = { git = "https://github.com/paritytech/substrate", branch = "master" }
 async-trait = "0.1.57"
 tikv-jemalloc-ctl = "0.5.0"
 

--- a/node/overseer/examples/minimal-example.rs
+++ b/node/overseer/examples/minimal-example.rs
@@ -30,7 +30,7 @@ use polkadot_overseer::{
 	self as overseer,
 	dummy::dummy_overseer_builder,
 	gen::{FromOrchestra, SpawnedSubsystem},
-	HeadSupportsParachains, SubsystemError,
+	HeadSupportsParachains, MajorSyncOracle, SubsystemError,
 };
 use polkadot_primitives::{CandidateReceipt, Hash};
 
@@ -153,13 +153,18 @@ fn main() {
 			Delay::new(Duration::from_secs(1)).await;
 		});
 
-		let (overseer, _handle) = dummy_overseer_builder(spawner, AlwaysSupportsParachains, None)
-			.unwrap()
-			.replace_candidate_validation(|_| Subsystem2)
-			.replace_candidate_backing(|orig| orig)
-			.replace_candidate_backing(|_orig| Subsystem1)
-			.build()
-			.unwrap();
+		let (overseer, _handle) = dummy_overseer_builder(
+			spawner,
+			AlwaysSupportsParachains,
+			None,
+			MajorSyncOracle::new_dummy(),
+		)
+		.unwrap()
+		.replace_candidate_validation(|_| Subsystem2)
+		.replace_candidate_backing(|orig| orig)
+		.replace_candidate_backing(|_orig| Subsystem1)
+		.build()
+		.unwrap();
 
 		let overseer_fut = overseer.run().fuse();
 		let timer_stream = timer_stream;

--- a/node/overseer/examples/minimal-example.rs
+++ b/node/overseer/examples/minimal-example.rs
@@ -158,6 +158,7 @@ fn main() {
 			AlwaysSupportsParachains,
 			None,
 			MajorSyncOracle::new_dummy(),
+			Vec::new(),
 		)
 		.unwrap()
 		.replace_candidate_validation(|_| Subsystem2)

--- a/node/overseer/src/dummy.rs
+++ b/node/overseer/src/dummy.rs
@@ -15,8 +15,8 @@
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
 use crate::{
-	prometheus::Registry, HeadSupportsParachains, InitializedOverseerBuilder, MetricsTrait,
-	Overseer, OverseerMetrics, OverseerSignal, OverseerSubsystemContext, SpawnGlue,
+	prometheus::Registry, HeadSupportsParachains, InitializedOverseerBuilder, MajorSyncOracle,
+	MetricsTrait, Overseer, OverseerMetrics, OverseerSignal, OverseerSubsystemContext, SpawnGlue,
 	KNOWN_LEAVES_CACHE_SIZE,
 };
 use lru::LruCache;
@@ -193,6 +193,7 @@ where
 		.leaves(Default::default())
 		.spawner(SpawnGlue(spawner))
 		.metrics(metrics)
+		.sync_oracle(MajorSyncOracle::new_dummy())
 		.supports_parachains(supports_parachains);
 	Ok(builder)
 }

--- a/node/overseer/src/dummy.rs
+++ b/node/overseer/src/dummy.rs
@@ -63,6 +63,7 @@ pub fn dummy_overseer_builder<Spawner, SupportsParachains>(
 	spawner: Spawner,
 	supports_parachains: SupportsParachains,
 	registry: Option<&Registry>,
+	sync_oracle: MajorSyncOracle,
 ) -> Result<
 	InitializedOverseerBuilder<
 		SpawnGlue<Spawner>,
@@ -96,7 +97,13 @@ where
 	SpawnGlue<Spawner>: orchestra::Spawner + 'static,
 	SupportsParachains: HeadSupportsParachains,
 {
-	one_for_all_overseer_builder(spawner, supports_parachains, DummySubsystem, registry)
+	one_for_all_overseer_builder(
+		spawner,
+		supports_parachains,
+		DummySubsystem,
+		registry,
+		sync_oracle,
+	)
 }
 
 /// Create an overseer with all subsystem being `Sub`.
@@ -105,6 +112,7 @@ pub fn one_for_all_overseer_builder<Spawner, SupportsParachains, Sub>(
 	supports_parachains: SupportsParachains,
 	subsystem: Sub,
 	registry: Option<&Registry>,
+	sync_oracle: MajorSyncOracle,
 ) -> Result<
 	InitializedOverseerBuilder<
 		SpawnGlue<Spawner>,
@@ -193,7 +201,7 @@ where
 		.leaves(Default::default())
 		.spawner(SpawnGlue(spawner))
 		.metrics(metrics)
-		.sync_oracle(MajorSyncOracle::new_dummy())
+		.sync_oracle(sync_oracle)
 		.supports_parachains(supports_parachains);
 	Ok(builder)
 }

--- a/node/overseer/src/dummy.rs
+++ b/node/overseer/src/dummy.rs
@@ -21,7 +21,7 @@ use crate::{
 };
 use lru::LruCache;
 use orchestra::{FromOrchestra, SpawnedSubsystem, Subsystem, SubsystemContext};
-use polkadot_node_subsystem_types::{errors::SubsystemError, messages::*};
+use polkadot_node_subsystem_types::{errors::SubsystemError, messages::*, BlockNumber, Hash};
 // Generated dummy messages
 use crate::messages::*;
 
@@ -64,6 +64,7 @@ pub fn dummy_overseer_builder<Spawner, SupportsParachains>(
 	supports_parachains: SupportsParachains,
 	registry: Option<&Registry>,
 	sync_oracle: MajorSyncOracle,
+	initial_leaves: Vec<(Hash, BlockNumber)>,
 ) -> Result<
 	InitializedOverseerBuilder<
 		SpawnGlue<Spawner>,
@@ -103,6 +104,7 @@ where
 		DummySubsystem,
 		registry,
 		sync_oracle,
+		initial_leaves,
 	)
 }
 
@@ -113,6 +115,7 @@ pub fn one_for_all_overseer_builder<Spawner, SupportsParachains, Sub>(
 	subsystem: Sub,
 	registry: Option<&Registry>,
 	sync_oracle: MajorSyncOracle,
+	initial_leaves: Vec<(Hash, BlockNumber)>,
 ) -> Result<
 	InitializedOverseerBuilder<
 		SpawnGlue<Spawner>,
@@ -198,7 +201,7 @@ where
 		.span_per_active_leaf(Default::default())
 		.active_leaves(Default::default())
 		.known_leaves(LruCache::new(KNOWN_LEAVES_CACHE_SIZE))
-		.leaves(Default::default())
+		.leaves(initial_leaves)
 		.spawner(SpawnGlue(spawner))
 		.metrics(metrics)
 		.sync_oracle(sync_oracle)

--- a/node/overseer/src/lib.rs
+++ b/node/overseer/src/lib.rs
@@ -885,7 +885,7 @@ where
 
 	async fn handle_stop(self) -> Result<(), SubsystemError> {
 		self.stop().await;
-		return Ok(())
+		Ok(())
 	}
 
 	fn handle_orchestra_rx(&mut self, msg: ToOrchestra) {

--- a/node/overseer/src/lib.rs
+++ b/node/overseer/src/lib.rs
@@ -861,7 +861,13 @@ where
 								self.broadcast_signal(OverseerSignal::ActiveLeaves(update)).await?;
 							}
 						},
-						Event::BlockFinalized(block) => _ = self.block_finalized(&block).await,
+						Event::BlockFinalized(block) => {
+							let update = self.block_finalized(&block).await;
+							if !update.is_empty() {
+								self.broadcast_signal(OverseerSignal::ActiveLeaves(update)).await?;
+							}
+							self.broadcast_signal(OverseerSignal::BlockFinalized(block.hash, block.number)).await?;
+						},
 						Event::ExternalRequest(request) => self.handle_external_request(request)
 					}
 				},

--- a/node/overseer/src/lib.rs
+++ b/node/overseer/src/lib.rs
@@ -821,7 +821,7 @@ where
 												?number,
 												"Span for active leaf not found. This is not expected"
 											);
-											let span = Arc::new(jaeger::Span::new(hash.clone(), "leaf-activated"));
+											let span = Arc::new(jaeger::Span::new(hash, "leaf-activated"));
 											self.span_per_active_leaf.insert(hash, span.clone());
 											span
 										}

--- a/node/overseer/src/lib.rs
+++ b/node/overseer/src/lib.rs
@@ -818,7 +818,7 @@ where
 								self.broadcast_signal(OverseerSignal::ActiveLeaves(update)).await?;
 							} else {
 								// if not - prepare one manually. All the required state should be already available.
-								let update = self.prepare_initial_active_leaves(&block).await;
+								let update = self.prepare_initial_active_leaves(&block);
 								self.broadcast_signal(OverseerSignal::ActiveLeaves(update)).await?;
 							}
 
@@ -872,7 +872,7 @@ where
 		}
 	}
 
-	async fn prepare_initial_active_leaves(&self, block: &BlockInfo) -> ActiveLeavesUpdate {
+	fn prepare_initial_active_leaves(&self, block: &BlockInfo) -> ActiveLeavesUpdate {
 		// In theory we can receive `BlockImported` during initial major sync. In this case the
 		// update will be empty.
 		let span = match self.span_per_active_leaf.get(&block.hash) {

--- a/node/overseer/src/tests.rs
+++ b/node/overseer/src/tests.rs
@@ -849,6 +849,9 @@ fn do_not_send_events_before_initial_major_sync_is_complete() {
 				span: Arc::new(jaeger::Span::Disabled),
 				status: LeafStatus::Fresh,
 			})),
+			OverseerSignal::ActiveLeaves(ActiveLeavesUpdate::stop_work(
+				imported_block_before_sync.hash,
+			)),
 			OverseerSignal::BlockFinalized(
 				imported_block_after_sync.hash,
 				imported_block_after_sync.number,

--- a/node/overseer/src/tests.rs
+++ b/node/overseer/src/tests.rs
@@ -754,6 +754,12 @@ fn do_not_send_empty_leaves_update_on_block_finalization() {
 				span: Arc::new(jaeger::Span::Disabled),
 				status: LeafStatus::Fresh,
 			})),
+			OverseerSignal::ActiveLeaves(ActiveLeavesUpdate::start_work(ActivatedLeaf {
+				hash: finalized_block.hash,
+				number: finalized_block.number,
+				span: Arc::new(jaeger::Span::Disabled),
+				status: LeafStatus::Fresh,
+			})),
 			OverseerSignal::BlockFinalized(finalized_block.hash, 1),
 		];
 
@@ -1261,7 +1267,7 @@ fn overseer_all_subsystems_receive_signals_and_messages() {
 
 		// send a signal to each subsystem
 		handle
-			.block_imported(BlockInfo {
+			.block_finalized(BlockInfo {
 				hash: Default::default(),
 				parent_hash: Default::default(),
 				number: Default::default(),
@@ -1345,7 +1351,7 @@ fn overseer_all_subsystems_receive_signals_and_messages() {
 
 		let res = overseer_fut.await;
 		assert_eq!(stop_signals_received.load(atomic::Ordering::SeqCst), NUM_SUBSYSTEMS);
-		assert_eq!(signals_received.load(atomic::Ordering::SeqCst), NUM_SUBSYSTEMS);
+		assert_eq!(signals_received.load(atomic::Ordering::SeqCst), NUM_SUBSYSTEMS * 2);
 		assert_eq!(msgs_received.load(atomic::Ordering::SeqCst), NUM_SUBSYSTEMS_MESSAGED);
 
 		assert!(res.is_ok());

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -49,7 +49,7 @@ use {
 	polkadot_node_network_protocol::{
 		peer_set::PeerSetProtocolNames, request_response::ReqProtocolNames,
 	},
-	polkadot_overseer::BlockInfo,
+	polkadot_overseer::{BlockInfo, MajorSyncOracle},
 	sc_client_api::BlockBackend,
 	sp_core::traits::SpawnNamed,
 	sp_trie::PrefixedMemoryDB,
@@ -1091,6 +1091,7 @@ where
 					overseer_message_channel_capacity_override,
 					req_protocol_names,
 					peerset_protocol_names,
+					sync_oracle: MajorSyncOracle::new(Box::new(network.clone())),
 				},
 			)
 			.map_err(|e| {

--- a/node/service/src/overseer.rs
+++ b/node/service/src/overseer.rs
@@ -34,8 +34,8 @@ pub use polkadot_overseer::{
 	HeadSupportsParachains,
 };
 use polkadot_overseer::{
-	metrics::Metrics as OverseerMetrics, BlockInfo, InitializedOverseerBuilder, MetricsTrait,
-	Overseer, OverseerConnector, OverseerHandle, SpawnGlue,
+	metrics::Metrics as OverseerMetrics, BlockInfo, InitializedOverseerBuilder, MajorSyncOracle,
+	MetricsTrait, Overseer, OverseerConnector, OverseerHandle, SpawnGlue,
 };
 
 use polkadot_primitives::runtime_api::ParachainHost;
@@ -125,6 +125,8 @@ where
 	pub req_protocol_names: ReqProtocolNames,
 	/// [`PeerSet`] protocol names to protocols mapping.
 	pub peerset_protocol_names: PeerSetProtocolNames,
+	/// SyncOracle is used to detect when initial full node sync is complete
+	pub sync_oracle: MajorSyncOracle,
 }
 
 /// Obtain a prepared `OverseerBuilder`, that is initialized
@@ -155,6 +157,7 @@ pub fn prepared_overseer_builder<Spawner, RuntimeClient>(
 		overseer_message_channel_capacity_override,
 		req_protocol_names,
 		peerset_protocol_names,
+		sync_oracle,
 	}: OverseerGenArgs<Spawner, RuntimeClient>,
 ) -> Result<
 	InitializedOverseerBuilder<
@@ -319,6 +322,7 @@ where
 		.supports_parachains(runtime_client)
 		.known_leaves(LruCache::new(KNOWN_LEAVES_CACHE_SIZE))
 		.metrics(metrics)
+		.sync_oracle(sync_oracle)
 		.spawner(spawner);
 
 	if let Some(capacity) = overseer_message_channel_capacity_override {

--- a/node/subsystem-test-helpers/src/lib.rs
+++ b/node/subsystem-test-helpers/src/lib.rs
@@ -435,7 +435,7 @@ impl Future for Yield {
 mod tests {
 	use super::*;
 	use futures::executor::block_on;
-	use polkadot_node_subsystem::messages::CollatorProtocolMessage;
+	use polkadot_node_subsystem::{messages::CollatorProtocolMessage, MajorSyncOracle};
 	use polkadot_overseer::{dummy::dummy_overseer_builder, Handle, HeadSupportsParachains};
 	use polkadot_primitives::Hash;
 	use sp_core::traits::SpawnNamed;
@@ -453,13 +453,18 @@ mod tests {
 	fn forward_subsystem_works() {
 		let spawner = sp_core::testing::TaskExecutor::new();
 		let (tx, rx) = mpsc::channel(2);
-		let (overseer, handle) =
-			dummy_overseer_builder(spawner.clone(), AlwaysSupportsParachains, None)
-				.unwrap()
-				.replace_collator_protocol(|_| ForwardSubsystem(tx))
-				.leaves(vec![])
-				.build()
-				.unwrap();
+		let (overseer, handle) = dummy_overseer_builder(
+			spawner.clone(),
+			AlwaysSupportsParachains,
+			None,
+			MajorSyncOracle::new_dummy(),
+			Vec::new(),
+		)
+		.unwrap()
+		.replace_collator_protocol(|_| ForwardSubsystem(tx))
+		.leaves(vec![])
+		.build()
+		.unwrap();
 
 		let mut handle = Handle::new(handle);
 


### PR DESCRIPTION
Adds major sync oracle to overseer. The oracle is used to detect when the node has completed an initial full sync.

The PR also changes the behavior of `ActiveLeaves` and `BlockFinalized` events generation. Now they are not sent until the full initial sync is complete.

Partially addresses https://github.com/paritytech/polkadot/issues/5885. Fixes https://github.com/paritytech/polkadot/issues/6694.