### PR TITLE
New template to generate a full pr list

### DIFF
--- a/scripts/ci/changelog/README.md
+++ b/scripts/ci/changelog/README.md
@@ -66,3 +66,15 @@ By default, if the changelog data from Github is already present, the calls to t
 and the local version of the data will be used. This is much faster.
 If you know that some labels have changed in Github, you will want to refresh the data.
 You can then either delete manually the `<chain>.json` file or `export NO_CACHE=1` to force refreshing the data.
+
+## Full PR list
+
+At times, it may be useful to get a raw full PR list.
+In order to produce this list, you first need to fetch the the latest `context.json` from the `release-notes-context` artifacts you can find [here](https://github.com/paritytech/polkadot/actions/workflows/release-30_publish-draft-release.yml). You may store this `context.json` under `scripts/ci/changelog`.
+
+Using the `full_pr_list.md.tera` template, you can generate the `raw` list of changes:
+
+```
+cd scripts/ci/changelog
+tera --env --env-key env  --template templates/full_pr_list.md.tera context.json
+```

--- a/scripts/ci/changelog/templates/full_pr_list.md.tera
+++ b/scripts/ci/changelog/templates/full_pr_list.md.tera
@@ -1,0 +1,16 @@
+{# This is a helper template to get the FULL PR list #}
+{# It is not used in the release notes #}
+
+# PR list
+
+## substrate
+
+{%- for change in  substrate.changes %}
+ - [S] [`{{ change.number }}`]({{ change.html_url }}) - {{ change.title }}
+{%- endfor %}
+
+## polkadot
+
+{%- for change in  polkadot.changes %}
+ - [P] [`{{ change.number }}`]({{ change.html_url }}) - {{ change.title }}
+{%- endfor %}


### PR DESCRIPTION
It is sometimes useful being able to generate a full list of all the PRs from a version.
This PR introduces a new template + doc in allowing to do so.

<details><summary>Sample output for v0.9.38</summary>

# PR list

## substrate
 - [S] [`13323`](https://github.com/paritytech/substrate/pull/13323) - Fix block pruning after long re-org
 - [S] [`13267`](https://github.com/paritytech/substrate/pull/13267) - Calling proxy doesn't remove announcement
 - [S] [`13264`](https://github.com/paritytech/substrate/pull/13264) - hooks default impl missing where clause
 - [S] [`13256`](https://github.com/paritytech/substrate/pull/13256) - Implement RIType traits for u8 array with an arbitrary size
 - [S] [`13249`](https://github.com/paritytech/substrate/pull/13249) - sc-finality-grandpa: Warp proof generation can not expect justifications
 - [S] [`13247`](https://github.com/paritytech/substrate/pull/13247) - Fix derive PassByInner with generics
 - [S] [`13245`](https://github.com/paritytech/substrate/pull/13245) - mutate_exists for StorageValue with ValueQuery
 - [S] [`13241`](https://github.com/paritytech/substrate/pull/13241) - docs: Fix broken documentation links for pallets
 - [S] [`13240`](https://github.com/paritytech/substrate/pull/13240) - Add task type label to task metrics
 - [S] [`13238`](https://github.com/paritytech/substrate/pull/13238) - CI: Rewrite `check-each-crate` in python
 - [S] [`13237`](https://github.com/paritytech/substrate/pull/13237) - grandpa: cleanup stale entries in set id session mapping
 - [S] [`13236`](https://github.com/paritytech/substrate/pull/13236) - [contracts] Add upfront weight of merkle trie proofs for storage reading functions
 - [S] [`13235`](https://github.com/paritytech/substrate/pull/13235) - migrate new benchmarking syntax from `frame_support::benchmarking` to `frame_benchmarking::v2`
 - [S] [`13234`](https://github.com/paritytech/substrate/pull/13234) - storage-monitor: statvfs arithmetic bug fixed
 - [S] [`13232`](https://github.com/paritytech/substrate/pull/13232) - implemented `contains_prefix` for StorageDoubleMap and StorageNMap
 - [S] [`13230`](https://github.com/paritytech/substrate/pull/13230) - upgrade nix to 0.26.1
 - [S] [`13229`](https://github.com/paritytech/substrate/pull/13229) - pallet-assets: Rename `total_supply` to `amount`
 - [S] [`13226`](https://github.com/paritytech/substrate/pull/13226) - Bump parity-db
 - [S] [`13223`](https://github.com/paritytech/substrate/pull/13223) - Fix try-runtime with create-snapshot
 - [S] [`13222`](https://github.com/paritytech/substrate/pull/13222) - beefy: Add LOG_TARGET constant
 - [S] [`13221`](https://github.com/paritytech/substrate/pull/13221) - Aura: Fix warp syncing
 - [S] [`13217`](https://github.com/paritytech/substrate/pull/13217) - Debug assert events at genesis
 - [S] [`13216`](https://github.com/paritytech/substrate/pull/13216) - Remove `uncles` related code
 - [S] [`13214`](https://github.com/paritytech/substrate/pull/13214) - [Fix] CountedMap::set now takes Counter into account
 - [S] [`13213`](https://github.com/paritytech/substrate/pull/13213) - Remove dead code
 - [S] [`13209`](https://github.com/paritytech/substrate/pull/13209) - Use non-binary pronouns in comments.
 - [S] [`13208`](https://github.com/paritytech/substrate/pull/13208) - Rename `*-private-ipv4` to `*-private-ip` CLI args
 - [S] [`13205`](https://github.com/paritytech/substrate/pull/13205) - Fix Up Node Template
 - [S] [`13204`](https://github.com/paritytech/substrate/pull/13204) - contracts: Deprecate random interface
 - [S] [`13199`](https://github.com/paritytech/substrate/pull/13199) - Fix flaky BABE test
 - [S] [`13198`](https://github.com/paritytech/substrate/pull/13198) - Move slow hardware warning print logic to CLI
 - [S] [`13194`](https://github.com/paritytech/substrate/pull/13194) - Correct arithmetical semantic of `PerDispatchClass`
 - [S] [`13193`](https://github.com/paritytech/substrate/pull/13193) - Use year 2023 in the License headers
 - [S] [`13185`](https://github.com/paritytech/substrate/pull/13185) - sc-network: Ensure private addresses are disabled if requested
 - [S] [`13183`](https://github.com/paritytech/substrate/pull/13183) - Fix potential huge allocation as a result of `validate_block` output
 - [S] [`13181`](https://github.com/paritytech/substrate/pull/13181) - contracts: Remove fixtures from crate
 - [S] [`13180`](https://github.com/paritytech/substrate/pull/13180) - txpool: LOG_TARGET const added
 - [S] [`13173`](https://github.com/paritytech/substrate/pull/13173) - BlockId removal: refactor: CallExecutor trait
 - [S] [`13169`](https://github.com/paritytech/substrate/pull/13169) - Make DispatchError impl MEL
 - [S] [`13161`](https://github.com/paritytech/substrate/pull/13161) - frame-benchmarking: Macros should not force a particular env
 - [S] [`13157`](https://github.com/paritytech/substrate/pull/13157) - Notification-based block pinning
 - [S] [`13155`](https://github.com/paritytech/substrate/pull/13155) - Refactory of `next_slot` method
 - [S] [`13154`](https://github.com/paritytech/substrate/pull/13154) - Fix the `storage_size`/`state_getStorageSize` RPC call
 - [S] [`13153`](https://github.com/paritytech/substrate/pull/13153) - More improvements for the crate publishing pipeline
 - [S] [`13152`](https://github.com/paritytech/substrate/pull/13152) - [client/network] Add support  for `/wss` addresses
 - [S] [`13151`](https://github.com/paritytech/substrate/pull/13151) - pallet-offences-benchmarking: Box events in verify
 - [S] [`13150`](https://github.com/paritytech/substrate/pull/13150) - Breakout mock runtimes to separate files
 - [S] [`13146`](https://github.com/paritytech/substrate/pull/13146) - Benchmark's successful origin api update
 - [S] [`13144`](https://github.com/paritytech/substrate/pull/13144) - Annotate thiserror for sp_core::crypto::SecretStringError
 - [S] [`13142`](https://github.com/paritytech/substrate/pull/13142) - *: update criterion to v0.4.0
 - [S] [`13139`](https://github.com/paritytech/substrate/pull/13139) - CI: Code mark to request a pipeline failure
 - [S] [`13136`](https://github.com/paritytech/substrate/pull/13136) - Use balance trait in transaction-payment pallets
 - [S] [`13135`](https://github.com/paritytech/substrate/pull/13135) - Babe: bad epoch index with skipped epochs and warp sync
 - [S] [`13134`](https://github.com/paritytech/substrate/pull/13134) - CI: Unpin `ci-linux` and use Rust 1.66.1
 - [S] [`13131`](https://github.com/paritytech/substrate/pull/13131) - sp-beefy: align authority id key type with its signature type
 - [S] [`13130`](https://github.com/paritytech/substrate/pull/13130) - [easy-but-important] client/beefy: fix logs
 - [S] [`13127`](https://github.com/paritytech/substrate/pull/13127) - Stop keeping track of epoch changes for the sync gap
 - [S] [`13124`](https://github.com/paritytech/substrate/pull/13124) - [NFTs] Track item's metadata depositor
 - [S] [`13123`](https://github.com/paritytech/substrate/pull/13123) - Bump git2 from 0.14.4 to 0.16.0
 - [S] [`13120`](https://github.com/paritytech/substrate/pull/13120) - reduce exec time of fast-unstake benchmarks
 - [S] [`13110`](https://github.com/paritytech/substrate/pull/13110) - Add WeightToFee and LengthToFee impls to transaction-payment Runtime API
 - [S] [`13105`](https://github.com/paritytech/substrate/pull/13105) - Scheduler is already at V4
 - [S] [`13094`](https://github.com/paritytech/substrate/pull/13094) - `IntegrityTest` implementation should be feature gated
 - [S] [`13082`](https://github.com/paritytech/substrate/pull/13082) - service: storage monitor added
 - [S] [`13065`](https://github.com/paritytech/substrate/pull/13065) - Allow duplicate topics in smart contract events
 - [S] [`13038`](https://github.com/paritytech/substrate/pull/13038) - Upgrade wasm-opt to 0.111.0
 - [S] [`13015`](https://github.com/paritytech/substrate/pull/13015) - zobmienet tests are not supposed to fail
 - [S] [`13004`](https://github.com/paritytech/substrate/pull/13004) - txpool: don't maintain the pool during major sync
 - [S] [`12993`](https://github.com/paritytech/substrate/pull/12993) - [contracts] Add integrity checks by pallet hook
 - [S] [`12982`](https://github.com/paritytech/substrate/pull/12982) - Rework the trie cache
 - [S] [`12979`](https://github.com/paritytech/substrate/pull/12979) - Add debug info in assert_has_event and assert_last_event
 - [S] [`12976`](https://github.com/paritytech/substrate/pull/12976) - [contracts] Adapt storage reading host functions to Weights V2
 - [S] [`12928`](https://github.com/paritytech/substrate/pull/12928) - NIS should retain funds in reserve
 - [S] [`12924`](https://github.com/paritytech/substrate/pull/12924) - new proc-macro-based benchmarking syntax
 - [S] [`12857`](https://github.com/paritytech/substrate/pull/12857) - Optimize merkle proofs for efficient verification in Solidity
 - [S] [`12707`](https://github.com/paritytech/substrate/pull/12707) - Expose `UnknownBlock` error via `ApiError`
 - [S] [`12620`](https://github.com/paritytech/substrate/pull/12620) - Warn validators with slow hardware
 - [S] [`11637`](https://github.com/paritytech/substrate/pull/11637) - Add Proof Size to Weight Output

## polkadot
 - [P] [`6651`](https://github.com/paritytech/polkadot/pull/6651) - Bump docker/build-push-action from 3 to 4
 - [P] [`6641`](https://github.com/paritytech/polkadot/pull/6641) - ignore fast-unstake remote test
 - [P] [`6635`](https://github.com/paritytech/polkadot/pull/6635) - Fix XCM transact bench
 - [P] [`6633`](https://github.com/paritytech/polkadot/pull/6633) - Metrics: add PoV size and validation code size in `candidate-validation`
 - [P] [`6630`](https://github.com/paritytech/polkadot/pull/6630) - clear migrations included in 0.9.37
 - [P] [`6626`](https://github.com/paritytech/polkadot/pull/6626) - companion for substrate #13237
 - [P] [`6622`](https://github.com/paritytech/polkadot/pull/6622) - nix upgrade to 0.26.1
 - [P] [`6619`](https://github.com/paritytech/polkadot/pull/6619) - Storage monitor added to polkadot node
 - [P] [`6617`](https://github.com/paritytech/polkadot/pull/6617) - Bump parity-db
 - [P] [`6616`](https://github.com/paritytech/polkadot/pull/6616) - libc crate update
 - [P] [`6615`](https://github.com/paritytech/polkadot/pull/6615) - Companion: Remove `uncles` related code
 - [P] [`6606`](https://github.com/paritytech/polkadot/pull/6606) - XCM: Add HRMP to SafeCallFilter
 - [P] [`6598`](https://github.com/paritytech/polkadot/pull/6598) - Update benchmark's successful origin api
 - [P] [`6597`](https://github.com/paritytech/polkadot/pull/6597) - Disallow decoding of phantom asset
 - [P] [`6595`](https://github.com/paritytech/polkadot/pull/6595) - docs: remove references to rpm
 - [P] [`6594`](https://github.com/paritytech/polkadot/pull/6594) - [ci] Change check-labels GHA
 - [P] [`6588`](https://github.com/paritytech/polkadot/pull/6588) - Make zombienet tests native friendly
 - [P] [`6587`](https://github.com/paritytech/polkadot/pull/6587) - Enable `try-runtime` flag in CI
 - [P] [`6585`](https://github.com/paritytech/polkadot/pull/6585) - Update changelog templates to use new labels
 - [P] [`6583`](https://github.com/paritytech/polkadot/pull/6583) - Companion for substrate: Make DispatchError impl MEL
 - [P] [`6582`](https://github.com/paritytech/polkadot/pull/6582) - Companion for Substrate #13157
 - [P] [`6579`](https://github.com/paritytech/polkadot/pull/6579) - Added `HaulBlobError` to pub re-exports
 - [P] [`6578`](https://github.com/paritytech/polkadot/pull/6578) - XCM: `ExpectTransactStatus` instruction
 - [P] [`6577`](https://github.com/paritytech/polkadot/pull/6577) - construct mmr leaf prior to session pallet hook
 - [P] [`6573`](https://github.com/paritytech/polkadot/pull/6573) - Allow AuctionAdmin to use Scheduler
 - [P] [`6570`](https://github.com/paritytech/polkadot/pull/6570) - Companion for substrate#13154
 - [P] [`6569`](https://github.com/paritytech/polkadot/pull/6569) - Co #12928: NIS should retain funds in reserve
 - [P] [`6566`](https://github.com/paritytech/polkadot/pull/6566) - Add runtime-benchmarks feature to test client and test service
 - [P] [`6563`](https://github.com/paritytech/polkadot/pull/6563) - Exclude CI related dictionary files from the CI team approval
 - [P] [`6562`](https://github.com/paritytech/polkadot/pull/6562) - CI: Code mark to request a pipeline failure
 - [P] [`6556`](https://github.com/paritytech/polkadot/pull/6556) - sync versions with release branch (0.9.37)
 - [P] [`6555`](https://github.com/paritytech/polkadot/pull/6555) - update weights (sync with 0.9.37)
 - [P] [`6554`](https://github.com/paritytech/polkadot/pull/6554) - Fix set-output deprecation
 - [P] [`6552`](https://github.com/paritytech/polkadot/pull/6552) - Co reducing fast-unstake bench time and more
 - [P] [`6541`](https://github.com/paritytech/polkadot/pull/6541) - Handle substrate-node-template and substrate-parachain-template
 - [P] [`6538`](https://github.com/paritytech/polkadot/pull/6538) - Bump lru from 0.8.1 to 0.9.0
 - [P] [`6537`](https://github.com/paritytech/polkadot/pull/6537) - pvf: Fix missing execution request when retrying preparation
 - [P] [`6536`](https://github.com/paritytech/polkadot/pull/6536) - 13110 Companion: Add WeightToFee and LengthToFee Runtime API
 - [P] [`6534`](https://github.com/paritytech/polkadot/pull/6534) - Updated Dwellir bootnodes. Now using wss.
 - [P] [`6531`](https://github.com/paritytech/polkadot/pull/6531) - Add a paragraph about slashing in runtime disputes section from the guide
 - [P] [`6512`](https://github.com/paritytech/polkadot/pull/6512) - Issue 4804: Notify chain selection of concluded disputes directly
 - [P] [`6508`](https://github.com/paritytech/polkadot/pull/6508) - New runners for weights and new weights
 - [P] [`6492`](https://github.com/paritytech/polkadot/pull/6492) - pre-checking: Reject failed PVFs
 - [P] [`6490`](https://github.com/paritytech/polkadot/pull/6490) - Enable treasury.spend by Root origin for Polkadot network before Gov2
 - [P] [`6487`](https://github.com/paritytech/polkadot/pull/6487) - Re-export current primitives in crate root
 - [P] [`6476`](https://github.com/paritytech/polkadot/pull/6476) - Add Polkadotters bootnodes for Westend, Kusama and Polkadot
 - [P] [`6336`](https://github.com/paritytech/polkadot/pull/6336) - Westend state trie to version 1
 - [P] [`6308`](https://github.com/paritytech/polkadot/pull/6308) - add erasure-coding benches
 - [P] [`6269`](https://github.com/paritytech/polkadot/pull/6269) - Warn validators with slow hardware
 - [P] [`6249`](https://github.com/paritytech/polkadot/pull/6249) - Some late short-term fixes for dispute slashing
 - [P] [`6103`](https://github.com/paritytech/polkadot/pull/6103) - Fix some unjustified disputes
 - [P] [`4097`](https://github.com/paritytech/polkadot/pull/4097) - XCM v3

</details>