### PR TITLE
Async Backing - Remove restart from runtime upgrade zombienet test

### DIFF
--- a/zombienet_tests/async_backing/002-async-backing-runtime-upgrade.zndsl
+++ b/zombienet_tests/async_backing/002-async-backing-runtime-upgrade.zndsl
@@ -32,12 +32,3 @@ bob: run ../misc/0002-download-polkadot-from-pr.sh with "{{POLKADOT_PR_BIN_URL}}
 
 # Bootstrap the runtime upgrade
 sleep 30 seconds
-
-alice: restart after 5 seconds
-bob: restart after 5 seconds
-
-alice: is up within 10 seconds
-bob: is up within 10 seconds
-
-alice: parachain 100 block height is at least 10 within 250 seconds
-bob: parachain 101 block height is at least 10 within 250 seconds


### PR DESCRIPTION
Removes the unnecessary restart test from the runtime upgrade test