### PR TITLE
avoid triggering unwanted room_id for the release notifs

### DIFF
--- a/.github/workflows/release-99_bot.yml
+++ b/.github/workflows/release-99_bot.yml
@@ -21,9 +21,6 @@ jobs:
           - name: '#polkadot-announcements:matrix.parity.io'
             room: '!UqHPWiCBGZWxrmYBkF:matrix.parity.io'
             pre-release: false
-          - name: 'Internal release-notes channel'
-            room: '!NTogofoetwjbTwOoPi:matrix.parity.io'
-            pre-release: true
           - name: 'Ledger <> Polkadot Coordination'
             room: '!EoIhaKfGPmFOBrNSHT:web3.foundation'
             pre-release: true
@@ -34,7 +31,7 @@ jobs:
         if: github.event.release.prerelease == false || matrix.channel.pre-release
         uses: s3krit/matrix-message-action@v0.0.3
         with:
-          room_id: ${{ matrix.channel.room }}
+          room_id: ${{ matrix.channel.name }}
           access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
-          server: "matrix.parity.io"
+          server: "m.parity.io"
           message: "***Polkadot ${{github.event.release.tag_name}} has been released!***<br/>${{github.event.release.html_url}}<br/><br/>${{github.event.release.body}}<br/>"


### PR DESCRIPTION
`Internal release-notes channel` is not needed anymore.