### PR TITLE
ci: update check-runtime-migration fixme issues

### DIFF
--- a/scripts/ci/gitlab/pipeline/check.yml
+++ b/scripts/ci/gitlab/pipeline/check.yml
@@ -87,7 +87,7 @@ check-runtime-migration-polkadot:
     - .check-runtime-migration
   variables:
     NETWORK: "polkadot"
-    allow_failure: true # FIXME https://github.com/paritytech/substrate/issues/13107
+  allow_failure: true # FIXME https://github.com/paritytech/substrate/issues/13107
 
 check-runtime-migration-kusama:
   stage: check
@@ -98,7 +98,7 @@ check-runtime-migration-kusama:
     - .check-runtime-migration
   variables:
     NETWORK: "kusama"
-    allow_failure: true # FIXME https://github.com/paritytech/substrate/issues/13107
+  allow_failure: true # FIXME https://github.com/paritytech/substrate/issues/13107
 
 check-runtime-migration-westend:
   stage: check

--- a/scripts/ci/gitlab/pipeline/check.yml
+++ b/scripts/ci/gitlab/pipeline/check.yml
@@ -87,6 +87,7 @@ check-runtime-migration-polkadot:
     - .check-runtime-migration
   variables:
     NETWORK: "polkadot"
+    allow_failure: true # FIXME https://github.com/paritytech/substrate/issues/13107
 
 check-runtime-migration-kusama:
   stage: check
@@ -97,6 +98,7 @@ check-runtime-migration-kusama:
     - .check-runtime-migration
   variables:
     NETWORK: "kusama"
+    allow_failure: true # FIXME https://github.com/paritytech/substrate/issues/13107
 
 check-runtime-migration-westend:
   stage: check

--- a/scripts/ci/gitlab/pipeline/check.yml
+++ b/scripts/ci/gitlab/pipeline/check.yml
@@ -87,7 +87,6 @@ check-runtime-migration-polkadot:
     - .check-runtime-migration
   variables:
     NETWORK: "polkadot"
-  allow_failure: true # FIXME https://github.com/paritytech/substrate/issues/14006
 
 check-runtime-migration-kusama:
   stage: check
@@ -98,7 +97,6 @@ check-runtime-migration-kusama:
     - .check-runtime-migration
   variables:
     NETWORK: "kusama"
-  allow_failure: true
 
 check-runtime-migration-westend:
   stage: check
@@ -109,7 +107,7 @@ check-runtime-migration-westend:
     - .check-runtime-migration
   variables:
     NETWORK: "westend"
-  allow_failure: true # FIXME https://github.com/paritytech/substrate/issues/14006
+  allow_failure: true # FIXME https://github.com/paritytech/substrate/issues/13107
 
 # is broken, need to fix
 check-no-default-features:


### PR DESCRIPTION
https://github.com/paritytech/substrate/issues/14006 is fixed in https://github.com/paritytech/substrate/pull/14030.

However, we need to keep these optional until https://github.com/paritytech/substrate/issues/13107 is fixed.