### PR TITLE
PVF: Remove `rayon` and some uses of `tokio`

### DIFF
--- a/node/core/pvf/worker/src/common.rs
+++ b/node/core/pvf/worker/src/common.rs
@@ -167,8 +167,8 @@ pub mod thread {
 	/// Contains the outcome of waiting on threads, or `Pending` if none are ready.
 	#[derive(Clone, Copy)]
 	pub enum WaitOutcome {
-		JobFinished,
-		CpuTimedOut,
+		Finished,
+		TimedOut,
 		Pending,
 	}
 

--- a/node/core/pvf/worker/src/common.rs
+++ b/node/core/pvf/worker/src/common.rs
@@ -152,6 +152,9 @@ fn kill_parent_node_in_emergency() {
 }
 
 /// Functionality related to threads spawned by the workers.
+///
+/// The motivation for this module is to coordinate worker threads without using async Rust. This
+/// lets us pull in less dependencies, making the worker binaries smaller and easier to secure.
 pub mod thread {
 	use std::{
 		panic,

--- a/node/core/pvf/worker/src/common.rs
+++ b/node/core/pvf/worker/src/common.rs
@@ -138,37 +138,51 @@ pub fn stringify_panic_payload(payload: Box<dyn Any + Send + 'static>) -> String
 	}
 }
 
+/// Contains the outcome of waiting on threads, or `Pending` if none are ready.
+#[derive(Clone, Copy)]
+pub enum WaitOutcome {
+	JobFinished,
+	CpuTimedOut,
+	Pending,
+}
+
+impl WaitOutcome {
+	pub fn is_pending(&self) -> bool {
+		matches!(self, Self::Pending)
+	}
+}
+
 /// Helper type.
-type Cond = Arc<(Mutex<bool>, Condvar)>;
+type Cond = Arc<(Mutex<WaitOutcome>, Condvar)>;
 
 /// Runs a thread, afterwards notifying the thread waiting on the condvar. Catches panics and
 /// resumes them after triggering the condvar, so that the waiting thread is notified on panics.
-pub fn cond_notify_on_done<F, R>(f: F, cond: Cond) -> R
+pub fn cond_notify_on_done<F, R>(f: F, cond: Cond, outcome: WaitOutcome) -> R
 where
 	F: FnOnce() -> R,
 	F: panic::UnwindSafe,
 {
 	let result = panic::catch_unwind(|| f());
-	cond_notify_one(cond);
+	cond_notify_one(cond, outcome);
 	match result {
 		Ok(inner) => return inner,
 		Err(err) => panic::resume_unwind(err),
 	}
 }
 
-/// Helper function to notify the thread waiting on this condvar. This follows the conventions in
-/// the std docs, including the use of a `pending` flag.
-fn cond_notify_one(cond: Cond) {
+/// Helper function to notify the thread waiting on this condvar.
+fn cond_notify_one(cond: Cond, outcome: WaitOutcome) {
 	let (lock, cvar) = &*cond;
-	let mut pending = lock.lock().unwrap();
-	*pending = false;
+	let mut flag = lock.lock().unwrap();
+	*flag = outcome;
 	cvar.notify_one();
 }
 
 /// Helper function to block the thread while it waits on the condvar.
-pub fn cond_wait_while(cond: Cond) {
+pub fn cond_wait_while(cond: Cond) -> WaitOutcome {
 	let (lock, cvar) = &*cond;
-	let _guard = cvar.wait_while(lock.lock().unwrap(), |pending| *pending).unwrap();
+	let guard = cvar.wait_while(lock.lock().unwrap(), |flag| flag.is_pending()).unwrap();
+	*guard
 }
 
 /// In case of node and worker version mismatch (as a result of in-place upgrade), send `SIGTERM`

--- a/node/core/pvf/worker/src/common.rs
+++ b/node/core/pvf/worker/src/common.rs
@@ -258,14 +258,10 @@ pub mod thread {
 	}
 
 	/// Block the thread while it waits on the condvar or on a timeout. If the timeout is hit,
-	/// returns `None`. The signature is different than [`wait_for_threads`] because this is
-	/// expected to be called in a loop, where we can't take ownership of a `Cond`.
+	/// returns `None`.
 	#[cfg_attr(not(any(target_os = "linux", feature = "jemalloc-allocator")), allow(dead_code))]
-	pub fn wait_for_threads_with_timeout(
-		lock: &Mutex<WaitOutcome>,
-		cvar: &Condvar,
-		dur: Duration,
-	) -> Option<WaitOutcome> {
+	pub fn wait_for_threads_with_timeout(cond: &Cond, dur: Duration) -> Option<WaitOutcome> {
+		let (lock, cvar) = &**cond;
 		let result = cvar
 			.wait_timeout_while(lock.lock().unwrap(), dur, |flag| flag.is_pending())
 			.unwrap();

--- a/node/core/pvf/worker/src/common.rs
+++ b/node/core/pvf/worker/src/common.rs
@@ -174,6 +174,10 @@ where
 fn cond_notify_one(cond: Cond, outcome: WaitOutcome) {
 	let (lock, cvar) = &*cond;
 	let mut flag = lock.lock().unwrap();
+	if !matches!(*flag, WaitOutcome::Pending) {
+		// Someone else already triggered the condvar.
+		return
+	}
 	*flag = outcome;
 	cvar.notify_one();
 }

--- a/node/core/pvf/worker/src/execute.rs
+++ b/node/core/pvf/worker/src/execute.rs
@@ -109,7 +109,7 @@ pub fn worker_entrypoint(socket_path: &str, node_version: Option<&str>) {
 					cpu_time_monitor_loop(cpu_time_start, execution_timeout, cpu_time_monitor_rx)
 				},
 				Arc::clone(&condvar),
-				WaitOutcome::CpuTimedOut,
+				WaitOutcome::TimedOut,
 			)?;
 			let executor_2 = executor.clone();
 			let execute_thread = thread::spawn_worker_thread_with_stack_size(
@@ -118,14 +118,14 @@ pub fn worker_entrypoint(socket_path: &str, node_version: Option<&str>) {
 					validate_using_artifact(&artifact_path, &params, executor_2, cpu_time_start)
 				},
 				Arc::clone(&condvar),
-				WaitOutcome::JobFinished,
+				WaitOutcome::Finished,
 				EXECUTE_THREAD_STACK_SIZE,
 			)?;
 
 			let outcome = thread::wait_for_threads(condvar);
 
 			let response = match outcome {
-				WaitOutcome::JobFinished => {
+				WaitOutcome::Finished => {
 					let _ = cpu_time_monitor_tx.send(());
 					execute_thread.join().unwrap_or_else(|e| {
 						// TODO: Use `Panic` error once that is implemented.
@@ -137,7 +137,7 @@ pub fn worker_entrypoint(socket_path: &str, node_version: Option<&str>) {
 				},
 				// If the CPU thread is not selected, we signal it to end, the join handle is
 				// dropped and the thread will finish in the background.
-				WaitOutcome::CpuTimedOut => {
+				WaitOutcome::TimedOut => {
 					match cpu_time_monitor_thread.join() {
 						Ok(Some(cpu_time_elapsed)) => {
 							// Log if we exceed the timeout and the other thread hasn't finished.
@@ -152,7 +152,7 @@ pub fn worker_entrypoint(socket_path: &str, node_version: Option<&str>) {
 						},
 						Ok(None) => Response::format_internal(
 							"cpu time monitor thread error",
-							"error communicating over finished channel".into(),
+							"error communicating over closed channel".into(),
 						),
 						// We can use an internal error here because errors in this thread are
 						// independent of the candidate.

--- a/node/core/pvf/worker/src/execute.rs
+++ b/node/core/pvf/worker/src/execute.rs
@@ -149,8 +149,8 @@ pub fn worker_entrypoint(socket_path: &str, node_version: Option<&str>) {
 						)
 					})
 				},
-				// If this thread is not selected, we signal it to end, the join handle is dropped
-				// and the thread will finish in the background.
+				// If the CPU thread is not selected, we signal it to end, the join handle is
+				// dropped and the thread will finish in the background.
 				WaitOutcome::CpuTimedOut => {
 					match cpu_time_monitor_thread.join() {
 						Ok(Some(cpu_time_elapsed)) => {
@@ -176,9 +176,8 @@ pub fn worker_entrypoint(socket_path: &str, node_version: Option<&str>) {
 						),
 					}
 				},
-				WaitOutcome::Pending => Response::InternalError(
-					"we run wait_while until the outcome is no longer pending; qed".into(),
-				),
+				WaitOutcome::Pending =>
+					unreachable!("we run wait_while until the outcome is no longer pending; qed"),
 			};
 
 			send_response(&mut stream, response).await?;

--- a/node/core/pvf/worker/src/execute.rs
+++ b/node/core/pvf/worker/src/execute.rs
@@ -179,13 +179,15 @@ fn validate_using_artifact(
 		Ok(d) => d,
 	};
 
-	let duration = cpu_time_start.elapsed();
-
 	let result_descriptor = match ValidationResult::decode(&mut &descriptor_bytes[..]) {
 		Err(err) =>
 			return Response::format_invalid("validation result decoding failed", &err.to_string()),
 		Ok(r) => r,
 	};
+
+	// Include the decoding in the measured time, to prevent any potential attacks exploiting some
+	// bug in decoding.
+	let duration = cpu_time_start.elapsed();
 
 	Response::Ok { result_descriptor, duration }
 }

--- a/node/core/pvf/worker/src/execute.rs
+++ b/node/core/pvf/worker/src/execute.rs
@@ -16,8 +16,9 @@
 
 use crate::{
 	common::{
-		bytes_to_path, cond_notify_on_done, cond_wait_while, cpu_time_monitor_loop,
-		stringify_panic_payload, worker_event_loop, WaitOutcome,
+		bytes_to_path, cpu_time_monitor_loop, stringify_panic_payload,
+		thread::{self, WaitOutcome},
+		worker_event_loop,
 	},
 	executor_intf::{Executor, EXECUTE_THREAD_STACK_SIZE},
 	LOG_TARGET,
@@ -30,8 +31,7 @@ use polkadot_node_core_pvf::{
 use polkadot_parachain::primitives::ValidationResult;
 use std::{
 	path::{Path, PathBuf},
-	sync::{mpsc::channel, Arc, Condvar, Mutex},
-	thread,
+	sync::{mpsc::channel, Arc},
 	time::Duration,
 };
 use tokio::{io, net::UnixStream};
@@ -97,46 +97,32 @@ pub fn worker_entrypoint(socket_path: &str, node_version: Option<&str>) {
 			);
 
 			// Conditional variable to notify us when a thread is done.
-			let cond_main = Arc::new((Mutex::new(WaitOutcome::Pending), Condvar::new()));
-			let cond_cpu = Arc::clone(&cond_main);
-			let cond_job = Arc::clone(&cond_main);
+			let condvar = thread::get_condvar();
 
 			let cpu_time_start = ProcessTime::now();
 
 			// Spawn a new thread that runs the CPU time monitor.
 			let (cpu_time_monitor_tx, cpu_time_monitor_rx) = channel::<()>();
-			let cpu_time_monitor_thread = thread::spawn(move || {
-				cond_notify_on_done(
-					|| {
-						cpu_time_monitor_loop(
-							cpu_time_start,
-							execution_timeout,
-							cpu_time_monitor_rx,
-						)
-					},
-					cond_cpu,
-					WaitOutcome::CpuTimedOut,
-				)
-			});
+			let cpu_time_monitor_thread = thread::spawn_worker_thread(
+				"cpu time monitor thread",
+				move || {
+					cpu_time_monitor_loop(cpu_time_start, execution_timeout, cpu_time_monitor_rx)
+				},
+				Arc::clone(&condvar),
+				WaitOutcome::CpuTimedOut,
+			)?;
 			let executor_2 = executor.clone();
-			let execute_thread =
-				thread::Builder::new().stack_size(EXECUTE_THREAD_STACK_SIZE).spawn(move || {
-					cond_notify_on_done(
-						|| {
-							validate_using_artifact(
-								&artifact_path,
-								&params,
-								executor_2,
-								cpu_time_start,
-							)
-						},
-						cond_job,
-						WaitOutcome::JobFinished,
-					)
-				})?;
+			let execute_thread = thread::spawn_worker_thread_with_stack_size(
+				"execute thread",
+				move || {
+					validate_using_artifact(&artifact_path, &params, executor_2, cpu_time_start)
+				},
+				Arc::clone(&condvar),
+				WaitOutcome::JobFinished,
+				EXECUTE_THREAD_STACK_SIZE,
+			)?;
 
-			// Wait for one of the threads to finish.
-			let outcome = cond_wait_while(cond_main);
+			let outcome = thread::wait_for_threads(condvar);
 
 			let response = match outcome {
 				WaitOutcome::JobFinished => {

--- a/node/core/pvf/worker/src/execute.rs
+++ b/node/core/pvf/worker/src/execute.rs
@@ -15,7 +15,10 @@
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
 use crate::{
-	common::{bytes_to_path, cpu_time_monitor_loop, stringify_panic_payload, worker_event_loop},
+	common::{
+		bytes_to_path, cond_notify_all, cond_wait_while, cpu_time_monitor_loop,
+		stringify_panic_payload, worker_event_loop,
+	},
 	executor_intf::{Executor, EXECUTE_THREAD_STACK_SIZE},
 	LOG_TARGET,
 };
@@ -27,7 +30,7 @@ use polkadot_node_core_pvf::{
 use polkadot_parachain::primitives::ValidationResult;
 use std::{
 	path::{Path, PathBuf},
-	sync::mpsc::channel,
+	sync::{mpsc::channel, Arc, Condvar, Mutex},
 	thread,
 	time::Duration,
 };
@@ -67,10 +70,14 @@ async fn send_response(stream: &mut UnixStream, response: Response) -> io::Resul
 	framed_send(stream, &response.encode()).await
 }
 
-/// The entrypoint that the spawned execute worker should start with. The `socket_path` specifies
-/// the path to the socket used to communicate with the host. The `node_version`, if `Some`,
-/// is checked against the worker version. A mismatch results in immediate worker termination.
-/// `None` is used for tests and in other situations when version check is not necessary.
+/// The entrypoint that the spawned execute worker should start with.
+///
+/// # Parameters
+///
+/// The `socket_path` specifies the path to the socket used to communicate with the host. The
+/// `node_version`, if `Some`, is checked against the worker version. A mismatch results in
+/// immediate worker termination. `None` is used for tests and in other situations when version
+/// check is not necessary.
 pub fn worker_entrypoint(socket_path: &str, node_version: Option<&str>) {
 	worker_event_loop("execute", socket_path, node_version, |mut stream| async move {
 		let worker_pid = std::process::id();
@@ -89,30 +96,45 @@ pub fn worker_entrypoint(socket_path: &str, node_version: Option<&str>) {
 				artifact_path.display(),
 			);
 
-			// Used to signal to the cpu time monitor thread that it can finish.
-			let (finished_tx, finished_rx) = channel::<()>();
+			// Conditional variable to notify us when a thread is done.
+			let cond_main = Arc::new((Mutex::new(true), Condvar::new()));
+			let cond_cpu = Arc::clone(&cond_main);
+			let cond_job = Arc::clone(&cond_main);
+
 			let cpu_time_start = ProcessTime::now();
 
 			// Spawn a new thread that runs the CPU time monitor.
+			let (cpu_time_monitor_tx, cpu_time_monitor_rx) = channel::<()>();
 			let cpu_time_monitor_thread = thread::spawn(move || {
-				cpu_time_monitor_loop(cpu_time_start, execution_timeout, finished_rx)
+				let result =
+					cpu_time_monitor_loop(cpu_time_start, execution_timeout, cpu_time_monitor_rx);
+				cond_notify_all(cond_cpu);
+				result
 			});
 			let executor_2 = executor.clone();
 			let execute_thread =
 				thread::Builder::new().stack_size(EXECUTE_THREAD_STACK_SIZE).spawn(move || {
-					validate_using_artifact(&artifact_path, &params, executor_2, cpu_time_start)
+					let result = validate_using_artifact(
+						&artifact_path,
+						&params,
+						executor_2,
+						cpu_time_start,
+					);
+					cond_notify_all(cond_job);
+					result
 				})?;
 
-			// "Select" the first thread that finishes by checking all threads in a naive loop.
+			// Wait for one of the threads to finish.
+			cond_wait_while(cond_main);
+
+			// A thread has signaled completion but it may not be "joinable" yet, so loop for a bit.
 			let response = loop {
-				// NOTE: The order in which we poll threads is important! This loop sleeps between
-				// polling, so it is possible to go over the timeout even when the worker thread
-				// finishes on time. So we want to prioritize selecting the worker thread and not
-				// the CPU thread. If the measured CPU time is over the timeout, we will reject the
-				// candidate later on the host-side. This avoids a source of indeterminism, where a
-				// job can trigger timeouts on some validators and not others.
+				// NOTE: We check the worker thread first to give it priority. This is for the rare
+				// case where it barely finishes in time, so we don't discard its result. On the
+				// other hand, if its measured CPU time is over the timeout, we will reject the
+				// candidate later on the host-side.
 				if execute_thread.is_finished() {
-					let _ = finished_tx.send(());
+					let _ = cpu_time_monitor_tx.send(());
 					break execute_thread.join().unwrap_or_else(|e| {
 						// TODO: Use `Panic` error once that is implemented.
 						Response::format_internal(
@@ -121,8 +143,8 @@ pub fn worker_entrypoint(socket_path: &str, node_version: Option<&str>) {
 						)
 					})
 				}
-				// If this thread is not selected, the join handle is dropped and the thread will
-				// finish in the background.
+				// If this thread is not selected, we signal it to end, the join handle is dropped
+				// and the thread will finish in the background.
 				if cpu_time_monitor_thread.is_finished() {
 					break match cpu_time_monitor_thread.join() {
 						Ok(Some(cpu_time_elapsed)) => {
@@ -147,8 +169,6 @@ pub fn worker_entrypoint(socket_path: &str, node_version: Option<&str>) {
 						),
 					}
 				}
-
-				thread::sleep(Duration::from_millis(10));
 			};
 
 			send_response(&mut stream, response).await?;

--- a/node/core/pvf/worker/src/executor_intf.rs
+++ b/node/core/pvf/worker/src/executor_intf.rs
@@ -29,6 +29,42 @@ use std::{
 	path::Path,
 };
 
+// Wasmtime powers the Substrate Executor. It compiles the wasm bytecode into native code.
+// That native code does not create any stacks and just reuses the stack of the thread that
+// wasmtime was invoked from.
+//
+// Also, we configure the executor to provide the deterministic stack and that requires
+// supplying the amount of the native stack space that wasm is allowed to use. This is
+// realized by supplying the limit into `wasmtime::Config::max_wasm_stack`.
+//
+// There are quirks to that configuration knob:
+//
+// 1. It only limits the amount of stack space consumed by wasm but does not ensure nor check
+//    that the stack space is actually available.
+//
+//    That means, if the calling thread has 1 MiB of stack space left and the wasm code consumes
+//    more, then the wasmtime limit will **not** trigger. Instead, the wasm code will hit the
+//    guard page and the Rust stack overflow handler will be triggered. That leads to an
+//    **abort**.
+//
+// 2. It cannot and does not limit the stack space consumed by Rust code.
+//
+//    Meaning that if the wasm code leaves no stack space for Rust code, then the Rust code
+//    will abort and that will abort the process as well.
+//
+// Typically on Linux the main thread gets the stack size specified by the `ulimit` and
+// typically it's configured to 8 MiB. Rust's spawned threads are 2 MiB. OTOH, the
+// NATIVE_STACK_MAX is set to 256 MiB. Not nearly enough.
+//
+// Hence we need to increase it. The simplest way to fix that is to spawn a thread with the desired
+// stack limit.
+//
+// The reasoning why we pick this particular size is:
+//
+// The default Rust thread stack limit 2 MiB + 256 MiB wasm stack.
+/// The stack size for the execute thread.
+pub const EXECUTE_THREAD_STACK_SIZE: usize = 2 * 1024 * 1024 + NATIVE_STACK_MAX as usize;
+
 // Memory configuration
 //
 // When Substrate Runtime is instantiated, a number of WASM pages are allocated for the Substrate
@@ -142,60 +178,17 @@ fn params_to_wasmtime_semantics(par: &ExecutorParams) -> Result<Semantics, Strin
 	Ok(sem)
 }
 
+#[derive(Clone)]
 pub struct Executor {
-	thread_pool: rayon::ThreadPool,
 	config: Config,
 }
 
 impl Executor {
 	pub fn new(params: ExecutorParams) -> Result<Self, String> {
-		// Wasmtime powers the Substrate Executor. It compiles the wasm bytecode into native code.
-		// That native code does not create any stacks and just reuses the stack of the thread that
-		// wasmtime was invoked from.
-		//
-		// Also, we configure the executor to provide the deterministic stack and that requires
-		// supplying the amount of the native stack space that wasm is allowed to use. This is
-		// realized by supplying the limit into `wasmtime::Config::max_wasm_stack`.
-		//
-		// There are quirks to that configuration knob:
-		//
-		// 1. It only limits the amount of stack space consumed by wasm but does not ensure nor check
-		//    that the stack space is actually available.
-		//
-		//    That means, if the calling thread has 1 MiB of stack space left and the wasm code consumes
-		//    more, then the wasmtime limit will **not** trigger. Instead, the wasm code will hit the
-		//    guard page and the Rust stack overflow handler will be triggered. That leads to an
-		//    **abort**.
-		//
-		// 2. It cannot and does not limit the stack space consumed by Rust code.
-		//
-		//    Meaning that if the wasm code leaves no stack space for Rust code, then the Rust code
-		//    will abort and that will abort the process as well.
-		//
-		// Typically on Linux the main thread gets the stack size specified by the `ulimit` and
-		// typically it's configured to 8 MiB. Rust's spawned threads are 2 MiB. OTOH, the
-		// NATIVE_STACK_MAX is set to 256 MiB. Not nearly enough.
-		//
-		// Hence we need to increase it.
-		//
-		// The simplest way to fix that is to spawn a thread with the desired stack limit. In order
-		// to avoid costs of creating a thread, we use a thread pool. The execution is
-		// single-threaded hence the thread pool has only one thread.
-		//
-		// The reasoning why we pick this particular size is:
-		//
-		// The default Rust thread stack limit 2 MiB + 256 MiB wasm stack.
-		let thread_stack_size = 2 * 1024 * 1024 + NATIVE_STACK_MAX as usize;
-		let thread_pool = rayon::ThreadPoolBuilder::new()
-			.num_threads(1)
-			.stack_size(thread_stack_size)
-			.build()
-			.map_err(|e| format!("Failed to create thread pool: {:?}", e))?;
-
 		let mut config = DEFAULT_CONFIG.clone();
 		config.semantics = params_to_wasmtime_semantics(&params)?;
 
-		Ok(Self { thread_pool, config })
+		Ok(Self { config })
 	}
 
 	/// Executes the given PVF in the form of a compiled artifact and returns the result of execution
@@ -212,45 +205,29 @@ impl Executor {
 	///
 	/// Failure to adhere to these requirements might lead to crashes and arbitrary code execution.
 	pub unsafe fn execute(
-		&self,
+		self,
 		compiled_artifact_path: &Path,
 		params: &[u8],
 	) -> Result<Vec<u8>, String> {
-		let mut result = None;
-		self.thread_pool.scope({
-			let result = &mut result;
-			move |s| {
-				s.spawn(move |_| {
-					// spawn does not return a value, so we need to use a variable to pass the result.
-					*result = Some(
-						do_execute(compiled_artifact_path, self.config.clone(), params)
-							.map_err(|err| format!("execute error: {:?}", err)),
-					);
-				});
-			}
-		});
-		result.unwrap_or_else(|| Err("rayon thread pool spawn failed".to_string()))
+		let mut extensions = sp_externalities::Extensions::new();
+
+		extensions.register(sp_core::traits::ReadRuntimeVersionExt::new(ReadRuntimeVersion));
+
+		let mut ext = ValidationExternalities(extensions);
+
+		match sc_executor::with_externalities_safe(&mut ext, || {
+			let runtime = sc_executor_wasmtime::create_runtime_from_artifact::<HostFunctions>(
+				compiled_artifact_path,
+				self.config,
+			)?;
+			runtime.new_instance()?.call(InvokeMethod::Export("validate_block"), params)
+		}) {
+			Ok(Ok(ok)) => Ok(ok),
+			Ok(Err(err)) => Err(err),
+			Err(err) => Err(err),
+		}
+		.map_err(|err| format!("execute error: {:?}", err))
 	}
-}
-
-unsafe fn do_execute(
-	compiled_artifact_path: &Path,
-	config: Config,
-	params: &[u8],
-) -> Result<Vec<u8>, sc_executor_common::error::Error> {
-	let mut extensions = sp_externalities::Extensions::new();
-
-	extensions.register(sp_core::traits::ReadRuntimeVersionExt::new(ReadRuntimeVersion));
-
-	let mut ext = ValidationExternalities(extensions);
-
-	sc_executor::with_externalities_safe(&mut ext, || {
-		let runtime = sc_executor_wasmtime::create_runtime_from_artifact::<HostFunctions>(
-			compiled_artifact_path,
-			config,
-		)?;
-		runtime.new_instance()?.call(InvokeMethod::Export("validate_block"), params)
-	})?
 }
 
 type HostFunctions = (

--- a/node/core/pvf/worker/src/executor_intf.rs
+++ b/node/core/pvf/worker/src/executor_intf.rs
@@ -205,7 +205,7 @@ impl Executor {
 	///
 	/// Failure to adhere to these requirements might lead to crashes and arbitrary code execution.
 	pub unsafe fn execute(
-		self,
+		&self,
 		compiled_artifact_path: &Path,
 		params: &[u8],
 	) -> Result<Vec<u8>, String> {
@@ -218,13 +218,12 @@ impl Executor {
 		match sc_executor::with_externalities_safe(&mut ext, || {
 			let runtime = sc_executor_wasmtime::create_runtime_from_artifact::<HostFunctions>(
 				compiled_artifact_path,
-				self.config,
+				self.config.clone(),
 			)?;
 			runtime.new_instance()?.call(InvokeMethod::Export("validate_block"), params)
 		}) {
 			Ok(Ok(ok)) => Ok(ok),
-			Ok(Err(err)) => Err(err),
-			Err(err) => Err(err),
+			Ok(Err(err)) | Err(err) => Err(err),
 		}
 		.map_err(|err| format!("execute error: {:?}", err))
 	}

--- a/node/core/pvf/worker/src/memory_stats.rs
+++ b/node/core/pvf/worker/src/memory_stats.rs
@@ -33,7 +33,7 @@
 /// NOTE: Requires jemalloc enabled.
 #[cfg(any(target_os = "linux", feature = "jemalloc-allocator"))]
 pub mod memory_tracker {
-	use crate::LOG_TARGET;
+	use crate::{common::stringify_panic_payload, LOG_TARGET};
 	use polkadot_node_core_pvf::MemoryAllocationStats;
 	use std::{
 		sync::mpsc::{Receiver, RecvTimeoutError, Sender},
@@ -156,7 +156,7 @@ pub mod memory_tracker {
 					gum::warn!(
 						target: LOG_TARGET,
 						%worker_pid,
-						"worker: error joining on memory tracker thread: {}", err
+						"worker: error joining on memory tracker thread: {}", stringify_panic_payload(err)
 					);
 					None
 				},

--- a/node/core/pvf/worker/src/memory_stats.rs
+++ b/node/core/pvf/worker/src/memory_stats.rs
@@ -104,7 +104,6 @@ pub mod memory_tracker {
 			Ok(())
 		};
 
-		let (lock, cvar) = &*condvar;
 		loop {
 			// Take a snapshot and update the max stats.
 			update_stats()?;
@@ -112,7 +111,7 @@ pub mod memory_tracker {
 			// Sleep for the poll interval, or wake up if the condvar is triggered. Note that
 			// `wait_timeout_while` is documented as not being very precise or reliable, which is
 			// fine here -- see note above.
-			match thread::wait_for_threads_with_timeout(lock, cvar, POLL_INTERVAL) {
+			match thread::wait_for_threads_with_timeout(&condvar, POLL_INTERVAL) {
 				Some(_outcome) => {
 					update_stats()?;
 					return Ok(max_stats)

--- a/node/core/pvf/worker/src/memory_stats.rs
+++ b/node/core/pvf/worker/src/memory_stats.rs
@@ -126,7 +126,6 @@ pub mod memory_tracker {
 		thread: JoinHandle<Result<MemoryAllocationStats, String>>,
 		worker_pid: u32,
 	) -> Option<MemoryAllocationStats> {
-		// Join on the thread handle.
 		match thread.join() {
 			Ok(Ok(stats)) => Some(stats),
 			Ok(Err(err)) => {

--- a/node/core/pvf/worker/src/prepare.rs
+++ b/node/core/pvf/worker/src/prepare.rs
@@ -202,8 +202,8 @@ pub fn worker_entrypoint(socket_path: &str, node_version: Option<&str>) {
 						},
 					}
 				},
-				// If this thread is not selected, we signal it to end, the join handle is dropped
-				// and the thread will finish in the background.
+				// If the CPU thread is not selected, we signal it to end, the join handle is
+				// dropped and the thread will finish in the background.
 				WaitOutcome::CpuTimedOut => {
 					match cpu_time_monitor_thread.join() {
 						Ok(Some(cpu_time_elapsed)) => {
@@ -224,9 +224,8 @@ pub fn worker_entrypoint(socket_path: &str, node_version: Option<&str>) {
 						Err(err) => Err(PrepareError::IoErr(stringify_panic_payload(err))),
 					}
 				},
-				WaitOutcome::Pending => Err(PrepareError::IoErr(
-					"we run wait_while until the outcome is no longer pending; qed".into(),
-				)),
+				WaitOutcome::Pending =>
+					unreachable!("we run wait_while until the outcome is no longer pending; qed"),
 			};
 
 			send_response(&mut stream, result).await?;

--- a/node/core/pvf/worker/src/prepare.rs
+++ b/node/core/pvf/worker/src/prepare.rs
@@ -20,8 +20,9 @@ use crate::memory_stats::max_rss_stat::{extract_max_rss_stat, get_max_rss_thread
 use crate::memory_stats::memory_tracker::{get_memory_tracker_loop_stats, memory_tracker_loop};
 use crate::{
 	common::{
-		bytes_to_path, cond_notify_on_done, cond_wait_while, cpu_time_monitor_loop,
-		stringify_panic_payload, worker_event_loop, WaitOutcome,
+		bytes_to_path, cpu_time_monitor_loop, stringify_panic_payload,
+		thread::{self, WaitOutcome},
+		worker_event_loop,
 	},
 	prepare, prevalidate, LOG_TARGET,
 };
@@ -33,8 +34,7 @@ use polkadot_node_core_pvf::{
 };
 use std::{
 	path::PathBuf,
-	sync::{mpsc::channel, Arc, Condvar, Mutex},
-	thread,
+	sync::{mpsc::channel, Arc},
 	time::Duration,
 };
 use tokio::{io, net::UnixStream};
@@ -109,47 +109,37 @@ pub fn worker_entrypoint(socket_path: &str, node_version: Option<&str>) {
 			let memory_tracker_thread = thread::spawn(move || memory_tracker_loop(memory_tracker_rx));
 
 			// Conditional variable to notify us when a thread is done.
-			let cond_main = Arc::new((Mutex::new(WaitOutcome::Pending), Condvar::new()));
-			let cond_cpu = Arc::clone(&cond_main);
-			let cond_job = Arc::clone(&cond_main);
+			let condvar = thread::get_condvar();
 
 			let cpu_time_start = ProcessTime::now();
 
 			// Spawn a new thread that runs the CPU time monitor.
 			let (cpu_time_monitor_tx, cpu_time_monitor_rx) = channel::<()>();
-			let cpu_time_monitor_thread = thread::spawn(move || {
-				cond_notify_on_done(
-					|| {
-						cpu_time_monitor_loop(
-							cpu_time_start,
-							preparation_timeout,
-							cpu_time_monitor_rx,
-						)
-					},
-					cond_cpu,
-					WaitOutcome::CpuTimedOut,
-				)
-			});
+			let cpu_time_monitor_thread = thread::spawn_worker_thread(
+				"cpu time monitor thread",
+				move || {
+					cpu_time_monitor_loop(cpu_time_start, preparation_timeout, cpu_time_monitor_rx)
+				},
+				Arc::clone(&condvar),
+				WaitOutcome::CpuTimedOut,
+			)?;
 			// Spawn another thread for preparation.
-			let prepare_thread = thread::spawn(move || {
-				cond_notify_on_done(
-					|| {
-						let result = prepare_artifact(pvf, cpu_time_start);
+			let prepare_thread = thread::spawn_worker_thread(
+				"prepare thread",
+				move || {
+					let result = prepare_artifact(pvf, cpu_time_start);
 
-						// Get the `ru_maxrss` stat. If supported, call getrusage for the thread.
-						#[cfg(target_os = "linux")]
-						let result = result
-							.map(|(artifact, elapsed)| (artifact, elapsed, get_max_rss_thread()));
+					// Get the `ru_maxrss` stat. If supported, call getrusage for the thread.
+					#[cfg(target_os = "linux")]
+					let result = result.map(|(artifact, elapsed)| (artifact, elapsed, get_max_rss_thread()));
 
-						result
-					},
-					cond_job,
-					WaitOutcome::JobFinished,
-				)
-			});
+					result
+				},
+				Arc::clone(&condvar),
+				WaitOutcome::JobFinished,
+			)?;
 
-			// Wait for one of the threads to finish.
-			let outcome = cond_wait_while(cond_main);
+			let outcome = thread::wait_for_threads(condvar);
 
 			let result = match outcome {
 				WaitOutcome::JobFinished => {

--- a/node/core/pvf/worker/src/prepare.rs
+++ b/node/core/pvf/worker/src/prepare.rs
@@ -107,9 +107,9 @@ pub fn worker_entrypoint(socket_path: &str, node_version: Option<&str>) {
 
 			// Run the memory tracker in a regular, non-worker thread.
 			#[cfg(any(target_os = "linux", feature = "jemalloc-allocator"))]
-			let memory_tracker_condvar = Arc::clone(&condvar);
+			let condvar_memory = Arc::clone(&condvar);
 			#[cfg(any(target_os = "linux", feature = "jemalloc-allocator"))]
-			let memory_tracker_thread = std::thread::spawn(|| memory_tracker_loop(memory_tracker_condvar));
+			let memory_tracker_thread = std::thread::spawn(|| memory_tracker_loop(condvar_memory));
 
 			let cpu_time_start = ProcessTime::now();
 

--- a/node/core/pvf/worker/src/prepare.rs
+++ b/node/core/pvf/worker/src/prepare.rs
@@ -96,7 +96,7 @@ pub fn worker_entrypoint(socket_path: &str, node_version: Option<&str>) {
 			#[cfg(any(target_os = "linux", feature = "jemalloc-allocator"))]
 			let (memory_tracker_tx, memory_tracker_rx) = channel::<()>();
 			#[cfg(any(target_os = "linux", feature = "jemalloc-allocator"))]
-			let memory_tracker_fut = thread::spawn(move || memory_tracker_loop(memory_tracker_rx));
+			let memory_tracker_thread = thread::spawn(move || memory_tracker_loop(memory_tracker_rx));
 
 			// Spawn a new thread that runs the CPU time monitor.
 			let (cpu_time_monitor_tx, cpu_time_monitor_rx) = channel::<()>();
@@ -137,7 +137,7 @@ pub fn worker_entrypoint(socket_path: &str, node_version: Option<&str>) {
 							// Stop the memory stats worker and get its observed memory stats.
 							#[cfg(any(target_os = "linux", feature = "jemalloc-allocator"))]
 							let memory_tracker_stats = get_memory_tracker_loop_stats(
-								memory_tracker_fut,
+								memory_tracker_thread,
 								memory_tracker_tx,
 								worker_pid,
 							)

--- a/node/core/pvf/worker/src/prepare.rs
+++ b/node/core/pvf/worker/src/prepare.rs
@@ -96,7 +96,7 @@ pub fn worker_entrypoint(socket_path: &str, node_version: Option<&str>) {
 			#[cfg(any(target_os = "linux", feature = "jemalloc-allocator"))]
 			let (memory_tracker_tx, memory_tracker_rx) = channel::<()>();
 			#[cfg(any(target_os = "linux", feature = "jemalloc-allocator"))]
-			let memory_tracker_fut = rt_handle.spawn_blocking(move || memory_tracker_loop(memory_tracker_rx));
+			let memory_tracker_fut = thread::spawn(move || memory_tracker_loop(memory_tracker_rx));
 
 			// Spawn a new thread that runs the CPU time monitor.
 			let (cpu_time_monitor_tx, cpu_time_monitor_rx) = channel::<()>();

--- a/node/core/pvf/worker/src/prepare.rs
+++ b/node/core/pvf/worker/src/prepare.rs
@@ -19,17 +19,16 @@ use crate::memory_stats::max_rss_stat::{extract_max_rss_stat, get_max_rss_thread
 #[cfg(any(target_os = "linux", feature = "jemalloc-allocator"))]
 use crate::memory_stats::memory_tracker::{get_memory_tracker_loop_stats, memory_tracker_loop};
 use crate::{
-	common::{bytes_to_path, cpu_time_monitor_loop, worker_event_loop},
+	common::{bytes_to_path, cpu_time_monitor_loop, stringify_panic_payload, worker_event_loop},
 	prepare, prevalidate, LOG_TARGET,
 };
 use cpu_time::ProcessTime;
-use futures::{pin_mut, select_biased, FutureExt};
 use parity_scale_codec::{Decode, Encode};
 use polkadot_node_core_pvf::{
 	framed_recv, framed_send, CompiledArtifact, MemoryStats, PrepareError, PrepareResult,
 	PrepareStats, PvfPrepData,
 };
-use std::{any::Any, panic, path::PathBuf, sync::mpsc::channel};
+use std::{panic, path::PathBuf, sync::mpsc::channel, thread, time::Duration};
 use tokio::{io, net::UnixStream};
 
 async fn recv_request(stream: &mut UnixStream) -> io::Result<(PvfPrepData, PathBuf)> {
@@ -79,7 +78,7 @@ async fn send_response(stream: &mut UnixStream, result: PrepareResult) -> io::Re
 /// 7. Send the result of preparation back to the host. If any error occurred in the above steps, we
 ///    send that in the `PrepareResult`.
 pub fn worker_entrypoint(socket_path: &str, node_version: Option<&str>) {
-	worker_event_loop("prepare", socket_path, node_version, |rt_handle, mut stream| async move {
+	worker_event_loop("prepare", socket_path, node_version, |mut stream| async move {
 		let worker_pid = std::process::id();
 
 		loop {
@@ -101,52 +100,35 @@ pub fn worker_entrypoint(socket_path: &str, node_version: Option<&str>) {
 
 			// Spawn a new thread that runs the CPU time monitor.
 			let (cpu_time_monitor_tx, cpu_time_monitor_rx) = channel::<()>();
-			let cpu_time_monitor_fut = rt_handle
-				.spawn_blocking(move || {
-					cpu_time_monitor_loop(cpu_time_start, preparation_timeout, cpu_time_monitor_rx)
-				})
-				.fuse();
+			let cpu_time_monitor_thread = thread::spawn(move || {
+				cpu_time_monitor_loop(cpu_time_start, preparation_timeout, cpu_time_monitor_rx)
+			});
 			// Spawn another thread for preparation.
-			let prepare_fut = rt_handle
-				.spawn_blocking(move || {
-					let result = prepare_artifact(pvf);
+			let prepare_thread = thread::spawn(move || {
+				let result = prepare_artifact(pvf);
 
-					// Get the `ru_maxrss` stat. If supported, call getrusage for the thread.
-					#[cfg(target_os = "linux")]
-					let result = result.map(|artifact| (artifact, get_max_rss_thread()));
+				// Get the `ru_maxrss` stat. If supported, call getrusage for the thread.
+				#[cfg(target_os = "linux")]
+				let result = result.map(|artifact| (artifact, get_max_rss_thread()));
 
-					result
-				})
-				.fuse();
+				result
+			});
 
-			pin_mut!(cpu_time_monitor_fut);
-			pin_mut!(prepare_fut);
-
-			let result = select_biased! {
-				// If this future is not selected, the join handle is dropped and the thread will
-				// finish in the background.
-				join_res = cpu_time_monitor_fut => {
-					match join_res {
-						Ok(Some(cpu_time_elapsed)) => {
-							// Log if we exceed the timeout and the other thread hasn't finished.
-							gum::warn!(
-								target: LOG_TARGET,
-								%worker_pid,
-								"prepare job took {}ms cpu time, exceeded prepare timeout {}ms",
-								cpu_time_elapsed.as_millis(),
-								preparation_timeout.as_millis(),
-							);
-							Err(PrepareError::TimedOut)
-						},
-						Ok(None) => Err(PrepareError::IoErr("error communicating over finished channel".into())),
-						Err(err) => Err(PrepareError::IoErr(err.to_string())),
-					}
-				},
-				prepare_res = prepare_fut => {
+			// "Select" the first thread that finishes by checking all threads in a naive loop.
+			let result = loop {
+				// NOTE: The order in which we poll threads is important! This loop sleeps between
+				// polling, so it is possible to go over the timeout even when the worker thread
+				// finishes on time. So we want to prioritize selecting the worker thread and not
+				// the CPU thread. If the measured CPU time is over the timeout, we will reject the
+				// candidate later on the host-side. This avoids a source of indeterminism, where a
+				// job can trigger timeouts on some validators and not others.
+				if prepare_thread.is_finished() {
 					let cpu_time_elapsed = cpu_time_start.elapsed();
 					let _ = cpu_time_monitor_tx.send(());
 
-					match prepare_res.unwrap_or_else(|err| Err(PrepareError::IoErr(err.to_string()))) {
+					break match prepare_thread.join().unwrap_or_else(|err| {
+						Err(PrepareError::Panic(stringify_panic_payload(err)))
+					}) {
 						Err(err) => {
 							// Serialized error will be written into the socket.
 							Err(err)
@@ -154,8 +136,12 @@ pub fn worker_entrypoint(socket_path: &str, node_version: Option<&str>) {
 						Ok(ok) => {
 							// Stop the memory stats worker and get its observed memory stats.
 							#[cfg(any(target_os = "linux", feature = "jemalloc-allocator"))]
-							let memory_tracker_stats =
-								get_memory_tracker_loop_stats(memory_tracker_fut, memory_tracker_tx, worker_pid).await;
+							let memory_tracker_stats = get_memory_tracker_loop_stats(
+								memory_tracker_fut,
+								memory_tracker_tx,
+								worker_pid,
+							)
+							.await;
 							#[cfg(target_os = "linux")]
 							let (ok, max_rss) = ok;
 							let memory_stats = MemoryStats {
@@ -180,10 +166,34 @@ pub fn worker_entrypoint(socket_path: &str, node_version: Option<&str>) {
 							);
 							tokio::fs::write(&dest, &ok).await?;
 
-							Ok(PrepareStats{cpu_time_elapsed, memory_stats})
+							Ok(PrepareStats { cpu_time_elapsed, memory_stats })
 						},
 					}
-				},
+				}
+				// If this thread is not selected, the join handle is dropped and the thread will
+				// finish in the background.
+				if cpu_time_monitor_thread.is_finished() {
+					break match cpu_time_monitor_thread.join() {
+						Ok(Some(cpu_time_elapsed)) => {
+							// Log if we exceed the timeout and the other thread hasn't finished.
+							gum::warn!(
+								target: LOG_TARGET,
+								%worker_pid,
+								"prepare job took {}ms cpu time, exceeded prepare timeout {}ms",
+								cpu_time_elapsed.as_millis(),
+								preparation_timeout.as_millis(),
+							);
+							Err(PrepareError::TimedOut)
+						},
+						Ok(None) => Err(PrepareError::IoErr(
+							"error communicating over finished channel".into(),
+						)),
+						// Errors in this thread are independent of the candidate.
+						Err(err) => Err(PrepareError::IoErr(stringify_panic_payload(err))),
+					}
+				}
+
+				thread::sleep(Duration::from_millis(10));
 			};
 
 			send_response(&mut stream, result).await?;
@@ -192,6 +202,7 @@ pub fn worker_entrypoint(socket_path: &str, node_version: Option<&str>) {
 }
 
 fn prepare_artifact(pvf: PvfPrepData) -> Result<CompiledArtifact, PrepareError> {
+	// TODO: Is this necessary? Panics are already caught by `std::thread::join`.
 	panic::catch_unwind(|| {
 		let blob = match prevalidate(&pvf.code()) {
 			Err(err) => return Err(PrepareError::Prevalidation(format!("{:?}", err))),
@@ -205,18 +216,4 @@ fn prepare_artifact(pvf: PvfPrepData) -> Result<CompiledArtifact, PrepareError> 
 	})
 	.map_err(|panic_payload| PrepareError::Panic(stringify_panic_payload(panic_payload)))
 	.and_then(|inner_result| inner_result)
-}
-
-/// Attempt to convert an opaque panic payload to a string.
-///
-/// This is a best effort, and is not guaranteed to provide the most accurate value.
-fn stringify_panic_payload(payload: Box<dyn Any + Send + 'static>) -> String {
-	match payload.downcast::<&'static str>() {
-		Ok(msg) => msg.to_string(),
-		Err(payload) => match payload.downcast::<String>() {
-			Ok(msg) => *msg,
-			// At least we tried...
-			Err(_) => "unknown panic payload".to_string(),
-		},
-	}
 }

--- a/node/core/pvf/worker/src/prepare.rs
+++ b/node/core/pvf/worker/src/prepare.rs
@@ -19,7 +19,10 @@ use crate::memory_stats::max_rss_stat::{extract_max_rss_stat, get_max_rss_thread
 #[cfg(any(target_os = "linux", feature = "jemalloc-allocator"))]
 use crate::memory_stats::memory_tracker::{get_memory_tracker_loop_stats, memory_tracker_loop};
 use crate::{
-	common::{bytes_to_path, cpu_time_monitor_loop, stringify_panic_payload, worker_event_loop},
+	common::{
+		bytes_to_path, cond_notify_all, cond_wait_while, cpu_time_monitor_loop,
+		stringify_panic_payload, worker_event_loop,
+	},
 	prepare, prevalidate, LOG_TARGET,
 };
 use cpu_time::ProcessTime;
@@ -28,7 +31,12 @@ use polkadot_node_core_pvf::{
 	framed_recv, framed_send, CompiledArtifact, MemoryStats, PrepareError, PrepareResult,
 	PrepareStats, PvfPrepData,
 };
-use std::{panic, path::PathBuf, sync::mpsc::channel, thread, time::Duration};
+use std::{
+	path::PathBuf,
+	sync::{mpsc::channel, Arc, Condvar, Mutex},
+	thread,
+	time::Duration,
+};
 use tokio::{io, net::UnixStream};
 
 async fn recv_request(stream: &mut UnixStream) -> io::Result<(PvfPrepData, PathBuf)> {
@@ -53,10 +61,14 @@ async fn send_response(stream: &mut UnixStream, result: PrepareResult) -> io::Re
 	framed_send(stream, &result.encode()).await
 }
 
-/// The entrypoint that the spawned prepare worker should start with. The `socket_path` specifies
-/// the path to the socket used to communicate with the host. The `node_version`, if `Some`,
-/// is checked against the worker version. A mismatch results in immediate worker termination.
-/// `None` is used for tests and in other situations when version check is not necessary.
+/// The entrypoint that the spawned prepare worker should start with.
+///
+/// # Parameters
+///
+/// The `socket_path` specifies the path to the socket used to communicate with the host. The
+/// `node_version`, if `Some`, is checked against the worker version. A mismatch results in
+/// immediate worker termination. `None` is used for tests and in other situations when version
+/// check is not necessary.
 ///
 /// # Flow
 ///
@@ -68,8 +80,7 @@ async fn send_response(stream: &mut UnixStream, result: PrepareResult) -> io::Re
 ///
 /// 3. Start the CPU time monitor loop and the actual preparation in two separate threads.
 ///
-/// 4. Select on the two threads created in step 3. If the CPU timeout was hit, the CPU time monitor
-///    thread will trigger first.
+/// 4. Wait on the two threads created in step 3.
 ///
 /// 5. Stop the memory tracker and get the stats.
 ///
@@ -89,7 +100,6 @@ pub fn worker_entrypoint(socket_path: &str, node_version: Option<&str>) {
 				"worker: preparing artifact",
 			);
 
-			let cpu_time_start = ProcessTime::now();
 			let preparation_timeout = pvf.prep_timeout();
 
 			// Run the memory tracker.
@@ -98,10 +108,20 @@ pub fn worker_entrypoint(socket_path: &str, node_version: Option<&str>) {
 			#[cfg(any(target_os = "linux", feature = "jemalloc-allocator"))]
 			let memory_tracker_thread = thread::spawn(move || memory_tracker_loop(memory_tracker_rx));
 
+			// Conditional variable to notify us when a thread is done.
+			let cond_main = Arc::new((Mutex::new(true), Condvar::new()));
+			let cond_cpu = Arc::clone(&cond_main);
+			let cond_job = Arc::clone(&cond_main);
+
+			let cpu_time_start = ProcessTime::now();
+
 			// Spawn a new thread that runs the CPU time monitor.
 			let (cpu_time_monitor_tx, cpu_time_monitor_rx) = channel::<()>();
 			let cpu_time_monitor_thread = thread::spawn(move || {
-				cpu_time_monitor_loop(cpu_time_start, preparation_timeout, cpu_time_monitor_rx)
+				let result =
+					cpu_time_monitor_loop(cpu_time_start, preparation_timeout, cpu_time_monitor_rx);
+				cond_notify_all(cond_cpu);
+				result
 			});
 			// Spawn another thread for preparation.
 			let prepare_thread = thread::spawn(move || {
@@ -111,17 +131,19 @@ pub fn worker_entrypoint(socket_path: &str, node_version: Option<&str>) {
 				#[cfg(target_os = "linux")]
 				let result = result.map(|artifact| (artifact, get_max_rss_thread()));
 
+				cond_notify_all(cond_job);
 				result
 			});
 
-			// "Select" the first thread that finishes by checking all threads in a naive loop.
+			// Wait for one of the threads to finish.
+			cond_wait_while(cond_main);
+
+			// A thread has signaled completion but it may not be "joinable" yet, so loop for a bit.
 			let result = loop {
-				// NOTE: The order in which we poll threads is important! This loop sleeps between
-				// polling, so it is possible to go over the timeout even when the worker thread
-				// finishes on time. So we want to prioritize selecting the worker thread and not
-				// the CPU thread. If the measured CPU time is over the timeout, we will reject the
-				// candidate later on the host-side. This avoids a source of indeterminism, where a
-				// job can trigger timeouts on some validators and not others.
+				// NOTE: We check the worker thread first to give it priority. This is for the rare
+				// case where it barely finishes in time, so we don't discard its result. On the
+				// other hand, if its measured CPU time is over the timeout, we will reject the
+				// candidate later on the host-side.
 				if prepare_thread.is_finished() {
 					let _ = cpu_time_monitor_tx.send(());
 
@@ -169,8 +191,8 @@ pub fn worker_entrypoint(socket_path: &str, node_version: Option<&str>) {
 						},
 					}
 				}
-				// If this thread is not selected, the join handle is dropped and the thread will
-				// finish in the background.
+				// If this thread is not selected, we signal it to end, the join handle is dropped
+				// and the thread will finish in the background.
 				if cpu_time_monitor_thread.is_finished() {
 					break match cpu_time_monitor_thread.join() {
 						Ok(Some(cpu_time_elapsed)) => {
@@ -191,8 +213,6 @@ pub fn worker_entrypoint(socket_path: &str, node_version: Option<&str>) {
 						Err(err) => Err(PrepareError::IoErr(stringify_panic_payload(err))),
 					}
 				}
-
-				thread::sleep(Duration::from_millis(10));
 			};
 
 			send_response(&mut stream, result).await?;


### PR DESCRIPTION
# PULL REQUEST

## Overview

1. We were using `rayon` to spawn a superfluous threadpool and thread to do execution, so it was removed.

2. We were using `rayon` to set a threadpool-specific thread stack size, and AFAIK we couldn't do that with `tokio` (it's possible [per-runtime](https://docs.rs/tokio/latest/tokio/runtime/struct.Builder.html#method.thread_stack_size) but not per-thread). Since we want to remove `tokio` from the workers [anyway](https://github.com/paritytech/polkadot/issues/7117), I changed it to spawn threads with the `std::thread` API instead of `tokio`.[^1]

[^1]: NOTE: This PR does not totally remove the `tokio` dependency just yet.

3. Since `std::thread` API is not async, we could no longer `select!` on the threads as futures, so the `select!` was removed in favor of non-async coordination using sync primitives.

I left some TODO's related to panics which I'm going to address soon as part of https://github.com/paritytech/polkadot/issues/7045.

## Related issues

Gets us closer to https://github.com/paritytech/polkadot/issues/7117.