### PR TITLE
approval-voting: simplify v2 assignments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7135,7 +7135,6 @@ name = "polkadot-node-network-protocol"
 version = "0.9.37"
 dependencies = [
  "async-trait",
- "bitvec",
  "derive_more",
  "fatality",
  "futures",
@@ -7158,6 +7157,7 @@ dependencies = [
 name = "polkadot-node-primitives"
 version = "0.9.37"
 dependencies = [
+ "bitvec",
  "bounded-vec",
  "futures",
  "parity-scale-codec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6428,6 +6428,7 @@ name = "polkadot-approval-distribution"
 version = "0.9.37"
 dependencies = [
  "assert_matches",
+ "bitvec",
  "env_logger 0.9.0",
  "futures",
  "itertools",
@@ -7134,6 +7135,7 @@ name = "polkadot-node-network-protocol"
 version = "0.9.37"
 dependencies = [
  "async-trait",
+ "bitvec",
  "derive_more",
  "fatality",
  "futures",
@@ -7206,6 +7208,7 @@ name = "polkadot-node-subsystem-types"
 version = "0.9.37"
 dependencies = [
  "async-trait",
+ "bitvec",
  "derive_more",
  "futures",
  "orchestra",

--- a/node/core/approval-voting/src/approval_db/v1/mod.rs
+++ b/node/core/approval-voting/src/approval_db/v1/mod.rs
@@ -161,12 +161,15 @@ pub struct Config {
 /// Details pertaining to our assignment on a block.
 #[derive(Encode, Decode, Debug, Clone, PartialEq)]
 pub struct OurAssignment {
+	/// Our assignment certificate.
 	pub cert: AssignmentCertV2,
+	/// The tranche for which the assignment refers to.
 	pub tranche: DelayTranche,
+	/// Our validator index for the session in which the candidate was included.
 	pub validator_index: ValidatorIndex,
-	// Whether the assignment has been triggered already.
+	/// Whether the assignment has been triggered already.
 	pub triggered: bool,
-	// Claimed core indices.
+	/// The core indices obtained from the VRF output.
 	pub claimed_core_indices: Vec<CoreIndex>,
 }
 

--- a/node/core/approval-voting/src/approval_db/v1/mod.rs
+++ b/node/core/approval-voting/src/approval_db/v1/mod.rs
@@ -166,6 +166,8 @@ pub struct OurAssignment {
 	pub validator_index: ValidatorIndex,
 	// Whether the assignment has been triggered already.
 	pub triggered: bool,
+	// Claimed core indices.
+	pub claimed_core_indices: Vec<CoreIndex>,
 }
 
 /// Metadata regarding a specific tranche of assignments for a specific candidate.

--- a/node/core/approval-voting/src/approval_db/v1/mod.rs
+++ b/node/core/approval-voting/src/approval_db/v1/mod.rs
@@ -17,7 +17,7 @@
 //! Version 1 of the DB schema.
 
 use parity_scale_codec::{Decode, Encode};
-use polkadot_node_primitives::approval::{AssignmentCertV2, DelayTranche};
+use polkadot_node_primitives::approval::{v2::AssignmentBitfield, AssignmentCertV2, DelayTranche};
 use polkadot_node_subsystem::{SubsystemError, SubsystemResult};
 use polkadot_node_subsystem_util::database::{DBTransaction, Database};
 use polkadot_primitives::{
@@ -170,7 +170,7 @@ pub struct OurAssignment {
 	/// Whether the assignment has been triggered already.
 	pub triggered: bool,
 	/// A subset of the core indices obtained from the VRF output.
-	pub claimed_core_indices: Vec<CoreIndex>,
+	pub assignment_bitfield: AssignmentBitfield,
 }
 
 /// Metadata regarding a specific tranche of assignments for a specific candidate.

--- a/node/core/approval-voting/src/approval_db/v1/mod.rs
+++ b/node/core/approval-voting/src/approval_db/v1/mod.rs
@@ -191,7 +191,7 @@ pub struct ApprovalEntry {
 	pub our_assignment: Option<OurAssignment>,
 	pub our_approval_sig: Option<ValidatorSignature>,
 	// `n_validators` bits.
-	pub assignments: Bitfield,
+	pub assigned_validators: Bitfield,
 	pub approved: bool,
 }
 

--- a/node/core/approval-voting/src/approval_db/v1/mod.rs
+++ b/node/core/approval-voting/src/approval_db/v1/mod.rs
@@ -17,7 +17,7 @@
 //! Version 1 of the DB schema.
 
 use parity_scale_codec::{Decode, Encode};
-use polkadot_node_primitives::approval::{v2::AssignmentBitfield, AssignmentCertV2, DelayTranche};
+use polkadot_node_primitives::approval::{v2::CoreBitfield, AssignmentCertV2, DelayTranche};
 use polkadot_node_subsystem::{SubsystemError, SubsystemResult};
 use polkadot_node_subsystem_util::database::{DBTransaction, Database};
 use polkadot_primitives::{
@@ -165,12 +165,12 @@ pub struct OurAssignment {
 	pub cert: AssignmentCertV2,
 	/// The tranche for which the assignment refers to.
 	pub tranche: DelayTranche,
-	/// Our validator index for the session in which the candidate was included.
+	/// Our validator index for the session in which the candidates were included.
 	pub validator_index: ValidatorIndex,
 	/// Whether the assignment has been triggered already.
 	pub triggered: bool,
 	/// A subset of the core indices obtained from the VRF output.
-	pub assignment_bitfield: AssignmentBitfield,
+	pub assignment_bitfield: CoreBitfield,
 }
 
 /// Metadata regarding a specific tranche of assignments for a specific candidate.

--- a/node/core/approval-voting/src/approval_db/v1/mod.rs
+++ b/node/core/approval-voting/src/approval_db/v1/mod.rs
@@ -169,7 +169,7 @@ pub struct OurAssignment {
 	pub validator_index: ValidatorIndex,
 	/// Whether the assignment has been triggered already.
 	pub triggered: bool,
-	/// The core indices obtained from the VRF output.
+	/// A subset of the core indices obtained from the VRF output.
 	pub claimed_core_indices: Vec<CoreIndex>,
 }
 

--- a/node/core/approval-voting/src/criteria.rs
+++ b/node/core/approval-voting/src/criteria.rs
@@ -629,7 +629,7 @@ pub(crate) enum InvalidAssignmentReason {
 /// Checks the crypto of an assignment cert. Failure conditions:
 ///   * Validator index out of bounds
 ///   * VRF signature check fails
-///   * VRF output doesn't match assigned core
+///   * VRF output doesn't match assigned cores
 ///   * Core is not covered by extra data in signature
 ///   * Core index out of bounds
 ///   * Sample is out of bounds
@@ -684,6 +684,11 @@ pub(crate) fn check_assignment_cert(
 				.map_err(|_| InvalidAssignment(Reason::VRFModuloOutputMismatch))?;
 
 			// Get unique core assignments from the VRF wrt `config.n_cores`.
+			// Some of the core indices might be invalid, as there was no candidate included in the
+			// relay chain block for that core.
+			//
+			// The caller must check if the claimed candidate indices are valid
+			// and refer to the valid subset of cores outputed by the VRF here.
 			let vrf_unique_cores = relay_vrf_modulo_cores(
 				&vrf_in_out,
 				config.relay_vrf_modulo_samples,

--- a/node/core/approval-voting/src/criteria.rs
+++ b/node/core/approval-voting/src/criteria.rs
@@ -277,7 +277,7 @@ impl AssignmentCriteria for RealAssignmentCriteria {
 		config: &Config,
 		leaving_cores: Vec<(CandidateHash, CoreIndex, GroupIndex)>,
 	) -> HashMap<CoreIndex, OurAssignment> {
-		compute_assignments(keystore, relay_vrf_story, config, leaving_cores, false)
+		compute_assignments(keystore, relay_vrf_story, config, leaving_cores, true)
 	}
 
 	fn check_assignment_cert(

--- a/node/core/approval-voting/src/criteria.rs
+++ b/node/core/approval-voting/src/criteria.rs
@@ -276,7 +276,7 @@ impl AssignmentCriteria for RealAssignmentCriteria {
 		config: &Config,
 		leaving_cores: Vec<(CandidateHash, CoreIndex, GroupIndex)>,
 	) -> HashMap<CoreIndex, OurAssignment> {
-		compute_assignments(keystore, relay_vrf_story, config, leaving_cores, true)
+		compute_assignments(keystore, relay_vrf_story, config, leaving_cores, false)
 	}
 
 	fn check_assignment_cert(

--- a/node/core/approval-voting/src/criteria.rs
+++ b/node/core/approval-voting/src/criteria.rs
@@ -273,7 +273,7 @@ impl AssignmentCriteria for RealAssignmentCriteria {
 		config: &Config,
 		leaving_cores: Vec<(CandidateHash, CoreIndex, GroupIndex)>,
 	) -> HashMap<CoreIndex, OurAssignment> {
-		compute_assignments(keystore, relay_vrf_story, config, leaving_cores, true)
+		compute_assignments(keystore, relay_vrf_story, config, leaving_cores, false)
 	}
 
 	fn check_assignment_cert(

--- a/node/core/approval-voting/src/criteria.rs
+++ b/node/core/approval-voting/src/criteria.rs
@@ -45,6 +45,7 @@ pub struct OurAssignment {
 	// Whether the assignment has been triggered already.
 	triggered: bool,
 	// The core indices obtained from the VRF output.
+	// TODO: make it a bitfield.
 	claimed_core_indices: Vec<CoreIndex>,
 }
 
@@ -75,7 +76,6 @@ impl OurAssignment {
 }
 
 impl From<crate::approval_db::v1::OurAssignment> for OurAssignment {
-	// TODO: OurAssignment changed -> migration for parachains db approval voting column.
 	fn from(entry: crate::approval_db::v1::OurAssignment) -> Self {
 		OurAssignment {
 			cert: entry.cert,

--- a/node/core/approval-voting/src/criteria.rs
+++ b/node/core/approval-voting/src/criteria.rs
@@ -44,8 +44,8 @@ pub struct OurAssignment {
 	validator_index: ValidatorIndex,
 	// Whether the assignment has been triggered already.
 	triggered: bool,
-	// Claimed core indices.
-	pub claimed_core_indices: Vec<CoreIndex>,
+	// The core indices obtained from the VRF output.
+	claimed_core_indices: Vec<CoreIndex>,
 }
 
 impl OurAssignment {
@@ -67,6 +67,10 @@ impl OurAssignment {
 
 	pub(crate) fn mark_triggered(&mut self) {
 		self.triggered = true;
+	}
+
+	pub(crate) fn claimed_core_indices(&self) -> &Vec<CoreIndex> {
+		&self.claimed_core_indices
 	}
 }
 
@@ -110,7 +114,7 @@ fn relay_vrf_modulo_transcript_inner(
 	transcript
 }
 
-fn relay_vrf_modulo_transcript(relay_vrf_story: RelayVRFStory, sample: u32) -> Transcript {
+fn relay_vrf_modulo_transcript_v1(relay_vrf_story: RelayVRFStory, sample: u32) -> Transcript {
 	relay_vrf_modulo_transcript_inner(
 		Transcript::new(approval_types::v1::RELAY_VRF_MODULO_CONTEXT),
 		relay_vrf_story,
@@ -418,7 +422,7 @@ fn compute_relay_vrf_modulo_assignments(
 			// into closure.
 			let core = &mut core;
 			assignments_key.vrf_sign_extra_after_check(
-				relay_vrf_modulo_transcript(relay_vrf_story.clone(), rvm_sample),
+				relay_vrf_modulo_transcript_v1(relay_vrf_story.clone(), rvm_sample),
 				|vrf_in_out| {
 					*core = relay_vrf_modulo_core(&vrf_in_out, config.n_cores);
 					if let Some((candidate_hash, _)) =
@@ -718,7 +722,7 @@ pub(crate) fn check_assignment_cert(
 
 			let (vrf_in_out, _) = public
 				.vrf_verify_extra(
-					relay_vrf_modulo_transcript(relay_vrf_story, *sample),
+					relay_vrf_modulo_transcript_v1(relay_vrf_story, *sample),
 					&vrf_output.0,
 					&vrf_proof.0,
 					assigned_core_transcript(claimed_core_index),

--- a/node/core/approval-voting/src/criteria.rs
+++ b/node/core/approval-voting/src/criteria.rs
@@ -18,7 +18,7 @@
 
 use parity_scale_codec::{Decode, Encode};
 use polkadot_node_primitives::approval::{
-	self as approval_types, v2::AssignmentBitfield, AssignmentCert, AssignmentCertKind,
+	self as approval_types, v2::CoreBitfield, AssignmentCert, AssignmentCertKind,
 	AssignmentCertKindV2, AssignmentCertV2, DelayTranche, RelayVRFStory,
 };
 use polkadot_primitives::{
@@ -45,7 +45,7 @@ pub struct OurAssignment {
 	// Whether the assignment has been triggered already.
 	triggered: bool,
 	// The core indices obtained from the VRF output.
-	assignment_bitfield: AssignmentBitfield,
+	assignment_bitfield: CoreBitfield,
 }
 
 impl OurAssignment {
@@ -69,7 +69,7 @@ impl OurAssignment {
 		self.triggered = true;
 	}
 
-	pub(crate) fn assignment_bitfield(&self) -> &AssignmentBitfield {
+	pub(crate) fn assignment_bitfield(&self) -> &CoreBitfield {
 		&self.assignment_bitfield
 	}
 }
@@ -263,7 +263,7 @@ pub(crate) trait AssignmentCriteria {
 		// Backing groups for each "leaving core".
 		backing_groups: Vec<GroupIndex>,
 		// TODO: maybe define record or something else than tuple
-	) -> Result<(AssignmentBitfield, DelayTranche), InvalidAssignment>;
+	) -> Result<(CoreBitfield, DelayTranche), InvalidAssignment>;
 }
 
 pub(crate) struct RealAssignmentCriteria;
@@ -287,7 +287,7 @@ impl AssignmentCriteria for RealAssignmentCriteria {
 		relay_vrf_story: RelayVRFStory,
 		assignment: &AssignmentCertV2,
 		backing_groups: Vec<GroupIndex>,
-	) -> Result<(AssignmentBitfield, DelayTranche), InvalidAssignment> {
+	) -> Result<(CoreBitfield, DelayTranche), InvalidAssignment> {
 		check_assignment_cert(
 			claimed_core_index,
 			validator_index,
@@ -647,7 +647,7 @@ pub(crate) fn check_assignment_cert(
 	relay_vrf_story: RelayVRFStory,
 	assignment: &AssignmentCertV2,
 	backing_groups: Vec<GroupIndex>,
-) -> Result<(AssignmentBitfield, DelayTranche), InvalidAssignment> {
+) -> Result<(CoreBitfield, DelayTranche), InvalidAssignment> {
 	use InvalidAssignmentReason as Reason;
 
 	let validator_public = config
@@ -712,7 +712,7 @@ pub(crate) fn check_assignment_cert(
 				})
 				.collect::<Vec<_>>();
 
-			AssignmentBitfield::try_from(resulting_cores)
+			CoreBitfield::try_from(resulting_cores)
 				.map(|bitfield| (bitfield, 0))
 				.map_err(|_| InvalidAssignment(Reason::NullAssignment))
 		},

--- a/node/core/approval-voting/src/lib.rs
+++ b/node/core/approval-voting/src/lib.rs
@@ -1122,7 +1122,7 @@ fn distribution_messages_for_activation(
 									cert: assignment.cert().clone(),
 								},
 								cores_to_candidate_indices(
-									&assignment.claimed_core_indices,
+									assignment.claimed_core_indices(),
 									&block_entry,
 								),
 							));
@@ -1135,7 +1135,7 @@ fn distribution_messages_for_activation(
 									cert: assignment.cert().clone(),
 								},
 								cores_to_candidate_indices(
-									&assignment.claimed_core_indices,
+									assignment.claimed_core_indices(),
 									&block_entry,
 								),
 							));

--- a/node/core/approval-voting/src/lib.rs
+++ b/node/core/approval-voting/src/lib.rs
@@ -748,7 +748,6 @@ enum Action {
 		indirect_cert: IndirectAssignmentCertV2,
 		assignment_tranche: DelayTranche,
 		relay_block_hash: Hash,
-		// candidate_index: CandidateIndex,
 		session: SessionIndex,
 		candidate: CandidateReceipt,
 		backing_group: GroupIndex,
@@ -1064,7 +1063,6 @@ async fn handle_actions<Context>(
 	Ok(conclude)
 }
 
-// TODO: Impl CandidateBitfield to wrap BitVec and implement invariants
 fn cores_to_candidate_indices(
 	core_indices: &AssignmentBitfield,
 	block_entry: &BlockEntry,

--- a/node/core/approval-voting/src/lib.rs
+++ b/node/core/approval-voting/src/lib.rs
@@ -1831,7 +1831,8 @@ fn check_and_import_assignment(
 	}
 
 	let claimed_core_index = match assignment.cert.kind {
-		// TODO, near future: remove CoreIndex from certificates completely.
+		// TODO: remove CoreIndex from certificates completely.
+		// https://github.com/paritytech/polkadot/issues/6988
 		AssignmentCertKindV2::RelayVRFDelay { .. } => Some(claimed_core_indices[0]),
 		AssignmentCertKindV2::RelayVRFModulo { .. } => Some(claimed_core_indices[0]),
 		// VRelayVRFModuloCompact assignment doesn't need the the claimed cores for checking.

--- a/node/core/approval-voting/src/lib.rs
+++ b/node/core/approval-voting/src/lib.rs
@@ -24,7 +24,7 @@
 use polkadot_node_jaeger as jaeger;
 use polkadot_node_primitives::{
 	approval::{
-		v2::{AssignmentBitfield, AssignmentBitfieldError},
+		v2::{BitfieldError, CandidateBitfield, CoreBitfield},
 		AssignmentCertKindV2, BlockApprovalMeta, DelayTranche, IndirectAssignmentCertV2,
 		IndirectSignedApprovalVote,
 	},
@@ -743,7 +743,7 @@ enum Action {
 		tick: Tick,
 	},
 	LaunchApproval {
-		claimed_core_indices: AssignmentBitfield,
+		claimed_core_indices: CoreBitfield,
 		candidate_hash: CandidateHash,
 		indirect_cert: IndirectAssignmentCertV2,
 		assignment_tranche: DelayTranche,
@@ -1064,9 +1064,9 @@ async fn handle_actions<Context>(
 }
 
 fn cores_to_candidate_indices(
-	core_indices: &AssignmentBitfield,
+	core_indices: &CoreBitfield,
 	block_entry: &BlockEntry,
-) -> Result<AssignmentBitfield, AssignmentBitfieldError> {
+) -> Result<CandidateBitfield, BitfieldError> {
 	let mut candidate_indices = Vec::new();
 
 	// Map from core index to candidate index.
@@ -1080,7 +1080,7 @@ fn cores_to_candidate_indices(
 		}
 	}
 
-	AssignmentBitfield::try_from(candidate_indices)
+	CandidateBitfield::try_from(candidate_indices)
 }
 
 fn distribution_messages_for_activation(
@@ -1757,7 +1757,7 @@ fn check_and_import_assignment(
 	state: &State,
 	db: &mut OverlayedBackend<'_, impl Backend>,
 	assignment: IndirectAssignmentCertV2,
-	candidate_indices: AssignmentBitfield,
+	candidate_indices: CandidateBitfield,
 ) -> SubsystemResult<(AssignmentCheckResult, Vec<Action>)> {
 	let tick_now = state.clock.tick_now();
 

--- a/node/core/approval-voting/src/persisted_entries.rs
+++ b/node/core/approval-voting/src/persisted_entries.rs
@@ -20,7 +20,9 @@
 //! Within that context, things are plain-old-data. Within this module,
 //! data and logic are intertwined.
 
-use polkadot_node_primitives::approval::{AssignmentCertV2, DelayTranche, RelayVRFStory};
+use polkadot_node_primitives::approval::{
+	v2::AssignmentBitfield, AssignmentCertV2, DelayTranche, RelayVRFStory,
+};
 use polkadot_primitives::{
 	BlockNumber, CandidateHash, CandidateReceipt, CoreIndex, GroupIndex, Hash, SessionIndex,
 	ValidatorIndex, ValidatorSignature,
@@ -107,7 +109,7 @@ impl ApprovalEntry {
 	pub fn trigger_our_assignment(
 		&mut self,
 		tick_now: Tick,
-	) -> Option<(Vec<CoreIndex>, AssignmentCertV2, ValidatorIndex, DelayTranche)> {
+	) -> Option<(AssignmentBitfield, AssignmentCertV2, ValidatorIndex, DelayTranche)> {
 		let our = self.our_assignment.as_mut().and_then(|a| {
 			if a.triggered() {
 				return None
@@ -120,7 +122,7 @@ impl ApprovalEntry {
 		our.map(|a| {
 			self.import_assignment(a.tranche(), a.validator_index(), tick_now);
 
-			(a.claimed_core_indices().clone(), a.cert().clone(), a.validator_index(), a.tranche())
+			(a.assignment_bitfield().clone(), a.cert().clone(), a.validator_index(), a.tranche())
 		})
 	}
 

--- a/node/core/approval-voting/src/persisted_entries.rs
+++ b/node/core/approval-voting/src/persisted_entries.rs
@@ -21,7 +21,7 @@
 //! data and logic are intertwined.
 
 use polkadot_node_primitives::approval::{
-	v2::AssignmentBitfield, AssignmentCertV2, DelayTranche, RelayVRFStory,
+	v2::CoreBitfield, AssignmentCertV2, DelayTranche, RelayVRFStory,
 };
 use polkadot_primitives::{
 	BlockNumber, CandidateHash, CandidateReceipt, CoreIndex, GroupIndex, Hash, SessionIndex,
@@ -118,7 +118,7 @@ impl ApprovalEntry {
 	pub fn trigger_our_assignment(
 		&mut self,
 		tick_now: Tick,
-	) -> Option<(AssignmentBitfield, AssignmentCertV2, ValidatorIndex, DelayTranche)> {
+	) -> Option<(CoreBitfield, AssignmentCertV2, ValidatorIndex, DelayTranche)> {
 		let our = self.our_assignment.as_mut().and_then(|a| {
 			if a.triggered() {
 				return None

--- a/node/core/approval-voting/src/persisted_entries.rs
+++ b/node/core/approval-voting/src/persisted_entries.rs
@@ -107,7 +107,7 @@ impl ApprovalEntry {
 	pub fn trigger_our_assignment(
 		&mut self,
 		tick_now: Tick,
-	) -> Option<(AssignmentCertV2, ValidatorIndex, DelayTranche)> {
+	) -> Option<(Vec<CoreIndex>, AssignmentCertV2, ValidatorIndex, DelayTranche)> {
 		let our = self.our_assignment.as_mut().and_then(|a| {
 			if a.triggered() {
 				return None
@@ -120,7 +120,7 @@ impl ApprovalEntry {
 		our.map(|a| {
 			self.import_assignment(a.tranche(), a.validator_index(), tick_now);
 
-			(a.cert().clone(), a.validator_index(), a.tranche())
+			(a.claimed_core_indices.clone(), a.cert().clone(), a.validator_index(), a.tranche())
 		})
 	}
 

--- a/node/core/approval-voting/src/persisted_entries.rs
+++ b/node/core/approval-voting/src/persisted_entries.rs
@@ -29,8 +29,10 @@ use polkadot_primitives::{
 };
 use sp_consensus_slots::Slot;
 
-use bitvec::{order::Lsb0 as BitOrderLsb0, slice::BitSlice, vec::BitVec};
+use bitvec::{order::Lsb0 as BitOrderLsb0, slice::BitSlice};
 use std::collections::BTreeMap;
+
+use crate::approval_db::v1::Bitfield;
 
 use super::{criteria::OurAssignment, time::Tick};
 
@@ -82,7 +84,7 @@ pub struct ApprovalEntry {
 	our_assignment: Option<OurAssignment>,
 	our_approval_sig: Option<ValidatorSignature>,
 	// `n_validators` bits.
-	assignments: BitVec<u8, BitOrderLsb0>,
+	assigned_validators: Bitfield,
 	approved: bool,
 }
 
@@ -94,10 +96,17 @@ impl ApprovalEntry {
 		our_assignment: Option<OurAssignment>,
 		our_approval_sig: Option<ValidatorSignature>,
 		// `n_validators` bits.
-		assignments: BitVec<u8, BitOrderLsb0>,
+		assigned_validators: Bitfield,
 		approved: bool,
 	) -> Self {
-		Self { tranches, backing_group, our_assignment, our_approval_sig, assignments, approved }
+		Self {
+			tranches,
+			backing_group,
+			our_assignment,
+			our_approval_sig,
+			assigned_validators,
+			approved,
+		}
 	}
 
 	// Access our assignment for this approval entry.
@@ -133,7 +142,10 @@ impl ApprovalEntry {
 
 	/// Whether a validator is already assigned.
 	pub fn is_assigned(&self, validator_index: ValidatorIndex) -> bool {
-		self.assignments.get(validator_index.0 as usize).map(|b| *b).unwrap_or(false)
+		self.assigned_validators
+			.get(validator_index.0 as usize)
+			.map(|b| *b)
+			.unwrap_or(false)
 	}
 
 	/// Import an assignment. No-op if already assigned on the same tranche.
@@ -160,14 +172,14 @@ impl ApprovalEntry {
 		};
 
 		self.tranches[idx].assignments.push((validator_index, tick_now));
-		self.assignments.set(validator_index.0 as _, true);
+		self.assigned_validators.set(validator_index.0 as _, true);
 	}
 
 	// Produce a bitvec indicating the assignments of all validators up to and
 	// including `tranche`.
-	pub fn assignments_up_to(&self, tranche: DelayTranche) -> BitVec<u8, BitOrderLsb0> {
+	pub fn assignments_up_to(&self, tranche: DelayTranche) -> Bitfield {
 		self.tranches.iter().take_while(|e| e.tranche <= tranche).fold(
-			bitvec::bitvec![u8, BitOrderLsb0; 0; self.assignments.len()],
+			bitvec::bitvec![u8, BitOrderLsb0; 0; self.assigned_validators.len()],
 			|mut a, e| {
 				for &(v, _) in &e.assignments {
 					a.set(v.0 as _, true);
@@ -195,12 +207,12 @@ impl ApprovalEntry {
 
 	/// Get the number of validators in this approval entry.
 	pub fn n_validators(&self) -> usize {
-		self.assignments.len()
+		self.assigned_validators.len()
 	}
 
 	/// Get the number of assignments by validators, including the local validator.
 	pub fn n_assignments(&self) -> usize {
-		self.assignments.count_ones()
+		self.assigned_validators.count_ones()
 	}
 
 	/// Get the backing group index of the approval entry.
@@ -228,7 +240,7 @@ impl From<crate::approval_db::v1::ApprovalEntry> for ApprovalEntry {
 			backing_group: entry.backing_group,
 			our_assignment: entry.our_assignment.map(Into::into),
 			our_approval_sig: entry.our_approval_sig.map(Into::into),
-			assignments: entry.assignments,
+			assigned_validators: entry.assigned_validators,
 			approved: entry.approved,
 		}
 	}
@@ -241,7 +253,7 @@ impl From<ApprovalEntry> for crate::approval_db::v1::ApprovalEntry {
 			backing_group: entry.backing_group,
 			our_assignment: entry.our_assignment.map(Into::into),
 			our_approval_sig: entry.our_approval_sig.map(Into::into),
-			assignments: entry.assignments,
+			assigned_validators: entry.assigned_validators,
 			approved: entry.approved,
 		}
 	}
@@ -255,7 +267,7 @@ pub struct CandidateEntry {
 	// Assignments are based on blocks, so we need to track assignments separately
 	// based on the block we are looking at.
 	pub block_assignments: BTreeMap<Hash, ApprovalEntry>,
-	pub approvals: BitVec<u8, BitOrderLsb0>,
+	pub approvals: Bitfield,
 }
 
 impl CandidateEntry {
@@ -338,7 +350,7 @@ pub struct BlockEntry {
 	// A bitfield where the i'th bit corresponds to the i'th candidate in `candidates`.
 	// The i'th bit is `true` iff the candidate has been approved in the context of this
 	// block. The block can be considered approved if the bitfield has all bits set to `true`.
-	pub approved_bitfield: BitVec<u8, BitOrderLsb0>,
+	pub approved_bitfield: Bitfield,
 	pub children: Vec<Hash>,
 }
 

--- a/node/core/approval-voting/src/persisted_entries.rs
+++ b/node/core/approval-voting/src/persisted_entries.rs
@@ -120,7 +120,7 @@ impl ApprovalEntry {
 		our.map(|a| {
 			self.import_assignment(a.tranche(), a.validator_index(), tick_now);
 
-			(a.claimed_core_indices.clone(), a.cert().clone(), a.validator_index(), a.tranche())
+			(a.claimed_core_indices().clone(), a.cert().clone(), a.validator_index(), a.tranche())
 		})
 	}
 

--- a/node/network/approval-distribution/Cargo.toml
+++ b/node/network/approval-distribution/Cargo.toml
@@ -15,6 +15,7 @@ itertools = "0.10.5"
 
 futures = "0.3.21"
 gum = { package = "tracing-gum", path = "../../gum" }
+bitvec = { version = "1.0.0", default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
 sp-authority-discovery = { git = "https://github.com/paritytech/substrate", branch = "master" }

--- a/node/network/approval-distribution/src/lib.rs
+++ b/node/network/approval-distribution/src/lib.rs
@@ -21,6 +21,7 @@
 #![warn(missing_docs)]
 
 use self::metrics::Metrics;
+use bitvec::vec::BitVec;
 use futures::{channel::oneshot, FutureExt as _};
 use itertools::Itertools;
 use net_protocol::peer_set::{ProtocolVersion, ValidationVersion};
@@ -104,8 +105,8 @@ struct ApprovalRouting {
 struct ApprovalEntry {
 	// The assignment certificate.
 	assignment: IndirectAssignmentCertV2,
-	// The candidates claimed by the certificate.
-	candidates: HashSet<CandidateIndex>,
+	// The candidates claimed by the certificate. A mapping between bit index and candidate index.
+	candidates: BitVec<u8, bitvec::order::Lsb0>,
 	// The approval signatures for each `CandidateIndex` claimed by the assignment certificate.
 	approvals: HashMap<CandidateIndex, IndirectSignedApprovalVote>,
 	// The validator index of the assignment signer.
@@ -114,17 +115,25 @@ struct ApprovalEntry {
 	routing_info: ApprovalRouting,
 }
 
+#[derive(Debug)]
+enum ApprovalEntryError {
+	InvalidValidatorIndex,
+	CandidateIndexOutOfBounds,
+	InvalidCandidateIndex,
+	DuplicateApproval,
+}
+
 impl ApprovalEntry {
 	pub fn new(
 		assignment: IndirectAssignmentCertV2,
-		candidates: Vec<CandidateIndex>,
+		candidates: BitVec<u8, bitvec::order::Lsb0>,
 		routing_info: ApprovalRouting,
 	) -> ApprovalEntry {
 		Self {
 			validator_index: assignment.validator,
 			assignment,
 			approvals: HashMap::with_capacity(candidates.len()),
-			candidates: HashSet::from_iter(candidates.into_iter()),
+			candidates,
 			routing_info,
 		}
 	}
@@ -132,25 +141,22 @@ impl ApprovalEntry {
 	// Create a `MessageSubject` to reference the assignment.
 	pub fn create_assignment_knowledge(&self, block_hash: Hash) -> (MessageSubject, MessageKind) {
 		(
-			MessageSubject(
-				block_hash,
-				self.candidates.iter().cloned().collect::<Vec<_>>(),
-				self.validator_index,
-			),
+			MessageSubject(block_hash, self.candidates.clone(), self.validator_index),
 			MessageKind::Assignment,
 		)
 	}
 
-	// Create a `MessageSubject` to reference the assignment.
+	// Create a `MessageSubject` to reference the approval.
 	pub fn create_approval_knowledge(
 		&self,
 		block_hash: Hash,
 		candidate_index: CandidateIndex,
 	) -> (MessageSubject, MessageKind) {
-		(
-			MessageSubject(block_hash, vec![candidate_index], self.validator_index),
-			MessageKind::Approval,
-		)
+		let mut bitfield =
+			bitvec::bitvec![u8, bitvec::order::Lsb0; 0; candidate_index as usize + 1];
+		bitfield.set(candidate_index as _, true);
+
+		(MessageSubject(block_hash, bitfield, self.validator_index), MessageKind::Approval)
 	}
 
 	// Updates routing information and returns the previous information if any.
@@ -169,28 +175,37 @@ impl ApprovalEntry {
 	}
 
 	// Records a new approval. Returns false if the claimed candidate is not found or we already have received the approval.
-	// TODO: use specific errors instead of `bool`.
-	pub fn note_approval(&mut self, approval: IndirectSignedApprovalVote) -> bool {
+	pub fn note_approval(
+		&mut self,
+		approval: IndirectSignedApprovalVote,
+	) -> Result<(), ApprovalEntryError> {
 		// First do some sanity checks:
 		// - check validator index matches
 		// - check claimed candidate
 		// - check for duplicate approval
 		if self.validator_index != approval.validator {
-			return false
+			return Err(ApprovalEntryError::InvalidValidatorIndex)
 		}
 
-		if !self.candidates.contains(&approval.candidate_index) ||
-			self.approvals.contains_key(&approval.candidate_index)
-		{
-			return false
+		if self.candidates.len() <= approval.candidate_index as usize {
+			return Err(ApprovalEntryError::CandidateIndexOutOfBounds)
 		}
 
-		self.approvals.insert(approval.candidate_index, approval).is_none()
+		if !self.candidates[approval.candidate_index as usize] {
+			return Err(ApprovalEntryError::InvalidCandidateIndex)
+		}
+
+		if self.approvals.contains_key(&approval.candidate_index) {
+			return Err(ApprovalEntryError::DuplicateApproval)
+		}
+
+		self.approvals.insert(approval.candidate_index, approval);
+		Ok(())
 	}
 
 	// Get the assignment certiticate and claimed candidates.
-	pub fn get_assignment(&self) -> (IndirectAssignmentCertV2, Vec<CandidateIndex>) {
-		(self.assignment.clone(), self.candidates.iter().cloned().collect::<Vec<_>>())
+	pub fn get_assignment(&self) -> (IndirectAssignmentCertV2, BitVec<u8, bitvec::order::Lsb0>) {
+		(self.assignment.clone(), self.candidates.clone())
 	}
 
 	// Get all approvals for all candidates claimed by the assignment.
@@ -248,7 +263,7 @@ enum MessageKind {
 // Assignments can span multiple candidates, while approvals refer to only one candidate.
 //
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
-struct MessageSubject(Hash, pub Vec<CandidateIndex>, ValidatorIndex);
+struct MessageSubject(Hash, pub BitVec<u8, bitvec::order::Lsb0>, ValidatorIndex);
 
 #[derive(Debug, Clone, Default)]
 struct Knowledge {
@@ -290,13 +305,13 @@ impl Knowledge {
 		// In case of succesful insertion of multiple candidate assignments create additional
 		// entries for each assigned candidate. This fakes knowledge of individual assignments, but
 		// we need to share the same `MessageSubject` with the followup approval candidate index.
-		if kind == MessageKind::Assignment && success && message.1.len() > 1 {
-			message.1.iter().fold(success, |success, candidate_index| {
-				success &
-					self.insert(
-						MessageSubject(message.0.clone(), vec![*candidate_index], message.2),
-						kind,
-					)
+		if kind == MessageKind::Assignment && success && message.1.count_ones() > 1 {
+			message.1.iter_ones().fold(success, |success, candidate_index| {
+				let mut bitfield =
+					bitvec::bitvec![u8, bitvec::order::Lsb0; 0; candidate_index as usize + 1];
+				bitfield.set(candidate_index, true);
+
+				success & self.insert(MessageSubject(message.0.clone(), bitfield, message.2), kind)
 			})
 		} else {
 			success
@@ -336,7 +351,7 @@ struct BlockEntry {
 	pub session: SessionIndex,
 	/// Approval entries for whole block. These also contain all approvals in the cae of multiple candidates
 	/// being claimed by assignments.
-	approval_entries: HashMap<(ValidatorIndex, Vec<CandidateIndex>), ApprovalEntry>,
+	approval_entries: HashMap<(ValidatorIndex, BitVec<u8, bitvec::order::Lsb0>), ApprovalEntry>,
 }
 
 impl BlockEntry {
@@ -349,13 +364,13 @@ impl BlockEntry {
 		// First map one entry per candidate to the same key we will use in `approval_entries`.
 		// Key is (Validator_index, Vec<CandidateIndex>) that links the `ApprovalEntry` to the (K,V)
 		// entry in `candidate_entry.messages`.
-		for claimed_candidate_index in &entry.candidates {
-			match self.candidates.get_mut(*claimed_candidate_index as usize) {
+		for claimed_candidate_index in entry.candidates.iter_ones() {
+			match self.candidates.get_mut(claimed_candidate_index) {
 				Some(candidate_entry) => {
 					candidate_entry
 						.messages
 						.entry(entry.get_validator_index())
-						.or_insert(entry.candidates.iter().cloned().collect::<Vec<_>>());
+						.or_insert(entry.candidates.clone());
 				},
 				None => {
 					// This should never happen, but if it happens, it means the subsystem is broken.
@@ -370,10 +385,7 @@ impl BlockEntry {
 		}
 
 		self.approval_entries
-			.entry((
-				entry.validator_index,
-				entry.candidates.clone().into_iter().collect::<Vec<_>>(),
-			))
+			.entry((entry.validator_index, entry.candidates.clone()))
 			.or_insert(entry)
 	}
 
@@ -441,7 +453,7 @@ impl BlockEntry {
 #[derive(Debug, Default)]
 struct CandidateEntry {
 	// The value represents part of the lookup key in `approval_entries` to fetch the assignment and existing votes.
-	messages: HashMap<ValidatorIndex, Vec<CandidateIndex>>,
+	messages: HashMap<ValidatorIndex, BitVec<u8, bitvec::order::Lsb0>>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -460,7 +472,7 @@ impl MessageSource {
 }
 
 enum PendingMessage {
-	Assignment(IndirectAssignmentCertV2, Vec<CandidateIndex>),
+	Assignment(IndirectAssignmentCertV2, BitVec<u8, bitvec::order::Lsb0>),
 	Approval(IndirectSignedApprovalVote),
 }
 
@@ -686,7 +698,7 @@ impl State {
 		ctx: &mut Context,
 		metrics: &Metrics,
 		peer_id: PeerId,
-		assignments: Vec<(IndirectAssignmentCertV2, Vec<CandidateIndex>)>,
+		assignments: Vec<(IndirectAssignmentCertV2, BitVec<u8, bitvec::order::Lsb0>)>,
 		rng: &mut R,
 	) where
 		R: CryptoRng + Rng,
@@ -761,7 +773,14 @@ impl State {
 					peer_id,
 					assignments
 						.into_iter()
-						.map(|(cert, candidate)| (cert.into(), vec![candidate]))
+						.map(|(cert, candidate)| {
+							// TODO: 1 liner would be better.
+							let mut bitfield =
+								bitvec::bitvec![u8, bitvec::order::Lsb0; 0; candidate as usize + 1];
+							bitfield.set(candidate as _, true);
+
+							(cert.into(), bitfield)
+						})
 						.collect::<Vec<_>>(),
 					rng,
 				)
@@ -907,7 +926,7 @@ impl State {
 		metrics: &Metrics,
 		source: MessageSource,
 		assignment: IndirectAssignmentCertV2,
-		claimed_candidate_indices: Vec<CandidateIndex>,
+		claimed_candidate_indices: BitVec<u8, bitvec::order::Lsb0>,
 		rng: &mut R,
 	) where
 		R: CryptoRng + Rng,
@@ -955,6 +974,15 @@ impl State {
 								"Duplicate assignment",
 							);
 							modify_reputation(ctx.sender(), peer_id, COST_DUPLICATE_MESSAGE).await;
+						} else {
+							gum::trace!(
+								target: LOG_TARGET,
+								?peer_id,
+								hash = ?block_hash,
+								?validator_index,
+								?message_subject,
+								"We sent the message to the peer while peer was sending it to us. Known race condition.",
+							);
 						}
 						return
 					}
@@ -1183,7 +1211,11 @@ impl State {
 		};
 
 		// compute metadata on the assignment.
-		let message_subject = MessageSubject(block_hash, vec![candidate_index], validator_index);
+		let mut bitfield =
+			bitvec::bitvec![u8, bitvec::order::Lsb0; 0; candidate_index as usize + 1];
+		bitfield.set(candidate_index as _, true);
+
+		let message_subject = MessageSubject(block_hash, bitfield, validator_index);
 		let message_kind = MessageKind::Approval;
 
 		if let Some(peer_id) = source.peer_id() {
@@ -1317,7 +1349,7 @@ impl State {
 		// Invariant: to our knowledge, none of the peers except for the `source` know about the approval.
 		metrics.on_approval_imported();
 
-		if !approval_entry.note_approval(vote.clone()) {
+		if let Err(err) = approval_entry.note_approval(vote.clone()) {
 			// this would indicate a bug in approval-voting:
 			// - validator index mismatch
 			// - candidate index mismatch
@@ -1327,7 +1359,8 @@ impl State {
 				hash = ?block_hash,
 				?candidate_index,
 				?validator_index,
-				"Possible bug: Vote import failed: validator/candidate index mismatch or duplicate",
+				?err,
+				"Possible bug: Vote import failed",
 			);
 
 			return
@@ -1942,7 +1975,7 @@ pub const MAX_APPROVAL_BATCH_SIZE: usize = ensure_size_not_zero(
 // Low level helper for sending assignments.
 async fn send_assignments_batched_inner(
 	sender: &mut impl overseer::ApprovalDistributionSenderTrait,
-	batch: Vec<(IndirectAssignmentCertV2, Vec<CandidateIndex>)>,
+	batch: Vec<(IndirectAssignmentCertV2, BitVec<u8, bitvec::order::Lsb0>)>,
 	peers: &Vec<PeerId>,
 	// TODO: use `ValidationVersion`.
 	peer_version: u32,
@@ -1962,7 +1995,18 @@ async fn send_assignments_batched_inner(
 		// `IndirectAssignmentCertV2` -> `IndirectAssignmentCert`
 		let batch = batch
 			.into_iter()
-			.filter_map(|(cert, candidates)| cert.try_into().ok().map(|cert| (cert, candidates[0])))
+			.filter_map(|(cert, candidates)| {
+				cert.try_into().ok().map(|cert| {
+					(
+						cert,
+						// First 1 bit index is the candidate index.
+						candidates
+							.first_one()
+							.map(|index| index as CandidateIndex)
+							.expect("Assignment was checked for not being empty; qed"),
+					)
+				})
+			})
 			.collect();
 		sender
 			.send_message(NetworkBridgeTxMessage::SendValidationMessage(
@@ -1982,7 +2026,7 @@ async fn send_assignments_batched_inner(
 /// of assignments and can `select!` other tasks.
 pub(crate) async fn send_assignments_batched(
 	sender: &mut impl overseer::ApprovalDistributionSenderTrait,
-	v2_assignments: Vec<(IndirectAssignmentCertV2, Vec<CandidateIndex>)>,
+	v2_assignments: Vec<(IndirectAssignmentCertV2, BitVec<u8, bitvec::order::Lsb0>)>,
 	peers: &Vec<(PeerId, ProtocolVersion)>,
 ) {
 	let v1_peers = filter_by_peer_version(peers, ValidationVersion::V1.into());
@@ -1991,7 +2035,7 @@ pub(crate) async fn send_assignments_batched(
 	if v1_peers.len() > 0 {
 		let mut v1_assignments = v2_assignments.clone();
 		// Older peers(v1) do not understand `AssignmentsV2` messages, so we have to filter these out.
-		v1_assignments.retain(|(_, candidates)| candidates.len() == 1);
+		v1_assignments.retain(|(_, candidates)| candidates.count_ones() == 1);
 
 		let mut v1_batches = v1_assignments.into_iter().peekable();
 

--- a/node/network/approval-distribution/src/lib.rs
+++ b/node/network/approval-distribution/src/lib.rs
@@ -308,7 +308,7 @@ impl Knowledge {
 				success &
 					self.insert(
 						MessageSubject(
-							message.0.clone(),
+							message.0,
 							(candidate_index as CandidateIndex).into(),
 							message.2,
 						),
@@ -1135,7 +1135,7 @@ impl State {
 				.as_ref()
 				.map(|t| t.local_grid_neighbors().route_to_peer(required_routing, &peer))
 			{
-				peers.push(peer.clone());
+				peers.push(peer);
 				continue
 			}
 
@@ -1147,7 +1147,7 @@ impl State {
 
 			if route_random {
 				approval_entry.routing_info_mut().random_routing.inc_sent();
-				peers.push(peer.clone());
+				peers.push(peer);
 			}
 		}
 
@@ -1172,9 +1172,7 @@ impl State {
 			let peers = peers
 				.iter()
 				.filter_map(|peer_id| {
-					self.peer_views
-						.get(peer_id)
-						.map(|peer_entry| (peer_id.clone(), peer_entry.version))
+					self.peer_views.get(peer_id).map(|peer_entry| (*peer_id, peer_entry.version))
 				})
 				.collect::<Vec<_>>();
 
@@ -1453,13 +1451,12 @@ impl State {
 			let sigs = block_entry
 				.get_approval_entries(index)
 				.into_iter()
-				.map(|approval_entry| {
+				.flat_map(|approval_entry| {
 					approval_entry
 						.get_approvals()
 						.into_iter()
 						.map(|approval| (approval.validator, approval.signature))
 				})
-				.flatten()
 				.collect::<HashMap<ValidatorIndex, ValidatorSignature>>();
 			all_sigs.extend(sigs);
 		}

--- a/node/network/bridge/src/rx/mod.rs
+++ b/node/network/bridge/src/rx/mod.rs
@@ -755,7 +755,7 @@ fn update_our_view<Net, Context>(
 			shared
 				.validation_peers
 				.iter()
-				.map(|(peer_id, peer_data)| (peer_id.clone(), peer_data.version))
+				.map(|(peer_id, peer_data)| (*peer_id, peer_data.version))
 				.collect::<Vec<_>>(),
 			shared.collation_peers.keys().cloned().collect::<Vec<_>>(),
 		)

--- a/node/network/protocol/Cargo.toml
+++ b/node/network/protocol/Cargo.toml
@@ -22,6 +22,7 @@ fatality = "0.0.6"
 rand = "0.8"
 derive_more = "0.99"
 gum = { package = "tracing-gum", path = "../../gum" }
+bitvec = { version = "1.0.0", default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
 rand_chacha = "0.3.1"

--- a/node/network/protocol/Cargo.toml
+++ b/node/network/protocol/Cargo.toml
@@ -22,7 +22,6 @@ fatality = "0.0.6"
 rand = "0.8"
 derive_more = "0.99"
 gum = { package = "tracing-gum", path = "../../gum" }
-bitvec = { version = "1.0.0", default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
 rand_chacha = "0.3.1"

--- a/node/network/protocol/src/lib.rs
+++ b/node/network/protocol/src/lib.rs
@@ -426,10 +426,9 @@ impl_versioned_try_from!(
 /// Changes:
 /// - assignment cert type changed, see `IndirectAssignmentCertV2`.
 pub mod vstaging {
-	use bitvec::vec::BitVec;
 	use parity_scale_codec::{Decode, Encode};
 	use polkadot_node_primitives::approval::{
-		IndirectAssignmentCertV2, IndirectSignedApprovalVote,
+		v2::AssignmentBitfield, IndirectAssignmentCertV2, IndirectSignedApprovalVote,
 	};
 
 	// Re-export stuff that has not changed since v1.
@@ -465,7 +464,7 @@ pub mod vstaging {
 		/// Actually checking the assignment may yield a different result.
 		/// TODO: Look at getting rid of bitfield in the future.
 		#[codec(index = 0)]
-		Assignments(Vec<(IndirectAssignmentCertV2, BitVec<u8, bitvec::order::Lsb0>)>),
+		Assignments(Vec<(IndirectAssignmentCertV2, AssignmentBitfield)>),
 		/// Approvals for candidates in some recent, unfinalized block.
 		#[codec(index = 1)]
 		Approvals(Vec<IndirectSignedApprovalVote>),

--- a/node/network/protocol/src/lib.rs
+++ b/node/network/protocol/src/lib.rs
@@ -426,12 +426,11 @@ impl_versioned_try_from!(
 /// Changes:
 /// - assignment cert type changed, see `IndirectAssignmentCertV2`.
 pub mod vstaging {
+	use bitvec::vec::BitVec;
 	use parity_scale_codec::{Decode, Encode};
 	use polkadot_node_primitives::approval::{
 		IndirectAssignmentCertV2, IndirectSignedApprovalVote,
 	};
-
-	use polkadot_primitives::CandidateIndex;
 
 	// Re-export stuff that has not changed since v1.
 	pub use crate::v1::{
@@ -461,10 +460,12 @@ pub mod vstaging {
 	#[derive(Debug, Clone, Encode, Decode, PartialEq, Eq)]
 	pub enum ApprovalDistributionMessage {
 		/// Assignments for candidates in recent, unfinalized blocks.
+		/// We use a bitfield to reference claimed candidates, where the bit index is equal to candidate index.
 		///
 		/// Actually checking the assignment may yield a different result.
+		/// TODO: Look at getting rid of bitfield in the future.
 		#[codec(index = 0)]
-		Assignments(Vec<(IndirectAssignmentCertV2, Vec<CandidateIndex>)>),
+		Assignments(Vec<(IndirectAssignmentCertV2, BitVec<u8, bitvec::order::Lsb0>)>),
 		/// Approvals for candidates in some recent, unfinalized block.
 		#[codec(index = 1)]
 		Approvals(Vec<IndirectSignedApprovalVote>),

--- a/node/network/protocol/src/lib.rs
+++ b/node/network/protocol/src/lib.rs
@@ -428,7 +428,7 @@ impl_versioned_try_from!(
 pub mod vstaging {
 	use parity_scale_codec::{Decode, Encode};
 	use polkadot_node_primitives::approval::{
-		v2::AssignmentBitfield, IndirectAssignmentCertV2, IndirectSignedApprovalVote,
+		v2::CandidateBitfield, IndirectAssignmentCertV2, IndirectSignedApprovalVote,
 	};
 
 	// Re-export stuff that has not changed since v1.
@@ -464,7 +464,7 @@ pub mod vstaging {
 		/// Actually checking the assignment may yield a different result.
 		/// TODO: Look at getting rid of bitfield in the future.
 		#[codec(index = 0)]
-		Assignments(Vec<(IndirectAssignmentCertV2, AssignmentBitfield)>),
+		Assignments(Vec<(IndirectAssignmentCertV2, CandidateBitfield)>),
 		/// Approvals for candidates in some recent, unfinalized block.
 		#[codec(index = 1)]
 		Approvals(Vec<IndirectSignedApprovalVote>),

--- a/node/primitives/Cargo.toml
+++ b/node/primitives/Cargo.toml
@@ -20,6 +20,7 @@ polkadot-parachain = { path = "../../parachain", default-features = false }
 schnorrkel = "0.9.1"
 thiserror = "1.0.31"
 serde = { version = "1.0.137", features = ["derive"] }
+bitvec = { version = "1.0.0", default-features = false, features = ["alloc"] }
 
 [target.'cfg(not(target_os = "unknown"))'.dependencies]
 zstd = { version = "0.11.2", default-features = false }

--- a/node/primitives/src/approval.rs
+++ b/node/primitives/src/approval.rs
@@ -31,24 +31,37 @@ use sp_consensus_babe as babe_primitives;
 /// Earlier tranches of validators check first, with later tranches serving as backup.
 pub type DelayTranche = u32;
 
-/// A static context used to compute the Relay VRF story based on the
-/// VRF output included in the header-chain.
-pub const RELAY_VRF_STORY_CONTEXT: &[u8] = b"A&V RC-VRF";
+/// Static contexts use to generate randomness for v1 assignments.
+pub mod v1 {
+	/// A static context used to compute the Relay VRF story based on the
+	/// VRF output included in the header-chain.
+	pub const RELAY_VRF_STORY_CONTEXT: &[u8] = b"A&V RC-VRF";
 
-/// A static context used for all relay-vrf-modulo VRFs.
-pub const RELAY_VRF_MODULO_CONTEXT: &[u8] = b"A&V MOD";
+	/// A static context used for all relay-vrf-modulo VRFs.
+	pub const RELAY_VRF_MODULO_CONTEXT: &[u8] = b"A&V MOD";
 
-/// A static context used for all relay-vrf-modulo VRFs.
-pub const RELAY_VRF_DELAY_CONTEXT: &[u8] = b"A&V DELAY";
+	/// A static context used for all relay-vrf-modulo VRFs.
+	pub const RELAY_VRF_DELAY_CONTEXT: &[u8] = b"A&V DELAY";
 
-/// A static context used for transcripts indicating assigned availability core.
-pub const ASSIGNED_CORE_CONTEXT: &[u8] = b"A&V ASSIGNED";
+	/// A static context used for transcripts indicating assigned availability core.
+	pub const ASSIGNED_CORE_CONTEXT: &[u8] = b"A&V ASSIGNED";
 
-/// A static context associated with producing randomness for a core.
-pub const CORE_RANDOMNESS_CONTEXT: &[u8] = b"A&V CORE";
+	/// A static context associated with producing randomness for a core.
+	pub const CORE_RANDOMNESS_CONTEXT: &[u8] = b"A&V CORE";
 
-/// A static context associated with producing randomness for a tranche.
-pub const TRANCHE_RANDOMNESS_CONTEXT: &[u8] = b"A&V TRANCHE";
+	/// A static context associated with producing randomness for a tranche.
+	pub const TRANCHE_RANDOMNESS_CONTEXT: &[u8] = b"A&V TRANCHE";
+}
+
+/// Static contexts use to generate randomness for v2 assignments.
+pub mod v2 {
+	/// A static context associated with producing randomness for a core.
+	pub const CORE_RANDOMNESS_CONTEXT: &[u8] = b"A&V CORE v2";
+	/// A static context associated with producing randomness for v2 multi-core assignments.
+	pub const ASSIGNED_CORE_CONTEXT: &[u8] = b"A&V ASSIGNED v2";
+	/// A static context used for all relay-vrf-modulo VRFs for v2 multi-core assignments.
+	pub const RELAY_VRF_MODULO_CONTEXT: &[u8] = b"A&V MOD v2";
+}
 
 /// random bytes derived from the VRF submitted within the block by the
 /// block author as a credential and used as input to approval assignment criteria.
@@ -84,25 +97,20 @@ pub enum AssignmentCertKindV2 {
 	/// An assignment story based on the VRF that authorized the relay-chain block where the
 	/// candidate was included combined with a sample number.
 	///
-	/// The context used to produce bytes is [`RELAY_VRF_MODULO_CONTEXT`]
+	/// The context used to produce bytes is [`v2::RELAY_VRF_MODULO_CONTEXT`]
 	RelayVRFModulo {
 		/// The sample number used in this cert.
 		sample: u32,
 	},
 	/// Multiple assignment stories based on the VRF that authorized the relay-chain block where the
-	/// candidate was included combined with a sample number.
+	/// candidate was included.
 	///
-	/// The context used to produce bytes is [`RELAY_VRF_MODULO_CONTEXT`]
-	RelayVRFModuloCompact {
-		/// The number of samples.
-		sample: u32,
-		/// The assigned cores.
-		core_indices: Vec<CoreIndex>,
-	},
+	/// The context is [`v2::RELAY_VRF_MODULO_CONTEXT`]
+	RelayVRFModuloCompact,
 	/// An assignment story based on the VRF that authorized the relay-chain block where the
 	/// candidate was included combined with the index of a particular core.
 	///
-	/// The context is [`RELAY_VRF_DELAY_CONTEXT`]
+	/// The context is [`v2::RELAY_VRF_DELAY_CONTEXT`]
 	RelayVRFDelay {
 		/// The core index chosen in this cert.
 		core_index: CoreIndex,
@@ -288,7 +296,7 @@ impl UnsafeVRFOutput {
 			.0
 			.attach_input_hash(&pubkey, transcript)
 			.map_err(ApprovalError::SchnorrkelSignature)?;
-		Ok(RelayVRFStory(inout.make_bytes(RELAY_VRF_STORY_CONTEXT)))
+		Ok(RelayVRFStory(inout.make_bytes(v1::RELAY_VRF_STORY_CONTEXT)))
 	}
 }
 

--- a/node/primitives/src/approval.rs
+++ b/node/primitives/src/approval.rs
@@ -67,26 +67,41 @@ pub mod v2 {
 	pub const ASSIGNED_CORE_CONTEXT: &[u8] = b"A&V ASSIGNED v2";
 	/// A static context used for all relay-vrf-modulo VRFs for v2 multi-core assignments.
 	pub const RELAY_VRF_MODULO_CONTEXT: &[u8] = b"A&V MOD v2";
-	/// A read-only bitvec wrapp to efficiently store candidate or core assignments. Each 1 bit identifies
-	/// a candidate(or core) by the bitfield bit index.
+	/// A read-only bitvec wrapper
 	#[derive(Clone, Debug, Encode, Decode, Hash, PartialEq, Eq)]
-	pub struct AssignmentBitfield(BitVec<u8, bitvec::order::Lsb0>);
+	pub struct Bitfield<T>(BitVec<u8, bitvec::order::Lsb0>, std::marker::PhantomData<T>);
+
+	/// A `read-only`, `non-zero` bitfield.
+	/// Each 1 bit identifies a candidate by the bitfield bit index.
+	pub type CandidateBitfield = Bitfield<CandidateIndex>;
+	/// A bitfield of core assignments.
+	pub type CoreBitfield = Bitfield<CoreIndex>;
 
 	/// Errors that can occur when creating and manipulating bitfields.
 	#[derive(Debug)]
-	pub enum AssignmentBitfieldError {
+	pub enum BitfieldError {
 		/// All bits are zero.
 		NullAssignment,
 	}
 
-	impl AssignmentBitfield {
+	/// A bit index in `Bitfield`.
+	#[cfg_attr(test, derive(PartialEq, Clone))]
+	pub struct BitIndex(pub usize);
+
+	/// Helper trait to convert primitives to `BitIndex`.
+	pub trait AsBitIndex {
+		/// Returns the index of the corresponding bit in `Bitfield`.
+		fn as_bit_index(&self) -> BitIndex;
+	}
+
+	impl<T> Bitfield<T> {
 		/// Returns the bit value at specified `index`. If `index` is greater than bitfield size,
 		/// returns `false`.
-		pub fn bit_at(&self, index: usize) -> bool {
-			if self.0.len() <= index {
+		pub fn bit_at(&self, index: BitIndex) -> bool {
+			if self.0.len() <= index.0 {
 				false
 			} else {
-				self.0[index]
+				self.0[index.0]
 			}
 		}
 
@@ -117,47 +132,64 @@ pub mod v2 {
 		}
 	}
 
-	impl From<CoreIndex> for AssignmentBitfield {
-		fn from(value: CoreIndex) -> Self {
-			Self({
-				let mut bv = bitvec::bitvec![u8, Lsb0; 0; value.0 as usize + 1];
-				bv.set(value.0 as usize, true);
-				bv
-			})
+	impl AsBitIndex for CandidateIndex {
+		fn as_bit_index(&self) -> BitIndex {
+			BitIndex(*self as usize)
 		}
 	}
 
-	impl From<CandidateIndex> for AssignmentBitfield {
-		fn from(value: CandidateIndex) -> Self {
-			Self({
-				let mut bv = bitvec::bitvec![u8, Lsb0; 0; value as usize + 1];
-				bv.set(value as usize, true);
-				bv
-			})
+	impl AsBitIndex for CoreIndex {
+		fn as_bit_index(&self) -> BitIndex {
+			BitIndex(self.0 as usize)
 		}
 	}
 
-	impl<T> TryFrom<Vec<T>> for AssignmentBitfield
+	impl AsBitIndex for usize {
+		fn as_bit_index(&self) -> BitIndex {
+			BitIndex(*self)
+		}
+	}
+
+	impl<T> From<T> for Bitfield<T>
 	where
-		T: Into<AssignmentBitfield>,
+		T: AsBitIndex,
 	{
-		type Error = AssignmentBitfieldError;
+		fn from(value: T) -> Self {
+			Self(
+				{
+					let mut bv = bitvec::bitvec![u8, Lsb0; 0; value.as_bit_index().0 + 1];
+					bv.set(value.as_bit_index().0, true);
+					bv
+				},
+				Default::default(),
+			)
+		}
+	}
+
+	impl<T> TryFrom<Vec<T>> for Bitfield<T>
+	where
+		T: Into<Bitfield<T>>,
+	{
+		type Error = BitfieldError;
 
 		fn try_from(mut value: Vec<T>) -> Result<Self, Self::Error> {
 			if value.is_empty() {
-				return Err(AssignmentBitfieldError::NullAssignment)
+				return Err(BitfieldError::NullAssignment)
 			}
 
 			let initial_bitfield =
 				value.pop().expect("Just checked above it's not empty; qed").into();
 
-			Ok(Self(value.into_iter().fold(initial_bitfield.0, |initial_bitfield, element| {
-				let mut bitfield: AssignmentBitfield = element.into();
-				bitfield
-					.0
-					.resize(std::cmp::max(initial_bitfield.len(), bitfield.0.len()), false);
-				bitfield.0.bitor(initial_bitfield)
-			})))
+			Ok(Self(
+				value.into_iter().fold(initial_bitfield.0, |initial_bitfield, element| {
+					let mut bitfield: Bitfield<T> = element.into();
+					bitfield
+						.0
+						.resize(std::cmp::max(initial_bitfield.len(), bitfield.0.len()), false);
+					bitfield.0.bitor(initial_bitfield)
+				}),
+				Default::default(),
+			))
 		}
 	}
 }
@@ -428,49 +460,54 @@ pub fn babe_unsafe_vrf_info(header: &Header) -> Option<UnsafeVRFOutput> {
 
 #[cfg(test)]
 mod test {
-	use super::{v2::AssignmentBitfield, *};
+	use super::{
+		v2::{BitIndex, Bitfield},
+		*,
+	};
 
 	#[test]
 	fn test_assignment_bitfield_from_vec() {
-		let candidate_indices = vec![1, 7, 3, 10, 45, 8, 200, 2];
-		let bitfield = AssignmentBitfield::try_from(candidate_indices.clone()).unwrap();
-		let max_index = candidate_indices.iter().cloned().max().unwrap();
+		let candidate_indices = vec![1u32, 7, 3, 10, 45, 8, 200, 2];
+		let max_index = *candidate_indices.iter().max().unwrap();
+		let bitfield = Bitfield::try_from(candidate_indices.clone()).unwrap();
+		let candidate_indices =
+			candidate_indices.into_iter().map(|i| BitIndex(i as usize)).collect::<Vec<_>>();
 
 		// Test 1 bits.
 		for index in candidate_indices.clone() {
-			assert!(bitfield.bit_at(index as usize));
+			assert!(bitfield.bit_at(index));
 		}
 
 		// Test 0 bits.
 		for index in 0..max_index {
-			if candidate_indices.contains(&index) {
+			if candidate_indices.contains(&BitIndex(index as usize)) {
 				continue
 			}
-			assert!(!bitfield.bit_at(index as usize));
+			assert!(!bitfield.bit_at(BitIndex(index as usize)));
 		}
 	}
 
 	#[test]
 	fn test_assignment_bitfield_invariant_msb() {
 		let core_indices = vec![CoreIndex(1), CoreIndex(3), CoreIndex(10), CoreIndex(20)];
-		let mut bitfield = AssignmentBitfield::try_from(core_indices.clone()).unwrap();
+		let mut bitfield = Bitfield::try_from(core_indices.clone()).unwrap();
 		assert!(bitfield.inner_mut().pop().unwrap());
 
 		for i in 0..1024 {
-			assert!(AssignmentBitfield::try_from(CoreIndex(i)).unwrap().inner_mut().pop().unwrap());
-			assert!(AssignmentBitfield::try_from(i).unwrap().inner_mut().pop().unwrap());
+			assert!(Bitfield::try_from(CoreIndex(i)).unwrap().inner_mut().pop().unwrap());
+			assert!(Bitfield::try_from(i).unwrap().inner_mut().pop().unwrap());
 		}
 	}
 
 	#[test]
 	fn test_assignment_bitfield_basic() {
-		let bitfield = AssignmentBitfield::try_from(CoreIndex(0)).unwrap();
-		assert!(bitfield.bit_at(0));
-		assert!(!bitfield.bit_at(1));
+		let bitfield = Bitfield::try_from(CoreIndex(0)).unwrap();
+		assert!(bitfield.bit_at(BitIndex(0)));
+		assert!(!bitfield.bit_at(BitIndex(1)));
 		assert_eq!(bitfield.len(), 1);
 
-		let mut bitfield = AssignmentBitfield::try_from(20).unwrap();
-		assert!(bitfield.bit_at(20));
+		let mut bitfield = Bitfield::try_from(20 as CandidateIndex).unwrap();
+		assert!(bitfield.bit_at(BitIndex(20)));
 		assert_eq!(bitfield.inner_mut().count_ones(), 1);
 		assert_eq!(bitfield.len(), 21);
 	}

--- a/node/primitives/src/approval.rs
+++ b/node/primitives/src/approval.rs
@@ -202,7 +202,7 @@ pub enum AssignmentCertKindV2 {
 		sample: u32,
 	},
 	/// Multiple assignment stories based on the VRF that authorized the relay-chain block where the
-	/// candidate was included.
+	/// candidates were included.
 	///
 	/// The context is [`v2::RELAY_VRF_MODULO_CONTEXT`]
 	RelayVRFModuloCompact,

--- a/node/subsystem-types/Cargo.toml
+++ b/node/subsystem-types/Cargo.toml
@@ -22,3 +22,4 @@ smallvec = "1.8.0"
 substrate-prometheus-endpoint = { git = "https://github.com/paritytech/substrate", branch = "master" }
 thiserror = "1.0.31"
 async-trait = "0.1.57"
+bitvec = { version = "1.0.0", default-features = false, features = ["alloc"] }

--- a/node/subsystem-types/src/messages.rs
+++ b/node/subsystem-types/src/messages.rs
@@ -22,6 +22,7 @@
 //!
 //! Subsystems' APIs are defined separately from their implementation, leading to easier mocking.
 
+use bitvec::prelude::BitVec;
 use futures::channel::oneshot;
 use sc_network::Multiaddr;
 use thiserror::Error;
@@ -770,7 +771,7 @@ pub enum ApprovalVotingMessage {
 	/// Should not be sent unless the block hash is known.
 	CheckAndImportAssignment(
 		IndirectAssignmentCertV2,
-		Vec<CandidateIndex>,
+		BitVec<u8, bitvec::order::Lsb0>,
 		oneshot::Sender<AssignmentCheckResult>,
 	),
 	/// Check if the approval vote is valid and can be accepted by our view of the
@@ -805,7 +806,7 @@ pub enum ApprovalDistributionMessage {
 	NewBlocks(Vec<BlockApprovalMeta>),
 	/// Distribute an assignment cert from the local validator. The cert is assumed
 	/// to be valid, relevant, and for the given relay-parent and validator index.
-	DistributeAssignment(IndirectAssignmentCertV2, Vec<CandidateIndex>),
+	DistributeAssignment(IndirectAssignmentCertV2, BitVec<u8, bitvec::order::Lsb0>),
 	/// Distribute an approval vote for the local validator. The approval vote is assumed to be
 	/// valid, relevant, and the corresponding approval already issued.
 	/// If not, the subsystem is free to drop the message.

--- a/node/subsystem-types/src/messages.rs
+++ b/node/subsystem-types/src/messages.rs
@@ -34,7 +34,7 @@ use polkadot_node_network_protocol::{
 };
 use polkadot_node_primitives::{
 	approval::{
-		v2::AssignmentBitfield, BlockApprovalMeta, IndirectAssignmentCertV2,
+		v2::CandidateBitfield, BlockApprovalMeta, IndirectAssignmentCertV2,
 		IndirectSignedApprovalVote,
 	},
 	AvailableData, BabeEpoch, BlockWeight, CandidateVotes, CollationGenerationConfig,
@@ -773,7 +773,7 @@ pub enum ApprovalVotingMessage {
 	/// Should not be sent unless the block hash is known.
 	CheckAndImportAssignment(
 		IndirectAssignmentCertV2,
-		AssignmentBitfield,
+		CandidateBitfield,
 		oneshot::Sender<AssignmentCheckResult>,
 	),
 	/// Check if the approval vote is valid and can be accepted by our view of the
@@ -808,7 +808,7 @@ pub enum ApprovalDistributionMessage {
 	NewBlocks(Vec<BlockApprovalMeta>),
 	/// Distribute an assignment cert from the local validator. The cert is assumed
 	/// to be valid, relevant, and for the given relay-parent and validator index.
-	DistributeAssignment(IndirectAssignmentCertV2, AssignmentBitfield),
+	DistributeAssignment(IndirectAssignmentCertV2, CandidateBitfield),
 	/// Distribute an approval vote for the local validator. The approval vote is assumed to be
 	/// valid, relevant, and the corresponding approval already issued.
 	/// If not, the subsystem is free to drop the message.

--- a/node/subsystem-types/src/messages.rs
+++ b/node/subsystem-types/src/messages.rs
@@ -22,7 +22,6 @@
 //!
 //! Subsystems' APIs are defined separately from their implementation, leading to easier mocking.
 
-use bitvec::prelude::BitVec;
 use futures::channel::oneshot;
 use sc_network::Multiaddr;
 use thiserror::Error;
@@ -34,7 +33,10 @@ use polkadot_node_network_protocol::{
 	UnifiedReputationChange,
 };
 use polkadot_node_primitives::{
-	approval::{BlockApprovalMeta, IndirectAssignmentCertV2, IndirectSignedApprovalVote},
+	approval::{
+		v2::AssignmentBitfield, BlockApprovalMeta, IndirectAssignmentCertV2,
+		IndirectSignedApprovalVote,
+	},
 	AvailableData, BabeEpoch, BlockWeight, CandidateVotes, CollationGenerationConfig,
 	CollationSecondedSignal, DisputeMessage, DisputeStatus, ErasureChunk, PoV,
 	SignedDisputeStatement, SignedFullStatement, ValidationResult,
@@ -771,7 +773,7 @@ pub enum ApprovalVotingMessage {
 	/// Should not be sent unless the block hash is known.
 	CheckAndImportAssignment(
 		IndirectAssignmentCertV2,
-		BitVec<u8, bitvec::order::Lsb0>,
+		AssignmentBitfield,
 		oneshot::Sender<AssignmentCheckResult>,
 	),
 	/// Check if the approval vote is valid and can be accepted by our view of the
@@ -806,7 +808,7 @@ pub enum ApprovalDistributionMessage {
 	NewBlocks(Vec<BlockApprovalMeta>),
 	/// Distribute an assignment cert from the local validator. The cert is assumed
 	/// to be valid, relevant, and for the given relay-parent and validator index.
-	DistributeAssignment(IndirectAssignmentCertV2, BitVec<u8, bitvec::order::Lsb0>),
+	DistributeAssignment(IndirectAssignmentCertV2, AssignmentBitfield),
 	/// Distribute an approval vote for the local validator. The approval vote is assumed to be
 	/// valid, relevant, and the corresponding approval already issued.
 	/// If not, the subsystem is free to drop the message.

--- a/roadmap/implementers-guide/src/node/approval/approval-voting.md
+++ b/roadmap/implementers-guide/src/node/approval/approval-voting.md
@@ -54,6 +54,8 @@ struct OurAssignment {
   tranche: DelayTranche,
   validator_index: ValidatorIndex,
   triggered: bool,
+  // Claimed core indices.
+	pub claimed_core_indices: Vec<CoreIndex>,
 }
 
 struct ApprovalEntry {

--- a/roadmap/implementers-guide/src/node/approval/approval-voting.md
+++ b/roadmap/implementers-guide/src/node/approval/approval-voting.md
@@ -54,7 +54,7 @@ struct OurAssignment {
   tranche: DelayTranche,
   validator_index: ValidatorIndex,
   triggered: bool,
-  // Claimed core indices.
+	/// A subset of the core indices obtained from the VRF output.
 	pub claimed_core_indices: Vec<CoreIndex>,
 }
 

--- a/roadmap/implementers-guide/src/node/approval/approval-voting.md
+++ b/roadmap/implementers-guide/src/node/approval/approval-voting.md
@@ -54,8 +54,8 @@ struct OurAssignment {
   tranche: DelayTranche,
   validator_index: ValidatorIndex,
   triggered: bool,
-	/// A subset of the core indices obtained from the VRF output.
-	pub claimed_core_indices: Vec<CoreIndex>,
+  /// A subset of the core indices obtained from the VRF output.
+  pub assignment_bitfield: AssignmentBitfield,
 }
 
 struct ApprovalEntry {


### PR DESCRIPTION
This is a child PR of https://github.com/paritytech/polkadot/pull/6782.

Implementing some TODOs and removing redundant information as suggested in review discussion: https://github.com/paritytech/polkadot/pull/6782#discussion_r1117750373

Changes:
- Separate transcript for v1/v2 assignments
- remove `sample` and `core_indices` from v2 certificate.
- update `check_assignment_cert` to return the assigned cores as outputed by VRF.
- impl TODO: bitfield instead of `Vec<CandidateIndex>`
- impl TODO: bitfield instead of `Vec<CoreIndex>`