### PR TITLE
Stop weighing XCM execution on pallet-xcm's send extrinsic

### DIFF
--- a/xcm/pallet-xcm/src/lib.rs
+++ b/xcm/pallet-xcm/src/lib.rs
@@ -779,16 +779,7 @@ pub mod pallet {
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
 		#[pallet::call_index(0)]
-		#[pallet::weight({
-			let maybe_msg: Result<Xcm<()>, ()> = (*message.clone()).try_into();
-			match maybe_msg {
-				Ok(msg) => {
-					T::Weigher::weight(&mut msg.into())
-						.map_or(Weight::MAX, |w| T::WeightInfo::send().saturating_add(w))
-				}
-				_ => Weight::MAX,
-			}
-		})]
+		#[pallet::weight(T::WeightInfo::send())]
 		pub fn send(
 			origin: OriginFor<T>,
 			dest: Box<VersionedMultiLocation>,

--- a/xcm/pallet-xcm/src/lib.rs
+++ b/xcm/pallet-xcm/src/lib.rs
@@ -821,6 +821,7 @@ pub mod pallet {
 					let count = assets.len() as u32;
 					let mut message = Xcm(vec![
 						WithdrawAsset(assets),
+						SetFeesMode { jit_withdraw: true },
 						InitiateTeleport {
 							assets: Wild(AllCounted(count)),
 							dest,
@@ -866,6 +867,7 @@ pub mod pallet {
 				(Ok(assets), Ok(dest)) => {
 					use sp_std::vec;
 					let mut message = Xcm(vec![
+						SetFeesMode { jit_withdraw: true },
 						TransferReserveAsset { assets, dest, xcm: Xcm(vec![]) }
 					]);
 					T::Weigher::weight(&mut message).map_or(Weight::MAX, |w| T::WeightInfo::reserve_transfer_assets().saturating_add(w))
@@ -1039,6 +1041,7 @@ pub mod pallet {
 				(Ok(assets), Ok(dest)) => {
 					use sp_std::vec;
 					let mut message = Xcm(vec![
+						SetFeesMode { jit_withdraw: true },
 						TransferReserveAsset { assets, dest, xcm: Xcm(vec![]) }
 					]);
 					T::Weigher::weight(&mut message).map_or(Weight::MAX, |w| T::WeightInfo::reserve_transfer_assets().saturating_add(w))
@@ -1090,6 +1093,7 @@ pub mod pallet {
 					use sp_std::vec;
 					let mut message = Xcm(vec![
 						WithdrawAsset(assets),
+						SetFeesMode { jit_withdraw: true },
 						InitiateTeleport { assets: Wild(All), dest, xcm: Xcm(vec![]) },
 					]);
 					T::Weigher::weight(&mut message).map_or(Weight::MAX, |w| T::WeightInfo::teleport_assets().saturating_add(w))


### PR DESCRIPTION
On the `send` extrinsic on `pallet-xcm`, we are currently weighing message _execution_ and then adding the weight from benchmarking the extrinsic. We shouldn't do this since we are not executing the message locally. A `BuyExecution` instruction will do that job on the destination of the message. We just need to weigh _sending_ the message.

Fixes #7182.