### PR TITLE
Have OCW mined election once a week on Westend

### DIFF
--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -337,7 +337,7 @@ impl Get<u32> for MaybeSignedPhase {
 		if Staking::current_era().unwrap_or(1) as u32 % 28 == 0 {
 			0
 		} else {
-			EPOCH_DURATION_IN_SLOTS / 4
+			SignedPhase::get()
 		}
 	}
 }
@@ -345,7 +345,7 @@ impl Get<u32> for MaybeSignedPhase {
 parameter_types! {
 	// phase durations. 1/4 of the last session for each.
 	pub SignedPhase: u32 = prod_or_fast!(
-		MaybeSignedPhase::get(),
+		EPOCH_DURATION_IN_SLOTS / 4,
 		(1 * MINUTES).min(EpochDuration::get().saturated_into::<u32>() / 2)
 	);
 	pub UnsignedPhase: u32 = prod_or_fast!(
@@ -423,7 +423,7 @@ impl pallet_election_provider_multi_phase::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type Currency = Balances;
 	type EstimateCallFee = TransactionPayment;
-	type SignedPhase = SignedPhase;
+	type SignedPhase = MaybeSignedPhase;
 	type UnsignedPhase = UnsignedPhase;
 	type SignedMaxSubmissions = SignedMaxSubmissions;
 	type SignedMaxRefunds = SignedMaxRefunds;

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -334,7 +334,7 @@ impl Get<u32> for MaybeSignedPhase {
 	fn get() -> u32 {
 		// 1 day = 4 eras -> 1 week = 28 eras. We want to disable signed phase once a week to test the fallback unsigned
 		// phase is able to compute elections on Westend.
-		if Staking::current_era().unwrap_or(1) as u32 % 28 == 0 {
+		if Staking::current_era().unwrap_or(1) % 28 == 0 {
 			0
 		} else {
 			SignedPhase::get()


### PR DESCRIPTION
closes https://github.com/paritytech/polkadot/issues/7193.

The election result computation is performed by election provider (EPM pallet) in phases. If there is at least one staking miner running and everything working as expected, `signed phase` is all that is needed to produce a good set of election winners. In rare cases where no good solution is submitted by a staking miner, there exists an `unsigned phase` in which the validators compute and submit a solution using Offchain workers. 

This PR disables the signed phase for one era every week in Westend so that OCW miners are used to compute election winners. Doing this on Westend would help us make sure our OCW miners run as expected and are able to keep the chain elections running properly if for some reason signed phase is not able to produce a solution.