### PR TITLE
Make `AssetId` and `MultiLocation` non-`Copy`; make `Instruction` 92% smaller

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10689,9 +10689,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info"
-version = "2.5.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cfdffd972d76b22f3d7f81c8be34b2296afd3a25e0a547bd9abe340a4dbbe97"
+checksum = "b569c32c806ec3abdf3b5869fb8bf1e0d275a7c1c9b0b05603d9464632649edf"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -10703,9 +10703,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info-derive"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61fa974aea2d63dd18a4ec3a49d59af9f34178c73a4f56d2f18205628d00681e"
+checksum = "53012eae69e5aa5c14671942a5dd47de59d4cdcff8532a6dd0e081faf1119482"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/runtime/common/src/xcm_sender.rs
+++ b/runtime/common/src/xcm_sender.rs
@@ -79,7 +79,7 @@ impl<T: configuration::Config + dmp::Config, W: xcm::WrapVersion, P: PriceForPar
 		msg: &mut Option<Xcm<()>>,
 	) -> SendResult<(HostConfiguration<T::BlockNumber>, ParaId, Vec<u8>)> {
 		let d = dest.take().ok_or(MissingArgument)?;
-		let id = if let MultiLocation { parents: 0, interior: X1(Parachain(id)) } = &d {
+		let id = if let (0, [Parachain(id)]) = d.unpack() {
 			*id
 		} else {
 			*dest = Some(d);

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -2055,7 +2055,7 @@ sp_api::impl_runtime_apis! {
 			}
 
 			parameter_types! {
-				pub const TrustedTeleporter: Option<(MultiLocation, MultiAsset)> = Some((
+				pub TrustedTeleporter: Option<(MultiLocation, MultiAsset)> = Some((
 					Statemine::get(),
 					MultiAsset { fun: Fungible(1 * UNITS), id: Concrete(TokenLocation::get()) },
 				));

--- a/runtime/kusama/src/xcm_config.rs
+++ b/runtime/kusama/src/xcm_config.rs
@@ -22,7 +22,7 @@ use super::{
 	XcmPallet,
 };
 use frame_support::{
-	match_types, parameter_types,
+	parameter_types,
 	traits::{Contains, Everything, Nothing},
 	weights::Weight,
 };
@@ -126,19 +126,20 @@ pub type XcmRouter = (
 
 parameter_types! {
 	pub const Ksm: MultiAssetFilter = Wild(AllOf { fun: WildFungible, id: Concrete(TokenLocation::get()) });
-	pub const Statemine: MultiLocation = Parachain(1000).into_location();
-	pub const Encointer: MultiLocation = Parachain(1001).into_location();
-	pub const KsmForStatemine: (MultiAssetFilter, MultiLocation) = (Ksm::get(), Statemine::get());
-	pub const KsmForEncointer: (MultiAssetFilter, MultiLocation) = (Ksm::get(), Encointer::get());
+	pub Statemine: MultiLocation = Parachain(1000).into_location();
+	pub Encointer: MultiLocation = Parachain(1001).into_location();
+	pub KsmForStatemine: (MultiAssetFilter, MultiLocation) = (Ksm::get(), Statemine::get());
+	pub KsmForEncointer: (MultiAssetFilter, MultiLocation) = (Ksm::get(), Encointer::get());
 	pub const MaxAssetsIntoHolding: u32 = 64;
 }
 pub type TrustedTeleporters =
 	(xcm_builder::Case<KsmForStatemine>, xcm_builder::Case<KsmForEncointer>);
 
-match_types! {
-	pub type OnlyParachains: impl Contains<MultiLocation> = {
-		MultiLocation { parents: 0, interior: X1(Parachain(_)) }
-	};
+pub struct OnlyParachains;
+impl Contains<MultiLocation> for OnlyParachains {
+	fn contains(loc: &MultiLocation) -> bool {
+		matches!(loc.unpack(), (0, [Parachain(_)]))
+	}
 }
 
 /// The barriers one of which must be passed for an XCM message to be executed.

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -2061,11 +2061,11 @@ sp_api::impl_runtime_apis! {
 			}
 
 			parameter_types! {
-				pub const TrustedTeleporter: Option<(MultiLocation, MultiAsset)> = Some((
+				pub TrustedTeleporter: Option<(MultiLocation, MultiAsset)> = Some((
 					Statemine::get(),
 					MultiAsset { fun: Fungible(1 * UNITS), id: Concrete(TokenLocation::get()) },
 				));
-				pub const TrustedReserve: Option<(MultiLocation, MultiAsset)> = Some((
+				pub TrustedReserve: Option<(MultiLocation, MultiAsset)> = Some((
 					Statemine::get(),
 					MultiAsset { fun: Fungible(1 * UNITS), id: Concrete(TokenLocation::get()) },
 				));

--- a/runtime/rococo/src/xcm_config.rs
+++ b/runtime/rococo/src/xcm_config.rs
@@ -21,7 +21,7 @@ use super::{
 	Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin, TransactionByteFee, WeightToFee, XcmPallet,
 };
 use frame_support::{
-	match_types, parameter_types,
+	parameter_types,
 	traits::{Contains, Everything, Nothing},
 	weights::Weight,
 };
@@ -45,7 +45,7 @@ use xcm_builder::{
 use xcm_executor::{traits::WithOriginFilter, XcmExecutor};
 
 parameter_types! {
-	pub const TokenLocation: MultiLocation = Here.into_location();
+	pub TokenLocation: MultiLocation = Here.into_location();
 	pub const ThisNetwork: NetworkId = NetworkId::Rococo;
 	pub UniversalLocation: InteriorMultiLocation = ThisNetwork::get().into();
 	pub CheckAccount: AccountId = XcmPallet::check_account();
@@ -105,19 +105,19 @@ pub type XcmRouter = (
 );
 
 parameter_types! {
-	pub const Roc: MultiAssetFilter = Wild(AllOf { fun: WildFungible, id: Concrete(TokenLocation::get()) });
-	pub const Statemine: MultiLocation = Parachain(1000).into_location();
-	pub const Contracts: MultiLocation = Parachain(1002).into_location();
-	pub const Encointer: MultiLocation = Parachain(1003).into_location();
-	pub const Tick: MultiLocation = Parachain(100).into_location();
-	pub const Trick: MultiLocation = Parachain(110).into_location();
-	pub const Track: MultiLocation = Parachain(120).into_location();
-	pub const RocForTick: (MultiAssetFilter, MultiLocation) = (Roc::get(), Tick::get());
-	pub const RocForTrick: (MultiAssetFilter, MultiLocation) = (Roc::get(), Trick::get());
-	pub const RocForTrack: (MultiAssetFilter, MultiLocation) = (Roc::get(), Track::get());
-	pub const RocForStatemine: (MultiAssetFilter, MultiLocation) = (Roc::get(), Statemine::get());
-	pub const RocForContracts: (MultiAssetFilter, MultiLocation) = (Roc::get(), Contracts::get());
-	pub const RocForEncointer: (MultiAssetFilter, MultiLocation) = (Roc::get(), Encointer::get());
+	pub Roc: MultiAssetFilter = Wild(AllOf { fun: WildFungible, id: Concrete(TokenLocation::get()) });
+	pub Statemine: MultiLocation = Parachain(1000).into_location();
+	pub Contracts: MultiLocation = Parachain(1002).into_location();
+	pub Encointer: MultiLocation = Parachain(1003).into_location();
+	pub Tick: MultiLocation = Parachain(100).into_location();
+	pub Trick: MultiLocation = Parachain(110).into_location();
+	pub Track: MultiLocation = Parachain(120).into_location();
+	pub RocForTick: (MultiAssetFilter, MultiLocation) = (Roc::get(), Tick::get());
+	pub RocForTrick: (MultiAssetFilter, MultiLocation) = (Roc::get(), Trick::get());
+	pub RocForTrack: (MultiAssetFilter, MultiLocation) = (Roc::get(), Track::get());
+	pub RocForStatemine: (MultiAssetFilter, MultiLocation) = (Roc::get(), Statemine::get());
+	pub RocForContracts: (MultiAssetFilter, MultiLocation) = (Roc::get(), Contracts::get());
+	pub RocForEncointer: (MultiAssetFilter, MultiLocation) = (Roc::get(), Encointer::get());
 	pub const MaxInstructions: u32 = 100;
 	pub const MaxAssetsIntoHolding: u32 = 64;
 }
@@ -130,10 +130,11 @@ pub type TrustedTeleporters = (
 	xcm_builder::Case<RocForEncointer>,
 );
 
-match_types! {
-	pub type OnlyParachains: impl Contains<MultiLocation> = {
-		MultiLocation { parents: 0, interior: X1(Parachain(_)) }
-	};
+pub struct OnlyParachains;
+impl Contains<MultiLocation> for OnlyParachains {
+	fn contains(loc: &MultiLocation) -> bool {
+		matches!(loc.unpack(), (0, [Parachain(_)]))
+	}
 }
 
 /// The barriers one of which must be passed for an XCM message to be executed.

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -1802,7 +1802,7 @@ sp_api::impl_runtime_apis! {
 			}
 
 			parameter_types! {
-				pub const TrustedTeleporter: Option<(MultiLocation, MultiAsset)> = Some((
+				pub TrustedTeleporter: Option<(MultiLocation, MultiAsset)> = Some((
 					Westmint::get(),
 					MultiAsset { fun: Fungible(1 * UNITS), id: Concrete(TokenLocation::get()) },
 				));

--- a/runtime/westend/src/xcm_config.rs
+++ b/runtime/westend/src/xcm_config.rs
@@ -90,11 +90,11 @@ pub type XcmRouter = (
 );
 
 parameter_types! {
-	pub const Westmint: MultiLocation = Parachain(1000).into_location();
-	pub const Collectives: MultiLocation = Parachain(1001).into_location();
+	pub Westmint: MultiLocation = Parachain(1000).into_location();
+	pub Collectives: MultiLocation = Parachain(1001).into_location();
 	pub const Wnd: MultiAssetFilter = Wild(AllOf { fun: WildFungible, id: Concrete(TokenLocation::get()) });
-	pub const WndForWestmint: (MultiAssetFilter, MultiLocation) = (Wnd::get(), Westmint::get());
-	pub const WndForCollectives: (MultiAssetFilter, MultiLocation) = (Wnd::get(), Collectives::get());
+	pub WndForWestmint: (MultiAssetFilter, MultiLocation) = (Wnd::get(), Westmint::get());
+	pub WndForCollectives: (MultiAssetFilter, MultiLocation) = (Wnd::get(), Collectives::get());
 	pub const MaxInstructions: u32 = 100;
 	pub const MaxAssetsIntoHolding: u32 = 64;
 }

--- a/xcm/Cargo.toml
+++ b/xcm/Cargo.toml
@@ -13,7 +13,7 @@ log = { version = "0.4.17", default-features = false }
 parity-scale-codec = { version = "3.4.0", default-features = false, features = [ "derive", "max-encoded-len" ] }
 scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
 sp-weights = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-serde = { version = "1.0.136", optional = true, features = ["derive"] }
+serde = { version = "1.0.136", optional = true, features = ["derive", "rc"] }
 xcm-procedural = { path = "procedural" }
 
 [dev-dependencies]

--- a/xcm/pallet-xcm-benchmarks/src/fungible/mock.rs
+++ b/xcm/pallet-xcm-benchmarks/src/fungible/mock.rs
@@ -167,7 +167,7 @@ impl crate::Config for Test {
 	type AccountIdConverter = AccountIdConverter;
 	fn valid_destination() -> Result<MultiLocation, BenchmarkError> {
 		let valid_destination: MultiLocation =
-			X1(AccountId32 { network: None, id: [0u8; 32] }).into();
+			[AccountId32 { network: None, id: [0u8; 32] }].into();
 
 		Ok(valid_destination)
 	}
@@ -183,14 +183,14 @@ pub type TrustedTeleporters = (xcm_builder::Case<TeleportConcreteFungible>,);
 
 parameter_types! {
 	pub const CheckingAccount: Option<(u64, MintLocation)> = Some((100, MintLocation::Local));
-	pub const ChildTeleporter: MultiLocation = Parachain(1000).into_location();
-	pub const TrustedTeleporter: Option<(MultiLocation, MultiAsset)> = Some((
+	pub ChildTeleporter: MultiLocation = Parachain(1000).into_location();
+	pub TrustedTeleporter: Option<(MultiLocation, MultiAsset)> = Some((
 		ChildTeleporter::get(),
 		MultiAsset { id: Concrete(Here.into_location()), fun: Fungible(100) },
 	));
-	pub const TeleportConcreteFungible: (MultiAssetFilter, MultiLocation) =
+	pub TeleportConcreteFungible: (MultiAssetFilter, MultiLocation) =
 		(Wild(AllOf { fun: WildFungible, id: Concrete(Here.into_location()) }), ChildTeleporter::get());
-	pub const ReserveConcreteFungible: (MultiAssetFilter, MultiLocation) =
+	pub ReserveConcreteFungible: (MultiAssetFilter, MultiLocation) =
 		(Wild(AllOf { fun: WildFungible, id: Concrete(Here.into_location()) }), ChildTeleporter::get());
 }
 

--- a/xcm/pallet-xcm-benchmarks/src/generic/benchmarking.rs
+++ b/xcm/pallet-xcm-benchmarks/src/generic/benchmarking.rs
@@ -156,7 +156,7 @@ benchmarks! {
 
 	descend_origin {
 		let mut executor = new_executor::<T>(Default::default());
-		let who = X2(OnlyChild, OnlyChild);
+		let who = Junctions::from([OnlyChild, OnlyChild]);
 		let instruction = Instruction::DescendOrigin(who.clone());
 		let xcm = Xcm(vec![instruction]);
 	} : {
@@ -493,7 +493,7 @@ benchmarks! {
 	} verify {
 		use frame_support::traits::Get;
 		let universal_location = <T::XcmConfig as xcm_executor::Config>::UniversalLocation::get();
-		assert_eq!(executor.origin(), &Some(X1(alias).relative_to(&universal_location)));
+		assert_eq!(executor.origin(), &Some(Junctions::from([alias]).relative_to(&universal_location)));
 	}
 
 	export_message {

--- a/xcm/pallet-xcm-benchmarks/src/generic/mock.rs
+++ b/xcm/pallet-xcm-benchmarks/src/generic/mock.rs
@@ -178,7 +178,7 @@ impl generic::Config for Test {
 
 	fn claimable_asset() -> Result<(MultiLocation, MultiLocation, MultiAssets), BenchmarkError> {
 		let assets: MultiAssets = (Concrete(Here.into()), 100).into();
-		let ticket = MultiLocation { parents: 0, interior: X1(GeneralIndex(0)) };
+		let ticket = MultiLocation { parents: 0, interior: [GeneralIndex(0)].into() };
 		Ok((Default::default(), ticket, assets))
 	}
 

--- a/xcm/pallet-xcm-benchmarks/src/mock.rs
+++ b/xcm/pallet-xcm-benchmarks/src/mock.rs
@@ -49,8 +49,8 @@ impl xcm_executor::traits::OnResponse for DevNull {
 pub struct AccountIdConverter;
 impl xcm_executor::traits::Convert<MultiLocation, u64> for AccountIdConverter {
 	fn convert(ml: MultiLocation) -> Result<u64, MultiLocation> {
-		match ml {
-			MultiLocation { parents: 0, interior: X1(Junction::AccountId32 { id, .. }) } =>
+		match ml.unpack() {
+			(0, [Junction::AccountId32 { id, .. }]) =>
 				Ok(<u64 as codec::Decode>::decode(&mut &*id.to_vec()).unwrap()),
 			_ => Err(ml),
 		}

--- a/xcm/pallet-xcm/src/benchmarking.rs
+++ b/xcm/pallet-xcm/src/benchmarking.rs
@@ -111,7 +111,7 @@ benchmarks! {
 		let loc = T::ReachableDest::get().ok_or(
 			BenchmarkError::Override(BenchmarkResult::from_weight(Weight::MAX)),
 		)?;
-		let versioned_loc: VersionedMultiLocation = loc.into();
+		let versioned_loc: VersionedMultiLocation = loc.clone().into();
 		let _ = Pallet::<T>::request_version_notify(loc);
 	}: _(RawOrigin::Root, Box::new(versioned_loc))
 

--- a/xcm/src/v2/junction.rs
+++ b/xcm/src/v2/junction.rs
@@ -16,7 +16,7 @@
 
 //! Support data structures for `MultiLocation`, primarily the `Junction` datatype.
 
-use super::{BodyId, BodyPart, Junctions, MultiLocation, NetworkId};
+use super::{BodyId, BodyPart, MultiLocation, NetworkId};
 use crate::v3::Junction as NewJunction;
 use bounded_collections::{ConstU32, WeakBoundedVec};
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
@@ -109,14 +109,14 @@ impl Junction {
 	/// Convert `self` into a `MultiLocation` containing 0 parents.
 	///
 	/// Similar to `Into::into`, except that this method can be used in a const evaluation context.
-	pub const fn into(self) -> MultiLocation {
-		MultiLocation { parents: 0, interior: Junctions::X1(self) }
+	pub fn into(self) -> MultiLocation {
+		MultiLocation { parents: 0, interior: [self].into() }
 	}
 
 	/// Convert `self` into a `MultiLocation` containing `n` parents.
 	///
 	/// Similar to `Self::into`, with the added ability to specify the number of parent junctions.
-	pub const fn into_exterior(self, n: u8) -> MultiLocation {
-		MultiLocation { parents: n, interior: Junctions::X1(self) }
+	pub fn into_exterior(self, n: u8) -> MultiLocation {
+		MultiLocation { parents: n, interior: [self].into() }
 	}
 }

--- a/xcm/src/v2/traits.rs
+++ b/xcm/src/v2/traits.rs
@@ -285,7 +285,8 @@ pub type SendResult = result::Result<(), SendError>;
 /// struct Sender2;
 /// impl SendXcm for Sender2 {
 ///     fn send_xcm(destination: impl Into<MultiLocation>, message: Xcm<()>) -> SendResult {
-///         if let MultiLocation { parents: 0, interior: X2(j1, j2) } = destination.into() {
+///         let destination = destination.into();
+///         if destination.parents == 0 && destination.interior.len() == 2 {
 ///             Ok(())
 ///         } else {
 ///             Err(SendError::Unroutable)

--- a/xcm/src/v3/junction.rs
+++ b/xcm/src/v3/junction.rs
@@ -16,7 +16,7 @@
 
 //! Support data structures for `MultiLocation`, primarily the `Junction` datatype.
 
-use super::{Junctions, MultiLocation};
+use super::MultiLocation;
 use crate::{
 	v2::{
 		BodyId as OldBodyId, BodyPart as OldBodyPart, Junction as OldJunction,
@@ -350,21 +350,21 @@ impl Junction {
 	/// Convert `self` into a `MultiLocation` containing 0 parents.
 	///
 	/// Similar to `Into::into`, except that this method can be used in a const evaluation context.
-	pub const fn into_location(self) -> MultiLocation {
-		MultiLocation { parents: 0, interior: Junctions::X1(self) }
+	pub fn into_location(self) -> MultiLocation {
+		MultiLocation { parents: 0, interior: [self].into() }
 	}
 
 	/// Convert `self` into a `MultiLocation` containing `n` parents.
 	///
 	/// Similar to `Self::into_location`, with the added ability to specify the number of parent junctions.
-	pub const fn into_exterior(self, n: u8) -> MultiLocation {
-		MultiLocation { parents: n, interior: Junctions::X1(self) }
+	pub fn into_exterior(self, n: u8) -> MultiLocation {
+		MultiLocation { parents: n, interior: [self].into() }
 	}
 
 	/// Convert `self` into a `VersionedMultiLocation` containing 0 parents.
 	///
 	/// Similar to `Into::into`, except that this method can be used in a const evaluation context.
-	pub const fn into_versioned(self) -> VersionedMultiLocation {
+	pub fn into_versioned(self) -> VersionedMultiLocation {
 		self.into_location().into_versioned()
 	}
 

--- a/xcm/src/v3/junctions.rs
+++ b/xcm/src/v3/junctions.rs
@@ -17,7 +17,8 @@
 //! XCM `Junctions`/`InteriorMultiLocation` datatype.
 
 use super::{Junction, MultiLocation, NetworkId};
-use core::{convert::TryFrom, mem, result};
+use alloc::sync::Arc;
+use core::{convert::TryFrom, mem, ops::Range, result};
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 
@@ -29,82 +30,100 @@ pub(crate) const MAX_JUNCTIONS: usize = 8;
 ///
 /// Parent junctions cannot be constructed with this type. Refer to `MultiLocation` for
 /// instructions on constructing parent junctions.
-#[derive(
-	Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, Debug, TypeInfo, MaxEncodedLen,
-)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, Debug, TypeInfo)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 pub enum Junctions {
 	/// The interpreting consensus system.
 	Here,
 	/// A relative path comprising 1 junction.
-	X1(Junction),
+	X1(Arc<[Junction; 1]>),
 	/// A relative path comprising 2 junctions.
-	X2(Junction, Junction),
+	X2(Arc<[Junction; 2]>),
 	/// A relative path comprising 3 junctions.
-	X3(Junction, Junction, Junction),
+	X3(Arc<[Junction; 3]>),
 	/// A relative path comprising 4 junctions.
-	X4(Junction, Junction, Junction, Junction),
+	X4(Arc<[Junction; 4]>),
 	/// A relative path comprising 5 junctions.
-	X5(Junction, Junction, Junction, Junction, Junction),
+	X5(Arc<[Junction; 5]>),
 	/// A relative path comprising 6 junctions.
-	X6(Junction, Junction, Junction, Junction, Junction, Junction),
+	X6(Arc<[Junction; 6]>),
 	/// A relative path comprising 7 junctions.
-	X7(Junction, Junction, Junction, Junction, Junction, Junction, Junction),
+	X7(Arc<[Junction; 7]>),
 	/// A relative path comprising 8 junctions.
-	X8(Junction, Junction, Junction, Junction, Junction, Junction, Junction, Junction),
+	X8(Arc<[Junction; 8]>),
 }
 
-pub struct JunctionsIterator(Junctions);
+// TODO: Remove this once deriving `MaxEncodedLen` on `Arc`s works.
+impl MaxEncodedLen for Junctions {
+	fn max_encoded_len() -> usize {
+		<[Junction; 8]>::max_encoded_len().saturating_add(1)
+	}
+}
+
+macro_rules! impl_junctions {
+	($count:expr, $variant:ident) => {
+		impl From<[Junction; $count]> for Junctions {
+			fn from(junctions: [Junction; $count]) -> Self {
+				Self::$variant(Arc::new(junctions))
+			}
+		}
+		impl PartialEq<[Junction; $count]> for Junctions {
+			fn eq(&self, rhs: &[Junction; $count]) -> bool {
+				self.as_slice() == rhs
+			}
+		}
+	};
+}
+
+impl_junctions!(1, X1);
+impl_junctions!(2, X2);
+impl_junctions!(3, X3);
+impl_junctions!(4, X4);
+impl_junctions!(5, X5);
+impl_junctions!(6, X6);
+impl_junctions!(7, X7);
+impl_junctions!(8, X8);
+
+pub struct JunctionsIterator {
+	junctions: Junctions,
+	range: Range<usize>,
+}
+
 impl Iterator for JunctionsIterator {
 	type Item = Junction;
 	fn next(&mut self) -> Option<Junction> {
-		self.0.take_first()
+		self.junctions.at(self.range.next()?).cloned()
 	}
 }
 
 impl DoubleEndedIterator for JunctionsIterator {
 	fn next_back(&mut self) -> Option<Junction> {
-		self.0.take_last()
+		self.junctions.at(self.range.next_back()?).cloned()
 	}
 }
 
 pub struct JunctionsRefIterator<'a> {
 	junctions: &'a Junctions,
-	next: usize,
-	back: usize,
+	range: Range<usize>,
 }
 
 impl<'a> Iterator for JunctionsRefIterator<'a> {
 	type Item = &'a Junction;
 	fn next(&mut self) -> Option<&'a Junction> {
-		if self.next.saturating_add(self.back) >= self.junctions.len() {
-			return None
-		}
-
-		let result = self.junctions.at(self.next);
-		self.next += 1;
-		result
+		self.junctions.at(self.range.next()?)
 	}
 }
 
 impl<'a> DoubleEndedIterator for JunctionsRefIterator<'a> {
 	fn next_back(&mut self) -> Option<&'a Junction> {
-		let next_back = self.back.saturating_add(1);
-		// checked_sub here, because if the result is less than 0, we end iteration
-		let index = self.junctions.len().checked_sub(next_back)?;
-		if self.next > index {
-			return None
-		}
-		self.back = next_back;
-
-		self.junctions.at(index)
+		self.junctions.at(self.range.next_back()?)
 	}
 }
 impl<'a> IntoIterator for &'a Junctions {
 	type Item = &'a Junction;
 	type IntoIter = JunctionsRefIterator<'a>;
 	fn into_iter(self) -> Self::IntoIter {
-		JunctionsRefIterator { junctions: self, next: 0, back: 0 }
+		JunctionsRefIterator { junctions: self, range: 0..self.len() }
 	}
 }
 
@@ -112,7 +131,7 @@ impl IntoIterator for Junctions {
 	type Item = Junction;
 	type IntoIter = JunctionsIterator;
 	fn into_iter(self) -> Self::IntoIter {
-		JunctionsIterator(self)
+		JunctionsIterator { range: 0..self.len(), junctions: self }
 	}
 }
 
@@ -131,6 +150,36 @@ impl Junctions {
 		MultiLocation { parents: n, interior: self }
 	}
 
+	/// Casts `self` into a slice containing `Junction`s.
+	pub fn as_slice(&self) -> &[Junction] {
+		match self {
+			Junctions::Here => &[],
+			Junctions::X1(ref a) => &a[..],
+			Junctions::X2(ref a) => &a[..],
+			Junctions::X3(ref a) => &a[..],
+			Junctions::X4(ref a) => &a[..],
+			Junctions::X5(ref a) => &a[..],
+			Junctions::X6(ref a) => &a[..],
+			Junctions::X7(ref a) => &a[..],
+			Junctions::X8(ref a) => &a[..],
+		}
+	}
+
+	/// Casts `self` into a mutable slice containing `Junction`s.
+	pub fn as_slice_mut(&mut self) -> &mut [Junction] {
+		match self {
+			Junctions::Here => &mut [],
+			Junctions::X1(ref mut a) => &mut Arc::make_mut(a)[..],
+			Junctions::X2(ref mut a) => &mut Arc::make_mut(a)[..],
+			Junctions::X3(ref mut a) => &mut Arc::make_mut(a)[..],
+			Junctions::X4(ref mut a) => &mut Arc::make_mut(a)[..],
+			Junctions::X5(ref mut a) => &mut Arc::make_mut(a)[..],
+			Junctions::X6(ref mut a) => &mut Arc::make_mut(a)[..],
+			Junctions::X7(ref mut a) => &mut Arc::make_mut(a)[..],
+			Junctions::X8(ref mut a) => &mut Arc::make_mut(a)[..],
+		}
+	}
+
 	/// Remove the `NetworkId` value in any `Junction`s.
 	pub fn remove_network_id(&mut self) {
 		self.for_each_mut(Junction::remove_network_id);
@@ -138,11 +187,12 @@ impl Junctions {
 
 	/// Treating `self` as the universal context, return the location of the local consensus system
 	/// from the point of view of the given `target`.
-	pub fn invert_target(mut self, target: &MultiLocation) -> Result<MultiLocation, ()> {
+	pub fn invert_target(&self, target: &MultiLocation) -> Result<MultiLocation, ()> {
+		let mut itself = self.clone();
 		let mut junctions = Self::Here;
 		for _ in 0..target.parent_count() {
 			junctions = junctions
-				.pushed_front_with(self.take_last().unwrap_or(Junction::OnlyChild))
+				.pushed_front_with(itself.take_last().unwrap_or(Junction::OnlyChild))
 				.map_err(|_| ())?;
 		}
 		let parents = target.interior().len() as u8;
@@ -151,62 +201,8 @@ impl Junctions {
 
 	/// Execute a function `f` on every junction. We use this since we cannot implement a mutable
 	/// `Iterator` without unsafe code.
-	pub fn for_each_mut(&mut self, mut x: impl FnMut(&mut Junction)) {
-		match self {
-			Junctions::Here => {},
-			Junctions::X1(a) => {
-				x(a);
-			},
-			Junctions::X2(a, b) => {
-				x(a);
-				x(b);
-			},
-			Junctions::X3(a, b, c) => {
-				x(a);
-				x(b);
-				x(c);
-			},
-			Junctions::X4(a, b, c, d) => {
-				x(a);
-				x(b);
-				x(c);
-				x(d);
-			},
-			Junctions::X5(a, b, c, d, e) => {
-				x(a);
-				x(b);
-				x(c);
-				x(d);
-				x(e);
-			},
-			Junctions::X6(a, b, c, d, e, f) => {
-				x(a);
-				x(b);
-				x(c);
-				x(d);
-				x(e);
-				x(f);
-			},
-			Junctions::X7(a, b, c, d, e, f, g) => {
-				x(a);
-				x(b);
-				x(c);
-				x(d);
-				x(e);
-				x(f);
-				x(g);
-			},
-			Junctions::X8(a, b, c, d, e, f, g, h) => {
-				x(a);
-				x(b);
-				x(c);
-				x(d);
-				x(e);
-				x(f);
-				x(g);
-				x(h);
-			},
-		}
+	pub fn for_each_mut(&mut self, x: impl FnMut(&mut Junction)) {
+		self.as_slice_mut().iter_mut().for_each(x)
 	}
 
 	/// Extract the network ID treating this value as a universal location.
@@ -270,32 +266,12 @@ impl Junctions {
 
 	/// Returns first junction, or `None` if the location is empty.
 	pub fn first(&self) -> Option<&Junction> {
-		match &self {
-			Junctions::Here => None,
-			Junctions::X1(ref a) => Some(a),
-			Junctions::X2(ref a, ..) => Some(a),
-			Junctions::X3(ref a, ..) => Some(a),
-			Junctions::X4(ref a, ..) => Some(a),
-			Junctions::X5(ref a, ..) => Some(a),
-			Junctions::X6(ref a, ..) => Some(a),
-			Junctions::X7(ref a, ..) => Some(a),
-			Junctions::X8(ref a, ..) => Some(a),
-		}
+		self.as_slice().first()
 	}
 
 	/// Returns last junction, or `None` if the location is empty.
 	pub fn last(&self) -> Option<&Junction> {
-		match &self {
-			Junctions::Here => None,
-			Junctions::X1(ref a) => Some(a),
-			Junctions::X2(.., ref a) => Some(a),
-			Junctions::X3(.., ref a) => Some(a),
-			Junctions::X4(.., ref a) => Some(a),
-			Junctions::X5(.., ref a) => Some(a),
-			Junctions::X6(.., ref a) => Some(a),
-			Junctions::X7(.., ref a) => Some(a),
-			Junctions::X8(.., ref a) => Some(a),
-		}
+		self.as_slice().last()
 	}
 
 	/// Splits off the first junction, returning the remaining suffix (first item in tuple) and the first element
@@ -303,14 +279,38 @@ impl Junctions {
 	pub fn split_first(self) -> (Junctions, Option<Junction>) {
 		match self {
 			Junctions::Here => (Junctions::Here, None),
-			Junctions::X1(a) => (Junctions::Here, Some(a)),
-			Junctions::X2(a, b) => (Junctions::X1(b), Some(a)),
-			Junctions::X3(a, b, c) => (Junctions::X2(b, c), Some(a)),
-			Junctions::X4(a, b, c, d) => (Junctions::X3(b, c, d), Some(a)),
-			Junctions::X5(a, b, c, d, e) => (Junctions::X4(b, c, d, e), Some(a)),
-			Junctions::X6(a, b, c, d, e, f) => (Junctions::X5(b, c, d, e, f), Some(a)),
-			Junctions::X7(a, b, c, d, e, f, g) => (Junctions::X6(b, c, d, e, f, g), Some(a)),
-			Junctions::X8(a, b, c, d, e, f, g, h) => (Junctions::X7(b, c, d, e, f, g, h), Some(a)),
+			Junctions::X1(xs) => {
+				let [a] = *xs;
+				(Junctions::Here, Some(a))
+			},
+			Junctions::X2(xs) => {
+				let [a, b] = *xs;
+				([b].into(), Some(a))
+			},
+			Junctions::X3(xs) => {
+				let [a, b, c] = *xs;
+				([b, c].into(), Some(a))
+			},
+			Junctions::X4(xs) => {
+				let [a, b, c, d] = *xs;
+				([b, c, d].into(), Some(a))
+			},
+			Junctions::X5(xs) => {
+				let [a, b, c, d, e] = *xs;
+				([b, c, d, e].into(), Some(a))
+			},
+			Junctions::X6(xs) => {
+				let [a, b, c, d, e, f] = *xs;
+				([b, c, d, e, f].into(), Some(a))
+			},
+			Junctions::X7(xs) => {
+				let [a, b, c, d, e, f, g] = *xs;
+				([b, c, d, e, f, g].into(), Some(a))
+			},
+			Junctions::X8(xs) => {
+				let [a, b, c, d, e, f, g, h] = *xs;
+				([b, c, d, e, f, g, h].into(), Some(a))
+			},
 		}
 	}
 
@@ -319,14 +319,38 @@ impl Junctions {
 	pub fn split_last(self) -> (Junctions, Option<Junction>) {
 		match self {
 			Junctions::Here => (Junctions::Here, None),
-			Junctions::X1(a) => (Junctions::Here, Some(a)),
-			Junctions::X2(a, b) => (Junctions::X1(a), Some(b)),
-			Junctions::X3(a, b, c) => (Junctions::X2(a, b), Some(c)),
-			Junctions::X4(a, b, c, d) => (Junctions::X3(a, b, c), Some(d)),
-			Junctions::X5(a, b, c, d, e) => (Junctions::X4(a, b, c, d), Some(e)),
-			Junctions::X6(a, b, c, d, e, f) => (Junctions::X5(a, b, c, d, e), Some(f)),
-			Junctions::X7(a, b, c, d, e, f, g) => (Junctions::X6(a, b, c, d, e, f), Some(g)),
-			Junctions::X8(a, b, c, d, e, f, g, h) => (Junctions::X7(a, b, c, d, e, f, g), Some(h)),
+			Junctions::X1(xs) => {
+				let [a] = *xs;
+				(Junctions::Here, Some(a))
+			},
+			Junctions::X2(xs) => {
+				let [a, b] = *xs;
+				([a].into(), Some(b))
+			},
+			Junctions::X3(xs) => {
+				let [a, b, c] = *xs;
+				([a, b].into(), Some(c))
+			},
+			Junctions::X4(xs) => {
+				let [a, b, c, d] = *xs;
+				([a, b, c].into(), Some(d))
+			},
+			Junctions::X5(xs) => {
+				let [a, b, c, d, e] = *xs;
+				([a, b, c, d].into(), Some(e))
+			},
+			Junctions::X6(xs) => {
+				let [a, b, c, d, e, f] = *xs;
+				([a, b, c, d, e].into(), Some(f))
+			},
+			Junctions::X7(xs) => {
+				let [a, b, c, d, e, f, g] = *xs;
+				([a, b, c, d, e, f].into(), Some(g))
+			},
+			Junctions::X8(xs) => {
+				let [a, b, c, d, e, f, g, h] = *xs;
+				([a, b, c, d, e, f, g].into(), Some(h))
+			},
 		}
 	}
 
@@ -387,14 +411,35 @@ impl Junctions {
 	pub fn pushed_with(self, new: impl Into<Junction>) -> result::Result<Self, (Self, Junction)> {
 		let new = new.into();
 		Ok(match self {
-			Junctions::Here => Junctions::X1(new),
-			Junctions::X1(a) => Junctions::X2(a, new),
-			Junctions::X2(a, b) => Junctions::X3(a, b, new),
-			Junctions::X3(a, b, c) => Junctions::X4(a, b, c, new),
-			Junctions::X4(a, b, c, d) => Junctions::X5(a, b, c, d, new),
-			Junctions::X5(a, b, c, d, e) => Junctions::X6(a, b, c, d, e, new),
-			Junctions::X6(a, b, c, d, e, f) => Junctions::X7(a, b, c, d, e, f, new),
-			Junctions::X7(a, b, c, d, e, f, g) => Junctions::X8(a, b, c, d, e, f, g, new),
+			Junctions::Here => [new].into(),
+			Junctions::X1(xs) => {
+				let [a] = *xs;
+				[a, new].into()
+			},
+			Junctions::X2(xs) => {
+				let [a, b] = *xs;
+				[a, b, new].into()
+			},
+			Junctions::X3(xs) => {
+				let [a, b, c] = *xs;
+				[a, b, c, new].into()
+			},
+			Junctions::X4(xs) => {
+				let [a, b, c, d] = *xs;
+				[a, b, c, d, new].into()
+			},
+			Junctions::X5(xs) => {
+				let [a, b, c, d, e] = *xs;
+				[a, b, c, d, e, new].into()
+			},
+			Junctions::X6(xs) => {
+				let [a, b, c, d, e, f] = *xs;
+				[a, b, c, d, e, f, new].into()
+			},
+			Junctions::X7(xs) => {
+				let [a, b, c, d, e, f, g] = *xs;
+				[a, b, c, d, e, f, g, new].into()
+			},
 			s => Err((s, new))?,
 		})
 	}
@@ -407,14 +452,35 @@ impl Junctions {
 	) -> result::Result<Self, (Self, Junction)> {
 		let new = new.into();
 		Ok(match self {
-			Junctions::Here => Junctions::X1(new),
-			Junctions::X1(a) => Junctions::X2(new, a),
-			Junctions::X2(a, b) => Junctions::X3(new, a, b),
-			Junctions::X3(a, b, c) => Junctions::X4(new, a, b, c),
-			Junctions::X4(a, b, c, d) => Junctions::X5(new, a, b, c, d),
-			Junctions::X5(a, b, c, d, e) => Junctions::X6(new, a, b, c, d, e),
-			Junctions::X6(a, b, c, d, e, f) => Junctions::X7(new, a, b, c, d, e, f),
-			Junctions::X7(a, b, c, d, e, f, g) => Junctions::X8(new, a, b, c, d, e, f, g),
+			Junctions::Here => [new].into(),
+			Junctions::X1(xs) => {
+				let [a] = *xs;
+				[new, a].into()
+			},
+			Junctions::X2(xs) => {
+				let [a, b] = *xs;
+				[new, a, b].into()
+			},
+			Junctions::X3(xs) => {
+				let [a, b, c] = *xs;
+				[new, a, b, c].into()
+			},
+			Junctions::X4(xs) => {
+				let [a, b, c, d] = *xs;
+				[new, a, b, c, d].into()
+			},
+			Junctions::X5(xs) => {
+				let [a, b, c, d, e] = *xs;
+				[new, a, b, c, d, e].into()
+			},
+			Junctions::X6(xs) => {
+				let [a, b, c, d, e, f] = *xs;
+				[new, a, b, c, d, e, f].into()
+			},
+			Junctions::X7(xs) => {
+				let [a, b, c, d, e, f, g] = *xs;
+				[new, a, b, c, d, e, f, g].into()
+			},
 			s => Err((s, new))?,
 		})
 	}
@@ -425,11 +491,11 @@ impl Junctions {
 	///
 	/// # Example
 	/// ```rust
-	/// # use xcm::v3::{Junctions::*, Junction::*, MultiLocation};
+	/// # use xcm::v3::{Junctions, Junction::*, MultiLocation};
 	/// # fn main() {
-	/// let mut m = X1(Parachain(21));
-	/// assert_eq!(m.append_with(X1(PalletInstance(3))), Ok(()));
-	/// assert_eq!(m, X2(Parachain(21), PalletInstance(3)));
+	/// let mut m = Junctions::from([Parachain(21)]);
+	/// assert_eq!(m.append_with([PalletInstance(3)]), Ok(()));
+	/// assert_eq!(m, [Parachain(21), PalletInstance(3)]);
 	/// # }
 	/// ```
 	pub fn append_with(&mut self, suffix: impl Into<Junctions>) -> Result<(), Junctions> {
@@ -444,110 +510,24 @@ impl Junctions {
 	}
 
 	/// Returns the number of junctions in `self`.
-	pub const fn len(&self) -> usize {
-		match &self {
-			Junctions::Here => 0,
-			Junctions::X1(..) => 1,
-			Junctions::X2(..) => 2,
-			Junctions::X3(..) => 3,
-			Junctions::X4(..) => 4,
-			Junctions::X5(..) => 5,
-			Junctions::X6(..) => 6,
-			Junctions::X7(..) => 7,
-			Junctions::X8(..) => 8,
-		}
+	pub fn len(&self) -> usize {
+		self.as_slice().len()
 	}
 
 	/// Returns the junction at index `i`, or `None` if the location doesn't contain that many elements.
 	pub fn at(&self, i: usize) -> Option<&Junction> {
-		Some(match (i, self) {
-			(0, Junctions::X1(ref a)) => a,
-			(0, Junctions::X2(ref a, ..)) => a,
-			(0, Junctions::X3(ref a, ..)) => a,
-			(0, Junctions::X4(ref a, ..)) => a,
-			(0, Junctions::X5(ref a, ..)) => a,
-			(0, Junctions::X6(ref a, ..)) => a,
-			(0, Junctions::X7(ref a, ..)) => a,
-			(0, Junctions::X8(ref a, ..)) => a,
-			(1, Junctions::X2(_, ref a)) => a,
-			(1, Junctions::X3(_, ref a, ..)) => a,
-			(1, Junctions::X4(_, ref a, ..)) => a,
-			(1, Junctions::X5(_, ref a, ..)) => a,
-			(1, Junctions::X6(_, ref a, ..)) => a,
-			(1, Junctions::X7(_, ref a, ..)) => a,
-			(1, Junctions::X8(_, ref a, ..)) => a,
-			(2, Junctions::X3(_, _, ref a)) => a,
-			(2, Junctions::X4(_, _, ref a, ..)) => a,
-			(2, Junctions::X5(_, _, ref a, ..)) => a,
-			(2, Junctions::X6(_, _, ref a, ..)) => a,
-			(2, Junctions::X7(_, _, ref a, ..)) => a,
-			(2, Junctions::X8(_, _, ref a, ..)) => a,
-			(3, Junctions::X4(_, _, _, ref a)) => a,
-			(3, Junctions::X5(_, _, _, ref a, ..)) => a,
-			(3, Junctions::X6(_, _, _, ref a, ..)) => a,
-			(3, Junctions::X7(_, _, _, ref a, ..)) => a,
-			(3, Junctions::X8(_, _, _, ref a, ..)) => a,
-			(4, Junctions::X5(_, _, _, _, ref a)) => a,
-			(4, Junctions::X6(_, _, _, _, ref a, ..)) => a,
-			(4, Junctions::X7(_, _, _, _, ref a, ..)) => a,
-			(4, Junctions::X8(_, _, _, _, ref a, ..)) => a,
-			(5, Junctions::X6(_, _, _, _, _, ref a)) => a,
-			(5, Junctions::X7(_, _, _, _, _, ref a, ..)) => a,
-			(5, Junctions::X8(_, _, _, _, _, ref a, ..)) => a,
-			(6, Junctions::X7(_, _, _, _, _, _, ref a)) => a,
-			(6, Junctions::X8(_, _, _, _, _, _, ref a, ..)) => a,
-			(7, Junctions::X8(_, _, _, _, _, _, _, ref a)) => a,
-			_ => return None,
-		})
+		self.as_slice().get(i)
 	}
 
 	/// Returns a mutable reference to the junction at index `i`, or `None` if the location doesn't contain that many
 	/// elements.
 	pub fn at_mut(&mut self, i: usize) -> Option<&mut Junction> {
-		Some(match (i, self) {
-			(0, Junctions::X1(ref mut a)) => a,
-			(0, Junctions::X2(ref mut a, ..)) => a,
-			(0, Junctions::X3(ref mut a, ..)) => a,
-			(0, Junctions::X4(ref mut a, ..)) => a,
-			(0, Junctions::X5(ref mut a, ..)) => a,
-			(0, Junctions::X6(ref mut a, ..)) => a,
-			(0, Junctions::X7(ref mut a, ..)) => a,
-			(0, Junctions::X8(ref mut a, ..)) => a,
-			(1, Junctions::X2(_, ref mut a)) => a,
-			(1, Junctions::X3(_, ref mut a, ..)) => a,
-			(1, Junctions::X4(_, ref mut a, ..)) => a,
-			(1, Junctions::X5(_, ref mut a, ..)) => a,
-			(1, Junctions::X6(_, ref mut a, ..)) => a,
-			(1, Junctions::X7(_, ref mut a, ..)) => a,
-			(1, Junctions::X8(_, ref mut a, ..)) => a,
-			(2, Junctions::X3(_, _, ref mut a)) => a,
-			(2, Junctions::X4(_, _, ref mut a, ..)) => a,
-			(2, Junctions::X5(_, _, ref mut a, ..)) => a,
-			(2, Junctions::X6(_, _, ref mut a, ..)) => a,
-			(2, Junctions::X7(_, _, ref mut a, ..)) => a,
-			(2, Junctions::X8(_, _, ref mut a, ..)) => a,
-			(3, Junctions::X4(_, _, _, ref mut a)) => a,
-			(3, Junctions::X5(_, _, _, ref mut a, ..)) => a,
-			(3, Junctions::X6(_, _, _, ref mut a, ..)) => a,
-			(3, Junctions::X7(_, _, _, ref mut a, ..)) => a,
-			(3, Junctions::X8(_, _, _, ref mut a, ..)) => a,
-			(4, Junctions::X5(_, _, _, _, ref mut a)) => a,
-			(4, Junctions::X6(_, _, _, _, ref mut a, ..)) => a,
-			(4, Junctions::X7(_, _, _, _, ref mut a, ..)) => a,
-			(4, Junctions::X8(_, _, _, _, ref mut a, ..)) => a,
-			(5, Junctions::X6(_, _, _, _, _, ref mut a)) => a,
-			(5, Junctions::X7(_, _, _, _, _, ref mut a, ..)) => a,
-			(5, Junctions::X8(_, _, _, _, _, ref mut a, ..)) => a,
-			(6, Junctions::X7(_, _, _, _, _, _, ref mut a)) => a,
-			(6, Junctions::X8(_, _, _, _, _, _, ref mut a, ..)) => a,
-			(7, Junctions::X8(_, _, _, _, _, _, _, ref mut a)) => a,
-			_ => return None,
-		})
+		self.as_slice_mut().get_mut(i)
 	}
 
 	/// Returns a reference iterator over the junctions.
 	pub fn iter(&self) -> JunctionsRefIterator {
-		JunctionsRefIterator { junctions: self, next: 0, back: 0 }
+		JunctionsRefIterator { junctions: self, range: 0..self.len() }
 	}
 
 	/// Ensures that self begins with `prefix` and that it has a single `Junction` item following.
@@ -555,11 +535,11 @@ impl Junctions {
 	///
 	/// # Example
 	/// ```rust
-	/// # use xcm::v3::{Junctions::*, Junction::*};
+	/// # use xcm::v3::{Junctions, Junction::*};
 	/// # fn main() {
-	/// let mut m = X3(Parachain(2), PalletInstance(3), OnlyChild);
-	/// assert_eq!(m.match_and_split(&X2(Parachain(2), PalletInstance(3))), Some(&OnlyChild));
-	/// assert_eq!(m.match_and_split(&X1(Parachain(2))), None);
+	/// let mut m = Junctions::from([Parachain(2), PalletInstance(3), OnlyChild]);
+	/// assert_eq!(m.match_and_split(&[Parachain(2), PalletInstance(3)].into()), Some(&OnlyChild));
+	/// assert_eq!(m.match_and_split(&[Parachain(2)].into()), None);
 	/// # }
 	/// ```
 	pub fn match_and_split(&self, prefix: &Junctions) -> Option<&Junction> {
@@ -592,7 +572,7 @@ impl TryFrom<MultiLocation> for Junctions {
 
 impl<T: Into<Junction>> From<T> for Junctions {
 	fn from(x: T) -> Self {
-		Self::X1(x.into())
+		[x.into()].into()
 	}
 }
 
@@ -632,77 +612,105 @@ mod tests {
 
 	#[test]
 	fn relative_to_works() {
-		use Junctions::*;
 		use NetworkId::*;
-		assert_eq!(X1(Polkadot.into()).relative_to(&X1(Kusama.into())), (Parent, Polkadot).into());
-		let base = X3(Kusama.into(), Parachain(1), PalletInstance(1));
+		assert_eq!(
+			Junctions::from([Polkadot.into()]).relative_to(&Junctions::from([Kusama.into()])),
+			(Parent, Polkadot).into()
+		);
+		let base = Junctions::from([Kusama.into(), Parachain(1), PalletInstance(1)]);
 
 		// Ancestors.
 		assert_eq!(Here.relative_to(&base), (Parent, Parent, Parent).into());
-		assert_eq!(X1(Kusama.into()).relative_to(&base), (Parent, Parent).into());
-		assert_eq!(X2(Kusama.into(), Parachain(1)).relative_to(&base), (Parent,).into());
+		assert_eq!(Junctions::from([Kusama.into()]).relative_to(&base), (Parent, Parent).into());
 		assert_eq!(
-			X3(Kusama.into(), Parachain(1), PalletInstance(1)).relative_to(&base),
+			Junctions::from([Kusama.into(), Parachain(1)]).relative_to(&base),
+			(Parent,).into()
+		);
+		assert_eq!(
+			Junctions::from([Kusama.into(), Parachain(1), PalletInstance(1)]).relative_to(&base),
 			Here.into()
 		);
 
 		// Ancestors with one child.
 		assert_eq!(
-			X1(Polkadot.into()).relative_to(&base),
+			Junctions::from([Polkadot.into()]).relative_to(&base),
 			(Parent, Parent, Parent, Polkadot).into()
 		);
 		assert_eq!(
-			X2(Kusama.into(), Parachain(2)).relative_to(&base),
+			Junctions::from([Kusama.into(), Parachain(2)]).relative_to(&base),
 			(Parent, Parent, Parachain(2)).into()
 		);
 		assert_eq!(
-			X3(Kusama.into(), Parachain(1), PalletInstance(2)).relative_to(&base),
+			Junctions::from([Kusama.into(), Parachain(1), PalletInstance(2)]).relative_to(&base),
 			(Parent, PalletInstance(2)).into()
 		);
 		assert_eq!(
-			X4(Kusama.into(), Parachain(1), PalletInstance(1), [1u8; 32].into()).relative_to(&base),
+			Junctions::from([Kusama.into(), Parachain(1), PalletInstance(1), [1u8; 32].into()])
+				.relative_to(&base),
 			([1u8; 32],).into()
 		);
 
 		// Ancestors with grandchildren.
 		assert_eq!(
-			X2(Polkadot.into(), Parachain(1)).relative_to(&base),
+			Junctions::from([Polkadot.into(), Parachain(1)]).relative_to(&base),
 			(Parent, Parent, Parent, Polkadot, Parachain(1)).into()
 		);
 		assert_eq!(
-			X3(Kusama.into(), Parachain(2), PalletInstance(1)).relative_to(&base),
+			Junctions::from([Kusama.into(), Parachain(2), PalletInstance(1)]).relative_to(&base),
 			(Parent, Parent, Parachain(2), PalletInstance(1)).into()
 		);
 		assert_eq!(
-			X4(Kusama.into(), Parachain(1), PalletInstance(2), [1u8; 32].into()).relative_to(&base),
+			Junctions::from([Kusama.into(), Parachain(1), PalletInstance(2), [1u8; 32].into()])
+				.relative_to(&base),
 			(Parent, PalletInstance(2), [1u8; 32]).into()
 		);
 		assert_eq!(
-			X5(Kusama.into(), Parachain(1), PalletInstance(1), [1u8; 32].into(), 1u128.into())
-				.relative_to(&base),
+			Junctions::from([
+				Kusama.into(),
+				Parachain(1),
+				PalletInstance(1),
+				[1u8; 32].into(),
+				1u128.into()
+			])
+			.relative_to(&base),
 			([1u8; 32], 1u128).into()
 		);
 	}
 
 	#[test]
 	fn global_consensus_works() {
-		use Junctions::*;
 		use NetworkId::*;
-		assert_eq!(X1(Polkadot.into()).global_consensus(), Ok(Polkadot));
-		assert_eq!(X2(Kusama.into(), 1u64.into()).global_consensus(), Ok(Kusama));
+		assert_eq!(Junctions::from([Polkadot.into()]).global_consensus(), Ok(Polkadot));
+		assert_eq!(Junctions::from([Kusama.into(), 1u64.into()]).global_consensus(), Ok(Kusama));
 		assert_eq!(Here.global_consensus(), Err(()));
-		assert_eq!(X1(1u64.into()).global_consensus(), Err(()));
-		assert_eq!(X2(1u64.into(), Kusama.into()).global_consensus(), Err(()));
+		assert_eq!(Junctions::from([1u64.into()]).global_consensus(), Err(()));
+		assert_eq!(Junctions::from([1u64.into(), Kusama.into()]).global_consensus(), Err(()));
 	}
 
 	#[test]
 	fn test_conversion() {
-		use super::{Junction::*, Junctions::*, NetworkId::*};
+		use super::{Junction::*, NetworkId::*};
 		let x: Junctions = GlobalConsensus(Polkadot).into();
-		assert_eq!(x, X1(GlobalConsensus(Polkadot)));
+		assert_eq!(x, Junctions::from([GlobalConsensus(Polkadot)]));
 		let x: Junctions = Polkadot.into();
-		assert_eq!(x, X1(GlobalConsensus(Polkadot)));
+		assert_eq!(x, Junctions::from([GlobalConsensus(Polkadot)]));
 		let x: Junctions = (Polkadot, Kusama).into();
-		assert_eq!(x, X2(GlobalConsensus(Polkadot), GlobalConsensus(Kusama)));
+		assert_eq!(x, Junctions::from([GlobalConsensus(Polkadot), GlobalConsensus(Kusama)]));
+	}
+
+	#[test]
+	fn encode_decode_junctions_works() {
+		let original = Junctions::from([
+			Polkadot.into(),
+			Kusama.into(),
+			1u64.into(),
+			GlobalConsensus(Polkadot),
+			Parachain(123),
+			PalletInstance(45),
+		]);
+		let encoded = original.encode();
+		assert_eq!(encoded, &[6, 9, 2, 9, 3, 2, 0, 4, 9, 2, 0, 237, 1, 4, 45]);
+		let decoded = Junctions::decode(&mut &encoded[..]).unwrap();
+		assert_eq!(decoded, original);
 	}
 }

--- a/xcm/src/v3/mod.rs
+++ b/xcm/src/v3/mod.rs
@@ -177,7 +177,7 @@ pub mod prelude {
 			Instruction::*,
 			InteriorMultiLocation,
 			Junction::{self, *},
-			Junctions::{self, *},
+			Junctions::{self, Here},
 			MaybeErrorCode, MultiAsset,
 			MultiAssetFilter::{self, *},
 			MultiAssets, MultiLocation,
@@ -895,7 +895,7 @@ pub enum Instruction<Call> {
 	///
 	/// As an example, to export a message for execution on Statemine (parachain #1000 in the
 	/// Kusama network), you would call with `network: NetworkId::Kusama` and
-	/// `destination: X1(Parachain(1000))`. Alternatively, to export a message for execution on
+	/// `destination: [Parachain(1000)].into()`. Alternatively, to export a message for execution on
 	/// Polkadot, you would call with `network: NetworkId:: Polkadot` and `destination: Here`.
 	///
 	/// Kind: *Instruction*

--- a/xcm/src/v3/multiasset.rs
+++ b/xcm/src/v3/multiasset.rs
@@ -325,9 +325,7 @@ impl TryFrom<OldWildFungibility> for WildFungibility {
 }
 
 /// Classification of an asset being concrete or abstract.
-#[derive(
-	Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Encode, Decode, TypeInfo, MaxEncodedLen,
-)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Encode, Decode, TypeInfo, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 pub enum AssetId {
 	/// A specific location identifying an asset.
@@ -369,7 +367,7 @@ impl AssetId {
 	/// Prepend a `MultiLocation` to a concrete asset, giving it a new root location.
 	pub fn prepend_with(&mut self, prepend: &MultiLocation) -> Result<(), ()> {
 		if let AssetId::Concrete(ref mut l) = self {
-			l.prepend_with(*prepend).map_err(|_| ())?;
+			l.prepend_with(prepend.clone()).map_err(|_| ())?;
 		}
 		Ok(())
 	}
@@ -379,7 +377,7 @@ impl AssetId {
 	pub fn reanchor(
 		&mut self,
 		target: &MultiLocation,
-		context: InteriorMultiLocation,
+		context: &InteriorMultiLocation,
 	) -> Result<(), ()> {
 		if let AssetId::Concrete(ref mut l) = self {
 			l.reanchor(target, context)?;
@@ -453,7 +451,7 @@ impl MultiAsset {
 	pub fn reanchor(
 		&mut self,
 		target: &MultiLocation,
-		context: InteriorMultiLocation,
+		context: &InteriorMultiLocation,
 	) -> Result<(), ()> {
 		self.id.reanchor(target, context)
 	}
@@ -463,7 +461,7 @@ impl MultiAsset {
 	pub fn reanchored(
 		mut self,
 		target: &MultiLocation,
-		context: InteriorMultiLocation,
+		context: &InteriorMultiLocation,
 	) -> Result<Self, ()> {
 		self.id.reanchor(target, context)?;
 		Ok(self)
@@ -675,7 +673,7 @@ impl MultiAssets {
 	pub fn reanchor(
 		&mut self,
 		target: &MultiLocation,
-		context: InteriorMultiLocation,
+		context: &InteriorMultiLocation,
 	) -> Result<(), ()> {
 		self.0.iter_mut().try_for_each(|i| i.reanchor(target, context))
 	}
@@ -757,7 +755,7 @@ impl WildMultiAsset {
 	pub fn reanchor(
 		&mut self,
 		target: &MultiLocation,
-		context: InteriorMultiLocation,
+		context: &InteriorMultiLocation,
 	) -> Result<(), ()> {
 		use WildMultiAsset::*;
 		match self {
@@ -849,7 +847,7 @@ impl MultiAssetFilter {
 	pub fn reanchor(
 		&mut self,
 		target: &MultiLocation,
-		context: InteriorMultiLocation,
+		context: &InteriorMultiLocation,
 	) -> Result<(), ()> {
 		match self {
 			MultiAssetFilter::Definite(ref mut assets) => assets.reanchor(target, context),

--- a/xcm/src/v3/traits.rs
+++ b/xcm/src/v3/traits.rs
@@ -412,8 +412,8 @@ impl<T> Unwrappable for Option<T> {
 /// impl SendXcm for Sender2 {
 ///     type Ticket = ();
 ///     fn validate(destination: &mut Option<MultiLocation>, message: &mut Option<Xcm<()>>) -> SendResult<()> {
-///         match destination.as_ref().ok_or(SendError::MissingArgument)? {
-///             MultiLocation { parents: 0, interior: X2(j1, j2) } => Ok(((), MultiAssets::new())),
+///         match destination.as_ref().ok_or(SendError::MissingArgument)?.unpack() {
+///             (0, [_, _]) => Ok(((), MultiAssets::new())),
 ///             _ => Err(SendError::Unroutable),
 ///         }
 ///     }

--- a/xcm/xcm-builder/src/asset_conversion.rs
+++ b/xcm/xcm-builder/src/asset_conversion.rs
@@ -233,13 +233,13 @@ mod tests {
 		>;
 		assert_eq!(
 			TrustBackedAssetsPalletLocation::get(),
-			MultiLocation { parents: 0, interior: X1(PalletInstance(50)) }
+			MultiLocation { parents: 0, interior: [PalletInstance(50)].into() }
 		);
 
 		// err - does not match
 		assert_eq!(
 			Converter::matches_fungibles(&MultiAsset {
-				id: Concrete(MultiLocation::new(1, X2(PalletInstance(50), GeneralIndex(1)))),
+				id: Concrete(MultiLocation::new(1, [PalletInstance(50), GeneralIndex(1)])),
 				fun: Fungible(12345),
 			}),
 			Err(MatchError::AssetNotHandled)
@@ -250,7 +250,7 @@ mod tests {
 			Converter::matches_fungibles(&MultiAsset {
 				id: Concrete(MultiLocation::new(
 					0,
-					X2(PalletInstance(50), GeneralKey { length: 1, data: [1; 32] })
+					[PalletInstance(50), GeneralKey { length: 1, data: [1; 32] }]
 				)),
 				fun: Fungible(12345),
 			}),
@@ -260,7 +260,7 @@ mod tests {
 		// err - matches, but NonFungible
 		assert_eq!(
 			Converter::matches_fungibles(&MultiAsset {
-				id: Concrete(MultiLocation::new(0, X2(PalletInstance(50), GeneralIndex(1)))),
+				id: Concrete(MultiLocation::new(0, [PalletInstance(50), GeneralIndex(1)])),
 				fun: NonFungible(Index(54321)),
 			}),
 			Err(MatchError::AssetNotHandled)
@@ -269,7 +269,7 @@ mod tests {
 		// ok
 		assert_eq!(
 			Converter::matches_fungibles(&MultiAsset {
-				id: Concrete(MultiLocation::new(0, X2(PalletInstance(50), GeneralIndex(1)))),
+				id: Concrete(MultiLocation::new(0, [PalletInstance(50), GeneralIndex(1)])),
 				fun: Fungible(12345),
 			}),
 			Ok((1, 12345))
@@ -305,13 +305,13 @@ mod tests {
 		>;
 		assert_eq!(
 			TrustBackedAssetsPalletLocation::get(),
-			MultiLocation { parents: 0, interior: X1(PalletInstance(50)) }
+			MultiLocation { parents: 0, interior: [PalletInstance(50)].into() }
 		);
 
 		// err - does not match
 		assert_eq!(
 			Converter::matches_nonfungibles(&MultiAsset {
-				id: Concrete(MultiLocation::new(1, X2(PalletInstance(50), GeneralIndex(1)))),
+				id: Concrete(MultiLocation::new(1, [PalletInstance(50), GeneralIndex(1)])),
 				fun: NonFungible(Index(54321)),
 			}),
 			Err(MatchError::AssetNotHandled)
@@ -322,7 +322,7 @@ mod tests {
 			Converter::matches_nonfungibles(&MultiAsset {
 				id: Concrete(MultiLocation::new(
 					0,
-					X2(PalletInstance(50), GeneralKey { length: 1, data: [1; 32] })
+					[PalletInstance(50), GeneralKey { length: 1, data: [1; 32] }]
 				)),
 				fun: NonFungible(Index(54321)),
 			}),
@@ -332,7 +332,7 @@ mod tests {
 		// err - matches, but Fungible vs NonFungible
 		assert_eq!(
 			Converter::matches_nonfungibles(&MultiAsset {
-				id: Concrete(MultiLocation::new(0, X2(PalletInstance(50), GeneralIndex(1)))),
+				id: Concrete(MultiLocation::new(0, [PalletInstance(50), GeneralIndex(1)])),
 				fun: Fungible(12345),
 			}),
 			Err(MatchError::AssetNotHandled)
@@ -341,7 +341,7 @@ mod tests {
 		// ok
 		assert_eq!(
 			Converter::matches_nonfungibles(&MultiAsset {
-				id: Concrete(MultiLocation::new(0, X2(PalletInstance(50), GeneralIndex(1)))),
+				id: Concrete(MultiLocation::new(0, [PalletInstance(50), GeneralIndex(1)])),
 				fun: NonFungible(Index(54321)),
 			}),
 			Ok((1, 54321))

--- a/xcm/xcm-builder/src/origin_conversion.rs
+++ b/xcm/xcm-builder/src/origin_conversion.rs
@@ -81,12 +81,11 @@ impl<ParaId: IsSystem + From<u32>, RuntimeOrigin: OriginTrait> ConvertOrigin<Run
 	) -> Result<RuntimeOrigin, MultiLocation> {
 		let origin = origin.into();
 		log::trace!(target: "xcm::origin_conversion", "ChildSystemParachainAsSuperuser origin: {:?}, kind: {:?}", origin, kind);
-		match (kind, origin) {
-			(
-				OriginKind::Superuser,
-				MultiLocation { parents: 0, interior: X1(Junction::Parachain(id)) },
-			) if ParaId::from(id).is_system() => Ok(RuntimeOrigin::root()),
-			(_, origin) => Err(origin),
+		match (kind, origin.unpack()) {
+			(OriginKind::Superuser, (0, [Junction::Parachain(id)]))
+				if ParaId::from(*id).is_system() =>
+				Ok(RuntimeOrigin::root()),
+			_ => Err(origin),
 		}
 	}
 }
@@ -107,12 +106,11 @@ impl<ParaId: IsSystem + From<u32>, RuntimeOrigin: OriginTrait> ConvertOrigin<Run
 			"SiblingSystemParachainAsSuperuser origin: {:?}, kind: {:?}",
 			origin, kind,
 		);
-		match (kind, origin) {
-			(
-				OriginKind::Superuser,
-				MultiLocation { parents: 1, interior: X1(Junction::Parachain(id)) },
-			) if ParaId::from(id).is_system() => Ok(RuntimeOrigin::root()),
-			(_, origin) => Err(origin),
+		match (kind, origin.unpack()) {
+			(OriginKind::Superuser, (1, [Junction::Parachain(id)]))
+				if ParaId::from(*id).is_system() =>
+				Ok(RuntimeOrigin::root()),
+			_ => Err(origin),
 		}
 	}
 }
@@ -129,12 +127,10 @@ impl<ParachainOrigin: From<u32>, RuntimeOrigin: From<ParachainOrigin>> ConvertOr
 	) -> Result<RuntimeOrigin, MultiLocation> {
 		let origin = origin.into();
 		log::trace!(target: "xcm::origin_conversion", "ChildParachainAsNative origin: {:?}, kind: {:?}", origin, kind);
-		match (kind, origin) {
-			(
-				OriginKind::Native,
-				MultiLocation { parents: 0, interior: X1(Junction::Parachain(id)) },
-			) => Ok(RuntimeOrigin::from(ParachainOrigin::from(id))),
-			(_, origin) => Err(origin),
+		match (kind, origin.unpack()) {
+			(OriginKind::Native, (0, [Junction::Parachain(id)])) =>
+				Ok(RuntimeOrigin::from(ParachainOrigin::from(*id))),
+			_ => Err(origin),
 		}
 	}
 }
@@ -155,12 +151,10 @@ impl<ParachainOrigin: From<u32>, RuntimeOrigin: From<ParachainOrigin>> ConvertOr
 			"SiblingParachainAsNative origin: {:?}, kind: {:?}",
 			origin, kind,
 		);
-		match (kind, origin) {
-			(
-				OriginKind::Native,
-				MultiLocation { parents: 1, interior: X1(Junction::Parachain(id)) },
-			) => Ok(RuntimeOrigin::from(ParachainOrigin::from(id))),
-			(_, origin) => Err(origin),
+		match (kind, origin.unpack()) {
+			(OriginKind::Native, (1, [Junction::Parachain(id)])) =>
+				Ok(RuntimeOrigin::from(ParachainOrigin::from(*id))),
+			_ => Err(origin),
 		}
 	}
 }
@@ -202,13 +196,11 @@ where
 			"SignedAccountId32AsNative origin: {:?}, kind: {:?}",
 			origin, kind,
 		);
-		match (kind, origin) {
-			(
-				OriginKind::Native,
-				MultiLocation { parents: 0, interior: X1(Junction::AccountId32 { id, network }) },
-			) if matches!(network, None) || network == Network::get() =>
-				Ok(RuntimeOrigin::signed(id.into())),
-			(_, origin) => Err(origin),
+		match (kind, origin.unpack()) {
+			(OriginKind::Native, (0, [Junction::AccountId32 { id, network }]))
+				if matches!(network, None) || *network == Network::get() =>
+				Ok(RuntimeOrigin::signed((*id).into())),
+			_ => Err(origin),
 		}
 	}
 }
@@ -231,13 +223,11 @@ where
 			"SignedAccountKey20AsNative origin: {:?}, kind: {:?}",
 			origin, kind,
 		);
-		match (kind, origin) {
-			(
-				OriginKind::Native,
-				MultiLocation { parents: 0, interior: X1(Junction::AccountKey20 { key, network }) },
-			) if (matches!(network, None) || network == Network::get()) =>
-				Ok(RuntimeOrigin::signed(key.into())),
-			(_, origin) => Err(origin),
+		match (kind, origin.unpack()) {
+			(OriginKind::Native, (0, [Junction::AccountKey20 { key, network }]))
+				if (matches!(network, None) || *network == Network::get()) =>
+				Ok(RuntimeOrigin::signed((*key).into())),
+			_ => Err(origin),
 		}
 	}
 }

--- a/xcm/xcm-builder/src/test_utils.rs
+++ b/xcm/xcm-builder/src/test_utils.rs
@@ -45,14 +45,14 @@ impl VersionChangeNotifier for TestSubscriptionService {
 		_context: &XcmContext,
 	) -> XcmResult {
 		let mut r = SubscriptionRequests::get();
-		r.push((*location, Some((query_id, max_weight))));
+		r.push((location.clone(), Some((query_id, max_weight))));
 		SubscriptionRequests::set(r);
 		Ok(())
 	}
 	fn stop(location: &MultiLocation, _context: &XcmContext) -> XcmResult {
 		let mut r = SubscriptionRequests::get();
 		r.retain(|(l, _q)| l != location);
-		r.push((*location, None));
+		r.push((location.clone(), None));
 		SubscriptionRequests::set(r);
 		Ok(())
 	}
@@ -71,7 +71,7 @@ pub struct TestAssetTrap;
 impl DropAssets for TestAssetTrap {
 	fn drop_assets(origin: &MultiLocation, assets: Assets, _context: &XcmContext) -> Weight {
 		let mut t: Vec<(MultiLocation, MultiAssets)> = TrappedAssets::get();
-		t.push((*origin, assets.into()));
+		t.push((origin.clone(), assets.into()));
 		TrappedAssets::set(t);
 		Weight::from_parts(5, 5)
 	}
@@ -85,7 +85,7 @@ impl ClaimAssets for TestAssetTrap {
 		_context: &XcmContext,
 	) -> bool {
 		let mut t: Vec<(MultiLocation, MultiAssets)> = TrappedAssets::get();
-		if let (0, X1(GeneralIndex(i))) = (ticket.parents, &ticket.interior) {
+		if let (0, [GeneralIndex(i)]) = ticket.unpack() {
 			if let Some((l, a)) = t.get(*i as usize) {
 				if l == origin && a == what {
 					t.swap_remove(*i as usize);

--- a/xcm/xcm-builder/src/tests/assets.rs
+++ b/xcm/xcm-builder/src/tests/assets.rs
@@ -110,13 +110,13 @@ fn paying_reserve_deposit_should_work() {
 #[test]
 fn transfer_should_work() {
 	// we'll let them have message execution for free.
-	AllowUnpaidFrom::set(vec![X1(Parachain(1)).into()]);
+	AllowUnpaidFrom::set(vec![[Parachain(1)].into()]);
 	// Child parachain #1 owns 1000 tokens held by us in reserve.
 	add_asset(Parachain(1), (Here, 1000));
 	// They want to transfer 100 of them to their sibling parachain #2
 	let message = Xcm(vec![TransferAsset {
 		assets: (Here, 100u128).into(),
-		beneficiary: X1(AccountIndex64 { index: 3, network: None }).into(),
+		beneficiary: [AccountIndex64 { index: 3, network: None }].into(),
 	}]);
 	let hash = fake_message_hash(&message);
 	let r = XcmExecutor::<TestConfig>::execute_xcm(
@@ -136,11 +136,11 @@ fn transfer_should_work() {
 
 #[test]
 fn reserve_transfer_should_work() {
-	AllowUnpaidFrom::set(vec![X1(Parachain(1)).into()]);
+	AllowUnpaidFrom::set(vec![[Parachain(1)].into()]);
 	// Child parachain #1 owns 1000 tokens held by us in reserve.
 	add_asset(Parachain(1), (Here, 1000));
 	// The remote account owned by gav.
-	let three: MultiLocation = X1(AccountIndex64 { index: 3, network: None }).into();
+	let three: MultiLocation = [AccountIndex64 { index: 3, network: None }].into();
 
 	// They want to transfer 100 of our native asset from sovereign account of parachain #1 into #2
 	// and let them know to hand it to account #3.
@@ -174,7 +174,7 @@ fn reserve_transfer_should_work() {
 #[test]
 fn burn_should_work() {
 	// we'll let them have message execution for free.
-	AllowUnpaidFrom::set(vec![X1(Parachain(1)).into()]);
+	AllowUnpaidFrom::set(vec![[Parachain(1)].into()]);
 	// Child parachain #1 owns 1000 tokens held by us in reserve.
 	add_asset(Parachain(1), (Here, 1000));
 	// They want to burn 100 of them
@@ -215,7 +215,7 @@ fn burn_should_work() {
 #[test]
 fn basic_asset_trap_should_work() {
 	// we'll let them have message execution for free.
-	AllowUnpaidFrom::set(vec![X1(Parachain(1)).into(), X1(Parachain(2)).into()]);
+	AllowUnpaidFrom::set(vec![[Parachain(1)].into(), [Parachain(2)].into()]);
 
 	// Child parachain #1 owns 1000 tokens held by us in reserve.
 	add_asset(Parachain(1), (Here, 1000));
@@ -343,7 +343,7 @@ fn basic_asset_trap_should_work() {
 #[test]
 fn max_assets_limit_should_work() {
 	// we'll let them have message execution for free.
-	AllowUnpaidFrom::set(vec![X1(Parachain(1)).into()]);
+	AllowUnpaidFrom::set(vec![[Parachain(1)].into()]);
 	// Child parachain #1 owns 1000 tokens held by us in reserve.
 	add_asset(Parachain(1), ([1u8; 32], 1000u128));
 	add_asset(Parachain(1), ([2u8; 32], 1000u128));

--- a/xcm/xcm-builder/src/tests/basic.rs
+++ b/xcm/xcm-builder/src/tests/basic.rs
@@ -28,11 +28,11 @@ fn basic_setup_works() {
 	assert_eq!(to_account((Parent, Parachain(1))), Ok(2001));
 	assert_eq!(to_account((Parent, Parachain(50))), Ok(2050));
 	assert_eq!(
-		to_account(MultiLocation::new(0, X1(AccountIndex64 { index: 1, network: None }))),
+		to_account(MultiLocation::new(0, [AccountIndex64 { index: 1, network: None }])),
 		Ok(1),
 	);
 	assert_eq!(
-		to_account(MultiLocation::new(0, X1(AccountIndex64 { index: 42, network: None }))),
+		to_account(MultiLocation::new(0, [AccountIndex64 { index: 42, network: None }])),
 		Ok(42),
 	);
 	assert_eq!(to_account(Here), Ok(3000));
@@ -65,7 +65,7 @@ fn code_registers_should_work() {
 		SetErrorHandler(Xcm(vec![
 			TransferAsset {
 				assets: (Here, 2u128).into(),
-				beneficiary: X1(AccountIndex64 { index: 3, network: None }).into(),
+				beneficiary: [(AccountIndex64 { index: 3, network: None })].into(),
 			},
 			// It was handled fine.
 			ClearError,
@@ -73,17 +73,17 @@ fn code_registers_should_work() {
 		// Set the appendix - this will always fire.
 		SetAppendix(Xcm(vec![TransferAsset {
 			assets: (Here, 4u128).into(),
-			beneficiary: X1(AccountIndex64 { index: 3, network: None }).into(),
+			beneficiary: [(AccountIndex64 { index: 3, network: None })].into(),
 		}])),
 		// First xfer always works ok
 		TransferAsset {
 			assets: (Here, 1u128).into(),
-			beneficiary: X1(AccountIndex64 { index: 3, network: None }).into(),
+			beneficiary: [(AccountIndex64 { index: 3, network: None })].into(),
 		},
 		// Second xfer results in error on the second message - our error handler will fire.
 		TransferAsset {
 			assets: (Here, 8u128).into(),
-			beneficiary: X1(AccountIndex64 { index: 3, network: None }).into(),
+			beneficiary: [(AccountIndex64 { index: 3, network: None })].into(),
 		},
 	]);
 	// Weight limit of 70 is needed.

--- a/xcm/xcm-builder/src/tests/bridging/local_para_para.rs
+++ b/xcm/xcm-builder/src/tests/bridging/local_para_para.rs
@@ -21,8 +21,8 @@
 use super::*;
 
 parameter_types! {
-	pub UniversalLocation: Junctions = X2(GlobalConsensus(Local::get()), Parachain(1));
-	pub RemoteUniversalLocation: Junctions = X2(GlobalConsensus(Remote::get()), Parachain(1));
+	pub UniversalLocation: Junctions = [GlobalConsensus(Local::get()), Parachain(1)].into();
+	pub RemoteUniversalLocation: Junctions = [GlobalConsensus(Remote::get()), Parachain(1)].into();
 }
 type TheBridge =
 	TestBridge<BridgeBlobDispatcher<TestRemoteIncomingRouter, RemoteUniversalLocation>>;

--- a/xcm/xcm-builder/src/tests/bridging/local_relay_relay.rs
+++ b/xcm/xcm-builder/src/tests/bridging/local_relay_relay.rs
@@ -21,8 +21,8 @@
 use super::*;
 
 parameter_types! {
-	pub UniversalLocation: Junctions = X1(GlobalConsensus(Local::get()));
-	pub RemoteUniversalLocation: Junctions = X1(GlobalConsensus(Remote::get()));
+	pub UniversalLocation: Junctions = [GlobalConsensus(Local::get())].into();
+	pub RemoteUniversalLocation: Junctions = [GlobalConsensus(Remote::get())].into();
 }
 type TheBridge =
 	TestBridge<BridgeBlobDispatcher<TestRemoteIncomingRouter, RemoteUniversalLocation>>;

--- a/xcm/xcm-builder/src/tests/bridging/paid_remote_relay_relay.rs
+++ b/xcm/xcm-builder/src/tests/bridging/paid_remote_relay_relay.rs
@@ -24,9 +24,9 @@
 use super::*;
 
 parameter_types! {
-	pub UniversalLocation: Junctions = X2(GlobalConsensus(Local::get()), Parachain(100));
-	pub RelayUniversalLocation: Junctions = X1(GlobalConsensus(Local::get()));
-	pub RemoteUniversalLocation: Junctions = X1(GlobalConsensus(Remote::get()));
+	pub UniversalLocation: Junctions = [GlobalConsensus(Local::get()), Parachain(100)].into();
+	pub RelayUniversalLocation: Junctions = [GlobalConsensus(Local::get())].into();
+	pub RemoteUniversalLocation: Junctions = [GlobalConsensus(Remote::get())].into();
 	pub static BridgeTable: Vec<(NetworkId, MultiLocation, Option<MultiAsset>)>
 		= vec![(Remote::get(), MultiLocation::parent(), Some((Parent, 200u128).into()))];
 	// ^^^ 100 to use the bridge (export) and 100 for the remote execution weight (5 instructions

--- a/xcm/xcm-builder/src/tests/bridging/remote_para_para.rs
+++ b/xcm/xcm-builder/src/tests/bridging/remote_para_para.rs
@@ -21,9 +21,9 @@
 use super::*;
 
 parameter_types! {
-	pub UniversalLocation: Junctions = X2(GlobalConsensus(Local::get()), Parachain(1000));
-	pub ParaBridgeUniversalLocation: Junctions = X2(GlobalConsensus(Local::get()), Parachain(1));
-	pub RemoteParaBridgeUniversalLocation: Junctions = X2(GlobalConsensus(Remote::get()), Parachain(1));
+	pub UniversalLocation: Junctions = [GlobalConsensus(Local::get()), Parachain(1000)].into();
+	pub ParaBridgeUniversalLocation: Junctions = [GlobalConsensus(Local::get()), Parachain(1)].into();
+	pub RemoteParaBridgeUniversalLocation: Junctions = [GlobalConsensus(Remote::get()), Parachain(1)].into();
 	pub BridgeTable: Vec<(NetworkId, MultiLocation, Option<MultiAsset>)>
 		= vec![(Remote::get(), (Parent, Parachain(1)).into(), None)];
 }

--- a/xcm/xcm-builder/src/tests/bridging/remote_para_para_via_relay.rs
+++ b/xcm/xcm-builder/src/tests/bridging/remote_para_para_via_relay.rs
@@ -21,9 +21,9 @@
 use super::*;
 
 parameter_types! {
-	pub UniversalLocation: Junctions = X1(GlobalConsensus(Local::get()));
-	pub ParaBridgeUniversalLocation: Junctions = X2(GlobalConsensus(Local::get()), Parachain(1));
-	pub RemoteParaBridgeUniversalLocation: Junctions = X2(GlobalConsensus(Remote::get()), Parachain(1));
+	pub UniversalLocation: Junctions = [GlobalConsensus(Local::get())].into();
+	pub ParaBridgeUniversalLocation: Junctions = [GlobalConsensus(Local::get()), Parachain(1)].into();
+	pub RemoteParaBridgeUniversalLocation: Junctions = [GlobalConsensus(Remote::get()), Parachain(1)].into();
 	pub BridgeTable: Vec<(NetworkId, MultiLocation, Option<MultiAsset>)>
 		= vec![(Remote::get(), Parachain(1).into(), None)];
 }

--- a/xcm/xcm-builder/src/tests/bridging/remote_relay_relay.rs
+++ b/xcm/xcm-builder/src/tests/bridging/remote_relay_relay.rs
@@ -21,9 +21,9 @@
 use super::*;
 
 parameter_types! {
-	pub UniversalLocation: Junctions = X2(GlobalConsensus(Local::get()), Parachain(1000));
-	pub RelayUniversalLocation: Junctions = X1(GlobalConsensus(Local::get()));
-	pub RemoteUniversalLocation: Junctions = X1(GlobalConsensus(Remote::get()));
+	pub UniversalLocation: Junctions = [GlobalConsensus(Local::get()), Parachain(1000)].into();
+	pub RelayUniversalLocation: Junctions = [GlobalConsensus(Local::get())].into();
+	pub RemoteUniversalLocation: Junctions = [GlobalConsensus(Remote::get())].into();
 	pub BridgeTable: Vec<(NetworkId, MultiLocation, Option<MultiAsset>)>
 		= vec![(Remote::get(), MultiLocation::parent(), None)];
 }

--- a/xcm/xcm-builder/src/tests/expecting.rs
+++ b/xcm/xcm-builder/src/tests/expecting.rs
@@ -18,7 +18,7 @@ use super::*;
 
 #[test]
 fn expect_pallet_should_work() {
-	AllowUnpaidFrom::set(vec![X1(Parachain(1)).into()]);
+	AllowUnpaidFrom::set(vec![[(Parachain(1))].into()]);
 	// They want to transfer 100 of our native asset from sovereign account of parachain #1 into #2
 	// and let them know to hand it to account #3.
 	let message = Xcm(vec![ExpectPallet {
@@ -56,7 +56,7 @@ fn expect_pallet_should_work() {
 
 #[test]
 fn expect_pallet_should_fail_correctly() {
-	AllowUnpaidFrom::set(vec![X1(Parachain(1)).into()]);
+	AllowUnpaidFrom::set(vec![[(Parachain(1))].into()]);
 	let message = Xcm(vec![ExpectPallet {
 		index: 1,
 		name: b"Balances".as_ref().into(),

--- a/xcm/xcm-builder/src/tests/origins.rs
+++ b/xcm/xcm-builder/src/tests/origins.rs
@@ -18,7 +18,7 @@ use super::*;
 
 #[test]
 fn universal_origin_should_work() {
-	AllowUnpaidFrom::set(vec![X1(Parachain(1)).into(), X1(Parachain(2)).into()]);
+	AllowUnpaidFrom::set(vec![[(Parachain(1))].into(), [(Parachain(2))].into()]);
 	clear_universal_aliases();
 	// Parachain 1 may represent Kusama to us
 	add_universal_alias(Parachain(1), Kusama);
@@ -70,7 +70,7 @@ fn universal_origin_should_work() {
 #[test]
 fn export_message_should_work() {
 	// Bridge chain (assumed to be Relay) lets Parachain #1 have message execution for free.
-	AllowUnpaidFrom::set(vec![X1(Parachain(1)).into()]);
+	AllowUnpaidFrom::set(vec![[(Parachain(1))].into()]);
 	// Local parachain #1 issues a transfer asset on Polkadot Relay-chain, transfering 100 Planck to
 	// Polkadot parachain #2.
 	let expected_message = Xcm(vec![TransferAsset {
@@ -101,10 +101,10 @@ fn export_message_should_work() {
 #[test]
 fn unpaid_execution_should_work() {
 	// Bridge chain (assumed to be Relay) lets Parachain #1 have message execution for free.
-	AllowUnpaidFrom::set(vec![X1(Parachain(1)).into()]);
+	AllowUnpaidFrom::set(vec![[(Parachain(1))].into()]);
 	// Bridge chain (assumed to be Relay) lets Parachain #2 have message execution for free if it
 	// asks.
-	AllowExplicitUnpaidFrom::set(vec![X1(Parachain(2)).into()]);
+	AllowExplicitUnpaidFrom::set(vec![[(Parachain(2))].into()]);
 	// Asking for unpaid execution of up to 9 weight on the assumption it is origin of #2.
 	let message = Xcm(vec![UnpaidExecution {
 		weight_limit: Limited(Weight::from_parts(9, 9)),

--- a/xcm/xcm-builder/src/tests/querying.rs
+++ b/xcm/xcm-builder/src/tests/querying.rs
@@ -18,7 +18,7 @@ use super::*;
 
 #[test]
 fn pallet_query_should_work() {
-	AllowUnpaidFrom::set(vec![X1(Parachain(1)).into()]);
+	AllowUnpaidFrom::set(vec![[(Parachain(1))].into()]);
 	// They want to transfer 100 of our native asset from sovereign account of parachain #1 into #2
 	// and let them know to hand it to account #3.
 	let message = Xcm(vec![QueryPallet {
@@ -50,7 +50,7 @@ fn pallet_query_should_work() {
 
 #[test]
 fn pallet_query_with_results_should_work() {
-	AllowUnpaidFrom::set(vec![X1(Parachain(1)).into()]);
+	AllowUnpaidFrom::set(vec![[(Parachain(1))].into()]);
 	// They want to transfer 100 of our native asset from sovereign account of parachain #1 into #2
 	// and let them know to hand it to account #3.
 	let message = Xcm(vec![QueryPallet {

--- a/xcm/xcm-builder/src/tests/version_subscriptions.rs
+++ b/xcm/xcm-builder/src/tests/version_subscriptions.rs
@@ -53,7 +53,7 @@ fn simple_version_subscriptions_should_work() {
 fn version_subscription_instruction_should_work() {
 	let origin = Parachain(1000);
 	let message = Xcm::<TestCall>(vec![
-		DescendOrigin(X1(AccountIndex64 { index: 1, network: None })),
+		DescendOrigin([AccountIndex64 { index: 1, network: None }].into()),
 		SubscribeVersion { query_id: 42, max_response_weight: Weight::from_parts(5000, 5000) },
 	]);
 	let hash = fake_message_hash(&message);
@@ -118,7 +118,7 @@ fn version_unsubscription_instruction_should_work() {
 
 	// Not allowed to do it when origin has been changed.
 	let message = Xcm::<TestCall>(vec![
-		DescendOrigin(X1(AccountIndex64 { index: 1, network: None })),
+		DescendOrigin([AccountIndex64 { index: 1, network: None }].into()),
 		UnsubscribeVersion,
 	]);
 	let hash = fake_message_hash(&message);

--- a/xcm/xcm-builder/src/tests/weight.rs
+++ b/xcm/xcm-builder/src/tests/weight.rs
@@ -57,17 +57,17 @@ fn errors_should_return_unused_weight() {
 		// First xfer results in an error on the last message only
 		TransferAsset {
 			assets: (Here, 1u128).into(),
-			beneficiary: X1(AccountIndex64 { index: 3, network: None }).into(),
+			beneficiary: [AccountIndex64 { index: 3, network: None }].into(),
 		},
 		// Second xfer results in error third message and after
 		TransferAsset {
 			assets: (Here, 2u128).into(),
-			beneficiary: X1(AccountIndex64 { index: 3, network: None }).into(),
+			beneficiary: [AccountIndex64 { index: 3, network: None }].into(),
 		},
 		// Third xfer results in error second message and after
 		TransferAsset {
 			assets: (Here, 4u128).into(),
-			beneficiary: X1(AccountIndex64 { index: 3, network: None }).into(),
+			beneficiary: [(AccountIndex64 { index: 3, network: None })].into(),
 		},
 	]);
 	// Weight limit of 70 is needed.
@@ -163,7 +163,8 @@ fn weight_trader_tuple_should_work() {
 	let mut traders = Traders::new();
 	// trader one failed; trader two buys weight
 	assert_eq!(
-		traders.buy_weight(Weight::from_parts(5, 5), fungible_multi_asset(para_1, 10).into()),
+		traders
+			.buy_weight(Weight::from_parts(5, 5), fungible_multi_asset(para_1.clone(), 10).into()),
 		Ok(vec![].into()),
 	);
 	// trader two refunds

--- a/xcm/xcm-executor/integration-tests/src/lib.rs
+++ b/xcm/xcm-executor/integration-tests/src/lib.rs
@@ -277,12 +277,12 @@ fn query_response_elicits_handler() {
 
 	client.state_at(block_hash).expect("state should exist").inspect_state(|| {
 		assert!(polkadot_test_runtime::System::events().iter().any(|r| matches!(
-			r.event,
+			&r.event,
 			TestNotifier(ResponseReceived(
-				MultiLocation { parents: 0, interior: X1(Junction::AccountId32 { .. }) },
+				location,
 				q,
 				Response::ExecutionResult(None),
-			)) if q == query_id,
+			)) if *q == query_id && matches!(location.unpack(), (0, [Junction::AccountId32 { .. }])),
 		)));
 	});
 }

--- a/xcm/xcm-executor/src/traits/conversion.rs
+++ b/xcm/xcm-executor/src/traits/conversion.rs
@@ -147,9 +147,9 @@ impl<T: Clone + Encode + Decode> Convert<Vec<u8>, T> for Decoded {
 /// struct BumpParaId;
 /// impl ConvertOrigin<u32> for BumpParaId {
 /// 	fn convert_origin(origin: impl Into<MultiLocation>, _: OriginKind) -> Result<u32, MultiLocation> {
-/// 		match origin.into() {
-/// 			MultiLocation { parents: 0, interior: Junctions::X1(Junction::Parachain(id)) } => {
-/// 				Err(Junctions::X1(Junction::Parachain(id + 1)).into())
+/// 		match origin.into().unpack() {
+/// 			(0, [Junction::Parachain(id)]) => {
+/// 				Err([Junction::Parachain(id + 1)].into())
 /// 			}
 /// 			_ => unreachable!()
 /// 		}
@@ -159,16 +159,17 @@ impl<T: Clone + Encode + Decode> Convert<Vec<u8>, T> for Decoded {
 /// struct AcceptPara7;
 /// impl ConvertOrigin<u32> for AcceptPara7 {
 /// 	fn convert_origin(origin: impl Into<MultiLocation>, _: OriginKind) -> Result<u32, MultiLocation> {
-/// 		match origin.into() {
-/// 			MultiLocation { parents: 0, interior: Junctions::X1(Junction::Parachain(id)) } if id == 7 => {
+/// 		let origin = origin.into();
+/// 		match origin.unpack() {
+/// 			(0, [Junction::Parachain(id)]) if *id == 7 => {
 /// 				Ok(7)
 /// 			}
-/// 			o => Err(o)
+/// 			_ => Err(origin)
 /// 		}
 /// 	}
 /// }
 /// # fn main() {
-/// let origin: MultiLocation = Junctions::X1(Junction::Parachain(6)).into();
+/// let origin: MultiLocation = [Junction::Parachain(6)].into();
 /// assert!(
 /// 	<(BumpParaId, AcceptPara7) as ConvertOrigin<u32>>::convert_origin(origin, OriginKind::Native)
 /// 		.is_ok()

--- a/xcm/xcm-executor/src/traits/transact_asset.rs
+++ b/xcm/xcm-executor/src/traits/transact_asset.rs
@@ -21,7 +21,7 @@ use xcm::latest::{Error as XcmError, MultiAsset, MultiLocation, Result as XcmRes
 /// Facility for asset transacting.
 ///
 /// This should work with as many asset/location combinations as possible. Locations to support may include non-account
-/// locations such as a `MultiLocation::X1(Junction::Parachain)`. Different chains may handle them in different ways.
+/// locations such as a `[Junction::Parachain]`. Different chains may handle them in different ways.
 ///
 /// Can be amalgamated as a tuple of items that implement this trait. In such executions, if any of the transactors
 /// returns `Ok(())`, then it will short circuit. Else, execution is passed to the next transactor.

--- a/xcm/xcm-simulator/fuzzer/src/parachain.rs
+++ b/xcm/xcm-simulator/fuzzer/src/parachain.rs
@@ -237,7 +237,7 @@ pub mod mock_msg_queue {
 			let message_hash = xcm.using_encoded(sp_io::hashing::blake2_256);
 			let (result, event) = match Xcm::<T::RuntimeCall>::try_from(xcm) {
 				Ok(xcm) => {
-					let location = MultiLocation::new(1, X1(Parachain(sender.into())));
+					let location = MultiLocation::new(1, [Parachain(sender.into())]);
 					match T::XcmExecutor::execute_xcm(location, xcm, message_hash, max_weight) {
 						Outcome::Error(e) => (Err(e.clone()), Event::Fail(Some(hash), e)),
 						Outcome::Complete(w) => (Ok(w), Event::Success(Some(hash))),

--- a/xcm/xcm-simulator/src/lib.rs
+++ b/xcm/xcm-simulator/src/lib.rs
@@ -290,8 +290,8 @@ macro_rules! decl_test_network {
 
 			while let Some((para_id, destination, message)) = $crate::PARA_MESSAGE_BUS.with(
 				|b| b.borrow_mut().pop_front()) {
-				match destination.interior() {
-					$crate::Junctions::Here if destination.parent_count() == 1 => {
+				match destination.unpack() {
+					(1, []) => {
 						let encoded = $crate::encode_xcm(message, $crate::MessageKind::Ump);
 						let r = <$relay_chain>::process_upward_message(
 							para_id, &encoded[..],
@@ -302,7 +302,7 @@ macro_rules! decl_test_network {
 						}
 					},
 					$(
-						$crate::X1($crate::Parachain(id)) if *id == $para_id && destination.parent_count() == 1 => {
+						(1, [$crate::Parachain(id)]) if *id == $para_id => {
 							let encoded = $crate::encode_xcm(message, $crate::MessageKind::Xcmp);
 							let messages = vec![(para_id, 1, &encoded[..])];
 							let _weight = <$parachain>::handle_xcmp_messages(
@@ -326,9 +326,9 @@ macro_rules! decl_test_network {
 
 			while let Some((destination, message)) = $crate::RELAY_MESSAGE_BUS.with(
 				|b| b.borrow_mut().pop_front()) {
-				match destination.interior() {
+				match destination.unpack() {
 					$(
-						$crate::X1($crate::Parachain(id)) if *id == $para_id && destination.parent_count() == 0 => {
+						(0, [$crate::Parachain(id)]) if *id == $para_id => {
 							let encoded = $crate::encode_xcm(message, $crate::MessageKind::Dmp);
 							// NOTE: RelayChainBlockNumber is hard-coded to 1
 							let messages = vec![(1, encoded)];
@@ -356,10 +356,10 @@ macro_rules! decl_test_network {
 				use $crate::{UmpSink, XcmpMessageHandlerT};
 
 				let d = destination.take().ok_or($crate::SendError::MissingArgument)?;
-				match (d.interior(), d.parent_count()) {
-					($crate::Junctions::Here, 1) => {},
+				match d.unpack() {
+					(1, []) => {},
 					$(
-						($crate::X1($crate::Parachain(id)), 1) if id == &$para_id => {}
+						(1, [$crate::Parachain(id)]) if id == &$para_id => {}
 					)*
 					_ => {
 						*destination = Some(d);
@@ -389,9 +389,9 @@ macro_rules! decl_test_network {
 				use $crate::DmpMessageHandlerT;
 
 				let d = destination.take().ok_or($crate::SendError::MissingArgument)?;
-				match (d.interior(), d.parent_count()) {
+				match d.unpack() {
 					$(
-						($crate::X1($crate::Parachain(id)), 0) if id == &$para_id => {},
+						(0, [$crate::Parachain(id)]) if id == &$para_id => {},
 					)*
 					_ => {
 						*destination = Some(d);


### PR DESCRIPTION
This PR makes the following changes:

1. `AssetId`, `MultiLocation`, `Junctions` are *not* `Copy` anymore and need to be explicitly `clone()`'d.
2. The size of XCM types are now drastically reduced.

   Before:

   ```
   v2::Instruction - 1208 bytes
   v3::Instruction - 1472 bytes
   v2::MultiAsset - 624 bytes
   v3::MultiAsset - 752 bytes
   v2::MultiLocation - 584 bytes
   v3::MultiLocation - 712 bytes
   v2::AssetId - 584 bytes
   v3::AssetId - 712 bytes
   v2::Junctions - 576 bytes
   v3::Junctions - 704 bytes
   ```

   After:

    ```
   v2::Instruction - 96 bytes
   v3::Instruction - 112 bytes
   v2::MultiAsset - 72 bytes
   v3::MultiAsset - 80 bytes
   v2::MultiLocation - 24 bytes
   v3::MultiLocation - 24 bytes
   v2::AssetId - 32 bytes
   v3::AssetId - 40 bytes
   v2::Junctions - 16 bytes
   v3::Junctions - 16 bytes
   ```

3. The `Junctions` type is now internally boxed, or more specifically `Arc`'d, and acts in a copy-on-write fashion. This makes it cheaper to clone (now it only has to bump the refcount instead of copying over half a kilobyte).
4. The canonical way of constructing a `Junctions` is now through a conversion from an array.

   Before: `let xs = Junctions::X2(OnlyChild, OnlyChild)`
   After: `let xs: Junctions = [OnlyChild, OnlyChild].into()`
5. Since Rust doesn't (yet) support pattern matching of boxed values this makes it not possible to directly match on them, however this can be worked around by converting the internal `Junctions` into a slice and matching on that, for example:

   Before:

   ```
   match location {
        MultiLocation { parents: 1, interior: X1(AccountId32 { id, .. }) } => { ... }
   }
   ```

   After:

   ```
   match location.unpack() {
       (1, [AccountId32 { id, .. }]) => { ... }
   }
   ```

6. A few of some of the previously `const` functions and statics were made not-`const` since an `Arc` cannot be constructed in a `const` context.

### Potential open questions

1. Do we want to make the `Junctions` type completely opaque? There might not be much of a point in keeping it as an enum now, since you can't directly match on it anyway. (Although this could potentially change in the future when Rust will support matching of boxed values.)
2. Do we want to keep `Junctions::unpack` returning a tuple, or perhaps introduce a `JunctionsRef` type so that the parameters are named when matching?