### PR TITLE
Avoid redundant clone.

### DIFF
--- a/runtime/parachains/src/paras_inherent/mod.rs
+++ b/runtime/parachains/src/paras_inherent/mod.rs
@@ -791,7 +791,7 @@ where
 /// as well as their indices in ascending order.
 fn random_sel<X, F: Fn(&X) -> Weight>(
 	rng: &mut rand_chacha::ChaChaRng,
-	selectables: Vec<X>,
+	selectables: &[X],
 	mut preferred_indices: Vec<usize>,
 	weight_fn: F,
 	weight_limit: Weight,
@@ -892,7 +892,7 @@ fn apply_weight_limit<T: Config + inclusion::Config>(
 		let (acc_candidate_weight, indices) =
 			random_sel::<BackedCandidate<<T as frame_system::Config>::Hash>, _>(
 				rng,
-				candidates.clone(),
+				&candidates,
 				preferred_indices,
 				|c| backed_candidate_weight::<T>(c),
 				max_consumable_by_candidates,
@@ -911,7 +911,7 @@ fn apply_weight_limit<T: Config + inclusion::Config>(
 	// into the block and skip the candidates entirely
 	let (total_consumed, indices) = random_sel::<UncheckedSignedAvailabilityBitfield, _>(
 		rng,
-		bitfields.clone(),
+		&bitfields,
 		vec![],
 		|_| <<T as Config>::WeightInfo as WeightInfo>::enter_bitfields(),
 		max_consumable_weight,
@@ -1282,7 +1282,7 @@ fn limit_and_sanitize_disputes<
 		// Select remote disputes at random until the block is full
 		let (_acc_remote_disputes_weight, mut indices) = random_sel::<u32, _>(
 			rng,
-			d,
+			&d,
 			vec![],
 			|v| <<T as Config>::WeightInfo as WeightInfo>::enter_variable_disputes(*v),
 			max_consumable_weight.saturating_sub(weight_acc),


### PR DESCRIPTION
While https://github.com/paritytech/polkadot/pull/6929 is currently blocked, not cloning megabytes of data in the runtime is probably still a good idea.