### PR TITLE
fix dependency for "cli" feature in polkadot-cli

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -57,6 +57,7 @@ cli = [
 	"polkadot-client",
 	"polkadot-node-core-pvf-execute-worker",
 	"polkadot-node-core-pvf-prepare-worker",
+	"service",
 ]
 runtime-benchmarks = [
 	"service/runtime-benchmarks",


### PR DESCRIPTION
The "cli" feature for this crate (without default features activated) requires the optional `polkadot-service` dependency to compile it but did not specify it until now.