### PR TITLE
use stable rust toolchain in ci

### DIFF
--- a/scripts/ci/gitlab/pipeline/build.yml
+++ b/scripts/ci/gitlab/pipeline/build.yml
@@ -129,7 +129,7 @@ build-rustdoc:
   script:
     # FIXME: it fails with `RUSTDOCFLAGS="-Dwarnings"` and `--all-features`
     # FIXME: return to stable when https://github.com/rust-lang/rust/issues/96937 gets into stable
-    - time cargo +nightly doc --workspace --verbose --no-deps
+    - time cargo doc --workspace --verbose --no-deps
     - rm -f ./target/doc/.lock
     - mv ./target/doc ./crate-docs
     # FIXME: remove me after CI image gets nonroot
@@ -169,6 +169,6 @@ build-short-benchmark:
     - .test-refs
     - .collect-artifacts
   script:
-    - cargo +nightly build --profile release --locked --features=runtime-benchmarks
+    - cargo build --profile release --locked --features=runtime-benchmarks
     - mkdir artifacts
     - cp ./target/release/polkadot ./artifacts/

--- a/scripts/ci/gitlab/pipeline/test.yml
+++ b/scripts/ci/gitlab/pipeline/test.yml
@@ -99,10 +99,8 @@ cargo-clippy:
   needs:
     - job: job-starter
       artifacts: false
-  variables:
-    RUSTY_CACHIER_TOOLCHAIN: nightly
   extends:
     - .docker-env
     - .test-refs
   script:
-    - SKIP_WASM_BUILD=1 env -u RUSTFLAGS cargo +nightly clippy --all-targets
+    - SKIP_WASM_BUILD=1 env -u RUSTFLAGS cargo clippy --all-targets


### PR DESCRIPTION
for https://github.com/paritytech/ci_cd/issues/767

cargo-fmt stays on the nightly pipeline; our fmt config uses a heap of
unstable features.