### PR TITLE
availability-recovery: move cpu burners in blocking tasks

### DIFF
--- a/node/core/approval-voting/src/lib.rs
+++ b/node/core/approval-voting/src/lib.rs
@@ -2519,6 +2519,17 @@ async fn launch_approval<Context>(
 						// do nothing. we'll just be a no-show and that'll cause others to rise up.
 						metrics_guard.take().on_approval_unavailable();
 					},
+					&RecoveryError::Internal => {
+						gum::warn!(
+							target: LOG_TARGET,
+							?para_id,
+							?candidate_hash,
+							"Internal error while recovering data for candidate {:?}",
+							(candidate_hash, candidate.descriptor.para_id),
+						);
+						// do nothing. we'll just be a no-show and that'll cause others to rise up.
+						metrics_guard.take().on_approval_unavailable();
+					},
 					&RecoveryError::Invalid => {
 						gum::warn!(
 							target: LOG_TARGET,

--- a/node/core/approval-voting/src/lib.rs
+++ b/node/core/approval-voting/src/lib.rs
@@ -2519,12 +2519,12 @@ async fn launch_approval<Context>(
 						// do nothing. we'll just be a no-show and that'll cause others to rise up.
 						metrics_guard.take().on_approval_unavailable();
 					},
-					&RecoveryError::Internal => {
+					&RecoveryError::ChannelClosed => {
 						gum::warn!(
 							target: LOG_TARGET,
 							?para_id,
 							?candidate_hash,
-							"Internal error while recovering data for candidate {:?}",
+							"Channel closed while recovering data for candidate {:?}",
 							(candidate_hash, candidate.descriptor.para_id),
 						);
 						// do nothing. we'll just be a no-show and that'll cause others to rise up.

--- a/node/core/dispute-coordinator/src/participation/mod.rs
+++ b/node/core/dispute-coordinator/src/participation/mod.rs
@@ -319,7 +319,7 @@ async fn participate(
 			send_result(&mut result_sender, req, ParticipationOutcome::Invalid).await;
 			return
 		},
-		Ok(Err(RecoveryError::Unavailable)) => {
+		Ok(Err(RecoveryError::Unavailable)) |  Ok(Err(RecoveryError::Internal)) => {
 			send_result(&mut result_sender, req, ParticipationOutcome::Unavailable).await;
 			return
 		},

--- a/node/core/dispute-coordinator/src/participation/mod.rs
+++ b/node/core/dispute-coordinator/src/participation/mod.rs
@@ -319,7 +319,7 @@ async fn participate(
 			send_result(&mut result_sender, req, ParticipationOutcome::Invalid).await;
 			return
 		},
-		Ok(Err(RecoveryError::Unavailable)) |  Ok(Err(RecoveryError::Internal)) => {
+		Ok(Err(RecoveryError::Unavailable)) | Ok(Err(RecoveryError::Internal)) => {
 			send_result(&mut result_sender, req, ParticipationOutcome::Unavailable).await;
 			return
 		},

--- a/node/core/dispute-coordinator/src/participation/mod.rs
+++ b/node/core/dispute-coordinator/src/participation/mod.rs
@@ -319,7 +319,7 @@ async fn participate(
 			send_result(&mut result_sender, req, ParticipationOutcome::Invalid).await;
 			return
 		},
-		Ok(Err(RecoveryError::Unavailable)) | Ok(Err(RecoveryError::Internal)) => {
+		Ok(Err(RecoveryError::Unavailable)) | Ok(Err(RecoveryError::ChannelClosed)) => {
 			send_result(&mut result_sender, req, ParticipationOutcome::Unavailable).await;
 			return
 		},

--- a/node/network/availability-recovery/src/lib.rs
+++ b/node/network/availability-recovery/src/lib.rs
@@ -1347,7 +1347,11 @@ impl ThreadPoolBuilder {
 	// Creates a pool of `size` workers, where 1 <= `size` <= `MAX_THREADS`.
 	//
 	// Each worker is created by `spawn_blocking` and takes the receiver side of a channel
-	// while all of the senders are returned to the caller.
+	// while all of the senders are returned to the caller. Each worker runs `erasure_task_thread` that
+	// polls the `Receiver` for an `ErasureTask` which is expected to be CPU intensive. The larger
+	// the input (more or larger chunks/availability data), the more CPU cycles will be spent.
+	//
+	// After executing such a task, the worker sends the response via a provided `oneshot` sender.
 	//
 	// The caller is responsible for routing work to the workers.
 	#[overseer::contextbounds(AvailabilityRecovery, prefix = self::overseer)]

--- a/node/network/availability-recovery/src/lib.rs
+++ b/node/network/availability-recovery/src/lib.rs
@@ -1200,7 +1200,8 @@ impl AvailabilityRecoverySubsystem {
 		// We use this iterator to assign work in a round-robin fashion to the workers in the pool.
 		//
 		// How work is dispatched to the pool from the recovery tasks:
-		// - Once a recovery tasks finish retrieving the availability data, it needs to do some heavy CPU computation.
+		// - Once a recovery task finishes retrieving the availability data, it needs to reconstruct from chunks and/or
+		// re-encode the data which are heavy CPU computations.
 		// To do so it sends an `ErasureTask` to the main loop via the `erasure_task` channel, and waits for the results
 		// over a `oneshot` channel.
 		// - In the subsystem main loop we poll the `erasure_task_rx` receiver.
@@ -1350,6 +1351,8 @@ impl ThreadPoolBuilder {
 	// while all of the senders are returned to the caller. Each worker runs `erasure_task_thread` that
 	// polls the `Receiver` for an `ErasureTask` which is expected to be CPU intensive. The larger
 	// the input (more or larger chunks/availability data), the more CPU cycles will be spent.
+	//
+	// For example, for 32KB PoVs, we'd expect re-encode to eat as much as 90ms and 500ms for 2.5MiB.
 	//
 	// After executing such a task, the worker sends the response via a provided `oneshot` sender.
 	//

--- a/node/network/availability-recovery/src/lib.rs
+++ b/node/network/availability-recovery/src/lib.rs
@@ -26,18 +26,21 @@ use std::{
 };
 
 use futures::{
-	channel::oneshot,
-	future::{FutureExt, RemoteHandle},
+	channel::oneshot::{self, channel},
+	future::{Future, FutureExt, RemoteHandle},
 	pin_mut,
 	prelude::*,
-	stream::FuturesUnordered,
+	sink::SinkExt,
+	stream::{FuturesUnordered, StreamExt},
 	task::{Context, Poll},
 };
 use lru::LruCache;
 use rand::seq::SliceRandom;
 
 use fatality::Nested;
-use polkadot_erasure_coding::{branch_hash, branches, obtain_chunks_v1, recovery_threshold};
+use polkadot_erasure_coding::{
+	branch_hash, branches, obtain_chunks_v1, recovery_threshold, Error as ErasureEncodingError,
+};
 #[cfg(not(test))]
 use polkadot_node_network_protocol::request_response::CHUNK_REQUEST_TIMEOUT;
 use polkadot_node_network_protocol::{
@@ -150,6 +153,8 @@ struct RequestFromBackers {
 	// a random shuffling of the validators from the backing group which indicates the order
 	// in which we connect to them and request the chunk.
 	shuffled_backers: Vec<ValidatorIndex>,
+	// channel to the erasure task handler.
+	erasure_task_tx: futures::channel::mpsc::Sender<ErasureTask>,
 }
 
 struct RequestChunksFromValidators {
@@ -165,6 +170,8 @@ struct RequestChunksFromValidators {
 	received_chunks: HashMap<ValidatorIndex, ErasureChunk>,
 	/// Pending chunk requests with soft timeout.
 	requesting_chunks: FuturesUndead<Result<Option<ErasureChunk>, (ValidatorIndex, RequestError)>>,
+	// channel to the erasure task handler.
+	erasure_task_tx: futures::channel::mpsc::Sender<ErasureTask>,
 }
 
 struct RecoveryParams {
@@ -198,6 +205,18 @@ enum Source {
 	RequestChunks(RequestChunksFromValidators),
 }
 
+/// Expensive erasure coding computations that we want to run on a blocking thread.
+enum ErasureTask {
+	/// Reconstructs `AvailableData` from chunks given `n_validators`.
+	Reconstruct(
+		usize,
+		HashMap<ValidatorIndex, ErasureChunk>,
+		oneshot::Sender<Result<AvailableData, ErasureEncodingError>>,
+	),
+	/// Re-encode `AvailableData` into erasure chunks in order to verify the provided root hash of the Merkle tree.
+	Reencode(usize, Hash, AvailableData, oneshot::Sender<bool>),
+}
+
 /// A stateful reconstruction of availability data in reference to
 /// a candidate hash.
 struct RecoveryTask<Sender> {
@@ -208,13 +227,19 @@ struct RecoveryTask<Sender> {
 
 	/// The source to obtain the availability data from.
 	source: Source,
+
+	// channel to the erasure task handler.
+	erasure_task_tx: futures::channel::mpsc::Sender<ErasureTask>,
 }
 
 impl RequestFromBackers {
-	fn new(mut backers: Vec<ValidatorIndex>) -> Self {
+	fn new(
+		mut backers: Vec<ValidatorIndex>,
+		erasure_task_tx: futures::channel::mpsc::Sender<ErasureTask>,
+	) -> Self {
 		backers.shuffle(&mut rand::thread_rng());
 
-		RequestFromBackers { shuffled_backers: backers }
+		RequestFromBackers { shuffled_backers: backers, erasure_task_tx }
 	}
 
 	// Run this phase to completion.
@@ -251,12 +276,21 @@ impl RequestFromBackers {
 
 			match response.await {
 				Ok(req_res::v1::AvailableDataFetchingResponse::AvailableData(data)) => {
-					if reconstructed_data_matches_root(
-						params.validators.len(),
-						&params.erasure_root,
-						&data,
-						&params.metrics,
-					) {
+					let (reencode_tx, reencode_rx) = channel();
+					// TODO: don't clone data as it is big, instead use `Option<Data>` instead of bool to send it back.
+					let _ = self
+						.erasure_task_tx
+						.send(ErasureTask::Reencode(
+							params.validators.len(),
+							params.erasure_root,
+							data.clone(),
+							reencode_tx,
+						))
+						.await;
+					let reencode_response =
+						reencode_rx.await.map_err(|_| RecoveryError::Internal)?;
+
+					if reencode_response {
 						gum::trace!(
 							target: LOG_TARGET,
 							candidate_hash = ?params.candidate_hash,
@@ -289,7 +323,10 @@ impl RequestFromBackers {
 }
 
 impl RequestChunksFromValidators {
-	fn new(n_validators: u32) -> Self {
+	fn new(
+		n_validators: u32,
+		erasure_task_tx: futures::channel::mpsc::Sender<ErasureTask>,
+	) -> Self {
 		let mut shuffling: Vec<_> = (0..n_validators).map(ValidatorIndex).collect();
 		shuffling.shuffle(&mut rand::thread_rng());
 
@@ -299,6 +336,7 @@ impl RequestChunksFromValidators {
 			shuffling: shuffling.into(),
 			received_chunks: HashMap::new(),
 			requesting_chunks: FuturesUndead::new(),
+			erasure_task_tx,
 		}
 	}
 
@@ -578,17 +616,37 @@ impl RequestChunksFromValidators {
 			if self.received_chunks.len() >= params.threshold {
 				let recovery_duration = metrics.time_erasure_recovery();
 
-				return match polkadot_erasure_coding::reconstruct_v1(
-					params.validators.len(),
-					self.received_chunks.values().map(|c| (&c.chunk[..], c.index.0 as usize)),
-				) {
+				// Send request to reconstruct available data from chunks.
+				let (avilable_data_tx, available_data_rx) = channel();
+				let _ = self
+					.erasure_task_tx
+					.send(ErasureTask::Reconstruct(
+						params.validators.len(),
+						//TODO: Avoid clone with `Option`.
+						self.received_chunks.clone(),
+						avilable_data_tx,
+					))
+					.await;
+				let available_data_response =
+					available_data_rx.await.map_err(|_| RecoveryError::Internal)?;
+
+				return match available_data_response {
 					Ok(data) => {
-						if reconstructed_data_matches_root(
-							params.validators.len(),
-							&params.erasure_root,
-							&data,
-							&metrics,
-						) {
+						// Send request to re-encode the chunks and check merkle root.
+						let (reencode_tx, reencode_rx) = channel();
+						let _ = self
+							.erasure_task_tx
+							.send(ErasureTask::Reencode(
+								params.validators.len(),
+								params.erasure_root,
+								data.clone(),
+								reencode_tx,
+							))
+							.await;
+						let reencode_response =
+							reencode_rx.await.map_err(|_| RecoveryError::Internal)?;
+
+						if reencode_response {
 							gum::trace!(
 								target: LOG_TARGET,
 								candidate_hash = ?params.candidate_hash,
@@ -746,9 +804,11 @@ where
 					match from_backers.run(&self.params, &mut self.sender).await {
 						Ok(data) => break Ok(data),
 						Err(RecoveryError::Invalid) => break Err(RecoveryError::Invalid),
+						Err(RecoveryError::Internal) => break Err(RecoveryError::Internal),
 						Err(RecoveryError::Unavailable) =>
 							self.source = Source::RequestChunks(RequestChunksFromValidators::new(
 								self.params.validators.len() as _,
+								self.erasure_task_tx.clone(),
 							)),
 					}
 				},
@@ -838,6 +898,7 @@ impl TryFrom<Result<AvailableData, RecoveryError>> for CachedRecovery {
 			// We don't want to cache unavailable state, as that state might change, so if
 			// requested again we want to try again!
 			Err(RecoveryError::Unavailable) => Err(()),
+			Err(RecoveryError::Internal) => Err(()),
 		}
 	}
 }
@@ -904,9 +965,9 @@ async fn launch_recovery_task<Context>(
 	response_sender: oneshot::Sender<Result<AvailableData, RecoveryError>>,
 	metrics: &Metrics,
 	recovery_strategy: &RecoveryStrategy,
+	erasure_task_tx: futures::channel::mpsc::Sender<ErasureTask>,
 ) -> error::Result<()> {
 	let candidate_hash = receipt.hash();
-
 	let params = RecoveryParams {
 		validator_authority_keys: session_info.discovery_keys.clone(),
 		validators: session_info.validators.clone(),
@@ -943,12 +1004,21 @@ async fn launch_recovery_task<Context>(
 
 	let phase = backing_group
 		.and_then(|g| session_info.validator_groups.get(g))
-		.map(|group| Source::RequestFromBackers(RequestFromBackers::new(group.clone())))
+		.map(|group| {
+			Source::RequestFromBackers(RequestFromBackers::new(
+				group.clone(),
+				erasure_task_tx.clone(),
+			))
+		})
 		.unwrap_or_else(|| {
-			Source::RequestChunks(RequestChunksFromValidators::new(params.validators.len() as _))
+			Source::RequestChunks(RequestChunksFromValidators::new(
+				params.validators.len() as _,
+				erasure_task_tx.clone(),
+			))
 		});
 
-	let recovery_task = RecoveryTask { sender: ctx.sender().clone(), params, source: phase };
+	let recovery_task =
+		RecoveryTask { sender: ctx.sender().clone(), params, source: phase, erasure_task_tx };
 
 	let (remote, remote_handle) = recovery_task.run().remote_handle();
 
@@ -980,6 +1050,7 @@ async fn handle_recover<Context>(
 	response_sender: oneshot::Sender<Result<AvailableData, RecoveryError>>,
 	metrics: &Metrics,
 	recovery_strategy: &RecoveryStrategy,
+	erasure_task_tx: futures::channel::mpsc::Sender<ErasureTask>,
 ) -> error::Result<()> {
 	let candidate_hash = receipt.hash();
 
@@ -1024,6 +1095,7 @@ async fn handle_recover<Context>(
 				response_sender,
 				metrics,
 				recovery_strategy,
+				erasure_task_tx,
 			)
 			.await,
 		None => {
@@ -1106,10 +1178,61 @@ impl AvailabilityRecoverySubsystem {
 		let mut state = State::default();
 		let Self { recovery_strategy, mut req_receiver, metrics } = self;
 
+		let (erasure_task_tx, erasure_task_rx) = futures::channel::mpsc::channel(16);
+		let mut erasure_task_rx = erasure_task_rx.fuse();
+
 		loop {
 			let recv_req = req_receiver.recv(|| vec![COST_INVALID_REQUEST]).fuse();
 			pin_mut!(recv_req);
 			futures::select! {
+				erasure_task = erasure_task_rx.next() => {
+					match erasure_task {
+						Some(ErasureTask::Reconstruct(n_validators, chunks, sender )) => {
+							let result = ctx.spawn_blocking("reconstruct_v1", Box::pin(async move {
+								let _ = sender.send(polkadot_erasure_coding::reconstruct_v1(
+									n_validators,
+									chunks.values().map(|c| (&c.chunk[..], c.index.0 as usize)),
+								));
+							}));
+
+							if let Err(e) = result {
+								gum::warn!(
+									target: LOG_TARGET,
+									err = ?e,
+									"Failed to spawn a erasure coding task",
+								);
+							}
+						},
+						Some(ErasureTask::Reencode(n_validators, root, available_data, sender)) => {
+							let metrics = metrics.clone();
+
+							let result = ctx.spawn_blocking("re-encode", Box::pin(async move {
+								let _ = sender.send(reconstructed_data_matches_root(
+									n_validators,
+									&root,
+									&available_data,
+									&metrics,
+								));
+							}));
+
+							if let Err(e) = result {
+								gum::warn!(
+									target: LOG_TARGET,
+									err = ?e,
+									"Failed to spawn a erasure coding task",
+								);
+							}
+						},
+						None => {
+							gum::debug!(
+								target: LOG_TARGET,
+								"Erasure task channel closed",
+							);
+
+							return Err(SubsystemError::with_origin("availability-recovery", RecoveryError::Internal))
+						}
+					}
+				}
 				v = ctx.recv().fuse() => {
 					match v? {
 						FromOrchestra::Signal(signal) => if handle_signal(
@@ -1135,6 +1258,7 @@ impl AvailabilityRecoverySubsystem {
 										response_sender,
 										&metrics,
 										&recovery_strategy,
+										erasure_task_tx.clone(),
 									).await {
 										gum::warn!(
 											target: LOG_TARGET,

--- a/node/network/availability-recovery/src/tests.rs
+++ b/node/network/availability-recovery/src/tests.rs
@@ -1595,20 +1595,20 @@ fn parallel_request_calculation_works_as_expected() {
 
 	let dummy_chunk =
 		ErasureChunk { chunk: Vec::new(), index: ValidatorIndex(0), proof: Proof::dummy_proof() };
-	phase.received_chunks.insert(ValidatorIndex(0), dummy_chunk.clone());
+	phase.insert_chunk(ValidatorIndex(0), dummy_chunk.clone());
 	phase.total_received_responses = 2;
 	// With given error rate - still saturating:
 	assert_eq!(phase.get_desired_request_count(threshold), threshold);
 	for i in 1..9 {
-		phase.received_chunks.insert(ValidatorIndex(i), dummy_chunk.clone());
+		phase.insert_chunk(ValidatorIndex(i), dummy_chunk.clone());
 	}
 	phase.total_received_responses += 8;
 	// error rate: 1/10
 	// remaining chunks needed: threshold (34) - 9
 	// expected: 24 * (1+ 1/10) = (next greater integer) = 27
 	assert_eq!(phase.get_desired_request_count(threshold), 27);
-	phase.received_chunks.insert(ValidatorIndex(9), dummy_chunk.clone());
+	phase.insert_chunk(ValidatorIndex(9), dummy_chunk.clone());
 	phase.error_count = 0;
 	// With error count zero - we should fetch exactly as needed:
-	assert_eq!(phase.get_desired_request_count(threshold), threshold - phase.received_chunks.len());
+	assert_eq!(phase.get_desired_request_count(threshold), threshold - phase.chunk_count());
 }

--- a/node/network/availability-recovery/src/tests.rs
+++ b/node/network/availability-recovery/src/tests.rs
@@ -1584,7 +1584,7 @@ fn invalid_local_chunk_is_ignored() {
 fn parallel_request_calculation_works_as_expected() {
 	let num_validators = 100;
 	let threshold = recovery_threshold(num_validators).unwrap();
-	let (_erasure_task_tx, erasure_task_rx) = futures::channel::mpsc::channel(16);
+	let (erasure_task_tx, _erasure_task_rx) = futures::channel::mpsc::channel(16);
 
 	let mut phase = RequestChunksFromValidators::new(100, erasure_task_tx);
 	assert_eq!(phase.get_desired_request_count(threshold), threshold);

--- a/node/network/availability-recovery/src/tests.rs
+++ b/node/network/availability-recovery/src/tests.rs
@@ -1584,7 +1584,9 @@ fn invalid_local_chunk_is_ignored() {
 fn parallel_request_calculation_works_as_expected() {
 	let num_validators = 100;
 	let threshold = recovery_threshold(num_validators).unwrap();
-	let mut phase = RequestChunksFromValidators::new(100);
+	let (_erasure_task_tx, erasure_task_rx) = futures::channel::mpsc::channel(16);
+
+	let mut phase = RequestChunksFromValidators::new(100, erasure_task_tx);
 	assert_eq!(phase.get_desired_request_count(threshold), threshold);
 	phase.error_count = 1;
 	phase.total_received_responses = 1;

--- a/node/subsystem-types/src/errors.rs
+++ b/node/subsystem-types/src/errors.rs
@@ -75,6 +75,9 @@ pub enum RecoveryError {
 
 	/// A requested chunk is unavailable.
 	Unavailable,
+
+	/// Internal error, channel closed.
+	Internal,
 }
 
 impl std::fmt::Display for RecoveryError {
@@ -82,6 +85,7 @@ impl std::fmt::Display for RecoveryError {
 		let msg = match self {
 			RecoveryError::Invalid => "Invalid",
 			RecoveryError::Unavailable => "Unavailable",
+			RecoveryError::Internal => "Internal",
 		};
 
 		write!(f, "{}", msg)

--- a/node/subsystem-types/src/errors.rs
+++ b/node/subsystem-types/src/errors.rs
@@ -76,8 +76,8 @@ pub enum RecoveryError {
 	/// A requested chunk is unavailable.
 	Unavailable,
 
-	/// Internal error, channel closed.
-	Internal,
+	/// Erasure task channel closed, usually means node is shutting down.
+	ChannelClosed,
 }
 
 impl std::fmt::Display for RecoveryError {
@@ -85,7 +85,7 @@ impl std::fmt::Display for RecoveryError {
 		let msg = match self {
 			RecoveryError::Invalid => "Invalid",
 			RecoveryError::Unavailable => "Unavailable",
-			RecoveryError::Internal => "Internal",
+			RecoveryError::ChannelClosed => "ChannelClosed",
 		};
 
 		write!(f, "{}", msg)


### PR DESCRIPTION
Fixes https://github.com/paritytech/polkadot/issues/7411

TODO:
- [x] Address some availability data cloning issues in the impl
- [x] Ensure chunks and backing group recovery works perfectly as before
- [x] Versi burn-in analysis
