### PR TITLE
Expose WASM bulk memory extension in execution environment parameters

### DIFF
--- a/node/core/pvf/src/executor_intf.rs
+++ b/node/core/pvf/src/executor_intf.rs
@@ -133,6 +133,7 @@ fn params_to_wasmtime_semantics(par: &ExecutorParams) -> Result<Semantics, Strin
 					HeapAllocStrategy::Dynamic { maximum_pages: Some(*max_pages) },
 			ExecutorParam::StackLogicalMax(slm) => stack_limit.logical_max = *slm,
 			ExecutorParam::StackNativeMax(snm) => stack_limit.native_stack_max = *snm,
+			ExecutorParam::WasmExtBulkMemory => sem.wasm_bulk_memory = true,
 			ExecutorParam::PrecheckingMaxMemory(_) => (), // TODO: Not implemented yet
 			ExecutorParam::PvfPrepTimeout(_, _) | ExecutorParam::PvfExecTimeout(_, _) => (), // Not used here
 		}

--- a/primitives/src/v4/executor_params.rs
+++ b/primitives/src/v4/executor_params.rs
@@ -49,6 +49,9 @@ pub enum ExecutorParam {
 	/// PVF execution timeouts, millisec
 	#[codec(index = 6)]
 	PvfExecTimeout(PvfExecTimeoutKind, u64),
+	/// Enables WASM bulk memory proposal
+	#[codec(index = 7)]
+	WasmExtBulkMemory,
 }
 
 /// Unit type wrapper around [`type@Hash`] that represents an execution parameter set hash.


### PR DESCRIPTION
Closes #6918 

Why the other extensions are not exposed: https://github.com/paritytech/substrate/pull/13811#issuecomment-1495479990
Why the Sign Extension Operators proposal is not exposed: paritytech/substrate#13814