### PR TITLE
Ensure candidate-backing and provisioner exit on missing Overseer

### DIFF
--- a/node/core/backing/src/error.rs
+++ b/node/core/backing/src/error.rs
@@ -70,6 +70,10 @@ pub enum Error {
 
 	#[error(transparent)]
 	SubsystemError(#[from] SubsystemError),
+
+	#[fatal]
+	#[error(transparent)]
+	OverseerExited(SubsystemError),
 }
 
 /// Utility for eating top level errors and log them.

--- a/node/core/backing/src/lib.rs
+++ b/node/core/backing/src/lib.rs
@@ -199,7 +199,8 @@ async fn run_iteration<Context>(
 				}
 			}
 			from_overseer = ctx.recv().fuse() => {
-				match from_overseer? {
+				// Map the error to ensure that the subsystem exits when the overseer is gone.
+				match from_overseer.map_err(Error::OverseerExited)? {
 					FromOrchestra::Signal(OverseerSignal::ActiveLeaves(update)) => handle_active_leaves_update(
 						&mut *ctx,
 						update,

--- a/node/core/provisioner/src/error.rs
+++ b/node/core/provisioner/src/error.rs
@@ -75,6 +75,10 @@ pub enum Error {
 
 	#[error(transparent)]
 	SubsystemError(#[from] SubsystemError),
+
+	#[fatal]
+	#[error(transparent)]
+	OverseerExited(SubsystemError),
 }
 
 /// Used by `get_onchain_disputes` to represent errors related to fetching on-chain disputes from the Runtime

--- a/node/core/provisioner/src/lib.rs
+++ b/node/core/provisioner/src/lib.rs
@@ -144,7 +144,8 @@ async fn run_iteration<Context>(
 	loop {
 		futures::select! {
 			from_overseer = ctx.recv().fuse() => {
-				match from_overseer? {
+				// Map the error to ensure that the subsystem exits when the overseer is gone.
+				match from_overseer.map_err(Error::OverseerExited)? {
 					FromOrchestra::Signal(OverseerSignal::ActiveLeaves(update)) =>
 						handle_active_leaves_update(update, per_relay_parent, inherent_delays),
 					FromOrchestra::Signal(OverseerSignal::BlockFinalized(..)) => {},


### PR DESCRIPTION
This ensures that both subsystems exit when the Overseer has exited because of some error.