### PR TITLE
lock parathreads when they receive a lease

### DIFF
--- a/runtime/common/src/paras_registrar.rs
+++ b/runtime/common/src/paras_registrar.rs
@@ -643,9 +643,9 @@ impl<T: Config> Pallet<T> {
 
 	/// Swap a parachain and parathread, which involves scheduling an appropriate lifecycle update.
 	fn do_thread_and_chain_swap(to_downgrade: ParaId, to_upgrade: ParaId) {
-		let res1 = runtime_parachains::schedule_parachain_downgrade::<T>(to_downgrade);
+		let res1 = Pallet::<T>::make_parathread(to_downgrade);
 		debug_assert!(res1.is_ok());
-		let res2 = runtime_parachains::schedule_parathread_upgrade::<T>(to_upgrade);
+		let res2 = Pallet::<T>::make_parachain(to_upgrade);
 		debug_assert!(res2.is_ok());
 		T::OnSwap::on_swap(to_upgrade, to_downgrade);
 	}


### PR DESCRIPTION
The default behavior is that a parathread becomes locked as soon as they receive a lease.

If a parachain swaps its lease with a still unlocked parathread (newly registered, didn't build any blocks) this parathread will stay unlocked even when its onboarded as a parachain.

This can be observed with the Parachains 2057 and 2086 on Polkadot.

1. Parachain 2057 receives a lease and is locked
2. Parathread 2086 is registered, but remains unlocked
3. Parachain 2057 swapped its lease with Parathread 2086 ([some time after block 11817168](https://polkadot.subscan.io/extrinsic/11817168-4))
4. Parathread 2086 was upgraded to Parachain, but remained unlocked. (sometime between blocks 11826851 ... 11827828)

I suggest to also lock parathreads once they receive a lease by swapping.