### PR TITLE
apply clippy 1.68 suggestions

### DIFF
--- a/node/core/approval-voting/src/approval_db/v1/tests.rs
+++ b/node/core/approval-voting/src/approval_db/v1/tests.rs
@@ -401,7 +401,7 @@ fn canonicalize_works() {
 			assert_eq!(entry.candidates.len(), with_candidates.len());
 
 			for x in with_candidates {
-				assert!(entry.candidates.iter().position(|&(_, ref c)| c == &x).is_some());
+				assert!(entry.candidates.iter().any(|(_, c)| c == &x));
 			}
 		}
 	};

--- a/node/core/approval-voting/src/criteria.rs
+++ b/node/core/approval-voting/src/criteria.rs
@@ -274,7 +274,7 @@ pub(crate) fn compute_assignments(
 	// Ignore any cores where the assigned group is our own.
 	let leaving_cores = leaving_cores
 		.into_iter()
-		.filter(|&(_, _, ref g)| !is_in_backing_group(&config.validator_groups, index, *g))
+		.filter(|(_, _, g)| !is_in_backing_group(&config.validator_groups, index, *g))
 		.map(|(c_hash, core, _)| (c_hash, core))
 		.collect::<Vec<_>>();
 
@@ -496,7 +496,7 @@ pub(crate) fn check_assignment_cert(
 		return Err(InvalidAssignment(Reason::IsInBackingGroup))
 	}
 
-	let &(ref vrf_output, ref vrf_proof) = &assignment.vrf;
+	let (vrf_output, vrf_proof) = &assignment.vrf;
 	match assignment.kind {
 		AssignmentCertKind::RelayVRFModulo { sample } => {
 			if sample >= config.relay_vrf_modulo_samples {

--- a/node/core/approval-voting/src/import.rs
+++ b/node/core/approval-voting/src/import.rs
@@ -1227,7 +1227,7 @@ pub(crate) mod tests {
 		let mut state = single_session_state(session, session_info);
 		overlay_db.write_block_entry(
 			v1::BlockEntry {
-				block_hash: parent_hash.clone(),
+				block_hash: parent_hash,
 				parent_hash: Default::default(),
 				block_number: 4,
 				session,

--- a/node/core/approval-voting/src/lib.rs
+++ b/node/core/approval-voting/src/lib.rs
@@ -491,7 +491,7 @@ impl Wakeups {
 			.collect();
 
 		let mut pruned_wakeups = BTreeMap::new();
-		self.reverse_wakeups.retain(|&(ref h, ref c_h), tick| {
+		self.reverse_wakeups.retain(|(h, c_h), tick| {
 			let live = !pruned_blocks.contains(h);
 			if !live {
 				pruned_wakeups.entry(*tick).or_insert_with(HashSet::new).insert((*h, *c_h));

--- a/node/core/approval-voting/src/ops.rs
+++ b/node/core/approval-voting/src/ops.rs
@@ -62,7 +62,7 @@ fn visit_and_remove_block_entry(
 	};
 
 	overlayed_db.delete_block_entry(&block_hash);
-	for &(_, ref candidate_hash) in block_entry.candidates() {
+	for (_, candidate_hash) in block_entry.candidates() {
 		let candidate = match visited_candidates.entry(*candidate_hash) {
 			Entry::Occupied(e) => e.into_mut(),
 			Entry::Vacant(e) => {
@@ -227,7 +227,7 @@ pub fn add_block_entry(
 
 	// read and write all updated entries.
 	{
-		for &(_, ref candidate_hash) in entry.candidates() {
+		for (_, candidate_hash) in entry.candidates() {
 			let NewCandidateInfo { candidate, backing_group, our_assignment } =
 				match candidate_info(candidate_hash) {
 					None => return Ok(Vec::new()),

--- a/node/core/approval-voting/src/tests.rs
+++ b/node/core/approval-voting/src/tests.rs
@@ -568,7 +568,7 @@ where
 }
 
 fn make_candidate(para_id: ParaId, hash: &Hash) -> CandidateReceipt {
-	let mut r = dummy_candidate_receipt_bad_sig(hash.clone(), Some(Default::default()));
+	let mut r = dummy_candidate_receipt_bad_sig(*hash, Some(Default::default()));
 	r.descriptor.para_id = para_id;
 	r
 }
@@ -662,13 +662,13 @@ impl ChainBuilder {
 		builder
 	}
 
-	pub fn add_block<'a>(
-		&'a mut self,
+	pub fn add_block(
+		&mut self,
 		hash: Hash,
 		parent_hash: Hash,
 		number: u32,
 		config: BlockConfig,
-	) -> &'a mut Self {
+	) -> &mut Self {
 		assert!(number != 0, "cannot add duplicate genesis block");
 		assert!(hash != Self::GENESIS_HASH, "cannot add block with genesis hash");
 		assert!(
@@ -679,13 +679,13 @@ impl ChainBuilder {
 		self.add_block_inner(hash, parent_hash, number, config)
 	}
 
-	fn add_block_inner<'a>(
-		&'a mut self,
+	fn add_block_inner(
+		&mut self,
 		hash: Hash,
 		parent_hash: Hash,
 		number: u32,
 		config: BlockConfig,
-	) -> &'a mut Self {
+	) -> &mut Self {
 		let header = ChainBuilder::make_header(parent_hash, config.slot, number);
 		assert!(
 			self.blocks_by_hash.insert(hash, (header, config)).is_none(),
@@ -1108,7 +1108,7 @@ fn blank_subsystem_act_on_bad_block() {
 			FromOrchestra::Communication {
 				msg: ApprovalVotingMessage::CheckAndImportAssignment(
 					IndirectAssignmentCert {
-						block_hash: bad_block_hash.clone(),
+						block_hash: bad_block_hash,
 						validator: 0u32.into(),
 						cert: garbage_assignment_cert(AssignmentCertKind::RelayVRFModulo {
 							sample: 0,
@@ -2605,11 +2605,7 @@ where
 				candidate_hash,
 				1,
 				expect_chain_approved,
-				Some(sign_approval(
-					validators[validator_index as usize].clone(),
-					candidate_hash,
-					1,
-				)),
+				Some(sign_approval(validators[validator_index as usize], candidate_hash, 1)),
 			)
 			.await;
 			assert_eq!(rx.await, Ok(ApprovalCheckResult::Accepted));

--- a/node/core/dispute-coordinator/src/import.rs
+++ b/node/core/dispute-coordinator/src/import.rs
@@ -97,7 +97,7 @@ pub enum OwnVoteState {
 }
 
 impl OwnVoteState {
-	fn new<'a>(votes: &CandidateVotes, env: &CandidateEnvironment<'a>) -> Self {
+	fn new(votes: &CandidateVotes, env: &CandidateEnvironment<'_>) -> Self {
 		let controlled_indices = env.controlled_indices();
 		if controlled_indices.is_empty() {
 			return Self::CannotVote


### PR DESCRIPTION
* Simplify &(ref foo, _) tuple pattern matches
* Drop unneccessary .clone() calls
* Replace .position(cond).is_some() by .any(cond)
* Drop unneccessary lifetime specs