### PR TITLE
bump zombienet version

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,7 +38,7 @@ variables:
   BUILDAH_COMMAND: "buildah --storage-driver overlay2"
   DOCKER_OS: "debian:stretch"
   ARCH: "x86_64"
-  ZOMBIENET_IMAGE: "docker.io/paritytech/zombienet:v1.3.50"
+  ZOMBIENET_IMAGE: "docker.io/paritytech/zombienet:v1.3.55"
 
 default:
   cache: {}


### PR DESCRIPTION
Bump to `v1.3.55`, fix logs url.
Thanks!