### PR TITLE
Optimize collator-protocol fetch request on validator side

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7007,6 +7007,7 @@ dependencies = [
  "sp-keystore",
  "sp-runtime",
  "thiserror",
+ "tokio-util",
  "tracing-gum",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6986,7 +6986,6 @@ dependencies = [
 name = "polkadot-collator-protocol"
 version = "0.9.43"
 dependencies = [
- "always-assert",
  "assert_matches",
  "bitvec",
  "env_logger 0.9.0",

--- a/node/network/collator-protocol/Cargo.toml
+++ b/node/network/collator-protocol/Cargo.toml
@@ -21,6 +21,7 @@ polkadot-node-subsystem-util = { path = "../../subsystem-util" }
 polkadot-node-subsystem = {path = "../../subsystem" }
 fatality = "0.0.6"
 thiserror = "1.0.31"
+tokio-util = "0.7.1"
 
 [dev-dependencies]
 log = "0.4.17"

--- a/node/network/collator-protocol/Cargo.toml
+++ b/node/network/collator-protocol/Cargo.toml
@@ -5,7 +5,6 @@ authors.workspace = true
 edition.workspace = true
 
 [dependencies]
-always-assert = "0.1.2"
 bitvec = { version = "1.0.1", default-features = false, features = ["alloc"] }
 futures = "0.3.21"
 futures-timer = "3"

--- a/node/network/collator-protocol/src/validator_side/tests.rs
+++ b/node/network/collator-protocol/src/validator_side/tests.rs
@@ -28,15 +28,15 @@ use polkadot_node_network_protocol::{
 	request_response::{Requests, ResponseSender},
 	ObservedRole,
 };
-use polkadot_node_primitives::BlockData;
+use polkadot_node_primitives::{BlockData, PoV};
 use polkadot_node_subsystem::messages::{
 	AllMessages, ReportPeerMessage, RuntimeApiMessage, RuntimeApiRequest,
 };
 use polkadot_node_subsystem_test_helpers as test_helpers;
 use polkadot_node_subsystem_util::{reputation::add_reputation, TimeoutExt};
 use polkadot_primitives::{
-	CollatorPair, CoreState, GroupIndex, GroupRotationInfo, OccupiedCore, ScheduledCore,
-	ValidatorId, ValidatorIndex,
+	CandidateReceipt, CollatorPair, CoreState, GroupIndex, GroupRotationInfo, OccupiedCore,
+	ScheduledCore, ValidatorId, ValidatorIndex,
 };
 use polkadot_primitives_test_helpers::{
 	dummy_candidate_descriptor, dummy_candidate_receipt_bad_sig, dummy_hash,

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,6 +1,3 @@
-# Note: Some of the rules here are unstable, such as `trailing_semicolon`. You need to install the nightly
-# toolchain and configure your editor to run `cargo +nightly fmt` on save (or just run it manually).
-
 # Basic
 hard_tabs = true
 max_width = 100

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,6 @@
+# Note: Some of the rules here are unstable, such as `trailing_semicolon`. You need to install the nightly
+# toolchain and configure your editor to run `cargo +nightly fmt` on save (or just run it manually).
+
 # Basic
 hard_tabs = true
 max_width = 100


### PR DESCRIPTION
1. Refactors the collation fetching code to use `FuturesUnordered` instead of a `HashMap` of futures.
This enables us to remove the 50 ms `CHECK_COLLATIONS_POLL` interval future. Prior to this, we were constantly breaking out of the main `select!` in order to check if any collators sent us the requested collation, which is inefficient.
We are now polling the NetworkBridge response channel instead and only break out of the `select!` once we know for sure that a collation response was received.
As a side effect, since we're no longer using a `HashMap`, we rely on [`CancellationToken`](https://docs.rs/tokio-util/latest/tokio_util/sync/struct.CancellationToken.html)s to cancel requests (for example when relay parents are removed).

2. Removes the intermediate `collation_fetches` channel. This was a needless indirection that forced the code to enter the `select!` loop twice before a response was fully handled.

Closes https://github.com/paritytech/polkadot/issues/4182 