### PR TITLE
[XCM - UnpaidRemoteExporter] Remove unreachable code

### DIFF
--- a/xcm/xcm-builder/src/universal_exports.rs
+++ b/xcm/xcm-builder/src/universal_exports.rs
@@ -161,9 +161,6 @@ impl<Bridges: ExporterFor, Router: SendXcm, UniversalLocation: Get<InteriorMulti
 		let message =
 			Xcm(vec![ExportMessage { network: remote_network, destination: remote_location, xcm }]);
 		let (v, mut cost) = validate_send::<Router>(bridge, message)?;
-		if let Some(payment) = maybe_payment {
-			cost.push(payment);
-		}
 		Ok((v, cost))
 	}
 

--- a/xcm/xcm-builder/src/universal_exports.rs
+++ b/xcm/xcm-builder/src/universal_exports.rs
@@ -160,7 +160,7 @@ impl<Bridges: ExporterFor, Router: SendXcm, UniversalLocation: Get<InteriorMulti
 		// export for free. Common-good chains will typically be afforded this.
 		let message =
 			Xcm(vec![ExportMessage { network: remote_network, destination: remote_location, xcm }]);
-		let (v, mut cost) = validate_send::<Router>(bridge, message)?;
+		let (v, cost) = validate_send::<Router>(bridge, message)?;
 		Ok((v, cost))
 	}
 


### PR DESCRIPTION
There is an `ensure!(maybe_payment.is_none(), Unroutable);` above, so this code shouldn't be reachable.