### PR TITLE
Revert default proof size back to 64 KB

### DIFF
--- a/runtime/kusama/src/xcm_config.rs
+++ b/runtime/kusama/src/xcm_config.rs
@@ -458,6 +458,7 @@ fn karura_liquid_staking_xcm_has_sane_weight_upper_limt() {
 	assert!(
 		call_weight.all_lte(*require_weight_at_most),
 		"call weight ({:?}) was not less than require_weight_at_most ({:?})",
-		call_weight, require_weight_at_most
+		call_weight,
+		require_weight_at_most
 	);
 }

--- a/runtime/kusama/src/xcm_config.rs
+++ b/runtime/kusama/src/xcm_config.rs
@@ -430,9 +430,12 @@ impl pallet_xcm::Config for Runtime {
 
 #[test]
 fn karura_liquid_staking_xcm_has_sane_weight_upper_limt() {
+	use frame_support::dispatch::GetDispatchInfo;
 	use parity_scale_codec::Decode;
 	use xcm::VersionedXcm;
 	use xcm_executor::traits::WeightBounds;
+
+	// should be [WithdrawAsset, BuyExecution, Transact, RefundSurplus, DepositAsset]
 	let blob = hex_literal::hex!("02140004000000000700e40b540213000000000700e40b54020006010700c817a804341801000006010b00c490bf4302140d010003ffffffff000100411f");
 	let Ok(VersionedXcm::V2(old_xcm)) =
 		VersionedXcm::<super::RuntimeCall>::decode(&mut &blob[..]) else { panic!("can't decode XCM blob") };
@@ -441,5 +444,20 @@ fn karura_liquid_staking_xcm_has_sane_weight_upper_limt() {
 	let weight = <XcmConfig as xcm_executor::Config>::Weigher::weight(&mut xcm)
 		.expect("weighing XCM failed");
 
+	// Test that the weigher gives us a sensible weight
 	assert_eq!(weight, Weight::from_parts(20_313_281_000, 65536));
+
+	let Some(Transact { require_weight_at_most, call, .. }) =
+		xcm.inner_mut().into_iter().find(|inst| matches!(inst, Transact { .. })) else {
+			panic!("no Transact instruction found")
+		};
+	// should be pallet_utility.as_derivative { index: 0, call: pallet_staking::bond_extra { max_additional: 2490000000000 } }
+	let message_call = call.take_decoded().expect("can't decode Transact call");
+	let call_weight = message_call.get_dispatch_info().weight;
+	// Ensure that the Transact instruction is giving a sensible `require_weight_at_most` value
+	assert!(
+		call_weight.all_lte(*require_weight_at_most),
+		"call weight ({:?}) was not less than require_weight_at_most ({:?})",
+		call_weight, require_weight_at_most
+	);
 }

--- a/runtime/kusama/src/xcm_config.rs
+++ b/runtime/kusama/src/xcm_config.rs
@@ -457,7 +457,7 @@ fn karura_liquid_staking_xcm_has_sane_weight_upper_limt() {
 	// Ensure that the Transact instruction is giving a sensible `require_weight_at_most` value
 	assert!(
 		call_weight.all_lte(*require_weight_at_most),
-		"call weight ({:?}) was not less than require_weight_at_most ({:?})",
+		"call weight ({:?}) was not less than or equal to require_weight_at_most ({:?})",
 		call_weight,
 		require_weight_at_most
 	);

--- a/runtime/kusama/src/xcm_config.rs
+++ b/runtime/kusama/src/xcm_config.rs
@@ -441,5 +441,5 @@ fn karura_liquid_staking_xcm_has_sane_weight_upper_limt() {
 	let weight = <XcmConfig as xcm_executor::Config>::Weigher::weight(&mut xcm)
 		.expect("weighing XCM failed");
 
-	assert_eq!(weight, Weight::from_parts(20_313_281_000, 0));
+	assert_eq!(weight, Weight::from_parts(20_313_281_000, 65536));
 }

--- a/xcm/src/v3/mod.rs
+++ b/xcm/src/v3/mod.rs
@@ -1191,9 +1191,9 @@ impl<Call> TryFrom<OldXcm<Call>> for Xcm<Call> {
 	}
 }
 
-/// Default value for the proof size weight component. Set at 0 KB.
+/// Default value for the proof size weight component when converting from V2. Set at 64 KB.
 /// NOTE: Make sure this is removed after we properly account for PoV weights.
-const DEFAULT_PROOF_SIZE: u64 = 0;
+const DEFAULT_PROOF_SIZE: u64 = 64 * 1024;
 
 // Convert from a v2 instruction to a v3 instruction.
 impl<Call> TryFrom<OldInstruction<Call>> for Instruction<Call> {


### PR DESCRIPTION
According to https://github.com/paritytech/polkadot/pull/7081#issuecomment-1517986505, we did not actually need to set the `DEFAULT_PROOF_SIZE` to 0 when we are converting from a V2 Transact to V3. 64 KB was good enough.