### PR TITLE
Propagate `runtime-benchmarks` feature

### DIFF
--- a/node/test/service/Cargo.toml
+++ b/node/test/service/Cargo.toml
@@ -64,4 +64,7 @@ tokio = { version = "1.24.2", features = ["macros"] }
 
 [features]
 runtime-metrics=["polkadot-test-runtime/runtime-metrics"]
-runtime-benchmarks=["polkadot-test-runtime/runtime-benchmarks"]
+runtime-benchmarks=[
+	"polkadot-test-runtime/runtime-benchmarks",
+	"polkadot-service/runtime-benchmarks",
+]


### PR DESCRIPTION
Minimal fix to get some benchmarks compiling in Cumulus :see_no_evil: 