### PR TITLE
Onchain scraper in `dispute-coordinator` will scrape `SCRAPED_FINALIZED_BLOCKS_COUNT` blocks before finality

### DIFF
--- a/node/core/dispute-coordinator/src/scraping/mod.rs
+++ b/node/core/dispute-coordinator/src/scraping/mod.rs
@@ -239,7 +239,8 @@ impl ChainScraper {
 			None => return Ok(ScrapedUpdates::new()),
 		};
 
-		// Fetch ancestry up to last finalized block.
+		// Fetch ancestry up to `SCRAPED_FINALIZED_BLOCKS_COUNT` blocks beyond
+		// the last finalized one
 		let ancestors = self
 			.get_relevant_block_ancestors(sender, activated.hash, activated.number)
 			.await?;
@@ -356,7 +357,7 @@ impl ChainScraper {
 	{
 		let target_ancestor = get_finalized_block_number(sender)
 			.await?
-			.saturating_sub(Self::SCRAPED_FINALIZED_BLOCKS_COUNT.get() - 1);
+			.saturating_sub(Self::SCRAPED_FINALIZED_BLOCKS_COUNT.get());
 
 		let mut ancestors = Vec::new();
 

--- a/node/core/dispute-coordinator/src/scraping/tests.rs
+++ b/node/core/dispute-coordinator/src/scraping/tests.rs
@@ -411,8 +411,7 @@ fn scraper_requests_candidates_of_non_finalized_ancestors() {
 			&chain,
 			finalized_block_number,
 			BLOCKS_TO_SKIP -
-				(finalized_block_number - ChainScraper::SCRAPED_FINALIZED_BLOCKS_COUNT.get())
-					as usize, // Expect the provider not to go past finalized block.
+				(finalized_block_number - DISPUTE_CANDIDATE_LIFETIME_AFTER_FINALIZATION) as usize, // Expect the provider not to go past finalized block.
 			get_backed_and_included_candidate_events,
 		);
 		join(process_active_leaves_update(ctx.sender(), &mut ordering, next_update), overseer_fut)

--- a/node/core/dispute-coordinator/src/scraping/tests.rs
+++ b/node/core/dispute-coordinator/src/scraping/tests.rs
@@ -411,7 +411,7 @@ fn scraper_requests_candidates_of_non_finalized_ancestors() {
 			&chain,
 			finalized_block_number,
 			BLOCKS_TO_SKIP -
-				(finalized_block_number - ChainScraper::SCRAPED_FINALIZED_BLOCKS_COUNT.get() + 1)
+				(finalized_block_number - ChainScraper::SCRAPED_FINALIZED_BLOCKS_COUNT.get())
 					as usize, // Expect the provider not to go past finalized block.
 			get_backed_and_included_candidate_events,
 		);

--- a/node/core/dispute-coordinator/src/scraping/tests.rs
+++ b/node/core/dispute-coordinator/src/scraping/tests.rs
@@ -410,7 +410,9 @@ fn scraper_requests_candidates_of_non_finalized_ancestors() {
 			&mut virtual_overseer,
 			&chain,
 			finalized_block_number,
-			BLOCKS_TO_SKIP - finalized_block_number as usize, // Expect the provider not to go past finalized block.
+			BLOCKS_TO_SKIP -
+				(finalized_block_number - ChainScraper::SCRAPED_FINALIZED_BLOCKS_COUNT.get() + 1)
+					as usize, // Expect the provider not to go past finalized block.
 			get_backed_and_included_candidate_events,
 		);
 		join(process_active_leaves_update(ctx.sender(), &mut ordering, next_update), overseer_fut)

--- a/node/primitives/src/lib.rs
+++ b/node/primitives/src/lib.rs
@@ -65,7 +65,7 @@ pub const VALIDATION_CODE_BOMB_LIMIT: usize = (MAX_CODE_SIZE * 4u32) as usize;
 pub const POV_BOMB_LIMIT: usize = (MAX_POV_SIZE * 4u32) as usize;
 
 /// How many blocks after finalization an information about backed/included candidate should be
-/// kept.
+/// pre-loaded (when scraoing onchain votes) and kept locally (when pruning).
 ///
 /// We don't want to remove scraped candidates on finalization because we want to
 /// be sure that disputes will conclude on abandoned forks.
@@ -73,6 +73,12 @@ pub const POV_BOMB_LIMIT: usize = (MAX_POV_SIZE * 4u32) as usize;
 /// avoid slashing. If a bad fork is abandoned too quickly because another
 /// better one gets finalized the entries for the bad fork will be pruned and we
 /// might never participate in a dispute for it.
+///
+/// Why pre-load finalized blocks? I dispute might be raised against finalized candidate. In most
+/// of the cases it will conclude valid (otherwise we are in big trouble) but never the less the
+/// node must participate. It's possible to see a vote for such dispute onchain before we have it
+/// imported by `dispute-distribution`. In this case we won't have `CandidateReceipt` and the import
+/// will fail unless we keep them preloaded.
 ///
 /// This value should consider the timeout we allow for participation in approval-voting. In
 /// particular, the following condition should hold:


### PR DESCRIPTION
Fixes https://github.com/paritytech/polkadot/issues/7009