### PR TITLE
Implement PVF pre-checking using pending ExecutorParams

### DIFF
--- a/node/core/runtime-api/src/cache.rs
+++ b/node/core/runtime-api/src/cache.rs
@@ -63,6 +63,7 @@ pub(crate) struct RequestResultCache {
 		LruCache<(Hash, ParaId, OccupiedCoreAssumption), Option<ValidationCodeHash>>,
 	version: LruCache<Hash, u32>,
 	disputes: LruCache<Hash, Vec<(SessionIndex, CandidateHash, DisputeState<BlockNumber>)>>,
+	pending_executor_params: LruCache<Hash, ExecutorParams>,
 }
 
 impl Default for RequestResultCache {
@@ -90,6 +91,7 @@ impl Default for RequestResultCache {
 			validation_code_hash: LruCache::new(DEFAULT_CACHE_CAP),
 			version: LruCache::new(DEFAULT_CACHE_CAP),
 			disputes: LruCache::new(DEFAULT_CACHE_CAP),
+			pending_executor_params: LruCache::new(DEFAULT_CACHE_CAP),
 		}
 	}
 }
@@ -385,6 +387,21 @@ impl RequestResultCache {
 	) {
 		self.disputes.put(relay_parent, value);
 	}
+
+	pub(crate) fn pending_executor_params(
+		&mut self,
+		relay_parent: &Hash,
+	) -> Option<&ExecutorParams> {
+		self.pending_executor_params.get(relay_parent)
+	}
+
+	pub(crate) fn cache_pending_executor_params(
+		&mut self,
+		relay_parent: Hash,
+		value: ExecutorParams,
+	) {
+		self.pending_executor_params.put(relay_parent, value);
+	}
 }
 
 pub(crate) enum RequestResult {
@@ -422,4 +439,5 @@ pub(crate) enum RequestResult {
 	ValidationCodeHash(Hash, ParaId, OccupiedCoreAssumption, Option<ValidationCodeHash>),
 	Version(Hash, u32),
 	Disputes(Hash, Vec<(SessionIndex, CandidateHash, DisputeState<BlockNumber>)>),
+	PendingExecutorParams(Hash, ExecutorParams),
 }

--- a/node/core/runtime-api/src/lib.rs
+++ b/node/core/runtime-api/src/lib.rs
@@ -157,6 +157,9 @@ where
 				self.requests_cache.cache_version(relay_parent, version),
 			Disputes(relay_parent, disputes) =>
 				self.requests_cache.cache_disputes(relay_parent, disputes),
+			PendingExecutorParams(relay_parent, pending_executor_params) => self
+				.requests_cache
+				.cache_pending_executor_params(relay_parent, pending_executor_params),
 		}
 	}
 
@@ -271,6 +274,8 @@ where
 					.map(|sender| Request::ValidationCodeHash(para, assumption, sender)),
 			Request::Disputes(sender) =>
 				query!(disputes(), sender).map(|sender| Request::Disputes(sender)),
+			Request::PendingExecutorParams(sender) => query!(pending_executor_params(), sender)
+				.map(|sender| Request::PendingExecutorParams(sender)),
 		}
 	}
 
@@ -490,5 +495,11 @@ where
 			query!(ValidationCodeHash, validation_code_hash(para, assumption), ver = 2, sender),
 		Request::Disputes(sender) =>
 			query!(Disputes, disputes(), ver = Request::DISPUTES_RUNTIME_REQUIREMENT, sender),
+		Request::PendingExecutorParams(sender) => query!(
+			PendingExecutorParams,
+			pending_executor_params(),
+			ver = Request::PENDING_EXECUTOR_PARAMS_RUNTIME_REQUIREMENT,
+			sender
+		),
 	}
 }

--- a/node/subsystem-types/src/messages.rs
+++ b/node/subsystem-types/src/messages.rs
@@ -603,6 +603,9 @@ pub enum RuntimeApiRequest {
 	),
 	/// Returns all on-chain disputes at given block number. Available in `v3`.
 	Disputes(RuntimeApiSender<Vec<(SessionIndex, CandidateHash, DisputeState<BlockNumber>)>>),
+	/// Returns the latest pending executor parameter set, or the current set if no configuration
+	/// changes are pending
+	PendingExecutorParams(RuntimeApiSender<ExecutorParams>),
 }
 
 impl RuntimeApiRequest {
@@ -613,6 +616,9 @@ impl RuntimeApiRequest {
 
 	/// `ExecutorParams`
 	pub const EXECUTOR_PARAMS_RUNTIME_REQUIREMENT: u32 = 4;
+
+	/// Pending `ExecutorParams`
+	pub const PENDING_EXECUTOR_PARAMS_RUNTIME_REQUIREMENT: u32 = 5;
 }
 
 /// A message to the Runtime API subsystem.

--- a/node/subsystem-types/src/runtime_client.rs
+++ b/node/subsystem-types/src/runtime_client.rs
@@ -201,6 +201,12 @@ pub trait RuntimeApiSubsystemClient {
 		&self,
 		at: Hash,
 	) -> std::result::Result<Vec<sp_authority_discovery::AuthorityId>, ApiError>;
+
+	/***** Staging *****/
+
+	/// Returns the latest pending executor parameter set, or the current set if no configuration
+	/// changes are pending
+	async fn pending_executor_params(&self, at: Hash) -> Result<ExecutorParams, ApiError>;
 }
 
 #[async_trait]
@@ -373,5 +379,9 @@ where
 		at: Hash,
 	) -> Result<Vec<(SessionIndex, CandidateHash, DisputeState<BlockNumber>)>, ApiError> {
 		self.runtime_api().disputes(at)
+	}
+
+	async fn pending_executor_params(&self, at: Hash) -> Result<ExecutorParams, ApiError> {
+		self.runtime_api().pending_executor_params(at)
 	}
 }

--- a/primitives/src/runtime_api.rs
+++ b/primitives/src/runtime_api.rs
@@ -218,5 +218,11 @@ sp_api::decl_runtime_apis! {
 
 		/// Returns execution parameters for the session.
 		fn session_executor_params(session_index: SessionIndex) -> Option<ExecutorParams>;
+
+		/***** STAGING *****/
+		/// Returns the latest pending executor parameter set, or the current set if no configuration
+		/// changes are pending
+		#[api_version(5)]
+		fn pending_executor_params() -> ExecutorParams;
 	}
 }

--- a/runtime/parachains/src/configuration.rs
+++ b/runtime/parachains/src/configuration.rs
@@ -1374,4 +1374,14 @@ impl<T: Config> Pallet<T> {
 
 		Ok(())
 	}
+
+	/// Returns the latest pending executor parameter set, or the current set if no configuration
+	/// changes are pending
+	pub fn pending_executor_params() -> ExecutorParams {
+		<PendingConfigs<T>>::get()
+			.last()
+			.map(|(_, config)| config.clone())
+			.unwrap_or_else(Self::config)
+			.executor_params
+	}
 }

--- a/runtime/parachains/src/runtime_api_impl/vstaging.rs
+++ b/runtime/parachains/src/runtime_api_impl/vstaging.rs
@@ -15,3 +15,12 @@
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
 //! Put implementations of functions from staging APIs here.
+
+use crate::configuration;
+use primitives::ExecutorParams;
+
+/// Returns the latest pending executor parameter set, or the current set if no configuration
+/// changes are pending
+pub fn pending_executor_params<T: configuration::Config>() -> ExecutorParams {
+	<configuration::Pallet<T>>::pending_executor_params()
+}

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -1645,6 +1645,7 @@ sp_api::impl_runtime_apis! {
 		}
 	}
 
+	#[api_version(5)]
 	impl primitives::runtime_api::ParachainHost<Block, Hash, BlockNumber> for Runtime {
 		fn validators() -> Vec<ValidatorId> {
 			parachains_runtime_api_impl::validators::<Runtime>()
@@ -1749,6 +1750,10 @@ sp_api::impl_runtime_apis! {
 
 		fn disputes() -> Vec<(SessionIndex, CandidateHash, DisputeState<BlockNumber>)> {
 			parachains_runtime_api_impl::get_session_disputes::<Runtime>()
+		}
+
+		fn pending_executor_params() -> ExecutorParams {
+			runtime_parachains::runtime_api_impl::vstaging::pending_executor_params::<Runtime>()
 		}
 	}
 

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -1361,6 +1361,7 @@ sp_api::impl_runtime_apis! {
 		}
 	}
 
+	#[api_version(5)]
 	impl primitives::runtime_api::ParachainHost<Block, Hash, BlockNumber> for Runtime {
 		fn validators() -> Vec<ValidatorId> {
 			parachains_runtime_api_impl::validators::<Runtime>()
@@ -1465,6 +1466,10 @@ sp_api::impl_runtime_apis! {
 
 		fn disputes() -> Vec<(SessionIndex, CandidateHash, DisputeState<BlockNumber>)> {
 			parachains_runtime_api_impl::get_session_disputes::<Runtime>()
+		}
+
+		fn pending_executor_params() -> ExecutorParams {
+			runtime_parachains::runtime_api_impl::vstaging::pending_executor_params::<Runtime>()
 		}
 	}
 


### PR DESCRIPTION
Closes #6876 (at least, I hope so).

Configuration changes are postponed for two sessions, and enacting a pre-checked PVF is also delayed for two sessions. So if we use executor parameters from the pending configuration to pre-check PVFs, we ensure the pending changes would not render a PVF just enacted unusable.