### PR TITLE
availability recovery: measure re-encoding time

### DIFF
--- a/node/network/availability-recovery/src/lib.rs
+++ b/node/network/availability-recovery/src/lib.rs
@@ -255,7 +255,7 @@ impl RequestFromBackers {
 						params.validators.len(),
 						&params.erasure_root,
 						&data,
-						&metrics,
+						&params.metrics,
 					) {
 						gum::trace!(
 							target: LOG_TARGET,

--- a/node/network/availability-recovery/src/lib.rs
+++ b/node/network/availability-recovery/src/lib.rs
@@ -255,6 +255,7 @@ impl RequestFromBackers {
 						params.validators.len(),
 						&params.erasure_root,
 						&data,
+						&metrics,
 					) {
 						gum::trace!(
 							target: LOG_TARGET,
@@ -586,6 +587,7 @@ impl RequestChunksFromValidators {
 							params.validators.len(),
 							&params.erasure_root,
 							&data,
+							&metrics,
 						) {
 							gum::trace!(
 								target: LOG_TARGET,
@@ -685,7 +687,10 @@ fn reconstructed_data_matches_root(
 	n_validators: usize,
 	expected_root: &Hash,
 	data: &AvailableData,
+	metrics: &Metrics,
 ) -> bool {
+	let _timer = metrics.time_reencode_chunks();
+
 	let chunks = match obtain_chunks_v1(n_validators, data) {
 		Ok(chunks) => chunks,
 		Err(e) => {

--- a/node/network/availability-recovery/src/metrics.rs
+++ b/node/network/availability-recovery/src/metrics.rs
@@ -46,6 +46,10 @@ struct MetricsInner {
 	/// The duration between the pure recovery and verification.
 	time_erasure_recovery: Histogram,
 
+	/// How much time it takes to re-encode the data into erasure chunks in order to verify
+	/// the root hash of the provided Merkle tree. See `reconstructed_data_matches_root`.
+	time_reencode_chunks: Histogram,
+
 	/// Time of a full recovery, including erasure decoding or until we gave
 	/// up.
 	time_full_recovery: Histogram,
@@ -118,6 +122,11 @@ impl Metrics {
 		self.0.as_ref().map(|metrics| metrics.time_erasure_recovery.start_timer())
 	}
 
+	/// Get a timer to time chunk encoding.
+	pub fn time_reencode_chunks(&self) -> Option<metrics::prometheus::prometheus::HistogramTimer> {
+		self.0.as_ref().map(|metrics| metrics.time_reencode_chunks.start_timer())
+	}
+
 	/// Get a timer to measure the time of the complete recovery process.
 	pub fn time_full_recovery(&self) -> Option<metrics::prometheus::prometheus::HistogramTimer> {
 		self.0.as_ref().map(|metrics| metrics.time_full_recovery.start_timer())
@@ -183,6 +192,13 @@ impl metrics::Metrics for Metrics {
 				prometheus::Histogram::with_opts(prometheus::HistogramOpts::new(
 					"polkadot_parachain_availability_recovery_time_erasure_recovery",
 					"Time spent to recover the erasure code and verify the merkle root by re-encoding as erasure chunks",
+				))?,
+				registry,
+			)?,
+			time_reencode_chunks: prometheus::register(
+				prometheus::Histogram::with_opts(prometheus::HistogramOpts::new(
+					"polkadot_parachain_availability_reencode_chunks",
+					"Time spent re-encoding the data as erasure chunks",
 				))?,
 				registry,
 			)?,


### PR DESCRIPTION
`reconstructed_data_matches_root` is expensive and mandatory to be called.  Even when fetching from backers, recovery time seems to be rather high for 2.5MB PoVs (testing in context of https://github.com/paritytech/polkadot/issues/7324).

<img width="896" alt="Screenshot 2023-06-21 at 14 54 32" src="https://github.com/paritytech/polkadot/assets/54316454/53fa7e61-ec56-404c-a7f9-09c25d8cc2d8">
