### PR TITLE
Use RuntimeHoldReason for the NIS pallet HoldReason

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,7 +466,7 @@ dependencies = [
 [[package]]
 name = "binary-merkle-tree"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "hash-db",
  "log",
@@ -2365,7 +2365,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "fork-tree"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -2388,7 +2388,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 [[package]]
 name = "frame-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -2413,7 +2413,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "Inflector",
  "array-bytes",
@@ -2460,7 +2460,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2471,7 +2471,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -2488,7 +2488,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2517,7 +2517,7 @@ dependencies = [
 [[package]]
 name = "frame-remote-externalities"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "futures",
  "log",
@@ -2533,7 +2533,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "bitflags",
  "environmental",
@@ -2566,7 +2566,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -2582,7 +2582,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -2594,7 +2594,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2604,7 +2604,7 @@ dependencies = [
 [[package]]
 name = "frame-support-test"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2628,7 +2628,7 @@ dependencies = [
 [[package]]
 name = "frame-support-test-pallet"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2639,7 +2639,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "frame-support",
  "log",
@@ -2657,7 +2657,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2672,7 +2672,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -2681,7 +2681,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -2863,7 +2863,7 @@ dependencies = [
 [[package]]
 name = "generate-bags"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "chrono",
  "frame-election-provider-support",
@@ -4661,7 +4661,7 @@ dependencies = [
 [[package]]
 name = "mmr-gadget"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "futures",
  "log",
@@ -4680,7 +4680,7 @@ dependencies = [
 [[package]]
 name = "mmr-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "anyhow",
  "jsonrpsee",
@@ -5264,7 +5264,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5279,7 +5279,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5295,7 +5295,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5309,7 +5309,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5333,7 +5333,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5353,7 +5353,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list-remote-tests"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "frame-election-provider-support",
  "frame-remote-externalities",
@@ -5372,7 +5372,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5387,7 +5387,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5406,7 +5406,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "array-bytes",
  "binary-merkle-tree",
@@ -5430,7 +5430,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5448,7 +5448,7 @@ dependencies = [
 [[package]]
 name = "pallet-child-bounties"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5467,7 +5467,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5484,7 +5484,7 @@ dependencies = [
 [[package]]
 name = "pallet-conviction-voting"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -5501,7 +5501,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5519,7 +5519,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5542,7 +5542,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5555,7 +5555,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "5.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5573,7 +5573,7 @@ dependencies = [
 [[package]]
 name = "pallet-fast-unstake"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5591,7 +5591,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5614,7 +5614,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -5630,7 +5630,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5650,7 +5650,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5667,7 +5667,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5684,7 +5684,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5701,7 +5701,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5717,7 +5717,7 @@ dependencies = [
 [[package]]
 name = "pallet-nis"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5733,7 +5733,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5750,7 +5750,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5770,7 +5770,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
 version = "1.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
@@ -5781,7 +5781,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5798,7 +5798,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5822,7 +5822,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5839,7 +5839,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5854,7 +5854,7 @@ dependencies = [
 [[package]]
 name = "pallet-ranked-collective"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5872,7 +5872,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5887,7 +5887,7 @@ dependencies = [
 [[package]]
 name = "pallet-referenda"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -5906,7 +5906,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5923,7 +5923,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5944,7 +5944,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5960,7 +5960,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5974,7 +5974,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5997,7 +5997,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -6008,7 +6008,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -6017,7 +6017,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6026,7 +6026,7 @@ dependencies = [
 [[package]]
 name = "pallet-state-trie-migration"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6043,7 +6043,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6057,7 +6057,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6075,7 +6075,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6094,7 +6094,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6110,7 +6110,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -6126,7 +6126,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -6138,7 +6138,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6155,7 +6155,7 @@ dependencies = [
 [[package]]
 name = "pallet-uniques"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6170,7 +6170,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6186,7 +6186,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6201,7 +6201,7 @@ dependencies = [
 [[package]]
 name = "pallet-whitelist"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9172,7 +9172,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "4.1.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "log",
  "sp-core",
@@ -9183,7 +9183,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "async-trait",
  "futures",
@@ -9211,7 +9211,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "futures",
  "futures-timer",
@@ -9234,7 +9234,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -9249,7 +9249,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "memmap2",
  "sc-chain-spec-derive",
@@ -9268,7 +9268,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -9279,7 +9279,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "array-bytes",
  "chrono",
@@ -9319,7 +9319,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "fnv",
  "futures",
@@ -9345,7 +9345,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -9371,7 +9371,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "async-trait",
  "futures",
@@ -9396,7 +9396,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -9435,7 +9435,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -9457,7 +9457,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -9492,7 +9492,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -9511,7 +9511,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -9524,7 +9524,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "ahash 0.8.2",
  "array-bytes",
@@ -9564,7 +9564,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "finality-grandpa",
  "futures",
@@ -9584,7 +9584,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "async-trait",
  "futures",
@@ -9607,7 +9607,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "lru 0.8.1",
  "parity-scale-codec",
@@ -9631,7 +9631,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "sc-allocator",
  "sp-maybe-compressed-blob",
@@ -9644,7 +9644,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "log",
  "sc-allocator",
@@ -9657,7 +9657,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -9675,7 +9675,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "ansi_term",
  "futures",
@@ -9691,7 +9691,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -9706,7 +9706,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "array-bytes",
  "async-channel",
@@ -9751,7 +9751,7 @@ dependencies = [
 [[package]]
 name = "sc-network-bitswap"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "cid",
  "futures",
@@ -9771,7 +9771,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -9799,7 +9799,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "ahash 0.8.2",
  "futures",
@@ -9818,7 +9818,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "array-bytes",
  "futures",
@@ -9840,7 +9840,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -9874,7 +9874,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "array-bytes",
  "futures",
@@ -9894,7 +9894,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "array-bytes",
  "bytes",
@@ -9925,7 +9925,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "futures",
  "libp2p",
@@ -9938,7 +9938,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -9947,7 +9947,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -9977,7 +9977,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -9996,7 +9996,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "http",
  "jsonrpsee",
@@ -10011,7 +10011,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "array-bytes",
  "futures",
@@ -10037,7 +10037,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "async-trait",
  "directories",
@@ -10103,7 +10103,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -10114,7 +10114,7 @@ dependencies = [
 [[package]]
 name = "sc-storage-monitor"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "clap 4.0.15",
  "fs4",
@@ -10130,7 +10130,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -10149,7 +10149,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "6.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "futures",
  "libc",
@@ -10168,7 +10168,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "chrono",
  "futures",
@@ -10187,7 +10187,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "ansi_term",
  "atty",
@@ -10218,7 +10218,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -10229,7 +10229,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "async-trait",
  "futures",
@@ -10256,7 +10256,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "async-trait",
  "futures",
@@ -10270,7 +10270,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "async-channel",
  "futures",
@@ -10809,7 +10809,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "hash-db",
  "log",
@@ -10827,7 +10827,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "Inflector",
  "blake2",
@@ -10841,7 +10841,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10854,7 +10854,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -10868,7 +10868,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10881,7 +10881,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -10893,7 +10893,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "futures",
  "log",
@@ -10911,7 +10911,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "async-trait",
  "futures",
@@ -10926,7 +10926,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -10944,7 +10944,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "async-trait",
  "merlin",
@@ -10967,7 +10967,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-beefy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "lazy_static",
  "parity-scale-codec",
@@ -10986,7 +10986,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -11004,7 +11004,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11016,7 +11016,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11029,7 +11029,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "array-bytes",
  "bitflags",
@@ -11072,7 +11072,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -11086,7 +11086,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11097,7 +11097,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.1",
@@ -11106,7 +11106,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11116,7 +11116,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.13.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -11127,7 +11127,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -11142,7 +11142,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "bytes",
  "ed25519",
@@ -11168,7 +11168,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -11179,7 +11179,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.13.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "futures",
  "merlin",
@@ -11195,7 +11195,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "4.1.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "thiserror",
  "zstd",
@@ -11204,7 +11204,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "ckb-merkle-mountain-range",
  "log",
@@ -11222,7 +11222,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11236,7 +11236,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -11246,7 +11246,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -11256,7 +11256,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -11266,7 +11266,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -11288,7 +11288,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -11306,7 +11306,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -11318,7 +11318,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11332,7 +11332,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11344,7 +11344,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.13.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "hash-db",
  "log",
@@ -11364,12 +11364,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 
 [[package]]
 name = "sp-storage"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -11382,7 +11382,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "async-trait",
  "futures-timer",
@@ -11397,7 +11397,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "parity-scale-codec",
  "sp-std",
@@ -11409,7 +11409,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -11418,7 +11418,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "async-trait",
  "log",
@@ -11434,7 +11434,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "ahash 0.8.2",
  "hash-db",
@@ -11457,7 +11457,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -11474,7 +11474,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -11485,7 +11485,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -11499,7 +11499,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11729,7 +11729,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "platforms 2.0.0",
 ]
@@ -11737,7 +11737,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures",
@@ -11756,7 +11756,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "hyper",
  "log",
@@ -11768,7 +11768,7 @@ dependencies = [
 [[package]]
 name = "substrate-rpc-client"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "async-trait",
  "jsonrpsee",
@@ -11781,7 +11781,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-trie-migration-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "jsonrpsee",
  "log",
@@ -11800,7 +11800,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -11826,7 +11826,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-utils"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "futures",
  "substrate-test-utils-derive",
@@ -11836,7 +11836,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-utils-derive"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -11847,7 +11847,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "5.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "ansi_term",
  "build-helper",
@@ -12677,7 +12677,7 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 [[package]]
 name = "try-runtime-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#a1d3d5004379976b13deab86b975c04ad78bcd72"
 dependencies = [
  "async-trait",
  "clap 4.0.15",

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -929,7 +929,7 @@ parameter_types! {
 	Decode,
 	RuntimeDebug,
 	MaxEncodedLen,
-	scale_info::TypeInfo,
+	TypeInfo,
 )]
 pub enum ProxyType {
 	Any,

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -2135,16 +2135,6 @@ sp_api::impl_runtime_apis! {
 }
 
 #[cfg(test)]
-mod encoding_tests {
-	use super::*;
-
-	#[test]
-	fn nis_hold_reason_encoding_is_correct() {
-		assert_eq!(NisHoldReason::get().encode(), [38, 0]);
-	}
-}
-
-#[cfg(test)]
 mod fees_tests {
 	use super::*;
 	use sp_runtime::assert_eq_error_rate;

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -1258,7 +1258,7 @@ parameter_types! {
 	pub const ThawThrottle: (Perquintill, BlockNumber) = (Perquintill::from_percent(25), 5);
 	pub storage NisTarget: Perquintill = Perquintill::zero();
 	pub const NisPalletId: PalletId = PalletId(*b"py/nis  ");
-	pub const NisHoldReason: RuntimeHoldReason = pallet_nis::HoldReason::NftReceipt.into();
+	pub const NisHoldReason: RuntimeHoldReason = RuntimeHoldReason::Nis(pallet_nis::HoldReason::NftReceipt);
 }
 
 impl pallet_nis::Config for Runtime {

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -1258,27 +1258,7 @@ parameter_types! {
 	pub const ThawThrottle: (Perquintill, BlockNumber) = (Perquintill::from_percent(25), 5);
 	pub storage NisTarget: Perquintill = Perquintill::zero();
 	pub const NisPalletId: PalletId = PalletId(*b"py/nis  ");
-	pub const NisHoldReason: HoldReason = HoldReason::Nis(HoldReasonNis::NftReceipt);
-}
-
-/// A reason for placing a hold on funds.
-#[derive(
-	Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, MaxEncodedLen, Debug, TypeInfo,
-)]
-pub enum HoldReason {
-	/// Some reason of the NIS pallet.
-	#[codec(index = 38)]
-	Nis(HoldReasonNis),
-}
-
-/// A reason for the NIS pallet placing a hold on funds.
-#[derive(
-	Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, MaxEncodedLen, Debug, TypeInfo,
-)]
-pub enum HoldReasonNis {
-	/// The NIS Pallet has reserved it for a non-fungible receipt.
-	#[codec(index = 0)]
-	NftReceipt = 0,
+	pub const NisHoldReason: RuntimeHoldReason = pallet_nis::HoldReason::NftReceipt.into();
 }
 
 impl pallet_nis::Config for Runtime {
@@ -1408,7 +1388,7 @@ construct_runtime! {
 		ElectionProviderMultiPhase: pallet_election_provider_multi_phase::{Pallet, Call, Storage, Event<T>, ValidateUnsigned} = 37,
 
 		// NIS pallet.
-		Nis: pallet_nis::{Pallet, Call, Storage, Event<T>} = 38,
+		Nis: pallet_nis::{Pallet, Call, Storage, Event<T>, HoldReason} = 38,
 //		pub type NisCounterpartInstance = pallet_balances::Instance2;
 		NisCounterpartBalances: pallet_balances::<Instance2> = 45,
 
@@ -2155,7 +2135,17 @@ sp_api::impl_runtime_apis! {
 }
 
 #[cfg(test)]
-mod tests_fess {
+mod encoding_tests {
+	use super::*;
+
+	#[test]
+	fn nis_hold_reason_encoding_is_correct() {
+		assert_eq!(NisHoldReason::get().encode(), [38, 0]);
+	}
+}
+
+#[cfg(test)]
+mod fees_tests {
 	use super::*;
 	use sp_runtime::assert_eq_error_rate;
 

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -303,7 +303,7 @@ impl pallet_balances::Config for Runtime {
 	type WeightInfo = weights::pallet_balances::WeightInfo<Runtime>;
 	type FreezeIdentifier = ();
 	type MaxFreezes = ();
-	type HoldIdentifier = HoldReason;
+	type HoldIdentifier = RuntimeHoldReason;
 	type MaxHolds = ConstU32<1>;
 }
 

--- a/runtime/kusama/src/tests.rs
+++ b/runtime/kusama/src/tests.rs
@@ -26,6 +26,11 @@ use separator::Separatable;
 use sp_runtime::FixedPointNumber;
 
 #[test]
+fn nis_hold_reason_encoding_is_correct() {
+	assert_eq!(NisHoldReason::get().encode(), [38, 0]);
+}
+
+#[test]
 fn remove_keys_weight_is_sensible() {
 	use runtime_common::crowdloan::WeightInfo;
 	let max_weight = <Runtime as crowdloan::Config>::WeightInfo::refund(RemoveKeysLimit::get());

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -875,7 +875,7 @@ parameter_types! {
 	Decode,
 	RuntimeDebug,
 	MaxEncodedLen,
-	scale_info::TypeInfo,
+	TypeInfo,
 )]
 pub enum ProxyType {
 	Any,

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -1196,7 +1196,7 @@ parameter_types! {
 	pub const ThawThrottle: (Perquintill, BlockNumber) = (Perquintill::from_percent(25), 5);
 	pub storage NisTarget: Perquintill = Perquintill::zero();
 	pub const NisPalletId: PalletId = PalletId(*b"py/nis  ");
-	pub const NisHoldReason: RuntimeHoldReason = pallet_nis::HoldReason::NftReceipt.into();
+	pub const NisHoldReason: RuntimeHoldReason = RuntimeHoldReason::Nis(pallet_nis::HoldReason::NftReceipt);
 }
 
 impl pallet_nis::Config for Runtime {

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -1196,27 +1196,7 @@ parameter_types! {
 	pub const ThawThrottle: (Perquintill, BlockNumber) = (Perquintill::from_percent(25), 5);
 	pub storage NisTarget: Perquintill = Perquintill::zero();
 	pub const NisPalletId: PalletId = PalletId(*b"py/nis  ");
-	pub const NisHoldReason: HoldReason = HoldReason::Nis(HoldReasonNis::NftReceipt);
-}
-
-/// A reason for placing a hold on funds.
-#[derive(
-	Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, MaxEncodedLen, Debug, TypeInfo,
-)]
-pub enum HoldReason {
-	/// Some reason of the NIS pallet.
-	#[codec(index = 38)]
-	Nis(HoldReasonNis),
-}
-
-/// A reason for the NIS pallet placing a hold on funds.
-#[derive(
-	Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, MaxEncodedLen, Debug, TypeInfo,
-)]
-pub enum HoldReasonNis {
-	/// The NIS Pallet has reserved it for a non-fungible receipt.
-	#[codec(index = 0)]
-	NftReceipt = 0,
+	pub const NisHoldReason: RuntimeHoldReason = pallet_nis::HoldReason::NftReceipt.into();
 }
 
 impl pallet_nis::Config for Runtime {
@@ -1416,7 +1396,7 @@ construct_runtime! {
 		Tips: pallet_tips::{Pallet, Call, Storage, Event<T>} = 36,
 
 		// NIS pallet.
-		Nis: pallet_nis::{Pallet, Call, Storage, Event<T>} = 38,
+		Nis: pallet_nis::{Pallet, Call, Storage, Event<T>, HoldReason} = 38,
 //		pub type NisCounterpartInstance = pallet_balances::Instance2;
 		NisCounterpartBalances: pallet_balances::<Instance2> = 45,
 
@@ -2149,6 +2129,16 @@ sp_api::impl_runtime_apis! {
 
 			Ok(batches)
 		}
+	}
+}
+
+#[cfg(test)]
+mod encoding_tests {
+	use super::*;
+
+	#[test]
+	fn nis_hold_reason_encoding_is_correct() {
+		assert_eq!(NisHoldReason::get().encode(), [38, 0]);
 	}
 }
 

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -284,7 +284,7 @@ impl pallet_balances::Config for Runtime {
 	type WeightInfo = weights::pallet_balances::WeightInfo<Runtime>;
 	type FreezeIdentifier = ();
 	type MaxFreezes = ConstU32<1>;
-	type HoldIdentifier = HoldReason;
+	type HoldIdentifier = RuntimeHoldReason;
 	type MaxHolds = ConstU32<1>;
 }
 


### PR DESCRIPTION
Partial paritytech/substrate#12918.

Removes the user-defined enums on the runtime source file and instead uses the macro-generated `RuntimeHoldReason` for the NIS pallet's `HoldReason`.