### PR TITLE
Reduce base proof size weight component to zero

### DIFF
--- a/runtime/kusama/src/xcm_config.rs
+++ b/runtime/kusama/src/xcm_config.rs
@@ -425,5 +425,5 @@ fn karura_liquid_staking_xcm_has_sane_weight_upper_limt() {
 	let weight = <XcmConfig as xcm_executor::Config>::Weigher::weight(&mut xcm)
 		.expect("weighing XCM failed");
 
-	assert_eq!(weight, Weight::from_parts(20_313_281_000, 65536));
+	assert_eq!(weight, Weight::from_parts(20_313_281_000, 0));
 }

--- a/runtime/polkadot/src/xcm_config.rs
+++ b/runtime/polkadot/src/xcm_config.rs
@@ -103,8 +103,8 @@ type LocalOriginConverter = (
 parameter_types! {
 	/// The amount of weight an XCM operation takes. This is a safe overestimate.
 	pub const BaseXcmWeight: Weight = Weight::from_parts(1_000_000_000, 1024);
-	/// A temporary weight value for each XCM instruction. Should be removed after we account for
-	/// PoV weights.
+	/// A temporary weight value for each XCM instruction.
+	/// NOTE: This should be removed after we account for PoV weights.
 	pub const TempFixedXcmWeight: Weight = Weight::from_parts(1_000_000_000, 0);
 	/// Maximum number of instructions in a single XCM fragment. A sanity check against weight
 	/// calculations getting too crazy.

--- a/runtime/polkadot/src/xcm_config.rs
+++ b/runtime/polkadot/src/xcm_config.rs
@@ -102,7 +102,7 @@ type LocalOriginConverter = (
 
 parameter_types! {
 	/// The amount of weight an XCM operation takes. This is a safe overestimate.
-	pub const BaseXcmWeight: Weight = Weight::from_parts(1_000_000_000, 64 * 1024);
+	pub const BaseXcmWeight: Weight = Weight::from_parts(1_000_000_000, 1024);
 	/// Maximum number of instructions in a single XCM fragment. A sanity check against weight
 	/// calculations getting too crazy.
 	pub const MaxInstructions: u32 = 100;

--- a/runtime/polkadot/src/xcm_config.rs
+++ b/runtime/polkadot/src/xcm_config.rs
@@ -103,6 +103,9 @@ type LocalOriginConverter = (
 parameter_types! {
 	/// The amount of weight an XCM operation takes. This is a safe overestimate.
 	pub const BaseXcmWeight: Weight = Weight::from_parts(1_000_000_000, 1024);
+	/// A temporary weight value for each XCM instruction. Should be removed after we account for
+	/// PoV weights.
+	pub const TempFixedXcmWeight: Weight = Weight::from_parts(1_000_000_000, 0);
 	/// Maximum number of instructions in a single XCM fragment. A sanity check against weight
 	/// calculations getting too crazy.
 	pub const MaxInstructions: u32 = 100;
@@ -340,7 +343,7 @@ impl xcm_executor::Config for XcmConfig {
 	type IsTeleporter = TrustedTeleporters;
 	type UniversalLocation = UniversalLocation;
 	type Barrier = Barrier;
-	type Weigher = FixedWeightBounds<BaseXcmWeight, RuntimeCall, MaxInstructions>;
+	type Weigher = FixedWeightBounds<TempFixedXcmWeight, RuntimeCall, MaxInstructions>;
 	// The weight trader piggybacks on the existing transaction-fee conversion logic.
 	type Trader =
 		UsingComponents<WeightToFee, TokenLocation, AccountId, Balances, ToAuthor<Runtime>>;

--- a/xcm/src/v3/mod.rs
+++ b/xcm/src/v3/mod.rs
@@ -1191,8 +1191,9 @@ impl<Call> TryFrom<OldXcm<Call>> for Xcm<Call> {
 	}
 }
 
-/// Default value for the proof size weight component. Set at 64 KB.
-const DEFAULT_PROOF_SIZE: u64 = 64 * 1024;
+/// Default value for the proof size weight component. Set at 0 KB.
+/// NOTE: Make sure this is set back to 64 KB after we properly account for PoV weights.
+const DEFAULT_PROOF_SIZE: u64 = 0;
 
 // Convert from a v2 instruction to a v3 instruction.
 impl<Call> TryFrom<OldInstruction<Call>> for Instruction<Call> {

--- a/xcm/src/v3/mod.rs
+++ b/xcm/src/v3/mod.rs
@@ -1192,7 +1192,7 @@ impl<Call> TryFrom<OldXcm<Call>> for Xcm<Call> {
 }
 
 /// Default value for the proof size weight component. Set at 0 KB.
-/// NOTE: Make sure this is set back to 64 KB after we properly account for PoV weights.
+/// NOTE: Make sure this is removed after we properly account for PoV weights.
 const DEFAULT_PROOF_SIZE: u64 = 0;
 
 // Convert from a v2 instruction to a v3 instruction.


### PR DESCRIPTION
It was found out that Polkadot still uses `FixedWeightBounds` for weighing XCM instructions, and as such is using a `BaseXcmWeight` that has a proof size component that's too large for average use cases such as asset transfers. This PR reduces it to 1KiB instead of the previous 64KiB.

While it's true that the relay chain doesn't require any PoV, the `Weigher` is being used in more places than just weighing incoming XCM instructions, so it does not seem wise to reduce it to 0.