### PR TITLE
CLI: Restrict os/arch for secure validators, add flag for insecure mode

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -118,6 +118,10 @@ pub struct RunCmd {
 	#[arg(long)]
 	pub beefy: bool,
 
+	/// Allows the validator to run insecurely if they know what they're doing.
+	#[arg(long = "insecure-validator-i-know-what-i-do", requires = "validator")]
+	pub insecure_validator: bool,
+
 	/// Add the destination address to the jaeger agent.
 	///
 	/// Must be valid socket address, of format `IP:Port`

--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -303,6 +303,12 @@ where
 		return Err(Error::Other("BEEFY disallowed on production networks".to_string()))
 	}
 
+	if cli.run.base.validator && !cli.run.insecure_validator {
+		if let Err(e) = can_run_as_secure_validator() {
+			return Err(Error::InsecureValidator(e))
+		}
+	}
+
 	set_default_ss58_version(chain_spec);
 
 	let grandpa_pause = if cli.run.grandpa_pause.is_empty() {
@@ -731,4 +737,18 @@ pub fn run() -> Result<()> {
 		pyroscope_agent.stop();
 	}
 	Ok(())
+}
+
+/// Returns an error if a secure validator cannot be built for the target OS and architecture.
+fn can_run_as_secure_validator() -> std::result::Result<(), String> {
+	#[cfg(not(target_os = "linux"))]
+	let result = Err("Must be on Linux to run a validator securely.".into());
+
+	#[cfg(all(target_os = "linux", not(target_arch = "x86_64")))]
+	let result = Err("Must be on x86_64 to run a validator securely.".into());
+
+	#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+	let result = Ok(());
+
+	result
 }

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -57,4 +57,7 @@ pub enum Error {
 
 	#[error("This subcommand is only available when compiled with `{feature}`")]
 	FeatureNotEnabled { feature: &'static str },
+
+	#[error("Insecure validator: {0} Run with --insecure-validator-i-know-what-i-do if you understand and accept the risks of running insecurely.")]
+	InsecureValidator(String),
 }


### PR DESCRIPTION
# PULL REQUEST

## Overview

Due to #4718 becoming high-priority for parathreads, we are now forced to provide a secure validator mode only for Linux x86-64 (to start).

We will still support other platforms with an `--insecure-validator-i-know-what-i-do` flag. (Naming follows [`interpreted-i-know-what-i-do`](https://github.com/paritytech/substrate/blob//client/cli/src/arg_enums.rs#L58).)

We may want to wait for https://github.com/paritytech/polkadot/issues/4718 before merging, but it seems at this point pretty certain that platform-specific code is a requirement for securely running the PVF workers. 

## TODO

- [ ] Add flag to zombienet (so existing commands don't break) (@pepoviola can we minimize breakage?)
- [ ] Anywhere else?
- [ ] Documentation (where? [validators' guide](https://wiki.polkadot.network/docs/maintain-guides-how-to-validate-polkadot#requirements)?)

## Related Issues

See https://github.com/paritytech/polkadot/issues/4718#issuecomment-1484137059

Closes https://github.com/paritytech/polkadot/issues/4720
