### PR TITLE
Sort migrations by release

### DIFF
--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -1475,7 +1475,7 @@ pub mod migrations {
 		>,
 		pallet_nomination_pools::migration::v5::MigrateToV5<Runtime>,
 	);
-	pub type V0941 = (); // node only
+	pub type V0941 = (); // Node only release - no migrations.
 	pub type V0942 = (
 		parachains_configuration::migration::v5::MigrateToV5<Runtime>,
 		pallet_offences::migration::v1::MigrateToV1<Runtime>,

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -1460,7 +1460,7 @@ impl Get<Perbill> for NominationPoolsMigrationV4OldPallet {
 /// All migrations that will run on the next runtime upgrade.
 ///
 /// This contains the combined migrations of the last 10 releases. It allows to skip runtime
-/// upgrades in case governance decides to do so.
+/// upgrades in case governance decides to do so. THE ORDER IS IMPORTANT.
 pub type Migrations = (V0940, V0941, V0942, Unreleased);
 
 /// The runtime migrations per release.

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -1461,19 +1461,33 @@ impl Get<Perbill> for NominationPoolsMigrationV4OldPallet {
 ///
 /// This contains the combined migrations of the last 10 releases. It allows to skip runtime
 /// upgrades in case governance decides to do so.
-#[allow(deprecated)]
-pub type Migrations = (
-	// 0.9.40
-	pallet_nomination_pools::migration::v4::MigrateToV4<
-		Runtime,
-		NominationPoolsMigrationV4OldPallet,
-	>,
-	pallet_nomination_pools::migration::v5::MigrateToV5<Runtime>,
-	// Unreleased - add new migrations here:
-	parachains_configuration::migration::v5::MigrateToV5<Runtime>,
-	pallet_offences::migration::v1::MigrateToV1<Runtime>,
-	runtime_common::session::migration::ClearOldSessionStorage<Runtime>,
-);
+pub type Migrations = migrations::SinceV0940;
+
+/// The runtime migrations per release.
+#[allow(deprecated, missing_docs)]
+pub mod migrations {
+	use super::*;
+
+	pub type V0940 = (
+		pallet_nomination_pools::migration::v4::MigrateToV4<
+			Runtime,
+			NominationPoolsMigrationV4OldPallet,
+		>,
+		pallet_nomination_pools::migration::v5::MigrateToV5<Runtime>,
+	);
+	pub type V0941 = (); // node only
+	pub type V0942 = (
+		parachains_configuration::migration::v5::MigrateToV5<Runtime>,
+		pallet_offences::migration::v1::MigrateToV1<Runtime>,
+		runtime_common::session::migration::ClearOldSessionStorage<Runtime>,
+	);
+
+	/// Unreleased migrations. Add new ones here:
+	pub type Unreleased = ();
+
+	/// All migrations that should run since (including) `0.9.40`.
+	pub type SinceV0940 = (V0940, V0941, V0942, Unreleased);
+}
 
 /// Unchecked extrinsic type as expected by this runtime.
 pub type UncheckedExtrinsic =

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -1461,7 +1461,7 @@ impl Get<Perbill> for NominationPoolsMigrationV4OldPallet {
 ///
 /// This contains the combined migrations of the last 10 releases. It allows to skip runtime
 /// upgrades in case governance decides to do so.
-pub type Migrations = migrations::SinceV0940;
+pub type Migrations = (V0940, V0941, V0942, Unreleased);
 
 /// The runtime migrations per release.
 #[allow(deprecated, missing_docs)]
@@ -1484,9 +1484,6 @@ pub mod migrations {
 
 	/// Unreleased migrations. Add new ones here:
 	pub type Unreleased = ();
-
-	/// All migrations that should run since (including) `0.9.40`.
-	pub type SinceV0940 = (V0940, V0941, V0942, Unreleased);
 }
 
 /// Unchecked extrinsic type as expected by this runtime.

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -1461,7 +1461,8 @@ impl Get<Perbill> for NominationPoolsMigrationV4OldPallet {
 ///
 /// This contains the combined migrations of the last 10 releases. It allows to skip runtime
 /// upgrades in case governance decides to do so. THE ORDER IS IMPORTANT.
-pub type Migrations = (V0940, V0941, V0942, Unreleased);
+pub type Migrations =
+	(migrations::V0940, migrations::V0941, migrations::V0942, migrations::Unreleased);
 
 /// The runtime migrations per release.
 #[allow(deprecated, missing_docs)]

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -1418,7 +1418,8 @@ impl Get<Perbill> for NominationPoolsMigrationV4OldPallet {
 ///
 /// This contains the combined migrations of the last 10 releases. It allows to skip runtime
 /// upgrades in case governance decides to do so. THE ORDER IS IMPORTANT.
-pub type Migrations = (V0940, V0941, V0942, Unreleased);
+pub type Migrations =
+	(migrations::V0940, migrations::V0941, migrations::V0942, migrations::Unreleased);
 
 /// The runtime migrations per release.
 #[allow(deprecated, missing_docs)]

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -1418,7 +1418,7 @@ impl Get<Perbill> for NominationPoolsMigrationV4OldPallet {
 ///
 /// This contains the combined migrations of the last 10 releases. It allows to skip runtime
 /// upgrades in case governance decides to do so.
-pub type Migrations = migrations::SinceV0940;
+pub type Migrations = (V0940, V0941, V0942, Unreleased);
 
 /// The runtime migrations per release.
 #[allow(deprecated, missing_docs)]
@@ -1441,9 +1441,6 @@ pub mod migrations {
 
 	/// Unreleased migrations. Add new ones here:
 	pub type Unreleased = ();
-
-	/// All migrations that should run since (including) `0.9.40`.
-	pub type SinceV0940 = (V0940, V0941, V0942, Unreleased);
 }
 
 /// Unchecked extrinsic type as expected by this runtime.

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -1416,20 +1416,35 @@ impl Get<Perbill> for NominationPoolsMigrationV4OldPallet {
 
 /// All migrations that will run on the next runtime upgrade.
 ///
-/// This contains the combined migrations of the last 10 releases. It allows to skip runtime upgrades in case governance decides to do so.
-#[allow(deprecated)]
-pub type Migrations = (
-	// 0.9.40
-	pallet_nomination_pools::migration::v4::MigrateToV4<
-		Runtime,
-		NominationPoolsMigrationV4OldPallet,
-	>,
-	pallet_nomination_pools::migration::v5::MigrateToV5<Runtime>,
-	// Unreleased - add new migrations here:
-	parachains_configuration::migration::v5::MigrateToV5<Runtime>,
-	pallet_offences::migration::v1::MigrateToV1<Runtime>,
-	runtime_common::session::migration::ClearOldSessionStorage<Runtime>,
-);
+/// This contains the combined migrations of the last 10 releases. It allows to skip runtime
+/// upgrades in case governance decides to do so.
+pub type Migrations = migrations::SinceV0940;
+
+/// The runtime migrations per release.
+#[allow(deprecated, missing_docs)]
+pub mod migrations {
+	use super::*;
+
+	pub type V0940 = (
+		pallet_nomination_pools::migration::v4::MigrateToV4<
+			Runtime,
+			NominationPoolsMigrationV4OldPallet,
+		>,
+		pallet_nomination_pools::migration::v5::MigrateToV5<Runtime>,
+	);
+	pub type V0941 = (); // node only
+	pub type V0942 = (
+		parachains_configuration::migration::v5::MigrateToV5<Runtime>,
+		pallet_offences::migration::v1::MigrateToV1<Runtime>,
+		runtime_common::session::migration::ClearOldSessionStorage<Runtime>,
+	);
+
+	/// Unreleased migrations. Add new ones here:
+	pub type Unreleased = ();
+
+	/// All migrations that should run since (including) `0.9.40`.
+	pub type SinceV0940 = (V0940, V0941, V0942, Unreleased);
+}
 
 /// Unchecked extrinsic type as expected by this runtime.
 pub type UncheckedExtrinsic =

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -1417,7 +1417,7 @@ impl Get<Perbill> for NominationPoolsMigrationV4OldPallet {
 /// All migrations that will run on the next runtime upgrade.
 ///
 /// This contains the combined migrations of the last 10 releases. It allows to skip runtime
-/// upgrades in case governance decides to do so.
+/// upgrades in case governance decides to do so. THE ORDER IS IMPORTANT.
 pub type Migrations = (V0940, V0941, V0942, Unreleased);
 
 /// The runtime migrations per release.

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -1432,7 +1432,7 @@ pub mod migrations {
 		>,
 		pallet_nomination_pools::migration::v5::MigrateToV5<Runtime>,
 	);
-	pub type V0941 = (); // node only
+	pub type V0941 = (); // Node only release - no migrations.
 	pub type V0942 = (
 		parachains_configuration::migration::v5::MigrateToV5<Runtime>,
 		pallet_offences::migration::v1::MigrateToV1<Runtime>,

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -1478,11 +1478,26 @@ pub type UncheckedExtrinsic =
 ///
 /// This contains the combined migrations of the last 10 releases. It allows to skip runtime
 /// upgrades in case governance decides to do so.
-pub type Migrations = (
-	// Unreleased - add new migrations here:
-	parachains_configuration::migration::v5::MigrateToV5<Runtime>,
-	pallet_offences::migration::v1::MigrateToV1<Runtime>,
-);
+pub type Migrations = migrations::SinceV0940;
+
+/// The runtime migrations per release.
+#[allow(deprecated, missing_docs)]
+pub mod migrations {
+	use super::*;
+
+	pub type V0940 = ();
+	pub type V0941 = (); // node only
+	pub type V0942 = (
+		parachains_configuration::migration::v5::MigrateToV5<Runtime>,
+		pallet_offences::migration::v1::MigrateToV1<Runtime>,
+	);
+
+	/// Unreleased migrations. Add new ones here:
+	pub type Unreleased = ();
+
+	/// All migrations that should run since (including) `0.9.40`.
+	pub type SinceV0940 = (V0940, V0941, V0942, Unreleased);
+}
 
 /// Executive: handles dispatch to the various modules.
 pub type Executive = frame_executive::Executive<

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -1486,7 +1486,7 @@ pub mod migrations {
 	use super::*;
 
 	pub type V0940 = ();
-	pub type V0941 = (); // node only
+	pub type V0941 = (); // Node only release - no migrations.
 	pub type V0942 = (
 		parachains_configuration::migration::v5::MigrateToV5<Runtime>,
 		pallet_offences::migration::v1::MigrateToV1<Runtime>,

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -1478,7 +1478,8 @@ pub type UncheckedExtrinsic =
 ///
 /// This contains the combined migrations of the last 10 releases. It allows to skip runtime
 /// upgrades in case governance decides to do so. THE ORDER IS IMPORTANT.
-pub type Migrations = (V0940, V0941, V0942, Unreleased);
+pub type Migrations =
+	(migrations::V0940, migrations::V0941, migrations::V0942, migrations::Unreleased);
 
 /// The runtime migrations per release.
 #[allow(deprecated, missing_docs)]

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -1477,7 +1477,7 @@ pub type UncheckedExtrinsic =
 /// All migrations that will run on the next runtime upgrade.
 ///
 /// This contains the combined migrations of the last 10 releases. It allows to skip runtime
-/// upgrades in case governance decides to do so.
+/// upgrades in case governance decides to do so. THE ORDER IS IMPORTANT.
 pub type Migrations = (V0940, V0941, V0942, Unreleased);
 
 /// The runtime migrations per release.

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -1478,7 +1478,7 @@ pub type UncheckedExtrinsic =
 ///
 /// This contains the combined migrations of the last 10 releases. It allows to skip runtime
 /// upgrades in case governance decides to do so.
-pub type Migrations = migrations::SinceV0940;
+pub type Migrations = (V0940, V0941, V0942, Unreleased);
 
 /// The runtime migrations per release.
 #[allow(deprecated, missing_docs)]
@@ -1494,9 +1494,6 @@ pub mod migrations {
 
 	/// Unreleased migrations. Add new ones here:
 	pub type Unreleased = ();
-
-	/// All migrations that should run since (including) `0.9.40`.
-	pub type SinceV0940 = (V0940, V0941, V0942, Unreleased);
 }
 
 /// Executive: handles dispatch to the various modules.

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -1213,7 +1213,7 @@ impl Get<Perbill> for NominationPoolsMigrationV4OldPallet {
 ///
 /// This contains the combined migrations of the last 10 releases. It allows to skip runtime
 /// upgrades in case governance decides to do so.
-pub type Migrations = migrations::SinceV0940;
+pub type Migrations = (V0940, V0941, V0942, Unreleased);
 
 /// The runtime migrations per release.
 #[allow(deprecated, missing_docs)]
@@ -1236,9 +1236,6 @@ pub mod migrations {
 
 	/// Unreleased migrations. Add new ones here:
 	pub type Unreleased = ();
-
-	/// All migrations that should run since (including) `0.9.40`.
-	pub type SinceV0940 = (V0940, V0941, V0942, Unreleased);
 }
 
 /// Unchecked extrinsic type as expected by this runtime.

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -1213,7 +1213,8 @@ impl Get<Perbill> for NominationPoolsMigrationV4OldPallet {
 ///
 /// This contains the combined migrations of the last 10 releases. It allows to skip runtime
 /// upgrades in case governance decides to do so. THE ORDER IS IMPORTANT.
-pub type Migrations = (V0940, V0941, V0942, Unreleased);
+pub type Migrations =
+	(migrations::V0940, migrations::V0941, migrations::V0942, migrations::Unreleased);
 
 /// The runtime migrations per release.
 #[allow(deprecated, missing_docs)]

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -1213,19 +1213,33 @@ impl Get<Perbill> for NominationPoolsMigrationV4OldPallet {
 ///
 /// This contains the combined migrations of the last 10 releases. It allows to skip runtime
 /// upgrades in case governance decides to do so.
-#[allow(deprecated)]
-pub type Migrations = (
-	// 0.9.40
-	clean_state_migration::CleanMigrate,
-	pallet_nomination_pools::migration::v4::MigrateToV4<
-		Runtime,
-		NominationPoolsMigrationV4OldPallet,
-	>,
-	pallet_nomination_pools::migration::v5::MigrateToV5<Runtime>,
-	// Unreleased - add new migrations here:
-	parachains_configuration::migration::v5::MigrateToV5<Runtime>,
-	pallet_offences::migration::v1::MigrateToV1<Runtime>,
-);
+pub type Migrations = migrations::SinceV0940;
+
+/// The runtime migrations per release.
+#[allow(deprecated, missing_docs)]
+pub mod migrations {
+	use super::*;
+
+	pub type V0940 = (
+		clean_state_migration::CleanMigrate,
+		pallet_nomination_pools::migration::v4::MigrateToV4<
+			Runtime,
+			NominationPoolsMigrationV4OldPallet,
+		>,
+		pallet_nomination_pools::migration::v5::MigrateToV5<Runtime>,
+	);
+	pub type V0941 = (); // node only
+	pub type V0942 = (
+		parachains_configuration::migration::v5::MigrateToV5<Runtime>,
+		pallet_offences::migration::v1::MigrateToV1<Runtime>,
+	);
+
+	/// Unreleased migrations. Add new ones here:
+	pub type Unreleased = ();
+
+	/// All migrations that should run since (including) `0.9.40`.
+	pub type SinceV0940 = (V0940, V0941, V0942, Unreleased);
+}
 
 /// Unchecked extrinsic type as expected by this runtime.
 pub type UncheckedExtrinsic =

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -1228,7 +1228,7 @@ pub mod migrations {
 		>,
 		pallet_nomination_pools::migration::v5::MigrateToV5<Runtime>,
 	);
-	pub type V0941 = (); // node only
+	pub type V0941 = (); // Node only release - no migrations.
 	pub type V0942 = (
 		parachains_configuration::migration::v5::MigrateToV5<Runtime>,
 		pallet_offences::migration::v1::MigrateToV1<Runtime>,

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -1212,7 +1212,7 @@ impl Get<Perbill> for NominationPoolsMigrationV4OldPallet {
 /// All migrations that will run on the next runtime upgrade.
 ///
 /// This contains the combined migrations of the last 10 releases. It allows to skip runtime
-/// upgrades in case governance decides to do so.
+/// upgrades in case governance decides to do so. THE ORDER IS IMPORTANT.
 pub type Migrations = (V0940, V0941, V0942, Unreleased);
 
 /// The runtime migrations per release.


### PR DESCRIPTION
Sorting them by release should make it easier to backport migrations and ensure that all are included.