### PR TITLE
bring forward migrations

### DIFF
--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -1419,6 +1419,14 @@ impl Get<Perbill> for NominationPoolsMigrationV4OldPallet {
 /// This contains the combined migrations of the last 10 releases. It allows to skip runtime upgrades in case governance decides to do so.
 #[allow(deprecated)]
 pub type Migrations = (
+	// 0.9.38
+	// "Use 2D weights in XCM v3" <https://github.com/paritytech/polkadot/pull/6134>
+	pallet_xcm::migration::v1::MigrateToV1<Runtime>,
+	parachains_ump::migration::v1::MigrateToV1<Runtime>,
+	// Remove stale entries in the set id -> session index storage map (after
+	// this release they will be properly pruned after the bonding duration has
+	// elapsed)
+	pallet_grandpa::migrations::CleanupSetIdSessionMap<Runtime>,
 	// 0.9.40
 	pallet_nomination_pools::migration::v4::MigrateToV4<
 		Runtime,


### PR DESCRIPTION
this allows us to skip enacting interim runtimes

see-also: https://github.com/paritytech/polkadot/issues/7162