### PR TITLE
runtime/inclusion: fix availability_threshold

### DIFF
--- a/primitives/src/v4/mod.rs
+++ b/primitives/src/v4/mod.rs
@@ -1609,13 +1609,13 @@ where
 /// The maximum number of validators `f` which may safely be faulty.
 ///
 /// The total number of validators is `n = 3f + e` where `e in { 1, 2, 3 }`.
-pub fn byzantine_threshold(n: usize) -> usize {
+pub const fn byzantine_threshold(n: usize) -> usize {
 	n.saturating_sub(1) / 3
 }
 
 /// The supermajority threshold of validators which represents a subset
 /// guaranteed to have at least f+1 honest validators.
-pub fn supermajority_threshold(n: usize) -> usize {
+pub const fn supermajority_threshold(n: usize) -> usize {
 	n - byzantine_threshold(n)
 }
 

--- a/runtime/parachains/src/inclusion/mod.rs
+++ b/runtime/parachains/src/inclusion/mod.rs
@@ -28,10 +28,10 @@ use bitvec::{order::Lsb0 as BitOrderLsb0, vec::BitVec};
 use frame_support::pallet_prelude::*;
 use parity_scale_codec::{Decode, Encode};
 use primitives::{
-	AvailabilityBitfield, BackedCandidate, CandidateCommitments, CandidateDescriptor,
-	CandidateHash, CandidateReceipt, CommittedCandidateReceipt, CoreIndex, GroupIndex, Hash,
-	HeadData, Id as ParaId, SigningContext, UncheckedSignedAvailabilityBitfields, ValidatorId,
-	ValidatorIndex, ValidityAttestation,
+	supermajority_threshold, AvailabilityBitfield, BackedCandidate, CandidateCommitments,
+	CandidateDescriptor, CandidateHash, CandidateReceipt, CommittedCandidateReceipt, CoreIndex,
+	GroupIndex, Hash, HeadData, Id as ParaId, SigningContext, UncheckedSignedAvailabilityBitfields,
+	ValidatorId, ValidatorIndex, ValidityAttestation,
 };
 use scale_info::TypeInfo;
 use sp_runtime::{traits::One, DispatchError};
@@ -899,9 +899,7 @@ impl<T: Config> Pallet<T> {
 }
 
 const fn availability_threshold(n_validators: usize) -> usize {
-	let mut threshold = (n_validators * 2) / 3;
-	threshold += (n_validators * 2) % 3;
-	threshold
+	supermajority_threshold(n_validators)
 }
 
 #[derive(derive_more::From, Debug)]

--- a/runtime/parachains/src/inclusion/tests.rs
+++ b/runtime/parachains/src/inclusion/tests.rs
@@ -711,6 +711,13 @@ fn bitfield_checks() {
 }
 
 #[test]
+fn availability_threshold_is_supermajority() {
+	assert_eq!(3, availability_threshold(4));
+	assert_eq!(5, availability_threshold(6));
+	assert_eq!(7, availability_threshold(9));
+}
+
+#[test]
 fn supermajority_bitfields_trigger_availability() {
 	let chain_a = ParaId::from(1_u32);
 	let chain_b = ParaId::from(2_u32);


### PR DESCRIPTION
This function was giving incorrect results mostly affecting small networks. It doesn't affect production networks where `n_validators` is currently at 200.
For example, for 4 validators, we expect the result to be 3 (2f + 1), whereas it would have returned 4.
For 6 validators, it would have returned 4 instead of 5.