### PR TITLE
Change `MaxMemorySize` to `MaxMemoryPages`

### DIFF
--- a/node/core/pvf/src/executor_intf.rs
+++ b/node/core/pvf/src/executor_intf.rs
@@ -121,7 +121,8 @@ fn params_to_wasmtime_semantics(par: ExecutorParams) -> Result<Semantics, String
 
 	for p in par.iter() {
 		match p {
-			ExecutorParam::MaxMemoryPages(mms) => sem.max_memory_size = Some((*mms as usize * 65536)),
+			ExecutorParam::MaxMemoryPages(mms) =>
+				sem.max_memory_size = Some((*mms as usize * 65536)),
 			ExecutorParam::StackLogicalMax(slm) => stack_limit.logical_max = *slm,
 			ExecutorParam::StackNativeMax(snm) => stack_limit.native_stack_max = *snm,
 			ExecutorParam::PrecheckingMaxMemory(_) => (), // TODO: Not implemented yet

--- a/node/core/pvf/src/executor_intf.rs
+++ b/node/core/pvf/src/executor_intf.rs
@@ -121,8 +121,7 @@ fn params_to_wasmtime_semantics(par: ExecutorParams) -> Result<Semantics, String
 
 	for p in par.iter() {
 		match p {
-			ExecutorParam::MaxMemoryPages(mms) =>
-				sem.max_memory_size = Some((*mms as usize * 65536)),
+			ExecutorParam::MaxMemoryPages(mms) => sem.max_memory_size = Some(*mms as usize * 65536),
 			ExecutorParam::StackLogicalMax(slm) => stack_limit.logical_max = *slm,
 			ExecutorParam::StackNativeMax(snm) => stack_limit.native_stack_max = *snm,
 			ExecutorParam::PrecheckingMaxMemory(_) => (), // TODO: Not implemented yet

--- a/node/core/pvf/src/executor_intf.rs
+++ b/node/core/pvf/src/executor_intf.rs
@@ -118,9 +118,10 @@ fn params_to_wasmtime_semantics(par: ExecutorParams) -> Result<Semantics, String
 	} else {
 		return Err("No default stack limit set".to_owned())
 	};
+
 	for p in par.iter() {
 		match p {
-			ExecutorParam::MaxMemorySize(mms) => sem.max_memory_size = Some(*mms as usize),
+			ExecutorParam::MaxMemoryPages(mms) => sem.max_memory_size = Some((*mms as usize * 65536)),
 			ExecutorParam::StackLogicalMax(slm) => stack_limit.logical_max = *slm,
 			ExecutorParam::StackNativeMax(snm) => stack_limit.native_stack_max = *snm,
 			ExecutorParam::PrecheckingMaxMemory(_) => (), // TODO: Not implemented yet

--- a/primitives/src/vstaging/executor_params.rs
+++ b/primitives/src/vstaging/executor_params.rs
@@ -27,12 +27,11 @@ use polkadot_core_primitives::Hash;
 use scale_info::TypeInfo;
 use sp_std::{ops::Deref, vec, vec::Vec};
 
-/// A single executor parameter
+/// The different executor parameters for changing the execution environment semantics.
 #[derive(Clone, Debug, Encode, Decode, PartialEq, Eq, TypeInfo)]
 pub enum ExecutorParam {
-	/// ## Parameters setting the executuion environment semantics:
-	/// Max. memory size
-	MaxMemorySize(u32),
+	/// Maximum number of memory pages (64KiB bytes per page) the executor can allocate.
+	MaxMemoryPages(u32),
 	/// Wasm logical stack size limit (max. number of Wasm values on stack)
 	StackLogicalMax(u32),
 	/// Executor machine stack size limit, in bytes


### PR DESCRIPTION
We should set the max memory for the executor in pages (64KiB) and not in bytes. The wasm memory is always a multiple of a page and we should use the same terminology.

Sorry to not have brought up this earlier :see_no_evil:  I just realized while doing some other things :see_no_evil: 