### PR TITLE
Introduce XcmFeesToAccount fee manager

### DIFF
--- a/xcm/pallet-xcm-benchmarks/src/generic/mock.rs
+++ b/xcm/pallet-xcm-benchmarks/src/generic/mock.rs
@@ -88,7 +88,11 @@ impl frame_system::Config for Test {
 /// The benchmarks in this pallet should never need an asset transactor to begin with.
 pub struct NoAssetTransactor;
 impl xcm_executor::traits::TransactAsset for NoAssetTransactor {
-	fn deposit_asset(_: &MultiAsset, _: &MultiLocation, _: &XcmContext) -> Result<(), XcmError> {
+	fn deposit_asset(
+		_: &MultiAsset,
+		_: &MultiLocation,
+		_: Option<&XcmContext>,
+	) -> Result<(), XcmError> {
 		unreachable!();
 	}
 

--- a/xcm/xcm-builder/src/currency_adapter.rs
+++ b/xcm/xcm-builder/src/currency_adapter.rs
@@ -191,7 +191,11 @@ impl<
 		}
 	}
 
-	fn deposit_asset(what: &MultiAsset, who: &MultiLocation, _context: &XcmContext) -> Result {
+	fn deposit_asset(
+		what: &MultiAsset,
+		who: &MultiLocation,
+		_context: Option<&XcmContext>,
+	) -> Result {
 		log::trace!(target: "xcm::currency_adapter", "deposit_asset what: {:?}, who: {:?}", what, who);
 		// Check we handle this asset.
 		let amount = Matcher::matches_fungible(&what).ok_or(Error::AssetNotHandled)?;

--- a/xcm/xcm-builder/src/fee_handling.rs
+++ b/xcm/xcm-builder/src/fee_handling.rs
@@ -1,0 +1,51 @@
+// Copyright Parity Technologies (UK) Ltd.
+// This file is part of Polkadot.
+
+// Polkadot is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Polkadot is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
+
+use core::marker::PhantomData;
+use frame_support::traits::{Contains, Get};
+use xcm::prelude::*;
+use xcm_executor::traits::{FeeManager, FeeReason, TransactAsset};
+
+/// A `FeeManager` implementation that simply deposits the fees handled into a specific on-chain
+/// `ReceiverAccount`.
+///
+/// It reuses the `AssetTransactor` configured on the XCM executor to deposit fee assets, and also
+/// permits specifying `WaivedLocations` for locations that are privileged to not pay for fees.
+pub struct XcmFeesToAccount<XcmConfig, WaivedLocations, AccountId, ReceiverAccount>(
+	PhantomData<(XcmConfig, WaivedLocations, AccountId, ReceiverAccount)>,
+);
+impl<
+		XcmConfig: xcm_executor::Config,
+		WaivedLocations: Contains<MultiLocation>,
+		AccountId: Clone + Into<[u8; 32]>,
+		ReceiverAccount: Get<Option<AccountId>>,
+	> FeeManager for XcmFeesToAccount<XcmConfig, WaivedLocations, AccountId, ReceiverAccount>
+{
+	fn is_waived(origin: Option<&MultiLocation>, _: FeeReason) -> bool {
+		let Some(loc) = origin else { return false };
+		WaivedLocations::contains(loc)
+	}
+
+	fn handle_fee(fees: MultiAssets, context: Option<&XcmContext>) {
+		if let Some(receiver) = ReceiverAccount::get() {
+			let dest = AccountId32 { network: None, id: receiver.into() }.into();
+			for asset in fees.into_inner() {
+				let ok = XcmConfig::AssetTransactor::deposit_asset(&asset, &dest, context).is_ok();
+				debug_assert!(ok, "`deposit_asset` cannot generally fail");
+			}
+		}
+	}
+}

--- a/xcm/xcm-builder/src/fungibles_adapter.rs
+++ b/xcm/xcm-builder/src/fungibles_adapter.rs
@@ -274,7 +274,11 @@ impl<
 		}
 	}
 
-	fn deposit_asset(what: &MultiAsset, who: &MultiLocation, _context: &XcmContext) -> XcmResult {
+	fn deposit_asset(
+		what: &MultiAsset,
+		who: &MultiLocation,
+		_context: Option<&XcmContext>,
+	) -> XcmResult {
 		log::trace!(
 			target: "xcm::fungibles_adapter",
 			"deposit_asset what: {:?}, who: {:?}",
@@ -371,7 +375,11 @@ impl<
 		>::check_out(dest, what, context)
 	}
 
-	fn deposit_asset(what: &MultiAsset, who: &MultiLocation, context: &XcmContext) -> XcmResult {
+	fn deposit_asset(
+		what: &MultiAsset,
+		who: &MultiLocation,
+		context: Option<&XcmContext>,
+	) -> XcmResult {
 		FungiblesMutateAdapter::<
 			Assets,
 			Matcher,

--- a/xcm/xcm-builder/src/lib.rs
+++ b/xcm/xcm-builder/src/lib.rs
@@ -57,6 +57,9 @@ pub use barriers::{
 mod currency_adapter;
 pub use currency_adapter::CurrencyAdapter;
 
+mod fee_handling;
+pub use fee_handling::XcmFeesToAccount;
+
 mod fungibles_adapter;
 pub use fungibles_adapter::{
 	AssetChecking, DualMint, FungiblesAdapter, FungiblesMutateAdapter, FungiblesTransferAdapter,

--- a/xcm/xcm-builder/src/nonfungibles_adapter.rs
+++ b/xcm/xcm-builder/src/nonfungibles_adapter.rs
@@ -192,7 +192,11 @@ impl<
 		}
 	}
 
-	fn deposit_asset(what: &MultiAsset, who: &MultiLocation, context: &XcmContext) -> XcmResult {
+	fn deposit_asset(
+		what: &MultiAsset,
+		who: &MultiLocation,
+		context: Option<&XcmContext>,
+	) -> XcmResult {
 		log::trace!(
 			target: "xcm::fungibles_adapter",
 			"deposit_asset what: {:?}, who: {:?}, context: {:?}",
@@ -288,7 +292,11 @@ impl<
 		>::check_out(dest, what, context)
 	}
 
-	fn deposit_asset(what: &MultiAsset, who: &MultiLocation, context: &XcmContext) -> XcmResult {
+	fn deposit_asset(
+		what: &MultiAsset,
+		who: &MultiLocation,
+		context: Option<&XcmContext>,
+	) -> XcmResult {
 		NonFungiblesMutateAdapter::<
 			Assets,
 			Matcher,

--- a/xcm/xcm-builder/src/tests/mock.rs
+++ b/xcm/xcm-builder/src/tests/mock.rs
@@ -243,7 +243,7 @@ impl TransactAsset for TestAssetTransactor {
 	fn deposit_asset(
 		what: &MultiAsset,
 		who: &MultiLocation,
-		_context: &XcmContext,
+		_context: Option<&XcmContext>,
 	) -> Result<(), XcmError> {
 		add_asset(who.clone(), what.clone());
 		Ok(())
@@ -441,7 +441,7 @@ impl FeeManager for TestFeeManager {
 	fn is_waived(_: Option<&MultiLocation>, r: FeeReason) -> bool {
 		IS_WAIVED.with(|l| l.borrow().contains(&r))
 	}
-	fn handle_fee(_: MultiAssets) {}
+	fn handle_fee(_: MultiAssets, _: Option<&XcmContext>) {}
 }
 
 #[derive(Clone, Eq, PartialEq, Debug)]

--- a/xcm/xcm-executor/src/lib.rs
+++ b/xcm/xcm-executor/src/lib.rs
@@ -245,7 +245,7 @@ impl<Config: config::Config> ExecuteXcm<Config::RuntimeCall> for XcmExecutor<Con
 			for asset in fees.inner() {
 				Config::AssetTransactor::withdraw_asset(&asset, &origin, None)?;
 			}
-			Config::FeeManager::handle_fee(fees);
+			Config::FeeManager::handle_fee(fees, None);
 		}
 		Ok(())
 	}
@@ -403,7 +403,7 @@ impl<Config: config::Config> XcmExecutor<Config> {
 		let (ticket, fee) = validate_send::<Config::XcmSender>(dest, msg)?;
 		if !Config::FeeManager::is_waived(self.origin_ref(), reason) {
 			let paid = self.holding.try_take(fee.into()).map_err(|_| XcmError::NotHoldingFees)?;
-			Config::FeeManager::handle_fee(paid.into());
+			Config::FeeManager::handle_fee(paid.into(), Some(&self.context));
 		}
 		Config::XcmSender::deliver(ticket).map_err(Into::into)
 	}
@@ -613,14 +613,18 @@ impl<Config: config::Config> XcmExecutor<Config> {
 			DepositAsset { assets, beneficiary } => {
 				let deposited = self.holding.saturating_take(assets);
 				for asset in deposited.into_assets_iter() {
-					Config::AssetTransactor::deposit_asset(&asset, &beneficiary, &self.context)?;
+					Config::AssetTransactor::deposit_asset(
+						&asset,
+						&beneficiary,
+						Some(&self.context),
+					)?;
 				}
 				Ok(())
 			},
 			DepositReserveAsset { assets, dest, xcm } => {
 				let deposited = self.holding.saturating_take(assets);
 				for asset in deposited.assets_iter() {
-					Config::AssetTransactor::deposit_asset(&asset, &dest, &self.context)?;
+					Config::AssetTransactor::deposit_asset(&asset, &dest, Some(&self.context))?;
 				}
 				// Note that we pass `None` as `maybe_failed_bin` and drop any assets which cannot
 				// be reanchored  because we have already called `deposit_asset` on all assets.
@@ -936,7 +940,7 @@ impl<Config: config::Config> XcmExecutor<Config> {
 		} else {
 			self.holding.try_take(fee.into()).map_err(|_| XcmError::NotHoldingFees)?.into()
 		};
-		Config::FeeManager::handle_fee(paid);
+		Config::FeeManager::handle_fee(paid, Some(&self.context));
 		Ok(())
 	}
 
@@ -971,7 +975,7 @@ impl<Config: config::Config> XcmExecutor<Config> {
 		let (ticket, fee) = validate_send::<Config::XcmSender>(destination, message)?;
 		if !Config::FeeManager::is_waived(self.origin_ref(), fee_reason) {
 			let paid = self.holding.try_take(fee.into()).map_err(|_| XcmError::NotHoldingFees)?;
-			Config::FeeManager::handle_fee(paid.into());
+			Config::FeeManager::handle_fee(paid.into(), Some(&self.context));
 		}
 		Config::XcmSender::deliver(ticket).map_err(Into::into)
 	}

--- a/xcm/xcm-executor/src/traits/fee_manager.rs
+++ b/xcm/xcm-executor/src/traits/fee_manager.rs
@@ -23,7 +23,7 @@ pub trait FeeManager {
 
 	/// Do something with the fee which has been paid. Doing nothing here silently burns the
 	/// fees.
-	fn handle_fee(fee: MultiAssets);
+	fn handle_fee(fee: MultiAssets, context: Option<&XcmContext>);
 }
 
 /// Context under which a fee is paid.
@@ -55,5 +55,5 @@ impl FeeManager for () {
 	fn is_waived(_: Option<&MultiLocation>, _: FeeReason) -> bool {
 		true
 	}
-	fn handle_fee(_: MultiAssets) {}
+	fn handle_fee(_: MultiAssets, _: Option<&XcmContext>) {}
 }

--- a/xcm/xcm-executor/src/traits/transact_asset.rs
+++ b/xcm/xcm-executor/src/traits/transact_asset.rs
@@ -78,7 +78,11 @@ pub trait TransactAsset {
 	/// Deposit the `what` asset into the account of `who`.
 	///
 	/// Implementations should return `XcmError::FailedToTransactAsset` if deposit failed.
-	fn deposit_asset(_what: &MultiAsset, _who: &MultiLocation, _context: &XcmContext) -> XcmResult {
+	fn deposit_asset(
+		_what: &MultiAsset,
+		_who: &MultiLocation,
+		_context: Option<&XcmContext>,
+	) -> XcmResult {
 		Err(XcmError::Unimplemented)
 	}
 
@@ -130,7 +134,7 @@ pub trait TransactAsset {
 			Err(XcmError::AssetNotFound | XcmError::Unimplemented) => {
 				let assets = Self::withdraw_asset(asset, from, Some(context))?;
 				// Not a very forgiving attitude; once we implement roll-backs then it'll be nicer.
-				Self::deposit_asset(asset, to, context)?;
+				Self::deposit_asset(asset, to, Some(context))?;
 				Ok(assets)
 			},
 			result => result,
@@ -186,7 +190,11 @@ impl TransactAsset for Tuple {
 		)* );
 	}
 
-	fn deposit_asset(what: &MultiAsset, who: &MultiLocation, context: &XcmContext) -> XcmResult {
+	fn deposit_asset(
+		what: &MultiAsset,
+		who: &MultiLocation,
+		context: Option<&XcmContext>,
+	) -> XcmResult {
 		for_tuples!( #(
 			match Tuple::deposit_asset(what, who, context) {
 				Err(XcmError::AssetNotFound) | Err(XcmError::Unimplemented) => (),
@@ -277,7 +285,7 @@ mod tests {
 		fn deposit_asset(
 			_what: &MultiAsset,
 			_who: &MultiLocation,
-			_context: &XcmContext,
+			_context: Option<&XcmContext>,
 		) -> XcmResult {
 			Err(XcmError::AssetNotFound)
 		}
@@ -321,7 +329,7 @@ mod tests {
 		fn deposit_asset(
 			_what: &MultiAsset,
 			_who: &MultiLocation,
-			_context: &XcmContext,
+			_context: Option<&XcmContext>,
 		) -> XcmResult {
 			Err(XcmError::Overflow)
 		}
@@ -365,7 +373,7 @@ mod tests {
 		fn deposit_asset(
 			_what: &MultiAsset,
 			_who: &MultiLocation,
-			_context: &XcmContext,
+			_context: Option<&XcmContext>,
 		) -> XcmResult {
 			Ok(())
 		}
@@ -397,7 +405,7 @@ mod tests {
 			MultiTransactor::deposit_asset(
 				&(Here, 1u128).into(),
 				&Here.into(),
-				&XcmContext::with_message_hash([0; 32]),
+				Some(&XcmContext::with_message_hash([0; 32])),
 			),
 			Err(XcmError::AssetNotFound)
 		);
@@ -411,7 +419,7 @@ mod tests {
 			MultiTransactor::deposit_asset(
 				&(Here, 1u128).into(),
 				&Here.into(),
-				&XcmContext::with_message_hash([0; 32]),
+				Some(&XcmContext::with_message_hash([0; 32])),
 			),
 			Ok(())
 		);
@@ -425,7 +433,7 @@ mod tests {
 			MultiTransactor::deposit_asset(
 				&(Here, 1u128).into(),
 				&Here.into(),
-				&XcmContext::with_message_hash([0; 32]),
+				Some(&XcmContext::with_message_hash([0; 32])),
 			),
 			Err(XcmError::Overflow)
 		);
@@ -439,7 +447,7 @@ mod tests {
 			MultiTransactor::deposit_asset(
 				&(Here, 1u128).into(),
 				&Here.into(),
-				&XcmContext::with_message_hash([0; 32]),
+				Some(&XcmContext::with_message_hash([0; 32])),
 			),
 			Ok(()),
 		);


### PR DESCRIPTION
This PR introduces a new `XcmFeesToAccount` struct which implements the `FeeManager` trait, and assigns this struct as the `FeeManager` in the XCM config for all runtimes.

The struct simply deposits all fees handled by the XCM executor to a specified account. In all runtimes, the specified account is configured as the treasury account.