### PR TITLE
Update XCM template and weights

### DIFF
--- a/runtime/kusama/src/weights/xcm/pallet_xcm_benchmarks_fungible.rs
+++ b/runtime/kusama/src/weights/xcm/pallet_xcm_benchmarks_fungible.rs
@@ -51,6 +51,7 @@ impl<T: frame_system::Config> WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
+	// FAIL-CI update me
 	// Storage: System Account (r:2 w:2)
 	pub(crate) fn transfer_asset() -> Weight {
 		Weight::from_parts(32_756_000 as u64, 0)

--- a/runtime/kusama/src/weights/xcm/pallet_xcm_benchmarks_generic.rs
+++ b/runtime/kusama/src/weights/xcm/pallet_xcm_benchmarks_generic.rs
@@ -19,7 +19,7 @@
 //! THIS FILE WAS AUTO-GENERATED USING THE SUBSTRATE BENCHMARK CLI VERSION 4.0.0-dev
 //! DATE: 2022-04-18, STEPS: `50`, REPEAT: 20, LOW RANGE: `[]`, HIGH RANGE: `[]`
 //! EXECUTION: Some(Wasm), WASM-EXECUTION: Compiled, CHAIN: Some("kusama-dev"), DB CACHE: 1024
-
+// FAIL-CI update me
 // Executed Command:
 // target/production/polkadot
 // benchmark

--- a/runtime/rococo/src/weights/xcm/pallet_xcm_benchmarks_fungible.rs
+++ b/runtime/rococo/src/weights/xcm/pallet_xcm_benchmarks_fungible.rs
@@ -19,7 +19,7 @@
 //! THIS FILE WAS AUTO-GENERATED USING THE SUBSTRATE BENCHMARK CLI VERSION 4.0.0-dev
 //! DATE: 2022-03-08, STEPS: `50`, REPEAT: 20, LOW RANGE: `[]`, HIGH RANGE: `[]`
 //! EXECUTION: Some(Wasm), WASM-EXECUTION: Compiled, CHAIN: Some("rococo-dev"), DB CACHE: 1024
-
+// FAIL-CI update me
 // Executed Command:
 // target/production/polkadot
 // benchmark

--- a/runtime/rococo/src/weights/xcm/pallet_xcm_benchmarks_generic.rs
+++ b/runtime/rococo/src/weights/xcm/pallet_xcm_benchmarks_generic.rs
@@ -19,7 +19,7 @@
 //! THIS FILE WAS AUTO-GENERATED USING THE SUBSTRATE BENCHMARK CLI VERSION 4.0.0-dev
 //! DATE: 2022-03-08, STEPS: `50`, REPEAT: 20, LOW RANGE: `[]`, HIGH RANGE: `[]`
 //! EXECUTION: Some(Wasm), WASM-EXECUTION: Compiled, CHAIN: Some("rococo-dev"), DB CACHE: 1024
-
+// FAIL-CI update me
 // Executed Command:
 // target/production/polkadot
 // benchmark

--- a/runtime/westend/src/weights/xcm/pallet_xcm_benchmarks_fungible.rs
+++ b/runtime/westend/src/weights/xcm/pallet_xcm_benchmarks_fungible.rs
@@ -19,7 +19,7 @@
 //! THIS FILE WAS AUTO-GENERATED USING THE SUBSTRATE BENCHMARK CLI VERSION 4.0.0-dev
 //! DATE: 2022-03-08, STEPS: `50`, REPEAT: 20, LOW RANGE: `[]`, HIGH RANGE: `[]`
 //! EXECUTION: Some(Wasm), WASM-EXECUTION: Compiled, CHAIN: Some("westend-dev"), DB CACHE: 1024
-
+// FAIL-CI update me
 // Executed Command:
 // target/production/polkadot
 // benchmark

--- a/runtime/westend/src/weights/xcm/pallet_xcm_benchmarks_generic.rs
+++ b/runtime/westend/src/weights/xcm/pallet_xcm_benchmarks_generic.rs
@@ -19,7 +19,7 @@
 //! THIS FILE WAS AUTO-GENERATED USING THE SUBSTRATE BENCHMARK CLI VERSION 4.0.0-dev
 //! DATE: 2022-12-12, STEPS: `50`, REPEAT: 20, LOW RANGE: `[]`, HIGH RANGE: `[]`
 //! EXECUTION: Some(Wasm), WASM-EXECUTION: Compiled, CHAIN: Some("westend-dev"), DB CACHE: 1024
-
+// FAIL-CI update me
 // Executed Command:
 // /home/benchbot/cargo_target_dir/production/polkadot
 // benchmark

--- a/xcm/pallet-xcm-benchmarks/template.hbs
+++ b/xcm/pallet-xcm-benchmarks/template.hbs
@@ -39,27 +39,37 @@ impl<T: frame_system::Config> WeightInfo<T> {
 	{{#each benchmark.comments as |comment|}}
 	// {{comment}}
 	{{/each}}
-	pub(crate) fn {{benchmark.name~}}
+	{{#each benchmark.component_ranges as |range|}}
+	/// The range of component `{{range.name}}` is `[{{range.min}}, {{range.max}}]`.
+	{{/each}}
+	pub fn {{benchmark.name~}}
 	(
 		{{~#each benchmark.components as |c| ~}}
 		{{~#if (not c.is_used)}}_{{/if}}{{c.name}}: u32, {{/each~}}
 	) -> Weight {
-		Weight::from_ref_time({{underscore benchmark.base_weight}} as u64)
+		// Proof Size summary in bytes:
+		//  Measured:  `{{benchmark.base_recorded_proof_size}}{{#each benchmark.component_recorded_proof_size as |cp|}} + {{cp.name}} * ({{cp.slope}} ±{{underscore cp.error}}){{/each}}`
+		//  Estimated: `{{benchmark.base_calculated_proof_size}}{{#each benchmark.component_calculated_proof_size as |cp|}} + {{cp.name}} * ({{cp.slope}} ±{{underscore cp.error}}){{/each}}`
+		// Minimum execution time: {{underscore benchmark.min_execution_time}}_000 picoseconds.
+		Weight::from_parts({{underscore benchmark.base_weight}}, {{benchmark.base_calculated_proof_size}})
 			{{#each benchmark.component_weight as |cw|}}
 			// Standard Error: {{underscore cw.error}}
-			.saturating_add(Weight::from_ref_time({{underscore cw.slope}} as u64).saturating_mul({{cw.name}} as u64))
+			.saturating_add(Weight::from_parts({{underscore cw.slope}}, 0).saturating_mul({{cw.name}}.into()))
 			{{/each}}
 			{{#if (ne benchmark.base_reads "0")}}
-			.saturating_add(T::DbWeight::get().reads({{benchmark.base_reads}} as u64))
+			.saturating_add(T::DbWeight::get().reads({{benchmark.base_reads}}))
 			{{/if}}
 			{{#each benchmark.component_reads as |cr|}}
-			.saturating_add(T::DbWeight::get().reads(({{cr.slope}} as u64).saturating_mul({{cr.name}} as u64)))
+			.saturating_add(T::DbWeight::get().reads(({{cr.slope}}_u64).saturating_mul({{cr.name}}.into())))
 			{{/each}}
 			{{#if (ne benchmark.base_writes "0")}}
-			.saturating_add(T::DbWeight::get().writes({{benchmark.base_writes}} as u64))
+			.saturating_add(T::DbWeight::get().writes({{benchmark.base_writes}}))
 			{{/if}}
 			{{#each benchmark.component_writes as |cw|}}
-			.saturating_add(T::DbWeight::get().writes(({{cw.slope}} as u64).saturating_mul({{cw.name}} as u64)))
+			.saturating_add(T::DbWeight::get().writes(({{cw.slope}}_u64).saturating_mul({{cw.name}}.into())))
+			{{/each}}
+			{{#each benchmark.component_calculated_proof_size as |cp|}}
+			.saturating_add(Weight::from_parts(0, {{cp.slope}}).saturating_mul({{cp.name}}.into()))
 			{{/each}}
 	}
 	{{/each}}


### PR DESCRIPTION
Regarding https://github.com/paritytech/polkadot/pull/7081

The CI script does not actually update the XCM weights in the release process [here](https://github.com/paritytech/polkadot/blob/master/scripts/ci/run_benches_for_runtime.sh#L48). Therefore now manually updating them.  
Also the XCM weight template is still on V1…

Changes:
- Update XCM weight template to output PoV
- Re-benchmark for Kusama, Westend and Rococo.