### PR TITLE
configuration: backport async backing parameters from the feature branch

### DIFF
--- a/primitives/src/vstaging/mod.rs
+++ b/primitives/src/vstaging/mod.rs
@@ -17,3 +17,26 @@
 //! Staging Primitives.
 
 // Put any primitives used by staging APIs functions here
+pub use crate::v4::*;
+use sp_std::prelude::*;
+
+use parity_scale_codec::{Decode, Encode};
+use primitives::RuntimeDebug;
+use scale_info::TypeInfo;
+
+/// Candidate's acceptance limitations for asynchronous backing per relay parent.
+#[derive(RuntimeDebug, Copy, Clone, PartialEq, Encode, Decode, TypeInfo)]
+#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+pub struct AsyncBackingParameters {
+	/// The maximum number of para blocks between the para head in a relay parent
+	/// and a new candidate. Restricts nodes from building arbitrary long chains
+	/// and spamming other validators.
+	///
+	/// When async backing is disabled, the only valid value is 0.
+	pub max_candidate_depth: u32,
+	/// How many ancestors of a relay parent are allowed to build candidates on top
+	/// of.
+	///
+	/// When async backing is disabled, the only valid value is 0.
+	pub allowed_ancestry_len: u32,
+}

--- a/primitives/src/vstaging/mod.rs
+++ b/primitives/src/vstaging/mod.rs
@@ -27,7 +27,7 @@ use scale_info::TypeInfo;
 /// Candidate's acceptance limitations for asynchronous backing per relay parent.
 #[derive(RuntimeDebug, Copy, Clone, PartialEq, Encode, Decode, TypeInfo)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
-pub struct AsyncBackingParameters {
+pub struct AsyncBackingParams {
 	/// The maximum number of para blocks between the para head in a relay parent
 	/// and a new candidate. Restricts nodes from building arbitrary long chains
 	/// and spamming other validators.

--- a/runtime/parachains/src/configuration.rs
+++ b/runtime/parachains/src/configuration.rs
@@ -24,7 +24,7 @@ use frame_system::pallet_prelude::*;
 use parity_scale_codec::{Decode, Encode};
 use polkadot_parachain::primitives::{MAX_HORIZONTAL_MESSAGE_NUM, MAX_UPWARD_MESSAGE_NUM};
 use primitives::{
-	vstaging::AsyncBackingParameters, Balance, SessionIndex, MAX_CODE_SIZE, MAX_HEAD_DATA_SIZE,
+	vstaging::AsyncBackingParams, Balance, SessionIndex, MAX_CODE_SIZE, MAX_HEAD_DATA_SIZE,
 	MAX_POV_SIZE,
 };
 use sp_runtime::traits::Zero;
@@ -122,7 +122,7 @@ pub struct HostConfiguration<BlockNumber> {
 	 */
 
 	/// Asynchronous backing parameters.
-	pub async_backing_parameters: AsyncBackingParameters,
+	pub async_backing_params: AsyncBackingParams,
 	/// The maximum POV block size, in bytes.
 	pub max_pov_size: u32,
 	/// The maximum size of a message that can be put in a downward message queue.
@@ -248,7 +248,7 @@ pub struct HostConfiguration<BlockNumber> {
 impl<BlockNumber: Default + From<u32>> Default for HostConfiguration<BlockNumber> {
 	fn default() -> Self {
 		Self {
-			async_backing_parameters: AsyncBackingParameters {
+			async_backing_params: AsyncBackingParams {
 				max_candidate_depth: 0,
 				allowed_ancestry_len: 0,
 			},
@@ -1154,13 +1154,13 @@ pub mod pallet {
 			T::WeightInfo::set_config_with_option_u32(), // The same size in bytes.
 			DispatchClass::Operational,
 		))]
-		pub fn set_async_backing_parameters(
+		pub fn set_async_backing_params(
 			origin: OriginFor<T>,
-			new: AsyncBackingParameters,
+			new: AsyncBackingParams,
 		) -> DispatchResult {
 			ensure_root(origin)?;
 			Self::schedule_config_update(|config| {
-				config.async_backing_parameters = new;
+				config.async_backing_params = new;
 			})
 		}
 	}

--- a/runtime/parachains/src/configuration.rs
+++ b/runtime/parachains/src/configuration.rs
@@ -23,7 +23,10 @@ use frame_support::{pallet_prelude::*, weights::constants::WEIGHT_REF_TIME_PER_M
 use frame_system::pallet_prelude::*;
 use parity_scale_codec::{Decode, Encode};
 use polkadot_parachain::primitives::{MAX_HORIZONTAL_MESSAGE_NUM, MAX_UPWARD_MESSAGE_NUM};
-use primitives::{Balance, SessionIndex, MAX_CODE_SIZE, MAX_HEAD_DATA_SIZE, MAX_POV_SIZE};
+use primitives::{
+	vstaging::AsyncBackingParameters, Balance, SessionIndex, MAX_CODE_SIZE, MAX_HEAD_DATA_SIZE,
+	MAX_POV_SIZE,
+};
 use sp_runtime::traits::Zero;
 use sp_std::prelude::*;
 
@@ -118,6 +121,8 @@ pub struct HostConfiguration<BlockNumber> {
 	 * The parameters that are not essential, but still may be of interest for parachains.
 	 */
 
+	/// Asynchronous backing parameters.
+	pub async_backing_parameters: AsyncBackingParameters,
 	/// The maximum POV block size, in bytes.
 	pub max_pov_size: u32,
 	/// The maximum size of a message that can be put in a downward message queue.
@@ -243,6 +248,10 @@ pub struct HostConfiguration<BlockNumber> {
 impl<BlockNumber: Default + From<u32>> Default for HostConfiguration<BlockNumber> {
 	fn default() -> Self {
 		Self {
+			async_backing_parameters: AsyncBackingParameters {
+				max_candidate_depth: 0,
+				allowed_ancestry_len: 0,
+			},
 			group_rotation_frequency: 1u32.into(),
 			chain_availability_period: 1u32.into(),
 			thread_availability_period: 1u32.into(),
@@ -1137,6 +1146,22 @@ pub mod pallet {
 			ensure_root(origin)?;
 			BypassConsistencyCheck::<T>::put(new);
 			Ok(())
+		}
+
+		/// Set the asynchronous backing parameters.
+		#[pallet::call_index(45)]
+		#[pallet::weight((
+			T::WeightInfo::set_config_with_option_u32(), // The same size in bytes.
+			DispatchClass::Operational,
+		))]
+		pub fn set_async_backing_parameters(
+			origin: OriginFor<T>,
+			new: AsyncBackingParameters,
+		) -> DispatchResult {
+			ensure_root(origin)?;
+			Self::schedule_config_update(|config| {
+				config.async_backing_parameters = new;
+			})
 		}
 	}
 

--- a/runtime/parachains/src/configuration/migration.rs
+++ b/runtime/parachains/src/configuration/migration.rs
@@ -19,6 +19,7 @@
 use crate::configuration::{self, ActiveConfig, Config, Pallet, PendingConfigs, MAX_POV_SIZE};
 use frame_support::{pallet_prelude::*, traits::StorageVersion, weights::Weight};
 use frame_system::pallet_prelude::BlockNumberFor;
+use primitives::vstaging::AsyncBackingParameters;
 use sp_std::vec::Vec;
 
 /// The current storage version.
@@ -226,6 +227,9 @@ ump_max_individual_weight                : pre.ump_max_individual_weight,
 pvf_checking_enabled                     : pre.pvf_checking_enabled,
 pvf_voting_ttl                           : pre.pvf_voting_ttl,
 minimum_validation_upgrade_delay         : pre.minimum_validation_upgrade_delay,
+
+// Default values are zeroes, thus it's ensured allowed ancestry never crosses the upgrade block.
+async_backing_parameters                 : AsyncBackingParameters { max_candidate_depth: 0, allowed_ancestry_len: 0 },
 		}
 	};
 
@@ -383,6 +387,10 @@ mod tests {
 					assert_eq!(v4.pvf_voting_ttl                           , v5.pvf_voting_ttl);
 					assert_eq!(v4.minimum_validation_upgrade_delay         , v5.minimum_validation_upgrade_delay);
 				}; // ; makes this a statement. `rustfmt::skip` cannot be put on an expression.
+
+				// additional checks for async backing.
+				assert_eq!(v5.async_backing_parameters.allowed_ancestry_len, 0);
+				assert_eq!(v5.async_backing_parameters.max_candidate_depth, 0);
 			}
 		});
 	}

--- a/runtime/parachains/src/configuration/migration.rs
+++ b/runtime/parachains/src/configuration/migration.rs
@@ -229,7 +229,7 @@ pvf_voting_ttl                           : pre.pvf_voting_ttl,
 minimum_validation_upgrade_delay         : pre.minimum_validation_upgrade_delay,
 
 // Default values are zeroes, thus it's ensured allowed ancestry never crosses the upgrade block.
-async_backing_params                 : AsyncBackingParams { max_candidate_depth: 0, allowed_ancestry_len: 0 },
+async_backing_params                     : AsyncBackingParams { max_candidate_depth: 0, allowed_ancestry_len: 0 },
 		}
 	};
 

--- a/runtime/parachains/src/configuration/migration.rs
+++ b/runtime/parachains/src/configuration/migration.rs
@@ -28,7 +28,7 @@ use sp_std::vec::Vec;
 /// v1-v2: <https://github.com/paritytech/polkadot/pull/4420>
 /// v2-v3: <https://github.com/paritytech/polkadot/pull/6091>
 /// v3-v4: <https://github.com/paritytech/polkadot/pull/6345>
-/// v4-v5: <https://github.com/paritytech/polkadot/pull/6937>
+/// v4-v5: <https://github.com/paritytech/polkadot/pull/6937> + <https://github.com/paritytech/polkadot/pull/6961>
 pub const STORAGE_VERSION: StorageVersion = StorageVersion::new(5);
 
 pub mod v5 {

--- a/runtime/parachains/src/configuration/migration.rs
+++ b/runtime/parachains/src/configuration/migration.rs
@@ -19,7 +19,7 @@
 use crate::configuration::{self, ActiveConfig, Config, Pallet, PendingConfigs, MAX_POV_SIZE};
 use frame_support::{pallet_prelude::*, traits::StorageVersion, weights::Weight};
 use frame_system::pallet_prelude::BlockNumberFor;
-use primitives::vstaging::AsyncBackingParameters;
+use primitives::vstaging::AsyncBackingParams;
 use sp_std::vec::Vec;
 
 /// The current storage version.
@@ -229,7 +229,7 @@ pvf_voting_ttl                           : pre.pvf_voting_ttl,
 minimum_validation_upgrade_delay         : pre.minimum_validation_upgrade_delay,
 
 // Default values are zeroes, thus it's ensured allowed ancestry never crosses the upgrade block.
-async_backing_parameters                 : AsyncBackingParameters { max_candidate_depth: 0, allowed_ancestry_len: 0 },
+async_backing_params                 : AsyncBackingParams { max_candidate_depth: 0, allowed_ancestry_len: 0 },
 		}
 	};
 
@@ -389,8 +389,8 @@ mod tests {
 				}; // ; makes this a statement. `rustfmt::skip` cannot be put on an expression.
 
 				// additional checks for async backing.
-				assert_eq!(v5.async_backing_parameters.allowed_ancestry_len, 0);
-				assert_eq!(v5.async_backing_parameters.max_candidate_depth, 0);
+				assert_eq!(v5.async_backing_params.allowed_ancestry_len, 0);
+				assert_eq!(v5.async_backing_params.max_candidate_depth, 0);
 			}
 		});
 	}

--- a/runtime/parachains/src/configuration/tests.rs
+++ b/runtime/parachains/src/configuration/tests.rs
@@ -281,7 +281,7 @@ fn consistency_bypass_works() {
 fn setting_pending_config_members() {
 	new_test_ext(Default::default()).execute_with(|| {
 		let new_config = HostConfiguration {
-			async_backing_parameters: primitives::vstaging::AsyncBackingParameters {
+			async_backing_params: primitives::vstaging::AsyncBackingParams {
 				allowed_ancestry_len: 0,
 				max_candidate_depth: 0,
 			},

--- a/runtime/parachains/src/configuration/tests.rs
+++ b/runtime/parachains/src/configuration/tests.rs
@@ -281,6 +281,10 @@ fn consistency_bypass_works() {
 fn setting_pending_config_members() {
 	new_test_ext(Default::default()).execute_with(|| {
 		let new_config = HostConfiguration {
+			async_backing_parameters: primitives::vstaging::AsyncBackingParameters {
+				allowed_ancestry_len: 0,
+				max_candidate_depth: 0,
+			},
 			validation_upgrade_cooldown: 100,
 			validation_upgrade_delay: 10,
 			code_retention_period: 5,


### PR DESCRIPTION
Follow-up #6937 to jump into the v5 config migration.

Async backing being enabled/disabled is defined by the runtime API version and special endpoint being available. Hence this change can safely be done in advance.