### PR TITLE
Add std and test features for SafeCallFilter

### DIFF
--- a/runtime/kusama/src/xcm_config.rs
+++ b/runtime/kusama/src/xcm_config.rs
@@ -157,7 +157,7 @@ pub type Barrier = (
 pub struct SafeCallFilter;
 impl Contains<RuntimeCall> for SafeCallFilter {
 	fn contains(call: &RuntimeCall) -> bool {
-		#[cfg(feature = "runtime-benchmarks")]
+		#[cfg(any(feature = "std", feature = "runtime-benchmarks", test))]
 		{
 			if matches!(call, RuntimeCall::System(frame_system::Call::remark_with_event { .. })) {
 				return true

--- a/runtime/polkadot/src/xcm_config.rs
+++ b/runtime/polkadot/src/xcm_config.rs
@@ -153,7 +153,7 @@ pub type Barrier = (
 pub struct SafeCallFilter;
 impl Contains<RuntimeCall> for SafeCallFilter {
 	fn contains(call: &RuntimeCall) -> bool {
-		#[cfg(feature = "runtime-benchmarks")]
+		#[cfg(any(feature = "std", feature = "runtime-benchmarks", test))]
 		{
 			if matches!(call, RuntimeCall::System(frame_system::Call::remark_with_event { .. })) {
 				return true

--- a/runtime/rococo/src/xcm_config.rs
+++ b/runtime/rococo/src/xcm_config.rs
@@ -151,7 +151,7 @@ pub type Barrier = (
 pub struct SafeCallFilter;
 impl Contains<RuntimeCall> for SafeCallFilter {
 	fn contains(call: &RuntimeCall) -> bool {
-		#[cfg(feature = "runtime-benchmarks")]
+		#[cfg(any(feature = "std", feature = "runtime-benchmarks", test))]
 		{
 			if matches!(call, RuntimeCall::System(frame_system::Call::remark_with_event { .. })) {
 				return true

--- a/runtime/westend/src/xcm_config.rs
+++ b/runtime/westend/src/xcm_config.rs
@@ -123,7 +123,7 @@ pub type Barrier = (
 pub struct SafeCallFilter;
 impl Contains<RuntimeCall> for SafeCallFilter {
 	fn contains(call: &RuntimeCall) -> bool {
-		#[cfg(feature = "runtime-benchmarks")]
+		#[cfg(any(feature = "std", feature = "runtime-benchmarks", test))]
 		{
 			if matches!(call, RuntimeCall::System(frame_system::Call::remark_with_event { .. })) {
 				return true


### PR DESCRIPTION
https://github.com/shaunxw/xcm-simulator/blob/6847a58888e483f0ed2e0b72f90e00767ea0ecac/xcm-emulator/example/src/lib.rs#L204-L226

We have some `kusama/polkadot` runtime tests that require `frame_system::Call::<kusama_runtime::Runtime>::remark_with_event`