### PR TITLE
Add a new profile for runtimes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,7 +190,14 @@ opt-level = 3
 [profile.dev.package.backtrace]
 inherits = "release"
 
+# Used to produce the node binary
 [profile.production]
+inherits = "release"
+lto = true
+codegen-units = 1
+
+# Used to build the runtimes
+[profile.runtime]
 inherits = "release"
 lto = true
 codegen-units = 1


### PR DESCRIPTION
## Abstract

Using the same optimisations for the runtime that we use for the node binary show a gain close to 10% in size.
This PR adds a new profile for the runtimes.


## Dependencies

By default, `srtool-actions` and `srtool-cli` use the `release` profile to build the runtimes.
`srtool-cli` already has a `profile` flag that can be used.

We can then use the new profile with `srtool-actions` once https://github.com/chevdor/srtool-actions/issues/18 is implemented.

(kudos @ggwpez for the test)

