### PR TITLE
Enact ImOnline migration

### DIFF
--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -1525,20 +1525,33 @@ pub mod migrations {
 	);
 
 	pub type V0943 = (
-		SetStorageVersions,
+		SetStorageVersionsV0943,
 		// Remove UMP dispatch queue <https://github.com/paritytech/polkadot/pull/6271>
 		parachains_configuration::migration::v6::MigrateToV6<Runtime>,
 		ump_migrations::UpdateUmpLimits,
 	);
 
 	/// Unreleased migrations. Add new ones here:
-	pub type Unreleased =
-		(pallet_society::migrations::MigrateToV2<Runtime, (), past_payouts::PastPayouts>,);
+	pub type Unreleased = (
+		pallet_society::migrations::MigrateToV2<Runtime, (), past_payouts::PastPayouts>,
+		SetStorageVersionsUnreleased,
+	);
 
 	/// Migrations that set `StorageVersion`s we missed to set.
-	pub struct SetStorageVersions;
+	pub struct SetStorageVersionsUnreleased;
+	impl OnRuntimeUpgrade for SetStorageVersionsUnreleased {
+		fn on_runtime_upgrade() -> Weight {
+			let storage_version = ImOnline::on_chain_storage_version();
+			if storage_version < 1 {
+				StorageVersion::new(1).put::<ImOnline>();
+			}
 
-	impl OnRuntimeUpgrade for SetStorageVersions {
+			RocksDbWeight::get().reads_writes(1, 1)
+		}
+	}
+
+	pub struct SetStorageVersionsV0943;
+	impl OnRuntimeUpgrade for SetStorageVersionsV0943 {
 		fn on_runtime_upgrade() -> Weight {
 			// The `NisCounterpartBalances` pallet was added to the chain after/with the migration.
 			// So, the migration never needed to be executed, but we also did not set the proper `StorageVersion`.


### PR DESCRIPTION
Need to set the onchain version for the pallet as part of fixing try-on-runtime-upgrade Kusama & Westend checks.

```
2023-06-20 13:39:37.179 ERROR main runtime::frame-support: ImOnline: On chain storage version StorageVersion(0) doesn't match current storage version StorageVersion(1).
```

todo: 
- [ ] check if rococo and polkadot also need this migration