### PR TITLE
Tests can use `dbg!` macro

### DIFF
--- a/node/gum/proc-macro/src/tests.rs
+++ b/node/gum/proc-macro/src/tests.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
+#![allow(clippy::dbg_macro)]
+
 use super::*;
 
 use assert_matches::assert_matches;
@@ -127,7 +129,6 @@ mod roundtrip {
 	}
 
 	#[test]
-
 	fn sample_w_candidate_hash_aliased_unnecessary() {
 		assert_matches!(impl_gum2(
 			quote! {


### PR DESCRIPTION
Preparation for the monorepo:  
There is a `deny(clippy::dbg_macro)` in the [crate root](https://github.com/paritytech/polkadot/blob/dbae30efe080a1d41fe54ef4da8af47614c9ca93/node/gum/proc-macro/src/lib.rs#L19), so the Clippy fails over there since tests use `dbg!`.
But `dbg!` in tests is fine IMHO.  

I cannot reproduce it locally, even on the the same version though :man_shrugging: 

cc @alvicsam 