### PR TITLE
ci: use nightly rustdoc

### DIFF
--- a/scripts/ci/gitlab/pipeline/build.yml
+++ b/scripts/ci/gitlab/pipeline/build.yml
@@ -130,8 +130,8 @@ build-rustdoc:
       - ./crate-docs/
   script:
     # FIXME: it fails with `RUSTDOCFLAGS="-Dwarnings"` and `--all-features`
-    # FIXME: return to stable when https://github.com/rust-lang/rust/issues/96937 gets into stable
-    - time cargo doc --workspace --verbose --no-deps
+    # FIXME: return to stable when https://github.com/rust-lang/rust/pull/111195 is in, eta rust 1.71
+    - time cargo +nightly doc --workspace --verbose --no-deps
     - rm -f ./target/doc/.lock
     - mv ./target/doc ./crate-docs
     # FIXME: remove me after CI image gets nonroot


### PR DESCRIPTION
Documenting our code triggers an ICE in rust 1.70, presumably the one fixed here: https://github.com/rust-lang/rust/pull/111195