### PR TITLE
metrics: Increase the resolution of histogram metrics

### DIFF
--- a/node/network/approval-distribution/src/metrics.rs
+++ b/node/network/approval-distribution/src/metrics.rs
@@ -15,7 +15,6 @@
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
 use polkadot_node_metrics::metrics::{prometheus, Metrics as MetricsTrait};
-use polkadot_node_subsystem::prometheus::exponential_buckets;
 
 /// Approval Distribution metrics.
 #[derive(Default, Clone)]
@@ -135,14 +134,14 @@ impl MetricsTrait for Metrics {
 				prometheus::Histogram::with_opts(prometheus::HistogramOpts::new(
 					"polkadot_parachain_time_import_pending_now_known",
 					"Time spent on importing pending assignments and approvals.",
-				).buckets(exponential_buckets(0.0001, 4.0, 9).expect("function parameters are constant and always valid; qed")))?,
+				).buckets(vec![0.0001, 0.0004, 0.0016, 0.0064, 0.0256, 0.1024, 0.4096, 1.6384, 3.2768, 4.9152, 6.5536,]))?,
 				registry,
 			)?,
 			time_awaiting_approval_voting: prometheus::register(
 				prometheus::Histogram::with_opts(prometheus::HistogramOpts::new(
 					"polkadot_parachain_time_awaiting_approval_voting",
 					"Time spent awaiting a reply from the Approval Voting Subsystem.",
-				).buckets(exponential_buckets(0.0001, 4.0, 9).expect("function parameters are constant and always valid; qed")))?,
+				).buckets(vec![0.0001, 0.0004, 0.0016, 0.0064, 0.0256, 0.1024, 0.4096, 1.6384, 3.2768, 4.9152, 6.5536,]))?,
 				registry,
 			)?,
 		};

--- a/node/network/approval-distribution/src/metrics.rs
+++ b/node/network/approval-distribution/src/metrics.rs
@@ -15,6 +15,7 @@
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
 use polkadot_node_metrics::metrics::{prometheus, Metrics as MetricsTrait};
+use polkadot_node_subsystem::prometheus::exponential_buckets;
 
 /// Approval Distribution metrics.
 #[derive(Default, Clone)]
@@ -134,14 +135,14 @@ impl MetricsTrait for Metrics {
 				prometheus::Histogram::with_opts(prometheus::HistogramOpts::new(
 					"polkadot_parachain_time_import_pending_now_known",
 					"Time spent on importing pending assignments and approvals.",
-				))?,
+				).buckets(exponential_buckets(0.0001, 4.0, 9).expect("function parameters are constant and always valid; qed")))?,
 				registry,
 			)?,
 			time_awaiting_approval_voting: prometheus::register(
 				prometheus::Histogram::with_opts(prometheus::HistogramOpts::new(
 					"polkadot_parachain_time_awaiting_approval_voting",
 					"Time spent awaiting a reply from the Approval Voting Subsystem.",
-				))?,
+				).buckets(exponential_buckets(0.0001, 4.0, 9).expect("function parameters are constant and always valid; qed")))?,
 				registry,
 			)?,
 		};

--- a/node/overseer/src/metrics.rs
+++ b/node/overseer/src/metrics.rs
@@ -17,7 +17,6 @@
 //! Prometheus metrics related to the overseer and its channels.
 
 use super::*;
-use polkadot_node_metrics::metrics::prometheus::exponential_buckets;
 pub use polkadot_node_metrics::metrics::{self, prometheus, Metrics as MetricsTrait};
 
 /// Overseer Prometheus metrics.
@@ -167,10 +166,10 @@ impl MetricsTrait for Metrics {
 						"polkadot_parachain_subsystem_bounded_tof",
 						"Duration spent in a particular channel from entrance to removal",
 					)
-					.buckets(
-						exponential_buckets(0.0001, 4.0, 9)
-							.expect("function parameters are constant and always valid; qed"),
-					),
+					.buckets(vec![
+						0.0001, 0.0004, 0.0016, 0.0064, 0.0256, 0.1024, 0.4096, 1.6384, 3.2768,
+						4.9152, 6.5536,
+					]),
 					&["subsystem_name"],
 				)?,
 				registry,
@@ -211,10 +210,10 @@ impl MetricsTrait for Metrics {
 						"polkadot_parachain_subsystem_unbounded_tof",
 						"Duration spent in a particular channel from entrance to removal",
 					)
-					.buckets(
-						exponential_buckets(0.0001, 4.0, 9)
-							.expect("function parameters are constant and always valid; qed"),
-					),
+					.buckets(vec![
+						0.0001, 0.0004, 0.0016, 0.0064, 0.0256, 0.1024, 0.4096, 1.6384, 3.2768,
+						4.9152, 6.5536,
+					]),
 					&["subsystem_name"],
 				)?,
 				registry,

--- a/node/overseer/src/metrics.rs
+++ b/node/overseer/src/metrics.rs
@@ -17,6 +17,7 @@
 //! Prometheus metrics related to the overseer and its channels.
 
 use super::*;
+use polkadot_node_metrics::metrics::prometheus::exponential_buckets;
 pub use polkadot_node_metrics::metrics::{self, prometheus, Metrics as MetricsTrait};
 
 /// Overseer Prometheus metrics.
@@ -165,6 +166,10 @@ impl MetricsTrait for Metrics {
 					prometheus::HistogramOpts::new(
 						"polkadot_parachain_subsystem_bounded_tof",
 						"Duration spent in a particular channel from entrance to removal",
+					)
+					.buckets(
+						exponential_buckets(0.0001, 4.0, 9)
+							.expect("function parameters are constant and always valid; qed"),
 					),
 					&["subsystem_name"],
 				)?,
@@ -205,6 +210,10 @@ impl MetricsTrait for Metrics {
 					prometheus::HistogramOpts::new(
 						"polkadot_parachain_subsystem_unbounded_tof",
 						"Duration spent in a particular channel from entrance to removal",
+					)
+					.buckets(
+						exponential_buckets(0.0001, 4.0, 9)
+							.expect("function parameters are constant and always valid; qed"),
 					),
 					&["subsystem_name"],
 				)?,


### PR DESCRIPTION
These metrics are using the default histogram buckets:
```
pub const DEFAULT_BUCKETS: &[f64; 11] = &[
    0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
];

```

Which give us a resolution of 5ms, that's good, but there are some subsystems where we process hundreds or even a few thousands of messages per second like approval-voting or approval-distribution, so it makes sense to increse the resoution of the bucket to better understand if the procesisng is in the range of useconds.

The new bucket ranges will be:
```
[0.0001, 0.0004, 0.0016, 0.0064, 0.0256, 0.1024, 0.4096, 1.6384, 6.5536]
```