### PR TITLE
Remove TODO comment

### DIFF
--- a/runtime/parachains/src/inclusion/mod.rs
+++ b/runtime/parachains/src/inclusion/mod.rs
@@ -1196,7 +1196,6 @@ impl<T: Config> OnQueueChanged<AggregateMessageOrigin> for Pallet<T> {
 		let para = match origin {
 			AggregateMessageOrigin::Ump(UmpQueueId::Para(p)) => p,
 		};
-		// TODO maybe migrate this to u64
 		let (count, size) = (count.saturated_into(), size.saturated_into());
 		// TODO paritytech/polkadot#6283: Remove all usages of `relay_dispatch_queue_size`
 		#[allow(deprecated)]


### PR DESCRIPTION
We should never migrate these types to `u64` as we will never have `u64` messages left nor `u64` as message size left.