### PR TITLE
Bump `MAX_CODE_SIZE` to 10MiB

### DIFF
--- a/primitives/src/v4/mod.rs
+++ b/primitives/src/v4/mod.rs
@@ -345,7 +345,7 @@ pub const ASSIGNMENT_KEY_TYPE_ID: KeyTypeId = KeyTypeId(*b"asgn");
 /// * checking updates to this stored runtime configuration do not exceed this limit
 /// * when detecting a code decompression bomb in the client
 // NOTE: This value is used in the runtime so be careful when changing it.
-pub const MAX_CODE_SIZE: u32 = 3 * 1024 * 1024;
+pub const MAX_CODE_SIZE: u32 = 10 * 1024 * 1024;
 
 /// Maximum head data size we support right now.
 ///


### PR DESCRIPTION
The current Polkadot HostConfiguration does not pass its [`consistency_check`](https://github.com/paritytech/polkadot/blob/df61c0bf0834f650e79ddd1a74dea34081ff2b46/runtime/parachains/src/configuration.rs#L375) since it is using 10MiB max code size and the hard-limit is set to 3MiB. I dont know how that happened, but I am now bumping `MAX_CODE_SIZE` to make the consistency check pass again.  
Note: without this bump the `consistency_check` will stay broken, since it has the [assumption](https://github.com/paritytech/polkadot/blob/df61c0bf0834f650e79ddd1a74dea34081ff2b46/runtime/parachains/src/configuration.rs#L1350): "You cannot break something that is already broken" and thereby future HostConfig upgrades would not get checked.

`MIN_BANDWIDTH_BYTES` will probably also need a bump.