### PR TITLE
Add staking-miner bin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,10 +2,6 @@
 name = "polkadot"
 path = "src/main.rs"
 
-[[bin]]
-name = "staking-miner"
-path = "utils/staking-miner/src/main.rs"
-
 [package]
 name = "polkadot"
 description = "Implementation of a `https://polkadot.network` node in Rust based on the Substrate framework."

--- a/utils/staking-miner/README.md
+++ b/utils/staking-miner/README.md
@@ -16,7 +16,7 @@ staking-miner --help
 
 You can build from the root of the Polkadot repository using:
 ```
-cargo build --profile production --locked --bin staking-miner
+cargo build --profile production --locked --package staking-miner --bin staking-miner
 ```
 
 ## Docker


### PR DESCRIPTION
This fix allows building the staking-miner exactly the same way we do for Polkadot.