### PR TITLE
add check for `locked` zero on locked value in pallet-xcm

### DIFF
--- a/xcm/pallet-xcm/src/lib.rs
+++ b/xcm/pallet-xcm/src/lib.rs
@@ -1692,7 +1692,12 @@ impl<T: Config> xcm_executor::traits::Enact for UnlockTicket<T> {
 		}
 		LockedFungibles::<T>::insert(&self.sovereign_account, locks);
 		let reasons = WithdrawReasons::all();
-		T::Currency::set_lock(*b"py/xcmlk", &self.sovereign_account, locked, reasons);
+		
+		if locked.is_zero() {
+			T::Currency::remove_lock(*b"py/xcmlk", &self.sovereign_account);
+		} else {
+			T::Currency::set_lock(*b"py/xcmlk", &self.sovereign_account, locked, reasons);
+		}
 		Ok(())
 	}
 }

--- a/xcm/pallet-xcm/src/lib.rs
+++ b/xcm/pallet-xcm/src/lib.rs
@@ -1692,7 +1692,10 @@ impl<T: Config> xcm_executor::traits::Enact for UnlockTicket<T> {
 		}
 		LockedFungibles::<T>::insert(&self.sovereign_account, locks);
 		let reasons = WithdrawReasons::all();
-		
+
+		// A locked value of zero means we do not have any outstanding locks anymore
+		// in the LockedFungibles storage for this sovereign account.
+		// We can then remove the `xcmlk` lock from this account.
 		if locked.is_zero() {
 			T::Currency::remove_lock(*b"py/xcmlk", &self.sovereign_account);
 		} else {

--- a/xcm/pallet-xcm/src/lib.rs
+++ b/xcm/pallet-xcm/src/lib.rs
@@ -1691,7 +1691,6 @@ impl<T: Config> xcm_executor::traits::Enact for UnlockTicket<T> {
 			locks.swap_remove(remove_index);
 		}
 		LockedFungibles::<T>::insert(&self.sovereign_account, locks);
-		let reasons = WithdrawReasons::all();
 
 		// A locked value of zero means we do not have any outstanding locks anymore
 		// in the LockedFungibles storage for this sovereign account.
@@ -1699,6 +1698,7 @@ impl<T: Config> xcm_executor::traits::Enact for UnlockTicket<T> {
 		if locked.is_zero() {
 			T::Currency::remove_lock(*b"py/xcmlk", &self.sovereign_account);
 		} else {
+			let reasons = WithdrawReasons::all();
 			T::Currency::set_lock(*b"py/xcmlk", &self.sovereign_account, locked, reasons);
 		}
 		Ok(())


### PR DESCRIPTION
Currently the `set_lock` function is not working when the `locked` amount is 0 and we use the implementation of the balances pallet as the `set_lock` implementation of the balances pallet is no-op when the locked amount is 0. So we remove the lock if the `locked` value is 0, meaning that there is no lock anymore in the LockedFungibles storage for this sovereign_account.