### PR TITLE
changelog: template fixup

### DIFF
--- a/scripts/ci/changelog/templates/host_functions.md.tera
+++ b/scripts/ci/changelog/templates/host_functions.md.tera
@@ -10,13 +10,12 @@
     {%- if pr.meta.E and pr.meta.E.E3 -%}
         {%- set_global host_fn_count = host_fn_count + 1 -%}
             - {{ m_c::change(c=pr) }}
-        {% endif -%}
     {% endif -%}
     {%- if pr.meta.E and pr.meta.E.E4 -%}
         {%- set_global upgrade_first = upgrade_first + 1 -%}
             - {{ m_c::change(c=pr) }}
-        {% endif -%}
     {% endif -%}
+{% endif -%}
 {%- endfor -%}
 
 <!-- {{ upgrade_first }} changes require node upgrade -->


### PR DESCRIPTION
removes an unmatched endif that slipped through and prevented changelogs from being generated

this fix is already deployed on the current release branch