### PR TITLE
Decrease expected peer count in zombinenet tests

### DIFF
--- a/zombienet_tests/functional/0001-parachains-pvf.zndsl
+++ b/zombienet_tests/functional/0001-parachains-pvf.zndsl
@@ -33,14 +33,14 @@ one: parachain 2006 is registered within 60 seconds
 two: parachain 2007 is registered within 60 seconds
 
 # Check if network is fully connected.
-alice: reports peers count is at least 15 within 20 seconds
-bob: reports peers count is at least 15 within 20 seconds
-charlie: reports peers count is at least 15 within 20 seconds
-dave: reports peers count is at least 15 within 20 seconds
-ferdie: reports peers count is at least 15 within 20 seconds
-eve: reports peers count is at least 15 within 20 seconds
-one: reports peers count is at least 15 within 20 seconds
-two: reports peers count is at least 15 within 20 seconds
+alice: reports peers count is at least 8 within 20 seconds
+bob: reports peers count is at least 8 within 20 seconds
+charlie: reports peers count is at least 8 within 20 seconds
+dave: reports peers count is at least 8 within 20 seconds
+ferdie: reports peers count is at least 8 within 20 seconds
+eve: reports peers count is at least 8 within 20 seconds
+one: reports peers count is at least 8 within 20 seconds
+two: reports peers count is at least 8 within 20 seconds
 
 # Ensure parachains made progress.
 alice: parachain 2000 block height is at least 10 within 300 seconds

--- a/zombienet_tests/functional/0001-parachains-pvf.zndsl
+++ b/zombienet_tests/functional/0001-parachains-pvf.zndsl
@@ -32,16 +32,6 @@ eve: parachain 2005 is registered within 60 seconds
 one: parachain 2006 is registered within 60 seconds
 two: parachain 2007 is registered within 60 seconds
 
-# Check if network is fully connected.
-alice: reports peers count is at least 8 within 20 seconds
-bob: reports peers count is at least 8 within 20 seconds
-charlie: reports peers count is at least 8 within 20 seconds
-dave: reports peers count is at least 8 within 20 seconds
-ferdie: reports peers count is at least 8 within 20 seconds
-eve: reports peers count is at least 8 within 20 seconds
-one: reports peers count is at least 8 within 20 seconds
-two: reports peers count is at least 8 within 20 seconds
-
 # Ensure parachains made progress.
 alice: parachain 2000 block height is at least 10 within 300 seconds
 alice: parachain 2001 block height is at least 10 within 300 seconds

--- a/zombienet_tests/functional/0002-parachains-disputes.zndsl
+++ b/zombienet_tests/functional/0002-parachains-disputes.zndsl
@@ -27,15 +27,6 @@ bob: parachain 2001 is registered within 30 seconds
 charlie: parachain 2002 is registered within 30 seconds
 dave: parachain 2003 is registered within 30 seconds
 
-alice: reports peers count is at least 8 within 20 seconds
-bob: reports peers count is at least 8 within 20 seconds
-charlie: reports peers count is at least 8 within 20 seconds
-dave: reports peers count is at least 8 within 20 seconds
-ferdie: reports peers count is at least 8 within 20 seconds
-eve: reports peers count is at least 8 within 20 seconds
-one: reports peers count is at least 8 within 20 seconds
-two: reports peers count is at least 8 within 20 seconds
-
 # Ensure parachains made progress.
 alice: parachain 2000 block height is at least 10 within 200 seconds
 alice: parachain 2001 block height is at least 10 within 200 seconds

--- a/zombienet_tests/functional/0002-parachains-disputes.zndsl
+++ b/zombienet_tests/functional/0002-parachains-disputes.zndsl
@@ -27,14 +27,14 @@ bob: parachain 2001 is registered within 30 seconds
 charlie: parachain 2002 is registered within 30 seconds
 dave: parachain 2003 is registered within 30 seconds
 
-alice: reports peers count is at least 11 within 20 seconds
-bob: reports peers count is at least 11 within 20 seconds
-charlie: reports peers count is at least 11 within 20 seconds
-dave: reports peers count is at least 11 within 20 seconds
-ferdie: reports peers count is at least 1 within 20 seconds
-eve: reports peers count is at least 11 within 20 seconds
-one: reports peers count is at least 11 within 20 seconds
-two: reports peers count is at least 11 within 20 seconds
+alice: reports peers count is at least 8 within 20 seconds
+bob: reports peers count is at least 8 within 20 seconds
+charlie: reports peers count is at least 8 within 20 seconds
+dave: reports peers count is at least 8 within 20 seconds
+ferdie: reports peers count is at least 8 within 20 seconds
+eve: reports peers count is at least 8 within 20 seconds
+one: reports peers count is at least 8 within 20 seconds
+two: reports peers count is at least 8 within 20 seconds
 
 # Ensure parachains made progress.
 alice: parachain 2000 block height is at least 10 within 200 seconds

--- a/zombienet_tests/misc/0001-paritydb.toml
+++ b/zombienet_tests/misc/0001-paritydb.toml
@@ -30,7 +30,7 @@ genesis_state_generator = "undying-collator export-genesis-state --pov-size={{10
     name = "collator"
     image = "{{COL_IMAGE}}"
     command = "undying-collator"
-    args = ["-lparachain=debug", "--pov-size={{10000*(id-1999)}}", "--parachain-id={{id}}", "--pvf-complexity={{id - 1999}} --out-peers 15"]
+    args = ["-lparachain=debug", "--pov-size={{10000*(id-1999)}}", "--parachain-id={{id}}", "--pvf-complexity={{id - 1999}}"]
 
 {% endfor %}
 

--- a/zombienet_tests/misc/0001-paritydb.toml
+++ b/zombienet_tests/misc/0001-paritydb.toml
@@ -30,7 +30,7 @@ genesis_state_generator = "undying-collator export-genesis-state --pov-size={{10
     name = "collator"
     image = "{{COL_IMAGE}}"
     command = "undying-collator"
-    args = ["-lparachain=debug", "--pov-size={{10000*(id-1999)}}", "--parachain-id={{id}}", "--pvf-complexity={{id - 1999}}"]
+    args = ["-lparachain=debug", "--pov-size={{10000*(id-1999)}}", "--parachain-id={{id}}", "--pvf-complexity={{id - 1999}} --out-peers 15"]
 
 {% endfor %}
 

--- a/zombienet_tests/misc/0001-paritydb.zndsl
+++ b/zombienet_tests/misc/0001-paritydb.zndsl
@@ -41,18 +41,6 @@ validator-0: parachain 2007 is registered
 validator-0: parachain 2008 is registered
 validator-0: parachain 2009 is registered
 
-# Check if network is fully connected.
-validator-0: reports peers count is at least 19 within 20 seconds
-validator-1: reports peers count is at least 19 within 20 seconds
-validator-2: reports peers count is at least 19 within 20 seconds
-validator-3: reports peers count is at least 19 within 20 seconds
-validator-4: reports peers count is at least 19 within 20 seconds
-validator-5: reports peers count is at least 19 within 20 seconds
-validator-6: reports peers count is at least 19 within 20 seconds
-validator-7: reports peers count is at least 19 within 20 seconds
-validator-8: reports peers count is at least 19 within 20 seconds
-validator-9: reports peers count is at least 19 within 20 seconds
-
 # Ensure parachains made some progress.
 validator-0: parachain 2000 block height is at least 3 within 30 seconds
 validator-0: parachain 2001 block height is at least 3 within 30 seconds

--- a/zombienet_tests/misc/0001-paritydb.zndsl
+++ b/zombienet_tests/misc/0001-paritydb.zndsl
@@ -42,16 +42,16 @@ validator-0: parachain 2008 is registered
 validator-0: parachain 2009 is registered
 
 # Check if network is fully connected.
-validator-0: reports peers count is at least 8 within 20 seconds
-validator-1: reports peers count is at least 8 within 20 seconds
-validator-2: reports peers count is at least 8 within 20 seconds
-validator-3: reports peers count is at least 8 within 20 seconds
-validator-4: reports peers count is at least 8 within 20 seconds
-validator-5: reports peers count is at least 8 within 20 seconds
-validator-6: reports peers count is at least 8 within 20 seconds
-validator-7: reports peers count is at least 8 within 20 seconds
-validator-8: reports peers count is at least 8 within 20 seconds
-validator-9: reports peers count is at least 8 within 20 seconds
+validator-0: reports peers count is at least 19 within 20 seconds
+validator-1: reports peers count is at least 19 within 20 seconds
+validator-2: reports peers count is at least 19 within 20 seconds
+validator-3: reports peers count is at least 19 within 20 seconds
+validator-4: reports peers count is at least 19 within 20 seconds
+validator-5: reports peers count is at least 19 within 20 seconds
+validator-6: reports peers count is at least 19 within 20 seconds
+validator-7: reports peers count is at least 19 within 20 seconds
+validator-8: reports peers count is at least 19 within 20 seconds
+validator-9: reports peers count is at least 19 within 20 seconds
 
 # Ensure parachains made some progress.
 validator-0: parachain 2000 block height is at least 3 within 30 seconds

--- a/zombienet_tests/misc/0001-paritydb.zndsl
+++ b/zombienet_tests/misc/0001-paritydb.zndsl
@@ -42,16 +42,16 @@ validator-0: parachain 2008 is registered
 validator-0: parachain 2009 is registered
 
 # Check if network is fully connected.
-validator-0: reports peers count is at least 19 within 20 seconds
-validator-1: reports peers count is at least 19 within 20 seconds
-validator-2: reports peers count is at least 19 within 20 seconds
-validator-3: reports peers count is at least 19 within 20 seconds
-validator-4: reports peers count is at least 19 within 20 seconds
-validator-5: reports peers count is at least 19 within 20 seconds
-validator-6: reports peers count is at least 19 within 20 seconds
-validator-7: reports peers count is at least 19 within 20 seconds
-validator-8: reports peers count is at least 19 within 20 seconds
-validator-9: reports peers count is at least 19 within 20 seconds
+validator-0: reports peers count is at least 8 within 20 seconds
+validator-1: reports peers count is at least 8 within 20 seconds
+validator-2: reports peers count is at least 8 within 20 seconds
+validator-3: reports peers count is at least 8 within 20 seconds
+validator-4: reports peers count is at least 8 within 20 seconds
+validator-5: reports peers count is at least 8 within 20 seconds
+validator-6: reports peers count is at least 8 within 20 seconds
+validator-7: reports peers count is at least 8 within 20 seconds
+validator-8: reports peers count is at least 8 within 20 seconds
+validator-9: reports peers count is at least 8 within 20 seconds
 
 # Ensure parachains made some progress.
 validator-0: parachain 2000 block height is at least 3 within 30 seconds


### PR DESCRIPTION
Recent change in the in/out peer ratio caused some of the zombienet tests to fail. Adjust the number of expected peers to reflect the new ratio to make tests pass again.