### PR TITLE
[Feature] XCM-emulator tool to test live runtimes.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1438,7 +1438,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-dmp-queue"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=master#a5a79db4f81725d10e0f1dd339fe7d9b9e837d9f"
+source = "git+https://github.com/paritytech/cumulus?branch=master#b0715f9bd9f24758c132fb7dc8adcd30551f7de4"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -1449,13 +1449,13 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "xcm 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "xcm",
 ]
 
 [[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=master#a5a79db4f81725d10e0f1dd339fe7d9b9e837d9f"
+source = "git+https://github.com/paritytech/cumulus?branch=master#b0715f9bd9f24758c132fb7dc8adcd30551f7de4"
 dependencies = [
  "bytes",
  "cumulus-pallet-parachain-system-proc-macro",
@@ -1467,7 +1467,7 @@ dependencies = [
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
- "polkadot-parachain 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "polkadot-parachain",
  "scale-info",
  "sp-core",
  "sp-externalities",
@@ -1478,13 +1478,13 @@ dependencies = [
  "sp-std",
  "sp-trie",
  "sp-version",
- "xcm 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "xcm",
 ]
 
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=master#a5a79db4f81725d10e0f1dd339fe7d9b9e837d9f"
+source = "git+https://github.com/paritytech/cumulus?branch=master#b0715f9bd9f24758c132fb7dc8adcd30551f7de4"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1493,9 +1493,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "cumulus-pallet-xcm"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/cumulus?branch=master#b0715f9bd9f24758c132fb7dc8adcd30551f7de4"
+dependencies = [
+ "cumulus-primitives-core",
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+ "xcm",
+]
+
+[[package]]
 name = "cumulus-pallet-xcmp-queue"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=master#a5a79db4f81725d10e0f1dd339fe7d9b9e837d9f"
+source = "git+https://github.com/paritytech/cumulus?branch=master#b0715f9bd9f24758c132fb7dc8adcd30551f7de4"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -1508,30 +1524,30 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "xcm 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
- "xcm-executor 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "xcm",
+ "xcm-executor",
 ]
 
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=master#a5a79db4f81725d10e0f1dd339fe7d9b9e837d9f"
+source = "git+https://github.com/paritytech/cumulus?branch=master#b0715f9bd9f24758c132fb7dc8adcd30551f7de4"
 dependencies = [
  "parity-scale-codec",
- "polkadot-core-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
- "polkadot-parachain 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "polkadot-core-primitives",
+ "polkadot-parachain",
  "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "sp-api",
  "sp-runtime",
  "sp-std",
  "sp-trie",
- "xcm 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "xcm",
 ]
 
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=master#a5a79db4f81725d10e0f1dd339fe7d9b9e837d9f"
+source = "git+https://github.com/paritytech/cumulus?branch=master#b0715f9bd9f24758c132fb7dc8adcd30551f7de4"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -1552,9 +1568,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "cumulus-primitives-utility"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/cumulus?branch=master#b0715f9bd9f24758c132fb7dc8adcd30551f7de4"
+dependencies = [
+ "cumulus-primitives-core",
+ "frame-support",
+ "log",
+ "parity-scale-codec",
+ "polkadot-runtime-common 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+ "xcm",
+ "xcm-builder 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "xcm-executor",
+]
+
+[[package]]
 name = "cumulus-relay-chain-interface"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=master#a5a79db4f81725d10e0f1dd339fe7d9b9e837d9f"
+source = "git+https://github.com/paritytech/cumulus?branch=master#b0715f9bd9f24758c132fb7dc8adcd30551f7de4"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -1572,7 +1606,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=master#a5a79db4f81725d10e0f1dd339fe7d9b9e837d9f"
+source = "git+https://github.com/paritytech/cumulus?branch=master#b0715f9bd9f24758c132fb7dc8adcd30551f7de4"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -2512,7 +2546,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "fork-tree"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -2535,7 +2569,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 [[package]]
 name = "frame-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -2607,7 +2641,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2618,7 +2652,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -2680,7 +2714,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "bitflags",
  "environmental",
@@ -2713,7 +2747,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -2729,7 +2763,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -2741,7 +2775,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2786,7 +2820,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "frame-support",
  "log",
@@ -3913,9 +3947,9 @@ dependencies = [
  "substrate-wasm-builder",
  "tiny-keccak",
  "tokio",
- "xcm 0.9.39",
- "xcm-builder",
- "xcm-executor 0.9.39",
+ "xcm",
+ "xcm-builder 0.9.39",
+ "xcm-executor",
 ]
 
 [[package]]
@@ -5426,7 +5460,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5442,7 +5476,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5456,7 +5490,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5519,7 +5553,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5666,7 +5700,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5689,7 +5723,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5720,7 +5754,7 @@ dependencies = [
 [[package]]
 name = "pallet-fast-unstake"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6070,7 +6104,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6121,7 +6155,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6155,7 +6189,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -6204,7 +6238,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6241,7 +6275,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6285,7 +6319,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6333,7 +6367,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6371,7 +6405,7 @@ dependencies = [
  "log",
  "pallet-balances",
  "parity-scale-codec",
- "polkadot-parachain 0.9.39",
+ "polkadot-parachain",
  "polkadot-runtime-parachains 0.9.39",
  "scale-info",
  "serde",
@@ -6379,9 +6413,9 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "xcm 0.9.39",
- "xcm-builder",
- "xcm-executor 0.9.39",
+ "xcm",
+ "xcm-builder 0.9.39",
+ "xcm-executor",
 ]
 
 [[package]]
@@ -6404,15 +6438,15 @@ dependencies = [
  "sp-runtime",
  "sp-std",
  "sp-tracing",
- "xcm 0.9.39",
- "xcm-builder",
- "xcm-executor 0.9.39",
+ "xcm",
+ "xcm-builder 0.9.39",
+ "xcm-executor",
 ]
 
 [[package]]
 name = "parachain-info"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=master#a5a79db4f81725d10e0f1dd339fe7d9b9e837d9f"
+source = "git+https://github.com/paritytech/cumulus?branch=master#b0715f9bd9f24758c132fb7dc8adcd30551f7de4"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -6725,7 +6759,7 @@ dependencies = [
  "color-eyre",
  "nix 0.26.2",
  "polkadot-cli",
- "polkadot-core-primitives 0.9.39",
+ "polkadot-core-primitives",
  "polkadot-node-core-pvf",
  "polkadot-overseer 0.9.39",
  "substrate-rpc-client",
@@ -6884,7 +6918,7 @@ dependencies = [
  "kusama-runtime",
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",
- "polkadot-core-primitives 0.9.39",
+ "polkadot-core-primitives",
  "polkadot-node-core-parachains-inherent",
  "polkadot-primitives 0.9.39",
  "polkadot-runtime",
@@ -6947,18 +6981,6 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "0.9.39"
-dependencies = [
- "parity-scale-codec",
- "scale-info",
- "sp-core",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
-name = "polkadot-core-primitives"
-version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#7b6ea485f568f836e2b6e0099f5f53c04d7d1c18"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -7213,7 +7235,7 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-test-helpers",
  "polkadot-node-subsystem-util",
- "polkadot-parachain 0.9.39",
+ "polkadot-parachain",
  "polkadot-primitives 0.9.39",
  "polkadot-primitives-test-helpers",
  "sp-core",
@@ -7340,10 +7362,10 @@ dependencies = [
  "libc",
  "parity-scale-codec",
  "pin-project",
- "polkadot-core-primitives 0.9.39",
+ "polkadot-core-primitives",
  "polkadot-node-metrics 0.9.39",
  "polkadot-node-primitives 0.9.39",
- "polkadot-parachain 0.9.39",
+ "polkadot-parachain",
  "polkadot-primitives 0.9.39",
  "rand 0.8.5",
  "rayon",
@@ -7430,7 +7452,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-jaeger"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#7b6ea485f568f836e2b6e0099f5f53c04d7d1c18"
+source = "git+https://github.com/paritytech/polkadot?branch=master#dbae30efe080a1d41fe54ef4da8af47614c9ca93"
 dependencies = [
  "lazy_static",
  "log",
@@ -7475,7 +7497,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-metrics"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#7b6ea485f568f836e2b6e0099f5f53c04d7d1c18"
+source = "git+https://github.com/paritytech/polkadot?branch=master#dbae30efe080a1d41fe54ef4da8af47614c9ca93"
 dependencies = [
  "bs58",
  "futures",
@@ -7516,7 +7538,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#7b6ea485f568f836e2b6e0099f5f53c04d7d1c18"
+source = "git+https://github.com/paritytech/polkadot?branch=master#dbae30efe080a1d41fe54ef4da8af47614c9ca93"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -7543,7 +7565,7 @@ dependencies = [
  "futures",
  "parity-scale-codec",
  "polkadot-erasure-coding",
- "polkadot-parachain 0.9.39",
+ "polkadot-parachain",
  "polkadot-primitives 0.9.39",
  "schnorrkel",
  "serde",
@@ -7561,12 +7583,12 @@ dependencies = [
 [[package]]
 name = "polkadot-node-primitives"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#7b6ea485f568f836e2b6e0099f5f53c04d7d1c18"
+source = "git+https://github.com/paritytech/polkadot?branch=master#dbae30efe080a1d41fe54ef4da8af47614c9ca93"
 dependencies = [
  "bounded-vec",
  "futures",
  "parity-scale-codec",
- "polkadot-parachain 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "polkadot-parachain",
  "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "schnorrkel",
  "serde",
@@ -7633,7 +7655,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-types"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#7b6ea485f568f836e2b6e0099f5f53c04d7d1c18"
+source = "git+https://github.com/paritytech/polkadot?branch=master#dbae30efe080a1d41fe54ef4da8af47614c9ca93"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -7723,7 +7745,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#7b6ea485f568f836e2b6e0099f5f53c04d7d1c18"
+source = "git+https://github.com/paritytech/polkadot?branch=master#dbae30efe080a1d41fe54ef4da8af47614c9ca93"
 dependencies = [
  "async-trait",
  "futures",
@@ -7751,24 +7773,7 @@ dependencies = [
  "derive_more",
  "frame-support",
  "parity-scale-codec",
- "polkadot-core-primitives 0.9.39",
- "scale-info",
- "serde",
- "sp-core",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
-name = "polkadot-parachain"
-version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#7b6ea485f568f836e2b6e0099f5f53c04d7d1c18"
-dependencies = [
- "bounded-collections",
- "derive_more",
- "frame-support",
- "parity-scale-codec",
- "polkadot-core-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "polkadot-core-primitives",
  "scale-info",
  "serde",
  "sp-core",
@@ -7798,8 +7803,8 @@ dependencies = [
  "bitvec",
  "hex-literal",
  "parity-scale-codec",
- "polkadot-core-primitives 0.9.39",
- "polkadot-parachain 0.9.39",
+ "polkadot-core-primitives",
+ "polkadot-parachain",
  "scale-info",
  "serde",
  "sp-api",
@@ -7819,13 +7824,13 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#7b6ea485f568f836e2b6e0099f5f53c04d7d1c18"
+source = "git+https://github.com/paritytech/polkadot?branch=master#dbae30efe080a1d41fe54ef4da8af47614c9ca93"
 dependencies = [
  "bitvec",
  "hex-literal",
  "parity-scale-codec",
- "polkadot-core-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
- "polkadot-parachain 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "polkadot-core-primitives",
+ "polkadot-parachain",
  "scale-info",
  "serde",
  "sp-api",
@@ -7981,9 +7986,9 @@ dependencies = [
  "substrate-wasm-builder",
  "tiny-keccak",
  "tokio",
- "xcm 0.9.39",
- "xcm-builder",
- "xcm-executor 0.9.39",
+ "xcm",
+ "xcm-builder 0.9.39",
+ "xcm-executor",
 ]
 
 [[package]]
@@ -8033,13 +8038,13 @@ dependencies = [
  "sp-staking",
  "sp-std",
  "static_assertions",
- "xcm 0.9.39",
+ "xcm",
 ]
 
 [[package]]
 name = "polkadot-runtime-common"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#7b6ea485f568f836e2b6e0099f5f53c04d7d1c18"
+source = "git+https://github.com/paritytech/polkadot?branch=master#dbae30efe080a1d41fe54ef4da8af47614c9ca93"
 dependencies = [
  "bitvec",
  "frame-election-provider-support",
@@ -8077,7 +8082,7 @@ dependencies = [
  "sp-staking",
  "sp-std",
  "static_assertions",
- "xcm 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "xcm",
 ]
 
 [[package]]
@@ -8108,7 +8113,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-metrics"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#7b6ea485f568f836e2b6e0099f5f53c04d7d1c18"
+source = "git+https://github.com/paritytech/polkadot?branch=master#dbae30efe080a1d41fe54ef4da8af47614c9ca93"
 dependencies = [
  "bs58",
  "parity-scale-codec",
@@ -8141,7 +8146,7 @@ dependencies = [
  "pallet-timestamp",
  "pallet-vesting",
  "parity-scale-codec",
- "polkadot-parachain 0.9.39",
+ "polkadot-parachain",
  "polkadot-primitives 0.9.39",
  "polkadot-primitives-test-helpers",
  "polkadot-runtime-metrics 0.9.39",
@@ -8166,14 +8171,14 @@ dependencies = [
  "sp-tracing",
  "static_assertions",
  "thousands",
- "xcm 0.9.39",
- "xcm-executor 0.9.39",
+ "xcm",
+ "xcm-executor",
 ]
 
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#7b6ea485f568f836e2b6e0099f5f53c04d7d1c18"
+source = "git+https://github.com/paritytech/polkadot?branch=master#dbae30efe080a1d41fe54ef4da8af47614c9ca93"
 dependencies = [
  "bitflags",
  "bitvec",
@@ -8190,7 +8195,7 @@ dependencies = [
  "pallet-timestamp",
  "pallet-vesting",
  "parity-scale-codec",
- "polkadot-parachain 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "polkadot-parachain",
  "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "polkadot-runtime-metrics 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "rand 0.8.5",
@@ -8207,8 +8212,8 @@ dependencies = [
  "sp-session",
  "sp-staking",
  "sp-std",
- "xcm 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
- "xcm-executor 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "xcm",
+ "xcm-executor",
 ]
 
 [[package]]
@@ -8264,7 +8269,7 @@ dependencies = [
  "polkadot-node-subsystem-types 0.9.39",
  "polkadot-node-subsystem-util",
  "polkadot-overseer 0.9.39",
- "polkadot-parachain 0.9.39",
+ "polkadot-parachain",
  "polkadot-primitives 0.9.39",
  "polkadot-rpc",
  "polkadot-runtime",
@@ -8370,7 +8375,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#7b6ea485f568f836e2b6e0099f5f53c04d7d1c18"
+source = "git+https://github.com/paritytech/polkadot?branch=master#dbae30efe080a1d41fe54ef4da8af47614c9ca93"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
@@ -8460,7 +8465,7 @@ dependencies = [
  "pallet-vesting",
  "pallet-xcm",
  "parity-scale-codec",
- "polkadot-parachain 0.9.39",
+ "polkadot-parachain",
  "polkadot-primitives 0.9.39",
  "polkadot-runtime-common 0.9.39",
  "polkadot-runtime-parachains 0.9.39",
@@ -8491,9 +8496,9 @@ dependencies = [
  "substrate-wasm-builder",
  "test-runtime-constants",
  "tiny-keccak",
- "xcm 0.9.39",
- "xcm-builder",
- "xcm-executor 0.9.39",
+ "xcm",
+ "xcm-builder 0.9.39",
+ "xcm-executor",
 ]
 
 [[package]]
@@ -8510,7 +8515,7 @@ dependencies = [
  "polkadot-node-primitives 0.9.39",
  "polkadot-node-subsystem",
  "polkadot-overseer 0.9.39",
- "polkadot-parachain 0.9.39",
+ "polkadot-parachain",
  "polkadot-primitives 0.9.39",
  "polkadot-rpc",
  "polkadot-runtime-common 0.9.39",
@@ -9365,7 +9370,7 @@ dependencies = [
  "pallet-xcm",
  "pallet-xcm-benchmarks",
  "parity-scale-codec",
- "polkadot-parachain 0.9.39",
+ "polkadot-parachain",
  "polkadot-primitives 0.9.39",
  "polkadot-runtime-common 0.9.39",
  "polkadot-runtime-parachains 0.9.39",
@@ -9399,9 +9404,9 @@ dependencies = [
  "substrate-wasm-builder",
  "tiny-keccak",
  "tokio",
- "xcm 0.9.39",
- "xcm-builder",
- "xcm-executor 0.9.39",
+ "xcm",
+ "xcm-builder 0.9.39",
+ "xcm-executor",
 ]
 
 [[package]]
@@ -9621,7 +9626,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "4.1.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "log",
  "sp-core",
@@ -9632,7 +9637,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "async-trait",
  "futures",
@@ -9683,7 +9688,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -9698,7 +9703,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "memmap2",
  "sc-chain-spec-derive",
@@ -9717,7 +9722,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -9728,7 +9733,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "array-bytes",
  "chrono",
@@ -9768,7 +9773,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "fnv",
  "futures",
@@ -9794,7 +9799,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -9820,7 +9825,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "async-trait",
  "futures",
@@ -10056,7 +10061,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "lru 0.8.1",
  "parity-scale-codec",
@@ -10080,7 +10085,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "sc-allocator",
  "sp-maybe-compressed-blob",
@@ -10093,7 +10098,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "log",
  "sc-allocator",
@@ -10106,7 +10111,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -10124,7 +10129,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "ansi_term",
  "futures",
@@ -10140,7 +10145,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -10155,7 +10160,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "array-bytes",
  "async-channel",
@@ -10200,7 +10205,7 @@ dependencies = [
 [[package]]
 name = "sc-network-bitswap"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "cid",
  "futures",
@@ -10220,7 +10225,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -10267,7 +10272,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "array-bytes",
  "futures",
@@ -10289,7 +10294,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -10323,7 +10328,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "array-bytes",
  "futures",
@@ -10343,7 +10348,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "array-bytes",
  "bytes",
@@ -10374,7 +10379,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "futures",
  "libp2p",
@@ -10396,7 +10401,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -10426,7 +10431,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -10445,7 +10450,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "http",
  "jsonrpsee",
@@ -10460,7 +10465,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "array-bytes",
  "futures",
@@ -10486,7 +10491,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "async-trait",
  "directories",
@@ -10552,7 +10557,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -10563,7 +10568,7 @@ dependencies = [
 [[package]]
 name = "sc-storage-monitor"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "clap 4.0.15",
  "fs4",
@@ -10598,7 +10603,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "6.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "futures",
  "libc",
@@ -10617,7 +10622,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "chrono",
  "futures",
@@ -10636,7 +10641,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "ansi_term",
  "atty",
@@ -10667,7 +10672,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -10678,7 +10683,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "async-trait",
  "futures",
@@ -10705,7 +10710,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "async-trait",
  "futures",
@@ -10719,7 +10724,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "async-channel",
  "futures",
@@ -11193,7 +11198,7 @@ dependencies = [
 [[package]]
 name = "slot-range-helper"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#7b6ea485f568f836e2b6e0099f5f53c04d7d1c18"
+source = "git+https://github.com/paritytech/polkadot?branch=master#dbae30efe080a1d41fe54ef4da8af47614c9ca93"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -11270,7 +11275,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "hash-db",
  "log",
@@ -11288,7 +11293,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "Inflector",
  "blake2",
@@ -11302,7 +11307,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11315,7 +11320,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -11329,7 +11334,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11342,7 +11347,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -11354,7 +11359,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "futures",
  "log",
@@ -11372,7 +11377,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "async-trait",
  "futures",
@@ -11405,7 +11410,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "async-trait",
  "merlin",
@@ -11447,7 +11452,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -11465,7 +11470,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11477,7 +11482,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11490,7 +11495,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "array-bytes",
  "bitflags",
@@ -11533,7 +11538,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -11547,7 +11552,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11558,7 +11563,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.1",
@@ -11567,7 +11572,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11577,7 +11582,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.13.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -11588,7 +11593,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -11603,7 +11608,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "bytes",
  "ed25519",
@@ -11629,7 +11634,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -11640,7 +11645,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.13.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "futures",
  "merlin",
@@ -11656,7 +11661,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "4.1.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "thiserror",
  "zstd",
@@ -11683,7 +11688,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11697,7 +11702,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -11707,7 +11712,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -11717,7 +11722,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -11727,7 +11732,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -11749,7 +11754,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -11767,7 +11772,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -11779,7 +11784,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11793,7 +11798,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11805,7 +11810,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.13.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "hash-db",
  "log",
@@ -11825,12 +11830,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 
 [[package]]
 name = "sp-storage"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -11843,7 +11848,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "async-trait",
  "futures-timer",
@@ -11858,7 +11863,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "parity-scale-codec",
  "sp-std",
@@ -11870,7 +11875,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -11879,7 +11884,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "async-trait",
  "log",
@@ -11895,7 +11900,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "ahash 0.8.2",
  "hash-db",
@@ -11918,7 +11923,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -11935,7 +11940,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -11946,7 +11951,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -11960,7 +11965,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12040,7 +12045,7 @@ dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
  "paste",
- "polkadot-core-primitives 0.9.39",
+ "polkadot-core-primitives",
  "polkadot-runtime",
  "polkadot-runtime-common 0.9.39",
  "sc-transaction-pool-api",
@@ -12217,7 +12222,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#2e94e253950457571e91a5df1e60f82ba7b841dd"
 dependencies = [
  "hyper",
  "log",
@@ -12471,7 +12476,7 @@ version = "0.9.39"
 dependencies = [
  "dlmalloc",
  "parity-scale-codec",
- "polkadot-parachain 0.9.39",
+ "polkadot-parachain",
  "sp-io",
  "sp-std",
  "substrate-wasm-builder",
@@ -12491,7 +12496,7 @@ dependencies = [
  "polkadot-node-core-pvf",
  "polkadot-node-primitives 0.9.39",
  "polkadot-node-subsystem",
- "polkadot-parachain 0.9.39",
+ "polkadot-parachain",
  "polkadot-primitives 0.9.39",
  "polkadot-service",
  "polkadot-test-service",
@@ -12519,7 +12524,7 @@ dependencies = [
  "dlmalloc",
  "log",
  "parity-scale-codec",
- "polkadot-parachain 0.9.39",
+ "polkadot-parachain",
  "sp-io",
  "sp-std",
  "substrate-wasm-builder",
@@ -12539,7 +12544,7 @@ dependencies = [
  "polkadot-node-core-pvf",
  "polkadot-node-primitives 0.9.39",
  "polkadot-node-subsystem",
- "polkadot-parachain 0.9.39",
+ "polkadot-parachain",
  "polkadot-primitives 0.9.39",
  "polkadot-service",
  "polkadot-test-service",
@@ -12990,7 +12995,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#7b6ea485f568f836e2b6e0099f5f53c04d7d1c18"
+source = "git+https://github.com/paritytech/polkadot?branch=master#dbae30efe080a1d41fe54ef4da8af47614c9ca93"
 dependencies = [
  "polkadot-node-jaeger 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
@@ -13013,7 +13018,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#7b6ea485f568f836e2b6e0099f5f53c04d7d1c18"
+source = "git+https://github.com/paritytech/polkadot?branch=master#dbae30efe080a1d41fe54ef4da8af47614c9ca93"
 dependencies = [
  "expander 0.0.6",
  "proc-macro-crate",
@@ -14160,7 +14165,7 @@ dependencies = [
  "pallet-xcm",
  "pallet-xcm-benchmarks",
  "parity-scale-codec",
- "polkadot-parachain 0.9.39",
+ "polkadot-parachain",
  "polkadot-primitives 0.9.39",
  "polkadot-runtime-common 0.9.39",
  "polkadot-runtime-parachains 0.9.39",
@@ -14193,9 +14198,9 @@ dependencies = [
  "tiny-keccak",
  "tokio",
  "westend-runtime-constants",
- "xcm 0.9.39",
- "xcm-builder",
- "xcm-executor 0.9.39",
+ "xcm",
+ "xcm-builder 0.9.39",
+ "xcm-executor",
 ]
 
 [[package]]
@@ -14522,23 +14527,7 @@ dependencies = [
  "serde",
  "sp-io",
  "sp-weights",
- "xcm-procedural 0.9.39",
-]
-
-[[package]]
-name = "xcm"
-version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#7b6ea485f568f836e2b6e0099f5f53c04d7d1c18"
-dependencies = [
- "bounded-collections",
- "derivative",
- "impl-trait-for-tuples",
- "log",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-weights",
- "xcm-procedural 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "xcm-procedural",
 ]
 
 [[package]]
@@ -14554,7 +14543,7 @@ dependencies = [
  "pallet-transaction-payment",
  "pallet-xcm",
  "parity-scale-codec",
- "polkadot-parachain 0.9.39",
+ "polkadot-parachain",
  "polkadot-runtime-parachains 0.9.39",
  "primitive-types",
  "scale-info",
@@ -14562,8 +14551,29 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "xcm 0.9.39",
- "xcm-executor 0.9.39",
+ "xcm",
+ "xcm-executor",
+]
+
+[[package]]
+name = "xcm-builder"
+version = "0.9.39"
+source = "git+https://github.com/paritytech/polkadot?branch=master#dbae30efe080a1d41fe54ef4da8af47614c9ca93"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "impl-trait-for-tuples",
+ "log",
+ "pallet-transaction-payment",
+ "parity-scale-codec",
+ "polkadot-parachain",
+ "scale-info",
+ "sp-arithmetic",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+ "xcm",
+ "xcm-executor",
 ]
 
 [[package]]
@@ -14587,8 +14597,33 @@ dependencies = [
  "sp-arithmetic",
  "sp-io",
  "sp-std",
- "xcm 0.9.39",
- "xcm-executor 0.9.39",
+ "xcm",
+ "xcm-executor",
+]
+
+[[package]]
+name = "xcm-emulator-example"
+version = "0.1.0"
+dependencies = [
+ "cumulus-pallet-xcmp-queue",
+ "cumulus-primitives-core",
+ "frame-support",
+ "frame-system",
+ "kusama-runtime",
+ "pallet-balances",
+ "pallet-xcm",
+ "parachain-info",
+ "parity-scale-codec",
+ "polkadot-parachain",
+ "polkadot-primitives 0.9.39",
+ "polkadot-runtime-parachains 0.9.39",
+ "proc-macro2",
+ "serde",
+ "sp-io",
+ "sp-runtime",
+ "xcm",
+ "xcm-emulator",
+ "yayoi",
 ]
 
 [[package]]
@@ -14607,26 +14642,7 @@ dependencies = [
  "sp-runtime",
  "sp-std",
  "sp-weights",
- "xcm 0.9.39",
-]
-
-[[package]]
-name = "xcm-executor"
-version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#7b6ea485f568f836e2b6e0099f5f53c04d7d1c18"
-dependencies = [
- "environmental",
- "frame-support",
- "impl-trait-for-tuples",
- "log",
- "parity-scale-codec",
- "sp-arithmetic",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std",
- "sp-weights",
- "xcm 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "xcm",
 ]
 
 [[package]]
@@ -14645,24 +14661,13 @@ dependencies = [
  "sp-runtime",
  "sp-state-machine",
  "sp-tracing",
- "xcm 0.9.39",
- "xcm-executor 0.9.39",
+ "xcm",
+ "xcm-executor",
 ]
 
 [[package]]
 name = "xcm-procedural"
 version = "0.9.39"
-dependencies = [
- "Inflector",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "xcm-procedural"
-version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#7b6ea485f568f836e2b6e0099f5f53c04d7d1c18"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -14677,13 +14682,13 @@ dependencies = [
  "frame-support",
  "parity-scale-codec",
  "paste",
- "polkadot-core-primitives 0.9.39",
- "polkadot-parachain 0.9.39",
+ "polkadot-core-primitives",
+ "polkadot-parachain",
  "polkadot-runtime-parachains 0.9.39",
  "sp-io",
  "sp-std",
- "xcm 0.9.39",
- "xcm-executor 0.9.39",
+ "xcm",
+ "xcm-executor",
 ]
 
 [[package]]
@@ -14697,8 +14702,8 @@ dependencies = [
  "pallet-uniques",
  "pallet-xcm",
  "parity-scale-codec",
- "polkadot-core-primitives 0.9.39",
- "polkadot-parachain 0.9.39",
+ "polkadot-core-primitives",
+ "polkadot-parachain",
  "polkadot-runtime-parachains 0.9.39",
  "scale-info",
  "sp-core",
@@ -14706,9 +14711,9 @@ dependencies = [
  "sp-runtime",
  "sp-std",
  "sp-tracing",
- "xcm 0.9.39",
- "xcm-builder",
- "xcm-executor 0.9.39",
+ "xcm",
+ "xcm-builder 0.9.39",
+ "xcm-executor",
  "xcm-simulator",
 ]
 
@@ -14723,17 +14728,17 @@ dependencies = [
  "pallet-balances",
  "pallet-xcm",
  "parity-scale-codec",
- "polkadot-core-primitives 0.9.39",
- "polkadot-parachain 0.9.39",
+ "polkadot-core-primitives",
+ "polkadot-parachain",
  "polkadot-runtime-parachains 0.9.39",
  "scale-info",
  "sp-core",
  "sp-io",
  "sp-runtime",
  "sp-std",
- "xcm 0.9.39",
- "xcm-builder",
- "xcm-executor 0.9.39",
+ "xcm",
+ "xcm-builder 0.9.39",
+ "xcm-executor",
  "xcm-simulator",
 ]
 
@@ -14758,6 +14763,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aed2e7a52e3744ab4d0c05c20aa065258e84c49fd4226f5191b2ed29712710b4"
 dependencies = [
  "time 0.3.17",
+]
+
+[[package]]
+name = "yayoi"
+version = "0.1.0"
+dependencies = [
+ "cumulus-pallet-dmp-queue",
+ "cumulus-pallet-parachain-system",
+ "cumulus-pallet-xcm",
+ "cumulus-pallet-xcmp-queue",
+ "cumulus-primitives-utility",
+ "frame-support",
+ "frame-system",
+ "pallet-balances",
+ "pallet-xcm",
+ "parachain-info",
+ "parity-scale-codec",
+ "polkadot-parachain",
+ "polkadot-runtime-parachains 0.9.39",
+ "scale-info",
+ "serde",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+ "xcm",
+ "xcm-builder 0.9.39",
+ "xcm-executor",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1581,7 +1581,7 @@ dependencies = [
  "sp-runtime",
  "sp-std",
  "xcm",
- "xcm-builder 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "xcm-builder",
  "xcm-executor",
 ]
 
@@ -3948,7 +3948,7 @@ dependencies = [
  "tiny-keccak",
  "tokio",
  "xcm",
- "xcm-builder 0.9.39",
+ "xcm-builder",
  "xcm-executor",
 ]
 
@@ -6414,7 +6414,7 @@ dependencies = [
  "sp-runtime",
  "sp-std",
  "xcm",
- "xcm-builder 0.9.39",
+ "xcm-builder",
  "xcm-executor",
 ]
 
@@ -6439,7 +6439,7 @@ dependencies = [
  "sp-std",
  "sp-tracing",
  "xcm",
- "xcm-builder 0.9.39",
+ "xcm-builder",
  "xcm-executor",
 ]
 
@@ -7987,7 +7987,7 @@ dependencies = [
  "tiny-keccak",
  "tokio",
  "xcm",
- "xcm-builder 0.9.39",
+ "xcm-builder",
  "xcm-executor",
 ]
 
@@ -8497,7 +8497,7 @@ dependencies = [
  "test-runtime-constants",
  "tiny-keccak",
  "xcm",
- "xcm-builder 0.9.39",
+ "xcm-builder",
  "xcm-executor",
 ]
 
@@ -9405,7 +9405,7 @@ dependencies = [
  "tiny-keccak",
  "tokio",
  "xcm",
- "xcm-builder 0.9.39",
+ "xcm-builder",
  "xcm-executor",
 ]
 
@@ -14199,7 +14199,7 @@ dependencies = [
  "tokio",
  "westend-runtime-constants",
  "xcm",
- "xcm-builder 0.9.39",
+ "xcm-builder",
  "xcm-executor",
 ]
 
@@ -14556,27 +14556,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "xcm-builder"
-version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dbae30efe080a1d41fe54ef4da8af47614c9ca93"
-dependencies = [
- "frame-support",
- "frame-system",
- "impl-trait-for-tuples",
- "log",
- "pallet-transaction-payment",
- "parity-scale-codec",
- "polkadot-parachain",
- "scale-info",
- "sp-arithmetic",
- "sp-io",
- "sp-runtime",
- "sp-std",
- "xcm",
- "xcm-executor",
-]
-
-[[package]]
 name = "xcm-emulator"
 version = "0.9.39"
 dependencies = [
@@ -14712,7 +14691,7 @@ dependencies = [
  "sp-std",
  "sp-tracing",
  "xcm",
- "xcm-builder 0.9.39",
+ "xcm-builder",
  "xcm-executor",
  "xcm-simulator",
 ]
@@ -14737,7 +14716,7 @@ dependencies = [
  "sp-runtime",
  "sp-std",
  "xcm",
- "xcm-builder 0.9.39",
+ "xcm-builder",
  "xcm-executor",
  "xcm-simulator",
 ]
@@ -14789,7 +14768,7 @@ dependencies = [
  "sp-runtime",
  "sp-std",
  "xcm",
- "xcm-builder 0.9.39",
+ "xcm-builder",
  "xcm-executor",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,13 +364,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.58"
+version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e805d94e6b5001b651426cf4cd446b1ab5f319d27bab5c644f61de0a804360c"
+checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -383,7 +383,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "memchr",
- "pin-project-lite 0.2.7",
+ "pin-project-lite 0.2.9",
 ]
 
 [[package]]
@@ -1433,6 +1433,153 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
 dependencies = [
  "cipher 0.3.0",
+]
+
+[[package]]
+name = "cumulus-pallet-dmp-queue"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/cumulus?branch=master#a5a79db4f81725d10e0f1dd339fe7d9b9e837d9f"
+dependencies = [
+ "cumulus-primitives-core",
+ "frame-support",
+ "frame-system",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+ "xcm 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+]
+
+[[package]]
+name = "cumulus-pallet-parachain-system"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/cumulus?branch=master#a5a79db4f81725d10e0f1dd339fe7d9b9e837d9f"
+dependencies = [
+ "bytes",
+ "cumulus-pallet-parachain-system-proc-macro",
+ "cumulus-primitives-core",
+ "cumulus-primitives-parachain-inherent",
+ "environmental",
+ "frame-support",
+ "frame-system",
+ "impl-trait-for-tuples",
+ "log",
+ "parity-scale-codec",
+ "polkadot-parachain 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "scale-info",
+ "sp-core",
+ "sp-externalities",
+ "sp-inherents",
+ "sp-io",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-std",
+ "sp-trie",
+ "sp-version",
+ "xcm 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+]
+
+[[package]]
+name = "cumulus-pallet-parachain-system-proc-macro"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/cumulus?branch=master#a5a79db4f81725d10e0f1dd339fe7d9b9e837d9f"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.13",
+]
+
+[[package]]
+name = "cumulus-pallet-xcmp-queue"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/cumulus?branch=master#a5a79db4f81725d10e0f1dd339fe7d9b9e837d9f"
+dependencies = [
+ "cumulus-primitives-core",
+ "frame-support",
+ "frame-system",
+ "log",
+ "parity-scale-codec",
+ "polkadot-runtime-common 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "rand_chacha 0.3.1",
+ "scale-info",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+ "xcm 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "xcm-executor 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+]
+
+[[package]]
+name = "cumulus-primitives-core"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/cumulus?branch=master#a5a79db4f81725d10e0f1dd339fe7d9b9e837d9f"
+dependencies = [
+ "parity-scale-codec",
+ "polkadot-core-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "polkadot-parachain 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "sp-api",
+ "sp-runtime",
+ "sp-std",
+ "sp-trie",
+ "xcm 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+]
+
+[[package]]
+name = "cumulus-primitives-parachain-inherent"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/cumulus?branch=master#a5a79db4f81725d10e0f1dd339fe7d9b9e837d9f"
+dependencies = [
+ "async-trait",
+ "cumulus-primitives-core",
+ "cumulus-relay-chain-interface",
+ "cumulus-test-relay-sproof-builder",
+ "parity-scale-codec",
+ "sc-client-api",
+ "scale-info",
+ "sp-api",
+ "sp-core",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-std",
+ "sp-storage",
+ "sp-trie",
+ "tracing",
+]
+
+[[package]]
+name = "cumulus-relay-chain-interface"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/cumulus?branch=master#a5a79db4f81725d10e0f1dd339fe7d9b9e837d9f"
+dependencies = [
+ "async-trait",
+ "cumulus-primitives-core",
+ "futures",
+ "jsonrpsee-core",
+ "parity-scale-codec",
+ "polkadot-overseer 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "sc-client-api",
+ "sp-api",
+ "sp-blockchain",
+ "sp-state-machine",
+ "thiserror",
+]
+
+[[package]]
+name = "cumulus-test-relay-sproof-builder"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/cumulus?branch=master#a5a79db4f81725d10e0f1dd339fe7d9b9e837d9f"
+dependencies = [
+ "cumulus-primitives-core",
+ "parity-scale-codec",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-std",
 ]
 
 [[package]]
@@ -2731,9 +2878,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.25"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38390104763dc37a5145a53c29c63c1290b5d316d6086ec32c293f6736051bb0"
+checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2746,9 +2893,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.25"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
+checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2756,15 +2903,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.25"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
+checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.25"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7acc85df6714c176ab5edf386123fafe217be88c0840ec11f199441134a074e2"
+checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2774,9 +2921,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.25"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
 
 [[package]]
 name = "futures-lite"
@@ -2789,19 +2936,19 @@ dependencies = [
  "futures-io",
  "memchr",
  "parking",
- "pin-project-lite 0.2.7",
+ "pin-project-lite 0.2.9",
  "waker-fn",
 ]
 
 [[package]]
 name = "futures-macro"
-version = "0.3.25"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -2817,15 +2964,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.25"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
 
 [[package]]
 name = "futures-task"
-version = "0.3.25"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
+checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
 
 [[package]]
 name = "futures-timer"
@@ -2835,9 +2982,9 @@ checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
-version = "0.3.25"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
+checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2846,7 +2993,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project-lite 0.2.7",
+ "pin-project-lite 0.2.9",
  "pin-utils",
  "slab",
 ]
@@ -3217,7 +3364,7 @@ checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
  "bytes",
  "http",
- "pin-project-lite 0.2.7",
+ "pin-project-lite 0.2.9",
 ]
 
 [[package]]
@@ -3269,7 +3416,7 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project-lite 0.2.7",
+ "pin-project-lite 0.2.9",
  "socket2",
  "tokio",
  "tower-service",
@@ -3731,9 +3878,9 @@ dependencies = [
  "pallet-xcm",
  "pallet-xcm-benchmarks",
  "parity-scale-codec",
- "polkadot-primitives",
- "polkadot-runtime-common",
- "polkadot-runtime-parachains",
+ "polkadot-primitives 0.9.39",
+ "polkadot-runtime-common 0.9.39",
+ "polkadot-runtime-parachains 0.9.39",
  "rustc-hex",
  "scale-info",
  "separator",
@@ -3766,9 +3913,9 @@ dependencies = [
  "substrate-wasm-builder",
  "tiny-keccak",
  "tokio",
- "xcm",
+ "xcm 0.9.39",
  "xcm-builder",
- "xcm-executor",
+ "xcm-executor 0.9.39",
 ]
 
 [[package]]
@@ -3776,8 +3923,8 @@ name = "kusama-runtime-constants"
 version = "0.9.39"
 dependencies = [
  "frame-support",
- "polkadot-primitives",
- "polkadot-runtime-common",
+ "polkadot-primitives 0.9.39",
+ "polkadot-runtime-common 0.9.39",
  "smallvec",
  "sp-core",
  "sp-runtime",
@@ -6224,17 +6371,17 @@ dependencies = [
  "log",
  "pallet-balances",
  "parity-scale-codec",
- "polkadot-parachain",
- "polkadot-runtime-parachains",
+ "polkadot-parachain 0.9.39",
+ "polkadot-runtime-parachains 0.9.39",
  "scale-info",
  "serde",
  "sp-core",
  "sp-io",
  "sp-runtime",
  "sp-std",
- "xcm",
+ "xcm 0.9.39",
  "xcm-builder",
- "xcm-executor",
+ "xcm-executor 0.9.39",
 ]
 
 [[package]]
@@ -6249,17 +6396,29 @@ dependencies = [
  "pallet-balances",
  "pallet-xcm",
  "parity-scale-codec",
- "polkadot-primitives",
- "polkadot-runtime-common",
+ "polkadot-primitives 0.9.39",
+ "polkadot-runtime-common 0.9.39",
  "scale-info",
  "sp-core",
  "sp-io",
  "sp-runtime",
  "sp-std",
  "sp-tracing",
- "xcm",
+ "xcm 0.9.39",
  "xcm-builder",
- "xcm-executor",
+ "xcm-executor 0.9.39",
+]
+
+[[package]]
+name = "parachain-info"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/cumulus?branch=master#a5a79db4f81725d10e0f1dd339fe7d9b9e837d9f"
+dependencies = [
+ "cumulus-primitives-core",
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "scale-info",
 ]
 
 [[package]]
@@ -6510,9 +6669,9 @@ checksum = "257b64915a082f7811703966789728173279bdebb956b143dbcd23f6f970a777"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.7"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
+checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
 
 [[package]]
 name = "pin-utils"
@@ -6566,9 +6725,9 @@ dependencies = [
  "color-eyre",
  "nix 0.26.2",
  "polkadot-cli",
- "polkadot-core-primitives",
+ "polkadot-core-primitives 0.9.39",
  "polkadot-node-core-pvf",
- "polkadot-overseer",
+ "polkadot-overseer 0.9.39",
  "substrate-rpc-client",
  "tempfile",
  "tikv-jemallocator",
@@ -6583,14 +6742,14 @@ dependencies = [
  "env_logger 0.9.0",
  "futures",
  "log",
- "polkadot-node-jaeger",
- "polkadot-node-metrics",
- "polkadot-node-network-protocol",
- "polkadot-node-primitives",
+ "polkadot-node-jaeger 0.9.39",
+ "polkadot-node-metrics 0.9.39",
+ "polkadot-node-network-protocol 0.9.39",
+ "polkadot-node-primitives 0.9.39",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-test-helpers",
  "polkadot-node-subsystem-util",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39",
  "polkadot-primitives-test-helpers",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -6598,7 +6757,7 @@ dependencies = [
  "schnorrkel",
  "sp-authority-discovery",
  "sp-core",
- "tracing-gum",
+ "tracing-gum 0.9.39",
 ]
 
 [[package]]
@@ -6611,11 +6770,11 @@ dependencies = [
  "futures",
  "log",
  "maplit",
- "polkadot-node-network-protocol",
+ "polkadot-node-network-protocol 0.9.39",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-test-helpers",
  "polkadot-node-subsystem-util",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "sp-application-crypto",
@@ -6623,7 +6782,7 @@ dependencies = [
  "sp-core",
  "sp-keyring",
  "sp-keystore",
- "tracing-gum",
+ "tracing-gum 0.9.39",
 ]
 
 [[package]]
@@ -6638,12 +6797,12 @@ dependencies = [
  "lru 0.9.0",
  "parity-scale-codec",
  "polkadot-erasure-coding",
- "polkadot-node-network-protocol",
- "polkadot-node-primitives",
+ "polkadot-node-network-protocol 0.9.39",
+ "polkadot-node-primitives 0.9.39",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-test-helpers",
  "polkadot-node-subsystem-util",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39",
  "polkadot-primitives-test-helpers",
  "rand 0.8.5",
  "sc-network",
@@ -6652,7 +6811,7 @@ dependencies = [
  "sp-keystore",
  "sp-tracing",
  "thiserror",
- "tracing-gum",
+ "tracing-gum 0.9.39",
 ]
 
 [[package]]
@@ -6668,12 +6827,12 @@ dependencies = [
  "lru 0.9.0",
  "parity-scale-codec",
  "polkadot-erasure-coding",
- "polkadot-node-network-protocol",
- "polkadot-node-primitives",
+ "polkadot-node-network-protocol 0.9.39",
+ "polkadot-node-primitives 0.9.39",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-test-helpers",
  "polkadot-node-subsystem-util",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39",
  "polkadot-primitives-test-helpers",
  "rand 0.8.5",
  "sc-network",
@@ -6681,7 +6840,7 @@ dependencies = [
  "sp-core",
  "sp-keyring",
  "thiserror",
- "tracing-gum",
+ "tracing-gum 0.9.39",
 ]
 
 [[package]]
@@ -6694,7 +6853,7 @@ dependencies = [
  "log",
  "polkadot-client",
  "polkadot-node-core-pvf",
- "polkadot-node-metrics",
+ "polkadot-node-metrics 0.9.39",
  "polkadot-performance-test",
  "polkadot-service",
  "pyroscope",
@@ -6725,11 +6884,11 @@ dependencies = [
  "kusama-runtime",
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",
- "polkadot-core-primitives",
+ "polkadot-core-primitives 0.9.39",
  "polkadot-node-core-parachains-inherent",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39",
  "polkadot-runtime",
- "polkadot-runtime-common",
+ "polkadot-runtime-common 0.9.39",
  "rococo-runtime",
  "sc-client-api",
  "sc-consensus",
@@ -6769,12 +6928,12 @@ dependencies = [
  "futures-timer",
  "log",
  "parity-scale-codec",
- "polkadot-node-network-protocol",
- "polkadot-node-primitives",
+ "polkadot-node-network-protocol 0.9.39",
+ "polkadot-node-primitives 0.9.39",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-test-helpers",
  "polkadot-node-subsystem-util",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39",
  "polkadot-primitives-test-helpers",
  "sc-network",
  "sp-core",
@@ -6782,12 +6941,24 @@ dependencies = [
  "sp-keystore",
  "sp-runtime",
  "thiserror",
- "tracing-gum",
+ "tracing-gum 0.9.39",
 ]
 
 [[package]]
 name = "polkadot-core-primitives"
 version = "0.9.39"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "polkadot-core-primitives"
+version = "0.9.39"
+source = "git+https://github.com/paritytech/polkadot?branch=master#7b6ea485f568f836e2b6e0099f5f53c04d7d1c18"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -6811,12 +6982,12 @@ dependencies = [
  "lru 0.9.0",
  "parity-scale-codec",
  "polkadot-erasure-coding",
- "polkadot-node-network-protocol",
- "polkadot-node-primitives",
+ "polkadot-node-network-protocol 0.9.39",
+ "polkadot-node-primitives 0.9.39",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-test-helpers",
  "polkadot-node-subsystem-util",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39",
  "polkadot-primitives-test-helpers",
  "sc-keystore",
  "sc-network",
@@ -6825,7 +6996,7 @@ dependencies = [
  "sp-keystore",
  "sp-tracing",
  "thiserror",
- "tracing-gum",
+ "tracing-gum 0.9.39",
 ]
 
 [[package]]
@@ -6834,8 +7005,8 @@ version = "0.9.39"
 dependencies = [
  "criterion",
  "parity-scale-codec",
- "polkadot-node-primitives",
- "polkadot-primitives",
+ "polkadot-node-primitives 0.9.39",
+ "polkadot-primitives 0.9.39",
  "reed-solomon-novelpoly",
  "sp-core",
  "sp-trie",
@@ -6851,11 +7022,11 @@ dependencies = [
  "futures",
  "futures-timer",
  "lazy_static",
- "polkadot-node-network-protocol",
+ "polkadot-node-network-protocol 0.9.39",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-test-helpers",
  "polkadot-node-subsystem-util",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "sc-network",
@@ -6866,7 +7037,7 @@ dependencies = [
  "sp-keyring",
  "sp-keystore",
  "sp-tracing",
- "tracing-gum",
+ "tracing-gum 0.9.39",
 ]
 
 [[package]]
@@ -6882,20 +7053,20 @@ dependencies = [
  "futures-timer",
  "parity-scale-codec",
  "parking_lot 0.12.1",
- "polkadot-node-metrics",
- "polkadot-node-network-protocol",
+ "polkadot-node-metrics 0.9.39",
+ "polkadot-node-network-protocol 0.9.39",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-test-helpers",
  "polkadot-node-subsystem-util",
- "polkadot-overseer",
- "polkadot-primitives",
+ "polkadot-overseer 0.9.39",
+ "polkadot-primitives 0.9.39",
  "polkadot-primitives-test-helpers",
  "sc-network",
  "sp-consensus",
  "sp-core",
  "sp-keyring",
  "thiserror",
- "tracing-gum",
+ "tracing-gum 0.9.39",
 ]
 
 [[package]]
@@ -6905,16 +7076,16 @@ dependencies = [
  "futures",
  "parity-scale-codec",
  "polkadot-erasure-coding",
- "polkadot-node-primitives",
+ "polkadot-node-primitives 0.9.39",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-test-helpers",
  "polkadot-node-subsystem-util",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39",
  "polkadot-primitives-test-helpers",
  "sp-core",
  "sp-maybe-compressed-blob",
  "thiserror",
- "tracing-gum",
+ "tracing-gum 0.9.39",
 ]
 
 [[package]]
@@ -6933,13 +7104,13 @@ dependencies = [
  "merlin",
  "parity-scale-codec",
  "parking_lot 0.12.1",
- "polkadot-node-jaeger",
- "polkadot-node-primitives",
+ "polkadot-node-jaeger 0.9.39",
+ "polkadot-node-primitives 0.9.39",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-test-helpers",
  "polkadot-node-subsystem-util",
- "polkadot-overseer",
- "polkadot-primitives",
+ "polkadot-overseer 0.9.39",
+ "polkadot-primitives 0.9.39",
  "polkadot-primitives-test-helpers",
  "rand_core 0.5.1",
  "sc-keystore",
@@ -6953,7 +7124,7 @@ dependencies = [
  "sp-keystore",
  "sp-runtime",
  "thiserror",
- "tracing-gum",
+ "tracing-gum 0.9.39",
 ]
 
 [[package]]
@@ -6971,18 +7142,18 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "polkadot-erasure-coding",
- "polkadot-node-primitives",
+ "polkadot-node-primitives 0.9.39",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-test-helpers",
  "polkadot-node-subsystem-util",
- "polkadot-overseer",
- "polkadot-primitives",
+ "polkadot-overseer 0.9.39",
+ "polkadot-primitives 0.9.39",
  "polkadot-primitives-test-helpers",
  "sp-consensus",
  "sp-core",
  "sp-keyring",
  "thiserror",
- "tracing-gum",
+ "tracing-gum 0.9.39",
 ]
 
 [[package]]
@@ -6994,13 +7165,13 @@ dependencies = [
  "fatality",
  "futures",
  "polkadot-erasure-coding",
- "polkadot-node-primitives",
+ "polkadot-node-primitives 0.9.39",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-test-helpers",
  "polkadot-node-subsystem-util",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39",
  "polkadot-primitives-test-helpers",
- "polkadot-statement-table",
+ "polkadot-statement-table 0.9.39",
  "sc-keystore",
  "sp-application-crypto",
  "sp-core",
@@ -7008,7 +7179,7 @@ dependencies = [
  "sp-keystore",
  "sp-tracing",
  "thiserror",
- "tracing-gum",
+ "tracing-gum 0.9.39",
 ]
 
 [[package]]
@@ -7019,11 +7190,11 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-test-helpers",
  "polkadot-node-subsystem-util",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39",
  "polkadot-primitives-test-helpers",
  "sp-keystore",
  "thiserror",
- "tracing-gum",
+ "tracing-gum 0.9.39",
  "wasm-timer",
 ]
 
@@ -7037,18 +7208,18 @@ dependencies = [
  "futures-timer",
  "parity-scale-codec",
  "polkadot-node-core-pvf",
- "polkadot-node-metrics",
- "polkadot-node-primitives",
+ "polkadot-node-metrics 0.9.39",
+ "polkadot-node-primitives 0.9.39",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-test-helpers",
  "polkadot-node-subsystem-util",
- "polkadot-parachain",
- "polkadot-primitives",
+ "polkadot-parachain 0.9.39",
+ "polkadot-primitives 0.9.39",
  "polkadot-primitives-test-helpers",
  "sp-core",
  "sp-keyring",
  "sp-maybe-compressed-blob",
- "tracing-gum",
+ "tracing-gum 0.9.39",
 ]
 
 [[package]]
@@ -7058,16 +7229,16 @@ dependencies = [
  "futures",
  "maplit",
  "parity-scale-codec",
- "polkadot-node-metrics",
- "polkadot-node-primitives",
+ "polkadot-node-metrics 0.9.39",
+ "polkadot-node-primitives 0.9.39",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-test-helpers",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39",
  "sc-client-api",
  "sc-consensus-babe",
  "sp-blockchain",
  "sp-core",
- "tracing-gum",
+ "tracing-gum 0.9.39",
 ]
 
 [[package]]
@@ -7081,14 +7252,14 @@ dependencies = [
  "kvdb-memorydb",
  "parity-scale-codec",
  "parking_lot 0.12.1",
- "polkadot-node-primitives",
+ "polkadot-node-primitives 0.9.39",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-test-helpers",
  "polkadot-node-subsystem-util",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39",
  "sp-core",
  "thiserror",
- "tracing-gum",
+ "tracing-gum 0.9.39",
 ]
 
 [[package]]
@@ -7103,11 +7274,11 @@ dependencies = [
  "kvdb-memorydb",
  "lru 0.9.0",
  "parity-scale-codec",
- "polkadot-node-primitives",
+ "polkadot-node-primitives 0.9.39",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-test-helpers",
  "polkadot-node-subsystem-util",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39",
  "polkadot-primitives-test-helpers",
  "sc-keystore",
  "sp-application-crypto",
@@ -7116,7 +7287,7 @@ dependencies = [
  "sp-keystore",
  "sp-tracing",
  "thiserror",
- "tracing-gum",
+ "tracing-gum 0.9.39",
 ]
 
 [[package]]
@@ -7127,12 +7298,12 @@ dependencies = [
  "futures",
  "futures-timer",
  "polkadot-node-subsystem",
- "polkadot-overseer",
- "polkadot-primitives",
+ "polkadot-overseer 0.9.39",
+ "polkadot-primitives 0.9.39",
  "sp-blockchain",
  "sp-inherents",
  "thiserror",
- "tracing-gum",
+ "tracing-gum 0.9.39",
 ]
 
 [[package]]
@@ -7143,17 +7314,17 @@ dependencies = [
  "fatality",
  "futures",
  "futures-timer",
- "polkadot-node-primitives",
+ "polkadot-node-primitives 0.9.39",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-test-helpers",
  "polkadot-node-subsystem-util",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39",
  "polkadot-primitives-test-helpers",
  "rand 0.8.5",
  "sp-application-crypto",
  "sp-keystore",
  "thiserror",
- "tracing-gum",
+ "tracing-gum 0.9.39",
 ]
 
 [[package]]
@@ -7169,11 +7340,11 @@ dependencies = [
  "libc",
  "parity-scale-codec",
  "pin-project",
- "polkadot-core-primitives",
- "polkadot-node-metrics",
- "polkadot-node-primitives",
- "polkadot-parachain",
- "polkadot-primitives",
+ "polkadot-core-primitives 0.9.39",
+ "polkadot-node-metrics 0.9.39",
+ "polkadot-node-primitives 0.9.39",
+ "polkadot-parachain 0.9.39",
+ "polkadot-primitives 0.9.39",
  "rand 0.8.5",
  "rayon",
  "sc-executor",
@@ -7192,7 +7363,7 @@ dependencies = [
  "test-parachain-halt",
  "tikv-jemalloc-ctl",
  "tokio",
- "tracing-gum",
+ "tracing-gum 0.9.39",
 ]
 
 [[package]]
@@ -7201,12 +7372,12 @@ version = "0.9.39"
 dependencies = [
  "futures",
  "futures-timer",
- "polkadot-node-primitives",
+ "polkadot-node-primitives 0.9.39",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-test-helpers",
  "polkadot-node-subsystem-util",
- "polkadot-overseer",
- "polkadot-primitives",
+ "polkadot-overseer 0.9.39",
+ "polkadot-primitives 0.9.39",
  "polkadot-primitives-test-helpers",
  "sc-keystore",
  "sp-application-crypto",
@@ -7215,7 +7386,7 @@ dependencies = [
  "sp-keystore",
  "sp-runtime",
  "thiserror",
- "tracing-gum",
+ "tracing-gum 0.9.39",
 ]
 
 [[package]]
@@ -7224,19 +7395,19 @@ version = "0.9.39"
 dependencies = [
  "futures",
  "lru 0.9.0",
- "polkadot-node-metrics",
- "polkadot-node-primitives",
+ "polkadot-node-metrics 0.9.39",
+ "polkadot-node-primitives 0.9.39",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-test-helpers",
- "polkadot-node-subsystem-types",
- "polkadot-primitives",
+ "polkadot-node-subsystem-types 0.9.39",
+ "polkadot-primitives 0.9.39",
  "polkadot-primitives-test-helpers",
  "sp-api",
  "sp-authority-discovery",
  "sp-consensus-babe",
  "sp-core",
  "sp-keyring",
- "tracing-gum",
+ "tracing-gum 0.9.39",
 ]
 
 [[package]]
@@ -7248,8 +7419,26 @@ dependencies = [
  "mick-jaeger",
  "parity-scale-codec",
  "parking_lot 0.12.1",
- "polkadot-node-primitives",
- "polkadot-primitives",
+ "polkadot-node-primitives 0.9.39",
+ "polkadot-primitives 0.9.39",
+ "sc-network",
+ "sp-core",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "polkadot-node-jaeger"
+version = "0.9.39"
+source = "git+https://github.com/paritytech/polkadot?branch=master#7b6ea485f568f836e2b6e0099f5f53c04d7d1c18"
+dependencies = [
+ "lazy_static",
+ "log",
+ "mick-jaeger",
+ "parity-scale-codec",
+ "parking_lot 0.12.1",
+ "polkadot-node-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "sc-network",
  "sp-core",
  "thiserror",
@@ -7267,7 +7456,7 @@ dependencies = [
  "hyper",
  "log",
  "parity-scale-codec",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39",
  "polkadot-test-service",
  "prioritized-metered-channel",
  "prometheus-parse",
@@ -7280,7 +7469,26 @@ dependencies = [
  "substrate-test-utils",
  "tempfile",
  "tokio",
- "tracing-gum",
+ "tracing-gum 0.9.39",
+]
+
+[[package]]
+name = "polkadot-node-metrics"
+version = "0.9.39"
+source = "git+https://github.com/paritytech/polkadot?branch=master#7b6ea485f568f836e2b6e0099f5f53c04d7d1c18"
+dependencies = [
+ "bs58",
+ "futures",
+ "futures-timer",
+ "log",
+ "parity-scale-codec",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "prioritized-metered-channel",
+ "sc-cli",
+ "sc-service",
+ "sc-tracing",
+ "substrate-prometheus-endpoint",
+ "tracing-gum 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
 ]
 
 [[package]]
@@ -7293,16 +7501,38 @@ dependencies = [
  "futures",
  "hex",
  "parity-scale-codec",
- "polkadot-node-jaeger",
- "polkadot-node-primitives",
- "polkadot-primitives",
+ "polkadot-node-jaeger 0.9.39",
+ "polkadot-node-primitives 0.9.39",
+ "polkadot-primitives 0.9.39",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "sc-authority-discovery",
  "sc-network",
  "strum",
  "thiserror",
- "tracing-gum",
+ "tracing-gum 0.9.39",
+]
+
+[[package]]
+name = "polkadot-node-network-protocol"
+version = "0.9.39"
+source = "git+https://github.com/paritytech/polkadot?branch=master#7b6ea485f568f836e2b6e0099f5f53c04d7d1c18"
+dependencies = [
+ "async-trait",
+ "derive_more",
+ "fatality",
+ "futures",
+ "hex",
+ "parity-scale-codec",
+ "polkadot-node-jaeger 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "polkadot-node-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "rand 0.8.5",
+ "sc-authority-discovery",
+ "sc-network",
+ "strum",
+ "thiserror",
+ "tracing-gum 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
 ]
 
 [[package]]
@@ -7313,8 +7543,31 @@ dependencies = [
  "futures",
  "parity-scale-codec",
  "polkadot-erasure-coding",
- "polkadot-parachain",
- "polkadot-primitives",
+ "polkadot-parachain 0.9.39",
+ "polkadot-primitives 0.9.39",
+ "schnorrkel",
+ "serde",
+ "sp-application-crypto",
+ "sp-consensus-babe",
+ "sp-consensus-vrf",
+ "sp-core",
+ "sp-keystore",
+ "sp-maybe-compressed-blob",
+ "sp-runtime",
+ "thiserror",
+ "zstd",
+]
+
+[[package]]
+name = "polkadot-node-primitives"
+version = "0.9.39"
+source = "git+https://github.com/paritytech/polkadot?branch=master#7b6ea485f568f836e2b6e0099f5f53c04d7d1c18"
+dependencies = [
+ "bounded-vec",
+ "futures",
+ "parity-scale-codec",
+ "polkadot-parachain 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "schnorrkel",
  "serde",
  "sp-application-crypto",
@@ -7332,9 +7585,9 @@ dependencies = [
 name = "polkadot-node-subsystem"
 version = "0.9.39"
 dependencies = [
- "polkadot-node-jaeger",
- "polkadot-node-subsystem-types",
- "polkadot-overseer",
+ "polkadot-node-jaeger 0.9.39",
+ "polkadot-node-subsystem-types 0.9.39",
+ "polkadot-overseer 0.9.39",
 ]
 
 [[package]]
@@ -7346,8 +7599,8 @@ dependencies = [
  "parking_lot 0.12.1",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-overseer",
- "polkadot-primitives",
+ "polkadot-overseer 0.9.39",
+ "polkadot-primitives 0.9.39",
  "sc-keystore",
  "sp-application-crypto",
  "sp-core",
@@ -7363,11 +7616,34 @@ dependencies = [
  "derive_more",
  "futures",
  "orchestra",
- "polkadot-node-jaeger",
- "polkadot-node-network-protocol",
- "polkadot-node-primitives",
- "polkadot-primitives",
- "polkadot-statement-table",
+ "polkadot-node-jaeger 0.9.39",
+ "polkadot-node-network-protocol 0.9.39",
+ "polkadot-node-primitives 0.9.39",
+ "polkadot-primitives 0.9.39",
+ "polkadot-statement-table 0.9.39",
+ "sc-network",
+ "smallvec",
+ "sp-api",
+ "sp-authority-discovery",
+ "sp-consensus-babe",
+ "substrate-prometheus-endpoint",
+ "thiserror",
+]
+
+[[package]]
+name = "polkadot-node-subsystem-types"
+version = "0.9.39"
+source = "git+https://github.com/paritytech/polkadot?branch=master#7b6ea485f568f836e2b6e0099f5f53c04d7d1c18"
+dependencies = [
+ "async-trait",
+ "derive_more",
+ "futures",
+ "orchestra",
+ "polkadot-node-jaeger 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "polkadot-node-network-protocol 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "polkadot-node-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "polkadot-statement-table 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "sc-network",
  "smallvec",
  "sp-api",
@@ -7399,14 +7675,14 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.11.2",
  "pin-project",
- "polkadot-node-jaeger",
- "polkadot-node-metrics",
- "polkadot-node-network-protocol",
- "polkadot-node-primitives",
+ "polkadot-node-jaeger 0.9.39",
+ "polkadot-node-metrics 0.9.39",
+ "polkadot-node-network-protocol 0.9.39",
+ "polkadot-node-primitives 0.9.39",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-test-helpers",
- "polkadot-overseer",
- "polkadot-primitives",
+ "polkadot-overseer 0.9.39",
+ "polkadot-primitives 0.9.39",
  "polkadot-primitives-test-helpers",
  "prioritized-metered-channel",
  "rand 0.8.5",
@@ -7415,7 +7691,7 @@ dependencies = [
  "sp-keystore",
  "tempfile",
  "thiserror",
- "tracing-gum",
+ "tracing-gum 0.9.39",
 ]
 
 [[package]]
@@ -7430,18 +7706,41 @@ dependencies = [
  "lru 0.9.0",
  "orchestra",
  "parking_lot 0.12.1",
- "polkadot-node-metrics",
- "polkadot-node-network-protocol",
- "polkadot-node-primitives",
- "polkadot-node-subsystem-types",
- "polkadot-primitives",
+ "polkadot-node-metrics 0.9.39",
+ "polkadot-node-network-protocol 0.9.39",
+ "polkadot-node-primitives 0.9.39",
+ "polkadot-node-subsystem-types 0.9.39",
+ "polkadot-primitives 0.9.39",
  "polkadot-primitives-test-helpers",
  "prioritized-metered-channel",
  "sc-client-api",
  "sp-api",
  "sp-core",
  "tikv-jemalloc-ctl",
- "tracing-gum",
+ "tracing-gum 0.9.39",
+]
+
+[[package]]
+name = "polkadot-overseer"
+version = "0.9.39"
+source = "git+https://github.com/paritytech/polkadot?branch=master#7b6ea485f568f836e2b6e0099f5f53c04d7d1c18"
+dependencies = [
+ "async-trait",
+ "futures",
+ "futures-timer",
+ "lru 0.9.0",
+ "orchestra",
+ "parking_lot 0.12.1",
+ "polkadot-node-metrics 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "polkadot-node-network-protocol 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "polkadot-node-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "polkadot-node-subsystem-types 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "sc-client-api",
+ "sp-api",
+ "sp-core",
+ "tikv-jemalloc-ctl",
+ "tracing-gum 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
 ]
 
 [[package]]
@@ -7452,7 +7751,24 @@ dependencies = [
  "derive_more",
  "frame-support",
  "parity-scale-codec",
- "polkadot-core-primitives",
+ "polkadot-core-primitives 0.9.39",
+ "scale-info",
+ "serde",
+ "sp-core",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "polkadot-parachain"
+version = "0.9.39"
+source = "git+https://github.com/paritytech/polkadot?branch=master#7b6ea485f568f836e2b6e0099f5f53c04d7d1c18"
+dependencies = [
+ "bounded-collections",
+ "derive_more",
+ "frame-support",
+ "parity-scale-codec",
+ "polkadot-core-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "scale-info",
  "serde",
  "sp-core",
@@ -7469,8 +7785,8 @@ dependencies = [
  "log",
  "polkadot-erasure-coding",
  "polkadot-node-core-pvf",
- "polkadot-node-primitives",
- "polkadot-primitives",
+ "polkadot-node-primitives 0.9.39",
+ "polkadot-primitives 0.9.39",
  "quote",
  "thiserror",
 ]
@@ -7482,8 +7798,34 @@ dependencies = [
  "bitvec",
  "hex-literal",
  "parity-scale-codec",
- "polkadot-core-primitives",
- "polkadot-parachain",
+ "polkadot-core-primitives 0.9.39",
+ "polkadot-parachain 0.9.39",
+ "scale-info",
+ "serde",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-arithmetic",
+ "sp-authority-discovery",
+ "sp-consensus-slots",
+ "sp-core",
+ "sp-inherents",
+ "sp-io",
+ "sp-keystore",
+ "sp-runtime",
+ "sp-staking",
+ "sp-std",
+]
+
+[[package]]
+name = "polkadot-primitives"
+version = "0.9.39"
+source = "git+https://github.com/paritytech/polkadot?branch=master#7b6ea485f568f836e2b6e0099f5f53c04d7d1c18"
+dependencies = [
+ "bitvec",
+ "hex-literal",
+ "parity-scale-codec",
+ "polkadot-core-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "polkadot-parachain 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "scale-info",
  "serde",
  "sp-api",
@@ -7504,7 +7846,7 @@ dependencies = [
 name = "polkadot-primitives-test-helpers"
 version = "0.9.39"
 dependencies = [
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39",
  "rand 0.8.5",
  "sp-application-crypto",
  "sp-core",
@@ -7519,7 +7861,7 @@ dependencies = [
  "jsonrpsee",
  "mmr-rpc",
  "pallet-transaction-payment-rpc",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39",
  "sc-chain-spec",
  "sc-client-api",
  "sc-consensus-babe",
@@ -7603,10 +7945,10 @@ dependencies = [
  "pallet-whitelist",
  "pallet-xcm",
  "parity-scale-codec",
- "polkadot-primitives",
- "polkadot-runtime-common",
+ "polkadot-primitives 0.9.39",
+ "polkadot-runtime-common 0.9.39",
  "polkadot-runtime-constants",
- "polkadot-runtime-parachains",
+ "polkadot-runtime-parachains 0.9.39",
  "rustc-hex",
  "scale-info",
  "separator",
@@ -7639,9 +7981,9 @@ dependencies = [
  "substrate-wasm-builder",
  "tiny-keccak",
  "tokio",
- "xcm",
+ "xcm 0.9.39",
  "xcm-builder",
- "xcm-executor",
+ "xcm-executor 0.9.39",
 ]
 
 [[package]]
@@ -7671,15 +8013,15 @@ dependencies = [
  "pallet-treasury",
  "pallet-vesting",
  "parity-scale-codec",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39",
  "polkadot-primitives-test-helpers",
- "polkadot-runtime-parachains",
+ "polkadot-runtime-parachains 0.9.39",
  "rustc-hex",
  "scale-info",
  "serde",
  "serde_derive",
  "serde_json",
- "slot-range-helper",
+ "slot-range-helper 0.9.39",
  "sp-api",
  "sp-core",
  "sp-inherents",
@@ -7691,7 +8033,51 @@ dependencies = [
  "sp-staking",
  "sp-std",
  "static_assertions",
- "xcm",
+ "xcm 0.9.39",
+]
+
+[[package]]
+name = "polkadot-runtime-common"
+version = "0.9.39"
+source = "git+https://github.com/paritytech/polkadot?branch=master#7b6ea485f568f836e2b6e0099f5f53c04d7d1c18"
+dependencies = [
+ "bitvec",
+ "frame-election-provider-support",
+ "frame-support",
+ "frame-system",
+ "impl-trait-for-tuples",
+ "libsecp256k1",
+ "log",
+ "pallet-authorship",
+ "pallet-balances",
+ "pallet-election-provider-multi-phase",
+ "pallet-fast-unstake",
+ "pallet-session",
+ "pallet-staking",
+ "pallet-staking-reward-fn",
+ "pallet-timestamp",
+ "pallet-transaction-payment",
+ "pallet-treasury",
+ "pallet-vesting",
+ "parity-scale-codec",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "polkadot-runtime-parachains 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "rustc-hex",
+ "scale-info",
+ "serde",
+ "serde_derive",
+ "slot-range-helper 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "sp-api",
+ "sp-core",
+ "sp-inherents",
+ "sp-io",
+ "sp-npos-elections",
+ "sp-runtime",
+ "sp-session",
+ "sp-staking",
+ "sp-std",
+ "static_assertions",
+ "xcm 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
 ]
 
 [[package]]
@@ -7699,8 +8085,8 @@ name = "polkadot-runtime-constants"
 version = "0.9.39"
 dependencies = [
  "frame-support",
- "polkadot-primitives",
- "polkadot-runtime-common",
+ "polkadot-primitives 0.9.39",
+ "polkadot-runtime-common 0.9.39",
  "smallvec",
  "sp-core",
  "sp-runtime",
@@ -7714,7 +8100,19 @@ dependencies = [
  "bs58",
  "frame-benchmarking",
  "parity-scale-codec",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39",
+ "sp-std",
+ "sp-tracing",
+]
+
+[[package]]
+name = "polkadot-runtime-metrics"
+version = "0.9.39"
+source = "git+https://github.com/paritytech/polkadot?branch=master#7b6ea485f568f836e2b6e0099f5f53c04d7d1c18"
+dependencies = [
+ "bs58",
+ "parity-scale-codec",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "sp-std",
  "sp-tracing",
 ]
@@ -7743,10 +8141,10 @@ dependencies = [
  "pallet-timestamp",
  "pallet-vesting",
  "parity-scale-codec",
- "polkadot-parachain",
- "polkadot-primitives",
+ "polkadot-parachain 0.9.39",
+ "polkadot-primitives 0.9.39",
  "polkadot-primitives-test-helpers",
- "polkadot-runtime-metrics",
+ "polkadot-runtime-metrics 0.9.39",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rustc-hex",
@@ -7768,8 +8166,49 @@ dependencies = [
  "sp-tracing",
  "static_assertions",
  "thousands",
- "xcm",
- "xcm-executor",
+ "xcm 0.9.39",
+ "xcm-executor 0.9.39",
+]
+
+[[package]]
+name = "polkadot-runtime-parachains"
+version = "0.9.39"
+source = "git+https://github.com/paritytech/polkadot?branch=master#7b6ea485f568f836e2b6e0099f5f53c04d7d1c18"
+dependencies = [
+ "bitflags",
+ "bitvec",
+ "derive_more",
+ "frame-support",
+ "frame-system",
+ "log",
+ "pallet-authority-discovery",
+ "pallet-authorship",
+ "pallet-babe",
+ "pallet-balances",
+ "pallet-session",
+ "pallet-staking",
+ "pallet-timestamp",
+ "pallet-vesting",
+ "parity-scale-codec",
+ "polkadot-parachain 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "polkadot-runtime-metrics 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rustc-hex",
+ "scale-info",
+ "serde",
+ "sp-api",
+ "sp-core",
+ "sp-inherents",
+ "sp-io",
+ "sp-keystore",
+ "sp-runtime",
+ "sp-session",
+ "sp-staking",
+ "sp-std",
+ "xcm 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "xcm-executor 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
 ]
 
 [[package]]
@@ -7818,19 +8257,19 @@ dependencies = [
  "polkadot-node-core-provisioner",
  "polkadot-node-core-pvf-checker",
  "polkadot-node-core-runtime-api",
- "polkadot-node-network-protocol",
- "polkadot-node-primitives",
+ "polkadot-node-network-protocol 0.9.39",
+ "polkadot-node-primitives 0.9.39",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-test-helpers",
- "polkadot-node-subsystem-types",
+ "polkadot-node-subsystem-types 0.9.39",
  "polkadot-node-subsystem-util",
- "polkadot-overseer",
- "polkadot-parachain",
- "polkadot-primitives",
+ "polkadot-overseer 0.9.39",
+ "polkadot-parachain 0.9.39",
+ "polkadot-primitives 0.9.39",
  "polkadot-rpc",
  "polkadot-runtime",
  "polkadot-runtime-constants",
- "polkadot-runtime-parachains",
+ "polkadot-runtime-parachains 0.9.39",
  "polkadot-statement-distribution",
  "polkadot-test-client",
  "rococo-runtime",
@@ -7883,7 +8322,7 @@ dependencies = [
  "substrate-prometheus-endpoint",
  "tempfile",
  "thiserror",
- "tracing-gum",
+ "tracing-gum 0.9.39",
  "westend-runtime",
  "westend-runtime-constants",
 ]
@@ -7899,12 +8338,12 @@ dependencies = [
  "futures-timer",
  "indexmap",
  "parity-scale-codec",
- "polkadot-node-network-protocol",
- "polkadot-node-primitives",
+ "polkadot-node-network-protocol 0.9.39",
+ "polkadot-node-primitives 0.9.39",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-test-helpers",
  "polkadot-node-subsystem-util",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39",
  "polkadot-primitives-test-helpers",
  "sc-keystore",
  "sc-network",
@@ -7916,7 +8355,7 @@ dependencies = [
  "sp-staking",
  "sp-tracing",
  "thiserror",
- "tracing-gum",
+ "tracing-gum 0.9.39",
 ]
 
 [[package]]
@@ -7924,7 +8363,17 @@ name = "polkadot-statement-table"
 version = "0.9.39"
 dependencies = [
  "parity-scale-codec",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39",
+ "sp-core",
+]
+
+[[package]]
+name = "polkadot-statement-table"
+version = "0.9.39"
+source = "git+https://github.com/paritytech/polkadot?branch=master#7b6ea485f568f836e2b6e0099f5f53c04d7d1c18"
+dependencies = [
+ "parity-scale-codec",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "sp-core",
 ]
 
@@ -7935,7 +8384,7 @@ dependencies = [
  "futures",
  "parity-scale-codec",
  "polkadot-node-subsystem",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39",
  "polkadot-test-runtime",
  "polkadot-test-service",
  "sc-block-builder",
@@ -7970,16 +8419,16 @@ dependencies = [
  "polkadot-node-core-candidate-validation",
  "polkadot-node-core-dispute-coordinator",
  "polkadot-node-core-pvf",
- "polkadot-node-primitives",
+ "polkadot-node-primitives 0.9.39",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-test-helpers",
- "polkadot-node-subsystem-types",
+ "polkadot-node-subsystem-types 0.9.39",
  "polkadot-node-subsystem-util",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39",
  "rand 0.8.5",
  "sp-core",
  "sp-keystore",
- "tracing-gum",
+ "tracing-gum 0.9.39",
 ]
 
 [[package]]
@@ -8011,10 +8460,10 @@ dependencies = [
  "pallet-vesting",
  "pallet-xcm",
  "parity-scale-codec",
- "polkadot-parachain",
- "polkadot-primitives",
- "polkadot-runtime-common",
- "polkadot-runtime-parachains",
+ "polkadot-parachain 0.9.39",
+ "polkadot-primitives 0.9.39",
+ "polkadot-runtime-common 0.9.39",
+ "polkadot-runtime-parachains 0.9.39",
  "rustc-hex",
  "scale-info",
  "serde",
@@ -8042,9 +8491,9 @@ dependencies = [
  "substrate-wasm-builder",
  "test-runtime-constants",
  "tiny-keccak",
- "xcm",
+ "xcm 0.9.39",
  "xcm-builder",
- "xcm-executor",
+ "xcm-executor 0.9.39",
 ]
 
 [[package]]
@@ -8058,14 +8507,14 @@ dependencies = [
  "pallet-balances",
  "pallet-staking",
  "pallet-transaction-payment",
- "polkadot-node-primitives",
+ "polkadot-node-primitives 0.9.39",
  "polkadot-node-subsystem",
- "polkadot-overseer",
- "polkadot-parachain",
- "polkadot-primitives",
+ "polkadot-overseer 0.9.39",
+ "polkadot-parachain 0.9.39",
+ "polkadot-primitives 0.9.39",
  "polkadot-rpc",
- "polkadot-runtime-common",
- "polkadot-runtime-parachains",
+ "polkadot-runtime-common 0.9.39",
+ "polkadot-runtime-parachains 0.9.39",
  "polkadot-service",
  "polkadot-test-runtime",
  "rand 0.8.5",
@@ -8098,7 +8547,7 @@ dependencies = [
  "tempfile",
  "test-runtime-constants",
  "tokio",
- "tracing-gum",
+ "tracing-gum 0.9.39",
 ]
 
 [[package]]
@@ -8304,9 +8753,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.53"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
 ]
@@ -8792,7 +9241,7 @@ dependencies = [
  "mime",
  "native-tls",
  "percent-encoding",
- "pin-project-lite 0.2.7",
+ "pin-project-lite 0.2.9",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -8916,10 +9365,10 @@ dependencies = [
  "pallet-xcm",
  "pallet-xcm-benchmarks",
  "parity-scale-codec",
- "polkadot-parachain",
- "polkadot-primitives",
- "polkadot-runtime-common",
- "polkadot-runtime-parachains",
+ "polkadot-parachain 0.9.39",
+ "polkadot-primitives 0.9.39",
+ "polkadot-runtime-common 0.9.39",
+ "polkadot-runtime-parachains 0.9.39",
  "rococo-runtime-constants",
  "scale-info",
  "separator",
@@ -8950,9 +9399,9 @@ dependencies = [
  "substrate-wasm-builder",
  "tiny-keccak",
  "tokio",
- "xcm",
+ "xcm 0.9.39",
  "xcm-builder",
- "xcm-executor",
+ "xcm-executor 0.9.39",
 ]
 
 [[package]]
@@ -8960,8 +9409,8 @@ name = "rococo-runtime-constants"
 version = "0.9.39"
 dependencies = [
  "frame-support",
- "polkadot-primitives",
- "polkadot-runtime-common",
+ "polkadot-primitives 0.9.39",
+ "polkadot-runtime-common 0.9.39",
  "smallvec",
  "sp-core",
  "sp-runtime",
@@ -10284,9 +10733,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info"
-version = "2.1.2"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c46be926081c9f4dd5dd9b6f1d3e3229f2360bc6502dd8836f84a93b7c75e99a"
+checksum = "0cfdffd972d76b22f3d7f81c8be34b2296afd3a25e0a547bd9abe340a4dbbe97"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -10298,9 +10747,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info-derive"
-version = "2.1.2"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50e334bb10a245e28e5fd755cabcafd96cfcd167c99ae63a46924ca8d8703a3c"
+checksum = "61fa974aea2d63dd18a4ec3a49d59af9f34178c73a4f56d2f18205628d00681e"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -10516,7 +10965,7 @@ checksum = "e801c1712f48475582b7696ac71e0ca34ebb30e09338425384269d9717c62cad"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.8",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -10733,6 +11182,18 @@ checksum = "03b634d87b960ab1a38c4fe143b508576f075e7c978bfad18217645ebfdfa2ec"
 [[package]]
 name = "slot-range-helper"
 version = "0.9.39"
+dependencies = [
+ "enumn",
+ "parity-scale-codec",
+ "paste",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "slot-range-helper"
+version = "0.9.39"
+source = "git+https://github.com/paritytech/polkadot?branch=master#7b6ea485f568f836e2b6e0099f5f53c04d7d1c18"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -11579,9 +12040,9 @@ dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
  "paste",
- "polkadot-core-primitives",
+ "polkadot-core-primitives 0.9.39",
  "polkadot-runtime",
- "polkadot-runtime-common",
+ "polkadot-runtime-common 0.9.39",
  "sc-transaction-pool-api",
  "serde",
  "serde_json",
@@ -11921,9 +12382,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.8"
+version = "2.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc02725fd69ab9f26eab07fad303e2497fad6fb9eba4f96c4d1687bdf704ad9"
+checksum = "4c9da457c5285ac1f936ebd076af6dac17a61cfe7826f2076b4d015cf47bc8ec"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12010,7 +12471,7 @@ version = "0.9.39"
 dependencies = [
  "dlmalloc",
  "parity-scale-codec",
- "polkadot-parachain",
+ "polkadot-parachain 0.9.39",
  "sp-io",
  "sp-std",
  "substrate-wasm-builder",
@@ -12028,10 +12489,10 @@ dependencies = [
  "parity-scale-codec",
  "polkadot-cli",
  "polkadot-node-core-pvf",
- "polkadot-node-primitives",
+ "polkadot-node-primitives 0.9.39",
  "polkadot-node-subsystem",
- "polkadot-parachain",
- "polkadot-primitives",
+ "polkadot-parachain 0.9.39",
+ "polkadot-primitives 0.9.39",
  "polkadot-service",
  "polkadot-test-service",
  "sc-cli",
@@ -12058,7 +12519,7 @@ dependencies = [
  "dlmalloc",
  "log",
  "parity-scale-codec",
- "polkadot-parachain",
+ "polkadot-parachain 0.9.39",
  "sp-io",
  "sp-std",
  "substrate-wasm-builder",
@@ -12076,10 +12537,10 @@ dependencies = [
  "parity-scale-codec",
  "polkadot-cli",
  "polkadot-node-core-pvf",
- "polkadot-node-primitives",
+ "polkadot-node-primitives 0.9.39",
  "polkadot-node-subsystem",
- "polkadot-parachain",
- "polkadot-primitives",
+ "polkadot-parachain 0.9.39",
+ "polkadot-primitives 0.9.39",
  "polkadot-service",
  "polkadot-test-service",
  "sc-cli",
@@ -12107,8 +12568,8 @@ name = "test-runtime-constants"
 version = "0.9.39"
 dependencies = [
  "frame-support",
- "polkadot-primitives",
- "polkadot-runtime-common",
+ "polkadot-primitives 0.9.39",
+ "polkadot-runtime-common 0.9.39",
  "smallvec",
  "sp-core",
  "sp-runtime",
@@ -12138,7 +12599,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.8",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -12314,7 +12775,7 @@ dependencies = [
  "mio",
  "num_cpus",
  "parking_lot 0.12.1",
- "pin-project-lite 0.2.7",
+ "pin-project-lite 0.2.9",
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
@@ -12360,7 +12821,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df54d54117d6fdc4e4fea40fe1e4e566b3505700e148a6827e59b34b0d2600d9"
 dependencies = [
  "futures-core",
- "pin-project-lite 0.2.7",
+ "pin-project-lite 0.2.9",
  "tokio",
  "tokio-util 0.7.1",
 ]
@@ -12387,7 +12848,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "log",
- "pin-project-lite 0.2.7",
+ "pin-project-lite 0.2.9",
  "tokio",
 ]
 
@@ -12401,7 +12862,7 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-sink",
- "pin-project-lite 0.2.7",
+ "pin-project-lite 0.2.9",
  "tokio",
 ]
 
@@ -12455,7 +12916,7 @@ dependencies = [
  "http",
  "http-body",
  "http-range-header",
- "pin-project-lite 0.2.7",
+ "pin-project-lite 0.2.9",
  "tower-layer",
  "tower-service",
 ]
@@ -12474,22 +12935,22 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.35"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a400e31aa60b9d44a52a8ee0343b5b18566b03a8321e0d321f695cf56e940160"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
  "log",
- "pin-project-lite 0.2.7",
+ "pin-project-lite 0.2.9",
  "tracing-attributes",
  "tracing-core",
 ]
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.20"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e65ce065b4b5c53e73bb28912318cb8c9e9ad3921f1d669eb0e68b4c8143a2b"
+checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12498,9 +12959,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.28"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b7358be39f2f274f322d2aaed611acc57f382e8eb1e5b48cb9ae30933495ce7"
+checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -12520,10 +12981,21 @@ dependencies = [
 name = "tracing-gum"
 version = "0.9.39"
 dependencies = [
- "polkadot-node-jaeger",
- "polkadot-primitives",
+ "polkadot-node-jaeger 0.9.39",
+ "polkadot-primitives 0.9.39",
  "tracing",
- "tracing-gum-proc-macro",
+ "tracing-gum-proc-macro 0.9.39",
+]
+
+[[package]]
+name = "tracing-gum"
+version = "0.9.39"
+source = "git+https://github.com/paritytech/polkadot?branch=master#7b6ea485f568f836e2b6e0099f5f53c04d7d1c18"
+dependencies = [
+ "polkadot-node-jaeger 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "tracing",
+ "tracing-gum-proc-macro 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
 ]
 
 [[package]]
@@ -12531,6 +13003,18 @@ name = "tracing-gum-proc-macro"
 version = "0.9.39"
 dependencies = [
  "assert_matches",
+ "expander 0.0.6",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "tracing-gum-proc-macro"
+version = "0.9.39"
+source = "git+https://github.com/paritytech/polkadot?branch=master#7b6ea485f568f836e2b6e0099f5f53c04d7d1c18"
+dependencies = [
  "expander 0.0.6",
  "proc-macro-crate",
  "proc-macro2",
@@ -13676,10 +14160,10 @@ dependencies = [
  "pallet-xcm",
  "pallet-xcm-benchmarks",
  "parity-scale-codec",
- "polkadot-parachain",
- "polkadot-primitives",
- "polkadot-runtime-common",
- "polkadot-runtime-parachains",
+ "polkadot-parachain 0.9.39",
+ "polkadot-primitives 0.9.39",
+ "polkadot-runtime-common 0.9.39",
+ "polkadot-runtime-parachains 0.9.39",
  "rustc-hex",
  "scale-info",
  "serde",
@@ -13709,9 +14193,9 @@ dependencies = [
  "tiny-keccak",
  "tokio",
  "westend-runtime-constants",
- "xcm",
+ "xcm 0.9.39",
  "xcm-builder",
- "xcm-executor",
+ "xcm-executor 0.9.39",
 ]
 
 [[package]]
@@ -13719,8 +14203,8 @@ name = "westend-runtime-constants"
 version = "0.9.39"
 dependencies = [
  "frame-support",
- "polkadot-primitives",
- "polkadot-runtime-common",
+ "polkadot-primitives 0.9.39",
+ "polkadot-runtime-common 0.9.39",
  "smallvec",
  "sp-core",
  "sp-runtime",
@@ -14038,7 +14522,23 @@ dependencies = [
  "serde",
  "sp-io",
  "sp-weights",
- "xcm-procedural",
+ "xcm-procedural 0.9.39",
+]
+
+[[package]]
+name = "xcm"
+version = "0.9.39"
+source = "git+https://github.com/paritytech/polkadot?branch=master#7b6ea485f568f836e2b6e0099f5f53c04d7d1c18"
+dependencies = [
+ "bounded-collections",
+ "derivative",
+ "impl-trait-for-tuples",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-weights",
+ "xcm-procedural 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
 ]
 
 [[package]]
@@ -14054,16 +14554,41 @@ dependencies = [
  "pallet-transaction-payment",
  "pallet-xcm",
  "parity-scale-codec",
- "polkadot-parachain",
- "polkadot-runtime-parachains",
+ "polkadot-parachain 0.9.39",
+ "polkadot-runtime-parachains 0.9.39",
  "primitive-types",
  "scale-info",
  "sp-arithmetic",
  "sp-io",
  "sp-runtime",
  "sp-std",
- "xcm",
- "xcm-executor",
+ "xcm 0.9.39",
+ "xcm-executor 0.9.39",
+]
+
+[[package]]
+name = "xcm-emulator"
+version = "0.9.39"
+dependencies = [
+ "cumulus-pallet-dmp-queue",
+ "cumulus-pallet-parachain-system",
+ "cumulus-pallet-xcmp-queue",
+ "cumulus-primitives-core",
+ "cumulus-primitives-parachain-inherent",
+ "cumulus-test-relay-sproof-builder",
+ "frame-support",
+ "frame-system",
+ "parachain-info",
+ "parity-scale-codec",
+ "paste",
+ "polkadot-primitives 0.9.39",
+ "polkadot-runtime-parachains 0.9.39",
+ "quote",
+ "sp-arithmetic",
+ "sp-io",
+ "sp-std",
+ "xcm 0.9.39",
+ "xcm-executor 0.9.39",
 ]
 
 [[package]]
@@ -14082,7 +14607,26 @@ dependencies = [
  "sp-runtime",
  "sp-std",
  "sp-weights",
- "xcm",
+ "xcm 0.9.39",
+]
+
+[[package]]
+name = "xcm-executor"
+version = "0.9.39"
+source = "git+https://github.com/paritytech/polkadot?branch=master#7b6ea485f568f836e2b6e0099f5f53c04d7d1c18"
+dependencies = [
+ "environmental",
+ "frame-support",
+ "impl-trait-for-tuples",
+ "log",
+ "parity-scale-codec",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+ "sp-weights",
+ "xcm 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
 ]
 
 [[package]]
@@ -14101,13 +14645,24 @@ dependencies = [
  "sp-runtime",
  "sp-state-machine",
  "sp-tracing",
- "xcm",
- "xcm-executor",
+ "xcm 0.9.39",
+ "xcm-executor 0.9.39",
 ]
 
 [[package]]
 name = "xcm-procedural"
 version = "0.9.39"
+dependencies = [
+ "Inflector",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "xcm-procedural"
+version = "0.9.39"
+source = "git+https://github.com/paritytech/polkadot?branch=master#7b6ea485f568f836e2b6e0099f5f53c04d7d1c18"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -14122,13 +14677,13 @@ dependencies = [
  "frame-support",
  "parity-scale-codec",
  "paste",
- "polkadot-core-primitives",
- "polkadot-parachain",
- "polkadot-runtime-parachains",
+ "polkadot-core-primitives 0.9.39",
+ "polkadot-parachain 0.9.39",
+ "polkadot-runtime-parachains 0.9.39",
  "sp-io",
  "sp-std",
- "xcm",
- "xcm-executor",
+ "xcm 0.9.39",
+ "xcm-executor 0.9.39",
 ]
 
 [[package]]
@@ -14142,18 +14697,18 @@ dependencies = [
  "pallet-uniques",
  "pallet-xcm",
  "parity-scale-codec",
- "polkadot-core-primitives",
- "polkadot-parachain",
- "polkadot-runtime-parachains",
+ "polkadot-core-primitives 0.9.39",
+ "polkadot-parachain 0.9.39",
+ "polkadot-runtime-parachains 0.9.39",
  "scale-info",
  "sp-core",
  "sp-io",
  "sp-runtime",
  "sp-std",
  "sp-tracing",
- "xcm",
+ "xcm 0.9.39",
  "xcm-builder",
- "xcm-executor",
+ "xcm-executor 0.9.39",
  "xcm-simulator",
 ]
 
@@ -14168,17 +14723,17 @@ dependencies = [
  "pallet-balances",
  "pallet-xcm",
  "parity-scale-codec",
- "polkadot-core-primitives",
- "polkadot-parachain",
- "polkadot-runtime-parachains",
+ "polkadot-core-primitives 0.9.39",
+ "polkadot-parachain 0.9.39",
+ "polkadot-runtime-parachains 0.9.39",
  "scale-info",
  "sp-core",
  "sp-io",
  "sp-runtime",
  "sp-std",
- "xcm",
+ "xcm 0.9.39",
  "xcm-builder",
- "xcm-executor",
+ "xcm-executor 0.9.39",
  "xcm-simulator",
 ]
 
@@ -14239,7 +14794,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-tungstenite",
- "tracing-gum",
+ "tracing-gum 0.9.39",
  "url",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -237,3 +237,4 @@ polkadot-core-primitives = { path = "core-primitives" }
 polkadot-parachain = { path = "parachain" }
 xcm = { path = "xcm" }
 xcm-executor = { path = "xcm/xcm-executor" }
+xcm-builder = { path = "xcm/xcm-builder" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ members = [
 	"xcm/xcm-simulator",
 	"xcm/xcm-simulator/example",
 	"xcm/xcm-simulator/fuzzer",
+	"xcm/xcm-emulator",
 	"xcm/pallet-xcm",
 	"xcm/pallet-xcm-benchmarks",
 	"xcm/procedural",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -232,6 +232,7 @@ conf-files = [
 config = "./scripts/ci/gitlab/spellcheck.toml"
 
 # Make sure xcm-emulator cumuls deps work as otherwise they depend on polkadot master/other branch.
+# This will also override any other polkadot transitive dependencies.
 [patch.'https://github.com/paritytech/polkadot']
 polkadot-core-primitives = { path = "core-primitives" }
 polkadot-parachain = { path = "parachain" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,8 @@ members = [
 	"xcm/xcm-simulator/example",
 	"xcm/xcm-simulator/fuzzer",
 	"xcm/xcm-emulator",
+	"xcm/xcm-emulator/example",
+	"xcm/xcm-emulator/yayoi",
 	"xcm/pallet-xcm",
 	"xcm/pallet-xcm-benchmarks",
 	"xcm/procedural",
@@ -228,3 +230,10 @@ conf-files = [
 
 [package.metadata.spellcheck]
 config = "./scripts/ci/gitlab/spellcheck.toml"
+
+# Make sure xcm-emulator cumuls deps work as otherwise they depend on polkadot master/other branch.
+[patch.'https://github.com/paritytech/polkadot']
+polkadot-core-primitives = { path = "core-primitives" }
+polkadot-parachain = { path = "parachain" }
+xcm = { path = "xcm" }
+xcm-executor = { path = "xcm/xcm-executor" }

--- a/core-primitives/Cargo.toml
+++ b/core-primitives/Cargo.toml
@@ -8,7 +8,7 @@ edition.workspace = true
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 sp-std = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-scale-info = { version = "2.1.2", default-features = false, features = ["derive"] }
+scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
 parity-scale-codec = { version = "3.4.0", default-features = false, features = [ "derive" ] }
 
 [features]

--- a/parachain/Cargo.toml
+++ b/parachain/Cargo.toml
@@ -10,7 +10,7 @@ version.workspace = true
 # this crate for WASM. This is critical to avoid forcing all parachain WASM into implementing
 # various unnecessary Substrate-specific endpoints.
 parity-scale-codec = { version = "3.4.0", default-features = false, features = [ "derive" ] }
-scale-info = { version = "2.1.2", default-features = false, features = ["derive"] }
+scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
 sp-std = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -8,7 +8,7 @@ edition.workspace = true
 bitvec = { version = "1.0.0", default-features = false, features = ["alloc"] }
 hex-literal = "0.3.4"
 parity-scale-codec = { version = "3.4.0", default-features = false, features = ["bit-vec", "derive"] }
-scale-info = { version = "2.1.2", default-features = false, features = ["bit-vec", "derive"] }
+scale-info = { version = "2.5.0", default-features = false, features = ["bit-vec", "derive"] }
 serde = { version = "1.0.137", optional = true, features = ["derive"] }
 
 application-crypto = { package = "sp-application-crypto", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -10,7 +10,7 @@ bitvec = { version = "1.0.0", default-features = false, features = ["alloc"] }
 parity-scale-codec = { version = "3.4.0", default-features = false, features = ["derive"] }
 log = { version = "0.4.17", default-features = false }
 rustc-hex = { version = "2.1.0", default-features = false }
-scale-info = { version = "2.1.2", default-features = false, features = ["derive"] }
+scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.139", default-features = false }
 serde_derive = { version = "1.0.117", optional = true }
 static_assertions = "1.1.0"

--- a/runtime/kusama/Cargo.toml
+++ b/runtime/kusama/Cargo.toml
@@ -8,7 +8,7 @@ edition.workspace = true
 [dependencies]
 bitvec = { version = "1.0.0", default-features = false, features = ["alloc"] }
 parity-scale-codec = { version = "3.4.0", default-features = false, features = ["derive", "max-encoded-len"] }
-scale-info = { version = "2.1.2", default-features = false, features = ["derive"] }
+scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
 log = { version = "0.4.17", default-features = false }
 rustc-hex = { version = "2.1.0", default-features = false }
 serde = { version = "1.0.139", default-features = false }

--- a/runtime/parachains/Cargo.toml
+++ b/runtime/parachains/Cargo.toml
@@ -9,7 +9,7 @@ bitvec = { version = "1.0.0", default-features = false, features = ["alloc"] }
 parity-scale-codec = { version = "3.4.0", default-features = false, features = ["derive", "max-encoded-len"] }
 log = { version = "0.4.17", default-features = false }
 rustc-hex = { version = "2.1.0", default-features = false }
-scale-info = { version = "2.1.2", default-features = false, features = ["derive"] }
+scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.139", features = [ "derive" ], optional = true }
 derive_more = "0.99.17"
 bitflags = "1.3.2"

--- a/runtime/polkadot/Cargo.toml
+++ b/runtime/polkadot/Cargo.toml
@@ -8,7 +8,7 @@ edition.workspace = true
 [dependencies]
 bitvec = { version = "1.0.0", default-features = false, features = ["alloc"] }
 parity-scale-codec = { version = "3.4.0", default-features = false, features = ["derive", "max-encoded-len"] }
-scale-info = { version = "2.1.2", default-features = false, features = ["derive"] }
+scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
 log = { version = "0.4.17", default-features = false }
 rustc-hex = { version = "2.1.0", default-features = false }
 serde = { version = "1.0.139", default-features = false }

--- a/runtime/rococo/Cargo.toml
+++ b/runtime/rococo/Cargo.toml
@@ -7,7 +7,7 @@ edition.workspace = true
 
 [dependencies]
 parity-scale-codec = { version = "3.4.0", default-features = false, features = ["derive", "max-encoded-len"] }
-scale-info = { version = "2.1.2", default-features = false, features = ["derive"] }
+scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
 log = { version = "0.4.17", default-features = false }
 serde = { version = "1.0.139", default-features = false }
 serde_derive = { version = "1.0.117", optional = true }

--- a/runtime/test-runtime/Cargo.toml
+++ b/runtime/test-runtime/Cargo.toml
@@ -10,7 +10,7 @@ bitvec = { version = "1.0.0", default-features = false, features = ["alloc"] }
 parity-scale-codec = { version = "3.4.0", default-features = false, features = ["derive"] }
 log = { version = "0.4.17", default-features = false }
 rustc-hex = { version = "2.1.0", default-features = false }
-scale-info = { version = "2.1.2", default-features = false, features = ["derive"] }
+scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.139", default-features = false }
 serde_derive = { version = "1.0.117", optional = true }
 smallvec = "1.8.0"

--- a/runtime/westend/Cargo.toml
+++ b/runtime/westend/Cargo.toml
@@ -8,7 +8,7 @@ edition.workspace = true
 [dependencies]
 bitvec = { version = "1.0.0", default-features = false, features = ["alloc"] }
 parity-scale-codec = { version = "3.4.0", default-features = false, features = ["derive", "max-encoded-len"] }
-scale-info = { version = "2.1.2", default-features = false, features = ["derive"] }
+scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
 log = { version = "0.4.17", default-features = false }
 rustc-hex = { version = "2.1.0", default-features = false }
 serde = { version = "1.0.139", default-features = false }

--- a/xcm/Cargo.toml
+++ b/xcm/Cargo.toml
@@ -11,7 +11,7 @@ derivative = { version = "2.2.0", default-features = false, features = [ "use_co
 impl-trait-for-tuples = "0.2.2"
 log = { version = "0.4.17", default-features = false }
 parity-scale-codec = { version = "3.4.0", default-features = false, features = [ "derive", "max-encoded-len" ] }
-scale-info = { version = "2.1.2", default-features = false, features = ["derive"] }
+scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
 sp-weights = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 serde = { version = "1.0.136", optional = true, features = ["derive"] }
 xcm-procedural = { path = "procedural" }

--- a/xcm/pallet-xcm-benchmarks/Cargo.toml
+++ b/xcm/pallet-xcm-benchmarks/Cargo.toml
@@ -9,7 +9,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false }
-scale-info = { version = "2.1.2", default-features = false, features = ["derive"] }
+scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
 frame-support = { default-features = false, branch = "master", git = "https://github.com/paritytech/substrate" }
 frame-system = { default-features = false, branch = "master", git = "https://github.com/paritytech/substrate" }
 sp-runtime = { default-features = false, branch = "master", git = "https://github.com/paritytech/substrate" }

--- a/xcm/pallet-xcm/Cargo.toml
+++ b/xcm/pallet-xcm/Cargo.toml
@@ -8,7 +8,7 @@ version.workspace = true
 [dependencies]
 bounded-collections = { version = "0.1.5", default-features = false }
 codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = ["derive"] }
-scale-info = { version = "2.1.2", default-features = false, features = ["derive"] }
+scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.137", optional = true, features = ["derive"] }
 log = { version = "0.4.17", default-features = false }
 

--- a/xcm/xcm-builder/Cargo.toml
+++ b/xcm/xcm-builder/Cargo.toml
@@ -8,7 +8,7 @@ version.workspace = true
 [dependencies]
 impl-trait-for-tuples = "0.2.1"
 parity-scale-codec = { version = "3.4.0", default-features = false, features = ["derive"] }
-scale-info = { version = "2.1.2", default-features = false, features = ["derive"] }
+scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
 xcm = { path = "..", default-features = false }
 xcm-executor = { path = "../xcm-executor", default-features = false }
 sp-std = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }

--- a/xcm/xcm-emulator/Cargo.toml
+++ b/xcm/xcm-emulator/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "xcm-emulator"
+description = "Test kit to emulate cross-chain message passing and XCM execution"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+
+[dependencies]
+codec = { package = "parity-scale-codec", version = "3.0.0" }
+paste = "1.0.5"
+quote = "1.0.23"
+
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "master" }
+frame-system = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-std = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-arithmetic = { git = "https://github.com/paritytech/substrate", branch = "master" }
+
+cumulus-primitives-core = { git = "https://github.com/paritytech/cumulus", branch = "master"}
+cumulus-pallet-xcmp-queue = { git = "https://github.com/paritytech/cumulus", branch = "master" }
+cumulus-pallet-dmp-queue = { git = "https://github.com/paritytech/cumulus", branch = "master" }
+cumulus-pallet-parachain-system = { git = "https://github.com/paritytech/cumulus", branch = "master" }
+parachain-info = { git = "https://github.com/paritytech/cumulus", branch = "master" }
+cumulus-primitives-parachain-inherent = { git = "https://github.com/paritytech/cumulus", branch = "master" }
+cumulus-test-relay-sproof-builder = { git = "https://github.com/paritytech/cumulus", branch = "master" }
+
+xcm = { path = "../" }
+xcm-executor = { path = "../xcm-executor" }
+polkadot-primitives = { path = "../../primitives"}
+polkadot-runtime-parachains = { path = "../../runtime/parachains" }

--- a/xcm/xcm-emulator/example/Cargo.toml
+++ b/xcm/xcm-emulator/example/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "xcm-emulator-example"
+version = "0.1.0"
+license = "Apache-2.0"
+authors = ["Shaun Wang <spxwang@gmail.com>"]
+edition = "2021"
+
+[dependencies]
+serde = { version = "1.0.137", optional = true }
+codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
+proc-macro2 = "1.0.40"
+
+frame-system = { git = "https://github.com/paritytech/substrate", branch = "master" }
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "master" }
+pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "master" }
+
+cumulus-primitives-core = { git = "https://github.com/paritytech/cumulus", branch = "master" }
+cumulus-pallet-xcmp-queue = { git = "https://github.com/paritytech/cumulus", branch = "master" }
+parachain-info = { git = "https://github.com/paritytech/cumulus", branch = "master" }
+
+xcm = { path = "../.."}
+polkadot-primitives = { path = "../../../primitives" }
+polkadot-parachain = { path = "../../../parachain" }
+polkadot-runtime-parachains = { path = "../../../runtime/parachains" }
+kusama-runtime = { path = "../../../runtime/kusama" }
+pallet-xcm = { path = "../../pallet-xcm"}
+
+
+xcm-emulator = { path = ".." }
+yayoi = { path = "../yayoi" }

--- a/xcm/xcm-emulator/example/src/lib.rs
+++ b/xcm/xcm-emulator/example/src/lib.rs
@@ -74,22 +74,19 @@ pub const INITIAL_BALANCE: u128 = 1_000_000_000_000;
 pub fn yayoi_ext(para_id: u32) -> sp_io::TestExternalities {
 	use yayoi::{Runtime, System};
 
-	let mut t = frame_system::GenesisConfig::default()
-		.build_storage::<Runtime>()
-		.unwrap();
+	let mut t = frame_system::GenesisConfig::default().build_storage::<Runtime>().unwrap();
 
-	let parachain_info_config = parachain_info::GenesisConfig {
-		parachain_id: para_id.into(),
-	};
+	let parachain_info_config = parachain_info::GenesisConfig { parachain_id: para_id.into() };
 
-	<parachain_info::GenesisConfig as GenesisBuild<Runtime, _>>::assimilate_storage(&parachain_info_config, &mut t)
-		.unwrap();
-
-	pallet_balances::GenesisConfig::<Runtime> {
-		balances: vec![(ALICE, INITIAL_BALANCE)],
-	}
-	.assimilate_storage(&mut t)
+	<parachain_info::GenesisConfig as GenesisBuild<Runtime, _>>::assimilate_storage(
+		&parachain_info_config,
+		&mut t,
+	)
 	.unwrap();
+
+	pallet_balances::GenesisConfig::<Runtime> { balances: vec![(ALICE, INITIAL_BALANCE)] }
+		.assimilate_storage(&mut t)
+		.unwrap();
 
 	let mut ext = sp_io::TestExternalities::new(t);
 	ext.execute_with(|| System::set_block_number(1));
@@ -97,7 +94,9 @@ pub fn yayoi_ext(para_id: u32) -> sp_io::TestExternalities {
 }
 
 fn default_parachains_host_configuration(
-) -> polkadot_runtime_parachains::configuration::HostConfiguration<polkadot_primitives::v4::BlockNumber> {
+) -> polkadot_runtime_parachains::configuration::HostConfiguration<
+	polkadot_primitives::v4::BlockNumber,
+> {
 	use polkadot_primitives::v4::{MAX_CODE_SIZE, MAX_POV_SIZE};
 
 	polkadot_runtime_parachains::configuration::HostConfiguration {
@@ -140,15 +139,11 @@ fn default_parachains_host_configuration(
 pub fn kusama_ext() -> sp_io::TestExternalities {
 	use kusama_runtime::{Runtime, System};
 
-	let mut t = frame_system::GenesisConfig::default()
-		.build_storage::<Runtime>()
-		.unwrap();
+	let mut t = frame_system::GenesisConfig::default().build_storage::<Runtime>().unwrap();
 
-	pallet_balances::GenesisConfig::<Runtime> {
-		balances: vec![(ALICE, INITIAL_BALANCE)],
-	}
-	.assimilate_storage(&mut t)
-	.unwrap();
+	pallet_balances::GenesisConfig::<Runtime> { balances: vec![(ALICE, INITIAL_BALANCE)] }
+		.assimilate_storage(&mut t)
+		.unwrap();
 
 	polkadot_runtime_parachains::configuration::GenesisConfig::<Runtime> {
 		config: default_parachains_host_configuration(),
@@ -176,9 +171,10 @@ mod tests {
 	fn dmp() {
 		Network::reset();
 
-		let remark = yayoi::RuntimeCall::System(frame_system::Call::<yayoi::Runtime>::remark_with_event {
-			remark: "Hello from Kusama!".as_bytes().to_vec(),
-		});
+		let remark =
+			yayoi::RuntimeCall::System(frame_system::Call::<yayoi::Runtime>::remark_with_event {
+				remark: "Hello from Kusama!".as_bytes().to_vec(),
+			});
 		KusamaNet::execute_with(|| {
 			assert_ok!(kusama_runtime::XcmPallet::force_default_xcm_version(
 				kusama_runtime::RuntimeOrigin::root(),
@@ -221,10 +217,11 @@ mod tests {
 			);
 		});
 
-		let remark =
-			kusama_runtime::RuntimeCall::System(frame_system::Call::<kusama_runtime::Runtime>::remark_with_event {
-				remark: "Hello from Pumpkin!".as_bytes().to_vec(),
-			});
+		let remark = kusama_runtime::RuntimeCall::System(frame_system::Call::<
+			kusama_runtime::Runtime,
+		>::remark_with_event {
+			remark: "Hello from Pumpkin!".as_bytes().to_vec(),
+		});
 		YayoiPumpkin::execute_with(|| {
 			assert_ok!(yayoi::PolkadotXcm::force_default_xcm_version(
 				yayoi::RuntimeOrigin::root(),
@@ -234,13 +231,13 @@ mod tests {
 				Here,
 				Parent,
 				Xcm(vec![
-					UnpaidExecution {
-						weight_limit: Unlimited,
-						check_origin: None,
-					},
+					UnpaidExecution { weight_limit: Unlimited, check_origin: None },
 					Transact {
 						origin_kind: OriginKind::SovereignAccount,
-						require_weight_at_most: Weight::from_parts(INITIAL_BALANCE as u64, 1024 * 1024),
+						require_weight_at_most: Weight::from_parts(
+							INITIAL_BALANCE as u64,
+							1024 * 1024
+						),
 						call: remark.encode().into(),
 					}
 				]),
@@ -269,9 +266,10 @@ mod tests {
 	fn xcmp() {
 		Network::reset();
 
-		let remark = yayoi::RuntimeCall::System(frame_system::Call::<yayoi::Runtime>::remark_with_event {
-			remark: "Hello from Pumpkin!".as_bytes().to_vec(),
-		});
+		let remark =
+			yayoi::RuntimeCall::System(frame_system::Call::<yayoi::Runtime>::remark_with_event {
+				remark: "Hello from Pumpkin!".as_bytes().to_vec(),
+			});
 		YayoiPumpkin::execute_with(|| {
 			assert_ok!(yayoi::PolkadotXcm::send_xcm(
 				Here,
@@ -333,9 +331,10 @@ mod tests {
 			use yayoi::{RuntimeEvent, System};
 			System::events().iter().for_each(|r| println!(">>> {:?}", r.event));
 
-			assert!(System::events()
-				.iter()
-				.any(|r| matches!(r.event, RuntimeEvent::PolkadotXcm(pallet_xcm::Event::Sent(_, _, _)))));
+			assert!(System::events().iter().any(|r| matches!(
+				r.event,
+				RuntimeEvent::PolkadotXcm(pallet_xcm::Event::Sent(_, _, _))
+			)));
 		});
 
 		YayoiOctopus::execute_with(|| {
@@ -391,9 +390,10 @@ mod tests {
 	}
 
 	fn kusama_send_rmrk(msg: &str, count: u32) {
-		let remark = yayoi::RuntimeCall::System(frame_system::Call::<yayoi::Runtime>::remark_with_event {
-			remark: msg.as_bytes().to_vec(),
-		});
+		let remark =
+			yayoi::RuntimeCall::System(frame_system::Call::<yayoi::Runtime>::remark_with_event {
+				remark: msg.as_bytes().to_vec(),
+			});
 		KusamaNet::execute_with(|| {
 			for _ in 0..count {
 				assert_ok!(kusama_runtime::XcmPallet::send_xcm(
@@ -401,7 +401,10 @@ mod tests {
 					Parachain(1),
 					Xcm(vec![Transact {
 						origin_kind: OriginKind::SovereignAccount,
-						require_weight_at_most: Weight::from_parts(INITIAL_BALANCE as u64, 1024 * 1024),
+						require_weight_at_most: Weight::from_parts(
+							INITIAL_BALANCE as u64,
+							1024 * 1024
+						),
 						call: remark.encode().into(),
 					}]),
 				));

--- a/xcm/xcm-emulator/example/src/lib.rs
+++ b/xcm/xcm-emulator/example/src/lib.rs
@@ -114,7 +114,7 @@ fn default_parachains_host_configuration(
 		max_upward_queue_count: 8,
 		max_upward_queue_size: 1024 * 1024,
 		max_downward_message_size: 1024,
-		ump_service_total_weight: Weight::from_ref_time(4 * 1_000_000_000),
+		ump_service_total_weight: Weight::from_parts(4 * 1_000_000_000, 0),
 		max_upward_message_size: 50 * 1024,
 		max_upward_message_num_per_candidate: 5,
 		hrmp_sender_deposit: 0,

--- a/xcm/xcm-emulator/example/src/lib.rs
+++ b/xcm/xcm-emulator/example/src/lib.rs
@@ -1,0 +1,432 @@
+// Copyright 2023 Parity Technologies (UK) Ltd.
+// This file is part of Polkadot.
+
+// Polkadot is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Polkadot is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
+
+use frame_support::{pallet_prelude::Weight, traits::GenesisBuild};
+use sp_runtime::AccountId32;
+
+use xcm_emulator::{decl_test_network, decl_test_parachain, decl_test_relay_chain};
+
+decl_test_relay_chain! {
+	pub struct KusamaNet {
+		Runtime = kusama_runtime::Runtime,
+		XcmConfig = kusama_runtime::xcm_config::XcmConfig,
+		new_ext = kusama_ext(),
+	}
+}
+
+decl_test_parachain! {
+	pub struct YayoiPumpkin {
+		Runtime = yayoi::Runtime,
+		RuntimeOrigin = yayoi::RuntimeOrigin,
+		XcmpMessageHandler = yayoi::XcmpQueue,
+		DmpMessageHandler = yayoi::DmpQueue,
+		new_ext = yayoi_ext(1),
+	}
+}
+
+decl_test_parachain! {
+	pub struct YayoiMushroom {
+		Runtime = yayoi::Runtime,
+		RuntimeOrigin = yayoi::RuntimeOrigin,
+		XcmpMessageHandler = yayoi::XcmpQueue,
+		DmpMessageHandler = yayoi::DmpQueue,
+		new_ext = yayoi_ext(2),
+	}
+}
+
+decl_test_parachain! {
+	pub struct YayoiOctopus {
+		Runtime = yayoi::Runtime,
+		RuntimeOrigin = yayoi::RuntimeOrigin,
+		XcmpMessageHandler = yayoi::XcmpQueue,
+		DmpMessageHandler = yayoi::DmpQueue,
+		new_ext = yayoi_ext(3),
+	}
+}
+
+decl_test_network! {
+	pub struct Network {
+		relay_chain = KusamaNet,
+		parachains = vec![
+			(1, YayoiPumpkin),
+			(2, YayoiMushroom),
+			(3, YayoiOctopus),
+		],
+	}
+}
+
+pub const ALICE: AccountId32 = AccountId32::new([0u8; 32]);
+pub const INITIAL_BALANCE: u128 = 1_000_000_000_000;
+
+pub fn yayoi_ext(para_id: u32) -> sp_io::TestExternalities {
+	use yayoi::{Runtime, System};
+
+	let mut t = frame_system::GenesisConfig::default()
+		.build_storage::<Runtime>()
+		.unwrap();
+
+	let parachain_info_config = parachain_info::GenesisConfig {
+		parachain_id: para_id.into(),
+	};
+
+	<parachain_info::GenesisConfig as GenesisBuild<Runtime, _>>::assimilate_storage(&parachain_info_config, &mut t)
+		.unwrap();
+
+	pallet_balances::GenesisConfig::<Runtime> {
+		balances: vec![(ALICE, INITIAL_BALANCE)],
+	}
+	.assimilate_storage(&mut t)
+	.unwrap();
+
+	let mut ext = sp_io::TestExternalities::new(t);
+	ext.execute_with(|| System::set_block_number(1));
+	ext
+}
+
+fn default_parachains_host_configuration(
+) -> polkadot_runtime_parachains::configuration::HostConfiguration<polkadot_primitives::v4::BlockNumber> {
+	use polkadot_primitives::v4::{MAX_CODE_SIZE, MAX_POV_SIZE};
+
+	polkadot_runtime_parachains::configuration::HostConfiguration {
+		minimum_validation_upgrade_delay: 5,
+		validation_upgrade_cooldown: 10u32,
+		validation_upgrade_delay: 10,
+		code_retention_period: 1200,
+		max_code_size: MAX_CODE_SIZE,
+		max_pov_size: MAX_POV_SIZE,
+		max_head_data_size: 32 * 1024,
+		group_rotation_frequency: 20,
+		chain_availability_period: 4,
+		thread_availability_period: 4,
+		max_upward_queue_count: 8,
+		max_upward_queue_size: 1024 * 1024,
+		max_downward_message_size: 1024,
+		ump_service_total_weight: Weight::from_ref_time(4 * 1_000_000_000),
+		max_upward_message_size: 50 * 1024,
+		max_upward_message_num_per_candidate: 5,
+		hrmp_sender_deposit: 0,
+		hrmp_recipient_deposit: 0,
+		hrmp_channel_max_capacity: 8,
+		hrmp_channel_max_total_size: 8 * 1024,
+		hrmp_max_parachain_inbound_channels: 4,
+		hrmp_max_parathread_inbound_channels: 4,
+		hrmp_channel_max_message_size: 1024 * 1024,
+		hrmp_max_parachain_outbound_channels: 4,
+		hrmp_max_parathread_outbound_channels: 4,
+		hrmp_max_message_num_per_candidate: 5,
+		dispute_period: 6,
+		no_show_slots: 2,
+		n_delay_tranches: 25,
+		needed_approvals: 2,
+		relay_vrf_modulo_samples: 2,
+		zeroth_delay_tranche_width: 0,
+		..Default::default()
+	}
+}
+
+pub fn kusama_ext() -> sp_io::TestExternalities {
+	use kusama_runtime::{Runtime, System};
+
+	let mut t = frame_system::GenesisConfig::default()
+		.build_storage::<Runtime>()
+		.unwrap();
+
+	pallet_balances::GenesisConfig::<Runtime> {
+		balances: vec![(ALICE, INITIAL_BALANCE)],
+	}
+	.assimilate_storage(&mut t)
+	.unwrap();
+
+	polkadot_runtime_parachains::configuration::GenesisConfig::<Runtime> {
+		config: default_parachains_host_configuration(),
+	}
+	.assimilate_storage(&mut t)
+	.unwrap();
+
+	let mut ext = sp_io::TestExternalities::new(t);
+	ext.execute_with(|| System::set_block_number(1));
+	ext
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use codec::Encode;
+
+	use cumulus_primitives_core::ParaId;
+	use frame_support::{assert_ok, dispatch::GetDispatchInfo, traits::Currency};
+	use sp_runtime::traits::AccountIdConversion;
+	use xcm::{v3::prelude::*, VersionedMultiLocation, VersionedXcm};
+	use xcm_emulator::TestExt;
+
+	#[test]
+	fn dmp() {
+		Network::reset();
+
+		let remark = yayoi::RuntimeCall::System(frame_system::Call::<yayoi::Runtime>::remark_with_event {
+			remark: "Hello from Kusama!".as_bytes().to_vec(),
+		});
+		KusamaNet::execute_with(|| {
+			assert_ok!(kusama_runtime::XcmPallet::force_default_xcm_version(
+				kusama_runtime::RuntimeOrigin::root(),
+				Some(3)
+			));
+			assert_ok!(kusama_runtime::XcmPallet::send_xcm(
+				Here,
+				Parachain(1),
+				Xcm(vec![Transact {
+					origin_kind: OriginKind::SovereignAccount,
+					require_weight_at_most: Weight::from_parts(INITIAL_BALANCE as u64, 1024 * 1024),
+					call: remark.encode().into(),
+				}]),
+			));
+		});
+
+		YayoiPumpkin::execute_with(|| {
+			use yayoi::{RuntimeEvent, System};
+			System::events().iter().for_each(|r| println!(">>> {:?}", r.event));
+
+			assert!(System::events().iter().any(|r| matches!(
+				r.event,
+				RuntimeEvent::System(frame_system::Event::Remarked { sender: _, hash: _ })
+			)));
+		});
+	}
+
+	#[test]
+	fn ump() {
+		Network::reset();
+
+		KusamaNet::execute_with(|| {
+			assert_ok!(kusama_runtime::XcmPallet::force_default_xcm_version(
+				kusama_runtime::RuntimeOrigin::root(),
+				Some(3)
+			));
+			let _ = kusama_runtime::Balances::deposit_creating(
+				&ParaId::from(1).into_account_truncating(),
+				1_000_000_000_000,
+			);
+		});
+
+		let remark =
+			kusama_runtime::RuntimeCall::System(frame_system::Call::<kusama_runtime::Runtime>::remark_with_event {
+				remark: "Hello from Pumpkin!".as_bytes().to_vec(),
+			});
+		YayoiPumpkin::execute_with(|| {
+			assert_ok!(yayoi::PolkadotXcm::force_default_xcm_version(
+				yayoi::RuntimeOrigin::root(),
+				Some(3)
+			));
+			assert_ok!(yayoi::PolkadotXcm::send_xcm(
+				Here,
+				Parent,
+				Xcm(vec![
+					UnpaidExecution {
+						weight_limit: Unlimited,
+						check_origin: None,
+					},
+					Transact {
+						origin_kind: OriginKind::SovereignAccount,
+						require_weight_at_most: Weight::from_parts(INITIAL_BALANCE as u64, 1024 * 1024),
+						call: remark.encode().into(),
+					}
+				]),
+			));
+		});
+
+		KusamaNet::execute_with(|| {
+			use kusama_runtime::{RuntimeEvent, System};
+			// TODO: https://github.com/paritytech/polkadot/pull/6824 or change this call to
+			// force_create_assets like we do in cumulus integration tests.
+			// assert!(System::events().iter().any(|r| matches!(
+			// 	r.event,
+			// 	RuntimeEvent::System(frame_system::Event::Remarked { sender: _, hash: _ })
+			// )));
+			assert!(System::events().iter().any(|r| matches!(
+				r.event,
+				RuntimeEvent::Ump(polkadot_runtime_parachains::ump::Event::ExecutedUpward(
+					_,
+					Outcome::Incomplete(_, XcmError::NoPermission)
+				))
+			)));
+		});
+	}
+
+	#[test]
+	fn xcmp() {
+		Network::reset();
+
+		let remark = yayoi::RuntimeCall::System(frame_system::Call::<yayoi::Runtime>::remark_with_event {
+			remark: "Hello from Pumpkin!".as_bytes().to_vec(),
+		});
+		YayoiPumpkin::execute_with(|| {
+			assert_ok!(yayoi::PolkadotXcm::send_xcm(
+				Here,
+				MultiLocation::new(1, X1(Parachain(2))),
+				Xcm(vec![Transact {
+					origin_kind: OriginKind::SovereignAccount,
+					require_weight_at_most: 20_000_000.into(),
+					call: remark.encode().into(),
+				}]),
+			));
+		});
+
+		YayoiMushroom::execute_with(|| {
+			use yayoi::{RuntimeEvent, System};
+			System::events().iter().for_each(|r| println!(">>> {:?}", r.event));
+
+			assert!(System::events().iter().any(|r| matches!(
+				r.event,
+				RuntimeEvent::System(frame_system::Event::Remarked { sender: _, hash: _ })
+			)));
+		});
+	}
+
+	#[test]
+	fn xcmp_through_a_parachain() {
+		use yayoi::{PolkadotXcm, Runtime, RuntimeCall};
+
+		Network::reset();
+
+		// The message goes through: Pumpkin --> Mushroom --> Octopus
+		let remark = RuntimeCall::System(frame_system::Call::<Runtime>::remark_with_event {
+			remark: "Hello from Pumpkin!".as_bytes().to_vec(),
+		});
+		let send_xcm_to_octopus = RuntimeCall::PolkadotXcm(pallet_xcm::Call::<Runtime>::send {
+			dest: Box::new(VersionedMultiLocation::V3(MultiLocation::new(1, X1(Parachain(3))))),
+			message: Box::new(VersionedXcm::V3(Xcm(vec![Transact {
+				origin_kind: OriginKind::SovereignAccount,
+				require_weight_at_most: 10_000_000.into(),
+				call: remark.encode().into(),
+			}]))),
+		});
+		assert_eq!(
+			send_xcm_to_octopus.get_dispatch_info().weight,
+			Weight::from_parts(110000010, 10000010)
+		);
+		YayoiPumpkin::execute_with(|| {
+			assert_ok!(PolkadotXcm::send_xcm(
+				Here,
+				MultiLocation::new(1, X1(Parachain(2))),
+				Xcm(vec![Transact {
+					origin_kind: OriginKind::SovereignAccount,
+					require_weight_at_most: 110_000_010.into(),
+					call: send_xcm_to_octopus.encode().into(),
+				}]),
+			));
+		});
+
+		YayoiMushroom::execute_with(|| {
+			use yayoi::{RuntimeEvent, System};
+			System::events().iter().for_each(|r| println!(">>> {:?}", r.event));
+
+			assert!(System::events()
+				.iter()
+				.any(|r| matches!(r.event, RuntimeEvent::PolkadotXcm(pallet_xcm::Event::Sent(_, _, _)))));
+		});
+
+		YayoiOctopus::execute_with(|| {
+			use yayoi::{RuntimeEvent, System};
+			// execution would fail, but good enough to check if the message is received
+			System::events().iter().for_each(|r| println!(">>> {:?}", r.event));
+
+			assert!(System::events().iter().any(|r| matches!(
+				r.event,
+				RuntimeEvent::XcmpQueue(cumulus_pallet_xcmp_queue::Event::Fail { .. })
+			)));
+		});
+	}
+
+	#[test]
+	fn deduplicate_dmp() {
+		Network::reset();
+		KusamaNet::execute_with(|| {
+			assert_ok!(kusama_runtime::XcmPallet::force_default_xcm_version(
+				kusama_runtime::RuntimeOrigin::root(),
+				Some(3)
+			));
+		});
+
+		kusama_send_rmrk("Kusama", 2);
+		parachain_receive_and_reset_events(true);
+
+		// a different dmp message in same relay-parent-block allow execution.
+		kusama_send_rmrk("Polkadot", 1);
+		parachain_receive_and_reset_events(true);
+
+		// same dmp message with same relay-parent-block wouldn't execution
+		kusama_send_rmrk("Kusama", 1);
+		parachain_receive_and_reset_events(false);
+
+		// different relay-parent-block allow dmp message execution
+		KusamaNet::execute_with(|| kusama_runtime::System::set_block_number(2));
+
+		kusama_send_rmrk("Kusama", 1);
+		parachain_receive_and_reset_events(true);
+
+		// reset can send same dmp message again
+		Network::reset();
+		KusamaNet::execute_with(|| {
+			assert_ok!(kusama_runtime::XcmPallet::force_default_xcm_version(
+				kusama_runtime::RuntimeOrigin::root(),
+				Some(3)
+			));
+		});
+
+		kusama_send_rmrk("Kusama", 1);
+		parachain_receive_and_reset_events(true);
+	}
+
+	fn kusama_send_rmrk(msg: &str, count: u32) {
+		let remark = yayoi::RuntimeCall::System(frame_system::Call::<yayoi::Runtime>::remark_with_event {
+			remark: msg.as_bytes().to_vec(),
+		});
+		KusamaNet::execute_with(|| {
+			for _ in 0..count {
+				assert_ok!(kusama_runtime::XcmPallet::send_xcm(
+					Here,
+					Parachain(1),
+					Xcm(vec![Transact {
+						origin_kind: OriginKind::SovereignAccount,
+						require_weight_at_most: Weight::from_parts(INITIAL_BALANCE as u64, 1024 * 1024),
+						call: remark.encode().into(),
+					}]),
+				));
+			}
+		});
+	}
+
+	fn parachain_receive_and_reset_events(received: bool) {
+		YayoiPumpkin::execute_with(|| {
+			use yayoi::{RuntimeEvent, System};
+			System::events().iter().for_each(|r| println!(">>> {:?}", r.event));
+
+			if received {
+				assert!(System::events().iter().any(|r| matches!(
+					r.event,
+					RuntimeEvent::System(frame_system::Event::Remarked { sender: _, hash: _ })
+				)));
+
+				System::reset_events();
+			} else {
+				assert!(System::events().iter().all(|r| !matches!(
+					r.event,
+					RuntimeEvent::System(frame_system::Event::Remarked { sender: _, hash: _ })
+				)));
+			}
+		});
+	}
+}

--- a/xcm/xcm-emulator/src/lib.rs
+++ b/xcm/xcm-emulator/src/lib.rs
@@ -73,9 +73,7 @@ macro_rules! decl_test_relay_chain {
 				use $crate::{TestExt, UmpSink};
 
 				Self::execute_with(|| {
-					$crate::XcmSink::<$crate::XcmExecutor<$xcm_config>, $runtime>::process_upward_message(
-										origin, msg, max_weight,
-									)
+					$crate::XcmSink::<$crate::XcmExecutor<$xcm_config>, $runtime>::process_upward_message(origin, msg, max_weight)
 				})
 			}
 		}

--- a/xcm/xcm-emulator/src/lib.rs
+++ b/xcm/xcm-emulator/src/lib.rs
@@ -1,3 +1,19 @@
+// Copyright 2023 Parity Technologies (UK) Ltd.
+// This file is part of Polkadot.
+
+// Polkadot is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Polkadot is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
+
 pub use codec::Encode;
 pub use paste;
 
@@ -14,8 +30,8 @@ pub use cumulus_pallet_dmp_queue;
 pub use cumulus_pallet_parachain_system;
 pub use cumulus_pallet_xcmp_queue;
 pub use cumulus_primitives_core::{
-	self, relay_chain::BlockNumber as RelayBlockNumber, DmpMessageHandler, ParaId, PersistedValidationData,
-	XcmpMessageHandler,
+	self, relay_chain::BlockNumber as RelayBlockNumber, DmpMessageHandler, ParaId,
+	PersistedValidationData, XcmpMessageHandler,
 };
 pub use cumulus_primitives_parachain_inherent::ParachainInherentData;
 pub use cumulus_test_relay_sproof_builder::RelayStateSproofBuilder;
@@ -58,8 +74,8 @@ macro_rules! decl_test_relay_chain {
 
 				Self::execute_with(|| {
 					$crate::XcmSink::<$crate::XcmExecutor<$xcm_config>, $runtime>::process_upward_message(
-						origin, msg, max_weight,
-					)
+								origin, msg, max_weight,
+							)
 				})
 			}
 		}
@@ -82,13 +98,18 @@ macro_rules! decl_test_parachain {
 		$crate::__impl_ext_for_parachain!($name, $runtime, $origin, $new_ext);
 
 		impl $crate::XcmpMessageHandler for $name {
-			fn handle_xcmp_messages<'a, I: Iterator<Item = ($crate::ParaId, $crate::RelayBlockNumber, &'a [u8])>>(
+			fn handle_xcmp_messages<
+				'a,
+				I: Iterator<Item = ($crate::ParaId, $crate::RelayBlockNumber, &'a [u8])>,
+			>(
 				iter: I,
 				max_weight: $crate::Weight,
 			) -> $crate::Weight {
 				use $crate::{TestExt, XcmpMessageHandler};
 
-				$name::execute_with(|| <$xcmp_message_handler>::handle_xcmp_messages(iter, max_weight))
+				$name::execute_with(|| {
+					<$xcmp_message_handler>::handle_xcmp_messages(iter, max_weight)
+				})
 			}
 		}
 
@@ -99,7 +120,9 @@ macro_rules! decl_test_parachain {
 			) -> $crate::Weight {
 				use $crate::{DmpMessageHandler, TestExt};
 
-				$name::execute_with(|| <$dmp_message_handler>::handle_dmp_messages(iter, max_weight))
+				$name::execute_with(|| {
+					<$dmp_message_handler>::handle_dmp_messages(iter, max_weight)
+				})
 			}
 		}
 	};

--- a/xcm/xcm-emulator/src/lib.rs
+++ b/xcm/xcm-emulator/src/lib.rs
@@ -74,8 +74,8 @@ macro_rules! decl_test_relay_chain {
 
 				Self::execute_with(|| {
 					$crate::XcmSink::<$crate::XcmExecutor<$xcm_config>, $runtime>::process_upward_message(
-								origin, msg, max_weight,
-							)
+										origin, msg, max_weight,
+									)
 				})
 			}
 		}

--- a/xcm/xcm-emulator/src/lib.rs
+++ b/xcm/xcm-emulator/src/lib.rs
@@ -1,0 +1,466 @@
+pub use codec::Encode;
+pub use paste;
+
+pub use frame_support::{
+	traits::{Get, Hooks},
+	weights::Weight,
+};
+pub use frame_system;
+pub use sp_arithmetic::traits::Bounded;
+pub use sp_io::TestExternalities;
+pub use sp_std::{cell::RefCell, collections::vec_deque::VecDeque, marker::PhantomData};
+
+pub use cumulus_pallet_dmp_queue;
+pub use cumulus_pallet_parachain_system;
+pub use cumulus_pallet_xcmp_queue;
+pub use cumulus_primitives_core::{
+	self, relay_chain::BlockNumber as RelayBlockNumber, DmpMessageHandler, ParaId, PersistedValidationData,
+	XcmpMessageHandler,
+};
+pub use cumulus_primitives_parachain_inherent::ParachainInherentData;
+pub use cumulus_test_relay_sproof_builder::RelayStateSproofBuilder;
+pub use parachain_info;
+
+pub use polkadot_primitives;
+pub use polkadot_runtime_parachains::{
+	dmp,
+	ump::{MessageId, UmpSink, XcmSink},
+};
+pub use xcm::{v3::prelude::*, VersionedXcm};
+pub use xcm_executor::XcmExecutor;
+
+pub trait TestExt {
+	fn new_ext() -> sp_io::TestExternalities;
+	fn reset_ext();
+	fn execute_with<R>(execute: impl FnOnce() -> R) -> R;
+}
+
+#[macro_export]
+macro_rules! decl_test_relay_chain {
+	(
+		pub struct $name:ident {
+			Runtime = $runtime:path,
+			XcmConfig = $xcm_config:path,
+			new_ext = $new_ext:expr,
+		}
+	) => {
+		pub struct $name;
+
+		$crate::__impl_ext_for_relay_chain!($name, $runtime, $new_ext);
+
+		impl $crate::UmpSink for $name {
+			fn process_upward_message(
+				origin: $crate::ParaId,
+				msg: &[u8],
+				max_weight: $crate::Weight,
+			) -> Result<$crate::Weight, ($crate::MessageId, $crate::Weight)> {
+				use $crate::{TestExt, UmpSink};
+
+				Self::execute_with(|| {
+					$crate::XcmSink::<$crate::XcmExecutor<$xcm_config>, $runtime>::process_upward_message(
+						origin, msg, max_weight,
+					)
+				})
+			}
+		}
+	};
+}
+
+#[macro_export]
+macro_rules! decl_test_parachain {
+	(
+		pub struct $name:ident {
+			Runtime = $runtime:path,
+			RuntimeOrigin = $origin:path,
+			XcmpMessageHandler = $xcmp_message_handler:path,
+			DmpMessageHandler = $dmp_message_handler:path,
+			new_ext = $new_ext:expr,
+		}
+	) => {
+		pub struct $name;
+
+		$crate::__impl_ext_for_parachain!($name, $runtime, $origin, $new_ext);
+
+		impl $crate::XcmpMessageHandler for $name {
+			fn handle_xcmp_messages<'a, I: Iterator<Item = ($crate::ParaId, $crate::RelayBlockNumber, &'a [u8])>>(
+				iter: I,
+				max_weight: $crate::Weight,
+			) -> $crate::Weight {
+				use $crate::{TestExt, XcmpMessageHandler};
+
+				$name::execute_with(|| <$xcmp_message_handler>::handle_xcmp_messages(iter, max_weight))
+			}
+		}
+
+		impl $crate::DmpMessageHandler for $name {
+			fn handle_dmp_messages(
+				iter: impl Iterator<Item = ($crate::RelayBlockNumber, Vec<u8>)>,
+				max_weight: $crate::Weight,
+			) -> $crate::Weight {
+				use $crate::{DmpMessageHandler, TestExt};
+
+				$name::execute_with(|| <$dmp_message_handler>::handle_dmp_messages(iter, max_weight))
+			}
+		}
+	};
+}
+
+#[macro_export]
+macro_rules! __impl_ext_for_relay_chain {
+	// entry point: generate ext name
+	($name:ident, $runtime:path, $new_ext:expr) => {
+		$crate::paste::paste! {
+			$crate::__impl_ext_for_relay_chain!(@impl $name, $runtime, $new_ext, [<EXT_ $name:upper>]);
+		}
+	};
+	// impl
+	(@impl $name:ident, $runtime:path, $new_ext:expr, $ext_name:ident) => {
+		thread_local! {
+			pub static $ext_name: $crate::RefCell<$crate::TestExternalities>
+				= $crate::RefCell::new($new_ext);
+		}
+
+		impl $crate::TestExt for $name {
+			fn new_ext() -> $crate::TestExternalities {
+				$new_ext
+			}
+
+			fn reset_ext() {
+				$ext_name.with(|v| *v.borrow_mut() = $new_ext);
+			}
+
+			fn execute_with<R>(execute: impl FnOnce() -> R) -> R {
+				let r = $ext_name.with(|v| v.borrow_mut().execute_with(execute));
+
+				// send messages if needed
+				$ext_name.with(|v| {
+					v.borrow_mut().execute_with(|| {
+						use $crate::polkadot_primitives::runtime_api::runtime_decl_for_parachain_host::ParachainHostV4;
+
+						//TODO: mark sent count & filter out sent msg
+						for para_id in _para_ids() {
+							// downward messages
+							let downward_messages = <$runtime>::dmq_contents(para_id.into())
+								.into_iter()
+								.map(|inbound| (inbound.sent_at, inbound.msg));
+							if downward_messages.len() == 0 {
+								continue;
+							}
+							_Messenger::send_downward_messages(para_id, downward_messages.into_iter());
+
+							// Note: no need to handle horizontal messages, as the
+							// simulator directly sends them to dest (not relayed).
+						}
+					})
+				});
+
+				_process_messages();
+
+				r
+			}
+		}
+	};
+}
+
+#[macro_export]
+macro_rules! __impl_ext_for_parachain {
+	// entry point: generate ext name
+	($name:ident, $runtime:path, $origin:path, $new_ext:expr) => {
+		$crate::paste::paste! {
+			$crate::__impl_ext_for_parachain!(@impl $name, $runtime, $origin, $new_ext, [<EXT_ $name:upper>]);
+		}
+	};
+	// impl
+	(@impl $name:ident, $runtime:path, $origin:path, $new_ext:expr, $ext_name:ident) => {
+		thread_local! {
+			pub static $ext_name: $crate::RefCell<$crate::TestExternalities>
+				= $crate::RefCell::new($new_ext);
+		}
+
+		impl $name {
+			fn prepare_for_xcmp() {
+				$ext_name.with(|v| {
+					v.borrow_mut().execute_with(|| {
+						use $crate::{Get, Hooks};
+						type ParachainSystem = $crate::cumulus_pallet_parachain_system::Pallet<$runtime>;
+
+						let block_number = $crate::frame_system::Pallet::<$runtime>::block_number();
+						let para_id = $crate::parachain_info::Pallet::<$runtime>::get();
+
+						let _ = ParachainSystem::set_validation_data(
+							<$origin>::none(),
+							_hrmp_channel_parachain_inherent_data(para_id.into(), 1),
+						);
+						// set `AnnouncedHrmpMessagesPerCandidate`
+						ParachainSystem::on_initialize(block_number);
+					})
+				});
+			}
+		}
+
+		impl $crate::TestExt for $name {
+			fn new_ext() -> $crate::TestExternalities {
+				$new_ext
+			}
+
+			fn reset_ext() {
+				$ext_name.with(|v| *v.borrow_mut() = $new_ext);
+			}
+
+			fn execute_with<R>(execute: impl FnOnce() -> R) -> R {
+				use $crate::{Get, Hooks};
+				type ParachainSystem = $crate::cumulus_pallet_parachain_system::Pallet<$runtime>;
+
+				$crate::GLOBAL_RELAY.with(|v| {
+					*v.borrow_mut() += 1;
+				});
+
+				$ext_name.with(|v| {
+					v.borrow_mut().execute_with(|| {
+						let para_id = $crate::parachain_info::Pallet::<$runtime>::get();
+						$crate::GLOBAL_RELAY.with(|v| {
+							let relay_block = *v.borrow();
+							let _ = ParachainSystem::set_validation_data(
+								<$origin>::none(),
+								_hrmp_channel_parachain_inherent_data(para_id.into(), relay_block),
+							);
+						});
+					})
+				});
+
+				let r = $ext_name.with(|v| v.borrow_mut().execute_with(execute));
+
+				// send messages if needed
+				$ext_name.with(|v| {
+					v.borrow_mut().execute_with(|| {
+						use sp_runtime::traits::Header as HeaderT;
+
+						let block_number = $crate::frame_system::Pallet::<$runtime>::block_number();
+						let mock_header = HeaderT::new(
+							0,
+							Default::default(),
+							Default::default(),
+							Default::default(),
+							Default::default(),
+						);
+
+						// get messages
+						ParachainSystem::on_finalize(block_number);
+						let collation_info = ParachainSystem::collect_collation_info(&mock_header);
+
+						// send upward messages
+						let para_id = $crate::parachain_info::Pallet::<$runtime>::get();
+						for msg in collation_info.upward_messages.clone() {
+							_Messenger::send_upward_message(para_id.into(), msg);
+						}
+
+						// send horizontal messages
+						for msg in collation_info.horizontal_messages {
+							$crate::GLOBAL_RELAY.with(|v| {
+								let relay_block = *v.borrow();
+								_Messenger::send_horizontal_messages(
+									msg.recipient.into(),
+									vec![(para_id.into(), relay_block, msg.data)].into_iter(),
+								);
+							});
+						}
+
+						// clean messages
+						ParachainSystem::on_initialize(block_number);
+					})
+				});
+
+				_process_messages();
+
+				r
+			}
+		}
+	};
+}
+
+thread_local! {
+	/// Downward messages, each message is: `(to_para_id, [(relay_block_number, msg)])`
+	#[allow(clippy::type_complexity)]
+	pub static DOWNWARD_MESSAGES: RefCell<VecDeque<(u32, Vec<(RelayBlockNumber, Vec<u8>)>)>>
+		= RefCell::new(VecDeque::new());
+		#[allow(clippy::type_complexity)]
+	/// Downward messages that already processed by parachains, each message is: `(to_para_id, relay_block_number, Vec<u8>)`
+	pub static DMP_DONE: RefCell<VecDeque<(u32, RelayBlockNumber, Vec<u8>)>>
+		= RefCell::new(VecDeque::new());
+	/// Horizontal messages, each message is: `(to_para_id, [(from_para_id, relay_block_number, msg)])`
+	#[allow(clippy::type_complexity)]
+	pub static HORIZONTAL_MESSAGES: RefCell<VecDeque<(u32, Vec<(ParaId, RelayBlockNumber, Vec<u8>)>)>>
+		= RefCell::new(VecDeque::new());
+	/// Upward messages, each message is: `(from_para_id, msg)
+	pub static UPWARD_MESSAGES: RefCell<VecDeque<(u32, Vec<u8>)>> = RefCell::new(VecDeque::new());
+	/// Global incremental relay chain block number
+	pub static GLOBAL_RELAY: RefCell<u32> = RefCell::new(1);
+}
+
+#[macro_export]
+macro_rules! decl_test_network {
+	(
+		pub struct $name:ident {
+			relay_chain = $relay_chain:ty,
+			parachains = vec![ $( ($para_id:expr, $parachain:ty), )* ],
+		}
+	) => {
+		pub struct $name;
+
+		impl $name {
+			pub fn reset() {
+				use $crate::{TestExt, VecDeque};
+
+				<$relay_chain>::reset_ext();
+				$( <$parachain>::reset_ext(); )*
+
+				$( <$parachain>::prepare_for_xcmp(); )*
+
+				$crate::DOWNWARD_MESSAGES.with(|b| b.replace(VecDeque::new()));
+				$crate::DMP_DONE.with(|b| b.replace(VecDeque::new()));
+			}
+		}
+
+		fn _para_ids() -> Vec<u32> {
+			vec![$( $para_id, )*]
+		}
+
+		fn _process_messages() {
+			while _has_unprocessed_messages() {
+				_process_upward_messages();
+				_process_horizontal_messages();
+				_process_downward_messages();
+			}
+		}
+
+		fn _has_unprocessed_messages() -> bool {
+			$crate::DOWNWARD_MESSAGES.with(|b| !b.borrow_mut().is_empty())
+			|| $crate::HORIZONTAL_MESSAGES.with(|b| !b.borrow_mut().is_empty())
+			|| $crate::UPWARD_MESSAGES.with(|b| !b.borrow_mut().is_empty())
+		}
+
+		fn _process_downward_messages() {
+			use $crate::{DmpMessageHandler, Bounded};
+			use polkadot_parachain::primitives::RelayChainBlockNumber;
+
+			while let Some((to_para_id, messages))
+				= $crate::DOWNWARD_MESSAGES.with(|b| b.borrow_mut().pop_front()) {
+				match to_para_id {
+					$(
+						$para_id => {
+							let mut msg_dedup: Vec<(RelayChainBlockNumber, Vec<u8>)> = Vec::new();
+							for m in messages {
+								msg_dedup.push((m.0, m.1.clone()));
+							}
+							msg_dedup.dedup();
+
+							let msgs = msg_dedup.clone().into_iter().filter(|m| {
+								!$crate::DMP_DONE.with(|b| b.borrow_mut().contains(&(to_para_id, m.0, m.1.clone())))
+							}).collect::<Vec<(RelayChainBlockNumber, Vec<u8>)>>();
+							if msgs.len() != 0 {
+								<$parachain>::handle_dmp_messages(msgs.clone().into_iter(), $crate::Weight::max_value());
+								for m in msgs {
+									$crate::DMP_DONE.with(|b| b.borrow_mut().push_back((to_para_id, m.0, m.1)));
+								}
+							}
+						},
+					)*
+					_ => unreachable!(),
+				}
+			}
+		}
+
+		fn _process_horizontal_messages() {
+			use $crate::{XcmpMessageHandler, Bounded};
+
+			while let Some((to_para_id, messages))
+				= $crate::HORIZONTAL_MESSAGES.with(|b| b.borrow_mut().pop_front()) {
+				let iter = messages.iter().map(|(p, b, m)| (*p, *b, &m[..])).collect::<Vec<_>>().into_iter();
+				match to_para_id {
+					$(
+						$para_id => {
+							<$parachain>::handle_xcmp_messages(iter, $crate::Weight::max_value());
+						},
+					)*
+					_ => unreachable!(),
+				}
+			}
+		}
+
+		fn _process_upward_messages() {
+			use $crate::{UmpSink, Bounded};
+			while let Some((from_para_id, msg)) = $crate::UPWARD_MESSAGES.with(|b| b.borrow_mut().pop_front()) {
+				let _ =  <$relay_chain>::process_upward_message(
+					from_para_id.into(),
+					&msg[..],
+					$crate::Weight::max_value(),
+				);
+			}
+		}
+
+		pub struct _Messenger;
+		impl _Messenger {
+			fn send_downward_messages(to_para_id: u32, iter: impl Iterator<Item = ($crate::RelayBlockNumber, Vec<u8>)>) {
+				$crate::DOWNWARD_MESSAGES.with(|b| b.borrow_mut().push_back((to_para_id, iter.collect())));
+			}
+
+			fn send_horizontal_messages<
+				I: Iterator<Item = ($crate::ParaId, $crate::RelayBlockNumber, Vec<u8>)>,
+			>(to_para_id: u32, iter: I) {
+				$crate::HORIZONTAL_MESSAGES.with(|b| b.borrow_mut().push_back((to_para_id, iter.collect())));
+			}
+
+			fn send_upward_message(from_para_id: u32, msg: Vec<u8>) {
+				$crate::UPWARD_MESSAGES.with(|b| b.borrow_mut().push_back((from_para_id, msg)));
+			}
+		}
+
+		fn _hrmp_channel_parachain_inherent_data(
+			para_id: u32,
+			relay_parent_number: u32,
+		) -> $crate::ParachainInherentData {
+			use $crate::cumulus_primitives_core::{relay_chain::HrmpChannelId, AbridgedHrmpChannel};
+
+			let mut sproof = $crate::RelayStateSproofBuilder::default();
+			sproof.para_id = para_id.into();
+
+			// egress channel
+			let e_index = sproof.hrmp_egress_channel_index.get_or_insert_with(Vec::new);
+			for recipient_para_id in &[ $( $para_id, )* ] {
+				let recipient_para_id = $crate::ParaId::from(*recipient_para_id);
+				if let Err(idx) = e_index.binary_search(&recipient_para_id) {
+					e_index.insert(idx, recipient_para_id);
+				}
+
+				sproof
+					.hrmp_channels
+					.entry(HrmpChannelId {
+						sender: sproof.para_id,
+						recipient: recipient_para_id,
+					})
+					.or_insert_with(|| AbridgedHrmpChannel {
+						max_capacity: 1024,
+						max_total_size: 1024 * 1024,
+						max_message_size: 1024 * 1024,
+						msg_count: 0,
+						total_size: 0,
+						mqc_head: Option::None,
+					});
+			}
+
+			let (relay_storage_root, proof) = sproof.into_state_root_and_proof();
+
+			$crate::ParachainInherentData {
+				validation_data: $crate::PersistedValidationData {
+					parent_head: Default::default(),
+					relay_parent_number,
+					relay_parent_storage_root: relay_storage_root,
+					max_pov_size: Default::default(),
+				},
+				relay_chain_state: proof,
+				downward_messages: Default::default(),
+				horizontal_messages: Default::default(),
+			}
+		}
+	};
+}

--- a/xcm/xcm-emulator/yayoi/Cargo.toml
+++ b/xcm/xcm-emulator/yayoi/Cargo.toml
@@ -64,3 +64,8 @@ std = [
 	"pallet-xcm/std",
 	"polkadot-runtime-parachains/std",
 ]
+
+runtime-benchmarks = [
+	"pallet-xcm/runtime-benchmarks",
+	"xcm-builder/runtime-benchmarks",
+]

--- a/xcm/xcm-emulator/yayoi/Cargo.toml
+++ b/xcm/xcm-emulator/yayoi/Cargo.toml
@@ -1,0 +1,66 @@
+[package]
+name = "yayoi"
+description = "A simple runtime for cross-chain messages tests."
+license = "Apache-2.0"
+version = "0.1.0"
+authors = ["Shaun Wang <spxwang@gmail.com>"]
+edition = "2021"
+
+[dependencies]
+serde = { version = "1.0.137", optional = true }
+codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
+scale-info = { version = "2.1", default-features = false, features = ["derive"] }
+
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "master" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "master" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "master" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "master" }
+pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "master" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "master" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "master" }
+
+cumulus-pallet-dmp-queue = { git = "https://github.com/paritytech/cumulus", default-features = false , branch = "master" }
+cumulus-pallet-xcmp-queue = { git = "https://github.com/paritytech/cumulus", default-features = false , branch = "master" }
+cumulus-pallet-xcm = { git = "https://github.com/paritytech/cumulus", default-features = false , branch = "master" }
+cumulus-pallet-parachain-system = { git = "https://github.com/paritytech/cumulus", default-features = false , branch = "master" }
+parachain-info = { git = "https://github.com/paritytech/cumulus", default-features = false , branch = "master" }
+cumulus-primitives-utility = { git = "https://github.com/paritytech/cumulus", default-features = false , branch = "master" }
+
+xcm = { path = "../.." }
+xcm-executor = { path = "../../xcm-executor", default-features = false }
+polkadot-parachain = { path = "../../../parachain", default-features = false }
+xcm-builder = { path = "../../xcm-builder", default-features = false }
+pallet-xcm = { path = "../../pallet-xcm", default-features = false  }
+polkadot-runtime-parachains = { path = "../../../runtime/parachains", default-features = false }
+
+
+[features]
+default = ["std"]
+no_std = []
+std = [
+	"serde/std",
+	"codec/std",
+	"scale-info/std",
+
+	"sp-runtime/std",
+	"sp-io/std",
+	"sp-std/std",
+	"sp-core/std",
+	"pallet-balances/std",
+	"frame-support/std",
+	"frame-system/std",
+
+	"cumulus-pallet-dmp-queue/std",
+	"cumulus-pallet-xcmp-queue/std",
+	"cumulus-pallet-xcm/std",
+	"cumulus-pallet-parachain-system/std",
+	"parachain-info/std",
+	"cumulus-primitives-utility/std",
+
+	"xcm/std",
+	"xcm-executor/std",
+	"polkadot-parachain/std",
+	"xcm-builder/std",
+	"pallet-xcm/std",
+	"polkadot-runtime-parachains/std",
+]

--- a/xcm/xcm-emulator/yayoi/src/lib.rs
+++ b/xcm/xcm-emulator/yayoi/src/lib.rs
@@ -1,0 +1,261 @@
+// Copyright 2023 Parity Technologies (UK) Ltd.
+// This file is part of Polkadot.
+
+// Polkadot is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Polkadot is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
+
+use frame_support::traits::ConstU32;
+use frame_support::{
+	construct_runtime, parameter_types,
+	traits::{Everything, Nothing},
+	weights::{constants::WEIGHT_REF_TIME_PER_SECOND, Weight},
+};
+use frame_system::EnsureRoot;
+use pallet_xcm::XcmPassthrough;
+use polkadot_parachain::primitives::Sibling;
+use sp_core::H256;
+use sp_runtime::{
+	testing::Header,
+	traits::{Convert, IdentityLookup},
+	AccountId32,
+};
+use xcm::v3::prelude::*;
+use xcm_builder::{
+	AccountId32Aliases, AllowUnpaidExecutionFrom, EnsureXcmOrigin, FixedWeightBounds, ParentIsPreset,
+	RelayChainAsNative, SiblingParachainAsNative, SiblingParachainConvertsVia, SignedAccountId32AsNative,
+	SignedToAccountId32, SovereignSignedViaLocation,
+};
+use xcm_executor::{Config, XcmExecutor};
+
+pub type AccountId = AccountId32;
+pub type Balance = u128;
+pub type Amount = i128;
+
+parameter_types! {
+	pub const BlockHashCount: u64 = 250;
+}
+
+impl frame_system::Config for Runtime {
+	type RuntimeOrigin = RuntimeOrigin;
+	type RuntimeCall = RuntimeCall;
+	type Index = u64;
+	type BlockNumber = u64;
+	type Hash = H256;
+	type Hashing = ::sp_runtime::traits::BlakeTwo256;
+	type AccountId = AccountId;
+	type Lookup = IdentityLookup<Self::AccountId>;
+	type Header = Header;
+	type RuntimeEvent = RuntimeEvent;
+	type BlockHashCount = BlockHashCount;
+	type BlockWeights = ();
+	type BlockLength = ();
+	type Version = ();
+	type PalletInfo = PalletInfo;
+	type AccountData = pallet_balances::AccountData<Balance>;
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type DbWeight = ();
+	type BaseCallFilter = Everything;
+	type SystemWeightInfo = ();
+	type SS58Prefix = ();
+	type OnSetCode = cumulus_pallet_parachain_system::ParachainSetCode<Self>;
+	type MaxConsumers = ConstU32<16>;
+}
+
+parameter_types! {
+	pub ExistentialDeposit: Balance = 1;
+	pub const MaxLocks: u32 = 50;
+	pub const MaxReserves: u32 = 50;
+}
+
+impl pallet_balances::Config for Runtime {
+	type MaxLocks = MaxLocks;
+	type Balance = Balance;
+	type RuntimeEvent = RuntimeEvent;
+	type DustRemoval = ();
+	type ExistentialDeposit = ExistentialDeposit;
+	type AccountStore = System;
+	type WeightInfo = ();
+	type MaxReserves = MaxReserves;
+	type ReserveIdentifier = [u8; 8];
+	type HoldIdentifier = ();
+	type FreezeIdentifier = ();
+	type MaxHolds = ();
+	type MaxFreezes = ();
+}
+
+impl parachain_info::Config for Runtime {}
+
+parameter_types! {
+	pub const RelayLocation: MultiLocation = MultiLocation::parent();
+	pub const RelayNetwork: NetworkId = NetworkId::Kusama;
+	pub RelayChainOrigin: RuntimeOrigin = cumulus_pallet_xcm::Origin::Relay.into();
+	pub UniversalLocation: InteriorMultiLocation = X2(GlobalConsensus(RelayNetwork::get()), Parachain(ParachainInfo::parachain_id().into()));
+}
+
+pub type LocationToAccountId = (
+	ParentIsPreset<AccountId>,
+	SiblingParachainConvertsVia<Sibling, AccountId>,
+	AccountId32Aliases<RelayNetwork, AccountId>,
+);
+
+pub type XcmOriginToCallOrigin = (
+	SovereignSignedViaLocation<LocationToAccountId, RuntimeOrigin>,
+	RelayChainAsNative<RelayChainOrigin, RuntimeOrigin>,
+	SiblingParachainAsNative<cumulus_pallet_xcm::Origin, RuntimeOrigin>,
+	SignedAccountId32AsNative<RelayNetwork, RuntimeOrigin>,
+	XcmPassthrough<RuntimeOrigin>,
+);
+
+parameter_types! {
+	pub const UnitWeightCost: u64 = 10;
+	pub const MaxInstructions: u32 = 100;
+	pub const MaxAssetsIntoHolding: u32 = 64;
+}
+
+pub type LocalAssetTransactor = ();
+
+/// The means for routing XCM messages which are not for local execution into
+/// the right message queues.
+pub type XcmRouter = (
+	// Two routers - use UMP to communicate with the relay chain:
+	cumulus_primitives_utility::ParentAsUmp<ParachainSystem, PolkadotXcm, ()>,
+	// ..and XCMP to communicate with the sibling chains.
+	XcmpQueue,
+);
+
+pub type Barrier = AllowUnpaidExecutionFrom<Everything>;
+
+pub struct XcmConfig;
+impl Config for XcmConfig {
+	type RuntimeCall = RuntimeCall;
+	type XcmSender = XcmRouter;
+	type AssetTransactor = LocalAssetTransactor;
+	type OriginConverter = XcmOriginToCallOrigin;
+	type IsReserve = ();
+	type IsTeleporter = ();
+	type UniversalLocation = UniversalLocation;
+	type Barrier = Barrier;
+	type Weigher = FixedWeightBounds<UnitWeightCost, RuntimeCall, MaxInstructions>;
+	type Trader = ();
+	type ResponseHandler = ();
+	type AssetTrap = ();
+	type AssetClaims = ();
+	type SubscriptionService = ();
+	type AssetLocker = PolkadotXcm;
+	type AssetExchanger = ();
+	type PalletInstancesInfo = ();
+	type MaxAssetsIntoHolding = MaxAssetsIntoHolding;
+	type FeeManager = ();
+	type MessageExporter = ();
+	type UniversalAliases = Nothing;
+	type CallDispatcher = RuntimeCall;
+	type SafeCallFilter = Everything;
+}
+
+parameter_types! {
+	pub const ReservedXcmpWeight: Weight = Weight::from_parts(WEIGHT_REF_TIME_PER_SECOND.saturating_div(4), 0);
+	pub const ReservedDmpWeight: Weight = Weight::from_parts(WEIGHT_REF_TIME_PER_SECOND.saturating_div(4), 0);
+}
+
+impl cumulus_pallet_parachain_system::Config for Runtime {
+	type RuntimeEvent = RuntimeEvent;
+	type OnSystemEvent = ();
+	type SelfParaId = ParachainInfo;
+	type DmpMessageHandler = DmpQueue;
+	type ReservedDmpWeight = ReservedDmpWeight;
+	type OutboundXcmpMessageSource = XcmpQueue;
+	type XcmpMessageHandler = XcmpQueue;
+	type ReservedXcmpWeight = ReservedXcmpWeight;
+	type CheckAssociatedRelayNumber = cumulus_pallet_parachain_system::RelayNumberStrictlyIncreases;
+}
+
+impl cumulus_pallet_xcmp_queue::Config for Runtime {
+	type RuntimeEvent = RuntimeEvent;
+	type XcmExecutor = XcmExecutor<XcmConfig>;
+	type ChannelInfo = ParachainSystem;
+	type VersionWrapper = ();
+	type ExecuteOverweightOrigin = EnsureRoot<AccountId>;
+	type ControllerOrigin = EnsureRoot<AccountId>;
+	type ControllerOriginConverter = XcmOriginToCallOrigin;
+	type WeightInfo = ();
+	type PriceForSiblingDelivery = ();
+}
+
+impl cumulus_pallet_dmp_queue::Config for Runtime {
+	type RuntimeEvent = RuntimeEvent;
+	type XcmExecutor = XcmExecutor<XcmConfig>;
+	type ExecuteOverweightOrigin = EnsureRoot<AccountId>;
+}
+
+impl cumulus_pallet_xcm::Config for Runtime {
+	type RuntimeEvent = RuntimeEvent;
+	type XcmExecutor = XcmExecutor<XcmConfig>;
+}
+
+pub type LocalOriginToLocation = SignedToAccountId32<RuntimeOrigin, AccountId, RelayNetwork>;
+
+impl pallet_xcm::Config for Runtime {
+	type RuntimeEvent = RuntimeEvent;
+	type SendXcmOrigin = EnsureXcmOrigin<RuntimeOrigin, LocalOriginToLocation>;
+	type XcmRouter = XcmRouter;
+	type ExecuteXcmOrigin = EnsureXcmOrigin<RuntimeOrigin, LocalOriginToLocation>;
+	type XcmExecuteFilter = Everything;
+	type XcmExecutor = XcmExecutor<XcmConfig>;
+	type XcmTeleportFilter = Nothing;
+	type XcmReserveTransferFilter = Everything;
+	type Weigher = FixedWeightBounds<UnitWeightCost, RuntimeCall, MaxInstructions>;
+	type UniversalLocation = UniversalLocation;
+	type RuntimeOrigin = RuntimeOrigin;
+	type RuntimeCall = RuntimeCall;
+	const VERSION_DISCOVERY_QUEUE_SIZE: u32 = 100;
+	type AdvertisedXcmVersion = pallet_xcm::CurrentXcmVersion;
+	type Currency = Balances;
+	type CurrencyMatcher = ();
+	type TrustedLockers = ();
+	type SovereignAccountOf = ();
+	type MaxLockers = ConstU32<8>;
+	type WeightInfo = pallet_xcm::TestWeightInfo;
+	type AdminOrigin = EnsureRoot<Self::AccountId>;
+}
+
+pub struct AccountIdToMultiLocation;
+impl Convert<AccountId, MultiLocation> for AccountIdToMultiLocation {
+	fn convert(account: AccountId) -> MultiLocation {
+		X1(Junction::AccountId32 {
+			network: None,
+			id: account.into(),
+		})
+		.into()
+	}
+}
+
+type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;
+type Block = frame_system::mocking::MockBlock<Runtime>;
+
+construct_runtime!(
+	pub enum Runtime where
+		Block = Block,
+		NodeBlock = Block,
+		UncheckedExtrinsic = UncheckedExtrinsic,
+	{
+		System: frame_system::{Pallet, Call, Storage, Config, Event<T>},
+		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
+		ParachainSystem: cumulus_pallet_parachain_system::{Pallet, Call, Storage, Inherent, Config, Event<T>},
+		ParachainInfo: parachain_info::{Pallet, Storage, Config},
+		XcmpQueue: cumulus_pallet_xcmp_queue::{Pallet, Call, Storage, Event<T>},
+		DmpQueue: cumulus_pallet_dmp_queue::{Pallet, Call, Storage, Event<T>},
+		CumulusXcm: cumulus_pallet_xcm::{Pallet, Event<T>, Origin},
+		PolkadotXcm: pallet_xcm::{Pallet, Call, Event<T>, Origin},
+	}
+);

--- a/xcm/xcm-emulator/yayoi/src/lib.rs
+++ b/xcm/xcm-emulator/yayoi/src/lib.rs
@@ -203,6 +203,11 @@ impl cumulus_pallet_xcm::Config for Runtime {
 	type XcmExecutor = XcmExecutor<XcmConfig>;
 }
 
+#[cfg(feature = "runtime-benchmarks")]
+parameter_types! {
+	pub ReachableDest: Option<MultiLocation> = Some(Parent.into());
+}
+
 pub type LocalOriginToLocation = SignedToAccountId32<RuntimeOrigin, AccountId, RelayNetwork>;
 
 impl pallet_xcm::Config for Runtime {
@@ -227,6 +232,8 @@ impl pallet_xcm::Config for Runtime {
 	type MaxLockers = ConstU32<8>;
 	type WeightInfo = pallet_xcm::TestWeightInfo;
 	type AdminOrigin = EnsureRoot<Self::AccountId>;
+	#[cfg(feature = "runtime-benchmarks")]
+	type ReachableDest = ReachableDest;
 }
 
 pub struct AccountIdToMultiLocation;

--- a/xcm/xcm-emulator/yayoi/src/lib.rs
+++ b/xcm/xcm-emulator/yayoi/src/lib.rs
@@ -14,10 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
-use frame_support::traits::ConstU32;
 use frame_support::{
 	construct_runtime, parameter_types,
-	traits::{Everything, Nothing},
+	traits::{ConstU32, Everything, Nothing},
 	weights::{constants::WEIGHT_REF_TIME_PER_SECOND, Weight},
 };
 use frame_system::EnsureRoot;
@@ -31,9 +30,9 @@ use sp_runtime::{
 };
 use xcm::v3::prelude::*;
 use xcm_builder::{
-	AccountId32Aliases, AllowUnpaidExecutionFrom, EnsureXcmOrigin, FixedWeightBounds, ParentIsPreset,
-	RelayChainAsNative, SiblingParachainAsNative, SiblingParachainConvertsVia, SignedAccountId32AsNative,
-	SignedToAccountId32, SovereignSignedViaLocation,
+	AccountId32Aliases, AllowUnpaidExecutionFrom, EnsureXcmOrigin, FixedWeightBounds,
+	ParentIsPreset, RelayChainAsNative, SiblingParachainAsNative, SiblingParachainConvertsVia,
+	SignedAccountId32AsNative, SignedToAccountId32, SovereignSignedViaLocation,
 };
 use xcm_executor::{Config, XcmExecutor};
 
@@ -239,11 +238,7 @@ impl pallet_xcm::Config for Runtime {
 pub struct AccountIdToMultiLocation;
 impl Convert<AccountId, MultiLocation> for AccountIdToMultiLocation {
 	fn convert(account: AccountId) -> MultiLocation {
-		X1(Junction::AccountId32 {
-			network: None,
-			id: account.into(),
-		})
-		.into()
+		X1(Junction::AccountId32 { network: None, id: account.into() }).into()
 	}
 }
 

--- a/xcm/xcm-simulator/example/Cargo.toml
+++ b/xcm/xcm-simulator/example/Cargo.toml
@@ -7,7 +7,7 @@ version.workspace = true
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.4.0" }
-scale-info = { version = "2.1.2", features = ["derive"] }
+scale-info = { version = "2.5.0", features = ["derive"] }
 log = { version = "0.4.14", default-features = false }
 
 frame-system = { git = "https://github.com/paritytech/substrate", branch = "master" }

--- a/xcm/xcm-simulator/fuzzer/Cargo.toml
+++ b/xcm/xcm-simulator/fuzzer/Cargo.toml
@@ -9,7 +9,7 @@ edition.workspace = true
 codec = { package = "parity-scale-codec", version = "3.4.0" }
 honggfuzz = "0.5.55"
 arbitrary = "1.2.0"
-scale-info = { version = "2.1.2", features = ["derive"] }
+scale-info = { version = "2.5.0", features = ["derive"] }
 
 frame-system = { git = "https://github.com/paritytech/substrate", branch = "master" }
 frame-support = { git = "https://github.com/paritytech/substrate", branch = "master" }


### PR DESCRIPTION
The original tool has been built by [Shaun](https://github.com/shaunxw) of Acala and lives in [here](https://github.com/shaunxw/xcm-simulator/tree/master/xcm-emulator). 
**Important:** once this gets accepted - make sure to tip Shaun for his good work. 
tip: 16PNhcMEvGbTYdCht9vLy6gj8qehRehEpb2Ef

**What is this for?**
This tool is designed for testing XCM configuration and message passing between pre-defined runtimes, e.g. Polkadot and Statemint. With up-to-date chain specs it allows for verifying whether specific XCM messages work in live networks. 

**Why does it have to live in polkadot repo?**
Mainly because we want it to target the latest code and relative polkadot paths as opposed to a certain release. Otherwise it's not possible to use it for testing cumulus runtimes that target polkadot master. This copy already diverges from the original tool. Furthermore, by running test examples in CI we'll be able to verify that the tool is still up-to-date with the latest polkadot and cumulus changes. It still needs `patch` overrides in cumulus workspace for all the cumulus dependencies it's using. 

**Trade-offs**
For the tests to work we need a [dependency override](https://github.com/paritytech/polkadot/pull/7037/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R234-R239) for polkadot dependencies of cumulus. Similarly, we have the same type of override on the cumulus side for xcm-emulator cumulus dependencies.


