### PR TITLE
Validator disabling strategy

### DIFF
--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -1196,6 +1196,7 @@ impl parachains_slashing::Config for Runtime {
 		Offences,
 		ReportLongevity,
 	>;
+	type DisablingStrategy = ();
 	type WeightInfo = weights::runtime_parachains_disputes_slashing::WeightInfo<Runtime>;
 	type BenchmarkingConfig = parachains_slashing::BenchConfig<1000>;
 }

--- a/runtime/parachains/src/disputes.rs
+++ b/runtime/parachains/src/disputes.rs
@@ -42,6 +42,7 @@ use sp_std::{cmp::Ordering, collections::btree_set::BTreeSet, prelude::*};
 #[allow(unused_imports)]
 pub(crate) use self::tests::run_to_block;
 
+pub mod disabling_strategy;
 pub mod slashing;
 #[cfg(test)]
 mod tests;

--- a/runtime/parachains/src/disputes/disabling_strategy.rs
+++ b/runtime/parachains/src/disputes/disabling_strategy.rs
@@ -26,6 +26,7 @@
 use super::slashing::ValidatorDisablingHandler;
 use frame_support::weights::Weight;
 use primitives::{vstaging::slashing::SlashingOffenceKind, SessionIndex, ValidatorIndex};
+use rand::{seq::SliceRandom, SeedableRng};
 use sp_std::prelude::*;
 
 // TODO: set this based on the number of validators
@@ -87,7 +88,7 @@ pub mod pallet {
 	use frame_system::pallet_prelude::*;
 
 	#[pallet::config]
-	pub trait Config: frame_system::Config {}
+	pub trait Config: frame_system::Config + pallet_babe::Config {}
 
 	#[pallet::pallet]
 	#[pallet::without_storage_info]
@@ -174,7 +175,11 @@ impl<T: Config> Pallet<T> {
 
 	fn random_selection(input: &mut Vec<ValidatorIndex>, capacity: usize) -> Vec<ValidatorIndex> {
 		debug_assert!(input.len() > capacity);
-		// TODO: source of randomness?!
+
+		let entropy = crate::util::compute_entropy::<T>(<frame_system::Pallet<T>>::parent_hash());
+		let mut rng = rand_chacha::ChaChaRng::from_seed(entropy.into());
+		input.shuffle(&mut rng);
+
 		input.split_off(capacity)
 	}
 }

--- a/runtime/parachains/src/disputes/disabling_strategy.rs
+++ b/runtime/parachains/src/disputes/disabling_strategy.rs
@@ -1,0 +1,93 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// This file is part of Polkadot.
+
+// Polkadot is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Polkadot is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
+
+//! A pallet implementing a strategy for validator disabling
+//! TODO: add more details
+
+use super::slashing::ValidatorDisablingHandler;
+use frame_support::weights::Weight;
+use primitives::{vstaging::slashing::SlashingOffenceKind, SessionIndex, ValidatorIndex};
+
+pub struct ValidatorDisabling<C> {
+	_phantom: sp_std::marker::PhantomData<C>,
+}
+
+impl<T> ValidatorDisablingHandler<T::BlockNumber> for ValidatorDisabling<Pallet<T>>
+where
+	T: pallet::Config,
+{
+	fn on_slash(
+		_validators: impl IntoIterator<Item = ValidatorIndex>,
+		_offence_kind: SlashingOffenceKind,
+	) {
+		todo!()
+	}
+
+	fn initializer_initialize(now: T::BlockNumber) -> Weight {
+		Pallet::<T>::initializer_initialize(now)
+	}
+
+	fn initializer_finalize() {
+		Pallet::<T>::initializer_finalize()
+	}
+
+	fn initializer_on_new_session(session_index: SessionIndex) {
+		Pallet::<T>::initializer_on_new_session(session_index)
+	}
+}
+
+pub use pallet::*;
+
+#[frame_support::pallet]
+pub mod pallet {
+	use super::*;
+	use frame_support::traits::Hooks;
+	use frame_system::pallet_prelude::*;
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {}
+
+	#[pallet::pallet]
+	#[pallet::without_storage_info]
+	pub struct Pallet<T>(_);
+
+	// TODO: a list of validators that have been slashed, sorted by slash amount
+
+	#[pallet::hooks]
+	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+		/// Called when a new block is being created
+		fn on_initialize(_n: T::BlockNumber) -> Weight {
+			todo!()
+			// TODO: block is being initialized, reshuffle disabled validators if necessary
+		}
+	}
+}
+
+impl<T: Config> Pallet<T> {
+	/// Called by the initializer to initialize the module.
+	fn initializer_initialize(_now: T::BlockNumber) -> Weight {
+		Weight::zero()
+	}
+
+	/// Called by the initializer to finalize the pallet.
+	fn initializer_finalize() {}
+
+	/// Called by the initializer to note a new session in the pallet.
+	fn initializer_on_new_session(_session_index: SessionIndex) {
+		todo!()
+		// TODO: clear validators list
+	}
+}

--- a/runtime/parachains/src/disputes/disabling_strategy.rs
+++ b/runtime/parachains/src/disputes/disabling_strategy.rs
@@ -27,6 +27,10 @@ use super::slashing::ValidatorDisablingHandler;
 use frame_support::weights::Weight;
 use primitives::{vstaging::slashing::SlashingOffenceKind, SessionIndex, ValidatorIndex};
 use sp_std::prelude::*;
+
+// TODO: set this based on the number of validators
+const MAX_DISABLED_VALIDATORS_COUNT: usize = 10;
+
 pub struct ValidatorDisabling<C> {
 	_phantom: sp_std::marker::PhantomData<C>,
 }
@@ -36,16 +40,29 @@ where
 	T: pallet::Config,
 {
 	fn report_offender(
-		_validators: impl IntoIterator<Item = ValidatorIndex>,
-		_offence_kind: SlashingOffenceKind,
+		validators: impl IntoIterator<Item = ValidatorIndex>,
+		offence_kind: SlashingOffenceKind,
 	) {
-		// Add to offenders
+		// Add all new offenders to `Offenders`
+		for validator_idx in validators.into_iter() {
+			<Offenders<T>>::mutate(validator_idx, |current_offence| {
+				let current_offence = current_offence.get_or_insert(offence_kind);
+				if *current_offence == SlashingOffenceKind::ForInvalid &&
+					offence_kind == SlashingOffenceKind::ForInvalid
+				{
+					*current_offence = offence_kind;
+				}
+			});
+		}
 
 		// Add to disabled validators, if there is enough space
+		let disabled = if <Offenders<T>>::iter().count() <= MAX_DISABLED_VALIDATORS_COUNT {
+			<Offenders<T>>::iter().map(|offender| offender.0).collect()
+		} else {
+			Self::reshuffle_disabled_validators()
+		};
 
-		// Else - reshuffle
-
-		todo!()
+		<DisabledValidators<T>>::set(disabled);
 	}
 
 	fn initializer_initialize(now: T::BlockNumber) -> Weight {
@@ -58,6 +75,57 @@ where
 
 	fn initializer_on_new_session(session_index: SessionIndex) {
 		Pallet::<T>::initializer_on_new_session(session_index)
+	}
+}
+
+impl<T> ValidatorDisabling<Pallet<T>>
+where
+	T: pallet::Config,
+{
+	fn reshuffle_disabled_validators() -> Vec<ValidatorIndex> {
+		let mut disabled_capacity = MAX_DISABLED_VALIDATORS_COUNT;
+		let mut disabled = Vec::new();
+
+		// First partition the validators by their offence. At the moment there are only two offence
+		// types so a simple partition can do the job.
+		let (big_offenders, small_offenders): (
+			Vec<(ValidatorIndex, SlashingOffenceKind)>,
+			Vec<(ValidatorIndex, SlashingOffenceKind)>,
+		) = <Offenders<T>>::iter().partition(|offender| offender.1 == SlashingOffenceKind::ForInvalid);
+
+		// Strip `SlashingOffenceKind`
+		let mut big_offenders =
+			big_offenders.into_iter().map(|offender| offender.0).collect::<Vec<_>>();
+
+		// If there are too many `big_offenders` pick offenders randomly until `disabled is out of
+		// capacity.
+		if big_offenders.len() > disabled_capacity {
+			return Self::random_selection(&mut big_offenders, disabled_capacity)
+		}
+
+		// If the `big_offenders` fits - add all validators from the disabled set
+		disabled_capacity -= big_offenders.len();
+		disabled.extend(big_offenders.into_iter());
+
+		// Strip `SlashingOffenceKind`
+		let mut small_offenders =
+			small_offenders.into_iter().map(|offender| offender.0).collect::<Vec<_>>();
+
+		// Next try to extend the disabled list with small offenders
+		if small_offenders.len() > disabled_capacity {
+			return Self::random_selection(&mut small_offenders, disabled_capacity)
+		}
+
+		// All small offenders can be inserted.
+		disabled.extend(small_offenders.into_iter());
+
+		disabled
+	}
+
+	fn random_selection(input: &mut Vec<ValidatorIndex>, capacity: usize) -> Vec<ValidatorIndex> {
+		debug_assert!(input.len() > capacity);
+		// TODO: source of randomness?!
+		input.split_off(capacity)
 	}
 }
 
@@ -124,11 +192,11 @@ pub mod pallet {
 	// Disabled validators at the moment
 	#[pallet::storage]
 	#[pallet::getter(fn disabled_validators)]
-	type DisabledValidators<T> = StorageValue<_, Vec<ValidatorIndex>, ValueQuery>;
+	pub type DisabledValidators<T> = StorageValue<_, Vec<ValidatorIndex>, ValueQuery>;
 
 	// All offenders reported during the current session
 	#[pallet::storage]
-	type Offenders<T> = StorageMap<_, Twox64Concat, ValidatorIndex, SlashingOffenceKind>;
+	pub type Offenders<T> = StorageMap<_, Twox64Concat, ValidatorIndex, SlashingOffenceKind>;
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {

--- a/runtime/parachains/src/disputes/disabling_strategy.rs
+++ b/runtime/parachains/src/disputes/disabling_strategy.rs
@@ -78,51 +78,6 @@ where
 	}
 }
 
-struct Offender {
-	index: ValidatorIndex,
-	offence: SlashingOffenceKind,
-}
-
-impl Offender {
-	fn cmp(&self, other: &Self) -> core::cmp::Ordering {
-		use SlashingOffenceKind::{AgainstValid, ForInvalid};
-
-		let Offender { index, offence } = self;
-		match (offence, other.offence) {
-			(AgainstValid, AgainstValid) | (ForInvalid, ForInvalid) => index.cmp(&other.index),
-			(AgainstValid, ForInvalid) => core::cmp::Ordering::Less,
-			(ForInvalid, AgainstValid) => core::cmp::Ordering::Greater,
-		}
-	}
-}
-impl PartialEq for Offender {
-	fn eq(&self, other: &Self) -> bool {
-		let Offender { index, offence } = self;
-		*index == other.index && *offence == other.offence
-	}
-}
-
-impl Eq for Offender {}
-
-impl PartialOrd for Offender {
-	fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
-		Some(self.cmp(other))
-	}
-}
-
-impl Ord for Offender {
-	fn cmp(&self, other: &Self) -> core::cmp::Ordering {
-		use SlashingOffenceKind::{AgainstValid, ForInvalid};
-
-		let Offender { index, offence } = self;
-		match (offence, other.offence) {
-			(AgainstValid, AgainstValid) | (ForInvalid, ForInvalid) => index.cmp(&other.index),
-			(AgainstValid, ForInvalid) => core::cmp::Ordering::Less,
-			(ForInvalid, AgainstValid) => core::cmp::Ordering::Greater,
-		}
-	}
-}
-
 pub use pallet::*;
 
 #[frame_support::pallet]

--- a/runtime/parachains/src/paras_inherent/mod.rs
+++ b/runtime/parachains/src/paras_inherent/mod.rs
@@ -29,16 +29,17 @@ use crate::{
 	initializer,
 	metrics::METRICS,
 	scheduler::{self, CoreAssignment, FreedReason},
-	shared, ParaId,
+	shared,
+	util::compute_entropy,
+	ParaId,
 };
 use bitvec::prelude::BitVec;
 use frame_support::{
 	inherent::{InherentData, InherentIdentifier, MakeFatalError, ProvideInherent},
 	pallet_prelude::*,
-	traits::Randomness,
 };
 use frame_system::pallet_prelude::*;
-use pallet_babe::{self, ParentBlockRandomness};
+use pallet_babe;
 use primitives::{
 	BackedCandidate, CandidateHash, CandidateReceipt, CheckedDisputeStatementSet,
 	CheckedMultiDisputeStatementSet, CoreIndex, DisputeStatementSet,
@@ -1177,29 +1178,6 @@ pub(crate) fn assure_sanity_backed_candidates<
 		return Err(Error::<T>::UnsortedOrDuplicateBackedCandidates)
 	}
 	Ok(())
-}
-
-/// Derive entropy from babe provided per block randomness.
-///
-/// In the odd case none is available, uses the `parent_hash` and
-/// a const value, while emitting a warning.
-fn compute_entropy<T: Config>(parent_hash: T::Hash) -> [u8; 32] {
-	const CANDIDATE_SEED_SUBJECT: [u8; 32] = *b"candidate-seed-selection-subject";
-	// NOTE: this is slightly gameable since this randomness was already public
-	// by the previous block, while for the block author this randomness was
-	// known 2 epochs ago. it is marginally better than using the parent block
-	// hash since it's harder to influence the VRF output than the block hash.
-	let vrf_random = ParentBlockRandomness::<T>::random(&CANDIDATE_SEED_SUBJECT[..]).0;
-	let mut entropy: [u8; 32] = CANDIDATE_SEED_SUBJECT;
-	if let Some(vrf_random) = vrf_random {
-		entropy.as_mut().copy_from_slice(vrf_random.as_ref());
-	} else {
-		// in case there is no VRF randomness present, we utilize the relay parent
-		// as seed, it's better than a static value.
-		log::warn!(target: LOG_TARGET, "ParentBlockRandomness did not provide entropy");
-		entropy.as_mut().copy_from_slice(parent_hash.as_ref());
-	}
-	entropy
 }
 
 /// Limit disputes in place.

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -1206,6 +1206,7 @@ impl parachains_slashing::Config for Runtime {
 		Offences,
 		ReportLongevity,
 	>;
+	type DisablingStrategy = ();
 	type WeightInfo = weights::runtime_parachains_disputes_slashing::WeightInfo<Runtime>;
 	type BenchmarkingConfig = parachains_slashing::BenchConfig<1000>;
 }

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -39,7 +39,7 @@ use sp_std::{cmp::Ordering, collections::btree_map::BTreeMap, prelude::*};
 
 use runtime_parachains::{
 	configuration as parachains_configuration, disputes as parachains_disputes,
-	disputes::slashing as parachains_slashing,
+	disputes::{disabling_strategy as parachains_disabling, slashing as parachains_slashing},
 	dmp as parachains_dmp, hrmp as parachains_hrmp, inclusion as parachains_inclusion,
 	inclusion::{AggregateMessageOrigin, UmpQueueId},
 	initializer as parachains_initializer, origin as parachains_origin, paras as parachains_paras,
@@ -1132,9 +1132,12 @@ impl parachains_slashing::Config for Runtime {
 		Offences,
 		ReportLongevity,
 	>;
+	type DisablingStrategy = parachains_disabling::ValidatorDisabling<ParasDisabling>;
 	type WeightInfo = parachains_slashing::TestWeightInfo;
 	type BenchmarkingConfig = parachains_slashing::BenchConfig<200>;
 }
+
+impl parachains_disabling::Config for Runtime {}
 
 parameter_types! {
 	pub const ParaDeposit: Balance = 40 * UNITS;
@@ -1465,6 +1468,7 @@ construct_runtime! {
 		ParasDisputes: parachains_disputes::{Pallet, Call, Storage, Event<T>} = 62,
 		ParasSlashing: parachains_slashing::{Pallet, Call, Storage, ValidateUnsigned} = 63,
 		MessageQueue: pallet_message_queue::{Pallet, Call, Storage, Event<T>} = 64,
+		ParasDisabling: parachains_disabling::{Pallet} = 65,
 
 		// Parachain Onboarding Pallets. Start indices at 70 to leave room.
 		Registrar: paras_registrar::{Pallet, Call, Storage, Event<T>, Config} = 70,

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -1043,6 +1043,7 @@ impl parachains_slashing::Config for Runtime {
 		Offences,
 		ReportLongevity,
 	>;
+	type DisablingStrategy = ();
 	type WeightInfo = weights::runtime_parachains_disputes_slashing::WeightInfo<Runtime>;
 	type BenchmarkingConfig = parachains_slashing::BenchConfig<300>;
 }


### PR DESCRIPTION
This PR implements a validator disabling strategy as described in https://github.com/paritytech/polkadot/issues/5948#issuecomment-1562682161

Related to https://github.com/paritytech/polkadot/issues/5948

Still work in progress.

# A few implementation notes
The PR adds a `DisablingStrategy` pallet in parachains. The pallet exposes a single function `report_offender` which adds a validator to the disabled list. On new session the disabled list is cleared. On each new block it is reshuffled if necessary (check the disabling strategy specification).

In terms of storage the pallet has got two items:
* `pub type DisabledValidators<T> = StorageValue<_, Vec<ValidatorIndex>, ValueQuery>;` which represents the currently disabled validators. This item will be exposed to the node via a runtime api and will indicate the disabled validators at the current block height.
* `pub type Offenders<T> = StorageMap<_, Twox64Concat, ValidatorIndex, SlashingOffenceKind>;` which represents all reported offenders during the session. Ideally this list should overlap with the `DisabledValidators` However in case there are too many disabled validators (more than we can safely disable)  this `StorageMap` will contain all reported offenders. It is used to select the currently disabled validators during reshuffling. 

`DisablingStrategy` interoperates with `Slashing` pallet via a trait - `ValidatorDisablingHandler`. Each time when an offence is reported by `Slashing` the corresponding offender(s) are reported to  `DisablingStrategy`  too.

At the moment `DisablingStrategy` is enabled only in rococo.

# TODOs and open questions

- [ ] Fix TODOs in the code.
- [ ] Implement a runtime api exposing `DisabledValidators`.
- [ ] Add unit/integration tests.
- [ ] Add benchmarks.
- [ ] Is it a good idea not to duplicate entries in `Offenders` and `DisabledValidators`? They can be complement each other instead. `Offenders` will keep only the validators which are left out from `DisabledValidators`.
- [x] Random selection implementation - what source of randomness should I use in the runtime?