### PR TITLE
Async Backing: Integrate `vstaging` of statement distribution into `lib.rs`

### DIFF
--- a/node/network/statement-distribution/src/legacy_v1/mod.rs
+++ b/node/network/statement-distribution/src/legacy_v1/mod.rs
@@ -103,7 +103,7 @@ const MAX_LARGE_STATEMENTS_PER_SENDER: usize = 20;
 
 /// Overall state of the legacy-v1 portion of the subsystem.
 pub(crate) struct State {
-	peers: HashMap<PeerId, PeerData>,
+	pub peers: HashMap<PeerId, PeerData>,
 	topology_storage: SessionBoundGridTopologyStorage,
 	authorities: HashMap<AuthorityDiscoveryId, PeerId>,
 	active_heads: HashMap<Hash, ActiveHeadData>,

--- a/node/network/statement-distribution/src/legacy_v1/mod.rs
+++ b/node/network/statement-distribution/src/legacy_v1/mod.rs
@@ -426,7 +426,7 @@ impl PeerRelayParentKnowledge {
 	}
 }
 
-struct PeerData {
+pub struct PeerData {
 	view: View,
 	protocol_version: ValidationVersion,
 	view_knowledge: HashMap<Hash, PeerRelayParentKnowledge>,

--- a/node/network/statement-distribution/src/legacy_v1/responder.rs
+++ b/node/network/statement-distribution/src/legacy_v1/responder.rs
@@ -48,8 +48,8 @@ pub enum ResponderMessage {
 
 /// A fetching task, taking care of fetching large statements via request/response.
 ///
-/// A fetch task does not know about a particular `Statement` instead it just tries fetching a
-/// `CommittedCandidateReceipt` from peers, whether this can be used to re-assemble one ore
+/// A fetch task does not know about a particular `Statement`, instead it just tries fetching a
+/// `CommittedCandidateReceipt` from peers, whether this can be used to re-assemble one or
 /// many `SignedFullStatement`s needs to be verified by the caller.
 pub async fn respond(
 	mut receiver: IncomingRequestReceiver<StatementFetchingRequest>,

--- a/node/network/statement-distribution/src/legacy_v1/tests.rs
+++ b/node/network/statement-distribution/src/legacy_v1/tests.rs
@@ -762,11 +762,13 @@ fn receiving_from_one_sends_to_another_and_to_candidate_backing() {
 
 	let req_protocol_names = ReqProtocolNames::new(&GENESIS_HASH, None);
 	let (statement_req_receiver, _) = IncomingRequest::get_config_receiver(&req_protocol_names);
+	let (candidate_req_receiver, _) = IncomingRequest::get_config_receiver(&req_protocol_names);
 
 	let bg = async move {
 		let s = StatementDistributionSubsystem::new(
 			Arc::new(LocalKeystore::in_memory()),
 			statement_req_receiver,
+			candidate_req_receiver,
 			Default::default(),
 			AlwaysZeroRng,
 		);
@@ -995,11 +997,13 @@ fn receiving_large_statement_from_one_sends_to_another_and_to_candidate_backing(
 	let req_protocol_names = ReqProtocolNames::new(&GENESIS_HASH, None);
 	let (statement_req_receiver, mut req_cfg) =
 		IncomingRequest::get_config_receiver(&req_protocol_names);
+	let (candidate_req_receiver, _) = IncomingRequest::get_config_receiver(&req_protocol_names);
 
 	let bg = async move {
 		let s = StatementDistributionSubsystem::new(
 			make_ferdie_keystore(),
 			statement_req_receiver,
+			candidate_req_receiver,
 			Default::default(),
 			AlwaysZeroRng,
 		);
@@ -1534,11 +1538,13 @@ fn share_prioritizes_backing_group() {
 	let req_protocol_names = ReqProtocolNames::new(&GENESIS_HASH, None);
 	let (statement_req_receiver, mut req_cfg) =
 		IncomingRequest::get_config_receiver(&req_protocol_names);
+	let (candidate_req_receiver, _) = IncomingRequest::get_config_receiver(&req_protocol_names);
 
 	let bg = async move {
 		let s = StatementDistributionSubsystem::new(
 			make_ferdie_keystore(),
 			statement_req_receiver,
+			candidate_req_receiver,
 			Default::default(),
 			AlwaysZeroRng,
 		);
@@ -1850,10 +1856,12 @@ fn peer_cant_flood_with_large_statements() {
 
 	let req_protocol_names = ReqProtocolNames::new(&GENESIS_HASH, None);
 	let (statement_req_receiver, _) = IncomingRequest::get_config_receiver(&req_protocol_names);
+	let (candidate_req_receiver, _) = IncomingRequest::get_config_receiver(&req_protocol_names);
 	let bg = async move {
 		let s = StatementDistributionSubsystem::new(
 			make_ferdie_keystore(),
 			statement_req_receiver,
+			candidate_req_receiver,
 			Default::default(),
 			AlwaysZeroRng,
 		);
@@ -2067,11 +2075,13 @@ fn handle_multiple_seconded_statements() {
 
 	let req_protocol_names = ReqProtocolNames::new(&GENESIS_HASH, None);
 	let (statement_req_receiver, _) = IncomingRequest::get_config_receiver(&req_protocol_names);
+	let (candidate_req_receiver, _) = IncomingRequest::get_config_receiver(&req_protocol_names);
 
 	let virtual_overseer_fut = async move {
 		let s = StatementDistributionSubsystem::new(
 			Arc::new(LocalKeystore::in_memory()),
 			statement_req_receiver,
+			candidate_req_receiver,
 			Default::default(),
 			AlwaysZeroRng,
 		);

--- a/node/network/statement-distribution/src/lib.rs
+++ b/node/network/statement-distribution/src/lib.rs
@@ -274,15 +274,17 @@ impl<R: rand::Rng> StatementDistributionSubsystem<R> {
 				let mut mode = None;
 				if let Some(ref activated) = activated {
 					mode = Some(prospective_parachains_mode(ctx.sender(), activated.hash).await?);
-					vstaging::handle_active_leaves_update(
-						ctx,
-						state,
-						ActiveLeavesUpdate {
-							activated: Some(activated.clone()),
-							deactivated: vec![].into(),
-						},
-					)
-					.await?;
+					if let Some(ProspectiveParachainsMode::Enabled { .. }) = mode {
+						vstaging::handle_active_leaves_update(
+							ctx,
+							state,
+							ActiveLeavesUpdate {
+								activated: Some(activated.clone()),
+								deactivated: vec![].into(),
+							},
+						)
+						.await?;
+					}
 				}
 				vstaging::handle_active_leaves_update(
 					ctx,

--- a/node/network/statement-distribution/src/lib.rs
+++ b/node/network/statement-distribution/src/lib.rs
@@ -26,8 +26,7 @@ use error::{log_error, FatalResult};
 
 use polkadot_node_network_protocol::{
 	request_response::{
-		v1 as request_v1, vstaging::AttestedCandidateRequest, IncomingRequest,
-		IncomingRequestReceiver,
+		v1 as request_v1, vstaging::AttestedCandidateRequest, IncomingRequestReceiver,
 	},
 	vstaging as protocol_vstaging, Versioned,
 };
@@ -101,7 +100,7 @@ enum MuxedMessage {
 	/// Messages from spawned v1 (legacy) responder background task.
 	V1Responder(Option<V1ResponderMessage>),
 	/// Messages from candidate responder background task.
-	Responder(Option<IncomingRequest<AttestedCandidateRequest>>),
+	Responder(Option<vstaging::ResponderMessage>),
 	/// Messages from answered requests.
 	Response(vstaging::UnhandledResponse),
 }
@@ -113,7 +112,7 @@ impl MuxedMessage {
 		state: &mut vstaging::State,
 		from_v1_requester: &mut mpsc::Receiver<V1RequesterMessage>,
 		from_v1_responder: &mut mpsc::Receiver<V1ResponderMessage>,
-		from_responder: &mut mpsc::Receiver<IncomingRequest<AttestedCandidateRequest>>,
+		from_responder: &mut mpsc::Receiver<vstaging::ResponderMessage>,
 	) -> MuxedMessage {
 		// We are only fusing here to make `select` happy, in reality we will quit if one of those
 		// streams end:

--- a/node/network/statement-distribution/src/vstaging/mod.rs
+++ b/node/network/statement-distribution/src/vstaging/mod.rs
@@ -218,6 +218,22 @@ pub(crate) struct State {
 	request_manager: RequestManager,
 }
 
+impl State {
+	/// Create a new state.
+	pub(crate) fn new(keystore: SyncCryptoStorePtr) -> Self {
+		State {
+			implicit_view: Default::default(),
+			candidates: Default::default(),
+			per_relay_parent: HashMap::new(),
+			per_session: HashMap::new(),
+			peers: HashMap::new(),
+			keystore,
+			authorities: HashMap::new(),
+			request_manager: RequestManager::new(),
+		}
+	}
+}
+
 // For the provided validator index, if there is a connected peer controlling the given authority
 // ID, then return that peer's `PeerId`.
 fn connected_validator_peer(
@@ -627,7 +643,7 @@ async fn handle_peer_view_update<Context>(
 fn find_validator_ids<'a>(
 	known_discovery_ids: impl IntoIterator<Item = &'a AuthorityDiscoveryId>,
 	discovery_mapping: impl Fn(&AuthorityDiscoveryId) -> Option<&'a ValidatorIndex>,
-) -> impl IntoIterator<Item = ValidatorIndex> {
+) -> impl Iterator<Item = ValidatorIndex> {
 	known_discovery_ids.into_iter().filter_map(discovery_mapping).cloned()
 }
 

--- a/node/network/statement-distribution/src/vstaging/mod.rs
+++ b/node/network/statement-distribution/src/vstaging/mod.rs
@@ -2422,7 +2422,6 @@ pub(crate) async fn dispatch_requests<Context>(ctx: &mut Context, state: &mut St
 	}
 }
 
-// TODO: How should this be used?
 /// Wait on the next incoming response. If there are no requests pending, this
 /// future never resolves. It is the responsibility of the user of this API
 /// to interrupt the future.

--- a/node/network/statement-distribution/src/vstaging/statement_store.rs
+++ b/node/network/statement-distribution/src/vstaging/statement_store.rs
@@ -223,7 +223,7 @@ impl StatementStore {
 		&'a self,
 		validators: &'a [ValidatorIndex],
 		candidate_hash: CandidateHash,
-	) -> impl IntoIterator<Item = &SignedStatement> + 'a {
+	) -> impl Iterator<Item = &SignedStatement> + 'a {
 		let s_st = CompactStatement::Seconded(candidate_hash);
 		let v_st = CompactStatement::Valid(candidate_hash);
 

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -897,6 +897,8 @@ where
 	config.network.request_response_protocols.push(cfg);
 	let (statement_req_receiver, cfg) = IncomingRequest::get_config_receiver(&req_protocol_names);
 	config.network.request_response_protocols.push(cfg);
+	let (candidate_req_receiver, cfg) = IncomingRequest::get_config_receiver(&req_protocol_names);
+	config.network.request_response_protocols.push(cfg);
 	let (dispute_req_receiver, cfg) = IncomingRequest::get_config_receiver(&req_protocol_names);
 	config.network.request_response_protocols.push(cfg);
 
@@ -1076,6 +1078,7 @@ where
 					collation_req_vstaging_receiver,
 					available_data_req_receiver,
 					statement_req_receiver,
+					candidate_req_receiver,
 					dispute_req_receiver,
 					registry: prometheus_registry.as_ref(),
 					spawner,

--- a/node/service/src/overseer.rs
+++ b/node/service/src/overseer.rs
@@ -110,6 +110,8 @@ where
 		IncomingRequestReceiver<request_v1::AvailableDataFetchingRequest>,
 	/// Receiver for incoming large statement requests.
 	pub statement_req_receiver: IncomingRequestReceiver<request_v1::StatementFetchingRequest>,
+	/// Receiver for incoming candidate requests.
+	pub candidate_req_receiver: IncomingRequestReceiver<request_vstaging::AttestedCandidateRequest>,
 	/// Receiver for incoming disputes.
 	pub dispute_req_receiver: IncomingRequestReceiver<request_v1::DisputeRequest>,
 	/// Prometheus registry, commonly used for production systems, less so for test.
@@ -154,6 +156,7 @@ pub fn prepared_overseer_builder<Spawner, RuntimeClient>(
 		collation_req_vstaging_receiver,
 		available_data_req_receiver,
 		statement_req_receiver,
+		candidate_req_receiver,
 		dispute_req_receiver,
 		registry,
 		spawner,
@@ -293,6 +296,7 @@ where
 		.statement_distribution(StatementDistributionSubsystem::new(
 			keystore.clone(),
 			statement_req_receiver,
+			candidate_req_receiver,
 			Metrics::register(registry)?,
 			rand::rngs::StdRng::from_entropy(),
 		))

--- a/node/subsystem-util/src/inclusion_emulator/staging.rs
+++ b/node/subsystem-util/src/inclusion_emulator/staging.rs
@@ -1358,7 +1358,7 @@ mod tests {
 			);
 		}
 
-		candidate.commitments.processed_downward_messages = 1;
+		candidate.commitments.to_mut().processed_downward_messages = 1;
 		assert!(Fragment::new(relay_parent, constraints, candidate).is_ok());
 	}
 


### PR DESCRIPTION
# PULL REQUEST

Closes #6712

## Subsystem Integration

-   [X] `handle_network_update`
-   [X] `handle_active_leaves_update`
    -   Should only be called for new leaves which support prospective parachains.
-   [X] `share_local_statement`
-   [X] `handle_backed_candidate_message`
-   [X] req/resp:
    -   [X] `dispatch_requests`
    -   [X] Request receiver
    -   [X] `answer_request`
    -   [X] `receive_response`
    -   [X] `handle_response`

## Request/Response Flow

### Requesting Validator

-   Requests are queued up with `RequestManager::get_or_insert`.
    -   Done as needed, when handling incoming manifests/statements.
-   `dispatch_request` sends any queued-up requests.
    -   Calls `RequestManager::next_request` to completion.
        -   Creates the `OutgoingRequest`, saves the receiver in
            `RequestManager::pending_responses`.
    -   Does nothing if we have more responses pending than the limit of parallel
        requests.

### Peer

-   Requests come in on a peer on the `IncomingRequestReceiver`.
    -   Runs in a background responder task and feeds request to `answer_request`
        through `MuxedMessage`.
    -   Responder task has a limit on number of parallel requests.
-   `answer_request` on the peer takes the request and sends a response.
    -   Does this using the response sender on the request.

### Requesting Validator

-   `receive_response` receives a response on the original validator.
    -   Response was sent on the request's response sender.
    -   `RequestManager::await_incoming` awaits on responses.
    -   Runs on the `MuxedMessage` receiver.
-   `handle_response` handles the response.
