### PR TITLE
fixed one member of two teams prs counting individually

### DIFF
--- a/.github/pr-custom-review.yml
+++ b/.github/pr-custom-review.yml
@@ -9,7 +9,7 @@ rules:
     condition:
       include: ^runtime\/(kusama|polkadot)\/src\/.+\.rs$
       exclude: ^runtime\/(kusama|polkadot)\/src\/weights\/.+\.rs$
-    all_distinct:
+    all:
       - min_approvals: 1
         teams:
           - locks-review


### PR DESCRIPTION
Fixed the problem that, if a member of two of the required teams reviews a Pr that belongs to `^runtime\/(kusama|polkadot)\/src\/.+\.rs$` it won't count as enough reviews.

By changing the `all_distinct` to `all` this will allow one member of both teams to fulfill the requirements for the PR