### PR TITLE
WIP: Split global prio into prios for runtime and node

### DIFF
--- a/scripts/ci/changelog/templates/global_priority.md.tera
+++ b/scripts/ci/changelog/templates/global_priority.md.tera
@@ -1,22 +1,46 @@
 {% import "high_priority.md.tera" as m_p -%}
 ## Upgrade Priority
 
-{%- set polkadot_prio = 0 -%}
-{%- set substrate_prio = 0 -%}
+{%- set polkadot_prio_runtime = 0 -%}
+{%- set substrate_prio_runtime = 0 -%}
+
+{%- set polkadot_prio_node = 0 -%}
+{%- set substrate_prio_node = 0 -%}
 
 {# We fetch the various priorities #}
 {%- if polkadot.meta.C -%}
-    {%- set polkadot_prio = polkadot.meta.C.max -%}
+    {%- if polkadot.meta.T and polkadot.meta.T0 -%}
+    {%- set polkadot_prio_node = polkadot.meta.C.max -%}
+    {%- endif -%}
+
+    {%- if polkadot.meta.T and polkadot.meta.T1 -%}
+    {%- set polkadot_prio_runtime = polkadot.meta.C.max -%}
+    {%- endif -%}
 {%- endif -%}
 {%- if substrate.meta.C -%}
-    {%- set substrate_prio = substrate.meta.C.max -%}
+    {%- if substrate.meta.T and substrate.meta.T0 -%}
+    {%- set substrate_prio_node = substrate.meta.C.max -%}
+    {%- endif -%}
+
+    {%- if substrate.meta.T and substrate.meta.T1 -%}
+    {%- set substrate_prio_runtime = substrate.meta.C.max -%}
+    {%- endif -%}
 {%- endif -%}
 
 {# We compute the global priority #}
-{%- set global_prio = polkadot_prio -%}
-{%- if substrate_prio > global_prio -%}
-    {%- set global_prio = substrate_prio -%}
+{%- set global_prio_node = polkadot_prio_node -%}
+{%- if substrate_prio_node > global_prio_node -%}
+    {%- set global_prio_node = substrate_prio_node -%}
 {%- endif -%}
+{%- set global_prio_runtime = polkadot_prio_runtime -%}
+{%- if substrate_prio_runtime > global_prio_runtime -%}
+    {%- set global_prio_runtime = substrate_prio_runtime -%}
+{%- endif %}
 
+### Node
 {#- We show the result #}
-{{ m_p::high_priority(p=global_prio, changes=changes) }}
+{{ m_p::high_priority(p=global_prio_node, changes=changes) }}
+
+### Runtime
+{#- We show the result #}
+{{ m_p::high_priority(p=global_prio_runtime, changes=changes) }}

--- a/scripts/ci/changelog/templates/high_priority.md.tera
+++ b/scripts/ci/changelog/templates/high_priority.md.tera
@@ -1,6 +1,6 @@
 {%- import "change.md.tera" as m_c -%}
 
-{# This macro convert a priority level into readable output #}
+{#- This macro convert a priority level into readable output #}
 {%- macro high_priority(p, changes) -%}
 
 {%- if p >= 7 -%}

--- a/scripts/ci/changelog/templates/host_functions.md.tera
+++ b/scripts/ci/changelog/templates/host_functions.md.tera
@@ -10,20 +10,19 @@
     {%- if pr.meta.E and pr.meta.E.E3 -%}
         {%- set_global host_fn_count = host_fn_count + 1 -%}
             - {{ m_c::change(c=pr) }}
-        {% endif -%}
     {% endif -%}
     {%- if pr.meta.E and pr.meta.E.E4 -%}
         {%- set_global upgrade_first = upgrade_first + 1 -%}
             - {{ m_c::change(c=pr) }}
-        {% endif -%}
     {% endif -%}
+{% endif -%}
 {%- endfor -%}
 
 <!-- {{ upgrade_first }} changes require node upgrade -->
 
 {%- if upgrade_first != 0 %}
 ## Node upgrade required
-⚠️ There is a runtime change that will require nodes to be upgraded BEFORE the runtime upgrade.  
+⚠️ There is a runtime change that will require nodes to be upgraded BEFORE the runtime upgrade.
 
 ⚠️ It is critical that you update your client before the chain switches to the new runtime.
 {%- endif %}


### PR DESCRIPTION
Currently we have a single priority computed over both runtime and node priorities.
This PR splits into 2 prios:
- runtime
- node
