### PR TITLE
Vstam1/xcm admin origin

### DIFF
--- a/runtime/kusama/src/xcm_config.rs
+++ b/runtime/kusama/src/xcm_config.rs
@@ -26,6 +26,7 @@ use frame_support::{
 	traits::{Contains, Everything, Nothing},
 	weights::Weight,
 };
+use frame_system::EnsureRoot;
 use runtime_common::{paras_registrar, xcm_sender, ToAuthor};
 use sp_core::ConstU32;
 use xcm::latest::prelude::*;
@@ -456,6 +457,7 @@ impl pallet_xcm::Config for Runtime {
 	type WeightInfo = crate::weights::pallet_xcm::WeightInfo<Runtime>;
 	#[cfg(feature = "runtime-benchmarks")]
 	type ReachableDest = ReachableDest;
+	type AdminOrigin = EnsureRoot<AccountId>;
 }
 
 #[test]

--- a/runtime/polkadot/src/xcm_config.rs
+++ b/runtime/polkadot/src/xcm_config.rs
@@ -25,6 +25,7 @@ use frame_support::{
 	traits::{Contains, Everything, Nothing},
 	weights::Weight,
 };
+use frame_system::EnsureRoot;
 use runtime_common::{paras_registrar, xcm_sender, ToAuthor};
 use sp_core::ConstU32;
 use xcm::latest::prelude::*;
@@ -389,4 +390,5 @@ impl pallet_xcm::Config for Runtime {
 	type WeightInfo = crate::weights::pallet_xcm::WeightInfo<Runtime>;
 	#[cfg(feature = "runtime-benchmarks")]
 	type ReachableDest = ReachableDest;
+	type AdminOrigin = EnsureRoot<AccountId>;
 }

--- a/runtime/rococo/src/xcm_config.rs
+++ b/runtime/rococo/src/xcm_config.rs
@@ -25,6 +25,7 @@ use frame_support::{
 	traits::{Contains, Everything, Nothing},
 	weights::Weight,
 };
+use frame_system::EnsureRoot;
 use runtime_common::{paras_registrar, xcm_sender, ToAuthor};
 use sp_core::ConstU32;
 use xcm::latest::prelude::*;
@@ -364,4 +365,5 @@ impl pallet_xcm::Config for Runtime {
 	type WeightInfo = crate::weights::pallet_xcm::WeightInfo<Runtime>;
 	#[cfg(feature = "runtime-benchmarks")]
 	type ReachableDest = ReachableDest;
+	type AdminOrigin = EnsureRoot<AccountId>;
 }

--- a/runtime/test-runtime/src/xcm_config.rs
+++ b/runtime/test-runtime/src/xcm_config.rs
@@ -19,6 +19,7 @@ use frame_support::{
 	traits::{Everything, Nothing},
 	weights::Weight,
 };
+use frame_system::EnsureRoot;
 use xcm::latest::prelude::*;
 use xcm_builder::{
 	AllowUnpaidExecutionFrom, EnsureXcmOrigin, FixedWeightBounds, SignedAccountId32AsNative,
@@ -146,4 +147,5 @@ impl pallet_xcm::Config for crate::Runtime {
 	type WeightInfo = pallet_xcm::TestWeightInfo;
 	#[cfg(feature = "runtime-benchmarks")]
 	type ReachableDest = ReachableDest;
+	type AdminOrigin = EnsureRoot<crate::AccountId>;
 }

--- a/runtime/westend/src/xcm_config.rs
+++ b/runtime/westend/src/xcm_config.rs
@@ -24,6 +24,7 @@ use frame_support::{
 	parameter_types,
 	traits::{Contains, Everything, Nothing},
 };
+use frame_system::EnsureRoot;
 use runtime_common::{paras_registrar, xcm_sender, ToAuthor};
 use sp_core::ConstU32;
 use xcm::latest::prelude::*;
@@ -279,4 +280,5 @@ impl pallet_xcm::Config for Runtime {
 	type WeightInfo = crate::weights::pallet_xcm::WeightInfo<Runtime>;
 	#[cfg(feature = "runtime-benchmarks")]
 	type ReachableDest = ReachableDest;
+	type AdminOrigin = EnsureRoot<AccountId>;
 }

--- a/xcm/pallet-xcm/src/lib.rs
+++ b/xcm/pallet-xcm/src/lib.rs
@@ -231,7 +231,7 @@ pub mod pallet {
 		/// `pallet_xcm::CurrentXcmVersion`.
 		type AdvertisedXcmVersion: Get<XcmVersion>;
 
-		/// The origin that is allowed to call privileged operations on the XCM pallet 
+		/// The origin that is allowed to call privileged operations on the XCM pallet
 		type AdminOrigin: EnsureOrigin<<Self as SysConfig>::RuntimeOrigin>;
 
 		/// The assets which we consider a given origin is trusted if they claim to have placed a

--- a/xcm/pallet-xcm/src/lib.rs
+++ b/xcm/pallet-xcm/src/lib.rs
@@ -231,6 +231,9 @@ pub mod pallet {
 		/// `pallet_xcm::CurrentXcmVersion`.
 		type AdvertisedXcmVersion: Get<XcmVersion>;
 
+		/// The origin that is allowed to call privileged operations on the XCM pallet 
+		type AdminOrigin: EnsureOrigin<<Self as SysConfig>::RuntimeOrigin>;
+
 		/// The assets which we consider a given origin is trusted if they claim to have placed a
 		/// lock.
 		type TrustedLockers: ContainsPair<MultiLocation, MultiAsset>;
@@ -915,7 +918,7 @@ pub mod pallet {
 			location: Box<MultiLocation>,
 			xcm_version: XcmVersion,
 		) -> DispatchResult {
-			ensure_root(origin)?;
+			T::AdminOrigin::ensure_origin(origin)?;
 			let location = *location;
 			SupportedVersion::<T>::insert(
 				XCM_VERSION,
@@ -937,7 +940,7 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			maybe_xcm_version: Option<XcmVersion>,
 		) -> DispatchResult {
-			ensure_root(origin)?;
+			T::AdminOrigin::ensure_origin(origin)?;
 			SafeXcmVersion::<T>::set(maybe_xcm_version);
 			Ok(())
 		}
@@ -952,7 +955,7 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			location: Box<VersionedMultiLocation>,
 		) -> DispatchResult {
-			ensure_root(origin)?;
+			T::AdminOrigin::ensure_origin(origin)?;
 			let location: MultiLocation =
 				(*location).try_into().map_err(|()| Error::<T>::BadLocation)?;
 			Self::request_version_notify(location).map_err(|e| {
@@ -976,7 +979,7 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			location: Box<VersionedMultiLocation>,
 		) -> DispatchResult {
-			ensure_root(origin)?;
+			T::AdminOrigin::ensure_origin(origin)?;
 			let location: MultiLocation =
 				(*location).try_into().map_err(|()| Error::<T>::BadLocation)?;
 			Self::unrequest_version_notify(location).map_err(|e| {

--- a/xcm/pallet-xcm/src/mock.rs
+++ b/xcm/pallet-xcm/src/mock.rs
@@ -20,6 +20,7 @@ use frame_support::{
 	traits::{ConstU32, Everything, Nothing},
 	weights::Weight,
 };
+use frame_system::EnsureRoot;
 use polkadot_parachain::primitives::Id as ParaId;
 use polkadot_runtime_parachains::origin;
 use sp_core::H256;
@@ -344,6 +345,7 @@ impl pallet_xcm::Config for Test {
 	type WeightInfo = TestWeightInfo;
 	#[cfg(feature = "runtime-benchmarks")]
 	type ReachableDest = ReachableDest;
+	type AdminOrigin = EnsureRoot<AccountId>;
 }
 
 impl origin::Config for Test {}

--- a/xcm/xcm-builder/tests/mock/mod.rs
+++ b/xcm/xcm-builder/tests/mock/mod.rs
@@ -19,6 +19,7 @@ use frame_support::{
 	traits::{ConstU32, Everything, Nothing},
 	weights::Weight,
 };
+use frame_system::EnsureRoot;
 use parity_scale_codec::Encode;
 use primitive_types::H256;
 use sp_runtime::{testing::Header, traits::IdentityLookup, AccountId32};
@@ -235,6 +236,7 @@ impl pallet_xcm::Config for Runtime {
 	type WeightInfo = pallet_xcm::TestWeightInfo;
 	#[cfg(feature = "runtime-benchmarks")]
 	type ReachableDest = ReachableDest;
+	type AdminOrigin = EnsureRoot<AccountId>;
 }
 
 impl origin::Config for Runtime {}

--- a/xcm/xcm-simulator/example/src/parachain.rs
+++ b/xcm/xcm-simulator/example/src/parachain.rs
@@ -23,8 +23,8 @@ use frame_support::{
 	weights::{constants::WEIGHT_REF_TIME_PER_SECOND, Weight},
 };
 
-use sp_core::{ConstU32, H256};
 use frame_system::EnsureRoot;
+use sp_core::{ConstU32, H256};
 use sp_runtime::{
 	testing::Header,
 	traits::{Hash, IdentityLookup},

--- a/xcm/xcm-simulator/example/src/parachain.rs
+++ b/xcm/xcm-simulator/example/src/parachain.rs
@@ -22,7 +22,9 @@ use frame_support::{
 	traits::{EnsureOrigin, EnsureOriginWithArg, Everything, EverythingBut, Nothing},
 	weights::{constants::WEIGHT_REF_TIME_PER_SECOND, Weight},
 };
+
 use sp_core::{ConstU32, H256};
+use frame_system::EnsureRoot;
 use sp_runtime::{
 	testing::Header,
 	traits::{Hash, IdentityLookup},
@@ -424,6 +426,7 @@ impl pallet_xcm::Config for Runtime {
 	type WeightInfo = pallet_xcm::TestWeightInfo;
 	#[cfg(feature = "runtime-benchmarks")]
 	type ReachableDest = ReachableDest;
+	type AdminOrigin = EnsureRoot<AccountId>;
 }
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;

--- a/xcm/xcm-simulator/example/src/relay_chain.rs
+++ b/xcm/xcm-simulator/example/src/relay_chain.rs
@@ -21,7 +21,9 @@ use frame_support::{
 	traits::{AsEnsureOriginWithArg, Everything, Nothing},
 	weights::Weight,
 };
+
 use sp_core::{ConstU32, H256};
+use frame_system::EnsureRoot;
 use sp_runtime::{testing::Header, traits::IdentityLookup, AccountId32};
 
 use polkadot_parachain::primitives::Id as ParaId;
@@ -221,6 +223,7 @@ impl pallet_xcm::Config for Runtime {
 	type WeightInfo = pallet_xcm::TestWeightInfo;
 	#[cfg(feature = "runtime-benchmarks")]
 	type ReachableDest = ReachableDest;
+	type AdminOrigin = EnsureRoot<AccountId>;
 }
 
 parameter_types! {

--- a/xcm/xcm-simulator/example/src/relay_chain.rs
+++ b/xcm/xcm-simulator/example/src/relay_chain.rs
@@ -22,8 +22,8 @@ use frame_support::{
 	weights::Weight,
 };
 
-use sp_core::{ConstU32, H256};
 use frame_system::EnsureRoot;
+use sp_core::{ConstU32, H256};
 use sp_runtime::{testing::Header, traits::IdentityLookup, AccountId32};
 
 use polkadot_parachain::primitives::Id as ParaId;

--- a/xcm/xcm-simulator/fuzzer/src/parachain.rs
+++ b/xcm/xcm-simulator/fuzzer/src/parachain.rs
@@ -23,8 +23,8 @@ use frame_support::{
 	weights::{constants::WEIGHT_REF_TIME_PER_SECOND, Weight},
 };
 
-use sp_core::{ConstU32, H256};
 use frame_system::EnsureRoot;
+use sp_core::{ConstU32, H256};
 use sp_runtime::{
 	testing::Header,
 	traits::{Hash, IdentityLookup},

--- a/xcm/xcm-simulator/fuzzer/src/parachain.rs
+++ b/xcm/xcm-simulator/fuzzer/src/parachain.rs
@@ -22,7 +22,9 @@ use frame_support::{
 	traits::{Everything, Nothing},
 	weights::{constants::WEIGHT_REF_TIME_PER_SECOND, Weight},
 };
+
 use sp_core::{ConstU32, H256};
+use frame_system::EnsureRoot;
 use sp_runtime::{
 	testing::Header,
 	traits::{Hash, IdentityLookup},
@@ -339,6 +341,7 @@ impl pallet_xcm::Config for Runtime {
 	type WeightInfo = pallet_xcm::TestWeightInfo;
 	#[cfg(feature = "runtime-benchmarks")]
 	type ReachableDest = ReachableDest;
+	type AdminOrigin = EnsureRoot<AccountId>;
 }
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;

--- a/xcm/xcm-simulator/fuzzer/src/relay_chain.rs
+++ b/xcm/xcm-simulator/fuzzer/src/relay_chain.rs
@@ -22,8 +22,8 @@ use frame_support::{
 	weights::Weight,
 };
 
-use sp_core::{ConstU32, H256};
 use frame_system::EnsureRoot;
+use sp_core::{ConstU32, H256};
 use sp_runtime::{testing::Header, traits::IdentityLookup, AccountId32};
 
 use polkadot_parachain::primitives::Id as ParaId;

--- a/xcm/xcm-simulator/fuzzer/src/relay_chain.rs
+++ b/xcm/xcm-simulator/fuzzer/src/relay_chain.rs
@@ -21,7 +21,9 @@ use frame_support::{
 	traits::{Everything, Nothing},
 	weights::Weight,
 };
+
 use sp_core::{ConstU32, H256};
+use frame_system::EnsureRoot;
 use sp_runtime::{testing::Header, traits::IdentityLookup, AccountId32};
 
 use polkadot_parachain::primitives::Id as ParaId;
@@ -185,6 +187,7 @@ impl pallet_xcm::Config for Runtime {
 	type WeightInfo = pallet_xcm::TestWeightInfo;
 	#[cfg(feature = "runtime-benchmarks")]
 	type ReachableDest = ReachableDest;
+	type AdminOrigin = EnsureRoot<AccountId>;
 }
 
 parameter_types! {


### PR DESCRIPTION
Fixes CI from https://github.com/paritytech/polkadot/pull/6632. Commit https://github.com/paritytech/polkadot/commit/5ae05e1a957857c449a43d8759a21292d03fd049 cherry-picked as solution for https://github.com/paritytech/polkadot/issues/6442

> Add new associated type, AdminOrigin, bounded by EnsureOrigin trait in XCM-pallet config. Replace ensure_root() with ensure_origin(). Use EnsureRoot in all implementations of XCM pallet to preserve the current behavior until Gov2 specific origins are implemented.