### PR TITLE
docs: update references to NetworkConfiguration::extra_sets

### DIFF
--- a/node/network/bridge/src/lib.rs
+++ b/node/network/bridge/src/lib.rs
@@ -34,7 +34,7 @@ use polkadot_node_network_protocol::{
 
 /// Peer set info for network initialization.
 ///
-/// To be added to [`FullNetworkConfiguration`]().
+/// To be passed to [`FullNetworkConfiguration::add_notification_protocol`]().
 pub use polkadot_node_network_protocol::peer_set::{peer_sets_info, IsAuthority};
 
 use std::{collections::HashMap, sync::Arc};

--- a/node/network/bridge/src/lib.rs
+++ b/node/network/bridge/src/lib.rs
@@ -34,7 +34,7 @@ use polkadot_node_network_protocol::{
 
 /// Peer set info for network initialization.
 ///
-/// To be added to [`NetworkConfiguration::extra_sets`].
+/// To be added to [`FullNetworkConfiguration`]().
 pub use polkadot_node_network_protocol::peer_set::{peer_sets_info, IsAuthority};
 
 use std::{collections::HashMap, sync::Arc};

--- a/node/network/bridge/src/rx/mod.rs
+++ b/node/network/bridge/src/rx/mod.rs
@@ -49,7 +49,7 @@ use polkadot_primitives::{AuthorityDiscoveryId, BlockNumber, Hash, ValidatorInde
 
 /// Peer set info for network initialization.
 ///
-/// To be added to [`NetworkConfiguration::extra_sets`].
+/// To be added to [`FullNetworkConfiguration`]().
 pub use polkadot_node_network_protocol::peer_set::{peer_sets_info, IsAuthority};
 
 use std::{

--- a/node/network/bridge/src/rx/mod.rs
+++ b/node/network/bridge/src/rx/mod.rs
@@ -49,7 +49,7 @@ use polkadot_primitives::{AuthorityDiscoveryId, BlockNumber, Hash, ValidatorInde
 
 /// Peer set info for network initialization.
 ///
-/// To be added to [`FullNetworkConfiguration`]().
+/// To be passed to [`FullNetworkConfiguration::add_notification_protocol`]().
 pub use polkadot_node_network_protocol::peer_set::{peer_sets_info, IsAuthority};
 
 use std::{

--- a/node/network/bridge/src/tx/mod.rs
+++ b/node/network/bridge/src/tx/mod.rs
@@ -31,7 +31,7 @@ use polkadot_node_subsystem::{
 
 /// Peer set info for network initialization.
 ///
-/// To be added to [`FullNetworkConfiguration`]().
+/// To be passed to [`FullNetworkConfiguration::add_notification_protocol`]().
 pub use polkadot_node_network_protocol::peer_set::{peer_sets_info, IsAuthority};
 use sc_network::ReputationChange;
 

--- a/node/network/bridge/src/tx/mod.rs
+++ b/node/network/bridge/src/tx/mod.rs
@@ -31,7 +31,7 @@ use polkadot_node_subsystem::{
 
 /// Peer set info for network initialization.
 ///
-/// To be added to [`NetworkConfiguration::extra_sets`].
+/// To be added to [`FullNetworkConfiguration`]().
 pub use polkadot_node_network_protocol::peer_set::{peer_sets_info, IsAuthority};
 use sc_network::ReputationChange;
 


### PR DESCRIPTION
Since paritytech/substrate#14080, this struct field no longer exists, now the `add_notification_protocol()` function of
`sc_network::config::FullNetworkConfiguration` is used.

Also neuter the doc links for now; rustdoc can't resolve them (presumably because sc_network::config isn't in scope, though weirdly enough even spelling the link out as
``[`FullNetworkConfiguration`](struct@sc_network::config::FullNetworkConfiguration)`` doesn't work?). Normally this wouldn't be an issue and rustdoc would just not generate links, but rust 1.70 has a bug that completely crashes rustdoc in this case.

Required for https://github.com/paritytech/ci_cd/issues/816