### PR TITLE
Add EventSpender Track on Kusama

### DIFF
--- a/runtime/kusama/src/governance/origins.rs
+++ b/runtime/kusama/src/governance/origins.rs
@@ -48,16 +48,18 @@ pub mod pallet_custom_origins {
 		ReferendumCanceller,
 		/// Origin able to kill referenda.
 		ReferendumKiller,
-		/// Origin able to spend up to 1 KSM from the treasury at once.
+		/// Origin able to spend up to 8.33 KSM from the treasury at once.
 		SmallTipper,
-		/// Origin able to spend up to 5 KSM from the treasury at once.
+		/// Origin able to spend up to 33 KSM from the treasury at once.
 		BigTipper,
-		/// Origin able to spend up to 50 KSM from the treasury at once.
+		/// Origin able to spend up to 333 KSM from the treasury at once.
 		SmallSpender,
-		/// Origin able to spend up to 500 KSM from the treasury at once.
+		/// Origin able to spend up to 3,333 KSM from the treasury at once.
 		MediumSpender,
-		/// Origin able to spend up to 5,000 KSM from the treasury at once.
+		/// Origin able to spend up to 33,333 KSM from the treasury at once.
 		BigSpender,
+		/// Origin able to spend up to 7,777 KSM from the treasury to fund ecosystem events.
+		EventSpender,
 		/// Origin able to dispatch a whitelisted call.
 		WhitelistedCaller,
 		/// Origin commanded by any members of the Polkadot Fellowship (no Dan grade needed).
@@ -175,6 +177,7 @@ pub mod pallet_custom_origins {
 			MediumSpender = 100 * GRAND,
 			BigSpender = 1_000 * GRAND,
 			Treasurer = 10_000 * GRAND,
+			EventSpender = 7_777 * UNITS,
 		}
 	}
 

--- a/runtime/kusama/src/governance/tracks.rs
+++ b/runtime/kusama/src/governance/tracks.rs
@@ -60,6 +60,8 @@ const SUP_MEDIUM_SPENDER: Curve =
 	Curve::make_reciprocal(16, 28, percent(1), percent(0), percent(50));
 const APP_BIG_SPENDER: Curve = Curve::make_linear(28, 28, percent(50), percent(100));
 const SUP_BIG_SPENDER: Curve = Curve::make_reciprocal(20, 28, percent(1), percent(0), percent(50));
+const APP_EVENT_SPENDER: Curve = Curve::make_linear(28, 28, percent(50), percent(100));
+const SUP_EVENT_SPENDER: Curve = Curve::make_reciprocal(20, 28, percent(1), percent(0), percent(50));
 const APP_WHITELISTED_CALLER: Curve =
 	Curve::make_reciprocal(16, 28 * 24, percent(96), percent(50), percent(100));
 const SUP_WHITELISTED_CALLER: Curve =
@@ -276,6 +278,20 @@ const TRACKS_DATA: [(u16, pallet_referenda::TrackInfo<Balance, BlockNumber>); 15
 			min_support: SUP_BIG_SPENDER,
 		},
 	),
+	(
+		35,
+		pallet_referenda::TrackInfo {
+			name: "event_spender",
+			max_deciding: 50,
+			decision_deposit: 400 * QUID,
+			prepare_period: 4 * HOURS,
+			decision_period: 14 * DAYS,
+			confirm_period: 48 * HOURS,
+			min_enactment_period: 24 * HOURS,
+			min_approval: APP_EVENT_SPENDER,
+			min_support: SUP_EVENT_SPENDER,
+		},
+	),
 ];
 
 pub struct TracksInfo;
@@ -310,6 +326,7 @@ impl pallet_referenda::TracksInfo<Balance, BlockNumber> for TracksInfo {
 				origins::Origin::SmallSpender => Ok(32),
 				origins::Origin::MediumSpender => Ok(33),
 				origins::Origin::BigSpender => Ok(34),
+				origins::Origin::EventSpender => Ok(35),
 				_ => Err(()),
 			}
 		} else {


### PR DESCRIPTION
Add spending track specifically for users seeking funds to host ecosystem events.

Also fix up comments on origin spend limits.

Context to this PR can be found [in this discussion](https://forum.polkadot.network/t/opengov-track-experiments-delegating-to-experts/2451).

Summary: based on our observations of treasury spends on gov2, we think it makes sense to move away from general spending tracks and create tracks for typical spending categories (such as Media, Events, Hackathons, UI, Infrastructure, Governance, Philanthropy, Business Development, R&D). The reasoning behind this is to allow users to delegate their votes to experts in each spending category. Therefore, creating spending tracks for various categories will harmonize on-chain vote delegations with expert vetting occurring on the "social layer."

We test this concept by creating the `EventSpender` track.