### PR TITLE
xcm-builder: remove clone for clippy

### DIFF
--- a/xcm/xcm-builder/src/routing.rs
+++ b/xcm/xcm-builder/src/routing.rs
@@ -41,7 +41,7 @@ impl<Inner: SendXcm> SendXcm for WithUniqueTopic<Inner> {
 			*id
 		} else {
 			let unique_id = unique(&message);
-			message.0.push(SetTopic(unique_id.clone()));
+			message.0.push(SetTopic(unique_id));
 			unique_id
 		};
 		let (ticket, assets) = Inner::validate(destination, &mut Some(message))
@@ -86,7 +86,7 @@ impl<Inner: SendXcm, TopicSource: SourceTopic> SendXcm for WithTopicSource<Inner
 			*id
 		} else {
 			let unique_id = TopicSource::source_topic(&message);
-			message.0.push(SetTopic(unique_id.clone()));
+			message.0.push(SetTopic(unique_id));
 			unique_id
 		};
 		let (ticket, assets) = Inner::validate(destination, &mut Some(message))


### PR DESCRIPTION
fix for:
```
error: using `clone` on type `[u8; 32]` which implements the `Copy`
trait
  --> xcm/xcm-builder/src/routing.rs:44:28
   |
44 |             message.0.push(SetTopic(unique_id.clone()));
   |                                     ^^^^^^^^^^^^^^^^^ help: try
removing the `clone` call: `unique_id`
   |
   = help: for further information visit
https://rust-lang.github.io/rust-clippy/master/index.html#clone_on_copy
   = note: `-D clippy::clone-on-copy` implied by `-D clippy::complexity`
```
