### PR TITLE
Added `origin` to config for `universal_origin` benchmark

### DIFF
--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -2093,7 +2093,7 @@ sp_api::impl_runtime_apis! {
 					Err(BenchmarkError::Skip)
 				}
 
-				fn universal_alias() -> Result<Junction, BenchmarkError> {
+				fn universal_alias() -> Result<(MultiLocation, Junction), BenchmarkError> {
 					// The XCM executor of Kusama doesn't have a configured `UniversalAliases`
 					Err(BenchmarkError::Skip)
 				}

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -2095,7 +2095,7 @@ sp_api::impl_runtime_apis! {
 					Err(BenchmarkError::Skip)
 				}
 
-				fn universal_alias() -> Result<Junction, BenchmarkError> {
+				fn universal_alias() -> Result<(MultiLocation, Junction), BenchmarkError> {
 					// The XCM executor of Rococo doesn't have a configured `UniversalAliases`
 					Err(BenchmarkError::Skip)
 				}

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -1819,7 +1819,7 @@ sp_api::impl_runtime_apis! {
 					Err(BenchmarkError::Skip)
 				}
 
-				fn universal_alias() -> Result<Junction, BenchmarkError> {
+				fn universal_alias() -> Result<(MultiLocation, Junction), BenchmarkError> {
 					// The XCM executor of Westend doesn't have a configured `UniversalAliases`
 					Err(BenchmarkError::Skip)
 				}

--- a/xcm/pallet-xcm-benchmarks/src/generic/benchmarking.rs
+++ b/xcm/pallet-xcm-benchmarks/src/generic/benchmarking.rs
@@ -482,9 +482,9 @@ benchmarks! {
 	}
 
 	universal_origin {
-		let alias = T::universal_alias().map_err(|_| BenchmarkError::Skip)?;
+		let (origin, alias) = T::universal_alias().map_err(|_| BenchmarkError::Skip)?;
 
-		let mut executor = new_executor::<T>(Here.into_location());
+		let mut executor = new_executor::<T>(origin);
 
 		let instruction = Instruction::UniversalOrigin(alias.clone());
 		let xcm = Xcm(vec![instruction]);

--- a/xcm/pallet-xcm-benchmarks/src/generic/mock.rs
+++ b/xcm/pallet-xcm-benchmarks/src/generic/mock.rs
@@ -163,8 +163,8 @@ impl generic::Config for Test {
 		Ok(Default::default())
 	}
 
-	fn universal_alias() -> Result<Junction, BenchmarkError> {
-		Ok(GlobalConsensus(ByGenesis([0; 32])))
+	fn universal_alias() -> Result<(MultiLocation, Junction), BenchmarkError> {
+		Ok((Here.into(), GlobalConsensus(ByGenesis([0; 32]))))
 	}
 
 	fn transact_origin_and_runtime_call(

--- a/xcm/pallet-xcm-benchmarks/src/generic/mod.rs
+++ b/xcm/pallet-xcm-benchmarks/src/generic/mod.rs
@@ -52,10 +52,10 @@ pub mod pallet {
 		/// If set to `Err`, benchmarks which rely on an `exchange_asset` will be skipped.
 		fn worst_case_asset_exchange() -> Result<(MultiAssets, MultiAssets), BenchmarkError>;
 
-		/// A `Junction` that is one of the `UniversalAliases` configured by the XCM executor.
+		/// A `(MultiLocation, Junction)` that is one of the `UniversalAliases` configured by the XCM executor.
 		///
 		/// If set to `Err`, benchmarks which rely on a universal alias will be skipped.
-		fn universal_alias() -> Result<Junction, BenchmarkError>;
+		fn universal_alias() -> Result<(MultiLocation, Junction), BenchmarkError>;
 
 		/// The `MultiLocation` and `RuntimeCall` used for successful transaction XCMs.
 		///


### PR DESCRIPTION
Cumulus Companion: https://github.com/paritytech/cumulus/pull/2416