### PR TITLE
Revert "fixed one member of two teams prs counting individually"

### DIFF
--- a/.github/pr-custom-review.yml
+++ b/.github/pr-custom-review.yml
@@ -9,7 +9,7 @@ rules:
     condition:
       include: ^runtime\/(kusama|polkadot)\/src\/.+\.rs$
       exclude: ^runtime\/(kusama|polkadot)\/src\/weights\/.+\.rs$
-    all:
+    all_distinct:
       - min_approvals: 1
         teams:
           - locks-review


### PR DESCRIPTION
Reverts paritytech/polkadot#7398

why: because it was wrong fix, the proper one here https://github.com/paritytech/pr-custom-review/pull/115