### PR TITLE
Companion for substrate#13509: bump API versions of {Beefy,Mmr}Api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,7 +466,7 @@ dependencies = [
 [[package]]
 name = "binary-merkle-tree"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "hash-db",
  "log",
@@ -2276,7 +2276,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "fork-tree"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -2299,7 +2299,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 [[package]]
 name = "frame-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -2324,7 +2324,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "Inflector",
  "array-bytes",
@@ -2371,7 +2371,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2382,7 +2382,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -2399,7 +2399,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2428,7 +2428,7 @@ dependencies = [
 [[package]]
 name = "frame-remote-externalities"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "futures",
  "log",
@@ -2444,7 +2444,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "bitflags",
  "environmental",
@@ -2477,7 +2477,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -2492,7 +2492,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -2504,7 +2504,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2514,7 +2514,7 @@ dependencies = [
 [[package]]
 name = "frame-support-test"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2538,7 +2538,7 @@ dependencies = [
 [[package]]
 name = "frame-support-test-pallet"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2549,7 +2549,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-support",
  "log",
@@ -2567,7 +2567,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2582,7 +2582,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -2591,7 +2591,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -2773,7 +2773,7 @@ dependencies = [
 [[package]]
 name = "generate-bags"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "chrono",
  "frame-election-provider-support",
@@ -4552,7 +4552,7 @@ dependencies = [
 [[package]]
 name = "mmr-gadget"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "futures",
  "log",
@@ -4571,7 +4571,7 @@ dependencies = [
 [[package]]
 name = "mmr-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "anyhow",
  "jsonrpsee",
@@ -5133,7 +5133,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5148,7 +5148,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5164,7 +5164,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5178,7 +5178,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5202,7 +5202,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5222,7 +5222,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list-remote-tests"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-election-provider-support",
  "frame-remote-externalities",
@@ -5241,7 +5241,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5256,7 +5256,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5275,7 +5275,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "array-bytes",
  "binary-merkle-tree",
@@ -5299,7 +5299,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5317,7 +5317,7 @@ dependencies = [
 [[package]]
 name = "pallet-child-bounties"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5336,7 +5336,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5353,7 +5353,7 @@ dependencies = [
 [[package]]
 name = "pallet-conviction-voting"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -5370,7 +5370,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5388,7 +5388,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5411,7 +5411,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5424,7 +5424,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "5.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5442,7 +5442,7 @@ dependencies = [
 [[package]]
 name = "pallet-fast-unstake"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5460,7 +5460,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5483,7 +5483,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -5499,7 +5499,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5519,7 +5519,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5536,7 +5536,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5553,7 +5553,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5570,7 +5570,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5586,7 +5586,7 @@ dependencies = [
 [[package]]
 name = "pallet-nis"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5602,7 +5602,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5619,7 +5619,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5639,7 +5639,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
 version = "1.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
@@ -5650,7 +5650,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5667,7 +5667,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5691,7 +5691,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5708,7 +5708,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5723,7 +5723,7 @@ dependencies = [
 [[package]]
 name = "pallet-ranked-collective"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5741,7 +5741,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5756,7 +5756,7 @@ dependencies = [
 [[package]]
 name = "pallet-referenda"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -5775,7 +5775,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5792,7 +5792,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5813,7 +5813,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5829,7 +5829,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5843,7 +5843,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5866,7 +5866,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -5877,7 +5877,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -5886,7 +5886,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -5895,7 +5895,7 @@ dependencies = [
 [[package]]
 name = "pallet-state-trie-migration"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5912,7 +5912,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5926,7 +5926,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5944,7 +5944,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5963,7 +5963,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5979,7 +5979,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -5995,7 +5995,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -6007,7 +6007,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6024,7 +6024,7 @@ dependencies = [
 [[package]]
 name = "pallet-uniques"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6039,7 +6039,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6055,7 +6055,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6070,7 +6070,7 @@ dependencies = [
 [[package]]
 name = "pallet-whitelist"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8998,7 +8998,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "4.1.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "log",
  "sp-core",
@@ -9009,7 +9009,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "async-trait",
  "futures",
@@ -9036,7 +9036,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "futures",
  "futures-timer",
@@ -9059,7 +9059,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -9074,7 +9074,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "memmap2",
  "sc-chain-spec-derive",
@@ -9093,7 +9093,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -9104,7 +9104,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "array-bytes",
  "chrono",
@@ -9144,7 +9144,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "fnv",
  "futures",
@@ -9170,7 +9170,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -9196,7 +9196,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "async-trait",
  "futures",
@@ -9221,7 +9221,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -9260,7 +9260,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -9282,7 +9282,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -9316,7 +9316,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -9335,7 +9335,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -9348,7 +9348,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "ahash 0.8.2",
  "array-bytes",
@@ -9388,7 +9388,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "finality-grandpa",
  "futures",
@@ -9408,7 +9408,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "async-trait",
  "futures",
@@ -9431,7 +9431,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "lru 0.8.1",
  "parity-scale-codec",
@@ -9455,7 +9455,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "sc-allocator",
  "sp-maybe-compressed-blob",
@@ -9468,7 +9468,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "log",
  "sc-allocator",
@@ -9481,7 +9481,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -9499,7 +9499,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "ansi_term",
  "futures",
@@ -9514,7 +9514,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -9529,7 +9529,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "array-bytes",
  "async-channel",
@@ -9572,7 +9572,7 @@ dependencies = [
 [[package]]
 name = "sc-network-bitswap"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "cid",
  "futures",
@@ -9591,7 +9591,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "async-trait",
  "bitflags",
@@ -9617,7 +9617,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "ahash 0.8.2",
  "futures",
@@ -9635,7 +9635,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "array-bytes",
  "futures",
@@ -9656,7 +9656,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -9688,7 +9688,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "array-bytes",
  "futures",
@@ -9707,7 +9707,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "array-bytes",
  "bytes",
@@ -9737,7 +9737,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "futures",
  "libp2p",
@@ -9750,7 +9750,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -9759,7 +9759,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -9789,7 +9789,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -9808,7 +9808,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "http",
  "jsonrpsee",
@@ -9823,7 +9823,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "array-bytes",
  "futures",
@@ -9849,7 +9849,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "async-trait",
  "directories",
@@ -9915,7 +9915,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -9926,7 +9926,7 @@ dependencies = [
 [[package]]
 name = "sc-storage-monitor"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "clap 4.0.15",
  "fs4",
@@ -9942,7 +9942,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -9961,7 +9961,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "6.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "futures",
  "libc",
@@ -9980,7 +9980,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "chrono",
  "futures",
@@ -9999,7 +9999,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "ansi_term",
  "atty",
@@ -10030,7 +10030,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -10041,7 +10041,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "async-trait",
  "futures",
@@ -10068,7 +10068,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "async-trait",
  "futures",
@@ -10082,7 +10082,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "backtrace",
  "futures",
@@ -10590,7 +10590,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "hash-db",
  "log",
@@ -10608,7 +10608,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "blake2",
  "proc-macro-crate",
@@ -10620,7 +10620,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10633,7 +10633,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -10647,7 +10647,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10660,7 +10660,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -10672,7 +10672,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "futures",
  "log",
@@ -10690,7 +10690,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "async-trait",
  "futures",
@@ -10705,7 +10705,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -10723,7 +10723,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "async-trait",
  "merlin",
@@ -10746,7 +10746,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-beefy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "lazy_static",
  "parity-scale-codec",
@@ -10765,7 +10765,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -10783,7 +10783,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10795,7 +10795,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10808,7 +10808,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "array-bytes",
  "base58",
@@ -10851,7 +10851,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "blake2",
  "byteorder",
@@ -10865,7 +10865,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10876,7 +10876,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.1",
@@ -10885,7 +10885,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10895,7 +10895,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.13.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -10906,7 +10906,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -10921,7 +10921,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "bytes",
  "ed25519",
@@ -10946,7 +10946,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -10957,7 +10957,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.13.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "async-trait",
  "futures",
@@ -10974,7 +10974,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "4.1.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "thiserror",
  "zstd",
@@ -10983,7 +10983,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "ckb-merkle-mountain-range",
  "log",
@@ -11001,7 +11001,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11015,7 +11015,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -11025,7 +11025,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -11035,7 +11035,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -11045,7 +11045,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -11067,7 +11067,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -11085,7 +11085,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -11097,7 +11097,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11111,7 +11111,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11123,7 +11123,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.13.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "hash-db",
  "log",
@@ -11143,12 +11143,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 
 [[package]]
 name = "sp-storage"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -11161,7 +11161,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "async-trait",
  "futures-timer",
@@ -11176,7 +11176,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "parity-scale-codec",
  "sp-std",
@@ -11188,7 +11188,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -11197,7 +11197,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "async-trait",
  "log",
@@ -11213,7 +11213,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "ahash 0.8.2",
  "hash-db",
@@ -11236,7 +11236,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -11253,7 +11253,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -11264,7 +11264,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -11278,7 +11278,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11498,7 +11498,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "platforms",
 ]
@@ -11506,7 +11506,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures",
@@ -11525,7 +11525,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "hyper",
  "log",
@@ -11537,7 +11537,7 @@ dependencies = [
 [[package]]
 name = "substrate-rpc-client"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "async-trait",
  "jsonrpsee",
@@ -11550,7 +11550,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-trie-migration-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "jsonrpsee",
  "log",
@@ -11569,7 +11569,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -11595,7 +11595,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-utils"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "futures",
  "substrate-test-utils-derive",
@@ -11605,7 +11605,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-utils-derive"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -11616,7 +11616,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "5.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "ansi_term",
  "build-helper",
@@ -12417,7 +12417,7 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 [[package]]
 name = "try-runtime-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "async-trait",
  "clap 4.0.15",

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -1772,6 +1772,7 @@ sp_api::impl_runtime_apis! {
 		}
 	}
 
+	#[api_version(2)]
 	impl beefy_primitives::BeefyApi<Block> for Runtime {
 		fn beefy_genesis() -> Option<BlockNumber> {
 			Beefy::genesis_block()
@@ -1809,6 +1810,7 @@ sp_api::impl_runtime_apis! {
 		}
 	}
 
+	#[api_version(2)]
 	impl mmr::MmrApi<Block, Hash, BlockNumber> for Runtime {
 		fn mmr_root() -> Result<Hash, mmr::Error> {
 			Ok(Mmr::mmr_root())


### PR DESCRIPTION
Versions `BeefyApi` & `MmrApi` deployed on rococo.

Companion for https://github.com/paritytech/substrate/pull/13509