### PR TITLE
PR review rules, include all rs files except weights

### DIFF
--- a/.github/pr-custom-review.yml
+++ b/.github/pr-custom-review.yml
@@ -6,7 +6,9 @@ action-review-team: ci
 rules:
   - name: Runtime files
     check_type: changed_files
-    condition: ^runtime/(kusama|polkadot)/src/[^/]+\.rs$
+    condition:
+      include: ^runtime\/(kusama|polkadot)\/src\/.+\.rs$
+      exclude: ^runtime\/(kusama|polkadot)\/src\/weights\/.+\.rs$
     all_distinct:
       - min_approvals: 1
         teams:


### PR DESCRIPTION
Sub modules like governance excluded now from "Runtime files" rules.

I assume only weights supposed to be excluded.