### PR TITLE
malus: dont panic on missing validation data

### DIFF
--- a/node/malus/Cargo.toml
+++ b/node/malus/Cargo.toml
@@ -37,6 +37,7 @@ rand = "0.8.5"
 
 [features]
 default = []
+fast-runtime = ["polkadot-cli/fast-runtime"]
 
 [dev-dependencies]
 polkadot-node-subsystem-test-helpers = { path = "../subsystem-test-helpers" }

--- a/node/malus/src/variants/suggest_garbage_candidate.rs
+++ b/node/malus/src/variants/suggest_garbage_candidate.rs
@@ -122,17 +122,22 @@ where
 							{
 								Ok(Some((validation_data, validation_code))) => {
 									sender
-										.send((validation_data, validation_code, n_validators))
+										.send(Some((
+											validation_data,
+											validation_code,
+											n_validators,
+										)))
 										.expect("channel is still open");
 								},
 								_ => {
-									panic!("Unable to fetch validation data");
+									sender.send(None).expect("channel is still open");
 								},
 							}
 						}),
 					);
 
-					let (validation_data, validation_code, n_validators) = receiver.recv().unwrap();
+					let (validation_data, validation_code, n_validators) =
+						receiver.recv().unwrap()?;
 
 					let validation_data_hash = validation_data.hash();
 					let validation_code_hash = validation_code.hash();


### PR DESCRIPTION
Observed spurious failures when testing https://github.com/paritytech/polkadot/pull/6811.
Sometimes, we get `AssumptionCheckOutcome::BadRequest` from validation data request, I guess because of pruning
```
WARN tokio-runtime-worker parachain::runtime-api: cannot query the runtime API version: Api called for an unknown Block: State already discarded
```