### PR TITLE
Add CollationGenerationMessage::Reinitialize

### DIFF
--- a/node/collation-generation/src/lib.rs
+++ b/node/collation-generation/src/lib.rs
@@ -141,6 +141,12 @@ impl CollationGenerationSubsystem {
 				}
 				false
 			},
+			Ok(FromOrchestra::Communication {
+				msg: CollationGenerationMessage::Reinitialize(config),
+			}) => {
+				self.config = Some(Arc::new(config));
+				false
+			},
 			Ok(FromOrchestra::Signal(OverseerSignal::BlockFinalized(..))) => false,
 			Err(err) => {
 				gum::error!(

--- a/node/subsystem-types/src/messages.rs
+++ b/node/subsystem-types/src/messages.rs
@@ -681,6 +681,8 @@ pub enum ProvisionerMessage {
 pub enum CollationGenerationMessage {
 	/// Initialize the collation generation subsystem
 	Initialize(CollationGenerationConfig),
+	/// Reinitialize the collation generation subsystem
+	Reinitialize(CollationGenerationConfig),
 }
 
 /// The result type of [`ApprovalVotingMessage::CheckAndImportAssignment`] request.


### PR DESCRIPTION
Allows to change the parachain for which the node will collate.