### PR TITLE
approval-distribution: Add approvals/assignments spans on all paths

### DIFF
--- a/node/jaeger/src/spans.rs
+++ b/node/jaeger/src/spans.rs
@@ -277,7 +277,7 @@ impl Span {
 	}
 
 	/// Derive a child span from `self`.
-	pub fn child(&self, name: &'static str) -> Self {
+	pub fn child(&self, name: &str) -> Self {
 		match self {
 			Self::Enabled(inner) => Self::Enabled(inner.child(name)),
 			Self::Disabled => Self::Disabled,
@@ -297,9 +297,20 @@ impl Span {
 		self
 	}
 
+	/// Attach a peer-id tag to the span.
 	#[inline(always)]
 	pub fn with_peer_id(self, peer: &PeerId) -> Self {
 		self.with_string_tag("peer-id", &peer.to_base58())
+	}
+
+	/// Attach a `peer-id` tag to the span when peer is present.
+	#[inline(always)]
+	pub fn with_optional_peer_id(self, peer: Option<&PeerId>) -> Self {
+		if let Some(peer) = peer {
+			self.with_peer_id(peer)
+		} else {
+			self
+		}
 	}
 
 	/// Attach a candidate hash to the span.

--- a/node/network/approval-distribution/src/lib.rs
+++ b/node/network/approval-distribution/src/lib.rs
@@ -725,6 +725,14 @@ impl State {
 	) where
 		R: CryptoRng + Rng,
 	{
+		let _span = self
+			.spans
+			.get(&assignment.block_hash)
+			.map(|span| span.child("import-and-distribute-assignment"))
+			.unwrap_or_else(|| jaeger::Span::new(&assignment.block_hash, "distribute-assignment"))
+			.with_string_tag("block-hash", format!("{:?}", assignment.block_hash))
+			.with_stage(jaeger::Stage::ApprovalDistribution);
+
 		let block_hash = assignment.block_hash;
 		let validator_index = assignment.validator;
 
@@ -985,6 +993,14 @@ impl State {
 		source: MessageSource,
 		vote: IndirectSignedApprovalVote,
 	) {
+		let _span = self
+			.spans
+			.get(&vote.block_hash)
+			.map(|span| span.child("import-and-distribute-approval"))
+			.unwrap_or_else(|| jaeger::Span::new(&vote.block_hash, "distribute-approval"))
+			.with_string_tag("block-hash", format!("{:?}", vote.block_hash))
+			.with_stage(jaeger::Stage::ApprovalDistribution);
+
 		let block_hash = vote.block_hash;
 		let validator_index = vote.validator;
 		let candidate_index = vote.candidate_index;
@@ -1724,14 +1740,6 @@ impl ApprovalDistribution {
 				state.handle_new_blocks(ctx, metrics, metas, rng).await;
 			},
 			ApprovalDistributionMessage::DistributeAssignment(cert, candidate_index) => {
-				let _span = state
-					.spans
-					.get(&cert.block_hash)
-					.map(|span| span.child("import-and-distribute-assignment"))
-					.unwrap_or_else(|| jaeger::Span::new(&cert.block_hash, "distribute-assignment"))
-					.with_string_tag("block-hash", format!("{:?}", cert.block_hash))
-					.with_stage(jaeger::Stage::ApprovalDistribution);
-
 				gum::debug!(
 					target: LOG_TARGET,
 					"Distributing our assignment on candidate (block={}, index={})",
@@ -1751,14 +1759,6 @@ impl ApprovalDistribution {
 					.await;
 			},
 			ApprovalDistributionMessage::DistributeApproval(vote) => {
-				let _span = state
-					.spans
-					.get(&vote.block_hash)
-					.map(|span| span.child("import-and-distribute-approval"))
-					.unwrap_or_else(|| jaeger::Span::new(&vote.block_hash, "distribute-approval"))
-					.with_string_tag("block-hash", format!("{:?}", vote.block_hash))
-					.with_stage(jaeger::Stage::ApprovalDistribution);
-
 				gum::debug!(
 					target: LOG_TARGET,
 					"Distributing our approval vote on candidate (block={}, index={})",


### PR DESCRIPTION
The approval and assignment logic gets called from multiple paths, so make sure we create a tracing span on all paths to make debugging easier and be able and correlate with the spans from approval-voting.