### PR TITLE
[xcm] Extend `haul_blob` with Channel + include `NetworkId` to channel id (`origin/(network, destination)`)

### DIFF
--- a/xcm/xcm-builder/src/tests/bridging/mod.rs
+++ b/xcm/xcm-builder/src/tests/bridging/mod.rs
@@ -21,7 +21,7 @@ use crate::universal_exports::*;
 use frame_support::{parameter_types, traits::Get};
 use std::{cell::RefCell, marker::PhantomData};
 use xcm_executor::{
-	traits::{export_xcm, validate_export},
+	traits::{export_xcm, validate_export, Channel},
 	XcmExecutor,
 };
 use SendError::*;
@@ -51,7 +51,7 @@ impl<D: DispatchBlob> TestBridge<D> {
 	}
 }
 impl<D: DispatchBlob> HaulBlob for TestBridge<D> {
-	fn haul_blob(blob: Vec<u8>) -> Result<(), HaulBlobError> {
+	fn haul_blob(blob: Vec<u8>, _channel: Channel) -> Result<(), HaulBlobError> {
 		BRIDGE_TRAFFIC.with(|t| t.borrow_mut().push(blob));
 		Ok(())
 	}

--- a/xcm/xcm-builder/src/tests/origins.rs
+++ b/xcm/xcm-builder/src/tests/origins.rs
@@ -94,7 +94,7 @@ fn export_message_should_work() {
 	let uni_src = (ByGenesis([0; 32]), Parachain(42), Parachain(1)).into();
 	assert_eq!(
 		exported_xcm(),
-		vec![(Polkadot, 403611790, uni_src, Here, expected_message, expected_hash)]
+		vec![(Polkadot, 470110423, uni_src, Here, expected_message, expected_hash)]
 	);
 }
 

--- a/xcm/xcm-executor/src/lib.rs
+++ b/xcm/xcm-executor/src/lib.rs
@@ -21,18 +21,17 @@ use frame_support::{
 	ensure,
 	traits::{Contains, ContainsPair, Get, PalletsInfoAccess},
 };
-use parity_scale_codec::{Decode, Encode};
+use parity_scale_codec::Encode;
 use sp_core::defer;
-use sp_io::hashing::blake2_128;
 use sp_std::{marker::PhantomData, prelude::*};
 use sp_weights::Weight;
 use xcm::latest::prelude::*;
 
 pub mod traits;
 use traits::{
-	validate_export, AssetExchange, AssetLock, CallDispatcher, ClaimAssets, ConvertOrigin,
-	DropAssets, Enact, ExportXcm, FeeManager, FeeReason, OnResponse, ShouldExecute, TransactAsset,
-	VersionChangeNotifier, WeightBounds, WeightTrader,
+	channel_from_params, validate_export, AssetExchange, AssetLock, CallDispatcher, ClaimAssets,
+	ConvertOrigin, DropAssets, Enact, ExportXcm, FeeManager, FeeReason, OnResponse, ShouldExecute,
+	TransactAsset, VersionChangeNotifier, WeightBounds, WeightTrader,
 };
 
 mod assets;
@@ -831,11 +830,7 @@ impl<Config: config::Config> XcmExecutor<Config> {
 				let universal_source = Config::UniversalLocation::get()
 					.within_global(origin)
 					.map_err(|()| XcmError::Unanchored)?;
-				let hash = (self.origin_ref(), &destination).using_encoded(blake2_128);
-				let channel = u32::decode(&mut hash.as_ref()).unwrap_or(0);
-				// Hash identifies the lane on the exporter which we use. We use the pairwise
-				// combination of the origin and destination to ensure origin/destination pairs will
-				// generally have their own lanes.
+				let channel = channel_from_params(self.origin_ref(), &network, &destination);
 				let (ticket, fee) = validate_export::<Config::MessageExporter>(
 					network,
 					channel,

--- a/xcm/xcm-executor/src/traits/mod.rs
+++ b/xcm/xcm-executor/src/traits/mod.rs
@@ -27,7 +27,7 @@ pub use asset_lock::{AssetLock, Enact, LockError};
 mod asset_exchange;
 pub use asset_exchange::AssetExchange;
 mod export;
-pub use export::{export_xcm, validate_export, ExportXcm};
+pub use export::{channel_from_params, export_xcm, validate_export, Channel, ExportXcm};
 mod fee_manager;
 pub use fee_manager::{FeeManager, FeeReason};
 mod filter_asset_location;


### PR DESCRIPTION
Useful for https://github.com/paritytech/parity-bridges-common/issues/1760

Open questions:
- [ ] Shouldnt `BridgeMessage` be versioned e.g.
   ```
   VersionedBridgeMessage {
        V3(v3::BridgeMessage)
   }
   ```
