### PR TITLE
Tighter bound on asset types teleported so that weight is cheaper

### DIFF
--- a/xcm/pallet-xcm/src/lib.rs
+++ b/xcm/pallet-xcm/src/lib.rs
@@ -1204,7 +1204,7 @@ impl<T: Config> Pallet<T> {
 			DepositAsset { assets: Wild(AllCounted(max_assets)), beneficiary },
 		]);
 		let mut message =
-			Xcm(vec![WithdrawAsset(assets), InitiateTeleport { assets: Wild(All), dest, xcm }]);
+			Xcm(vec![WithdrawAsset(assets), InitiateTeleport { assets: Wild(AllCounted(max_assets)), dest, xcm }]);
 		let weight =
 			T::Weigher::weight(&mut message).map_err(|()| Error::<T>::UnweighableMessage)?;
 		let hash = message.using_encoded(sp_io::hashing::blake2_256);

--- a/xcm/pallet-xcm/src/lib.rs
+++ b/xcm/pallet-xcm/src/lib.rs
@@ -1203,8 +1203,10 @@ impl<T: Config> Pallet<T> {
 			BuyExecution { fees, weight_limit },
 			DepositAsset { assets: Wild(AllCounted(max_assets)), beneficiary },
 		]);
-		let mut message =
-			Xcm(vec![WithdrawAsset(assets), InitiateTeleport { assets: Wild(AllCounted(max_assets)), dest, xcm }]);
+		let mut message = Xcm(vec![
+			WithdrawAsset(assets),
+			InitiateTeleport { assets: Wild(AllCounted(max_assets)), dest, xcm },
+		]);
 		let weight =
 			T::Weigher::weight(&mut message).map_err(|()| Error::<T>::UnweighableMessage)?;
 		let hash = message.using_encoded(sp_io::hashing::blake2_256);


### PR DESCRIPTION
If we can bound the assets then the teleport cost requires less weight as worst case cost is less. Fixes https://github.com/paritytech/cumulus/issues/2392 where we were seeing teleports costing 38bn weight due to assuming there could be 100 different assets.