### PR TITLE
Cache `SessionInfo` on new activated leaf in `dispute-distribution`

### DIFF
--- a/node/network/dispute-distribution/src/sender/mod.rs
+++ b/node/network/dispute-distribution/src/sender/mod.rs
@@ -366,6 +366,13 @@ async fn get_active_session_indices<Context>(
 	// Iterate all heads we track as active and fetch the child' session indices.
 	for head in active_heads {
 		let session_index = runtime.get_session_index_for_child(ctx.sender(), *head).await?;
+		// Cache session info
+		match runtime.get_session_info_by_index(ctx.sender(), *head, session_index).await {
+			Ok(_) => { /* do nothing */ },
+			Err(err) => {
+				gum::warn!(target: LOG_TARGET, ?err, ?session_index, "Can't cache SessionInfo");
+			},
+		}
 		indeces.insert(session_index, *head);
 	}
 	Ok(indeces)

--- a/node/network/dispute-distribution/src/sender/mod.rs
+++ b/node/network/dispute-distribution/src/sender/mod.rs
@@ -367,7 +367,9 @@ async fn get_active_session_indices<Context>(
 	for head in active_heads {
 		let session_index = runtime.get_session_index_for_child(ctx.sender(), *head).await?;
 		// Cache session info
-		if let Err(err) = runtime.get_session_info_by_index(ctx.sender(), *head, session_index).await {
+		if let Err(err) =
+			runtime.get_session_info_by_index(ctx.sender(), *head, session_index).await
+		{
 			gum::warn!(target: LOG_TARGET, ?err, ?session_index, "Can't cache SessionInfo");
 		}
 		indeces.insert(session_index, *head);

--- a/node/network/dispute-distribution/src/sender/mod.rs
+++ b/node/network/dispute-distribution/src/sender/mod.rs
@@ -367,11 +367,8 @@ async fn get_active_session_indices<Context>(
 	for head in active_heads {
 		let session_index = runtime.get_session_index_for_child(ctx.sender(), *head).await?;
 		// Cache session info
-		match runtime.get_session_info_by_index(ctx.sender(), *head, session_index).await {
-			Ok(_) => { /* do nothing */ },
-			Err(err) => {
-				gum::warn!(target: LOG_TARGET, ?err, ?session_index, "Can't cache SessionInfo");
-			},
+		if let Err(err) = runtime.get_session_info_by_index(ctx.sender(), *head, session_index).await {
+			gum::warn!(target: LOG_TARGET, ?err, ?session_index, "Can't cache SessionInfo");
 		}
 		indeces.insert(session_index, *head);
 	}

--- a/node/network/dispute-distribution/src/sender/mod.rs
+++ b/node/network/dispute-distribution/src/sender/mod.rs
@@ -370,7 +370,7 @@ async fn get_active_session_indices<Context>(
 		if let Err(err) =
 			runtime.get_session_info_by_index(ctx.sender(), *head, session_index).await
 		{
-			gum::warn!(target: LOG_TARGET, ?err, ?session_index, "Can't cache SessionInfo");
+			gum::debug!(target: LOG_TARGET, ?err, ?session_index, "Can't cache SessionInfo");
 		}
 		indeces.insert(session_index, *head);
 	}


### PR DESCRIPTION
Issue a request fetching the `SessionInfo` as soon as a new leaf is activated. This approach minimizes the risk to get an error fetching the `SessionInfo` at later point because the leaf was pruned quickly.