### PR TITLE
Set bounties `SpendOrigin` in Rococo to `EnsureRoot`

### DIFF
--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -576,7 +576,7 @@ impl pallet_treasury::Config for Runtime {
 	type MaxApprovals = MaxApprovals;
 	type WeightInfo = weights::pallet_treasury::WeightInfo<Runtime>;
 	type SpendFunds = Bounties;
-	type SpendOrigin = frame_support::traits::NeverEnsureOrigin<Balance>;
+	type SpendOrigin = EnsureRoot<AccountId>;
 }
 
 parameter_types! {


### PR DESCRIPTION
Pretty much the title of the MR.

`SpendOrigin` for `pallet_bounties` was set to `NeverEnsureOrigin<Balance>;` and seems that was blocking some testing. This, should dampen this blocker.