### PR TITLE
Patch CI for split out worker binaries

### DIFF
--- a/scripts/ci/dockerfiles/polkadot_injected_debug.Dockerfile
+++ b/scripts/ci/dockerfiles/polkadot_injected_debug.Dockerfile
@@ -33,7 +33,7 @@ RUN apt-get update && \
 	ln -s /data /polkadot/.local/share/polkadot
 
 # add polkadot binary to docker image
-COPY ./polkadot /usr/local/bin
+COPY ./polkadot ./polkadot-*-worker /usr/local/bin
 
 USER polkadot
 

--- a/scripts/ci/gitlab/pipeline/build.yml
+++ b/scripts/ci/gitlab/pipeline/build.yml
@@ -26,6 +26,8 @@ build-linux-stable:
     - mkdir -p ./artifacts
     - VERSION="${CI_COMMIT_REF_NAME}" # will be tag or branch name
     - mv ./target/testnet/polkadot ./artifacts/.
+    - mv ./target/testnet/polkadot-prepare-worker ./artifacts/. 2 > /dev/null || true
+    - mv ./target/testnet/polkadot-execute-worker ./artifacts/. 2 > /dev/null || true
     - pushd artifacts
     - sha256sum polkadot | tee polkadot.sha256
     - shasum -c polkadot.sha256


### PR DESCRIPTION
Blocks #7337 

We're experimenting with splitting out the PVF workers to separate binaries which are supposed to be distributed along with the main `polkadot` binary in the future. This PR aims to incorporate the binaries in question into the docker images pushed to dockerhub to enable downstream pipelines, like zombienet tests, to run in that configuration, still preserving backward compatibility for builds that do not require multiple binaries.

I didn't test these changes. They are obvious, and I checked the docs twice, but I'm lacking the infrastructure required to perform testing on my machine.