### PR TITLE
[companion] Get rid of `Peerset` compatibility layer

### DIFF
--- a/node/network/bridge/src/network.rs
+++ b/node/network/bridge/src/network.rs
@@ -94,7 +94,11 @@ pub trait Network: Clone + Send + 'static {
 	) -> Result<(), String>;
 
 	/// Removes the peers for the protocol's peer set (both reserved and non-reserved).
-	async fn remove_from_peers_set(&mut self, protocol: ProtocolName, peers: Vec<PeerId>);
+	async fn remove_from_peers_set(
+		&mut self,
+		protocol: ProtocolName,
+		peers: Vec<PeerId>,
+	) -> Result<(), String>;
 
 	/// Send a request to a remote peer.
 	async fn start_request<AD: AuthorityDiscovery>(
@@ -129,8 +133,12 @@ impl Network for Arc<NetworkService<Block, Hash>> {
 		NetworkService::set_reserved_peers(&**self, protocol, multiaddresses)
 	}
 
-	async fn remove_from_peers_set(&mut self, protocol: ProtocolName, peers: Vec<PeerId>) {
-		NetworkService::remove_peers_from_reserved_set(&**self, protocol, peers);
+	async fn remove_from_peers_set(
+		&mut self,
+		protocol: ProtocolName,
+		peers: Vec<PeerId>,
+	) -> Result<(), String> {
+		NetworkService::remove_peers_from_reserved_set(&**self, protocol, peers)
 	}
 
 	fn report_peer(&self, who: PeerId, cost_benefit: Rep) {

--- a/node/network/bridge/src/rx/tests.rs
+++ b/node/network/bridge/src/rx/tests.rs
@@ -117,7 +117,13 @@ impl Network for TestNetwork {
 		Ok(())
 	}
 
-	async fn remove_from_peers_set(&mut self, _protocol: ProtocolName, _: Vec<PeerId>) {}
+	async fn remove_from_peers_set(
+		&mut self,
+		_protocol: ProtocolName,
+		_: Vec<PeerId>,
+	) -> Result<(), String> {
+		Ok(())
+	}
 
 	async fn start_request<AD: AuthorityDiscovery>(
 		&self,

--- a/node/network/bridge/src/tx/tests.rs
+++ b/node/network/bridge/src/tx/tests.rs
@@ -105,7 +105,13 @@ impl Network for TestNetwork {
 		Ok(())
 	}
 
-	async fn remove_from_peers_set(&mut self, _protocol: ProtocolName, _: Vec<PeerId>) {}
+	async fn remove_from_peers_set(
+		&mut self,
+		_protocol: ProtocolName,
+		_: Vec<PeerId>,
+	) -> Result<(), String> {
+		Ok(())
+	}
 
 	async fn start_request<AD: AuthorityDiscovery>(
 		&self,

--- a/node/network/bridge/src/validator_discovery.rs
+++ b/node/network/bridge/src/validator_discovery.rs
@@ -236,8 +236,13 @@ mod tests {
 			Ok(())
 		}
 
-		async fn remove_from_peers_set(&mut self, _protocol: ProtocolName, peers: Vec<PeerId>) {
+		async fn remove_from_peers_set(
+			&mut self,
+			_protocol: ProtocolName,
+			peers: Vec<PeerId>,
+		) -> Result<(), String> {
 			self.peers_set.retain(|elem| !peers.contains(elem));
+			Ok(())
 		}
 
 		async fn start_request<AD: AuthorityDiscovery>(


### PR DESCRIPTION
Companion to https://github.com/paritytech/substrate/pull/14337.