### PR TITLE
miscellaneous fixes to make asynchronous backing work

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -208,6 +208,7 @@ fast-runtime = [ "polkadot-cli/fast-runtime" ]
 runtime-metrics = [ "polkadot-cli/runtime-metrics" ]
 pyroscope = ["polkadot-cli/pyroscope"]
 jemalloc-allocator = ["polkadot-node-core-pvf/jemalloc-allocator", "polkadot-overseer/jemalloc-allocator"]
+network-protocol-staging = ["polkadot-cli/network-protocol-staging"]
 
 # Configuration for building a .deb package - for use with `cargo-deb`
 [package.metadata.deb]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -75,3 +75,4 @@ rococo-native = ["service/rococo-native"]
 
 malus = ["full-node", "service/malus"]
 runtime-metrics = ["service/runtime-metrics", "polkadot-node-metrics/runtime-metrics"]
+network-protocol-staging = ["service/network-protocol-staging"]

--- a/node/collation-generation/src/lib.rs
+++ b/node/collation-generation/src/lib.rs
@@ -198,15 +198,15 @@ async fn handle_new_activations<Context>(
 			let (scheduled_core, assumption) = match core {
 				CoreState::Scheduled(scheduled_core) =>
 					(scheduled_core, OccupiedCoreAssumption::Free),
-				CoreState::Occupied(_occupied_core) => {
-					// TODO: https://github.com/paritytech/polkadot/issues/1573
-					gum::trace!(
-						target: LOG_TARGET,
-						core_idx = %core_idx,
-						relay_parent = ?relay_parent,
-						"core is occupied. Keep going.",
-					);
-					continue
+				CoreState::Occupied(occupied_core) => {
+					// TODO [now]: this assumes that next up == current.
+					// in practice we should only set `OccupiedCoreAssumption::Included`
+					// when the candidate occupying the core is also of the same para.
+					if let Some(scheduled) = occupied_core.next_up_on_available {
+						(scheduled, OccupiedCoreAssumption::Included)
+					} else {
+						continue
+					}
 				},
 				CoreState::Free => {
 					gum::trace!(

--- a/node/core/prospective-parachains/src/fragment_tree.rs
+++ b/node/core/prospective-parachains/src/fragment_tree.rs
@@ -1018,9 +1018,17 @@ mod tests {
 
 		let max_depth = 2;
 		let base_constraints = make_constraints(8, vec![8, 9], vec![1, 2, 3].into());
+		let pending_availability = Vec::new();
 
 		assert_matches!(
-			Scope::with_ancestors(para_id, relay_parent, base_constraints, max_depth, ancestors),
+			Scope::with_ancestors(
+				para_id,
+				relay_parent,
+				base_constraints,
+				pending_availability,
+				max_depth,
+				ancestors
+			),
 			Err(UnexpectedAncestor { number: 8, prev: 10 })
 		);
 	}
@@ -1042,9 +1050,17 @@ mod tests {
 
 		let max_depth = 2;
 		let base_constraints = make_constraints(0, vec![], vec![1, 2, 3].into());
+		let pending_availability = Vec::new();
 
 		assert_matches!(
-			Scope::with_ancestors(para_id, relay_parent, base_constraints, max_depth, ancestors,),
+			Scope::with_ancestors(
+				para_id,
+				relay_parent,
+				base_constraints,
+				pending_availability,
+				max_depth,
+				ancestors,
+			),
 			Err(UnexpectedAncestor { number: 99999, prev: 0 })
 		);
 	}
@@ -1078,10 +1094,17 @@ mod tests {
 
 		let max_depth = 2;
 		let base_constraints = make_constraints(3, vec![2], vec![1, 2, 3].into());
+		let pending_availability = Vec::new();
 
-		let scope =
-			Scope::with_ancestors(para_id, relay_parent, base_constraints, max_depth, ancestors)
-				.unwrap();
+		let scope = Scope::with_ancestors(
+			para_id,
+			relay_parent,
+			base_constraints,
+			pending_availability,
+			max_depth,
+			ancestors,
+		)
+		.unwrap();
 
 		assert_eq!(scope.ancestors.len(), 2);
 		assert_eq!(scope.ancestors_by_hash.len(), 2);
@@ -1166,6 +1189,7 @@ mod tests {
 		let candidate_b_hash = candidate_b.hash();
 
 		let base_constraints = make_constraints(0, vec![0], vec![0x0a].into());
+		let pending_availability = Vec::new();
 
 		let ancestors = vec![RelayChainBlockInfo {
 			number: pvd_a.relay_parent_number,
@@ -1181,9 +1205,15 @@ mod tests {
 
 		storage.add_candidate(candidate_a, pvd_a).unwrap();
 		storage.add_candidate(candidate_b, pvd_b).unwrap();
-		let scope =
-			Scope::with_ancestors(para_id, relay_parent_b_info, base_constraints, 4, ancestors)
-				.unwrap();
+		let scope = Scope::with_ancestors(
+			para_id,
+			relay_parent_b_info,
+			base_constraints,
+			pending_availability,
+			4,
+			ancestors,
+		)
+		.unwrap();
 		let tree = FragmentTree::populate(scope, &storage);
 
 		let candidates: Vec<_> = tree.candidates().collect();
@@ -1238,6 +1268,7 @@ mod tests {
 		let candidate_a2_hash = candidate_a2.hash();
 
 		let base_constraints = make_constraints(0, vec![0], vec![0x0a].into());
+		let pending_availability = Vec::new();
 
 		let ancestors = vec![RelayChainBlockInfo {
 			number: pvd_a.relay_parent_number,
@@ -1253,9 +1284,15 @@ mod tests {
 
 		storage.add_candidate(candidate_a, pvd_a).unwrap();
 		storage.add_candidate(candidate_b, pvd_b).unwrap();
-		let scope =
-			Scope::with_ancestors(para_id, relay_parent_b_info, base_constraints, 4, ancestors)
-				.unwrap();
+		let scope = Scope::with_ancestors(
+			para_id,
+			relay_parent_b_info,
+			base_constraints,
+			pending_availability,
+			4,
+			ancestors,
+		)
+		.unwrap();
 		let mut tree = FragmentTree::populate(scope, &storage);
 
 		storage.add_candidate(candidate_a2, pvd_a2).unwrap();
@@ -1295,6 +1332,7 @@ mod tests {
 		let candidate_b_hash = candidate_b.hash();
 
 		let base_constraints = make_constraints(0, vec![0], vec![0x0a].into());
+		let pending_availability = Vec::new();
 
 		let relay_parent_a_info = RelayChainBlockInfo {
 			number: pvd_a.relay_parent_number,
@@ -1303,9 +1341,15 @@ mod tests {
 		};
 
 		storage.add_candidate(candidate_a, pvd_a).unwrap();
-		let scope =
-			Scope::with_ancestors(para_id, relay_parent_a_info, base_constraints, 4, vec![])
-				.unwrap();
+		let scope = Scope::with_ancestors(
+			para_id,
+			relay_parent_a_info,
+			base_constraints,
+			pending_availability,
+			4,
+			vec![],
+		)
+		.unwrap();
 		let mut tree = FragmentTree::populate(scope, &storage);
 
 		storage.add_candidate(candidate_b, pvd_b).unwrap();
@@ -1344,6 +1388,7 @@ mod tests {
 		let candidate_b_hash = candidate_b.hash();
 
 		let base_constraints = make_constraints(0, vec![0], vec![0x0a].into());
+		let pending_availability = Vec::new();
 
 		let relay_parent_a_info = RelayChainBlockInfo {
 			number: pvd_a.relay_parent_number,
@@ -1352,9 +1397,15 @@ mod tests {
 		};
 
 		storage.add_candidate(candidate_a, pvd_a).unwrap();
-		let scope =
-			Scope::with_ancestors(para_id, relay_parent_a_info, base_constraints, 4, vec![])
-				.unwrap();
+		let scope = Scope::with_ancestors(
+			para_id,
+			relay_parent_a_info,
+			base_constraints,
+			pending_availability,
+			4,
+			vec![],
+		)
+		.unwrap();
 		let mut tree = FragmentTree::populate(scope, &storage);
 
 		storage.add_candidate(candidate_b, pvd_b).unwrap();
@@ -1383,6 +1434,7 @@ mod tests {
 		);
 		let candidate_a_hash = candidate_a.hash();
 		let base_constraints = make_constraints(0, vec![0], vec![0x0a].into());
+		let pending_availability = Vec::new();
 
 		let relay_parent_a_info = RelayChainBlockInfo {
 			number: pvd_a.relay_parent_number,
@@ -1396,6 +1448,7 @@ mod tests {
 			para_id,
 			relay_parent_a_info,
 			base_constraints,
+			pending_availability,
 			max_depth,
 			vec![],
 		)
@@ -1447,6 +1500,7 @@ mod tests {
 		let candidate_b_hash = candidate_b.hash();
 
 		let base_constraints = make_constraints(0, vec![0], vec![0x0a].into());
+		let pending_availability = Vec::new();
 
 		let relay_parent_a_info = RelayChainBlockInfo {
 			number: pvd_a.relay_parent_number,
@@ -1461,6 +1515,7 @@ mod tests {
 			para_id,
 			relay_parent_a_info,
 			base_constraints,
+			pending_availability,
 			max_depth,
 			vec![],
 		)
@@ -1512,6 +1567,7 @@ mod tests {
 		let candidate_b_hash = candidate_b.hash();
 
 		let base_constraints = make_constraints(0, vec![0], vec![0x0a].into());
+		let pending_availability = Vec::new();
 
 		let relay_parent_a_info = RelayChainBlockInfo {
 			number: pvd_a.relay_parent_number,
@@ -1526,6 +1582,7 @@ mod tests {
 			para_id,
 			relay_parent_a_info,
 			base_constraints,
+			pending_availability,
 			max_depth,
 			vec![],
 		)
@@ -1608,6 +1665,7 @@ mod tests {
 		let candidate_a_hash = candidate_a.hash();
 
 		let base_constraints = make_constraints(0, vec![0], vec![0x0a].into());
+		let pending_availability = Vec::new();
 
 		let relay_parent_a_info = RelayChainBlockInfo {
 			number: pvd_a.relay_parent_number,
@@ -1620,6 +1678,7 @@ mod tests {
 			para_id,
 			relay_parent_a_info,
 			base_constraints,
+			pending_availability,
 			max_depth,
 			vec![],
 		)
@@ -1689,6 +1748,7 @@ mod tests {
 		);
 
 		let base_constraints = make_constraints(0, vec![0], vec![0x0a].into());
+		let pending_availability = Vec::new();
 
 		let relay_parent_a_info = RelayChainBlockInfo {
 			number: pvd_a.relay_parent_number,
@@ -1709,6 +1769,7 @@ mod tests {
 			para_id,
 			relay_parent_a_info,
 			base_constraints,
+			pending_availability,
 			max_depth,
 			vec![],
 		)

--- a/node/core/prospective-parachains/src/fragment_tree.rs
+++ b/node/core/prospective-parachains/src/fragment_tree.rs
@@ -818,7 +818,7 @@ impl FragmentTree {
 				// 1. parent hash is correct
 				// 2. relay-parent does not move backwards.
 				// 3. all non-pending-availability candidates have relay-parent in scope.
-				// 3. candidate outputs fulfill constraints
+				// 4. candidate outputs fulfill constraints
 				let required_head_hash = child_constraints.required_parent.hash();
 				for candidate in storage.iter_para_children(&required_head_hash) {
 					let pending = self.scope.get_pending_availability(&candidate.candidate_hash);

--- a/node/core/prospective-parachains/src/tests.rs
+++ b/node/core/prospective-parachains/src/tests.rs
@@ -1374,7 +1374,7 @@ fn persists_pending_availability_candidate() {
 		let leaf_b_hash = Hash::from_low_u64_be(1);
 		let leaf_b_number = leaf_a.number + 1;
 
-		// Activate leaves.
+		// Activate leaf.
 		activate_leaf(&mut virtual_overseer, &leaf_a, &test_state).await;
 
 		// Candidate A

--- a/node/core/runtime-api/src/cache.rs
+++ b/node/core/runtime-api/src/cache.rs
@@ -65,8 +65,7 @@ pub(crate) struct RequestResultCache {
 	version: LruCache<Hash, u32>,
 	disputes: LruCache<Hash, Vec<(SessionIndex, CandidateHash, DisputeState<BlockNumber>)>>,
 
-	staging_validity_constraints:
-		LruCache<(Hash, ParaId), Option<vstaging_primitives::Constraints>>,
+	staging_para_backing_state: LruCache<(Hash, ParaId), Option<vstaging_primitives::BackingState>>,
 	staging_async_backing_parameters: LruCache<Hash, vstaging_primitives::AsyncBackingParameters>,
 }
 
@@ -96,7 +95,7 @@ impl Default for RequestResultCache {
 			version: LruCache::new(DEFAULT_CACHE_CAP),
 			disputes: LruCache::new(DEFAULT_CACHE_CAP),
 
-			staging_validity_constraints: LruCache::new(DEFAULT_CACHE_CAP),
+			staging_para_backing_state: LruCache::new(DEFAULT_CACHE_CAP),
 			staging_async_backing_parameters: LruCache::new(DEFAULT_CACHE_CAP),
 		}
 	}
@@ -394,19 +393,19 @@ impl RequestResultCache {
 		self.disputes.put(relay_parent, value);
 	}
 
-	pub(crate) fn staging_validity_constraints(
+	pub(crate) fn staging_para_backing_state(
 		&mut self,
 		key: (Hash, ParaId),
-	) -> Option<&Option<vstaging_primitives::Constraints>> {
-		self.staging_validity_constraints.get(&key)
+	) -> Option<&Option<vstaging_primitives::BackingState>> {
+		self.staging_para_backing_state.get(&key)
 	}
 
-	pub(crate) fn cache_staging_validity_constraints(
+	pub(crate) fn cache_staging_para_backing_state(
 		&mut self,
 		key: (Hash, ParaId),
-		value: Option<vstaging_primitives::Constraints>,
+		value: Option<vstaging_primitives::BackingState>,
 	) {
-		self.staging_validity_constraints.put(key, value);
+		self.staging_para_backing_state.put(key, value);
 	}
 
 	pub(crate) fn staging_async_backing_parameters(
@@ -461,6 +460,6 @@ pub(crate) enum RequestResult {
 	Version(Hash, u32),
 	Disputes(Hash, Vec<(SessionIndex, CandidateHash, DisputeState<BlockNumber>)>),
 
-	StagingValidityConstraints(Hash, ParaId, Option<vstaging_primitives::Constraints>),
+	StagingParaBackingState(Hash, ParaId, Option<vstaging_primitives::BackingState>),
 	StagingAsyncBackingParameters(Hash, vstaging_primitives::AsyncBackingParameters),
 }

--- a/node/core/runtime-api/src/lib.rs
+++ b/node/core/runtime-api/src/lib.rs
@@ -506,7 +506,7 @@ where
 			query!(
 				StagingParaBackingState,
 				staging_para_backing_state(para),
-				ver = Request::VALIDITY_CONSTRAINTS,
+				ver = Request::STAGING_BACKING_STATE,
 				sender
 			)
 		},
@@ -514,7 +514,7 @@ where
 			query!(
 				StagingAsyncBackingParameters,
 				staging_async_backing_parameters(),
-				ver = Request::VALIDITY_CONSTRAINTS,
+				ver = Request::STAGING_BACKING_STATE,
 				sender
 			)
 		},

--- a/node/core/runtime-api/src/lib.rs
+++ b/node/core/runtime-api/src/lib.rs
@@ -158,9 +158,9 @@ where
 			Disputes(relay_parent, disputes) =>
 				self.requests_cache.cache_disputes(relay_parent, disputes),
 
-			StagingValidityConstraints(relay_parent, para_id, constraints) => self
+			StagingParaBackingState(relay_parent, para_id, constraints) => self
 				.requests_cache
-				.cache_staging_validity_constraints((relay_parent, para_id), constraints),
+				.cache_staging_para_backing_state((relay_parent, para_id), constraints),
 			StagingAsyncBackingParameters(relay_parent, params) =>
 				self.requests_cache.cache_staging_async_backing_parameters(relay_parent, params),
 		}
@@ -277,9 +277,9 @@ where
 					.map(|sender| Request::ValidationCodeHash(para, assumption, sender)),
 			Request::Disputes(sender) =>
 				query!(disputes(), sender).map(|sender| Request::Disputes(sender)),
-			Request::StagingValidityConstraints(para, sender) =>
-				query!(staging_validity_constraints(para), sender)
-					.map(|sender| Request::StagingValidityConstraints(para, sender)),
+			Request::StagingParaBackingState(para, sender) =>
+				query!(staging_para_backing_state(para), sender)
+					.map(|sender| Request::StagingParaBackingState(para, sender)),
 			Request::StagingAsyncBackingParameters(sender) =>
 				query!(staging_async_backing_parameters(), sender)
 					.map(|sender| Request::StagingAsyncBackingParameters(sender)),
@@ -502,10 +502,10 @@ where
 			query!(ValidationCodeHash, validation_code_hash(para, assumption), ver = 2, sender),
 		Request::Disputes(sender) =>
 			query!(Disputes, disputes(), ver = Request::DISPUTES_RUNTIME_REQUIREMENT, sender),
-		Request::StagingValidityConstraints(para, sender) => {
+		Request::StagingParaBackingState(para, sender) => {
 			query!(
-				StagingValidityConstraints,
-				staging_validity_constraints(para),
+				StagingParaBackingState,
+				staging_para_backing_state(para),
 				ver = Request::VALIDITY_CONSTRAINTS,
 				sender
 			)

--- a/node/core/runtime-api/src/tests.rs
+++ b/node/core/runtime-api/src/tests.rs
@@ -194,7 +194,7 @@ sp_api::mock_impl_runtime_apis! {
 			self.validation_code_hash.get(&para).map(|c| c.clone())
 		}
 
-		fn staging_validity_constraints(_: ParaId) -> Option<vstaging::Constraints> {
+		fn staging_para_backing_states(_: ParaId) -> Option<vstaging::BackingState> {
 			unimplemented!("Staging API not implemented");
 		}
 	}

--- a/node/core/runtime-api/src/tests.rs
+++ b/node/core/runtime-api/src/tests.rs
@@ -21,7 +21,7 @@ use polkadot_node_primitives::{BabeAllowedSlots, BabeEpoch, BabeEpochConfigurati
 use polkadot_node_subsystem::SpawnGlue;
 use polkadot_node_subsystem_test_helpers::make_subsystem_context;
 use polkadot_primitives::{
-	runtime_api::ParachainHost, vstaging, AuthorityDiscoveryId, Block, CandidateEvent,
+	runtime_api::ParachainHost, AuthorityDiscoveryId, Block, CandidateEvent,
 	CommittedCandidateReceipt, CoreState, GroupRotationInfo, Id as ParaId, InboundDownwardMessage,
 	InboundHrmpMessage, OccupiedCoreAssumption, PersistedValidationData, PvfCheckStatement,
 	ScrapedOnChainVotes, SessionIndex, SessionInfo, ValidationCode, ValidationCodeHash,
@@ -192,10 +192,6 @@ sp_api::mock_impl_runtime_apis! {
 			_assumption: OccupiedCoreAssumption,
 		) -> Option<ValidationCodeHash> {
 			self.validation_code_hash.get(&para).map(|c| c.clone())
-		}
-
-		fn staging_para_backing_states(_: ParaId) -> Option<vstaging::BackingState> {
-			unimplemented!("Staging API not implemented");
 		}
 	}
 

--- a/node/network/statement-distribution/src/vstaging/mod.rs
+++ b/node/network/statement-distribution/src/vstaging/mod.rs
@@ -1437,13 +1437,6 @@ fn handle_cluster_statement(
 		}
 	};
 
-	println!(
-		"got cluster statement {:?} by {:?} from {:?}",
-		statement.unchecked_payload(),
-		statement.unchecked_validator_index(),
-		cluster_sender_index
-	);
-
 	// Ensure the statement is correctly signed.
 	let checked_statement =
 		match check_statement_signature(session, &session_info.validators, relay_parent, statement)
@@ -2380,8 +2373,6 @@ pub(crate) async fn dispatch_requests<Context>(ctx: &mut Context, state: &mut St
 	};
 
 	while let Some(request) = state.request_manager.next_request(request_props, peer_advertised) {
-		println!("dispatching request {:?}", request.payload.candidate_hash);
-
 		// Peer is supposedly connected.
 		ctx.send_message(NetworkBridgeTxMessage::SendRequests(
 			vec![Requests::AttestedCandidateVStaging(request)],
@@ -2409,8 +2400,6 @@ pub(crate) async fn handle_response<Context>(
 	state: &mut State,
 	response: UnhandledResponse,
 ) {
-	println!("got response");
-
 	let &requests::CandidateIdentifier { relay_parent, candidate_hash, group_index } =
 		response.candidate_identifier();
 
@@ -2533,8 +2522,6 @@ pub(crate) fn answer_request(state: &mut State, message: ResponderMessage) {
 	// Signal to the responder that we started processing this request.
 	let _ = sent_feedback.send(());
 
-	println!("starting to answer request");
-
 	let confirmed = match state.candidates.get_confirmed(&candidate_hash) {
 		None => return, // drop request, candidate not known.
 		Some(c) => c,
@@ -2559,8 +2546,6 @@ pub(crate) fn answer_request(state: &mut State, message: ResponderMessage) {
 		None => return,
 		Some(d) => d,
 	};
-
-	println!("answering request");
 
 	let group_size = per_session
 		.groups

--- a/node/network/statement-distribution/src/vstaging/mod.rs
+++ b/node/network/statement-distribution/src/vstaging/mod.rs
@@ -1437,6 +1437,13 @@ fn handle_cluster_statement(
 		}
 	};
 
+	println!(
+		"got cluster statement {:?} by {:?} from {:?}",
+		statement.unchecked_payload(),
+		statement.unchecked_validator_index(),
+		cluster_sender_index
+	);
+
 	// Ensure the statement is correctly signed.
 	let checked_statement =
 		match check_statement_signature(session, &session_info.validators, relay_parent, statement)
@@ -2373,6 +2380,8 @@ pub(crate) async fn dispatch_requests<Context>(ctx: &mut Context, state: &mut St
 	};
 
 	while let Some(request) = state.request_manager.next_request(request_props, peer_advertised) {
+		println!("dispatching request {:?}", request.payload.candidate_hash);
+
 		// Peer is supposedly connected.
 		ctx.send_message(NetworkBridgeTxMessage::SendRequests(
 			vec![Requests::AttestedCandidateVStaging(request)],
@@ -2400,6 +2409,8 @@ pub(crate) async fn handle_response<Context>(
 	state: &mut State,
 	response: UnhandledResponse,
 ) {
+	println!("got response");
+
 	let &requests::CandidateIdentifier { relay_parent, candidate_hash, group_index } =
 		response.candidate_identifier();
 
@@ -2522,6 +2533,8 @@ pub(crate) fn answer_request(state: &mut State, message: ResponderMessage) {
 	// Signal to the responder that we started processing this request.
 	let _ = sent_feedback.send(());
 
+	println!("starting to answer request");
+
 	let confirmed = match state.candidates.get_confirmed(&candidate_hash) {
 		None => return, // drop request, candidate not known.
 		Some(c) => c,
@@ -2546,6 +2559,8 @@ pub(crate) fn answer_request(state: &mut State, message: ResponderMessage) {
 		None => return,
 		Some(d) => d,
 	};
+
+	println!("answering request");
 
 	let group_size = per_session
 		.groups

--- a/node/service/Cargo.toml
+++ b/node/service/Cargo.toml
@@ -210,3 +210,5 @@ runtime-metrics = [
 	"polkadot-runtime?/runtime-metrics",
 	"polkadot-runtime-parachains/runtime-metrics"
 ]
+
+network-protocol-staging = ["polkadot-node-network-protocol/network-protocol-staging"]

--- a/node/subsystem-types/src/messages.rs
+++ b/node/subsystem-types/src/messages.rs
@@ -639,7 +639,7 @@ pub enum RuntimeApiRequest {
 	Disputes(RuntimeApiSender<Vec<(SessionIndex, CandidateHash, DisputeState<BlockNumber>)>>),
 	/// Get the validity constraints of the given para.
 	/// This is a staging API that will not be available on production runtimes.
-	StagingValidityConstraints(ParaId, RuntimeApiSender<Option<vstaging_primitives::Constraints>>),
+	StagingParaBackingState(ParaId, RuntimeApiSender<Option<vstaging_primitives::BackingState>>),
 	/// Get candidate's acceptance limitations for asynchronous backing for a relay parent.
 	///
 	/// If it's not supported by the Runtime, the async backing is said to be disabled.

--- a/node/subsystem-types/src/messages.rs
+++ b/node/subsystem-types/src/messages.rs
@@ -637,7 +637,7 @@ pub enum RuntimeApiRequest {
 	),
 	/// Returns all on-chain disputes at given block number. Available in `v3`.
 	Disputes(RuntimeApiSender<Vec<(SessionIndex, CandidateHash, DisputeState<BlockNumber>)>>),
-	/// Get the validity constraints of the given para.
+	/// Get the backing state of the given para.
 	/// This is a staging API that will not be available on production runtimes.
 	StagingParaBackingState(ParaId, RuntimeApiSender<Option<vstaging_primitives::BackingState>>),
 	/// Get candidate's acceptance limitations for asynchronous backing for a relay parent.
@@ -655,10 +655,10 @@ impl RuntimeApiRequest {
 	/// `ExecutorParams`
 	pub const EXECUTOR_PARAMS_RUNTIME_REQUIREMENT: u32 = 4;
 
-	/// Minimum version for validity constraints, required for async backing.
+	/// Minimum version for backing state, required for async backing.
 	///
 	/// 99 for now, should be adjusted to VSTAGING/actual runtime version once released.
-	pub const VALIDITY_CONSTRAINTS: u32 = 99;
+	pub const STAGING_BACKING_STATE: u32 = 99;
 }
 
 /// A message to the Runtime API subsystem.

--- a/node/subsystem-types/src/runtime_client.rs
+++ b/node/subsystem-types/src/runtime_client.rs
@@ -182,13 +182,13 @@ pub trait RuntimeApiSubsystemClient {
 		at: Hash,
 	) -> Result<Vec<(SessionIndex, CandidateHash, DisputeState<BlockNumber>)>, ApiError>;
 
-	/// Returns the base constraints of the given para, if they exist.
+	/// Returns the state of parachain backing for a given para.
 	/// This is a staging method! Do not use on production runtimes!
-	async fn staging_validity_constraints(
+	async fn staging_para_backing_state(
 		&self,
 		at: Hash,
 		para_id: Id,
-	) -> Result<Option<polkadot_primitives::vstaging::Constraints>, ApiError>;
+	) -> Result<Option<polkadot_primitives::vstaging::BackingState>, ApiError>;
 
 	// === BABE API ===
 
@@ -391,12 +391,12 @@ where
 		self.runtime_api().disputes(at)
 	}
 
-	async fn staging_validity_constraints(
+	async fn staging_para_backing_state(
 		&self,
 		at: Hash,
 		para_id: Id,
-	) -> Result<Option<polkadot_primitives::vstaging::Constraints>, ApiError> {
-		self.runtime_api().staging_validity_constraints(at, para_id)
+	) -> Result<Option<polkadot_primitives::vstaging::BackingState>, ApiError> {
+		self.runtime_api().staging_para_backing_state(at, para_id)
 	}
 
 	/// Returns candidate's acceptance limitations for asynchronous backing for a relay parent.

--- a/parachain/test-parachains/adder/collator/Cargo.toml
+++ b/parachain/test-parachains/adder/collator/Cargo.toml
@@ -45,3 +45,6 @@ sc-service = { git = "https://github.com/paritytech/substrate", branch = "master
 sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "master" }
 
 tokio = { version = "1.24.2", features = ["macros"] }
+
+[features]
+network-protocol-staging = ["polkadot-cli/network-protocol-staging"]

--- a/primitives/src/runtime_api.rs
+++ b/primitives/src/runtime_api.rs
@@ -225,10 +225,10 @@ sp_api::decl_runtime_apis! {
 
 		/***** Asynchronous backing *****/
 
-		/// Returns the base constraints of the given para, if they exist.
+		/// Returns the state of parachain backing for a given para.
 		/// This is a staging method! Do not use on production runtimes!
 		#[api_version(99)]
-		fn staging_validity_constraints(_: ppp::Id) -> Option<vstaging::Constraints>;
+		fn staging_para_backing_state(_: ppp::Id) -> Option<vstaging::BackingState<H, N>>;
 
 		/// Returns candidate's acceptance limitations for asynchronous backing for a relay parent.
 		#[api_version(99)]

--- a/primitives/src/vstaging/mod.rs
+++ b/primitives/src/vstaging/mod.rs
@@ -120,7 +120,9 @@ pub struct CandidatePendingAvailability<H = Hash, N = BlockNumber> {
 pub struct BackingState<H = Hash, N = BlockNumber> {
 	/// The state-machine constraints of the parachain.
 	pub constraints: Constraints<N>,
-	/// The candidates pending availability.
+	/// The candidates pending availability. These should be ordered, i.e. they should form
+	/// a sub-chain, where the first candidate builds on top of the required parent of the constraints
+	/// and each subsequent builds on top of the previous head-data.
 	pub pending_availability: Vec<CandidatePendingAvailability<H, N>>,
 }
 

--- a/primitives/src/vstaging/mod.rs
+++ b/primitives/src/vstaging/mod.rs
@@ -99,5 +99,28 @@ pub struct Constraints<N = BlockNumber> {
 	pub future_validation_code: Option<(N, ValidationCodeHash)>,
 }
 
+/// A candidate pending availability.
+#[derive(RuntimeDebug, Clone, PartialEq, Encode, Decode, TypeInfo)]
+pub struct CandidatePendingAvailability<H = Hash, N = BlockNumber> {
+	/// The hash of the candidate.
+	pub candidate_hash: CandidateHash,
+	/// The candidate's descriptor.
+	pub descriptor: CandidateDescriptor<H>,
+	/// The commitments of the candidate.
+	pub commitments: CandidateCommitments<N>,
+	/// The candidate's persisted validation data.
+	pub persisted_validation_data: PersistedValidationData<H, N>,
+}
+
+/// The per-parachain state of the backing system, including
+/// state-machine constraints and candidates pending availability.
+#[derive(RuntimeDebug, Clone, PartialEq, Encode, Decode, TypeInfo)]
+pub struct BackingState<H = Hash, N = BlockNumber> {
+	/// The state-machine constraints of the parachain.
+	pub constraints: Constraints<N>,
+	/// The candidates pending availability.
+	pub pending_availability: Vec<CandidatePendingAvailability<H, N>>,
+}
+
 pub mod executor_params;
 pub use executor_params::{ExecutorParam, ExecutorParams, ExecutorParamsHash};

--- a/primitives/src/vstaging/mod.rs
+++ b/primitives/src/vstaging/mod.rs
@@ -107,9 +107,11 @@ pub struct CandidatePendingAvailability<H = Hash, N = BlockNumber> {
 	/// The candidate's descriptor.
 	pub descriptor: CandidateDescriptor<H>,
 	/// The commitments of the candidate.
-	pub commitments: CandidateCommitments<N>,
-	/// The candidate's persisted validation data.
-	pub persisted_validation_data: PersistedValidationData<H, N>,
+	pub commitments: CandidateCommitments,
+	/// The candidate's relay parent's number.
+	pub relay_parent_number: N,
+	/// The maximum Proof-of-Validity size allowed, in bytes.
+	pub max_pov_size: u32,
 }
 
 /// The per-parachain state of the backing system, including

--- a/runtime/parachains/src/inclusion/mod.rs
+++ b/runtime/parachains/src/inclusion/mod.rs
@@ -118,6 +118,14 @@ impl<H, N> CandidatePendingAvailability<H, N> {
 		&self.descriptor
 	}
 
+	/// Get the candidate's relay parent's number.
+	pub(crate) fn relay_parent_number(&self) -> N
+	where
+		N: Clone,
+	{
+		self.relay_parent_number.clone()
+	}
+
 	#[cfg(any(feature = "runtime-benchmarks", test))]
 	pub(crate) fn new(
 		core: CoreIndex,

--- a/runtime/parachains/src/paras_inherent/mod.rs
+++ b/runtime/parachains/src/paras_inherent/mod.rs
@@ -727,7 +727,7 @@ impl<T: Config> Pallet<T> {
 					&validator_public[..],
 					bitfields.clone(),
 					<scheduler::Pallet<T>>::core_para,
-					false,
+					true, // we must enact the previous candidate for subsequent validation
 				);
 
 			let freed = collect_all_freed_cores::<T, _>(freed_concluded.iter().cloned());

--- a/runtime/parachains/src/runtime_api_impl/vstaging.rs
+++ b/runtime/parachains/src/runtime_api_impl/vstaging.rs
@@ -110,7 +110,7 @@ pub fn backing_state<T: initializer::Config>(
 	};
 
 	let pending_availability = {
-		// Note: the APi deals with a `Vec` as it is future-proof for cases
+		// Note: the API deals with a `Vec` as it is future-proof for cases
 		// where there may be multiple candidates pending availability at a time.
 		// But at the moment only one candidate can be pending availability per
 		// parachain.

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -1781,8 +1781,8 @@ sp_api::impl_runtime_apis! {
 			runtime_parachains::runtime_api_impl::vstaging::get_session_disputes::<Runtime>()
 		}
 
-		fn staging_validity_constraints(para_id: ParaId) -> Option<primitives::vstaging::Constraints> {
-			runtime_parachains::runtime_api_impl::vstaging::validity_constraints::<Runtime>(para_id)
+		fn staging_para_backing_state(para_id: ParaId) -> Option<primitives::vstaging::BackingState> {
+			runtime_parachains::runtime_api_impl::vstaging::backing_state::<Runtime>(para_id)
 		}
 
 		fn staging_async_backing_parameters() -> primitives::vstaging::AsyncBackingParameters {

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -1488,8 +1488,8 @@ sp_api::impl_runtime_apis! {
 			runtime_parachains::runtime_api_impl::vstaging::get_session_disputes::<Runtime>()
 		}
 
-		fn staging_validity_constraints(para_id: ParaId) -> Option<primitives::vstaging::Constraints> {
-			runtime_parachains::runtime_api_impl::vstaging::validity_constraints::<Runtime>(para_id)
+		fn staging_para_backing_state(para_id: ParaId) -> Option<primitives::vstaging::BackingState> {
+			runtime_parachains::runtime_api_impl::vstaging::backing_state::<Runtime>(para_id)
 		}
 
 		fn staging_async_backing_parameters() -> primitives::vstaging::AsyncBackingParameters {


### PR DESCRIPTION
A few fixes (ignoring backports already made to 5999)
  - propagate the `network-protocol-staging` Cargo feature to all binaries. This is required to build nodes that use the new network protocol.
  - collation-generation: build on top of occupied cores as well as scheduled ones. This assumes slot auction semantics, i.e. cores are assigned to a single parachain per session.
  - Replaces the `staging_validity_constraints` runtime API with a `staging_para_backing_state` that returns `Constraints` along with information about any candidates pending availability candidates
  - Updates the prospective parachains subsystem to account for pending availability candidates possibly having relay-parents _before_ the "earliest allowed relay parent". This is done with some special-casing and has broken tests
    - [x] fix tests
  - Have the `paras_inherent::create_inherent` enact candidates based on bitfields while sanity-checking the data provided by the provisioner subsystem. Without this change, nodes would omit candidates from a `paras_inherent` which built upon the candidate pending availability, even when such a candidate was valid.