### PR TITLE
edit xcm simulator test code

### DIFF
--- a/xcm/xcm-simulator/example/src/lib.rs
+++ b/xcm/xcm-simulator/example/src/lib.rs
@@ -253,7 +253,7 @@ mod tests {
 				0,
 			));
 			assert_eq!(
-				parachain::Balances::free_balance(&child_account_id(1)),
+				relay_chain::Balances::free_balance(&child_account_id(1)),
 				INITIAL_BALANCE + withdraw_amount
 			);
 		});


### PR DESCRIPTION
Request minor change in XCM-simulator test code for `reserve_transfer`. Should check sovereign account in relay chain