### PR TITLE
Added NominationPools proxy type

### DIFF
--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -1062,9 +1062,8 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 					RuntimeCall::Slots(..)
 			),
 			ProxyType::Society => matches!(c, RuntimeCall::Society(..)),
-			ProxyType::NominationPools => matches!(
-				c, RuntimeCall::NominationPools(..) | RuntimeCall::Utility(..)
-			),
+			ProxyType::NominationPools =>
+				matches!(c, RuntimeCall::NominationPools(..) | RuntimeCall::Utility(..)),
 		}
 	}
 	fn is_superset(&self, o: &Self) -> bool {

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -952,6 +952,7 @@ pub enum ProxyType {
 	CancelProxy,
 	Auction,
 	Society,
+	NominationPools,
 }
 
 impl Default for ProxyType {
@@ -1061,6 +1062,9 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 					RuntimeCall::Slots(..)
 			),
 			ProxyType::Society => matches!(c, RuntimeCall::Society(..)),
+			ProxyType::NominationPools => matches!(
+				c, RuntimeCall::NominationPools(..) | RuntimeCall::Utility(..)
+			),
 		}
 	}
 	fn is_superset(&self, o: &Self) -> bool {

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -1232,9 +1232,8 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 					RuntimeCall::Registrar(..) |
 					RuntimeCall::Slots(..)
 			),
-			ProxyType::NominationPools => matches!(
-				c, RuntimeCall::NominationPools(..) | RuntimeCall::Utility(..)
-			),
+			ProxyType::NominationPools =>
+				matches!(c, RuntimeCall::NominationPools(..) | RuntimeCall::Utility(..)),
 		}
 	}
 	fn is_superset(&self, o: &Self) -> bool {

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -1112,6 +1112,7 @@ pub enum ProxyType {
 	IdentityJudgement = 5,
 	CancelProxy = 6,
 	Auction = 7,
+	NominationPools = 8,
 }
 
 #[cfg(test)]
@@ -1230,6 +1231,9 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 					RuntimeCall::Crowdloan(..) |
 					RuntimeCall::Registrar(..) |
 					RuntimeCall::Slots(..)
+			),
+			ProxyType::NominationPools => matches!(
+				c, RuntimeCall::NominationPools(..) | RuntimeCall::Utility(..)
 			),
 		}
 	}

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -843,9 +843,8 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 					RuntimeCall::Registrar(..) |
 					RuntimeCall::Slots(..)
 			),
-			ProxyType::NominationPools => matches!(
-				c, RuntimeCall::NominationPools(..) | RuntimeCall::Utility(..)
-			),
+			ProxyType::NominationPools =>
+				matches!(c, RuntimeCall::NominationPools(..) | RuntimeCall::Utility(..)),
 		}
 	}
 	fn is_superset(&self, o: &Self) -> bool {

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -761,6 +761,7 @@ pub enum ProxyType {
 	IdentityJudgement,
 	CancelProxy,
 	Auction,
+	NominationPools,
 }
 impl Default for ProxyType {
 	fn default() -> Self {
@@ -841,6 +842,9 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 					RuntimeCall::Crowdloan(..) |
 					RuntimeCall::Registrar(..) |
 					RuntimeCall::Slots(..)
+			),
+			ProxyType::NominationPools => matches!(
+				c, RuntimeCall::NominationPools(..) | RuntimeCall::Utility(..)
 			),
 		}
 	}


### PR DESCRIPTION
Added `NominationPools` proxy type.

It allows to create a Proxy with type `NominationPools`. The proxy with NominationPools type should be used for `nomination-pools` module calls. 
