### PR TITLE
Delay reputation updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6933,6 +6933,7 @@ dependencies = [
  "bitvec",
  "env_logger 0.9.0",
  "futures",
+ "futures-timer",
  "log",
  "maplit",
  "polkadot-node-network-protocol",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6905,6 +6905,7 @@ dependencies = [
  "assert_matches",
  "env_logger 0.9.0",
  "futures",
+ "futures-timer",
  "log",
  "polkadot-node-jaeger",
  "polkadot-node-metrics",

--- a/node/network/approval-distribution/Cargo.toml
+++ b/node/network/approval-distribution/Cargo.toml
@@ -14,6 +14,7 @@ polkadot-node-jaeger = { path = "../../jaeger" }
 rand = "0.8"
 
 futures = "0.3.21"
+futures-timer = "3.0.2"
 gum = { package = "tracing-gum", path = "../../gum" }
 
 [dev-dependencies]

--- a/node/network/approval-distribution/Cargo.toml
+++ b/node/network/approval-distribution/Cargo.toml
@@ -9,6 +9,7 @@ polkadot-node-metrics = { path = "../../metrics" }
 polkadot-node-network-protocol = { path = "../protocol" }
 polkadot-node-primitives = { path = "../../primitives" }
 polkadot-node-subsystem = { path = "../../subsystem" }
+polkadot-node-subsystem-util = { path = "../../subsystem-util" }
 polkadot-primitives = { path = "../../../primitives" }
 polkadot-node-jaeger = { path = "../../jaeger" }
 rand = "0.8"
@@ -21,7 +22,6 @@ gum = { package = "tracing-gum", path = "../../gum" }
 sp-authority-discovery = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "master", features = ["std"] }
 
-polkadot-node-subsystem-util = { path = "../../subsystem-util" }
 polkadot-node-subsystem-test-helpers = { path = "../../subsystem-test-helpers" }
 polkadot-primitives-test-helpers = { path = "../../../primitives/test-helpers" }
 

--- a/node/network/approval-distribution/src/lib.rs
+++ b/node/network/approval-distribution/src/lib.rs
@@ -38,7 +38,7 @@ use polkadot_node_subsystem::{
 	},
 	overseer, FromOrchestra, OverseerSignal, SpawnedSubsystem, SubsystemError,
 };
-use polkadot_node_subsystem_util::reputation::ReputationAggregator;
+use polkadot_node_subsystem_util::reputation::{ReputationAggregator, REPUTATION_CHANGE_INTERVAL};
 use polkadot_primitives::{
 	BlockNumber, CandidateIndex, Hash, SessionIndex, ValidatorIndex, ValidatorSignature,
 };
@@ -1772,8 +1772,6 @@ async fn modify_reputation(
 	);
 	reputation.modify(sender, peer_id, rep).await;
 }
-
-const REPUTATION_CHANGE_INTERVAL: Duration = Duration::from_secs(30);
 
 #[overseer::contextbounds(ApprovalDistribution, prefix = self::overseer)]
 impl ApprovalDistribution {

--- a/node/network/approval-distribution/src/lib.rs
+++ b/node/network/approval-distribution/src/lib.rs
@@ -1806,9 +1806,8 @@ impl ApprovalDistribution {
 					state.reputation.send(ctx.sender()).await;
 					reputation_delay = new_reputation_delay();
 				},
-				// Will run if no futures are immediately ready
-				default => {
-					let message = match ctx.recv().await {
+				message = ctx.recv().fuse() => {
+					let message = match message {
 						Ok(message) => message,
 						Err(e) => {
 							gum::debug!(target: LOG_TARGET, err = ?e, "Failed to receive a message from Overseer, exiting");

--- a/node/network/approval-distribution/src/lib.rs
+++ b/node/network/approval-distribution/src/lib.rs
@@ -187,6 +187,9 @@ struct State {
 
 	/// Current approval checking finality lag.
 	approval_checking_lag: BlockNumber,
+
+	/// Buffering of reputation changes
+	reputation_aggregator: ReputationAggregator,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -330,6 +333,11 @@ enum PendingMessage {
 
 #[overseer::contextbounds(ApprovalDistribution, prefix = self::overseer)]
 impl State {
+	#[cfg(test)]
+	fn new(reputation_aggregator: ReputationAggregator) -> Self {
+		Self { reputation_aggregator, ..Default::default() }
+	}
+
 	async fn handle_network_msg<Context>(
 		&mut self,
 		ctx: &mut Context,
@@ -755,7 +763,13 @@ impl State {
 						"Unexpected assignment",
 					);
 					if !self.recent_outdated_blocks.is_recent_outdated(&block_hash) {
-						modify_reputation(ctx.sender(), peer_id, COST_UNEXPECTED_MESSAGE).await;
+						modify_reputation(
+							&mut self.reputation_aggregator,
+							ctx.sender(),
+							peer_id,
+							COST_UNEXPECTED_MESSAGE,
+						)
+						.await;
 					}
 				}
 				return
@@ -780,7 +794,13 @@ impl State {
 								?message_subject,
 								"Duplicate assignment",
 							);
-							modify_reputation(ctx.sender(), peer_id, COST_DUPLICATE_MESSAGE).await;
+							modify_reputation(
+								&mut self.reputation_aggregator,
+								ctx.sender(),
+								peer_id,
+								COST_DUPLICATE_MESSAGE,
+							)
+							.await;
 						}
 						return
 					}
@@ -792,13 +812,25 @@ impl State {
 						?message_subject,
 						"Assignment from a peer is out of view",
 					);
-					modify_reputation(ctx.sender(), peer_id, COST_UNEXPECTED_MESSAGE).await;
+					modify_reputation(
+						&mut self.reputation_aggregator,
+						ctx.sender(),
+						peer_id,
+						COST_UNEXPECTED_MESSAGE,
+					)
+					.await;
 				},
 			}
 
 			// if the assignment is known to be valid, reward the peer
 			if entry.knowledge.contains(&message_subject, message_kind) {
-				modify_reputation(ctx.sender(), peer_id, BENEFIT_VALID_MESSAGE).await;
+				modify_reputation(
+					&mut self.reputation_aggregator,
+					ctx.sender(),
+					peer_id,
+					BENEFIT_VALID_MESSAGE,
+				)
+				.await;
 				if let Some(peer_knowledge) = entry.known_by.get_mut(&peer_id) {
 					gum::trace!(target: LOG_TARGET, ?peer_id, ?message_subject, "Known assignment");
 					peer_knowledge.received.insert(message_subject, message_kind);
@@ -834,7 +866,13 @@ impl State {
 			);
 			match result {
 				AssignmentCheckResult::Accepted => {
-					modify_reputation(ctx.sender(), peer_id, BENEFIT_VALID_MESSAGE_FIRST).await;
+					modify_reputation(
+						&mut self.reputation_aggregator,
+						ctx.sender(),
+						peer_id,
+						BENEFIT_VALID_MESSAGE_FIRST,
+					)
+					.await;
 					entry.knowledge.known_messages.insert(message_subject.clone(), message_kind);
 					if let Some(peer_knowledge) = entry.known_by.get_mut(&peer_id) {
 						peer_knowledge.received.insert(message_subject.clone(), message_kind);
@@ -862,8 +900,13 @@ impl State {
 						?peer_id,
 						"Got an assignment too far in the future",
 					);
-					modify_reputation(ctx.sender(), peer_id, COST_ASSIGNMENT_TOO_FAR_IN_THE_FUTURE)
-						.await;
+					modify_reputation(
+						&mut self.reputation_aggregator,
+						ctx.sender(),
+						peer_id,
+						COST_ASSIGNMENT_TOO_FAR_IN_THE_FUTURE,
+					)
+					.await;
 					return
 				},
 				AssignmentCheckResult::Bad(error) => {
@@ -874,7 +917,13 @@ impl State {
 						%error,
 						"Got a bad assignment from peer",
 					);
-					modify_reputation(ctx.sender(), peer_id, COST_INVALID_MESSAGE).await;
+					modify_reputation(
+						&mut self.reputation_aggregator,
+						ctx.sender(),
+						peer_id,
+						COST_INVALID_MESSAGE,
+					)
+					.await;
 					return
 				},
 			}
@@ -1024,7 +1073,13 @@ impl State {
 			_ => {
 				if let Some(peer_id) = source.peer_id() {
 					if !self.recent_outdated_blocks.is_recent_outdated(&block_hash) {
-						modify_reputation(ctx.sender(), peer_id, COST_UNEXPECTED_MESSAGE).await;
+						modify_reputation(
+							&mut self.reputation_aggregator,
+							ctx.sender(),
+							peer_id,
+							COST_UNEXPECTED_MESSAGE,
+						)
+						.await;
 					}
 				}
 				return
@@ -1043,7 +1098,13 @@ impl State {
 					?message_subject,
 					"Unknown approval assignment",
 				);
-				modify_reputation(ctx.sender(), peer_id, COST_UNEXPECTED_MESSAGE).await;
+				modify_reputation(
+					&mut self.reputation_aggregator,
+					ctx.sender(),
+					peer_id,
+					COST_UNEXPECTED_MESSAGE,
+				)
+				.await;
 				return
 			}
 
@@ -1060,7 +1121,13 @@ impl State {
 								"Duplicate approval",
 							);
 
-							modify_reputation(ctx.sender(), peer_id, COST_DUPLICATE_MESSAGE).await;
+							modify_reputation(
+								&mut self.reputation_aggregator,
+								ctx.sender(),
+								peer_id,
+								COST_DUPLICATE_MESSAGE,
+							)
+							.await;
 						}
 						return
 					}
@@ -1072,14 +1139,26 @@ impl State {
 						?message_subject,
 						"Approval from a peer is out of view",
 					);
-					modify_reputation(ctx.sender(), peer_id, COST_UNEXPECTED_MESSAGE).await;
+					modify_reputation(
+						&mut self.reputation_aggregator,
+						ctx.sender(),
+						peer_id,
+						COST_UNEXPECTED_MESSAGE,
+					)
+					.await;
 				},
 			}
 
 			// if the approval is known to be valid, reward the peer
 			if entry.knowledge.contains(&message_subject, message_kind) {
 				gum::trace!(target: LOG_TARGET, ?peer_id, ?message_subject, "Known approval");
-				modify_reputation(ctx.sender(), peer_id, BENEFIT_VALID_MESSAGE).await;
+				modify_reputation(
+					&mut self.reputation_aggregator,
+					ctx.sender(),
+					peer_id,
+					BENEFIT_VALID_MESSAGE,
+				)
+				.await;
 				if let Some(peer_knowledge) = entry.known_by.get_mut(&peer_id) {
 					peer_knowledge.received.insert(message_subject.clone(), message_kind);
 				}
@@ -1110,7 +1189,13 @@ impl State {
 			);
 			match result {
 				ApprovalCheckResult::Accepted => {
-					modify_reputation(ctx.sender(), peer_id, BENEFIT_VALID_MESSAGE_FIRST).await;
+					modify_reputation(
+						&mut self.reputation_aggregator,
+						ctx.sender(),
+						peer_id,
+						BENEFIT_VALID_MESSAGE_FIRST,
+					)
+					.await;
 
 					entry.knowledge.insert(message_subject.clone(), message_kind);
 					if let Some(peer_knowledge) = entry.known_by.get_mut(&peer_id) {
@@ -1118,7 +1203,13 @@ impl State {
 					}
 				},
 				ApprovalCheckResult::Bad(error) => {
-					modify_reputation(ctx.sender(), peer_id, COST_INVALID_MESSAGE).await;
+					modify_reputation(
+						&mut self.reputation_aggregator,
+						ctx.sender(),
+						peer_id,
+						COST_INVALID_MESSAGE,
+					)
+					.await;
 					gum::info!(
 						target: LOG_TARGET,
 						?peer_id,
@@ -1667,8 +1758,90 @@ async fn adjust_required_routing_and_propagate<Context, BlockFilter, RoutingModi
 	}
 }
 
+const REPUTATION_AGGREGATOR_DELAY_IN_MS: u64 = 5;
+struct ReputationAggregator {
+	delay_in_ms: u64,
+	delay: futures::future::Fuse<futures_timer::Delay>,
+	by_peer: std::collections::HashMap<PeerId, i32>,
+}
+
+impl Default for ReputationAggregator {
+	fn default() -> Self {
+		Self::new(REPUTATION_AGGREGATOR_DELAY_IN_MS)
+	}
+}
+
+impl ReputationAggregator {
+	fn new(delay_in_ms: u64) -> Self {
+		Self {
+			delay_in_ms,
+			delay: Self::init_delay(delay_in_ms),
+			by_peer: std::collections::HashMap::new(),
+		}
+	}
+
+	/// Used for tests to send reputation changes immediately
+	#[cfg(test)]
+	fn without_delay() -> Self {
+		Self::new(0)
+	}
+
+	fn init_delay(delay_in_ms: u64) -> futures::future::Fuse<futures_timer::Delay> {
+		futures_timer::Delay::new(std::time::Duration::from_millis(delay_in_ms)).fuse()
+	}
+
+	fn clear(&mut self) {
+		self.delay = Self::init_delay(self.delay_in_ms);
+		self.by_peer.clear();
+	}
+
+	async fn modify(
+		&mut self,
+		sender: &mut impl overseer::ApprovalDistributionSenderTrait,
+		peer_id: PeerId,
+		rep: Rep,
+	) {
+		self.update_reputation(peer_id, rep);
+
+		// No need to check delay if it's zero or malicious behavior reported
+		if self.delay_in_ms == 0 || matches!(rep, Rep::Malicious(_)) {
+			return self.flush(sender).await
+		}
+
+		futures::select! {
+			_ = &mut self.delay => return self.flush(sender).await,
+			default => (), // Will run if no futures are immediately ready
+		}
+	}
+
+	fn update_reputation(&mut self, peer_id: PeerId, rep: Rep) {
+		let current = match self.by_peer.get(&peer_id) {
+			Some(v) => *v,
+			None => 0,
+		};
+		let new_value = current.saturating_add(rep.cost_or_benefit());
+		self.by_peer.insert(peer_id, new_value);
+	}
+
+	async fn flush(&mut self, sender: &mut impl overseer::ApprovalDistributionSenderTrait) {
+		for (peer_id, score) in &self.by_peer {
+			sender
+				.send_message(NetworkBridgeTxMessage::ReportPeer(
+					*peer_id,
+					net_protocol::ReputationChange::new(
+						*score,
+						"Reputation changed during approval-distribution",
+					),
+				))
+				.await;
+		}
+		self.clear();
+	}
+}
+
 /// Modify the reputation of a peer based on its behavior.
 async fn modify_reputation(
+	reputation_aggregator: &mut ReputationAggregator,
 	sender: &mut impl overseer::ApprovalDistributionSenderTrait,
 	peer_id: PeerId,
 	rep: Rep,
@@ -1680,7 +1853,7 @@ async fn modify_reputation(
 		"Reputation change for peer",
 	);
 
-	sender.send_message(NetworkBridgeTxMessage::ReportPeer(peer_id, rep)).await;
+	reputation_aggregator.modify(sender, peer_id, rep).await;
 }
 
 #[overseer::contextbounds(ApprovalDistribution, prefix = self::overseer)]

--- a/node/network/approval-distribution/src/lib.rs
+++ b/node/network/approval-distribution/src/lib.rs
@@ -1803,10 +1803,8 @@ impl ApprovalDistribution {
 		let mut reputation_delay = new_reputation_delay();
 
 		loop {
-			println!("New loop");
 			select! {
 				_ = reputation_delay => {
-					println!("Reputation timer fired");
 					state.reputation.send(ctx.sender()).await;
 					reputation_delay = new_reputation_delay();
 				},

--- a/node/network/approval-distribution/src/lib.rs
+++ b/node/network/approval-distribution/src/lib.rs
@@ -764,8 +764,8 @@ impl State {
 					);
 					if !self.recent_outdated_blocks.is_recent_outdated(&block_hash) {
 						modify_reputation(
-							ctx.sender(),
 							&mut self.reputation,
+							ctx.sender(),
 							peer_id,
 							COST_UNEXPECTED_MESSAGE,
 						)
@@ -795,8 +795,8 @@ impl State {
 								"Duplicate assignment",
 							);
 							modify_reputation(
-								ctx.sender(),
 								&mut self.reputation,
+								ctx.sender(),
 								peer_id,
 								COST_DUPLICATE_MESSAGE,
 							)
@@ -813,8 +813,8 @@ impl State {
 						"Assignment from a peer is out of view",
 					);
 					modify_reputation(
-						ctx.sender(),
 						&mut self.reputation,
+						ctx.sender(),
 						peer_id,
 						COST_UNEXPECTED_MESSAGE,
 					)
@@ -825,8 +825,8 @@ impl State {
 			// if the assignment is known to be valid, reward the peer
 			if entry.knowledge.contains(&message_subject, message_kind) {
 				modify_reputation(
-					ctx.sender(),
 					&mut self.reputation,
+					ctx.sender(),
 					peer_id,
 					BENEFIT_VALID_MESSAGE,
 				)
@@ -867,8 +867,8 @@ impl State {
 			match result {
 				AssignmentCheckResult::Accepted => {
 					modify_reputation(
-						ctx.sender(),
 						&mut self.reputation,
+						ctx.sender(),
 						peer_id,
 						BENEFIT_VALID_MESSAGE_FIRST,
 					)
@@ -901,8 +901,8 @@ impl State {
 						"Got an assignment too far in the future",
 					);
 					modify_reputation(
-						ctx.sender(),
 						&mut self.reputation,
+						ctx.sender(),
 						peer_id,
 						COST_ASSIGNMENT_TOO_FAR_IN_THE_FUTURE,
 					)
@@ -918,8 +918,8 @@ impl State {
 						"Got a bad assignment from peer",
 					);
 					modify_reputation(
-						ctx.sender(),
 						&mut self.reputation,
+						ctx.sender(),
 						peer_id,
 						COST_INVALID_MESSAGE,
 					)
@@ -1074,8 +1074,8 @@ impl State {
 				if let Some(peer_id) = source.peer_id() {
 					if !self.recent_outdated_blocks.is_recent_outdated(&block_hash) {
 						modify_reputation(
-							ctx.sender(),
 							&mut self.reputation,
+							ctx.sender(),
 							peer_id,
 							COST_UNEXPECTED_MESSAGE,
 						)
@@ -1099,8 +1099,8 @@ impl State {
 					"Unknown approval assignment",
 				);
 				modify_reputation(
-					ctx.sender(),
 					&mut self.reputation,
+					ctx.sender(),
 					peer_id,
 					COST_UNEXPECTED_MESSAGE,
 				)
@@ -1122,8 +1122,8 @@ impl State {
 							);
 
 							modify_reputation(
-								ctx.sender(),
 								&mut self.reputation,
+								ctx.sender(),
 								peer_id,
 								COST_DUPLICATE_MESSAGE,
 							)
@@ -1140,8 +1140,8 @@ impl State {
 						"Approval from a peer is out of view",
 					);
 					modify_reputation(
-						ctx.sender(),
 						&mut self.reputation,
+						ctx.sender(),
 						peer_id,
 						COST_UNEXPECTED_MESSAGE,
 					)
@@ -1153,8 +1153,8 @@ impl State {
 			if entry.knowledge.contains(&message_subject, message_kind) {
 				gum::trace!(target: LOG_TARGET, ?peer_id, ?message_subject, "Known approval");
 				modify_reputation(
-					ctx.sender(),
 					&mut self.reputation,
+					ctx.sender(),
 					peer_id,
 					BENEFIT_VALID_MESSAGE,
 				)
@@ -1190,8 +1190,8 @@ impl State {
 			match result {
 				ApprovalCheckResult::Accepted => {
 					modify_reputation(
-						ctx.sender(),
 						&mut self.reputation,
+						ctx.sender(),
 						peer_id,
 						BENEFIT_VALID_MESSAGE_FIRST,
 					)
@@ -1204,8 +1204,8 @@ impl State {
 				},
 				ApprovalCheckResult::Bad(error) => {
 					modify_reputation(
-						ctx.sender(),
 						&mut self.reputation,
+						ctx.sender(),
 						peer_id,
 						COST_INVALID_MESSAGE,
 					)
@@ -1760,8 +1760,8 @@ async fn adjust_required_routing_and_propagate<Context, BlockFilter, RoutingModi
 
 /// Modify the reputation of a peer based on its behavior.
 async fn modify_reputation(
-	sender: &mut impl overseer::ApprovalDistributionSenderTrait,
 	reputation: &mut ReputationAggregator,
+	sender: &mut impl overseer::ApprovalDistributionSenderTrait,
 	peer_id: PeerId,
 	rep: Rep,
 ) {

--- a/node/network/approval-distribution/src/lib.rs
+++ b/node/network/approval-distribution/src/lib.rs
@@ -20,7 +20,8 @@
 
 #![warn(missing_docs)]
 
-use futures::{channel::oneshot, FutureExt as _};
+use futures::{channel::oneshot, future::Fuse, select, FutureExt as _};
+use futures_timer::Delay;
 use polkadot_node_jaeger as jaeger;
 use polkadot_node_network_protocol::{
 	self as net_protocol,
@@ -187,9 +188,6 @@ struct State {
 
 	/// Current approval checking finality lag.
 	approval_checking_lag: BlockNumber,
-
-	/// Buffering of reputation changes
-	reputation_aggregator: ReputationAggregator,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -333,14 +331,10 @@ enum PendingMessage {
 
 #[overseer::contextbounds(ApprovalDistribution, prefix = self::overseer)]
 impl State {
-	#[cfg(test)]
-	fn new(reputation_aggregator: ReputationAggregator) -> Self {
-		Self { reputation_aggregator, ..Default::default() }
-	}
-
 	async fn handle_network_msg<Context>(
 		&mut self,
 		ctx: &mut Context,
+		rep_aggregator: &mut ReputationAggregator,
 		metrics: &Metrics,
 		event: NetworkBridgeEvent<net_protocol::ApprovalDistributionMessage>,
 		rng: &mut (impl CryptoRng + Rng),
@@ -391,7 +385,8 @@ impl State {
 				});
 			},
 			NetworkBridgeEvent::PeerMessage(peer_id, Versioned::V1(msg)) => {
-				self.process_incoming_peer_message(ctx, metrics, peer_id, msg, rng).await;
+				self.process_incoming_peer_message(ctx, rep_aggregator, metrics, peer_id, msg, rng)
+					.await;
 			},
 		}
 	}
@@ -399,6 +394,7 @@ impl State {
 	async fn handle_new_blocks<Context>(
 		&mut self,
 		ctx: &mut Context,
+		rep_aggregator: &mut ReputationAggregator,
 		metrics: &Metrics,
 		metas: Vec<BlockApprovalMeta>,
 		rng: &mut (impl CryptoRng + Rng),
@@ -499,6 +495,7 @@ impl State {
 						PendingMessage::Assignment(assignment, claimed_index) => {
 							self.import_and_circulate_assignment(
 								ctx,
+								rep_aggregator,
 								metrics,
 								MessageSource::Peer(peer_id),
 								assignment,
@@ -510,6 +507,7 @@ impl State {
 						PendingMessage::Approval(approval_vote) => {
 							self.import_and_circulate_approval(
 								ctx,
+								rep_aggregator,
 								metrics,
 								MessageSource::Peer(peer_id),
 								approval_vote,
@@ -558,6 +556,7 @@ impl State {
 	async fn process_incoming_peer_message<Context, R>(
 		&mut self,
 		ctx: &mut Context,
+		rep_aggregator: &mut ReputationAggregator,
 		metrics: &Metrics,
 		peer_id: PeerId,
 		msg: protocol_v1::ApprovalDistributionMessage,
@@ -596,6 +595,7 @@ impl State {
 
 					self.import_and_circulate_assignment(
 						ctx,
+						rep_aggregator,
 						metrics,
 						MessageSource::Peer(peer_id),
 						assignment,
@@ -634,6 +634,7 @@ impl State {
 
 					self.import_and_circulate_approval(
 						ctx,
+						rep_aggregator,
 						metrics,
 						MessageSource::Peer(peer_id),
 						approval_vote,
@@ -725,6 +726,7 @@ impl State {
 	async fn import_and_circulate_assignment<Context, R>(
 		&mut self,
 		ctx: &mut Context,
+		mut rep_aggregator: &mut ReputationAggregator,
 		metrics: &Metrics,
 		source: MessageSource,
 		assignment: IndirectAssignmentCert,
@@ -763,13 +765,8 @@ impl State {
 						"Unexpected assignment",
 					);
 					if !self.recent_outdated_blocks.is_recent_outdated(&block_hash) {
-						modify_reputation(
-							&mut self.reputation_aggregator,
-							ctx.sender(),
-							peer_id,
-							COST_UNEXPECTED_MESSAGE,
-						)
-						.await;
+						modify_reputation(&mut rep_aggregator, peer_id, COST_UNEXPECTED_MESSAGE)
+							.await;
 					}
 				}
 				return
@@ -794,13 +791,8 @@ impl State {
 								?message_subject,
 								"Duplicate assignment",
 							);
-							modify_reputation(
-								&mut self.reputation_aggregator,
-								ctx.sender(),
-								peer_id,
-								COST_DUPLICATE_MESSAGE,
-							)
-							.await;
+							modify_reputation(&mut rep_aggregator, peer_id, COST_DUPLICATE_MESSAGE)
+								.await;
 						}
 						return
 					}
@@ -812,25 +804,13 @@ impl State {
 						?message_subject,
 						"Assignment from a peer is out of view",
 					);
-					modify_reputation(
-						&mut self.reputation_aggregator,
-						ctx.sender(),
-						peer_id,
-						COST_UNEXPECTED_MESSAGE,
-					)
-					.await;
+					modify_reputation(&mut rep_aggregator, peer_id, COST_UNEXPECTED_MESSAGE).await;
 				},
 			}
 
 			// if the assignment is known to be valid, reward the peer
 			if entry.knowledge.contains(&message_subject, message_kind) {
-				modify_reputation(
-					&mut self.reputation_aggregator,
-					ctx.sender(),
-					peer_id,
-					BENEFIT_VALID_MESSAGE,
-				)
-				.await;
+				modify_reputation(&mut rep_aggregator, peer_id, BENEFIT_VALID_MESSAGE).await;
 				if let Some(peer_knowledge) = entry.known_by.get_mut(&peer_id) {
 					gum::trace!(target: LOG_TARGET, ?peer_id, ?message_subject, "Known assignment");
 					peer_knowledge.received.insert(message_subject, message_kind);
@@ -866,13 +846,8 @@ impl State {
 			);
 			match result {
 				AssignmentCheckResult::Accepted => {
-					modify_reputation(
-						&mut self.reputation_aggregator,
-						ctx.sender(),
-						peer_id,
-						BENEFIT_VALID_MESSAGE_FIRST,
-					)
-					.await;
+					modify_reputation(&mut rep_aggregator, peer_id, BENEFIT_VALID_MESSAGE_FIRST)
+						.await;
 					entry.knowledge.known_messages.insert(message_subject.clone(), message_kind);
 					if let Some(peer_knowledge) = entry.known_by.get_mut(&peer_id) {
 						peer_knowledge.received.insert(message_subject.clone(), message_kind);
@@ -901,8 +876,7 @@ impl State {
 						"Got an assignment too far in the future",
 					);
 					modify_reputation(
-						&mut self.reputation_aggregator,
-						ctx.sender(),
+						&mut rep_aggregator,
 						peer_id,
 						COST_ASSIGNMENT_TOO_FAR_IN_THE_FUTURE,
 					)
@@ -917,13 +891,7 @@ impl State {
 						%error,
 						"Got a bad assignment from peer",
 					);
-					modify_reputation(
-						&mut self.reputation_aggregator,
-						ctx.sender(),
-						peer_id,
-						COST_INVALID_MESSAGE,
-					)
-					.await;
+					modify_reputation(&mut rep_aggregator, peer_id, COST_INVALID_MESSAGE).await;
 					return
 				},
 			}
@@ -1045,6 +1013,7 @@ impl State {
 	async fn import_and_circulate_approval<Context>(
 		&mut self,
 		ctx: &mut Context,
+		mut rep_aggregator: &mut ReputationAggregator,
 		metrics: &Metrics,
 		source: MessageSource,
 		vote: IndirectSignedApprovalVote,
@@ -1073,13 +1042,7 @@ impl State {
 			_ => {
 				if let Some(peer_id) = source.peer_id() {
 					if !self.recent_outdated_blocks.is_recent_outdated(&block_hash) {
-						modify_reputation(
-							&mut self.reputation_aggregator,
-							ctx.sender(),
-							peer_id,
-							COST_UNEXPECTED_MESSAGE,
-						)
-						.await;
+						modify_reputation(rep_aggregator, peer_id, COST_UNEXPECTED_MESSAGE).await;
 					}
 				}
 				return
@@ -1098,13 +1061,7 @@ impl State {
 					?message_subject,
 					"Unknown approval assignment",
 				);
-				modify_reputation(
-					&mut self.reputation_aggregator,
-					ctx.sender(),
-					peer_id,
-					COST_UNEXPECTED_MESSAGE,
-				)
-				.await;
+				modify_reputation(&mut rep_aggregator, peer_id, COST_UNEXPECTED_MESSAGE).await;
 				return
 			}
 
@@ -1121,13 +1078,8 @@ impl State {
 								"Duplicate approval",
 							);
 
-							modify_reputation(
-								&mut self.reputation_aggregator,
-								ctx.sender(),
-								peer_id,
-								COST_DUPLICATE_MESSAGE,
-							)
-							.await;
+							modify_reputation(&mut rep_aggregator, peer_id, COST_DUPLICATE_MESSAGE)
+								.await;
 						}
 						return
 					}
@@ -1139,26 +1091,14 @@ impl State {
 						?message_subject,
 						"Approval from a peer is out of view",
 					);
-					modify_reputation(
-						&mut self.reputation_aggregator,
-						ctx.sender(),
-						peer_id,
-						COST_UNEXPECTED_MESSAGE,
-					)
-					.await;
+					modify_reputation(&mut rep_aggregator, peer_id, COST_UNEXPECTED_MESSAGE).await;
 				},
 			}
 
 			// if the approval is known to be valid, reward the peer
 			if entry.knowledge.contains(&message_subject, message_kind) {
 				gum::trace!(target: LOG_TARGET, ?peer_id, ?message_subject, "Known approval");
-				modify_reputation(
-					&mut self.reputation_aggregator,
-					ctx.sender(),
-					peer_id,
-					BENEFIT_VALID_MESSAGE,
-				)
-				.await;
+				modify_reputation(&mut rep_aggregator, peer_id, BENEFIT_VALID_MESSAGE).await;
 				if let Some(peer_knowledge) = entry.known_by.get_mut(&peer_id) {
 					peer_knowledge.received.insert(message_subject.clone(), message_kind);
 				}
@@ -1189,13 +1129,8 @@ impl State {
 			);
 			match result {
 				ApprovalCheckResult::Accepted => {
-					modify_reputation(
-						&mut self.reputation_aggregator,
-						ctx.sender(),
-						peer_id,
-						BENEFIT_VALID_MESSAGE_FIRST,
-					)
-					.await;
+					modify_reputation(&mut rep_aggregator, peer_id, BENEFIT_VALID_MESSAGE_FIRST)
+						.await;
 
 					entry.knowledge.insert(message_subject.clone(), message_kind);
 					if let Some(peer_knowledge) = entry.known_by.get_mut(&peer_id) {
@@ -1203,13 +1138,7 @@ impl State {
 					}
 				},
 				ApprovalCheckResult::Bad(error) => {
-					modify_reputation(
-						&mut self.reputation_aggregator,
-						ctx.sender(),
-						peer_id,
-						COST_INVALID_MESSAGE,
-					)
-					.await;
+					modify_reputation(&mut rep_aggregator, peer_id, COST_INVALID_MESSAGE).await;
 					gum::info!(
 						target: LOG_TARGET,
 						?peer_id,
@@ -1758,63 +1687,40 @@ async fn adjust_required_routing_and_propagate<Context, BlockFilter, RoutingModi
 	}
 }
 
-const REPUTATION_AGGREGATOR_DELAY_IN_MS: u64 = 5;
+#[derive(Debug, Clone)]
 struct ReputationAggregator {
-	delay_in_ms: u64,
-	delay: futures::future::Fuse<futures_timer::Delay>,
+	overflow: bool,
 	by_peer: std::collections::HashMap<PeerId, i32>,
 }
 
 impl Default for ReputationAggregator {
 	fn default() -> Self {
-		Self::new(REPUTATION_AGGREGATOR_DELAY_IN_MS)
+		Self::new()
+	}
+}
+
+impl IntoIterator for ReputationAggregator {
+	type Item = (PeerId, i32);
+	type IntoIter = std::collections::hash_map::IntoIter<PeerId, i32>;
+
+	fn into_iter(self) -> Self::IntoIter {
+		self.by_peer.into_iter()
 	}
 }
 
 impl ReputationAggregator {
-	fn new(delay_in_ms: u64) -> Self {
-		Self {
-			delay_in_ms,
-			delay: Self::init_delay(delay_in_ms),
-			by_peer: std::collections::HashMap::new(),
-		}
+	pub fn new() -> Self {
+		Self { ..Default::default() }
 	}
 
-	/// Used for tests to send reputation changes immediately
-	#[cfg(test)]
-	fn without_delay() -> Self {
-		Self::new(0)
-	}
-
-	fn init_delay(delay_in_ms: u64) -> futures::future::Fuse<futures_timer::Delay> {
-		futures_timer::Delay::new(std::time::Duration::from_millis(delay_in_ms)).fuse()
-	}
-
-	fn clear(&mut self) {
-		self.delay = Self::init_delay(self.delay_in_ms);
+	pub fn clear(&mut self) {
 		self.by_peer.clear();
 	}
 
-	async fn modify(
-		&mut self,
-		sender: &mut impl overseer::ApprovalDistributionSenderTrait,
-		peer_id: PeerId,
-		rep: Rep,
-	) {
-		self.update_reputation(peer_id, rep);
-
-		// No need to check delay if it's zero or malicious behavior reported
-		if self.delay_in_ms == 0 || matches!(rep, Rep::Malicious(_)) {
-			return self.flush(sender).await
+	pub fn update(&mut self, peer_id: PeerId, rep: Rep) {
+		if matches!(rep, Rep::Malicious(_)) {
+			self.overflow = true;
 		}
-
-		futures::select! {
-			_ = &mut self.delay => return self.flush(sender).await,
-			default => (), // Will run if no futures are immediately ready
-		}
-	}
-
-	fn update_reputation(&mut self, peer_id: PeerId, rep: Rep) {
 		let current = match self.by_peer.get(&peer_id) {
 			Some(v) => *v,
 			None => 0,
@@ -1823,29 +1729,13 @@ impl ReputationAggregator {
 		self.by_peer.insert(peer_id, new_value);
 	}
 
-	async fn flush(&mut self, sender: &mut impl overseer::ApprovalDistributionSenderTrait) {
-		for (peer_id, score) in &self.by_peer {
-			sender
-				.send_message(NetworkBridgeTxMessage::ReportPeer(
-					*peer_id,
-					net_protocol::ReputationChange::new(
-						*score,
-						"Reputation changed during approval-distribution",
-					),
-				))
-				.await;
-		}
-		self.clear();
+	pub fn overflow(&self) -> bool {
+		self.overflow
 	}
 }
 
 /// Modify the reputation of a peer based on its behavior.
-async fn modify_reputation(
-	reputation_aggregator: &mut ReputationAggregator,
-	sender: &mut impl overseer::ApprovalDistributionSenderTrait,
-	peer_id: PeerId,
-	rep: Rep,
-) {
+async fn modify_reputation(rep_aggregator: &mut ReputationAggregator, peer_id: PeerId, rep: Rep) {
 	gum::trace!(
 		target: LOG_TARGET,
 		reputation = ?rep,
@@ -1853,7 +1743,43 @@ async fn modify_reputation(
 		"Reputation change for peer",
 	);
 
-	reputation_aggregator.modify(sender, peer_id, rep).await;
+	rep_aggregator.update(peer_id, rep);
+}
+
+async fn maybe_send_reputation(
+	sender: &mut impl overseer::ApprovalDistributionSenderTrait,
+	rep_aggregator: &mut ReputationAggregator,
+	mut delay: &mut Fuse<Delay>,
+) -> bool {
+	if rep_aggregator.overflow() {
+		send_reputation(sender, rep_aggregator).await;
+		return true
+	}
+
+	select! {
+		_ = delay => {
+			send_reputation(sender, rep_aggregator).await;
+			true
+		},
+		default => false, // Will run if no futures are immediately ready
+	}
+}
+
+async fn send_reputation(
+	sender: &mut impl overseer::ApprovalDistributionSenderTrait,
+	rep_aggregator: &mut ReputationAggregator,
+) {
+	for (peer_id, score) in rep_aggregator.clone() {
+		sender
+			.send_message(NetworkBridgeTxMessage::ReportPeer(
+				peer_id,
+				net_protocol::ReputationChange::new(
+					score,
+					"Reputation changed during approval-distribution",
+				),
+			))
+			.await;
+	}
 }
 
 #[overseer::contextbounds(ApprovalDistribution, prefix = self::overseer)]
@@ -1865,11 +1791,14 @@ impl ApprovalDistribution {
 
 	async fn run<Context>(self, ctx: Context) {
 		let mut state = State::default();
+		let mut rep_aggregator = ReputationAggregator::new();
+		let rep_delay_fn = || Delay::new(std::time::Duration::from_millis(5)).fuse();
 
 		// According to the docs of `rand`, this is a ChaCha12 RNG in practice
 		// and will always be chosen for strong performance and security properties.
 		let mut rng = rand::rngs::StdRng::from_entropy();
-		self.run_inner(ctx, &mut state, &mut rng).await
+		self.run_inner(ctx, &mut state, &mut rep_aggregator, rep_delay_fn, &mut rng)
+			.await
 	}
 
 	/// Used for testing.
@@ -1877,8 +1806,12 @@ impl ApprovalDistribution {
 		self,
 		mut ctx: Context,
 		state: &mut State,
+		rep_aggregator: &mut ReputationAggregator,
+		rep_delay_fn: impl Fn() -> Fuse<Delay>,
 		rng: &mut (impl CryptoRng + Rng),
 	) {
+		let mut rep_delay = rep_delay_fn();
+
 		loop {
 			let message = match ctx.recv().await {
 				Ok(message) => message,
@@ -1889,7 +1822,8 @@ impl ApprovalDistribution {
 			};
 			match message {
 				FromOrchestra::Communication { msg } =>
-					Self::handle_incoming(&mut ctx, state, msg, &self.metrics, rng).await,
+					Self::handle_incoming(&mut ctx, state, rep_aggregator, msg, &self.metrics, rng)
+						.await,
 				FromOrchestra::Signal(OverseerSignal::ActiveLeaves(update)) => {
 					gum::trace!(target: LOG_TARGET, "active leaves signal (ignored)");
 					// the relay chain blocks relevant to the approval subsystems
@@ -1909,22 +1843,28 @@ impl ApprovalDistribution {
 				},
 				FromOrchestra::Signal(OverseerSignal::Conclude) => return,
 			}
+
+			if maybe_send_reputation(ctx.sender(), rep_aggregator, &mut rep_delay).await {
+				rep_aggregator.clear();
+				rep_delay = rep_delay_fn()
+			}
 		}
 	}
 
 	async fn handle_incoming<Context>(
 		ctx: &mut Context,
 		state: &mut State,
+		rep_aggregator: &mut ReputationAggregator,
 		msg: ApprovalDistributionMessage,
 		metrics: &Metrics,
 		rng: &mut (impl CryptoRng + Rng),
 	) {
 		match msg {
 			ApprovalDistributionMessage::NetworkBridgeUpdate(event) => {
-				state.handle_network_msg(ctx, metrics, event, rng).await;
+				state.handle_network_msg(ctx, rep_aggregator, metrics, event, rng).await;
 			},
 			ApprovalDistributionMessage::NewBlocks(metas) => {
-				state.handle_new_blocks(ctx, metrics, metas, rng).await;
+				state.handle_new_blocks(ctx, rep_aggregator, metrics, metas, rng).await;
 			},
 			ApprovalDistributionMessage::DistributeAssignment(cert, candidate_index) => {
 				gum::debug!(
@@ -1937,6 +1877,7 @@ impl ApprovalDistribution {
 				state
 					.import_and_circulate_assignment(
 						ctx,
+						rep_aggregator,
 						&metrics,
 						MessageSource::Local,
 						cert,
@@ -1954,7 +1895,13 @@ impl ApprovalDistribution {
 				);
 
 				state
-					.import_and_circulate_approval(ctx, metrics, MessageSource::Local, vote)
+					.import_and_circulate_approval(
+						ctx,
+						rep_aggregator,
+						metrics,
+						MessageSource::Local,
+						vote,
+					)
 					.await;
 			},
 			ApprovalDistributionMessage::GetApprovalSignatures(indices, tx) => {

--- a/node/network/approval-distribution/src/lib.rs
+++ b/node/network/approval-distribution/src/lib.rs
@@ -334,10 +334,6 @@ enum PendingMessage {
 
 #[overseer::contextbounds(ApprovalDistribution, prefix = self::overseer)]
 impl State {
-	pub fn new(reputation: ReputationAggregator) -> Self {
-		Self { reputation, ..Default::default() }
-	}
-
 	async fn handle_network_msg<Context>(
 		&mut self,
 		ctx: &mut Context,
@@ -1782,8 +1778,7 @@ impl ApprovalDistribution {
 	}
 
 	async fn run<Context>(self, ctx: Context) {
-		let reputation = ReputationAggregator::default();
-		let mut state = State::new(reputation);
+		let mut state = State::default();
 		let reputation_interval = std::time::Duration::from_secs(30);
 
 		// According to the docs of `rand`, this is a ChaCha12 RNG in practice

--- a/node/network/approval-distribution/src/lib.rs
+++ b/node/network/approval-distribution/src/lib.rs
@@ -1770,6 +1770,8 @@ async fn modify_reputation(
 	reputation.modify(sender, peer_id, rep).await;
 }
 
+const REPUTATION_CHANGE_DELAY: u64 = 30;
+
 #[overseer::contextbounds(ApprovalDistribution, prefix = self::overseer)]
 impl ApprovalDistribution {
 	/// Create a new instance of the [`ApprovalDistribution`] subsystem.
@@ -1779,7 +1781,7 @@ impl ApprovalDistribution {
 
 	async fn run<Context>(self, ctx: Context) {
 		let mut state = State::default();
-		let reputation_interval = std::time::Duration::from_secs(30);
+		let reputation_interval = std::time::Duration::from_secs(REPUTATION_CHANGE_DELAY);
 
 		// According to the docs of `rand`, this is a ChaCha12 RNG in practice
 		// and will always be chosen for strong performance and security properties.

--- a/node/network/approval-distribution/src/tests.rs
+++ b/node/network/approval-distribution/src/tests.rs
@@ -284,7 +284,7 @@ async fn expect_reputation_change(
 			)
 		) => {
 			assert_eq!(peer_id, &rep_peer);
-			assert_eq!(expected_reputation_change, rep);
+			assert_eq!(expected_reputation_change.cost_or_benefit(), rep.value);
 		}
 	);
 }
@@ -300,8 +300,9 @@ fn try_import_the_same_assignment() {
 	let peer_d = PeerId::random();
 	let parent_hash = Hash::repeat_byte(0xFF);
 	let hash = Hash::repeat_byte(0xAA);
+	let state = State::new(ReputationAggregator::without_delay());
 
-	let _ = test_harness(State::default(), |mut virtual_overseer| async move {
+	let _ = test_harness(state, |mut virtual_overseer| async move {
 		let overseer = &mut virtual_overseer;
 		// setup peers
 		setup_peer_with_view(overseer, &peer_a, view![]).await;
@@ -384,8 +385,9 @@ fn spam_attack_results_in_negative_reputation_change() {
 	let parent_hash = Hash::repeat_byte(0xFF);
 	let peer_a = PeerId::random();
 	let hash_b = Hash::repeat_byte(0xBB);
+	let state = State::new(ReputationAggregator::without_delay());
 
-	let _ = test_harness(State::default(), |mut virtual_overseer| async move {
+	let _ = test_harness(state, |mut virtual_overseer| async move {
 		let overseer = &mut virtual_overseer;
 		let peer = &peer_a;
 		setup_peer_with_view(overseer, peer, view![]).await;
@@ -468,8 +470,9 @@ fn peer_sending_us_the_same_we_just_sent_them_is_ok() {
 	let parent_hash = Hash::repeat_byte(0xFF);
 	let peer_a = PeerId::random();
 	let hash = Hash::repeat_byte(0xAA);
+	let state = State::new(ReputationAggregator::without_delay());
 
-	let _ = test_harness(State::default(), |mut virtual_overseer| async move {
+	let _ = test_harness(state, |mut virtual_overseer| async move {
 		let overseer = &mut virtual_overseer;
 		let peer = &peer_a;
 		setup_peer_with_view(overseer, peer, view![]).await;
@@ -544,8 +547,9 @@ fn import_approval_happy_path() {
 	let peer_c = PeerId::random();
 	let parent_hash = Hash::repeat_byte(0xFF);
 	let hash = Hash::repeat_byte(0xAA);
+	let state = State::new(ReputationAggregator::without_delay());
 
-	let _ = test_harness(State::default(), |mut virtual_overseer| async move {
+	let _ = test_harness(state, |mut virtual_overseer| async move {
 		let overseer = &mut virtual_overseer;
 		// setup peers
 		setup_peer_with_view(overseer, &peer_a, view![]).await;
@@ -632,8 +636,9 @@ fn import_approval_bad() {
 	let peer_b = PeerId::random();
 	let parent_hash = Hash::repeat_byte(0xFF);
 	let hash = Hash::repeat_byte(0xAA);
+	let state = State::new(ReputationAggregator::without_delay());
 
-	let _ = test_harness(State::default(), |mut virtual_overseer| async move {
+	let _ = test_harness(state, |mut virtual_overseer| async move {
 		let overseer = &mut virtual_overseer;
 		// setup peers
 		setup_peer_with_view(overseer, &peer_a, view![]).await;
@@ -714,8 +719,9 @@ fn update_our_view() {
 	let hash_a = Hash::repeat_byte(0xAA);
 	let hash_b = Hash::repeat_byte(0xBB);
 	let hash_c = Hash::repeat_byte(0xCC);
+	let state = State::new(ReputationAggregator::without_delay());
 
-	let state = test_harness(State::default(), |mut virtual_overseer| async move {
+	let state = test_harness(state, |mut virtual_overseer| async move {
 		let overseer = &mut virtual_overseer;
 		// new block `hash_a` with 1 candidates
 		let meta_a = BlockApprovalMeta {
@@ -790,8 +796,9 @@ fn update_peer_view() {
 	let hash_d = Hash::repeat_byte(0xDD);
 	let peer_a = PeerId::random();
 	let peer = &peer_a;
+	let state = State::new(ReputationAggregator::without_delay());
 
-	let state = test_harness(State::default(), |mut virtual_overseer| async move {
+	let state = test_harness(state, |mut virtual_overseer| async move {
 		let overseer = &mut virtual_overseer;
 		// new block `hash_a` with 1 candidates
 		let meta_a = BlockApprovalMeta {
@@ -941,8 +948,9 @@ fn import_remotely_then_locally() {
 	let parent_hash = Hash::repeat_byte(0xFF);
 	let hash = Hash::repeat_byte(0xAA);
 	let peer = &peer_a;
+	let state = State::new(ReputationAggregator::without_delay());
 
-	let _ = test_harness(State::default(), |mut virtual_overseer| async move {
+	let _ = test_harness(state, |mut virtual_overseer| async move {
 		let overseer = &mut virtual_overseer;
 		// setup the peer
 		setup_peer_with_view(overseer, peer, view![hash]).await;
@@ -1028,8 +1036,9 @@ fn sends_assignments_even_when_state_is_approved() {
 	let parent_hash = Hash::repeat_byte(0xFF);
 	let hash = Hash::repeat_byte(0xAA);
 	let peer = &peer_a;
+	let state = State::new(ReputationAggregator::without_delay());
 
-	let _ = test_harness(State::default(), |mut virtual_overseer| async move {
+	let _ = test_harness(state, |mut virtual_overseer| async move {
 		let overseer = &mut virtual_overseer;
 
 		// new block `hash_a` with 1 candidates
@@ -1113,8 +1122,9 @@ fn race_condition_in_local_vs_remote_view_update() {
 	let parent_hash = Hash::repeat_byte(0xFF);
 	let peer_a = PeerId::random();
 	let hash_b = Hash::repeat_byte(0xBB);
+	let state = State::new(ReputationAggregator::without_delay());
 
-	let _ = test_harness(State::default(), |mut virtual_overseer| async move {
+	let _ = test_harness(state, |mut virtual_overseer| async move {
 		let overseer = &mut virtual_overseer;
 		let peer = &peer_a;
 
@@ -1188,8 +1198,9 @@ fn propagates_locally_generated_assignment_to_both_dimensions() {
 	let hash = Hash::repeat_byte(0xAA);
 
 	let peers = make_peers_and_authority_ids(100);
+	let state = State::new(ReputationAggregator::without_delay());
 
-	let _ = test_harness(State::default(), |mut virtual_overseer| async move {
+	let _ = test_harness(state, |mut virtual_overseer| async move {
 		let overseer = &mut virtual_overseer;
 
 		// Connect all peers.
@@ -1293,8 +1304,9 @@ fn propagates_assignments_along_unshared_dimension() {
 	let hash = Hash::repeat_byte(0xAA);
 
 	let peers = make_peers_and_authority_ids(100);
+	let state = State::new(ReputationAggregator::without_delay());
 
-	let _ = test_harness(State::default(), |mut virtual_overseer| async move {
+	let _ = test_harness(state, |mut virtual_overseer| async move {
 		let overseer = &mut virtual_overseer;
 
 		// Connect all peers.
@@ -1432,8 +1444,9 @@ fn propagates_to_required_after_connect() {
 	let hash = Hash::repeat_byte(0xAA);
 
 	let peers = make_peers_and_authority_ids(100);
+	let state = State::new(ReputationAggregator::without_delay());
 
-	let _ = test_harness(State::default(), |mut virtual_overseer| async move {
+	let _ = test_harness(state, |mut virtual_overseer| async move {
 		let overseer = &mut virtual_overseer;
 
 		let omitted = [0, 10, 50, 51];
@@ -1573,8 +1586,9 @@ fn sends_to_more_peers_after_getting_topology() {
 	let hash = Hash::repeat_byte(0xAA);
 
 	let peers = make_peers_and_authority_ids(100);
+	let state = State::new(ReputationAggregator::without_delay());
 
-	let _ = test_harness(State::default(), |mut virtual_overseer| async move {
+	let _ = test_harness(state, |mut virtual_overseer| async move {
 		let overseer = &mut virtual_overseer;
 
 		// Connect all peers except omitted.
@@ -1722,7 +1736,7 @@ fn originator_aggression_l1() {
 
 	let peers = make_peers_and_authority_ids(100);
 
-	let mut state = State::default();
+	let mut state = State::new(ReputationAggregator::without_delay());
 	state.aggression_config.resend_unfinalized_period = None;
 	let aggression_l1_threshold = state.aggression_config.l1_threshold.clone().unwrap();
 
@@ -1883,7 +1897,7 @@ fn non_originator_aggression_l1() {
 
 	let peers = make_peers_and_authority_ids(100);
 
-	let mut state = State::default();
+	let mut state = State::new(ReputationAggregator::without_delay());
 	state.aggression_config.resend_unfinalized_period = None;
 	let aggression_l1_threshold = state.aggression_config.l1_threshold.clone().unwrap();
 
@@ -1987,7 +2001,7 @@ fn non_originator_aggression_l2() {
 
 	let peers = make_peers_and_authority_ids(100);
 
-	let mut state = State::default();
+	let mut state = State::new(ReputationAggregator::without_delay());
 	state.aggression_config.resend_unfinalized_period = None;
 
 	let aggression_l1_threshold = state.aggression_config.l1_threshold.clone().unwrap();
@@ -2154,7 +2168,7 @@ fn resends_messages_periodically() {
 
 	let peers = make_peers_and_authority_ids(100);
 
-	let mut state = State::default();
+	let mut state = State::new(ReputationAggregator::without_delay());
 	state.aggression_config.l1_threshold = None;
 	state.aggression_config.l2_threshold = None;
 	state.aggression_config.resend_unfinalized_period = Some(2);
@@ -2292,7 +2306,7 @@ fn resends_messages_periodically() {
 fn batch_test_round(message_count: usize) {
 	use polkadot_node_subsystem::SubsystemContext;
 	let pool = sp_core::testing::TaskExecutor::new();
-	let mut state = State::default();
+	let mut state = State::new(ReputationAggregator::without_delay());
 
 	let (mut context, mut virtual_overseer) = test_helpers::make_subsystem_context(pool.clone());
 	let subsystem = ApprovalDistribution::new(Default::default());

--- a/node/network/approval-distribution/src/tests.rs
+++ b/node/network/approval-distribution/src/tests.rs
@@ -38,6 +38,10 @@ use std::time::Duration;
 
 type VirtualOverseer = test_helpers::TestSubsystemContextHandle<ApprovalDistributionMessage>;
 
+fn zero_delay() -> Fuse<Delay> {
+	Delay::new(std::time::Duration::from_millis(0)).fuse()
+}
+
 fn test_harness<T: Future<Output = VirtualOverseer>>(
 	mut state: State,
 	test_fn: impl FnOnce(VirtualOverseer) -> T,
@@ -53,8 +57,10 @@ fn test_harness<T: Future<Output = VirtualOverseer>>(
 	let subsystem = ApprovalDistribution::new(Default::default());
 	{
 		let mut rng = rand_chacha::ChaCha12Rng::seed_from_u64(12345);
+		let mut rep_aggregator = ReputationAggregator::new();
 
-		let subsystem = subsystem.run_inner(context, &mut state, &mut rng);
+		let subsystem =
+			subsystem.run_inner(context, &mut state, &mut rep_aggregator, zero_delay, &mut rng);
 
 		let test_fut = test_fn(virtual_overseer);
 
@@ -300,7 +306,7 @@ fn try_import_the_same_assignment() {
 	let peer_d = PeerId::random();
 	let parent_hash = Hash::repeat_byte(0xFF);
 	let hash = Hash::repeat_byte(0xAA);
-	let state = State::new(ReputationAggregator::without_delay());
+	let state = State::default();
 
 	let _ = test_harness(state, |mut virtual_overseer| async move {
 		let overseer = &mut virtual_overseer;
@@ -385,7 +391,7 @@ fn spam_attack_results_in_negative_reputation_change() {
 	let parent_hash = Hash::repeat_byte(0xFF);
 	let peer_a = PeerId::random();
 	let hash_b = Hash::repeat_byte(0xBB);
-	let state = State::new(ReputationAggregator::without_delay());
+	let state = State::default();
 
 	let _ = test_harness(state, |mut virtual_overseer| async move {
 		let overseer = &mut virtual_overseer;
@@ -470,7 +476,7 @@ fn peer_sending_us_the_same_we_just_sent_them_is_ok() {
 	let parent_hash = Hash::repeat_byte(0xFF);
 	let peer_a = PeerId::random();
 	let hash = Hash::repeat_byte(0xAA);
-	let state = State::new(ReputationAggregator::without_delay());
+	let state = State::default();
 
 	let _ = test_harness(state, |mut virtual_overseer| async move {
 		let overseer = &mut virtual_overseer;
@@ -547,7 +553,7 @@ fn import_approval_happy_path() {
 	let peer_c = PeerId::random();
 	let parent_hash = Hash::repeat_byte(0xFF);
 	let hash = Hash::repeat_byte(0xAA);
-	let state = State::new(ReputationAggregator::without_delay());
+	let state = State::default();
 
 	let _ = test_harness(state, |mut virtual_overseer| async move {
 		let overseer = &mut virtual_overseer;
@@ -636,7 +642,7 @@ fn import_approval_bad() {
 	let peer_b = PeerId::random();
 	let parent_hash = Hash::repeat_byte(0xFF);
 	let hash = Hash::repeat_byte(0xAA);
-	let state = State::new(ReputationAggregator::without_delay());
+	let state = State::default();
 
 	let _ = test_harness(state, |mut virtual_overseer| async move {
 		let overseer = &mut virtual_overseer;
@@ -719,7 +725,7 @@ fn update_our_view() {
 	let hash_a = Hash::repeat_byte(0xAA);
 	let hash_b = Hash::repeat_byte(0xBB);
 	let hash_c = Hash::repeat_byte(0xCC);
-	let state = State::new(ReputationAggregator::without_delay());
+	let state = State::default();
 
 	let state = test_harness(state, |mut virtual_overseer| async move {
 		let overseer = &mut virtual_overseer;
@@ -796,7 +802,7 @@ fn update_peer_view() {
 	let hash_d = Hash::repeat_byte(0xDD);
 	let peer_a = PeerId::random();
 	let peer = &peer_a;
-	let state = State::new(ReputationAggregator::without_delay());
+	let state = State::default();
 
 	let state = test_harness(state, |mut virtual_overseer| async move {
 		let overseer = &mut virtual_overseer;
@@ -948,7 +954,7 @@ fn import_remotely_then_locally() {
 	let parent_hash = Hash::repeat_byte(0xFF);
 	let hash = Hash::repeat_byte(0xAA);
 	let peer = &peer_a;
-	let state = State::new(ReputationAggregator::without_delay());
+	let state = State::default();
 
 	let _ = test_harness(state, |mut virtual_overseer| async move {
 		let overseer = &mut virtual_overseer;
@@ -1036,7 +1042,7 @@ fn sends_assignments_even_when_state_is_approved() {
 	let parent_hash = Hash::repeat_byte(0xFF);
 	let hash = Hash::repeat_byte(0xAA);
 	let peer = &peer_a;
-	let state = State::new(ReputationAggregator::without_delay());
+	let state = State::default();
 
 	let _ = test_harness(state, |mut virtual_overseer| async move {
 		let overseer = &mut virtual_overseer;
@@ -1122,7 +1128,7 @@ fn race_condition_in_local_vs_remote_view_update() {
 	let parent_hash = Hash::repeat_byte(0xFF);
 	let peer_a = PeerId::random();
 	let hash_b = Hash::repeat_byte(0xBB);
-	let state = State::new(ReputationAggregator::without_delay());
+	let state = State::default();
 
 	let _ = test_harness(state, |mut virtual_overseer| async move {
 		let overseer = &mut virtual_overseer;
@@ -1198,7 +1204,7 @@ fn propagates_locally_generated_assignment_to_both_dimensions() {
 	let hash = Hash::repeat_byte(0xAA);
 
 	let peers = make_peers_and_authority_ids(100);
-	let state = State::new(ReputationAggregator::without_delay());
+	let state = State::default();
 
 	let _ = test_harness(state, |mut virtual_overseer| async move {
 		let overseer = &mut virtual_overseer;
@@ -1304,7 +1310,7 @@ fn propagates_assignments_along_unshared_dimension() {
 	let hash = Hash::repeat_byte(0xAA);
 
 	let peers = make_peers_and_authority_ids(100);
-	let state = State::new(ReputationAggregator::without_delay());
+	let state = State::default();
 
 	let _ = test_harness(state, |mut virtual_overseer| async move {
 		let overseer = &mut virtual_overseer;
@@ -1444,7 +1450,7 @@ fn propagates_to_required_after_connect() {
 	let hash = Hash::repeat_byte(0xAA);
 
 	let peers = make_peers_and_authority_ids(100);
-	let state = State::new(ReputationAggregator::without_delay());
+	let state = State::default();
 
 	let _ = test_harness(state, |mut virtual_overseer| async move {
 		let overseer = &mut virtual_overseer;
@@ -1586,7 +1592,7 @@ fn sends_to_more_peers_after_getting_topology() {
 	let hash = Hash::repeat_byte(0xAA);
 
 	let peers = make_peers_and_authority_ids(100);
-	let state = State::new(ReputationAggregator::without_delay());
+	let state = State::default();
 
 	let _ = test_harness(state, |mut virtual_overseer| async move {
 		let overseer = &mut virtual_overseer;
@@ -1736,7 +1742,7 @@ fn originator_aggression_l1() {
 
 	let peers = make_peers_and_authority_ids(100);
 
-	let mut state = State::new(ReputationAggregator::without_delay());
+	let mut state = State::default();
 	state.aggression_config.resend_unfinalized_period = None;
 	let aggression_l1_threshold = state.aggression_config.l1_threshold.clone().unwrap();
 
@@ -1897,7 +1903,7 @@ fn non_originator_aggression_l1() {
 
 	let peers = make_peers_and_authority_ids(100);
 
-	let mut state = State::new(ReputationAggregator::without_delay());
+	let mut state = State::default();
 	state.aggression_config.resend_unfinalized_period = None;
 	let aggression_l1_threshold = state.aggression_config.l1_threshold.clone().unwrap();
 
@@ -2001,7 +2007,7 @@ fn non_originator_aggression_l2() {
 
 	let peers = make_peers_and_authority_ids(100);
 
-	let mut state = State::new(ReputationAggregator::without_delay());
+	let mut state = State::default();
 	state.aggression_config.resend_unfinalized_period = None;
 
 	let aggression_l1_threshold = state.aggression_config.l1_threshold.clone().unwrap();
@@ -2168,7 +2174,7 @@ fn resends_messages_periodically() {
 
 	let peers = make_peers_and_authority_ids(100);
 
-	let mut state = State::new(ReputationAggregator::without_delay());
+	let mut state = State::default();
 	state.aggression_config.l1_threshold = None;
 	state.aggression_config.l2_threshold = None;
 	state.aggression_config.resend_unfinalized_period = Some(2);
@@ -2306,13 +2312,15 @@ fn resends_messages_periodically() {
 fn batch_test_round(message_count: usize) {
 	use polkadot_node_subsystem::SubsystemContext;
 	let pool = sp_core::testing::TaskExecutor::new();
-	let mut state = State::new(ReputationAggregator::without_delay());
+	let mut state = State::default();
+	let mut rep_aggregator = ReputationAggregator::new();
 
 	let (mut context, mut virtual_overseer) = test_helpers::make_subsystem_context(pool.clone());
 	let subsystem = ApprovalDistribution::new(Default::default());
 	let mut rng = rand_chacha::ChaCha12Rng::seed_from_u64(12345);
 	let mut sender = context.sender().clone();
-	let subsystem = subsystem.run_inner(context, &mut state, &mut rng);
+	let subsystem =
+		subsystem.run_inner(context, &mut state, &mut rep_aggregator, zero_delay, &mut rng);
 
 	let test_fut = async move {
 		let overseer = &mut virtual_overseer;

--- a/node/network/approval-distribution/src/tests.rs
+++ b/node/network/approval-distribution/src/tests.rs
@@ -304,7 +304,7 @@ fn try_import_the_same_assignment() {
 	let reputation = ReputationAggregator::new(|rep| {
 		matches!(rep, COST_UNEXPECTED_MESSAGE | BENEFIT_VALID_MESSAGE_FIRST | BENEFIT_VALID_MESSAGE)
 	});
-	let state = State::new(reputation);
+	let state = State { reputation, ..Default::default() };
 
 	let _ = test_harness(state, |mut virtual_overseer| async move {
 		let overseer = &mut virtual_overseer;
@@ -392,7 +392,7 @@ fn spam_attack_results_in_negative_reputation_change() {
 	let reputation = ReputationAggregator::new(|rep| {
 		matches!(rep, COST_UNEXPECTED_MESSAGE | BENEFIT_VALID_MESSAGE_FIRST | BENEFIT_VALID_MESSAGE)
 	});
-	let state = State::new(reputation);
+	let state = State { reputation, ..Default::default() };
 
 	let _ = test_harness(state, |mut virtual_overseer| async move {
 		let overseer = &mut virtual_overseer;
@@ -478,7 +478,7 @@ fn peer_sending_us_the_same_we_just_sent_them_is_ok() {
 	let peer_a = PeerId::random();
 	let hash = Hash::repeat_byte(0xAA);
 	let reputation = ReputationAggregator::new(|rep| matches!(rep, COST_DUPLICATE_MESSAGE));
-	let state = State::new(reputation);
+	let state = State { reputation, ..Default::default() };
 
 	let _ = test_harness(state, |mut virtual_overseer| async move {
 		let overseer = &mut virtual_overseer;
@@ -556,7 +556,7 @@ fn import_approval_happy_path() {
 	let parent_hash = Hash::repeat_byte(0xFF);
 	let hash = Hash::repeat_byte(0xAA);
 	let reputation = ReputationAggregator::new(|rep| matches!(rep, BENEFIT_VALID_MESSAGE_FIRST));
-	let state = State::new(reputation);
+	let state = State { reputation, ..Default::default() };
 
 	let _ = test_harness(state, |mut virtual_overseer| async move {
 		let overseer = &mut virtual_overseer;
@@ -648,7 +648,7 @@ fn import_approval_bad() {
 	let reputation = ReputationAggregator::new(|rep| {
 		matches!(rep, COST_UNEXPECTED_MESSAGE | BENEFIT_VALID_MESSAGE_FIRST | COST_INVALID_MESSAGE)
 	});
-	let state = State::new(reputation);
+	let state = State { reputation, ..Default::default() };
 
 	let _ = test_harness(state, |mut virtual_overseer| async move {
 		let overseer = &mut virtual_overseer;
@@ -959,7 +959,7 @@ fn import_remotely_then_locally() {
 	let hash = Hash::repeat_byte(0xAA);
 	let peer = &peer_a;
 	let reputation = ReputationAggregator::new(|rep| matches!(rep, BENEFIT_VALID_MESSAGE_FIRST));
-	let state = State::new(reputation);
+	let state = State { reputation, ..Default::default() };
 
 	let _ = test_harness(state, |mut virtual_overseer| async move {
 		let overseer = &mut virtual_overseer;
@@ -1133,7 +1133,7 @@ fn race_condition_in_local_vs_remote_view_update() {
 	let peer_a = PeerId::random();
 	let hash_b = Hash::repeat_byte(0xBB);
 	let reputation = ReputationAggregator::new(|rep| matches!(rep, BENEFIT_VALID_MESSAGE_FIRST));
-	let state = State::new(reputation);
+	let state = State { reputation, ..Default::default() };
 
 	let _ = test_harness(state, |mut virtual_overseer| async move {
 		let overseer = &mut virtual_overseer;
@@ -1315,7 +1315,7 @@ fn propagates_assignments_along_unshared_dimension() {
 
 	let peers = make_peers_and_authority_ids(100);
 	let reputation = ReputationAggregator::new(|rep| matches!(rep, BENEFIT_VALID_MESSAGE_FIRST));
-	let state = State::new(reputation);
+	let state = State { reputation, ..Default::default() };
 
 	let _ = test_harness(state, |mut virtual_overseer| async move {
 		let overseer = &mut virtual_overseer;
@@ -1907,7 +1907,7 @@ fn non_originator_aggression_l1() {
 	let peers = make_peers_and_authority_ids(100);
 
 	let reputation = ReputationAggregator::new(|rep| matches!(rep, BENEFIT_VALID_MESSAGE_FIRST));
-	let mut state = State::new(reputation);
+	let mut state = State { reputation, ..Default::default() };
 	state.aggression_config.resend_unfinalized_period = None;
 	let aggression_l1_threshold = state.aggression_config.l1_threshold.clone().unwrap();
 
@@ -2012,7 +2012,7 @@ fn non_originator_aggression_l2() {
 	let peers = make_peers_and_authority_ids(100);
 
 	let reputation = ReputationAggregator::new(|rep| matches!(rep, BENEFIT_VALID_MESSAGE_FIRST));
-	let mut state = State::new(reputation);
+	let mut state = State { reputation, ..Default::default() };
 	state.aggression_config.resend_unfinalized_period = None;
 
 	let aggression_l1_threshold = state.aggression_config.l1_threshold.clone().unwrap();
@@ -2180,7 +2180,7 @@ fn resends_messages_periodically() {
 	let peers = make_peers_and_authority_ids(100);
 
 	let reputation = ReputationAggregator::new(|rep| matches!(rep, BENEFIT_VALID_MESSAGE_FIRST));
-	let mut state = State::new(reputation);
+	let mut state = State { reputation, ..Default::default() };
 	state.aggression_config.l1_threshold = None;
 	state.aggression_config.l2_threshold = None;
 	state.aggression_config.resend_unfinalized_period = Some(2);

--- a/node/network/approval-distribution/src/tests.rs
+++ b/node/network/approval-distribution/src/tests.rs
@@ -38,10 +38,6 @@ use std::time::Duration;
 
 type VirtualOverseer = test_helpers::TestSubsystemContextHandle<ApprovalDistributionMessage>;
 
-fn zero_delay() -> Fuse<Delay> {
-	Delay::new(std::time::Duration::from_millis(0)).fuse()
-}
-
 fn test_harness<T: Future<Output = VirtualOverseer>>(
 	mut state: State,
 	test_fn: impl FnOnce(VirtualOverseer) -> T,
@@ -59,8 +55,13 @@ fn test_harness<T: Future<Output = VirtualOverseer>>(
 		let mut rng = rand_chacha::ChaCha12Rng::seed_from_u64(12345);
 		let mut reputation = ReputationAggregator::new();
 
-		let subsystem =
-			subsystem.run_inner(context, &mut state, &mut reputation, zero_delay, &mut rng);
+		let subsystem = subsystem.run_inner(
+			context,
+			&mut state,
+			&mut reputation,
+			std::time::Duration::from_millis(0),
+			&mut rng,
+		);
 
 		let test_fut = test_fn(virtual_overseer);
 
@@ -2330,7 +2331,13 @@ fn batch_test_round(message_count: usize) {
 	let subsystem = ApprovalDistribution::new(Default::default());
 	let mut rng = rand_chacha::ChaCha12Rng::seed_from_u64(12345);
 	let mut sender = context.sender().clone();
-	let subsystem = subsystem.run_inner(context, &mut state, &mut reputation, zero_delay, &mut rng);
+	let subsystem = subsystem.run_inner(
+		context,
+		&mut state,
+		&mut reputation,
+		std::time::Duration::from_millis(0),
+		&mut rng,
+	);
 
 	let test_fut = async move {
 		let overseer = &mut virtual_overseer;

--- a/node/network/approval-distribution/src/tests.rs
+++ b/node/network/approval-distribution/src/tests.rs
@@ -409,7 +409,7 @@ fn try_import_the_same_assignment() {
 
 /// import an assignment
 /// connect a new peer
-/// the new peer sends us the same assignment
+/// state sends aggregated reputation change
 #[test]
 fn delay_reputation_change() {
 	let peer = PeerId::random();
@@ -1384,6 +1384,7 @@ fn propagates_locally_generated_assignment_to_both_dimensions() {
 fn propagates_assignments_along_unshared_dimension() {
 	let parent_hash = Hash::repeat_byte(0xFF);
 	let hash = Hash::repeat_byte(0xAA);
+
 	let peers = make_peers_and_authority_ids(100);
 
 	let _ = test_harness(state_without_reputation_delay(), |mut virtual_overseer| async move {
@@ -1972,6 +1973,7 @@ fn originator_aggression_l1() {
 fn non_originator_aggression_l1() {
 	let parent_hash = Hash::repeat_byte(0xFF);
 	let hash = Hash::repeat_byte(0xAA);
+
 	let peers = make_peers_and_authority_ids(100);
 
 	let mut state = state_without_reputation_delay();
@@ -2075,6 +2077,7 @@ fn non_originator_aggression_l1() {
 fn non_originator_aggression_l2() {
 	let parent_hash = Hash::repeat_byte(0xFF);
 	let hash = Hash::repeat_byte(0xAA);
+
 	let peers = make_peers_and_authority_ids(100);
 
 	let mut state = state_without_reputation_delay();
@@ -2241,6 +2244,7 @@ fn non_originator_aggression_l2() {
 fn resends_messages_periodically() {
 	let parent_hash = Hash::repeat_byte(0xFF);
 	let hash = Hash::repeat_byte(0xAA);
+
 	let peers = make_peers_and_authority_ids(100);
 
 	let mut state = state_without_reputation_delay();

--- a/node/network/approval-distribution/src/tests.rs
+++ b/node/network/approval-distribution/src/tests.rs
@@ -53,15 +53,9 @@ fn test_harness<T: Future<Output = VirtualOverseer>>(
 	let subsystem = ApprovalDistribution::new(Default::default());
 	{
 		let mut rng = rand_chacha::ChaCha12Rng::seed_from_u64(12345);
-		let mut reputation = ReputationAggregator::new();
 
-		let subsystem = subsystem.run_inner(
-			context,
-			&mut state,
-			&mut reputation,
-			std::time::Duration::from_millis(0),
-			&mut rng,
-		);
+		let subsystem =
+			subsystem.run_inner(context, &mut state, std::time::Duration::from_millis(0), &mut rng);
 
 		let test_fut = test_fn(virtual_overseer);
 
@@ -2325,19 +2319,13 @@ fn batch_test_round(message_count: usize) {
 	use polkadot_node_subsystem::SubsystemContext;
 	let pool = sp_core::testing::TaskExecutor::new();
 	let mut state = State::default();
-	let mut reputation = ReputationAggregator::new();
 
 	let (mut context, mut virtual_overseer) = test_helpers::make_subsystem_context(pool.clone());
 	let subsystem = ApprovalDistribution::new(Default::default());
 	let mut rng = rand_chacha::ChaCha12Rng::seed_from_u64(12345);
 	let mut sender = context.sender().clone();
-	let subsystem = subsystem.run_inner(
-		context,
-		&mut state,
-		&mut reputation,
-		std::time::Duration::from_millis(0),
-		&mut rng,
-	);
+	let subsystem =
+		subsystem.run_inner(context, &mut state, std::time::Duration::from_millis(0), &mut rng);
 
 	let test_fut = async move {
 		let overseer = &mut virtual_overseer;

--- a/node/network/approval-distribution/src/tests.rs
+++ b/node/network/approval-distribution/src/tests.rs
@@ -55,7 +55,7 @@ fn test_harness<T: Future<Output = VirtualOverseer>>(
 		let mut rng = rand_chacha::ChaCha12Rng::seed_from_u64(12345);
 
 		let subsystem =
-			subsystem.run_inner(context, &mut state, REPUTATION_CHANGE_INTERVAL, &mut rng);
+			subsystem.run_inner(context, &mut state, REPUTATION_CHANGE_TEST_INTERVAL, &mut rng);
 
 		let test_fut = test_fn(virtual_overseer);
 
@@ -79,7 +79,7 @@ fn test_harness<T: Future<Output = VirtualOverseer>>(
 }
 
 const TIMEOUT: Duration = Duration::from_millis(200);
-const REPUTATION_CHANGE_INTERVAL: Duration = Duration::from_millis(1);
+const REPUTATION_CHANGE_TEST_INTERVAL: Duration = Duration::from_millis(1);
 
 async fn overseer_send(overseer: &mut VirtualOverseer, msg: ApprovalDistributionMessage) {
 	gum::trace!(msg = ?msg, "Sending message");
@@ -2391,7 +2391,8 @@ fn batch_test_round(message_count: usize) {
 	let subsystem = ApprovalDistribution::new(Default::default());
 	let mut rng = rand_chacha::ChaCha12Rng::seed_from_u64(12345);
 	let mut sender = context.sender().clone();
-	let subsystem = subsystem.run_inner(context, &mut state, REPUTATION_CHANGE_INTERVAL, &mut rng);
+	let subsystem =
+		subsystem.run_inner(context, &mut state, REPUTATION_CHANGE_TEST_INTERVAL, &mut rng);
 
 	let test_fut = async move {
 		let overseer = &mut virtual_overseer;

--- a/node/network/approval-distribution/src/tests.rs
+++ b/node/network/approval-distribution/src/tests.rs
@@ -731,10 +731,8 @@ fn update_our_view() {
 	let hash_a = Hash::repeat_byte(0xAA);
 	let hash_b = Hash::repeat_byte(0xBB);
 	let hash_c = Hash::repeat_byte(0xCC);
-	let reputation = ReputationAggregator::new(|_rep| false);
-	let state = State::new(reputation);
 
-	let state = test_harness(state, |mut virtual_overseer| async move {
+	let state = test_harness(State::default(), |mut virtual_overseer| async move {
 		let overseer = &mut virtual_overseer;
 		// new block `hash_a` with 1 candidates
 		let meta_a = BlockApprovalMeta {
@@ -809,10 +807,8 @@ fn update_peer_view() {
 	let hash_d = Hash::repeat_byte(0xDD);
 	let peer_a = PeerId::random();
 	let peer = &peer_a;
-	let reputation = ReputationAggregator::new(|_rep| false);
-	let state = State::new(reputation);
 
-	let state = test_harness(state, |mut virtual_overseer| async move {
+	let state = test_harness(State::default(), |mut virtual_overseer| async move {
 		let overseer = &mut virtual_overseer;
 		// new block `hash_a` with 1 candidates
 		let meta_a = BlockApprovalMeta {
@@ -1051,10 +1047,8 @@ fn sends_assignments_even_when_state_is_approved() {
 	let parent_hash = Hash::repeat_byte(0xFF);
 	let hash = Hash::repeat_byte(0xAA);
 	let peer = &peer_a;
-	let reputation = ReputationAggregator::new(|_rep| false);
-	let state = State::new(reputation);
 
-	let _ = test_harness(state, |mut virtual_overseer| async move {
+	let _ = test_harness(State::default(), |mut virtual_overseer| async move {
 		let overseer = &mut virtual_overseer;
 
 		// new block `hash_a` with 1 candidates
@@ -1215,10 +1209,8 @@ fn propagates_locally_generated_assignment_to_both_dimensions() {
 	let hash = Hash::repeat_byte(0xAA);
 
 	let peers = make_peers_and_authority_ids(100);
-	let reputation = ReputationAggregator::new(|_rep| false);
-	let state = State::new(reputation);
 
-	let _ = test_harness(state, |mut virtual_overseer| async move {
+	let _ = test_harness(State::default(), |mut virtual_overseer| async move {
 		let overseer = &mut virtual_overseer;
 
 		// Connect all peers.
@@ -1463,10 +1455,8 @@ fn propagates_to_required_after_connect() {
 	let hash = Hash::repeat_byte(0xAA);
 
 	let peers = make_peers_and_authority_ids(100);
-	let reputation = ReputationAggregator::new(|_rep| false);
-	let state = State::new(reputation);
 
-	let _ = test_harness(state, |mut virtual_overseer| async move {
+	let _ = test_harness(State::default(), |mut virtual_overseer| async move {
 		let overseer = &mut virtual_overseer;
 
 		let omitted = [0, 10, 50, 51];
@@ -1606,10 +1596,8 @@ fn sends_to_more_peers_after_getting_topology() {
 	let hash = Hash::repeat_byte(0xAA);
 
 	let peers = make_peers_and_authority_ids(100);
-	let reputation = ReputationAggregator::new(|_rep| false);
-	let state = State::new(reputation);
 
-	let _ = test_harness(state, |mut virtual_overseer| async move {
+	let _ = test_harness(State::default(), |mut virtual_overseer| async move {
 		let overseer = &mut virtual_overseer;
 
 		// Connect all peers except omitted.
@@ -1757,8 +1745,7 @@ fn originator_aggression_l1() {
 
 	let peers = make_peers_and_authority_ids(100);
 
-	let reputation = ReputationAggregator::new(|_rep| false);
-	let mut state = State::new(reputation);
+	let mut state = State::default();
 	state.aggression_config.resend_unfinalized_period = None;
 	let aggression_l1_threshold = state.aggression_config.l1_threshold.clone().unwrap();
 
@@ -2331,8 +2318,7 @@ fn resends_messages_periodically() {
 fn batch_test_round(message_count: usize) {
 	use polkadot_node_subsystem::SubsystemContext;
 	let pool = sp_core::testing::TaskExecutor::new();
-	let reputation = ReputationAggregator::new(|_rep| false);
-	let mut state = State::new(reputation);
+	let mut state = State::default();
 
 	let (mut context, mut virtual_overseer) = test_helpers::make_subsystem_context(pool.clone());
 	let subsystem = ApprovalDistribution::new(Default::default());

--- a/node/network/bitfield-distribution/Cargo.toml
+++ b/node/network/bitfield-distribution/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 
 [dependencies]
 futures = "0.3.21"
+futures-timer = "3.0.2"
 gum = { package = "tracing-gum", path = "../../gum" }
 polkadot-primitives = { path = "../../../primitives" }
 polkadot-node-subsystem = {path = "../../subsystem" }

--- a/node/network/bitfield-distribution/src/lib.rs
+++ b/node/network/bitfield-distribution/src/lib.rs
@@ -209,9 +209,8 @@ impl BitfieldDistribution {
 					state.reputation.send(ctx.sender()).await;
 					reputation_delay = new_reputation_delay();
 				},
-				// Will run if no futures are immediately ready
-				default => {
-					let message = match ctx.recv().await {
+				message = ctx.recv().fuse() => {
+					let message = match message {
 						Ok(message) => message,
 						Err(err) => {
 							gum::error!(

--- a/node/network/bitfield-distribution/src/lib.rs
+++ b/node/network/bitfield-distribution/src/lib.rs
@@ -35,7 +35,10 @@ use polkadot_node_subsystem::{
 	jaeger, messages::*, overseer, ActiveLeavesUpdate, FromOrchestra, OverseerSignal, PerLeafSpan,
 	SpawnedSubsystem, SubsystemError, SubsystemResult,
 };
-use polkadot_node_subsystem_util::{self as util, reputation::ReputationAggregator};
+use polkadot_node_subsystem_util::{
+	self as util,
+	reputation::{ReputationAggregator, REPUTATION_CHANGE_INTERVAL},
+};
 
 use futures::select;
 use polkadot_primitives::{Hash, SignedAvailabilityBitfield, SigningContext, ValidatorId};
@@ -168,7 +171,7 @@ impl PerRelayParentData {
 }
 
 const LOG_TARGET: &str = "parachain::bitfield-distribution";
-const REPUTATION_CHANGE_INTERVAL: Duration = Duration::from_secs(30);
+
 /// The bitfield distribution subsystem.
 pub struct BitfieldDistribution {
 	metrics: Metrics,

--- a/node/network/bitfield-distribution/src/tests.rs
+++ b/node/network/bitfield-distribution/src/tests.rs
@@ -87,7 +87,7 @@ fn prewarmed_state(
 		peer_views: peers.iter().cloned().map(|peer| (peer, view!(relay_parent))).collect(),
 		topologies,
 		view: our_view!(relay_parent),
-		reputation: ReputationAggregator::new(|_| false),
+		reputation: ReputationAggregator::new(|_| true),
 	}
 }
 
@@ -95,7 +95,8 @@ fn state_with_view(
 	view: OurView,
 	relay_parent: Hash,
 ) -> (ProtocolState, SigningContext, KeystorePtr, ValidatorId) {
-	let mut state = ProtocolState::default();
+	let mut state =
+		ProtocolState { reputation: ReputationAggregator::new(|_| true), ..Default::default() };
 
 	let signing_context = SigningContext { session_index: 1, parent_hash: relay_parent.clone() };
 

--- a/node/network/bitfield-distribution/src/tests.rs
+++ b/node/network/bitfield-distribution/src/tests.rs
@@ -500,9 +500,6 @@ fn delay_reputation_change() {
 			}
 		);
 
-		// Wait enough to fire reputation delay
-		futures_timer::Delay::new(reputation_interval).await;
-
 		// let peer send the initial message again
 		handle
 			.send(FromOrchestra::Communication {
@@ -514,6 +511,9 @@ fn delay_reputation_change() {
 				),
 			})
 			.await;
+
+		// Wait enough to fire reputation delay
+		futures_timer::Delay::new(reputation_interval).await;
 
 		let expected_change = vec![BENEFIT_VALID_MESSAGE_FIRST, COST_PEER_DUPLICATE_MESSAGE]
 			.iter()

--- a/node/network/bitfield-distribution/src/tests.rs
+++ b/node/network/bitfield-distribution/src/tests.rs
@@ -87,6 +87,7 @@ fn prewarmed_state(
 		peer_views: peers.iter().cloned().map(|peer| (peer, view!(relay_parent))).collect(),
 		topologies,
 		view: our_view!(relay_parent),
+		reputation: ReputationAggregator::new(|_| false),
 	}
 }
 
@@ -237,7 +238,7 @@ fn receive_invalid_signature() {
 				NetworkBridgeTxMessage::ReportPeer(peer, rep)
 			) => {
 				assert_eq!(peer, peer_b);
-				assert_eq!(rep, COST_SIGNATURE_INVALID)
+				assert_eq!(rep.value, COST_SIGNATURE_INVALID.cost_or_benefit())
 			}
 		);
 	});
@@ -298,7 +299,7 @@ fn receive_invalid_validator_index() {
 				NetworkBridgeTxMessage::ReportPeer(peer, rep)
 			) => {
 				assert_eq!(peer, peer_b);
-				assert_eq!(rep, COST_VALIDATOR_INDEX_INVALID)
+				assert_eq!(rep.value, COST_VALIDATOR_INDEX_INVALID.cost_or_benefit())
 			}
 		);
 	});
@@ -374,7 +375,7 @@ fn receive_duplicate_messages() {
 				NetworkBridgeTxMessage::ReportPeer(peer, rep)
 			) => {
 				assert_eq!(peer, peer_b);
-				assert_eq!(rep, BENEFIT_VALID_MESSAGE_FIRST)
+				assert_eq!(rep.value, BENEFIT_VALID_MESSAGE_FIRST.cost_or_benefit())
 			}
 		);
 
@@ -393,7 +394,7 @@ fn receive_duplicate_messages() {
 				NetworkBridgeTxMessage::ReportPeer(peer, rep)
 			) => {
 				assert_eq!(peer, peer_a);
-				assert_eq!(rep, BENEFIT_VALID_MESSAGE)
+				assert_eq!(rep.value, BENEFIT_VALID_MESSAGE.cost_or_benefit())
 			}
 		);
 
@@ -412,7 +413,7 @@ fn receive_duplicate_messages() {
 				NetworkBridgeTxMessage::ReportPeer(peer, rep)
 			) => {
 				assert_eq!(peer, peer_b);
-				assert_eq!(rep, COST_PEER_DUPLICATE_MESSAGE)
+				assert_eq!(rep.value, COST_PEER_DUPLICATE_MESSAGE.cost_or_benefit())
 			}
 		);
 	});
@@ -621,7 +622,7 @@ fn changing_view() {
 				NetworkBridgeTxMessage::ReportPeer(peer, rep)
 			) => {
 				assert_eq!(peer, peer_b);
-				assert_eq!(rep, BENEFIT_VALID_MESSAGE_FIRST)
+				assert_eq!(rep.value, BENEFIT_VALID_MESSAGE_FIRST.cost_or_benefit())
 			}
 		);
 
@@ -653,7 +654,7 @@ fn changing_view() {
 				NetworkBridgeTxMessage::ReportPeer(peer, rep)
 			) => {
 				assert_eq!(peer, peer_b);
-				assert_eq!(rep, COST_PEER_DUPLICATE_MESSAGE)
+				assert_eq!(rep.value, COST_PEER_DUPLICATE_MESSAGE.cost_or_benefit())
 			}
 		);
 
@@ -685,7 +686,7 @@ fn changing_view() {
 				NetworkBridgeTxMessage::ReportPeer(peer, rep)
 			) => {
 				assert_eq!(peer, peer_a);
-				assert_eq!(rep, COST_NOT_IN_VIEW)
+				assert_eq!(rep.value, COST_NOT_IN_VIEW.cost_or_benefit())
 			}
 		);
 	});
@@ -770,7 +771,7 @@ fn do_not_send_message_back_to_origin() {
 				NetworkBridgeTxMessage::ReportPeer(peer, rep)
 			) => {
 				assert_eq!(peer, peer_b);
-				assert_eq!(rep, BENEFIT_VALID_MESSAGE_FIRST)
+				assert_eq!(rep.value, BENEFIT_VALID_MESSAGE_FIRST.cost_or_benefit())
 			}
 		);
 	});
@@ -891,7 +892,7 @@ fn topology_test() {
 				NetworkBridgeTxMessage::ReportPeer(peer, rep)
 			) => {
 				assert_eq!(peer, peers_x[0]);
-				assert_eq!(rep, BENEFIT_VALID_MESSAGE_FIRST)
+				assert_eq!(rep.value, BENEFIT_VALID_MESSAGE_FIRST.cost_or_benefit())
 			}
 		);
 	});

--- a/node/network/bridge/src/metrics.rs
+++ b/node/network/bridge/src/metrics.rs
@@ -103,10 +103,9 @@ impl Metrics {
 		});
 	}
 
-	pub fn on_report_event(&self, by: u64) {
+	pub fn on_report_event(&self) {
 		if let Some(metrics) = self.0.as_ref() {
-			metrics.report_events.inc();
-			metrics.aggregated_report_events.inc_by(by);
+			metrics.report_events.inc()
 		}
 	}
 }
@@ -118,7 +117,6 @@ pub(crate) struct MetricsInner {
 	disconnected_events: prometheus::CounterVec<prometheus::U64>,
 	desired_peer_count: prometheus::GaugeVec<prometheus::U64>,
 	report_events: prometheus::Counter<prometheus::U64>,
-	aggregated_report_events: prometheus::Counter<prometheus::U64>,
 
 	notifications_received: prometheus::CounterVec<prometheus::U64>,
 	notifications_sent: prometheus::CounterVec<prometheus::U64>,
@@ -176,13 +174,6 @@ impl metrics::Metrics for Metrics {
 				prometheus::Counter::new(
 					"polkadot_parachain_network_report_events_total",
 					"The amount of reputation changes issued by subsystems",
-				)?,
-				registry,
-			)?,
-			aggregated_report_events: prometheus::register(
-				prometheus::Counter::new(
-					"polkadot_parachain_network_aggregated_report_events_total",
-					"The amount of original reputation changes issued by subsystems",
 				)?,
 				registry,
 			)?,

--- a/node/network/bridge/src/metrics.rs
+++ b/node/network/bridge/src/metrics.rs
@@ -103,9 +103,10 @@ impl Metrics {
 		});
 	}
 
-	pub fn on_report_event(&self) {
+	pub fn on_report_event(&self, by: u64) {
 		if let Some(metrics) = self.0.as_ref() {
-			metrics.report_events.inc()
+			metrics.report_events.inc();
+			metrics.aggregated_report_events.inc_by(by);
 		}
 	}
 }
@@ -117,6 +118,7 @@ pub(crate) struct MetricsInner {
 	disconnected_events: prometheus::CounterVec<prometheus::U64>,
 	desired_peer_count: prometheus::GaugeVec<prometheus::U64>,
 	report_events: prometheus::Counter<prometheus::U64>,
+	aggregated_report_events: prometheus::Counter<prometheus::U64>,
 
 	notifications_received: prometheus::CounterVec<prometheus::U64>,
 	notifications_sent: prometheus::CounterVec<prometheus::U64>,
@@ -174,6 +176,13 @@ impl metrics::Metrics for Metrics {
 				prometheus::Counter::new(
 					"polkadot_parachain_network_report_events_total",
 					"The amount of reputation changes issued by subsystems",
+				)?,
+				registry,
+			)?,
+			aggregated_report_events: prometheus::register(
+				prometheus::Counter::new(
+					"polkadot_parachain_network_aggregated_report_events_total",
+					"The amount of original reputation changes issued by subsystems",
 				)?,
 				registry,
 			)?,

--- a/node/network/bridge/src/network.rs
+++ b/node/network/bridge/src/network.rs
@@ -24,13 +24,13 @@ use parity_scale_codec::Encode;
 use sc_network::{
 	config::parse_addr, multiaddr::Multiaddr, types::ProtocolName, Event as NetworkEvent,
 	IfDisconnected, NetworkEventStream, NetworkNotification, NetworkPeers, NetworkRequest,
-	NetworkService, OutboundFailure, RequestFailure,
+	NetworkService, OutboundFailure, ReputationChange, RequestFailure,
 };
 
 use polkadot_node_network_protocol::{
 	peer_set::{PeerSet, PeerSetProtocolNames, ProtocolVersion},
 	request_response::{OutgoingRequest, Recipient, ReqProtocolNames, Requests},
-	PeerId, UnifiedReputationChange as Rep,
+	PeerId,
 };
 use polkadot_primitives::{AuthorityDiscoveryId, Block, Hash};
 
@@ -106,7 +106,7 @@ pub trait Network: Clone + Send + 'static {
 	);
 
 	/// Report a given peer as either beneficial (+) or costly (-) according to the given scalar.
-	fn report_peer(&self, who: PeerId, cost_benefit: Rep);
+	fn report_peer(&self, who: PeerId, rep: ReputationChange);
 
 	/// Disconnect a given peer from the protocol specified without harming reputation.
 	fn disconnect_peer(&self, who: PeerId, protocol: ProtocolName);
@@ -133,8 +133,8 @@ impl Network for Arc<NetworkService<Block, Hash>> {
 		NetworkService::remove_peers_from_reserved_set(&**self, protocol, peers);
 	}
 
-	fn report_peer(&self, who: PeerId, cost_benefit: Rep) {
-		NetworkService::report_peer(&**self, who, cost_benefit.into_base_rep());
+	fn report_peer(&self, who: PeerId, rep: ReputationChange) {
+		NetworkService::report_peer(&**self, who, rep);
 	}
 
 	fn disconnect_peer(&self, who: PeerId, protocol: ProtocolName) {

--- a/node/network/bridge/src/rx/mod.rs
+++ b/node/network/bridge/src/rx/mod.rs
@@ -364,7 +364,7 @@ where
 				let v_messages = match v_messages {
 					Err(rep) => {
 						gum::debug!(target: LOG_TARGET, action = "ReportPeer");
-						network_service.report_peer(remote, rep);
+						network_service.report_peer(remote, rep.into());
 
 						continue
 					},
@@ -395,7 +395,7 @@ where
 				let c_messages = match c_messages {
 					Err(rep) => {
 						gum::debug!(target: LOG_TARGET, action = "ReportPeer");
-						network_service.report_peer(remote, rep);
+						network_service.report_peer(remote, rep.into());
 
 						continue
 					},
@@ -441,7 +441,7 @@ where
 						};
 
 					for report in reports {
-						network_service.report_peer(remote, report);
+						network_service.report_peer(remote, report.into());
 					}
 
 					dispatch_validation_events_to_all(events, &mut sender).await;
@@ -474,7 +474,7 @@ where
 						};
 
 					for report in reports {
-						network_service.report_peer(remote, report);
+						network_service.report_peer(remote, report.into());
 					}
 
 					dispatch_collation_events_to_all(events, &mut sender).await;

--- a/node/network/bridge/src/rx/tests.rs
+++ b/node/network/bridge/src/rx/tests.rs
@@ -947,10 +947,7 @@ fn relays_collation_protocol_messages() {
 		let actions = network_handle.next_network_actions(3).await;
 		assert_network_actions_contains(
 			&actions,
-			&NetworkAction::ReputationChange(
-				peer_a.clone(),
-				UNCONNECTED_PEERSET_COST.into_base_rep(),
-			),
+			&NetworkAction::ReputationChange(peer_a.clone(), UNCONNECTED_PEERSET_COST.into()),
 		);
 
 		// peer B has the message relayed.
@@ -1145,7 +1142,7 @@ fn view_finalized_number_can_not_go_down() {
 		let actions = network_handle.next_network_actions(2).await;
 		assert_network_actions_contains(
 			&actions,
-			&NetworkAction::ReputationChange(peer_a.clone(), MALFORMED_VIEW_COST.into_base_rep()),
+			&NetworkAction::ReputationChange(peer_a.clone(), MALFORMED_VIEW_COST.into()),
 		);
 		virtual_overseer
 	});

--- a/node/network/bridge/src/rx/tests.rs
+++ b/node/network/bridge/src/rx/tests.rs
@@ -27,7 +27,7 @@ use std::{
 	sync::atomic::{AtomicBool, Ordering},
 };
 
-use sc_network::{Event as NetworkEvent, IfDisconnected, ProtocolName};
+use sc_network::{Event as NetworkEvent, IfDisconnected, ProtocolName, ReputationChange};
 
 use polkadot_node_network_protocol::{
 	peer_set::PeerSetProtocolNames,
@@ -51,12 +51,12 @@ use polkadot_primitives::{AuthorityDiscoveryId, Hash};
 use sc_network::Multiaddr;
 use sp_keyring::Sr25519Keyring;
 
-use crate::{network::Network, validator_discovery::AuthorityDiscovery, Rep};
+use crate::{network::Network, validator_discovery::AuthorityDiscovery};
 
 #[derive(Debug, PartialEq)]
 pub enum NetworkAction {
 	/// Note a change in reputation for a peer.
-	ReputationChange(PeerId, Rep),
+	ReputationChange(PeerId, ReputationChange),
 	/// Disconnect a peer from the given peer-set.
 	DisconnectPeer(PeerId, PeerSet),
 	/// Write a notification to a given peer on the given peer-set.
@@ -128,10 +128,10 @@ impl Network for TestNetwork {
 	) {
 	}
 
-	fn report_peer(&self, who: PeerId, cost_benefit: Rep) {
+	fn report_peer(&self, who: PeerId, rep: ReputationChange) {
 		self.action_tx
 			.lock()
-			.unbounded_send(NetworkAction::ReputationChange(who, cost_benefit))
+			.unbounded_send(NetworkAction::ReputationChange(who, rep))
 			.unwrap();
 	}
 
@@ -947,7 +947,10 @@ fn relays_collation_protocol_messages() {
 		let actions = network_handle.next_network_actions(3).await;
 		assert_network_actions_contains(
 			&actions,
-			&NetworkAction::ReputationChange(peer_a.clone(), UNCONNECTED_PEERSET_COST),
+			&NetworkAction::ReputationChange(
+				peer_a.clone(),
+				UNCONNECTED_PEERSET_COST.into_base_rep(),
+			),
 		);
 
 		// peer B has the message relayed.
@@ -1142,7 +1145,7 @@ fn view_finalized_number_can_not_go_down() {
 		let actions = network_handle.next_network_actions(2).await;
 		assert_network_actions_contains(
 			&actions,
-			&NetworkAction::ReputationChange(peer_a.clone(), MALFORMED_VIEW_COST),
+			&NetworkAction::ReputationChange(peer_a.clone(), MALFORMED_VIEW_COST.into_base_rep()),
 		);
 		virtual_overseer
 	});

--- a/node/network/bridge/src/tx/mod.rs
+++ b/node/network/bridge/src/tx/mod.rs
@@ -159,14 +159,8 @@ where
 			network_service.report_peer(peer, rep);
 		},
 		NetworkBridgeTxMessage::ReportPeer(ReportPeerMessage::Batch(batch)) => {
-			let reports: Vec<(PeerId, ReputationChange)> = batch
-				.iter()
-				.map(|(&peer, &score)| {
-					(peer, ReputationChange::new(score, "Aggregated reputation change"))
-				})
-				.collect();
-
-			for (peer, rep) in reports {
+			for (peer, score) in batch {
+				let rep = ReputationChange::new(score, "Aggregated reputation change");
 				if !rep.value.is_positive() {
 					gum::debug!(target: LOG_TARGET, ?peer, ?rep, action = "ReportPeer");
 				}

--- a/node/network/bridge/src/tx/mod.rs
+++ b/node/network/bridge/src/tx/mod.rs
@@ -159,7 +159,7 @@ where
 			network_service.report_peer(peer, rep);
 		},
 		NetworkBridgeTxMessage::ReportPeer(ReportPeerMessage::Batch(batch)) => {
-			let reports = batch
+			let reports: Vec<(PeerId, ReputationChange)> = batch
 				.iter()
 				.map(|(&peer, &score)| {
 					(peer, ReputationChange::new(score, "Aggregated reputation change"))

--- a/node/network/bridge/src/tx/mod.rs
+++ b/node/network/bridge/src/tx/mod.rs
@@ -155,23 +155,17 @@ where
 				gum::debug!(target: LOG_TARGET, ?peer, ?rep, action = "ReportPeer");
 			}
 
-			metrics.on_report_event();
+			metrics.on_report_event(1);
 			network_service.report_peer(peer, rep);
 		},
 		NetworkBridgeTxMessage::ReportPeer(ReportPeerMessage::Batch(batch)) => {
-			let reports: Vec<(PeerId, ReputationChange)> = batch
-				.iter()
-				.map(|(&peer, &score)| {
-					(peer, ReputationChange::new(score, "Aggregated reputation change"))
-				})
-				.collect();
-
-			for (peer, rep) in reports {
+			for (peer, (score, counter)) in batch {
+				let rep = ReputationChange::new(score, "Aggregated reputation change");
 				if !rep.value.is_positive() {
 					gum::debug!(target: LOG_TARGET, ?peer, ?rep, action = "ReportPeer");
 				}
 
-				metrics.on_report_event();
+				metrics.on_report_event(counter);
 				network_service.report_peer(peer, rep);
 			}
 		},

--- a/node/network/bridge/src/tx/mod.rs
+++ b/node/network/bridge/src/tx/mod.rs
@@ -149,7 +149,7 @@ where
 {
 	match msg {
 		NetworkBridgeTxMessage::ReportPeer(peer, rep) => {
-			if !rep.is_benefit() {
+			if !rep.value.is_positive() {
 				gum::debug!(target: LOG_TARGET, ?peer, ?rep, action = "ReportPeer");
 			}
 

--- a/node/network/bridge/src/tx/tests.rs
+++ b/node/network/bridge/src/tx/tests.rs
@@ -22,7 +22,7 @@ use async_trait::async_trait;
 use parking_lot::Mutex;
 use std::collections::HashSet;
 
-use sc_network::{Event as NetworkEvent, IfDisconnected, ProtocolName};
+use sc_network::{Event as NetworkEvent, IfDisconnected, ProtocolName, ReputationChange};
 
 use polkadot_node_network_protocol::{
 	peer_set::PeerSetProtocolNames,
@@ -39,12 +39,12 @@ use sp_keyring::Sr25519Keyring;
 
 const TIMEOUT: std::time::Duration = polkadot_node_subsystem_test_helpers::TestSubsystemContextHandle::<NetworkBridgeTxMessage>::TIMEOUT;
 
-use crate::{network::Network, validator_discovery::AuthorityDiscovery, Rep};
+use crate::{network::Network, validator_discovery::AuthorityDiscovery};
 
 #[derive(Debug, PartialEq)]
 pub enum NetworkAction {
 	/// Note a change in reputation for a peer.
-	ReputationChange(PeerId, Rep),
+	ReputationChange(PeerId, ReputationChange),
 	/// Disconnect a peer from the given peer-set.
 	DisconnectPeer(PeerId, PeerSet),
 	/// Write a notification to a given peer on the given peer-set.
@@ -116,10 +116,10 @@ impl Network for TestNetwork {
 	) {
 	}
 
-	fn report_peer(&self, who: PeerId, cost_benefit: Rep) {
+	fn report_peer(&self, who: PeerId, rep: ReputationChange) {
 		self.action_tx
 			.lock()
-			.unbounded_send(NetworkAction::ReputationChange(who, cost_benefit))
+			.unbounded_send(NetworkAction::ReputationChange(who, rep))
 			.unwrap();
 	}
 

--- a/node/network/bridge/src/validator_discovery.rs
+++ b/node/network/bridge/src/validator_discovery.rs
@@ -174,7 +174,7 @@ mod tests {
 		PeerId,
 	};
 	use polkadot_primitives::Hash;
-	use sc_network::{Event as NetworkEvent, IfDisconnected, ProtocolName};
+	use sc_network::{Event as NetworkEvent, IfDisconnected, ProtocolName, ReputationChange};
 	use sp_keyring::Sr25519Keyring;
 	use std::collections::{HashMap, HashSet};
 
@@ -249,7 +249,7 @@ mod tests {
 		) {
 		}
 
-		fn report_peer(&self, _: PeerId, _: crate::Rep) {
+		fn report_peer(&self, _: PeerId, _: ReputationChange) {
 			panic!()
 		}
 

--- a/node/network/collator-protocol/src/collator_side/mod.rs
+++ b/node/network/collator-protocol/src/collator_side/mod.rs
@@ -707,8 +707,11 @@ async fn handle_incoming_peer_message<Context>(
 				"AdvertiseCollation message is not expected on the collator side of the protocol",
 			);
 
-			ctx.send_message(NetworkBridgeTxMessage::ReportPeer(origin, COST_UNEXPECTED_MESSAGE))
-				.await;
+			ctx.send_message(NetworkBridgeTxMessage::ReportPeer(
+				origin,
+				COST_UNEXPECTED_MESSAGE.into_base_rep(),
+			))
+			.await;
 
 			// If we are advertised to, this is another collator, and we should disconnect.
 			ctx.send_message(NetworkBridgeTxMessage::DisconnectPeer(origin, PeerSet::Collation))
@@ -794,8 +797,11 @@ async fn handle_incoming_request<Context>(
 					target: LOG_TARGET,
 					"Dropping incoming request as peer has a request in flight already."
 				);
-				ctx.send_message(NetworkBridgeTxMessage::ReportPeer(req.peer, COST_APPARENT_FLOOD))
-					.await;
+				ctx.send_message(NetworkBridgeTxMessage::ReportPeer(
+					req.peer,
+					COST_APPARENT_FLOOD.into_base_rep(),
+				))
+				.await;
 				return Ok(())
 			}
 

--- a/node/network/collator-protocol/src/collator_side/mod.rs
+++ b/node/network/collator-protocol/src/collator_side/mod.rs
@@ -709,7 +709,7 @@ async fn handle_incoming_peer_message<Context>(
 
 			ctx.send_message(NetworkBridgeTxMessage::ReportPeer(
 				origin,
-				COST_UNEXPECTED_MESSAGE.into_base_rep(),
+				COST_UNEXPECTED_MESSAGE.into(),
 			))
 			.await;
 
@@ -799,7 +799,7 @@ async fn handle_incoming_request<Context>(
 				);
 				ctx.send_message(NetworkBridgeTxMessage::ReportPeer(
 					req.peer,
-					COST_APPARENT_FLOOD.into_base_rep(),
+					COST_APPARENT_FLOOD.into(),
 				))
 				.await;
 				return Ok(())

--- a/node/network/collator-protocol/src/collator_side/mod.rs
+++ b/node/network/collator-protocol/src/collator_side/mod.rs
@@ -709,7 +709,7 @@ async fn handle_incoming_peer_message<Context>(
 
 			ctx.send_message(NetworkBridgeTxMessage::ReportPeer(
 				origin,
-				COST_UNEXPECTED_MESSAGE.into(),
+				COST_UNEXPECTED_MESSAGE.into_base_rep(),
 			))
 			.await;
 
@@ -799,7 +799,7 @@ async fn handle_incoming_request<Context>(
 				);
 				ctx.send_message(NetworkBridgeTxMessage::ReportPeer(
 					req.peer,
-					COST_APPARENT_FLOOD.into(),
+					COST_APPARENT_FLOOD.into_base_rep(),
 				))
 				.await;
 				return Ok(())

--- a/node/network/collator-protocol/src/collator_side/tests.rs
+++ b/node/network/collator-protocol/src/collator_side/tests.rs
@@ -49,6 +49,8 @@ use polkadot_primitives::{
 };
 use polkadot_primitives_test_helpers::TestCandidateBuilder;
 
+const REPUTATION_CHANGE_TEST_INTERVAL: Duration = Duration::from_millis(1);
+
 #[derive(Clone)]
 struct TestState {
 	para_id: ParaId,
@@ -223,6 +225,7 @@ fn test_harness<T: Future<Output = TestHarness>>(
 			collation_req_receiver,
 			Default::default(),
 			reputation,
+			REPUTATION_CHANGE_TEST_INTERVAL,
 		)
 		.await
 		.unwrap();

--- a/node/network/collator-protocol/src/collator_side/tests.rs
+++ b/node/network/collator-protocol/src/collator_side/tests.rs
@@ -197,6 +197,7 @@ struct TestHarness {
 fn test_harness<T: Future<Output = TestHarness>>(
 	local_peer_id: PeerId,
 	collator_pair: CollatorPair,
+	reputation: ReputationAggregator,
 	test: impl FnOnce(TestHarness) -> T,
 ) {
 	let _ = env_logger::builder()
@@ -215,9 +216,16 @@ fn test_harness<T: Future<Output = TestHarness>>(
 	let (collation_req_receiver, req_cfg) =
 		IncomingRequest::get_config_receiver(&req_protocol_names);
 	let subsystem = async {
-		run(context, local_peer_id, collator_pair, collation_req_receiver, Default::default())
-			.await
-			.unwrap();
+		run_inner(
+			context,
+			local_peer_id,
+			collator_pair,
+			collation_req_receiver,
+			Default::default(),
+			reputation,
+		)
+		.await
+		.unwrap();
 	};
 
 	let test_fut = test(TestHarness { virtual_overseer, req_cfg });
@@ -511,60 +519,47 @@ fn advertise_and_send_collation() {
 	let local_peer_id = test_state.local_peer_id.clone();
 	let collator_pair = test_state.collator_pair.clone();
 
-	test_harness(local_peer_id, collator_pair, |test_harness| async move {
-		let mut virtual_overseer = test_harness.virtual_overseer;
-		let mut req_cfg = test_harness.req_cfg;
+	test_harness(
+		local_peer_id,
+		collator_pair,
+		ReputationAggregator::new(|_| true),
+		|test_harness| async move {
+			let mut virtual_overseer = test_harness.virtual_overseer;
+			let mut req_cfg = test_harness.req_cfg;
 
-		setup_system(&mut virtual_overseer, &test_state).await;
+			setup_system(&mut virtual_overseer, &test_state).await;
 
-		let DistributeCollation { candidate, pov_block } =
-			distribute_collation(&mut virtual_overseer, &test_state, true).await;
+			let DistributeCollation { candidate, pov_block } =
+				distribute_collation(&mut virtual_overseer, &test_state, true).await;
 
-		for (val, peer) in test_state
-			.current_group_validator_authority_ids()
-			.into_iter()
-			.zip(test_state.current_group_validator_peer_ids())
-		{
-			connect_peer(&mut virtual_overseer, peer.clone(), Some(val.clone())).await;
-		}
+			for (val, peer) in test_state
+				.current_group_validator_authority_ids()
+				.into_iter()
+				.zip(test_state.current_group_validator_peer_ids())
+			{
+				connect_peer(&mut virtual_overseer, peer.clone(), Some(val.clone())).await;
+			}
 
-		// We declare to the connected validators that we are a collator.
-		// We need to catch all `Declare` messages to the validators we've
-		// previously connected to.
-		for peer_id in test_state.current_group_validator_peer_ids() {
-			expect_declare_msg(&mut virtual_overseer, &test_state, &peer_id).await;
-		}
+			// We declare to the connected validators that we are a collator.
+			// We need to catch all `Declare` messages to the validators we've
+			// previously connected to.
+			for peer_id in test_state.current_group_validator_peer_ids() {
+				expect_declare_msg(&mut virtual_overseer, &test_state, &peer_id).await;
+			}
 
-		let peer = test_state.current_group_validator_peer_ids()[0].clone();
+			let peer = test_state.current_group_validator_peer_ids()[0].clone();
 
-		// Send info about peer's view.
-		send_peer_view_change(&mut virtual_overseer, &peer, vec![test_state.relay_parent]).await;
+			// Send info about peer's view.
+			send_peer_view_change(&mut virtual_overseer, &peer, vec![test_state.relay_parent])
+				.await;
 
-		// The peer is interested in a leaf that we have a collation for;
-		// advertise it.
-		expect_advertise_collation_msg(&mut virtual_overseer, &peer, test_state.relay_parent).await;
+			// The peer is interested in a leaf that we have a collation for;
+			// advertise it.
+			expect_advertise_collation_msg(&mut virtual_overseer, &peer, test_state.relay_parent)
+				.await;
 
-		// Request a collation.
-		let (pending_response, rx) = oneshot::channel();
-		req_cfg
-			.inbound_queue
-			.as_mut()
-			.unwrap()
-			.send(RawIncomingRequest {
-				peer,
-				payload: CollationFetchingRequest {
-					relay_parent: test_state.relay_parent,
-					para_id: test_state.para_id,
-				}
-				.encode(),
-				pending_response,
-			})
-			.await
-			.unwrap();
-		// Second request by same validator should get dropped and peer reported:
-		{
+			// Request a collation.
 			let (pending_response, rx) = oneshot::channel();
-
 			req_cfg
 				.inbound_queue
 				.as_mut()
@@ -580,76 +575,97 @@ fn advertise_and_send_collation() {
 				})
 				.await
 				.unwrap();
-			assert_matches!(
-				overseer_recv(&mut virtual_overseer).await,
-				AllMessages::NetworkBridgeTx(NetworkBridgeTxMessage::ReportPeer(bad_peer, _)) => {
-					assert_eq!(bad_peer, peer);
-				}
-			);
+			// Second request by same validator should get dropped and peer reported:
+			{
+				let (pending_response, rx) = oneshot::channel();
+
+				req_cfg
+					.inbound_queue
+					.as_mut()
+					.unwrap()
+					.send(RawIncomingRequest {
+						peer,
+						payload: CollationFetchingRequest {
+							relay_parent: test_state.relay_parent,
+							para_id: test_state.para_id,
+						}
+						.encode(),
+						pending_response,
+					})
+					.await
+					.unwrap();
+				assert_matches!(
+					overseer_recv(&mut virtual_overseer).await,
+					AllMessages::NetworkBridgeTx(NetworkBridgeTxMessage::ReportPeer(bad_peer, _)) => {
+						assert_eq!(bad_peer, peer);
+					}
+				);
+				assert_matches!(
+					rx.await,
+					Err(_),
+					"Multiple concurrent requests by the same validator should get dropped."
+				);
+			}
+
 			assert_matches!(
 				rx.await,
-				Err(_),
-				"Multiple concurrent requests by the same validator should get dropped."
-			);
-		}
-
-		assert_matches!(
-			rx.await,
-			Ok(full_response) => {
-				let CollationFetchingResponse::Collation(receipt, pov): CollationFetchingResponse
-					= CollationFetchingResponse::decode(
-						&mut full_response.result
-						.expect("We should have a proper answer").as_ref()
-				)
-				.expect("Decoding should work");
-				assert_eq!(receipt, candidate);
-				assert_eq!(pov, pov_block);
-			}
-		);
-
-		let old_relay_parent = test_state.relay_parent;
-		test_state.advance_to_new_round(&mut virtual_overseer, false).await;
-
-		let peer = test_state.validator_peer_id[2].clone();
-
-		// Re-request a collation.
-		let (pending_response, rx) = oneshot::channel();
-
-		req_cfg
-			.inbound_queue
-			.as_mut()
-			.unwrap()
-			.send(RawIncomingRequest {
-				peer,
-				payload: CollationFetchingRequest {
-					relay_parent: old_relay_parent,
-					para_id: test_state.para_id,
+				Ok(full_response) => {
+					let CollationFetchingResponse::Collation(receipt, pov): CollationFetchingResponse
+						= CollationFetchingResponse::decode(
+							&mut full_response.result
+							.expect("We should have a proper answer").as_ref()
+					)
+					.expect("Decoding should work");
+					assert_eq!(receipt, candidate);
+					assert_eq!(pov, pov_block);
 				}
-				.encode(),
-				pending_response,
-			})
-			.await
-			.unwrap();
-		// Re-requesting collation should fail:
-		rx.await.unwrap_err();
+			);
 
-		assert!(overseer_recv_with_timeout(&mut virtual_overseer, TIMEOUT).await.is_none());
+			let old_relay_parent = test_state.relay_parent;
+			test_state.advance_to_new_round(&mut virtual_overseer, false).await;
 
-		distribute_collation(&mut virtual_overseer, &test_state, true).await;
+			let peer = test_state.validator_peer_id[2].clone();
 
-		// Send info about peer's view.
-		overseer_send(
-			&mut virtual_overseer,
-			CollatorProtocolMessage::NetworkBridgeUpdate(NetworkBridgeEvent::PeerViewChange(
-				peer.clone(),
-				view![test_state.relay_parent],
-			)),
-		)
-		.await;
+			// Re-request a collation.
+			let (pending_response, rx) = oneshot::channel();
 
-		expect_advertise_collation_msg(&mut virtual_overseer, &peer, test_state.relay_parent).await;
-		TestHarness { virtual_overseer, req_cfg }
-	});
+			req_cfg
+				.inbound_queue
+				.as_mut()
+				.unwrap()
+				.send(RawIncomingRequest {
+					peer,
+					payload: CollationFetchingRequest {
+						relay_parent: old_relay_parent,
+						para_id: test_state.para_id,
+					}
+					.encode(),
+					pending_response,
+				})
+				.await
+				.unwrap();
+			// Re-requesting collation should fail:
+			rx.await.unwrap_err();
+
+			assert!(overseer_recv_with_timeout(&mut virtual_overseer, TIMEOUT).await.is_none());
+
+			distribute_collation(&mut virtual_overseer, &test_state, true).await;
+
+			// Send info about peer's view.
+			overseer_send(
+				&mut virtual_overseer,
+				CollatorProtocolMessage::NetworkBridgeUpdate(NetworkBridgeEvent::PeerViewChange(
+					peer.clone(),
+					view![test_state.relay_parent],
+				)),
+			)
+			.await;
+
+			expect_advertise_collation_msg(&mut virtual_overseer, &peer, test_state.relay_parent)
+				.await;
+			TestHarness { virtual_overseer, req_cfg }
+		},
+	);
 }
 
 #[test]
@@ -681,17 +697,23 @@ fn collators_declare_to_connected_peers() {
 	let local_peer_id = test_state.local_peer_id.clone();
 	let collator_pair = test_state.collator_pair.clone();
 
-	test_harness(local_peer_id, collator_pair, |mut test_harness| async move {
-		let peer = test_state.validator_peer_id[0].clone();
-		let validator_id = test_state.current_group_validator_authority_ids()[0].clone();
+	test_harness(
+		local_peer_id,
+		collator_pair,
+		ReputationAggregator::new(|_| true),
+		|mut test_harness| async move {
+			let peer = test_state.validator_peer_id[0].clone();
+			let validator_id = test_state.current_group_validator_authority_ids()[0].clone();
 
-		setup_system(&mut test_harness.virtual_overseer, &test_state).await;
+			setup_system(&mut test_harness.virtual_overseer, &test_state).await;
 
-		// A validator connected to us
-		connect_peer(&mut test_harness.virtual_overseer, peer.clone(), Some(validator_id)).await;
-		expect_declare_msg(&mut test_harness.virtual_overseer, &test_state, &peer).await;
-		test_harness
-	})
+			// A validator connected to us
+			connect_peer(&mut test_harness.virtual_overseer, peer.clone(), Some(validator_id))
+				.await;
+			expect_declare_msg(&mut test_harness.virtual_overseer, &test_state, &peer).await;
+			test_harness
+		},
+	)
 }
 
 #[test]
@@ -700,40 +722,45 @@ fn collations_are_only_advertised_to_validators_with_correct_view() {
 	let local_peer_id = test_state.local_peer_id.clone();
 	let collator_pair = test_state.collator_pair.clone();
 
-	test_harness(local_peer_id, collator_pair, |mut test_harness| async move {
-		let virtual_overseer = &mut test_harness.virtual_overseer;
+	test_harness(
+		local_peer_id,
+		collator_pair,
+		ReputationAggregator::new(|_| true),
+		|mut test_harness| async move {
+			let virtual_overseer = &mut test_harness.virtual_overseer;
 
-		let peer = test_state.current_group_validator_peer_ids()[0].clone();
-		let validator_id = test_state.current_group_validator_authority_ids()[0].clone();
+			let peer = test_state.current_group_validator_peer_ids()[0].clone();
+			let validator_id = test_state.current_group_validator_authority_ids()[0].clone();
 
-		let peer2 = test_state.current_group_validator_peer_ids()[1].clone();
-		let validator_id2 = test_state.current_group_validator_authority_ids()[1].clone();
+			let peer2 = test_state.current_group_validator_peer_ids()[1].clone();
+			let validator_id2 = test_state.current_group_validator_authority_ids()[1].clone();
 
-		setup_system(virtual_overseer, &test_state).await;
+			setup_system(virtual_overseer, &test_state).await;
 
-		// A validator connected to us
-		connect_peer(virtual_overseer, peer.clone(), Some(validator_id)).await;
+			// A validator connected to us
+			connect_peer(virtual_overseer, peer.clone(), Some(validator_id)).await;
 
-		// Connect the second validator
-		connect_peer(virtual_overseer, peer2.clone(), Some(validator_id2)).await;
+			// Connect the second validator
+			connect_peer(virtual_overseer, peer2.clone(), Some(validator_id2)).await;
 
-		expect_declare_msg(virtual_overseer, &test_state, &peer).await;
-		expect_declare_msg(virtual_overseer, &test_state, &peer2).await;
+			expect_declare_msg(virtual_overseer, &test_state, &peer).await;
+			expect_declare_msg(virtual_overseer, &test_state, &peer2).await;
 
-		// And let it tell us that it is has the same view.
-		send_peer_view_change(virtual_overseer, &peer2, vec![test_state.relay_parent]).await;
+			// And let it tell us that it is has the same view.
+			send_peer_view_change(virtual_overseer, &peer2, vec![test_state.relay_parent]).await;
 
-		distribute_collation(virtual_overseer, &test_state, true).await;
+			distribute_collation(virtual_overseer, &test_state, true).await;
 
-		expect_advertise_collation_msg(virtual_overseer, &peer2, test_state.relay_parent).await;
+			expect_advertise_collation_msg(virtual_overseer, &peer2, test_state.relay_parent).await;
 
-		// The other validator announces that it changed its view.
-		send_peer_view_change(virtual_overseer, &peer, vec![test_state.relay_parent]).await;
+			// The other validator announces that it changed its view.
+			send_peer_view_change(virtual_overseer, &peer, vec![test_state.relay_parent]).await;
 
-		// After changing the view we should receive the advertisement
-		expect_advertise_collation_msg(virtual_overseer, &peer, test_state.relay_parent).await;
-		test_harness
-	})
+			// After changing the view we should receive the advertisement
+			expect_advertise_collation_msg(virtual_overseer, &peer, test_state.relay_parent).await;
+			test_harness
+		},
+	)
 }
 
 #[test]
@@ -742,43 +769,48 @@ fn collate_on_two_different_relay_chain_blocks() {
 	let local_peer_id = test_state.local_peer_id.clone();
 	let collator_pair = test_state.collator_pair.clone();
 
-	test_harness(local_peer_id, collator_pair, |mut test_harness| async move {
-		let virtual_overseer = &mut test_harness.virtual_overseer;
+	test_harness(
+		local_peer_id,
+		collator_pair,
+		ReputationAggregator::new(|_| true),
+		|mut test_harness| async move {
+			let virtual_overseer = &mut test_harness.virtual_overseer;
 
-		let peer = test_state.current_group_validator_peer_ids()[0].clone();
-		let validator_id = test_state.current_group_validator_authority_ids()[0].clone();
+			let peer = test_state.current_group_validator_peer_ids()[0].clone();
+			let validator_id = test_state.current_group_validator_authority_ids()[0].clone();
 
-		let peer2 = test_state.current_group_validator_peer_ids()[1].clone();
-		let validator_id2 = test_state.current_group_validator_authority_ids()[1].clone();
+			let peer2 = test_state.current_group_validator_peer_ids()[1].clone();
+			let validator_id2 = test_state.current_group_validator_authority_ids()[1].clone();
 
-		setup_system(virtual_overseer, &test_state).await;
+			setup_system(virtual_overseer, &test_state).await;
 
-		// A validator connected to us
-		connect_peer(virtual_overseer, peer.clone(), Some(validator_id)).await;
+			// A validator connected to us
+			connect_peer(virtual_overseer, peer.clone(), Some(validator_id)).await;
 
-		// Connect the second validator
-		connect_peer(virtual_overseer, peer2.clone(), Some(validator_id2)).await;
+			// Connect the second validator
+			connect_peer(virtual_overseer, peer2.clone(), Some(validator_id2)).await;
 
-		expect_declare_msg(virtual_overseer, &test_state, &peer).await;
-		expect_declare_msg(virtual_overseer, &test_state, &peer2).await;
+			expect_declare_msg(virtual_overseer, &test_state, &peer).await;
+			expect_declare_msg(virtual_overseer, &test_state, &peer2).await;
 
-		distribute_collation(virtual_overseer, &test_state, true).await;
+			distribute_collation(virtual_overseer, &test_state, true).await;
 
-		let old_relay_parent = test_state.relay_parent;
+			let old_relay_parent = test_state.relay_parent;
 
-		// Advance to a new round, while informing the subsystem that the old and the new relay parent are active.
-		test_state.advance_to_new_round(virtual_overseer, true).await;
+			// Advance to a new round, while informing the subsystem that the old and the new relay parent are active.
+			test_state.advance_to_new_round(virtual_overseer, true).await;
 
-		distribute_collation(virtual_overseer, &test_state, true).await;
+			distribute_collation(virtual_overseer, &test_state, true).await;
 
-		send_peer_view_change(virtual_overseer, &peer, vec![old_relay_parent]).await;
-		expect_advertise_collation_msg(virtual_overseer, &peer, old_relay_parent).await;
+			send_peer_view_change(virtual_overseer, &peer, vec![old_relay_parent]).await;
+			expect_advertise_collation_msg(virtual_overseer, &peer, old_relay_parent).await;
 
-		send_peer_view_change(virtual_overseer, &peer2, vec![test_state.relay_parent]).await;
+			send_peer_view_change(virtual_overseer, &peer2, vec![test_state.relay_parent]).await;
 
-		expect_advertise_collation_msg(virtual_overseer, &peer2, test_state.relay_parent).await;
-		test_harness
-	})
+			expect_advertise_collation_msg(virtual_overseer, &peer2, test_state.relay_parent).await;
+			test_harness
+		},
+	)
 }
 
 #[test]
@@ -787,33 +819,38 @@ fn validator_reconnect_does_not_advertise_a_second_time() {
 	let local_peer_id = test_state.local_peer_id.clone();
 	let collator_pair = test_state.collator_pair.clone();
 
-	test_harness(local_peer_id, collator_pair, |mut test_harness| async move {
-		let virtual_overseer = &mut test_harness.virtual_overseer;
+	test_harness(
+		local_peer_id,
+		collator_pair,
+		ReputationAggregator::new(|_| true),
+		|mut test_harness| async move {
+			let virtual_overseer = &mut test_harness.virtual_overseer;
 
-		let peer = test_state.current_group_validator_peer_ids()[0].clone();
-		let validator_id = test_state.current_group_validator_authority_ids()[0].clone();
+			let peer = test_state.current_group_validator_peer_ids()[0].clone();
+			let validator_id = test_state.current_group_validator_authority_ids()[0].clone();
 
-		setup_system(virtual_overseer, &test_state).await;
+			setup_system(virtual_overseer, &test_state).await;
 
-		// A validator connected to us
-		connect_peer(virtual_overseer, peer.clone(), Some(validator_id.clone())).await;
-		expect_declare_msg(virtual_overseer, &test_state, &peer).await;
+			// A validator connected to us
+			connect_peer(virtual_overseer, peer.clone(), Some(validator_id.clone())).await;
+			expect_declare_msg(virtual_overseer, &test_state, &peer).await;
 
-		distribute_collation(virtual_overseer, &test_state, true).await;
+			distribute_collation(virtual_overseer, &test_state, true).await;
 
-		send_peer_view_change(virtual_overseer, &peer, vec![test_state.relay_parent]).await;
-		expect_advertise_collation_msg(virtual_overseer, &peer, test_state.relay_parent).await;
+			send_peer_view_change(virtual_overseer, &peer, vec![test_state.relay_parent]).await;
+			expect_advertise_collation_msg(virtual_overseer, &peer, test_state.relay_parent).await;
 
-		// Disconnect and reconnect directly
-		disconnect_peer(virtual_overseer, peer.clone()).await;
-		connect_peer(virtual_overseer, peer.clone(), Some(validator_id)).await;
-		expect_declare_msg(virtual_overseer, &test_state, &peer).await;
+			// Disconnect and reconnect directly
+			disconnect_peer(virtual_overseer, peer.clone()).await;
+			connect_peer(virtual_overseer, peer.clone(), Some(validator_id)).await;
+			expect_declare_msg(virtual_overseer, &test_state, &peer).await;
 
-		send_peer_view_change(virtual_overseer, &peer, vec![test_state.relay_parent]).await;
+			send_peer_view_change(virtual_overseer, &peer, vec![test_state.relay_parent]).await;
 
-		assert!(overseer_recv_with_timeout(virtual_overseer, TIMEOUT).await.is_none());
-		test_harness
-	})
+			assert!(overseer_recv_with_timeout(virtual_overseer, TIMEOUT).await.is_none());
+			test_harness
+		},
+	)
 }
 
 #[test]
@@ -823,40 +860,45 @@ fn collators_reject_declare_messages() {
 	let collator_pair = test_state.collator_pair.clone();
 	let collator_pair2 = CollatorPair::generate().0;
 
-	test_harness(local_peer_id, collator_pair, |mut test_harness| async move {
-		let virtual_overseer = &mut test_harness.virtual_overseer;
+	test_harness(
+		local_peer_id,
+		collator_pair,
+		ReputationAggregator::new(|_| true),
+		|mut test_harness| async move {
+			let virtual_overseer = &mut test_harness.virtual_overseer;
 
-		let peer = test_state.current_group_validator_peer_ids()[0].clone();
-		let validator_id = test_state.current_group_validator_authority_ids()[0].clone();
+			let peer = test_state.current_group_validator_peer_ids()[0].clone();
+			let validator_id = test_state.current_group_validator_authority_ids()[0].clone();
 
-		setup_system(virtual_overseer, &test_state).await;
+			setup_system(virtual_overseer, &test_state).await;
 
-		// A validator connected to us
-		connect_peer(virtual_overseer, peer.clone(), Some(validator_id)).await;
-		expect_declare_msg(virtual_overseer, &test_state, &peer).await;
+			// A validator connected to us
+			connect_peer(virtual_overseer, peer.clone(), Some(validator_id)).await;
+			expect_declare_msg(virtual_overseer, &test_state, &peer).await;
 
-		overseer_send(
-			virtual_overseer,
-			CollatorProtocolMessage::NetworkBridgeUpdate(NetworkBridgeEvent::PeerMessage(
-				peer.clone(),
-				Versioned::V1(protocol_v1::CollatorProtocolMessage::Declare(
-					collator_pair2.public(),
-					ParaId::from(5),
-					collator_pair2.sign(b"garbage"),
+			overseer_send(
+				virtual_overseer,
+				CollatorProtocolMessage::NetworkBridgeUpdate(NetworkBridgeEvent::PeerMessage(
+					peer.clone(),
+					Versioned::V1(protocol_v1::CollatorProtocolMessage::Declare(
+						collator_pair2.public(),
+						ParaId::from(5),
+						collator_pair2.sign(b"garbage"),
+					)),
 				)),
-			)),
-		)
-		.await;
+			)
+			.await;
 
-		assert_matches!(
-			overseer_recv(virtual_overseer).await,
-			AllMessages::NetworkBridgeTx(NetworkBridgeTxMessage::DisconnectPeer(
-				p,
-				PeerSet::Collation,
-			)) if p == peer
-		);
-		test_harness
-	})
+			assert_matches!(
+				overseer_recv(virtual_overseer).await,
+				AllMessages::NetworkBridgeTx(NetworkBridgeTxMessage::DisconnectPeer(
+					p,
+					PeerSet::Collation,
+				)) if p == peer
+			);
+			test_harness
+		},
+	)
 }
 
 /// Run tests on validator response sequence.
@@ -877,118 +919,125 @@ where
 	let local_peer_id = test_state.local_peer_id.clone();
 	let collator_pair = test_state.collator_pair.clone();
 
-	test_harness(local_peer_id, collator_pair, |mut test_harness| async move {
-		let virtual_overseer = &mut test_harness.virtual_overseer;
-		let req_cfg = &mut test_harness.req_cfg;
+	test_harness(
+		local_peer_id,
+		collator_pair,
+		ReputationAggregator::new(|_| true),
+		|mut test_harness| async move {
+			let virtual_overseer = &mut test_harness.virtual_overseer;
+			let req_cfg = &mut test_harness.req_cfg;
 
-		setup_system(virtual_overseer, &test_state).await;
+			setup_system(virtual_overseer, &test_state).await;
 
-		let DistributeCollation { candidate, pov_block } =
-			distribute_collation(virtual_overseer, &test_state, true).await;
+			let DistributeCollation { candidate, pov_block } =
+				distribute_collation(virtual_overseer, &test_state, true).await;
 
-		for (val, peer) in test_state
-			.current_group_validator_authority_ids()
-			.into_iter()
-			.zip(test_state.current_group_validator_peer_ids())
-		{
-			connect_peer(virtual_overseer, peer.clone(), Some(val.clone())).await;
-		}
-
-		// We declare to the connected validators that we are a collator.
-		// We need to catch all `Declare` messages to the validators we've
-		// previously connected to.
-		for peer_id in test_state.current_group_validator_peer_ids() {
-			expect_declare_msg(virtual_overseer, &test_state, &peer_id).await;
-		}
-
-		let validator_0 = test_state.current_group_validator_peer_ids()[0].clone();
-		let validator_1 = test_state.current_group_validator_peer_ids()[1].clone();
-
-		// Send info about peer's view.
-		send_peer_view_change(virtual_overseer, &validator_0, vec![test_state.relay_parent]).await;
-		send_peer_view_change(virtual_overseer, &validator_1, vec![test_state.relay_parent]).await;
-
-		// The peer is interested in a leaf that we have a collation for;
-		// advertise it.
-		expect_advertise_collation_msg(virtual_overseer, &validator_0, test_state.relay_parent)
-			.await;
-		expect_advertise_collation_msg(virtual_overseer, &validator_1, test_state.relay_parent)
-			.await;
-
-		// Request a collation.
-		let (pending_response, rx) = oneshot::channel();
-		req_cfg
-			.inbound_queue
-			.as_mut()
-			.unwrap()
-			.send(RawIncomingRequest {
-				peer: validator_0,
-				payload: CollationFetchingRequest {
-					relay_parent: test_state.relay_parent,
-					para_id: test_state.para_id,
-				}
-				.encode(),
-				pending_response,
-			})
-			.await
-			.unwrap();
-
-		// Keep the feedback channel alive because we need to use it to inform about the finished transfer.
-		let feedback_tx = assert_matches!(
-			rx.await,
-			Ok(full_response) => {
-				let CollationFetchingResponse::Collation(receipt, pov): CollationFetchingResponse
-					= CollationFetchingResponse::decode(
-						&mut full_response.result
-						.expect("We should have a proper answer").as_ref()
-				)
-				.expect("Decoding should work");
-				assert_eq!(receipt, candidate);
-				assert_eq!(pov, pov_block);
-
-				full_response.sent_feedback.expect("Feedback channel is always set")
+			for (val, peer) in test_state
+				.current_group_validator_authority_ids()
+				.into_iter()
+				.zip(test_state.current_group_validator_peer_ids())
+			{
+				connect_peer(virtual_overseer, peer.clone(), Some(val.clone())).await;
 			}
-		);
 
-		// Let the second validator request the collation.
-		let (pending_response, rx) = oneshot::channel();
-		req_cfg
-			.inbound_queue
-			.as_mut()
-			.unwrap()
-			.send(RawIncomingRequest {
-				peer: validator_1,
-				payload: CollationFetchingRequest {
-					relay_parent: test_state.relay_parent,
-					para_id: test_state.para_id,
-				}
-				.encode(),
-				pending_response,
-			})
-			.await
-			.unwrap();
-
-		let rx = handle_first_response(rx, feedback_tx).await;
-
-		// Now we should send it to the second validator
-		assert_matches!(
-			rx.await,
-			Ok(full_response) => {
-				let CollationFetchingResponse::Collation(receipt, pov): CollationFetchingResponse
-					= CollationFetchingResponse::decode(
-						&mut full_response.result
-						.expect("We should have a proper answer").as_ref()
-				)
-				.expect("Decoding should work");
-				assert_eq!(receipt, candidate);
-				assert_eq!(pov, pov_block);
-
-				full_response.sent_feedback.expect("Feedback channel is always set")
+			// We declare to the connected validators that we are a collator.
+			// We need to catch all `Declare` messages to the validators we've
+			// previously connected to.
+			for peer_id in test_state.current_group_validator_peer_ids() {
+				expect_declare_msg(virtual_overseer, &test_state, &peer_id).await;
 			}
-		);
 
-		test_harness
-	});
+			let validator_0 = test_state.current_group_validator_peer_ids()[0].clone();
+			let validator_1 = test_state.current_group_validator_peer_ids()[1].clone();
+
+			// Send info about peer's view.
+			send_peer_view_change(virtual_overseer, &validator_0, vec![test_state.relay_parent])
+				.await;
+			send_peer_view_change(virtual_overseer, &validator_1, vec![test_state.relay_parent])
+				.await;
+
+			// The peer is interested in a leaf that we have a collation for;
+			// advertise it.
+			expect_advertise_collation_msg(virtual_overseer, &validator_0, test_state.relay_parent)
+				.await;
+			expect_advertise_collation_msg(virtual_overseer, &validator_1, test_state.relay_parent)
+				.await;
+
+			// Request a collation.
+			let (pending_response, rx) = oneshot::channel();
+			req_cfg
+				.inbound_queue
+				.as_mut()
+				.unwrap()
+				.send(RawIncomingRequest {
+					peer: validator_0,
+					payload: CollationFetchingRequest {
+						relay_parent: test_state.relay_parent,
+						para_id: test_state.para_id,
+					}
+					.encode(),
+					pending_response,
+				})
+				.await
+				.unwrap();
+
+			// Keep the feedback channel alive because we need to use it to inform about the finished transfer.
+			let feedback_tx = assert_matches!(
+				rx.await,
+				Ok(full_response) => {
+					let CollationFetchingResponse::Collation(receipt, pov): CollationFetchingResponse
+						= CollationFetchingResponse::decode(
+							&mut full_response.result
+							.expect("We should have a proper answer").as_ref()
+					)
+					.expect("Decoding should work");
+					assert_eq!(receipt, candidate);
+					assert_eq!(pov, pov_block);
+
+					full_response.sent_feedback.expect("Feedback channel is always set")
+				}
+			);
+
+			// Let the second validator request the collation.
+			let (pending_response, rx) = oneshot::channel();
+			req_cfg
+				.inbound_queue
+				.as_mut()
+				.unwrap()
+				.send(RawIncomingRequest {
+					peer: validator_1,
+					payload: CollationFetchingRequest {
+						relay_parent: test_state.relay_parent,
+						para_id: test_state.para_id,
+					}
+					.encode(),
+					pending_response,
+				})
+				.await
+				.unwrap();
+
+			let rx = handle_first_response(rx, feedback_tx).await;
+
+			// Now we should send it to the second validator
+			assert_matches!(
+				rx.await,
+				Ok(full_response) => {
+					let CollationFetchingResponse::Collation(receipt, pov): CollationFetchingResponse
+						= CollationFetchingResponse::decode(
+							&mut full_response.result
+							.expect("We should have a proper answer").as_ref()
+					)
+					.expect("Decoding should work");
+					assert_eq!(receipt, candidate);
+					assert_eq!(pov, pov_block);
+
+					full_response.sent_feedback.expect("Feedback channel is always set")
+				}
+			);
+
+			test_harness
+		},
+	);
 }
 
 #[test]
@@ -997,97 +1046,102 @@ fn connect_to_buffered_groups() {
 	let local_peer_id = test_state.local_peer_id.clone();
 	let collator_pair = test_state.collator_pair.clone();
 
-	test_harness(local_peer_id, collator_pair, |test_harness| async move {
-		let mut virtual_overseer = test_harness.virtual_overseer;
-		let mut req_cfg = test_harness.req_cfg;
+	test_harness(
+		local_peer_id,
+		collator_pair,
+		ReputationAggregator::new(|_| true),
+		|test_harness| async move {
+			let mut virtual_overseer = test_harness.virtual_overseer;
+			let mut req_cfg = test_harness.req_cfg;
 
-		setup_system(&mut virtual_overseer, &test_state).await;
+			setup_system(&mut virtual_overseer, &test_state).await;
 
-		let group_a = test_state.current_group_validator_authority_ids();
-		let peers_a = test_state.current_group_validator_peer_ids();
-		assert!(group_a.len() > 1);
+			let group_a = test_state.current_group_validator_authority_ids();
+			let peers_a = test_state.current_group_validator_peer_ids();
+			assert!(group_a.len() > 1);
 
-		distribute_collation(&mut virtual_overseer, &test_state, false).await;
+			distribute_collation(&mut virtual_overseer, &test_state, false).await;
 
-		assert_matches!(
-			overseer_recv(&mut virtual_overseer).await,
-			AllMessages::NetworkBridgeTx(
-				NetworkBridgeTxMessage::ConnectToValidators { validator_ids, .. }
-			) => {
-				assert_eq!(group_a, validator_ids);
-			}
-		);
-
-		let head_a = test_state.relay_parent;
-
-		for (val, peer) in group_a.iter().zip(&peers_a) {
-			connect_peer(&mut virtual_overseer, peer.clone(), Some(val.clone())).await;
-		}
-
-		for peer_id in &peers_a {
-			expect_declare_msg(&mut virtual_overseer, &test_state, peer_id).await;
-		}
-
-		// Update views.
-		for peed_id in &peers_a {
-			send_peer_view_change(&mut virtual_overseer, peed_id, vec![head_a]).await;
-			expect_advertise_collation_msg(&mut virtual_overseer, peed_id, head_a).await;
-		}
-
-		let peer = peers_a[0];
-		// Peer from the group fetches the collation.
-		let (pending_response, rx) = oneshot::channel();
-		req_cfg
-			.inbound_queue
-			.as_mut()
-			.unwrap()
-			.send(RawIncomingRequest {
-				peer,
-				payload: CollationFetchingRequest {
-					relay_parent: head_a,
-					para_id: test_state.para_id,
+			assert_matches!(
+				overseer_recv(&mut virtual_overseer).await,
+				AllMessages::NetworkBridgeTx(
+					NetworkBridgeTxMessage::ConnectToValidators { validator_ids, .. }
+				) => {
+					assert_eq!(group_a, validator_ids);
 				}
-				.encode(),
-				pending_response,
-			})
-			.await
-			.unwrap();
-		assert_matches!(
-			rx.await,
-			Ok(full_response) => {
-				let CollationFetchingResponse::Collation(..): CollationFetchingResponse =
-					CollationFetchingResponse::decode(
-						&mut full_response.result.expect("We should have a proper answer").as_ref(),
-					)
-					.expect("Decoding should work");
+			);
+
+			let head_a = test_state.relay_parent;
+
+			for (val, peer) in group_a.iter().zip(&peers_a) {
+				connect_peer(&mut virtual_overseer, peer.clone(), Some(val.clone())).await;
 			}
-		);
 
-		test_state.advance_to_new_round(&mut virtual_overseer, true).await;
-		test_state.group_rotation_info = test_state.group_rotation_info.bump_rotation();
+			for peer_id in &peers_a {
+				expect_declare_msg(&mut virtual_overseer, &test_state, peer_id).await;
+			}
 
-		let head_b = test_state.relay_parent;
-		let group_b = test_state.current_group_validator_authority_ids();
-		assert_ne!(head_a, head_b);
-		assert_ne!(group_a, group_b);
+			// Update views.
+			for peed_id in &peers_a {
+				send_peer_view_change(&mut virtual_overseer, peed_id, vec![head_a]).await;
+				expect_advertise_collation_msg(&mut virtual_overseer, peed_id, head_a).await;
+			}
 
-		distribute_collation(&mut virtual_overseer, &test_state, false).await;
-
-		// Should be connected to both groups except for the validator that fetched advertised
-		// collation.
-		assert_matches!(
-			overseer_recv(&mut virtual_overseer).await,
-			AllMessages::NetworkBridgeTx(
-				NetworkBridgeTxMessage::ConnectToValidators { validator_ids, .. }
-			) => {
-				assert!(!validator_ids.contains(&group_a[0]));
-
-				for validator in group_a[1..].iter().chain(&group_b) {
-					assert!(validator_ids.contains(validator));
+			let peer = peers_a[0];
+			// Peer from the group fetches the collation.
+			let (pending_response, rx) = oneshot::channel();
+			req_cfg
+				.inbound_queue
+				.as_mut()
+				.unwrap()
+				.send(RawIncomingRequest {
+					peer,
+					payload: CollationFetchingRequest {
+						relay_parent: head_a,
+						para_id: test_state.para_id,
+					}
+					.encode(),
+					pending_response,
+				})
+				.await
+				.unwrap();
+			assert_matches!(
+				rx.await,
+				Ok(full_response) => {
+					let CollationFetchingResponse::Collation(..): CollationFetchingResponse =
+						CollationFetchingResponse::decode(
+							&mut full_response.result.expect("We should have a proper answer").as_ref(),
+						)
+						.expect("Decoding should work");
 				}
-			}
-		);
+			);
 
-		TestHarness { virtual_overseer, req_cfg }
-	});
+			test_state.advance_to_new_round(&mut virtual_overseer, true).await;
+			test_state.group_rotation_info = test_state.group_rotation_info.bump_rotation();
+
+			let head_b = test_state.relay_parent;
+			let group_b = test_state.current_group_validator_authority_ids();
+			assert_ne!(head_a, head_b);
+			assert_ne!(group_a, group_b);
+
+			distribute_collation(&mut virtual_overseer, &test_state, false).await;
+
+			// Should be connected to both groups except for the validator that fetched advertised
+			// collation.
+			assert_matches!(
+				overseer_recv(&mut virtual_overseer).await,
+				AllMessages::NetworkBridgeTx(
+					NetworkBridgeTxMessage::ConnectToValidators { validator_ids, .. }
+				) => {
+					assert!(!validator_ids.contains(&group_a[0]));
+
+					for validator in group_a[1..].iter().chain(&group_b) {
+						assert!(validator_ids.contains(validator));
+					}
+				}
+			);
+
+			TestHarness { virtual_overseer, req_cfg }
+		},
+	);
 }

--- a/node/network/collator-protocol/src/lib.rs
+++ b/node/network/collator-protocol/src/lib.rs
@@ -28,6 +28,7 @@ use futures::{
 	FutureExt, TryFutureExt,
 };
 
+use polkadot_node_subsystem_util::reputation::ReputationAggregator;
 use sp_keystore::KeystorePtr;
 
 use polkadot_node_network_protocol::{
@@ -36,9 +37,7 @@ use polkadot_node_network_protocol::{
 };
 use polkadot_primitives::CollatorPair;
 
-use polkadot_node_subsystem::{
-	errors::SubsystemError, messages::NetworkBridgeTxMessage, overseer, SpawnedSubsystem,
-};
+use polkadot_node_subsystem::{errors::SubsystemError, overseer, SpawnedSubsystem};
 
 mod error;
 
@@ -124,6 +123,7 @@ impl<Context> CollatorProtocolSubsystem {
 
 /// Modify the reputation of a peer based on its behavior.
 async fn modify_reputation(
+	reputation: &mut ReputationAggregator,
 	sender: &mut impl overseer::CollatorProtocolSenderTrait,
 	peer: PeerId,
 	rep: Rep,
@@ -135,7 +135,7 @@ async fn modify_reputation(
 		"reputation change for peer",
 	);
 
-	sender.send_message(NetworkBridgeTxMessage::ReportPeer(peer, rep)).await;
+	reputation.modify(sender, peer, rep).await;
 }
 
 /// Wait until tick and return the timestamp for the following one.

--- a/node/network/collator-protocol/src/validator_side/mod.rs
+++ b/node/network/collator-protocol/src/validator_side/mod.rs
@@ -1239,7 +1239,8 @@ pub(crate) async fn run<Context>(
 	eviction_policy: crate::CollatorEvictionPolicy,
 	metrics: Metrics,
 ) -> std::result::Result<(), crate::error::FatalError> {
-	let mut state = State { metrics, ..Default::default() };
+	let mut state =
+		State { metrics, reputation: ReputationAggregator::new(|_| true), ..Default::default() };
 
 	let next_inactivity_stream = tick_stream(ACTIVITY_POLL);
 	futures::pin_mut!(next_inactivity_stream);

--- a/node/network/collator-protocol/src/validator_side/mod.rs
+++ b/node/network/collator-protocol/src/validator_side/mod.rs
@@ -1234,13 +1234,23 @@ async fn process_msg<Context>(
 /// The main run loop.
 #[overseer::contextbounds(CollatorProtocol, prefix = self::overseer)]
 pub(crate) async fn run<Context>(
-	mut ctx: Context,
+	ctx: Context,
 	keystore: KeystorePtr,
 	eviction_policy: crate::CollatorEvictionPolicy,
 	metrics: Metrics,
 ) -> std::result::Result<(), crate::error::FatalError> {
-	let mut state =
-		State { metrics, reputation: ReputationAggregator::new(|_| true), ..Default::default() };
+	run_inner(ctx, keystore, eviction_policy, metrics, ReputationAggregator::default()).await
+}
+
+#[overseer::contextbounds(CollatorProtocol, prefix = self::overseer)]
+async fn run_inner<Context>(
+	mut ctx: Context,
+	keystore: KeystorePtr,
+	eviction_policy: crate::CollatorEvictionPolicy,
+	metrics: Metrics,
+	reputation: ReputationAggregator,
+) -> std::result::Result<(), crate::error::FatalError> {
+	let mut state = State { metrics, reputation, ..Default::default() };
 
 	let next_inactivity_stream = tick_stream(ACTIVITY_POLL);
 	futures::pin_mut!(next_inactivity_stream);

--- a/node/network/collator-protocol/src/validator_side/mod.rs
+++ b/node/network/collator-protocol/src/validator_side/mod.rs
@@ -52,7 +52,10 @@ use polkadot_node_subsystem::{
 	},
 	overseer, FromOrchestra, OverseerSignal, PerLeafSpan, SubsystemSender,
 };
-use polkadot_node_subsystem_util::metrics::{self, prometheus};
+use polkadot_node_subsystem_util::{
+	metrics::{self, prometheus},
+	reputation::ReputationAggregator,
+};
 use polkadot_primitives::{CandidateReceipt, CollatorId, Hash, Id as ParaId};
 
 use crate::error::Result;
@@ -612,6 +615,9 @@ struct State {
 
 	/// Keep track of all pending candidate collations
 	pending_candidates: HashMap<Hash, CollationEvent>,
+
+	/// Aggregated reputation change
+	reputation: ReputationAggregator,
 }
 
 // O(n) search for collator ID by iterating through the peers map. This should be fast enough
@@ -675,28 +681,31 @@ async fn fetch_collation(
 
 /// Report a collator for some malicious actions.
 async fn report_collator(
+	reputation: &mut ReputationAggregator,
 	sender: &mut impl overseer::CollatorProtocolSenderTrait,
 	peer_data: &HashMap<PeerId, PeerData>,
 	id: CollatorId,
 ) {
 	if let Some(peer_id) = collator_peer_id(peer_data, &id) {
-		modify_reputation(sender, peer_id, COST_REPORT_BAD).await;
+		modify_reputation(reputation, sender, peer_id, COST_REPORT_BAD).await;
 	}
 }
 
 /// Some other subsystem has reported a collator as a good one, bump reputation.
 async fn note_good_collation(
+	reputation: &mut ReputationAggregator,
 	sender: &mut impl overseer::CollatorProtocolSenderTrait,
 	peer_data: &HashMap<PeerId, PeerData>,
 	id: CollatorId,
 ) {
 	if let Some(peer_id) = collator_peer_id(peer_data, &id) {
-		modify_reputation(sender, peer_id, BENEFIT_NOTIFY_GOOD).await;
+		modify_reputation(reputation, sender, peer_id, BENEFIT_NOTIFY_GOOD).await;
 	}
 }
 
 /// Notify a collator that its collation got seconded.
 async fn notify_collation_seconded(
+	reputation: &mut ReputationAggregator,
 	sender: &mut impl overseer::CollatorProtocolSenderTrait,
 	peer_id: PeerId,
 	relay_parent: Hash,
@@ -711,7 +720,7 @@ async fn notify_collation_seconded(
 		))
 		.await;
 
-	modify_reputation(sender, peer_id, BENEFIT_NOTIFY_GOOD).await;
+	modify_reputation(reputation, sender, peer_id, BENEFIT_NOTIFY_GOOD).await;
 }
 
 /// A peer's view has changed. A number of things should be done:
@@ -813,7 +822,13 @@ async fn process_incoming_peer_message<Context>(
 	match msg {
 		Declare(collator_id, para_id, signature) => {
 			if collator_peer_id(&state.peer_data, &collator_id).is_some() {
-				modify_reputation(ctx.sender(), origin, COST_UNEXPECTED_MESSAGE).await;
+				modify_reputation(
+					&mut state.reputation,
+					ctx.sender(),
+					origin,
+					COST_UNEXPECTED_MESSAGE,
+				)
+				.await;
 				return
 			}
 
@@ -826,7 +841,13 @@ async fn process_incoming_peer_message<Context>(
 						?para_id,
 						"Unknown peer",
 					);
-					modify_reputation(ctx.sender(), origin, COST_UNEXPECTED_MESSAGE).await;
+					modify_reputation(
+						&mut state.reputation,
+						ctx.sender(),
+						origin,
+						COST_UNEXPECTED_MESSAGE,
+					)
+					.await;
 					return
 				},
 			};
@@ -838,7 +859,13 @@ async fn process_incoming_peer_message<Context>(
 					?para_id,
 					"Peer is not in the collating state",
 				);
-				modify_reputation(ctx.sender(), origin, COST_UNEXPECTED_MESSAGE).await;
+				modify_reputation(
+					&mut state.reputation,
+					ctx.sender(),
+					origin,
+					COST_UNEXPECTED_MESSAGE,
+				)
+				.await;
 				return
 			}
 
@@ -849,7 +876,13 @@ async fn process_incoming_peer_message<Context>(
 					?para_id,
 					"Signature verification failure",
 				);
-				modify_reputation(ctx.sender(), origin, COST_INVALID_SIGNATURE).await;
+				modify_reputation(
+					&mut state.reputation,
+					ctx.sender(),
+					origin,
+					COST_INVALID_SIGNATURE,
+				)
+				.await;
 				return
 			}
 
@@ -872,7 +905,13 @@ async fn process_incoming_peer_message<Context>(
 					"Declared as collator for unneeded para",
 				);
 
-				modify_reputation(ctx.sender(), origin, COST_UNNEEDED_COLLATOR).await;
+				modify_reputation(
+					&mut state.reputation,
+					ctx.sender(),
+					origin,
+					COST_UNNEEDED_COLLATOR,
+				)
+				.await;
 				gum::trace!(target: LOG_TARGET, "Disconnecting unneeded collator");
 				disconnect_peer(ctx.sender(), origin).await;
 			}
@@ -890,7 +929,13 @@ async fn process_incoming_peer_message<Context>(
 					"Advertise collation out of view",
 				);
 
-				modify_reputation(ctx.sender(), origin, COST_UNEXPECTED_MESSAGE).await;
+				modify_reputation(
+					&mut state.reputation,
+					ctx.sender(),
+					origin,
+					COST_UNEXPECTED_MESSAGE,
+				)
+				.await;
 				return
 			}
 
@@ -902,7 +947,13 @@ async fn process_incoming_peer_message<Context>(
 						?relay_parent,
 						"Advertise collation message has been received from an unknown peer",
 					);
-					modify_reputation(ctx.sender(), origin, COST_UNEXPECTED_MESSAGE).await;
+					modify_reputation(
+						&mut state.reputation,
+						ctx.sender(),
+						origin,
+						COST_UNEXPECTED_MESSAGE,
+					)
+					.await;
 					return
 				},
 				Some(p) => p,
@@ -961,7 +1012,13 @@ async fn process_incoming_peer_message<Context>(
 						"Invalid advertisement",
 					);
 
-					modify_reputation(ctx.sender(), origin, COST_UNEXPECTED_MESSAGE).await;
+					modify_reputation(
+						&mut state.reputation,
+						ctx.sender(),
+						origin,
+						COST_UNEXPECTED_MESSAGE,
+					)
+					.await;
 				},
 			}
 		},
@@ -1106,7 +1163,7 @@ async fn process_msg<Context>(
 			);
 		},
 		ReportCollator(id) => {
-			report_collator(ctx.sender(), &state.peer_data, id).await;
+			report_collator(&mut state.reputation, ctx.sender(), &state.peer_data, id).await;
 		},
 		NetworkBridgeUpdate(event) => {
 			if let Err(e) = handle_network_msg(ctx, state, keystore, event).await {
@@ -1121,8 +1178,21 @@ async fn process_msg<Context>(
 			if let Some(collation_event) = state.pending_candidates.remove(&parent) {
 				let (collator_id, pending_collation) = collation_event;
 				let PendingCollation { relay_parent, peer_id, .. } = pending_collation;
-				note_good_collation(ctx.sender(), &state.peer_data, collator_id).await;
-				notify_collation_seconded(ctx.sender(), peer_id, relay_parent, stmt).await;
+				note_good_collation(
+					&mut state.reputation,
+					ctx.sender(),
+					&state.peer_data,
+					collator_id,
+				)
+				.await;
+				notify_collation_seconded(
+					&mut state.reputation,
+					ctx.sender(),
+					peer_id,
+					relay_parent,
+					stmt,
+				)
+				.await;
 
 				if let Some(collations) = state.collations_per_relay_parent.get_mut(&parent) {
 					collations.status = CollationStatus::Seconded;
@@ -1153,7 +1223,8 @@ async fn process_msg<Context>(
 				Entry::Vacant(_) => return,
 			};
 
-			report_collator(ctx.sender(), &state.peer_data, id.clone()).await;
+			report_collator(&mut state.reputation, ctx.sender(), &state.peer_data, id.clone())
+				.await;
 
 			dequeue_next_collation_and_fetch(ctx, state, parent, id).await;
 		},
@@ -1217,7 +1288,7 @@ pub(crate) async fn run<Context>(
 				).await;
 
 				for (peer_id, rep) in reputation_changes {
-					modify_reputation(ctx.sender(), peer_id, rep).await;
+					modify_reputation(&mut state.reputation,ctx.sender(), peer_id, rep).await;
 				}
 			},
 		}

--- a/node/network/collator-protocol/src/validator_side/tests.rs
+++ b/node/network/collator-protocol/src/validator_side/tests.rs
@@ -436,7 +436,7 @@ fn collator_reporting_works() {
 				NetworkBridgeTxMessage::ReportPeer(peer, rep),
 			) => {
 				assert_eq!(peer, peer_b);
-				assert_eq!(rep, COST_REPORT_BAD);
+				assert_eq!(rep.value, COST_REPORT_BAD.cost_or_benefit());
 			}
 		);
 
@@ -486,7 +486,7 @@ fn collator_authentication_verification_works() {
 				NetworkBridgeTxMessage::ReportPeer(peer, rep),
 			) => {
 				assert_eq!(peer, peer_b);
-				assert_eq!(rep, COST_INVALID_SIGNATURE);
+				assert_eq!(rep.value, COST_INVALID_SIGNATURE.cost_or_benefit());
 			}
 		);
 		virtual_overseer
@@ -713,7 +713,7 @@ fn reject_connection_to_next_group() {
 				rep,
 			)) => {
 				assert_eq!(peer, peer_b);
-				assert_eq!(rep, COST_UNNEEDED_COLLATOR);
+				assert_eq!(rep.value, COST_UNNEEDED_COLLATOR.cost_or_benefit());
 			}
 		);
 
@@ -806,7 +806,7 @@ fn fetch_next_collation_on_invalid_collation() {
 				rep,
 			)) => {
 				assert_eq!(peer, peer_b);
-				assert_eq!(rep, COST_REPORT_BAD);
+				assert_eq!(rep.value, COST_REPORT_BAD.cost_or_benefit());
 			}
 		);
 
@@ -1021,7 +1021,7 @@ fn disconnect_if_wrong_declare() {
 				rep,
 			)) => {
 				assert_eq!(peer, peer_b);
-				assert_eq!(rep, COST_UNNEEDED_COLLATOR);
+				assert_eq!(rep.value, COST_UNNEEDED_COLLATOR.cost_or_benefit());
 			}
 		);
 

--- a/node/network/collator-protocol/src/validator_side/tests.rs
+++ b/node/network/collator-protocol/src/validator_side/tests.rs
@@ -42,6 +42,7 @@ use polkadot_primitives_test_helpers::{
 
 const ACTIVITY_TIMEOUT: Duration = Duration::from_millis(500);
 const DECLARE_TIMEOUT: Duration = Duration::from_millis(25);
+const REPUTATION_CHANGE_TEST_INTERVAL: Duration = Duration::from_millis(1);
 
 #[derive(Clone)]
 struct TestState {
@@ -150,6 +151,7 @@ fn test_harness<T: Future<Output = VirtualOverseer>>(
 		},
 		Metrics::default(),
 		reputation,
+		REPUTATION_CHANGE_TEST_INTERVAL,
 	);
 
 	let test_fut = test(TestHarness { virtual_overseer });

--- a/node/network/protocol/src/reputation.rs
+++ b/node/network/protocol/src/reputation.rs
@@ -42,7 +42,7 @@ impl UnifiedReputationChange {
 	///
 	/// The whole range of an `i32` should be used, so order of magnitude of
 	/// something malicious should be `1<<20` (give or take).
-	const fn cost_or_benefit(&self) -> i32 {
+	pub const fn cost_or_benefit(&self) -> i32 {
 		match self {
 			Self::CostMinor(_) => -100_000,
 			Self::CostMajor(_) => -300_000,

--- a/node/network/protocol/src/reputation.rs
+++ b/node/network/protocol/src/reputation.rs
@@ -87,3 +87,9 @@ impl UnifiedReputationChange {
 		ReputationChange::new(self.cost_or_benefit(), self.description())
 	}
 }
+
+impl From<UnifiedReputationChange> for ReputationChange {
+	fn from(value: UnifiedReputationChange) -> Self {
+		value.into_base_rep()
+	}
+}

--- a/node/network/protocol/src/reputation.rs
+++ b/node/network/protocol/src/reputation.rs
@@ -81,15 +81,10 @@ impl UnifiedReputationChange {
 			_ => false,
 		}
 	}
-
-	/// Convert into a base reputation as used with substrate.
-	pub const fn into_base_rep(self) -> ReputationChange {
-		ReputationChange::new(self.cost_or_benefit(), self.description())
-	}
 }
 
 impl From<UnifiedReputationChange> for ReputationChange {
 	fn from(value: UnifiedReputationChange) -> Self {
-		value.into()
+		ReputationChange::new(value.cost_or_benefit(), value.description())
 	}
 }

--- a/node/network/protocol/src/reputation.rs
+++ b/node/network/protocol/src/reputation.rs
@@ -90,6 +90,6 @@ impl UnifiedReputationChange {
 
 impl From<UnifiedReputationChange> for ReputationChange {
 	fn from(value: UnifiedReputationChange) -> Self {
-		value.into_base_rep()
+		value.into()
 	}
 }

--- a/node/network/protocol/src/request_response/incoming/mod.rs
+++ b/node/network/protocol/src/request_response/incoming/mod.rs
@@ -88,8 +88,7 @@ where
 		let payload = match Req::decode(&mut payload.as_ref()) {
 			Ok(payload) => payload,
 			Err(err) => {
-				let reputation_changes =
-					reputation_changes.into_iter().map(|r| r.into_base_rep()).collect();
+				let reputation_changes = reputation_changes.into_iter().map(|r| r.into()).collect();
 				let response = sc_network::config::OutgoingResponse {
 					result: Err(()),
 					reputation_changes,
@@ -175,7 +174,7 @@ where
 
 		let response = netconfig::OutgoingResponse {
 			result: result.map(|v| v.encode()),
-			reputation_changes: reputation_changes.into_iter().map(|c| c.into_base_rep()).collect(),
+			reputation_changes: reputation_changes.into_iter().map(|c| c.into()).collect(),
 			sent_feedback,
 		};
 

--- a/node/network/statement-distribution/Cargo.toml
+++ b/node/network/statement-distribution/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 
 [dependencies]
 futures = "0.3.21"
+futures-timer = "3.0.2"
 gum = { package = "tracing-gum", path = "../../gum" }
 polkadot-primitives = { path = "../../../primitives" }
 sp-staking = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }

--- a/node/network/statement-distribution/src/lib.rs
+++ b/node/network/statement-distribution/src/lib.rs
@@ -1172,9 +1172,7 @@ async fn report_peer(
 	peer: PeerId,
 	rep: Rep,
 ) {
-	sender
-		.send_message(NetworkBridgeTxMessage::ReportPeer(peer, rep.into_base_rep()))
-		.await
+	sender.send_message(NetworkBridgeTxMessage::ReportPeer(peer, rep.into())).await
 }
 
 /// If message contains a statement, then retrieve it, otherwise fork task to fetch it.

--- a/node/network/statement-distribution/src/lib.rs
+++ b/node/network/statement-distribution/src/lib.rs
@@ -1172,7 +1172,9 @@ async fn report_peer(
 	peer: PeerId,
 	rep: Rep,
 ) {
-	sender.send_message(NetworkBridgeTxMessage::ReportPeer(peer, rep)).await
+	sender
+		.send_message(NetworkBridgeTxMessage::ReportPeer(peer, rep.into_base_rep()))
+		.await
 }
 
 /// If message contains a statement, then retrieve it, otherwise fork task to fetch it.

--- a/node/network/statement-distribution/src/tests.rs
+++ b/node/network/statement-distribution/src/tests.rs
@@ -863,7 +863,7 @@ fn receiving_from_one_sends_to_another_and_to_candidate_backing() {
 			handle.recv().await,
 			AllMessages::NetworkBridgeTx(
 				NetworkBridgeTxMessage::ReportPeer(p, r)
-			) if p == peer_a && r == BENEFIT_VALID_STATEMENT_FIRST => {}
+			) if p == peer_a && r.value == BENEFIT_VALID_STATEMENT_FIRST.cost_or_benefit() => {}
 		);
 
 		assert_matches!(
@@ -1227,7 +1227,7 @@ fn receiving_large_statement_from_one_sends_to_another_and_to_candidate_backing(
 			handle.recv().await,
 			AllMessages::NetworkBridgeTx(
 				NetworkBridgeTxMessage::ReportPeer(p, r)
-			) if p == peer_bad && r == COST_WRONG_HASH => {}
+			) if p == peer_bad && r.value == COST_WRONG_HASH.cost_or_benefit() => {}
 		);
 
 		// a is tried again (retried in reverse order):
@@ -1278,21 +1278,21 @@ fn receiving_large_statement_from_one_sends_to_another_and_to_candidate_backing(
 			handle.recv().await,
 			AllMessages::NetworkBridgeTx(
 				NetworkBridgeTxMessage::ReportPeer(p, r)
-			) if p == peer_a && r == COST_FETCH_FAIL => {}
+			) if p == peer_a && r.value == COST_FETCH_FAIL.cost_or_benefit() => {}
 		);
 
 		assert_matches!(
 			handle.recv().await,
 			AllMessages::NetworkBridgeTx(
 				NetworkBridgeTxMessage::ReportPeer(p, r)
-			) if p == peer_c && r == BENEFIT_VALID_RESPONSE => {}
+			) if p == peer_c && r.value == BENEFIT_VALID_RESPONSE.cost_or_benefit() => {}
 		);
 
 		assert_matches!(
 			handle.recv().await,
 			AllMessages::NetworkBridgeTx(
 				NetworkBridgeTxMessage::ReportPeer(p, r)
-			) if p == peer_a && r == BENEFIT_VALID_STATEMENT_FIRST => {}
+			) if p == peer_a && r.value == BENEFIT_VALID_STATEMENT_FIRST.cost_or_benefit() => {}
 		);
 
 		assert_matches!(
@@ -1874,7 +1874,7 @@ fn peer_cant_flood_with_large_statements() {
 				},
 
 				AllMessages::NetworkBridgeTx(NetworkBridgeTxMessage::ReportPeer(p, r))
-					if p == peer_a && r == COST_APPARENT_FLOOD =>
+					if p == peer_a && r.value == COST_APPARENT_FLOOD.cost_or_benefit() =>
 				{
 					punished = true;
 				},
@@ -2139,7 +2139,7 @@ fn handle_multiple_seconded_statements() {
 				NetworkBridgeTxMessage::ReportPeer(p, r)
 			) => {
 				assert_eq!(p, peer_a);
-				assert_eq!(r, BENEFIT_VALID_STATEMENT_FIRST);
+				assert_eq!(r.value, BENEFIT_VALID_STATEMENT_FIRST.cost_or_benefit());
 			}
 		);
 
@@ -2191,7 +2191,7 @@ fn handle_multiple_seconded_statements() {
 				NetworkBridgeTxMessage::ReportPeer(p, r)
 			) => {
 				assert_eq!(p, peer_b);
-				assert_eq!(r, BENEFIT_VALID_STATEMENT);
+				assert_eq!(r.value, BENEFIT_VALID_STATEMENT.cost_or_benefit());
 			}
 		);
 
@@ -2240,7 +2240,7 @@ fn handle_multiple_seconded_statements() {
 				NetworkBridgeTxMessage::ReportPeer(p, r)
 			) => {
 				assert_eq!(p, peer_a);
-				assert_eq!(r, BENEFIT_VALID_STATEMENT_FIRST);
+				assert_eq!(r.value, BENEFIT_VALID_STATEMENT_FIRST.cost_or_benefit());
 			}
 		);
 
@@ -2293,7 +2293,7 @@ fn handle_multiple_seconded_statements() {
 				NetworkBridgeTxMessage::ReportPeer(p, r)
 			) => {
 				assert_eq!(p, peer_b);
-				assert_eq!(r, BENEFIT_VALID_STATEMENT);
+				assert_eq!(r.value, BENEFIT_VALID_STATEMENT.cost_or_benefit());
 			}
 		);
 

--- a/node/network/statement-distribution/src/tests.rs
+++ b/node/network/statement-distribution/src/tests.rs
@@ -1395,6 +1395,448 @@ fn receiving_large_statement_from_one_sends_to_another_and_to_candidate_backing(
 }
 
 #[test]
+fn delay_reputation_changes() {
+	sp_tracing::try_init_simple();
+	let hash_a = Hash::repeat_byte(1);
+
+	let candidate = {
+		let mut c = dummy_committed_candidate_receipt(dummy_hash());
+		c.descriptor.relay_parent = hash_a;
+		c.descriptor.para_id = 1.into();
+		c.commitments.new_validation_code = Some(ValidationCode(vec![1, 2, 3]));
+		c
+	};
+
+	let peer_a = PeerId::random(); // Alice
+	let peer_b = PeerId::random(); // Bob
+	let peer_c = PeerId::random(); // Charlie
+	let peer_bad = PeerId::random(); // No validator
+
+	let validators = vec![
+		Sr25519Keyring::Alice.pair(),
+		Sr25519Keyring::Bob.pair(),
+		Sr25519Keyring::Charlie.pair(),
+		// We:
+		Sr25519Keyring::Ferdie.pair(),
+	];
+
+	let session_info = make_session_info(validators, vec![vec![0, 1, 2, 4], vec![3]]);
+
+	let session_index = 1;
+
+	let pool = sp_core::testing::TaskExecutor::new();
+	let (ctx, mut handle) = polkadot_node_subsystem_test_helpers::make_subsystem_context(pool);
+
+	let req_protocol_names = ReqProtocolNames::new(&GENESIS_HASH, None);
+	let (statement_req_receiver, _) = IncomingRequest::get_config_receiver(&req_protocol_names);
+
+	let reputation_interval = Duration::from_millis(100);
+
+	let bg = async move {
+		let s = StatementDistributionSubsystem {
+			keystore: make_ferdie_keystore(),
+			req_receiver: Some(statement_req_receiver),
+			metrics: Default::default(),
+			rng: AlwaysZeroRng,
+			reputation: ReputationAggregator::new(|_| false),
+		};
+		s.run_inner(ctx, reputation_interval).await.unwrap();
+	};
+
+	let test_fut = async move {
+		// register our active heads.
+		handle
+			.send(FromOrchestra::Signal(OverseerSignal::ActiveLeaves(
+				ActiveLeavesUpdate::start_work(ActivatedLeaf {
+					hash: hash_a,
+					number: 1,
+					status: LeafStatus::Fresh,
+					span: Arc::new(jaeger::Span::Disabled),
+				}),
+			)))
+			.await;
+
+		assert_matches!(
+			handle.recv().await,
+			AllMessages::RuntimeApi(
+				RuntimeApiMessage::Request(r, RuntimeApiRequest::SessionIndexForChild(tx))
+			)
+				if r == hash_a
+			=> {
+				let _ = tx.send(Ok(session_index));
+			}
+		);
+
+		assert_matches!(
+			handle.recv().await,
+			AllMessages::RuntimeApi(
+				RuntimeApiMessage::Request(r, RuntimeApiRequest::SessionInfo(sess_index, tx))
+			)
+				if r == hash_a && sess_index == session_index
+			=> {
+				let _ = tx.send(Ok(Some(session_info)));
+			}
+		);
+
+		// notify of peers and view
+		handle
+			.send(FromOrchestra::Communication {
+				msg: StatementDistributionMessage::NetworkBridgeUpdate(
+					NetworkBridgeEvent::PeerConnected(
+						peer_a.clone(),
+						ObservedRole::Full,
+						ValidationVersion::V1.into(),
+						Some(HashSet::from([Sr25519Keyring::Alice.public().into()])),
+					),
+				),
+			})
+			.await;
+
+		handle
+			.send(FromOrchestra::Communication {
+				msg: StatementDistributionMessage::NetworkBridgeUpdate(
+					NetworkBridgeEvent::PeerConnected(
+						peer_b.clone(),
+						ObservedRole::Full,
+						ValidationVersion::V1.into(),
+						Some(HashSet::from([Sr25519Keyring::Bob.public().into()])),
+					),
+				),
+			})
+			.await;
+		handle
+			.send(FromOrchestra::Communication {
+				msg: StatementDistributionMessage::NetworkBridgeUpdate(
+					NetworkBridgeEvent::PeerConnected(
+						peer_c.clone(),
+						ObservedRole::Full,
+						ValidationVersion::V1.into(),
+						Some(HashSet::from([Sr25519Keyring::Charlie.public().into()])),
+					),
+				),
+			})
+			.await;
+		handle
+			.send(FromOrchestra::Communication {
+				msg: StatementDistributionMessage::NetworkBridgeUpdate(
+					NetworkBridgeEvent::PeerConnected(
+						peer_bad.clone(),
+						ObservedRole::Full,
+						ValidationVersion::V1.into(),
+						None,
+					),
+				),
+			})
+			.await;
+
+		handle
+			.send(FromOrchestra::Communication {
+				msg: StatementDistributionMessage::NetworkBridgeUpdate(
+					NetworkBridgeEvent::PeerViewChange(peer_a.clone(), view![hash_a]),
+				),
+			})
+			.await;
+
+		handle
+			.send(FromOrchestra::Communication {
+				msg: StatementDistributionMessage::NetworkBridgeUpdate(
+					NetworkBridgeEvent::PeerViewChange(peer_b.clone(), view![hash_a]),
+				),
+			})
+			.await;
+		handle
+			.send(FromOrchestra::Communication {
+				msg: StatementDistributionMessage::NetworkBridgeUpdate(
+					NetworkBridgeEvent::PeerViewChange(peer_c.clone(), view![hash_a]),
+				),
+			})
+			.await;
+		handle
+			.send(FromOrchestra::Communication {
+				msg: StatementDistributionMessage::NetworkBridgeUpdate(
+					NetworkBridgeEvent::PeerViewChange(peer_bad.clone(), view![hash_a]),
+				),
+			})
+			.await;
+
+		// receive a seconded statement from peer A, which does not provide the request data,
+		// then get that data from peer C. It should be propagated onwards to peer B and to
+		// candidate backing.
+		let statement = {
+			let signing_context = SigningContext { parent_hash: hash_a, session_index };
+
+			let keystore: KeystorePtr = Arc::new(LocalKeystore::in_memory());
+			let alice_public = Keystore::sr25519_generate_new(
+				&*keystore,
+				ValidatorId::ID,
+				Some(&Sr25519Keyring::Alice.to_seed()),
+			)
+			.unwrap();
+
+			SignedFullStatement::sign(
+				&keystore,
+				Statement::Seconded(candidate.clone()),
+				&signing_context,
+				ValidatorIndex(0),
+				&alice_public.into(),
+			)
+			.ok()
+			.flatten()
+			.expect("should be signed")
+		};
+
+		let metadata = derive_metadata_assuming_seconded(hash_a, statement.clone().into());
+
+		handle
+			.send(FromOrchestra::Communication {
+				msg: StatementDistributionMessage::NetworkBridgeUpdate(
+					NetworkBridgeEvent::PeerMessage(
+						peer_a.clone(),
+						Versioned::V1(protocol_v1::StatementDistributionMessage::LargeStatement(
+							metadata.clone(),
+						)),
+					),
+				),
+			})
+			.await;
+
+		assert_matches!(
+			handle.recv().await,
+			AllMessages::NetworkBridgeTx(
+				NetworkBridgeTxMessage::SendRequests(
+					mut reqs, IfDisconnected::ImmediateError
+				)
+			) => {
+				let reqs = reqs.pop().unwrap();
+				let outgoing = match reqs {
+					Requests::StatementFetchingV1(outgoing) => outgoing,
+					_ => panic!("Unexpected request"),
+				};
+				let req = outgoing.payload;
+				assert_eq!(req.relay_parent, metadata.relay_parent);
+				assert_eq!(req.candidate_hash, metadata.candidate_hash);
+				assert_eq!(outgoing.peer, Recipient::Peer(peer_a));
+				// Just drop request - should trigger error.
+			}
+		);
+
+		// There is a race between request handler asking for more peers and processing of the
+		// coming `PeerMessage`s, we want the request handler to ask first here for better test
+		// coverage:
+		Delay::new(Duration::from_millis(20)).await;
+
+		handle
+			.send(FromOrchestra::Communication {
+				msg: StatementDistributionMessage::NetworkBridgeUpdate(
+					NetworkBridgeEvent::PeerMessage(
+						peer_c.clone(),
+						Versioned::V1(protocol_v1::StatementDistributionMessage::LargeStatement(
+							metadata.clone(),
+						)),
+					),
+				),
+			})
+			.await;
+
+		// Malicious peer:
+		handle
+			.send(FromOrchestra::Communication {
+				msg: StatementDistributionMessage::NetworkBridgeUpdate(
+					NetworkBridgeEvent::PeerMessage(
+						peer_bad.clone(),
+						Versioned::V1(protocol_v1::StatementDistributionMessage::LargeStatement(
+							metadata.clone(),
+						)),
+					),
+				),
+			})
+			.await;
+
+		// Let c fail once too:
+		assert_matches!(
+			handle.recv().await,
+			AllMessages::NetworkBridgeTx(
+				NetworkBridgeTxMessage::SendRequests(
+					mut reqs, IfDisconnected::ImmediateError
+				)
+			) => {
+				let reqs = reqs.pop().unwrap();
+				let outgoing = match reqs {
+					Requests::StatementFetchingV1(outgoing) => outgoing,
+					_ => panic!("Unexpected request"),
+				};
+				let req = outgoing.payload;
+				assert_eq!(req.relay_parent, metadata.relay_parent);
+				assert_eq!(req.candidate_hash, metadata.candidate_hash);
+				assert_eq!(outgoing.peer, Recipient::Peer(peer_c));
+			}
+		);
+
+		// a fails again:
+		assert_matches!(
+			handle.recv().await,
+			AllMessages::NetworkBridgeTx(
+				NetworkBridgeTxMessage::SendRequests(
+					mut reqs, IfDisconnected::ImmediateError
+				)
+			) => {
+				let reqs = reqs.pop().unwrap();
+				let outgoing = match reqs {
+					Requests::StatementFetchingV1(outgoing) => outgoing,
+					_ => panic!("Unexpected request"),
+				};
+				let req = outgoing.payload;
+				assert_eq!(req.relay_parent, metadata.relay_parent);
+				assert_eq!(req.candidate_hash, metadata.candidate_hash);
+				// On retry, we should have reverse order:
+				assert_eq!(outgoing.peer, Recipient::Peer(peer_a));
+			}
+		);
+
+		// Send invalid response (all other peers have been tried now):
+		assert_matches!(
+			handle.recv().await,
+			AllMessages::NetworkBridgeTx(
+				NetworkBridgeTxMessage::SendRequests(
+					mut reqs, IfDisconnected::ImmediateError
+				)
+			) => {
+				let reqs = reqs.pop().unwrap();
+				let outgoing = match reqs {
+					Requests::StatementFetchingV1(outgoing) => outgoing,
+					_ => panic!("Unexpected request"),
+				};
+				let req = outgoing.payload;
+				assert_eq!(req.relay_parent, metadata.relay_parent);
+				assert_eq!(req.candidate_hash, metadata.candidate_hash);
+				assert_eq!(outgoing.peer, Recipient::Peer(peer_bad));
+				let bad_candidate = {
+					let mut bad = candidate.clone();
+					bad.descriptor.para_id = 0xeadbeaf.into();
+					bad
+				};
+				let response = StatementFetchingResponse::Statement(bad_candidate);
+				outgoing.pending_response.send(Ok(response.encode())).unwrap();
+			}
+		);
+
+		// a is tried again (retried in reverse order):
+		assert_matches!(
+			handle.recv().await,
+			AllMessages::NetworkBridgeTx(
+				NetworkBridgeTxMessage::SendRequests(
+					mut reqs, IfDisconnected::ImmediateError
+				)
+			) => {
+				let reqs = reqs.pop().unwrap();
+				let outgoing = match reqs {
+					Requests::StatementFetchingV1(outgoing) => outgoing,
+					_ => panic!("Unexpected request"),
+				};
+				let req = outgoing.payload;
+				assert_eq!(req.relay_parent, metadata.relay_parent);
+				assert_eq!(req.candidate_hash, metadata.candidate_hash);
+				// On retry, we should have reverse order:
+				assert_eq!(outgoing.peer, Recipient::Peer(peer_a));
+			}
+		);
+
+		// c succeeds now:
+		assert_matches!(
+			handle.recv().await,
+			AllMessages::NetworkBridgeTx(
+				NetworkBridgeTxMessage::SendRequests(
+					mut reqs, IfDisconnected::ImmediateError
+				)
+			) => {
+				let reqs = reqs.pop().unwrap();
+				let outgoing = match reqs {
+					Requests::StatementFetchingV1(outgoing) => outgoing,
+					_ => panic!("Unexpected request"),
+				};
+				let req = outgoing.payload;
+				assert_eq!(req.relay_parent, metadata.relay_parent);
+				assert_eq!(req.candidate_hash, metadata.candidate_hash);
+				// On retry, we should have reverse order:
+				assert_eq!(outgoing.peer, Recipient::Peer(peer_c));
+				let response = StatementFetchingResponse::Statement(candidate.clone());
+				outgoing.pending_response.send(Ok(response.encode())).unwrap();
+			}
+		);
+
+		assert_matches!(
+			handle.recv().await,
+			AllMessages::CandidateBacking(
+				CandidateBackingMessage::Statement(r, s)
+			) if r == hash_a && s == statement => {}
+		);
+
+		// Now messages should go out:
+		assert_matches!(
+			handle.recv().await,
+			AllMessages::NetworkBridgeTx(
+				NetworkBridgeTxMessage::SendValidationMessage(
+					mut recipients,
+					Versioned::V1(protocol_v1::ValidationProtocol::StatementDistribution(
+						protocol_v1::StatementDistributionMessage::LargeStatement(meta)
+					)),
+				)
+			) => {
+				gum::debug!(
+					target: LOG_TARGET,
+					?recipients,
+					"Recipients received"
+				);
+				recipients.sort();
+				let mut expected = vec![peer_b, peer_c, peer_bad];
+				expected.sort();
+				assert_eq!(recipients, expected);
+				assert_eq!(meta.relay_parent, hash_a);
+				assert_eq!(meta.candidate_hash, statement.payload().candidate_hash());
+				assert_eq!(meta.signed_by, statement.validator_index());
+				assert_eq!(&meta.signature, statement.signature());
+			}
+		);
+
+		// Wait enough to fire reputation delay
+		futures_timer::Delay::new(reputation_interval).await;
+		let aggregated_change = |v: Vec<Rep>| {
+			v.iter().fold(0_i32, |acc, rep| acc.saturating_add(rep.cost_or_benefit()))
+		};
+
+		for report in vec![handle.recv().await, handle.recv().await, handle.recv().await] {
+			if let AllMessages::NetworkBridgeTx(NetworkBridgeTxMessage::ReportPeer(p, r)) = report {
+				if p == peer_a {
+					assert_eq!(
+						r.value,
+						aggregated_change(vec![COST_FETCH_FAIL, BENEFIT_VALID_STATEMENT_FIRST])
+					);
+				} else if p == peer_c {
+					assert_eq!(
+						r.value,
+						aggregated_change(vec![BENEFIT_VALID_RESPONSE, BENEFIT_VALID_STATEMENT])
+					);
+				} else if p == peer_bad {
+					assert_eq!(
+						r.value,
+						aggregated_change(vec![COST_WRONG_HASH, BENEFIT_VALID_STATEMENT])
+					);
+				} else {
+					panic!("Messages should contain only peer reports");
+				}
+			}
+		}
+
+		handle.send(FromOrchestra::Signal(OverseerSignal::Conclude)).await;
+	};
+
+	futures::pin_mut!(test_fut);
+	futures::pin_mut!(bg);
+
+	executor::block_on(future::join(test_fut, bg));
+}
+
+#[test]
 fn share_prioritizes_backing_group() {
 	sp_tracing::try_init_simple();
 	let hash_a = Hash::repeat_byte(1);

--- a/node/network/statement-distribution/src/tests.rs
+++ b/node/network/statement-distribution/src/tests.rs
@@ -733,12 +733,13 @@ fn receiving_from_one_sends_to_another_and_to_candidate_backing() {
 	let (statement_req_receiver, _) = IncomingRequest::get_config_receiver(&req_protocol_names);
 
 	let bg = async move {
-		let s = StatementDistributionSubsystem::new(
-			Arc::new(LocalKeystore::in_memory()),
-			statement_req_receiver,
-			Default::default(),
-			AlwaysZeroRng,
-		);
+		let s = StatementDistributionSubsystem {
+			keystore: Arc::new(LocalKeystore::in_memory()),
+			req_receiver: Some(statement_req_receiver),
+			metrics: Default::default(),
+			rng: AlwaysZeroRng,
+			reputation: ReputationAggregator::new(|_| true),
+		};
 		s.run(ctx).await.unwrap();
 	};
 
@@ -936,12 +937,13 @@ fn receiving_large_statement_from_one_sends_to_another_and_to_candidate_backing(
 		IncomingRequest::get_config_receiver(&req_protocol_names);
 
 	let bg = async move {
-		let s = StatementDistributionSubsystem::new(
-			make_ferdie_keystore(),
-			statement_req_receiver,
-			Default::default(),
-			AlwaysZeroRng,
-		);
+		let s = StatementDistributionSubsystem {
+			keystore: make_ferdie_keystore(),
+			req_receiver: Some(statement_req_receiver),
+			metrics: Default::default(),
+			rng: AlwaysZeroRng,
+			reputation: ReputationAggregator::new(|_| true),
+		};
 		s.run(ctx).await.unwrap();
 	};
 
@@ -1448,12 +1450,13 @@ fn share_prioritizes_backing_group() {
 		IncomingRequest::get_config_receiver(&req_protocol_names);
 
 	let bg = async move {
-		let s = StatementDistributionSubsystem::new(
-			make_ferdie_keystore(),
-			statement_req_receiver,
-			Default::default(),
-			AlwaysZeroRng,
-		);
+		let s = StatementDistributionSubsystem {
+			keystore: make_ferdie_keystore(),
+			req_receiver: Some(statement_req_receiver),
+			metrics: Default::default(),
+			rng: AlwaysZeroRng,
+			reputation: ReputationAggregator::new(|_| true),
+		};
 		s.run(ctx).await.unwrap();
 	};
 
@@ -1741,12 +1744,13 @@ fn peer_cant_flood_with_large_statements() {
 	let req_protocol_names = ReqProtocolNames::new(&GENESIS_HASH, None);
 	let (statement_req_receiver, _) = IncomingRequest::get_config_receiver(&req_protocol_names);
 	let bg = async move {
-		let s = StatementDistributionSubsystem::new(
-			make_ferdie_keystore(),
-			statement_req_receiver,
-			Default::default(),
-			AlwaysZeroRng,
-		);
+		let s = StatementDistributionSubsystem {
+			keystore: make_ferdie_keystore(),
+			req_receiver: Some(statement_req_receiver),
+			metrics: Default::default(),
+			rng: AlwaysZeroRng,
+			reputation: ReputationAggregator::new(|_| true),
+		};
 		s.run(ctx).await.unwrap();
 	};
 
@@ -1945,12 +1949,13 @@ fn handle_multiple_seconded_statements() {
 	let (statement_req_receiver, _) = IncomingRequest::get_config_receiver(&req_protocol_names);
 
 	let virtual_overseer_fut = async move {
-		let s = StatementDistributionSubsystem::new(
-			Arc::new(LocalKeystore::in_memory()),
-			statement_req_receiver,
-			Default::default(),
-			AlwaysZeroRng,
-		);
+		let s = StatementDistributionSubsystem {
+			keystore: Arc::new(LocalKeystore::in_memory()),
+			req_receiver: Some(statement_req_receiver),
+			metrics: Default::default(),
+			rng: AlwaysZeroRng,
+			reputation: ReputationAggregator::new(|_| true),
+		};
 		s.run(ctx).await.unwrap();
 	};
 

--- a/node/overseer/src/tests.rs
+++ b/node/overseer/src/tests.rs
@@ -855,7 +855,10 @@ fn test_availability_store_msg() -> AvailabilityStoreMessage {
 }
 
 fn test_network_bridge_tx_msg() -> NetworkBridgeTxMessage {
-	NetworkBridgeTxMessage::ReportPeer(PeerId::random(), UnifiedReputationChange::BenefitMinor(""))
+	NetworkBridgeTxMessage::ReportPeer(
+		PeerId::random(),
+		UnifiedReputationChange::BenefitMinor("").into_base_rep(),
+	)
 }
 
 fn test_network_bridge_rx_msg() -> NetworkBridgeRxMessage {

--- a/node/overseer/src/tests.rs
+++ b/node/overseer/src/tests.rs
@@ -26,7 +26,7 @@ use polkadot_node_primitives::{
 };
 use polkadot_node_subsystem_types::{
 	jaeger,
-	messages::{NetworkBridgeEvent, RuntimeApiRequest},
+	messages::{NetworkBridgeEvent, ReportPeerMessage, RuntimeApiRequest},
 	ActivatedLeaf, LeafStatus,
 };
 use polkadot_primitives::{
@@ -855,10 +855,10 @@ fn test_availability_store_msg() -> AvailabilityStoreMessage {
 }
 
 fn test_network_bridge_tx_msg() -> NetworkBridgeTxMessage {
-	NetworkBridgeTxMessage::ReportPeer(
+	NetworkBridgeTxMessage::ReportPeer(ReportPeerMessage::Single(
 		PeerId::random(),
 		UnifiedReputationChange::BenefitMinor("").into(),
-	)
+	))
 }
 
 fn test_network_bridge_rx_msg() -> NetworkBridgeRxMessage {

--- a/node/overseer/src/tests.rs
+++ b/node/overseer/src/tests.rs
@@ -857,7 +857,7 @@ fn test_availability_store_msg() -> AvailabilityStoreMessage {
 fn test_network_bridge_tx_msg() -> NetworkBridgeTxMessage {
 	NetworkBridgeTxMessage::ReportPeer(
 		PeerId::random(),
-		UnifiedReputationChange::BenefitMinor("").into_base_rep(),
+		UnifiedReputationChange::BenefitMinor("").into(),
 	)
 }
 

--- a/node/subsystem-types/src/messages.rs
+++ b/node/subsystem-types/src/messages.rs
@@ -23,14 +23,13 @@
 //! Subsystems' APIs are defined separately from their implementation, leading to easier mocking.
 
 use futures::channel::oneshot;
-use sc_network::Multiaddr;
+use sc_network::{Multiaddr, ReputationChange};
 use thiserror::Error;
 
 pub use sc_network::IfDisconnected;
 
 use polkadot_node_network_protocol::{
 	self as net_protocol, peer_set::PeerSet, request_response::Requests, PeerId,
-	UnifiedReputationChange,
 };
 use polkadot_node_primitives::{
 	approval::{BlockApprovalMeta, IndirectAssignmentCert, IndirectSignedApprovalVote},
@@ -309,7 +308,7 @@ pub enum NetworkBridgeRxMessage {
 #[derive(Debug)]
 pub enum NetworkBridgeTxMessage {
 	/// Report a peer for their actions.
-	ReportPeer(PeerId, UnifiedReputationChange),
+	ReportPeer(PeerId, ReputationChange),
 
 	/// Disconnect a peer from the given peer-set without affecting their reputation.
 	DisconnectPeer(PeerId, PeerSet),

--- a/node/subsystem-types/src/messages.rs
+++ b/node/subsystem-types/src/messages.rs
@@ -310,7 +310,7 @@ pub enum ReportPeerMessage {
 	/// Single peer report about malicious actions which should be sent right away
 	Single(PeerId, ReputationChange),
 	/// Delayed report for other actions.
-	Batch(HashMap<PeerId, i32>),
+	Batch(HashMap<PeerId, (i32, u64)>),
 }
 
 /// Messages received from other subsystems by the network bridge subsystem.

--- a/node/subsystem-types/src/messages.rs
+++ b/node/subsystem-types/src/messages.rs
@@ -310,7 +310,7 @@ pub enum ReportPeerMessage {
 	/// Single peer report about malicious actions which should be sent right away
 	Single(PeerId, ReputationChange),
 	/// Delayed report for other actions.
-	Batch(HashMap<PeerId, (i32, u64)>),
+	Batch(HashMap<PeerId, i32>),
 }
 
 /// Messages received from other subsystems by the network bridge subsystem.

--- a/node/subsystem-types/src/messages.rs
+++ b/node/subsystem-types/src/messages.rs
@@ -304,11 +304,20 @@ pub enum NetworkBridgeRxMessage {
 	},
 }
 
+/// Type of peer reporting
+#[derive(Debug)]
+pub enum ReportPeerMessage {
+	/// Single peer report about malicious actions which should be sent right away
+	Single(PeerId, ReputationChange),
+	/// Delayed report for other actions.
+	Batch(HashMap<PeerId, i32>),
+}
+
 /// Messages received from other subsystems by the network bridge subsystem.
 #[derive(Debug)]
 pub enum NetworkBridgeTxMessage {
 	/// Report a peer for their actions.
-	ReportPeer(PeerId, ReputationChange),
+	ReportPeer(ReportPeerMessage),
 
 	/// Disconnect a peer from the given peer-set without affecting their reputation.
 	DisconnectPeer(PeerId, PeerSet),

--- a/node/subsystem-util/src/lib.rs
+++ b/node/subsystem-util/src/lib.rs
@@ -77,6 +77,8 @@ pub mod database;
 /// tasks, sending messages back.
 pub mod nesting_sender;
 
+pub mod reputation;
+
 mod determine_new_blocks;
 
 #[cfg(test)]

--- a/node/subsystem-util/src/reputation.rs
+++ b/node/subsystem-util/src/reputation.rs
@@ -18,7 +18,9 @@
 
 use polkadot_node_network_protocol::{self as net_protocol, PeerId, UnifiedReputationChange};
 use polkadot_node_subsystem::{messages::NetworkBridgeTxMessage, overseer};
+use std::time::Duration;
 
+pub const REPUTATION_CHANGE_INTERVAL: Duration = Duration::from_secs(30);
 /// Collects reputation changes and sends them in one batch to relieve network channels
 #[derive(Debug, Clone)]
 pub struct ReputationAggregator {

--- a/node/subsystem-util/src/reputation.rs
+++ b/node/subsystem-util/src/reputation.rs
@@ -80,11 +80,10 @@ impl ReputationAggregator {
 	}
 
 	fn add(&mut self, peer_id: PeerId, rep: UnifiedReputationChange) {
-		let current = match self.by_peer.get(&peer_id) {
-			Some(v) => *v,
-			None => 0,
-		};
-		let new_value = current.saturating_add(rep.cost_or_benefit());
-		self.by_peer.insert(peer_id, new_value);
+		let cost = rep.cost_or_benefit();
+		self.by_peer
+			.entry(peer_id)
+			.and_modify(|v| *v = v.saturating_add(cost))
+			.or_insert(cost);
 	}
 }

--- a/node/subsystem-util/src/reputation.rs
+++ b/node/subsystem-util/src/reputation.rs
@@ -1,0 +1,59 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// This file is part of Polkadot.
+
+// Polkadot is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Polkadot is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
+
+use polkadot_node_network_protocol::{PeerId, UnifiedReputationChange};
+
+#[derive(Debug, Clone)]
+pub struct ReputationAggregator {
+	malicious_reported: bool,
+	by_peer: std::collections::HashMap<PeerId, i32>,
+}
+
+impl Default for ReputationAggregator {
+	fn default() -> Self {
+		Self::new()
+	}
+}
+
+impl ReputationAggregator {
+	pub fn new() -> Self {
+		Self { malicious_reported: false, by_peer: std::collections::HashMap::new() }
+	}
+
+	pub fn clear(&mut self) {
+		self.by_peer.clear();
+	}
+
+	pub fn update(&mut self, peer_id: PeerId, rep: UnifiedReputationChange) {
+		if matches!(rep, UnifiedReputationChange::Malicious(_)) {
+			self.malicious_reported = true;
+		}
+		let current = match self.by_peer.get(&peer_id) {
+			Some(v) => *v,
+			None => 0,
+		};
+		let new_value = current.saturating_add(rep.cost_or_benefit());
+		self.by_peer.insert(peer_id, new_value);
+	}
+
+	pub fn malicious_reported(&self) -> bool {
+		self.malicious_reported
+	}
+
+	pub fn by_peer(&self) -> &std::collections::HashMap<PeerId, i32> {
+		&self.by_peer
+	}
+}

--- a/node/subsystem-util/src/reputation.rs
+++ b/node/subsystem-util/src/reputation.rs
@@ -26,13 +26,7 @@ use std::{collections::HashMap, time::Duration};
 /// Default delay for sending reputation changes
 pub const REPUTATION_CHANGE_INTERVAL: Duration = Duration::from_secs(30);
 
-type BatchReputationChange = HashMap<
-	PeerId,
-	(
-		i32, // Aggregated value
-		u64, // Counter
-	),
->;
+type BatchReputationChange = HashMap<PeerId, i32>;
 
 /// Collects reputation changes and sends them in one batch to relieve network channels
 #[derive(Debug, Clone)]
@@ -118,7 +112,5 @@ pub fn add_reputation(
 	rep: UnifiedReputationChange,
 ) {
 	let cost = rep.cost_or_benefit();
-	acc.entry(peer_id)
-		.and_modify(|v| *v = (v.0.saturating_add(cost), v.1 + 1))
-		.or_insert((cost, 1));
+	acc.entry(peer_id).and_modify(|v| *v = v.saturating_add(cost)).or_insert(cost);
 }

--- a/node/subsystem-util/src/reputation.rs
+++ b/node/subsystem-util/src/reputation.rs
@@ -26,7 +26,13 @@ use std::{collections::HashMap, time::Duration};
 /// Default delay for sending reputation changes
 pub const REPUTATION_CHANGE_INTERVAL: Duration = Duration::from_secs(30);
 
-type BatchReputationChange = HashMap<PeerId, i32>;
+type BatchReputationChange = HashMap<
+	PeerId,
+	(
+		i32, // Aggregated value
+		u64, // Counter
+	),
+>;
 
 /// Collects reputation changes and sends them in one batch to relieve network channels
 #[derive(Debug, Clone)]
@@ -113,5 +119,7 @@ pub fn add_reputation(
 	rep: UnifiedReputationChange,
 ) {
 	let cost = rep.cost_or_benefit();
-	acc.entry(peer_id).and_modify(|v| *v = v.saturating_add(cost)).or_insert(cost);
+	acc.entry(peer_id)
+		.and_modify(|v| *v = (v.0.saturating_add(cost), v.1 + 1))
+		.or_insert((cost, 1));
 }

--- a/node/subsystem-util/src/reputation.rs
+++ b/node/subsystem-util/src/reputation.rs
@@ -48,7 +48,7 @@ impl ReputationAggregator {
 	///
 	/// * `send_immediately_if` - A function, takes `UnifiedReputationChange`,
 	/// results shows if we need to send the changes right away.
-	/// Useful for malicious changes and tests.
+	/// By default, it is used for sending `UnifiedReputationChange::Malicious` changes immediately and for testing.
 	pub fn new(send_immediately_if: fn(UnifiedReputationChange) -> bool) -> Self {
 		Self { by_peer: Default::default(), send_immediately_if }
 	}

--- a/node/subsystem-util/src/reputation.rs
+++ b/node/subsystem-util/src/reputation.rs
@@ -20,7 +20,9 @@ use polkadot_node_network_protocol::{self as net_protocol, PeerId, UnifiedReputa
 use polkadot_node_subsystem::{messages::NetworkBridgeTxMessage, overseer};
 use std::time::Duration;
 
+/// Default delay for sending reputation changes
 pub const REPUTATION_CHANGE_INTERVAL: Duration = Duration::from_secs(30);
+
 /// Collects reputation changes and sends them in one batch to relieve network channels
 #[derive(Debug, Clone)]
 pub struct ReputationAggregator {

--- a/node/subsystem-util/src/reputation.rs
+++ b/node/subsystem-util/src/reputation.rs
@@ -14,10 +14,12 @@
 // You should have received a copy of the GNU General Public License
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
+//! A utility abstraction to collect and send reputation changes.
+
 use polkadot_node_network_protocol::{self as net_protocol, PeerId, UnifiedReputationChange};
 use polkadot_node_subsystem::{messages::NetworkBridgeTxMessage, overseer};
 
-/// TODO
+/// Collects reputation changes and sends them in one batch to relieve network channels
 #[derive(Debug, Clone)]
 pub struct ReputationAggregator {
 	send_immediately_if: fn(UnifiedReputationChange) -> bool,
@@ -31,12 +33,19 @@ impl Default for ReputationAggregator {
 }
 
 impl ReputationAggregator {
-	/// TODO
+	/// New ReputationAggregator
+	///
+	/// # Arguments
+	///
+	/// * `send_immediately_if` - A function, takes `UnifiedReputationChange`,
+	/// results shows if we need to send the changes right away.
+	/// Useful for malicious changes and tests.
 	pub fn new(send_immediately_if: fn(UnifiedReputationChange) -> bool) -> Self {
 		Self { by_peer: Default::default(), send_immediately_if }
 	}
 
-	/// TODO
+	/// Sends collected reputation changes in a batch,
+	/// removing them from inner state
 	pub async fn send(
 		&mut self,
 		sender: &mut impl overseer::SubsystemSender<NetworkBridgeTxMessage>,
@@ -52,7 +61,8 @@ impl ReputationAggregator {
 		self.by_peer.clear();
 	}
 
-	/// TODO
+	/// Adds reputation change to inner state,
+	/// сhecks if the change is dangerous, sends all collected changes in a batch if it is
 	pub async fn modify(
 		&mut self,
 		sender: &mut impl overseer::SubsystemSender<NetworkBridgeTxMessage>,

--- a/node/subsystem-util/src/reputation.rs
+++ b/node/subsystem-util/src/reputation.rs
@@ -55,7 +55,7 @@ impl ReputationAggregator {
 	/// TODO
 	pub async fn modify(
 		&mut self,
-		sender: &mut impl overseer::ApprovalDistributionSenderTrait,
+		sender: &mut impl overseer::SubsystemSender<NetworkBridgeTxMessage>,
 		peer_id: PeerId,
 		rep: UnifiedReputationChange,
 	) {

--- a/node/subsystem-util/src/reputation.rs
+++ b/node/subsystem-util/src/reputation.rs
@@ -87,7 +87,7 @@ impl ReputationAggregator {
 		rep: UnifiedReputationChange,
 	) {
 		sender
-			.send_message(NetworkBridgeTxMessage::ReportPeer(peer_id, rep.into_base_rep()))
+			.send_message(NetworkBridgeTxMessage::ReportPeer(peer_id, rep.into()))
 			.await;
 	}
 


### PR DESCRIPTION
### Problem

Nodes are sending numerous peer reputation changes, which is overloading or blocking the channels.

### Hypothesis

We can address this issue by aggregating reputation changes and sending them to the network bridge in one batch every 30 seconds. However, there are certain changes that still require immediate reporting, so we will send those as individual messages right away.

### Results

To test the hypothesis, we changed the sending of reputation changes in group A validators and compared the results with groups B, C, and D. 

<img width="1458" alt="image" src="https://github.com/paritytech/polkadot/assets/27277055/f791bf1a-efba-431d-835b-adf2769eab40">
Group A sends changes in one batch, while others send them in individual messages. Thanos stopped working for some time, so there is no data at the end of the charts

In the left charts we see a huge difference in the number of messages sent. Group A sends about 200 times fewer messages. 

However, the channel load on the right charts is almost unchanged. The peaks in group A are about 15% smaller.

### Related

Fixes https://github.com/paritytech/polkadot/issues/7203