### PR TITLE
Whitelist from benchmarking XCM storage keys read each block

### DIFF
--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -2098,6 +2098,12 @@ sp_api::impl_runtime_apis! {
 				hex_literal::hex!("06de3d8a54d27e44a9d5ce189618f22db4b49d95320d9021994c850f25b8e385").to_vec().into(),
 				// The transactional storage limit.
 				hex_literal::hex!("3a7472616e73616374696f6e5f6c6576656c3a").to_vec().into(),
+				// XcmPallet SupportedVersion
+				hex_literal::hex!("1405f2411d0af5a7ff397e7c9dc68d19908b4dae59e7d658f23d261c5e5db22b").to_vec().into(),
+				// XcmPallet VersionDiscoveryQueue
+				hex_literal::hex!("1405f2411d0af5a7ff397e7c9dc68d194a222ba0333561192e474c59ed8e30e1").to_vec().into(),
+				// XcmPallet SafeXcmVersion
+				hex_literal::hex!("1405f2411d0af5a7ff397e7c9dc68d196323ae84c43568be0d1394d5d0d522c4").to_vec().into(),
 			];
 
 			let mut batches = Vec::<BenchmarkBatch>::new();

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -2128,6 +2128,12 @@ sp_api::impl_runtime_apis! {
 				hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef780d41e5e16056765bc8461851072c9d7").to_vec().into(),
 				// Treasury Account
 				hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef7b99d880ec681799c0cf30e8886371da95ecffd7b6c0f78751baa9d281e0bfa3a6d6f646c70792f74727372790000000000000000000000000000000000000000").to_vec().into(),
+				// XcmPallet SupportedVersion
+				hex_literal::hex!("1405f2411d0af5a7ff397e7c9dc68d19908b4dae59e7d658f23d261c5e5db22b").to_vec().into(),
+				// XcmPallet VersionDiscoveryQueue
+				hex_literal::hex!("1405f2411d0af5a7ff397e7c9dc68d194a222ba0333561192e474c59ed8e30e1").to_vec().into(),
+				// XcmPallet SafeXcmVersion
+				hex_literal::hex!("1405f2411d0af5a7ff397e7c9dc68d196323ae84c43568be0d1394d5d0d522c4").to_vec().into(),
 			];
 
 			let mut batches = Vec::<BenchmarkBatch>::new();

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -2121,6 +2121,12 @@ sp_api::impl_runtime_apis! {
 				hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef780d41e5e16056765bc8461851072c9d7").to_vec().into(),
 				// Treasury Account
 				hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef7b99d880ec681799c0cf30e8886371da95ecffd7b6c0f78751baa9d281e0bfa3a6d6f646c70792f74727372790000000000000000000000000000000000000000").to_vec().into(),
+				// XcmPallet SupportedVersion
+				hex_literal::hex!("1405f2411d0af5a7ff397e7c9dc68d19908b4dae59e7d658f23d261c5e5db22b").to_vec().into(),
+				// XcmPallet VersionDiscoveryQueue
+				hex_literal::hex!("1405f2411d0af5a7ff397e7c9dc68d194a222ba0333561192e474c59ed8e30e1").to_vec().into(),
+				// XcmPallet SafeXcmVersion
+				hex_literal::hex!("1405f2411d0af5a7ff397e7c9dc68d196323ae84c43568be0d1394d5d0d522c4").to_vec().into(),
 			];
 
 			let mut batches = Vec::<BenchmarkBatch>::new();

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -1844,6 +1844,12 @@ sp_api::impl_runtime_apis! {
 				hex_literal::hex!("06de3d8a54d27e44a9d5ce189618f22db4b49d95320d9021994c850f25b8e385").to_vec().into(),
 				// The transactional storage limit.
 				hex_literal::hex!("3a7472616e73616374696f6e5f6c6576656c3a").to_vec().into(),
+				// XcmPallet SupportedVersion
+				hex_literal::hex!("1405f2411d0af5a7ff397e7c9dc68d19908b4dae59e7d658f23d261c5e5db22b").to_vec().into(),
+				// XcmPallet VersionDiscoveryQueue
+				hex_literal::hex!("1405f2411d0af5a7ff397e7c9dc68d194a222ba0333561192e474c59ed8e30e1").to_vec().into(),
+				// XcmPallet SafeXcmVersion
+				hex_literal::hex!("1405f2411d0af5a7ff397e7c9dc68d196323ae84c43568be0d1394d5d0d522c4").to_vec().into(),
 			];
 
 			let mut batches = Vec::<BenchmarkBatch>::new();


### PR DESCRIPTION
Added the following XcmPallet storage keys to the benchmark whitelist on all runtimes since they are read every block:
- SupportedVersion
- VersionDiscoveryQueue
- SafeXcmVersion

Addresses https://github.com/paritytech/polkadot/issues/5203