### PR TITLE
Rename original_origin and origin in XcmExecutor

### DIFF
--- a/xcm/src/v3/mod.rs
+++ b/xcm/src/v3/mod.rs
@@ -340,7 +340,8 @@ impl TryFrom<OldWeightLimit> for WeightLimit {
 #[derive(Clone, Eq, PartialEq, Encode, Decode, Debug)]
 pub struct XcmContext {
 	/// The `MultiLocation` origin of the corresponding XCM.
-	/// The computed origin would usually be sending a message onbehalf of itself.
+	/// The computed origin is the author of the message, as opposed to the physical
+	/// origin, which represents the location of the message deliverer 
 	pub computed_origin: Option<MultiLocation>,
 	/// The hash of the XCM.
 	pub message_hash: XcmHash,

--- a/xcm/src/v3/mod.rs
+++ b/xcm/src/v3/mod.rs
@@ -340,7 +340,9 @@ impl TryFrom<OldWeightLimit> for WeightLimit {
 #[derive(Clone, Eq, PartialEq, Encode, Decode, Debug)]
 pub struct XcmContext {
 	/// The `MultiLocation` origin of the corresponding XCM.
-	pub origin: Option<MultiLocation>,
+	/// The origin is could point to physical locations (Chains, etc),
+	/// but also conceptual locations such as Accounts or Pallet.
+	pub computed_origin: Option<MultiLocation>,
 	/// The hash of the XCM.
 	pub message_hash: XcmHash,
 	/// The topic of the XCM.
@@ -351,7 +353,7 @@ impl XcmContext {
 	/// Constructor which sets the message hash to the supplied parameter and leaves the origin and
 	/// topic unset.
 	pub fn with_message_hash(message_hash: XcmHash) -> XcmContext {
-		XcmContext { origin: None, message_hash, topic: None }
+		XcmContext { computed_origin: None, message_hash, topic: None }
 	}
 }
 

--- a/xcm/src/v3/mod.rs
+++ b/xcm/src/v3/mod.rs
@@ -340,8 +340,7 @@ impl TryFrom<OldWeightLimit> for WeightLimit {
 #[derive(Clone, Eq, PartialEq, Encode, Decode, Debug)]
 pub struct XcmContext {
 	/// The `MultiLocation` origin of the corresponding XCM.
-	/// The origin is could point to physical locations (Chains, etc),
-	/// but also conceptual locations such as Accounts or Pallet.
+	/// The computed origin would usually be sending a message onbehalf of itself.
 	pub computed_origin: Option<MultiLocation>,
 	/// The hash of the XCM.
 	pub message_hash: XcmHash,

--- a/xcm/src/v3/traits.rs
+++ b/xcm/src/v3/traits.rs
@@ -257,38 +257,38 @@ pub trait ExecuteXcm<Call> {
 	type Prepared: PreparedMessage;
 	fn prepare(message: Xcm<Call>) -> result::Result<Self::Prepared, Xcm<Call>>;
 	fn execute(
-		origin: impl Into<MultiLocation>,
+		physical_origin: impl Into<MultiLocation>,
 		pre: Self::Prepared,
 		hash: XcmHash,
 		weight_credit: Weight,
 	) -> Outcome;
 
-	/// Execute some XCM `message` with the message `hash` from `origin` using no more than `weight_limit` weight.
+	/// Execute some XCM `message` with the message `hash` from `physical_origin` using no more than `weight_limit` weight.
 	/// The weight limit is a basic hard-limit and the implementation may place further restrictions or requirements
 	/// on weight and other aspects.
 	fn execute_xcm(
-		origin: impl Into<MultiLocation>,
+		physical_origin: impl Into<MultiLocation>,
 		message: Xcm<Call>,
 		hash: XcmHash,
 		weight_limit: Weight,
 	) -> Outcome {
-		let origin = origin.into();
+		let physical_origin = physical_origin.into();
 		log::debug!(
 			target: "xcm::execute_xcm",
-			"origin: {:?}, message: {:?}, weight_limit: {:?}",
-			origin,
+			"physical_origin: {:?}, message: {:?}, weight_limit: {:?}",
+			physical_origin,
 			message,
 			weight_limit,
 		);
-		Self::execute_xcm_in_credit(origin, message, hash, weight_limit, Weight::zero())
+		Self::execute_xcm_in_credit(physical_origin, message, hash, weight_limit, Weight::zero())
 	}
 
-	/// Execute some XCM `message` with the message `hash` from `origin` using no more than `weight_limit` weight.
+	/// Execute some XCM `message` with the message `hash` from `physical_origin` using no more than `weight_limit` weight.
 	///
 	/// Some amount of `weight_credit` may be provided which, depending on the implementation, may allow
 	/// execution without associated payment.
 	fn execute_xcm_in_credit(
-		origin: impl Into<MultiLocation>,
+		physical_origin: impl Into<MultiLocation>,
 		message: Xcm<Call>,
 		hash: XcmHash,
 		weight_limit: Weight,
@@ -302,7 +302,7 @@ pub trait ExecuteXcm<Call> {
 		if xcm_weight.any_gt(weight_limit) {
 			return Outcome::Error(Error::WeightLimitReached(xcm_weight))
 		}
-		Self::execute(origin, pre, hash, weight_credit)
+		Self::execute(physical_origin, pre, hash, weight_credit)
 	}
 
 	/// Deduct some `fees` to the sovereign account of the given `location` and place them as per

--- a/xcm/xcm-executor/src/lib.rs
+++ b/xcm/xcm-executor/src/lib.rs
@@ -95,16 +95,16 @@ impl<Config: config::Config> XcmExecutor<Config> {
 		self.holding_limit = v
 	}
 	pub fn origin(&self) -> &Option<MultiLocation> {
-		&self.context.origin
+		&self.context.computed_origin
 	}
 	pub fn set_origin(&mut self, v: Option<MultiLocation>) {
-		self.context.origin = v
+		self.context.computed_origin = v
 	}
 	pub fn original_origin(&self) -> &MultiLocation {
-		&self.original_origin
+		&self.physical_origin
 	}
 	pub fn set_original_origin(&mut self, v: MultiLocation) {
-		self.original_origin = v
+		self.physical_origin = v
 	}
 	pub fn trader(&self) -> &Config::Trader {
 		&self.trader

--- a/xcm/xcm-executor/src/lib.rs
+++ b/xcm/xcm-executor/src/lib.rs
@@ -192,21 +192,21 @@ impl<Config: config::Config> ExecuteXcm<Config::RuntimeCall> for XcmExecutor<Con
 		}
 	}
 	fn execute(
-		computed_origin: impl Into<MultiLocation>,
+		origin: impl Into<MultiLocation>,
 		WeighedMessage(xcm_weight, mut message): WeighedMessage<Config::RuntimeCall>,
 		message_hash: XcmHash,
 		mut weight_credit: Weight,
 	) -> Outcome {
-		let computed_origin = computed_origin.into();
+		let origin = origin.into();
 		log::trace!(
 			target: "xcm::execute_xcm_in_credit",
 			"origin: {:?}, message: {:?}, weight_credit: {:?}",
-			computed_origin,
+			origin,
 			message,
 			weight_credit,
 		);
 		if let Err(e) = Config::Barrier::should_execute(
-			&computed_origin,
+			&origin,
 			message.inner_mut(),
 			xcm_weight,
 			&mut weight_credit,
@@ -215,14 +215,14 @@ impl<Config: config::Config> ExecuteXcm<Config::RuntimeCall> for XcmExecutor<Con
 				target: "xcm::execute_xcm_in_credit",
 				"Barrier blocked execution! Error: {:?}. (origin: {:?}, message: {:?}, weight_credit: {:?})",
 				e,
-				computed_origin,
+				origin,
 				message,
 				weight_credit,
 			);
 			return Outcome::Error(XcmError::Barrier)
 		}
 
-		let mut vm = Self::new(computed_origin, message_hash);
+		let mut vm = Self::new(origin, message_hash);
 
 		while !message.0.is_empty() {
 			let result = vm.process(message);

--- a/xcm/xcm-executor/src/lib.rs
+++ b/xcm/xcm-executor/src/lib.rs
@@ -192,21 +192,21 @@ impl<Config: config::Config> ExecuteXcm<Config::RuntimeCall> for XcmExecutor<Con
 		}
 	}
 	fn execute(
-		origin: impl Into<MultiLocation>,
+		physical_origin: impl Into<MultiLocation>,
 		WeighedMessage(xcm_weight, mut message): WeighedMessage<Config::RuntimeCall>,
 		message_hash: XcmHash,
 		mut weight_credit: Weight,
 	) -> Outcome {
-		let origin = origin.into();
+		let physical_origin = physical_origin.into();
 		log::trace!(
 			target: "xcm::execute_xcm_in_credit",
 			"origin: {:?}, message: {:?}, weight_credit: {:?}",
-			origin,
+			physical_origin,
 			message,
 			weight_credit,
 		);
 		if let Err(e) = Config::Barrier::should_execute(
-			&origin,
+			&physical_origin,
 			message.inner_mut(),
 			xcm_weight,
 			&mut weight_credit,
@@ -215,14 +215,14 @@ impl<Config: config::Config> ExecuteXcm<Config::RuntimeCall> for XcmExecutor<Con
 				target: "xcm::execute_xcm_in_credit",
 				"Barrier blocked execution! Error: {:?}. (origin: {:?}, message: {:?}, weight_credit: {:?})",
 				e,
-				origin,
+				physical_origin,
 				message,
 				weight_credit,
 			);
 			return Outcome::Error(XcmError::Barrier)
 		}
 
-		let mut vm = Self::new(origin, message_hash);
+		let mut vm = Self::new(physical_origin, message_hash);
 
 		while !message.0.is_empty() {
 			let result = vm.process(message);

--- a/xcm/xcm-executor/src/lib.rs
+++ b/xcm/xcm-executor/src/lib.rs
@@ -273,17 +273,17 @@ impl From<ExecutorError> for frame_benchmarking::BenchmarkError {
 }
 
 impl<Config: config::Config> XcmExecutor<Config> {
-	pub fn new(computed_origin: impl Into<MultiLocation>, message_hash: XcmHash) -> Self {
-		let computed_origin = computed_origin.into();
+	pub fn new(physical_origin: impl Into<MultiLocation>, message_hash: XcmHash) -> Self {
+		let physical_origin = physical_origin.into();
 		Self {
 			holding: Assets::new(),
 			holding_limit: Config::MaxAssetsIntoHolding::get() as usize,
 			context: XcmContext {
-				computed_origin: Some(computed_origin),
+				computed_origin: Some(physical_origin),
 				message_hash,
 				topic: None,
 			},
-			physical_origin: computed_origin,
+			physical_origin,
 			trader: Config::Trader::new(),
 			error: None,
 			total_surplus: Weight::zero(),

--- a/xcm/xcm-executor/src/lib.rs
+++ b/xcm/xcm-executor/src/lib.rs
@@ -273,17 +273,13 @@ impl From<ExecutorError> for frame_benchmarking::BenchmarkError {
 }
 
 impl<Config: config::Config> XcmExecutor<Config> {
-	pub fn new(physical_origin: impl Into<MultiLocation>, message_hash: XcmHash) -> Self {
-		let physical_origin = physical_origin.into();
+	pub fn new(origin: impl Into<MultiLocation>, message_hash: XcmHash) -> Self {
+		let origin = origin.into();
 		Self {
 			holding: Assets::new(),
 			holding_limit: Config::MaxAssetsIntoHolding::get() as usize,
-			context: XcmContext {
-				computed_origin: Some(physical_origin),
-				message_hash,
-				topic: None,
-			},
-			physical_origin,
+			context: XcmContext { computed_origin: Some(origin), message_hash, topic: None },
+			physical_origin: origin,
 			trader: Config::Trader::new(),
 			error: None,
 			total_surplus: Weight::zero(),


### PR DESCRIPTION
These are semantic changes for the variables to have clearer meanings.
`original_origin` was renamed to `physical_origin` since it should point to the actual chain.
`origin` was renamed to `computed_origin` in some cases since those origins could be more conceptual and might point to Accounts, or Pallets or other entities. And not necessary the chain executing the XCM instructions.