### PR TITLE
Revert "Introduce Tinkernet multisig XCM configs to Kusama/Rococo through xcm-builder"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14472,7 +14472,6 @@ dependencies = [
  "primitive-types",
  "scale-info",
  "sp-arithmetic",
- "sp-core",
  "sp-io",
  "sp-runtime",
  "sp-std",

--- a/runtime/kusama/src/xcm_config.rs
+++ b/runtime/kusama/src/xcm_config.rs
@@ -41,9 +41,8 @@ use xcm_builder::{
 	ChildParachainConvertsVia, ChildSystemParachainAsSuperuser,
 	CurrencyAdapter as XcmCurrencyAdapter, FixedWeightBounds, IsChildSystemParachain, IsConcrete,
 	MintLocation, OriginToPluralityVoice, SignedAccountId32AsNative, SignedToAccountId32,
-	SovereignSignedViaLocation, TakeWeightCredit, TinkernetMultisigAsAccountId,
-	TinkernetMultisigAsNative, TrailingSetTopicAsId, UsingComponents, WeightInfoBounds,
-	WithComputedOrigin, WithUniqueTopic,
+	SovereignSignedViaLocation, TakeWeightCredit, TrailingSetTopicAsId, UsingComponents,
+	WeightInfoBounds, WithComputedOrigin, WithUniqueTopic,
 };
 use xcm_executor::traits::WithOriginFilter;
 
@@ -71,8 +70,6 @@ pub type SovereignAccountOf = (
 	ChildParachainConvertsVia<ParaId, AccountId>,
 	// We can directly alias an `AccountId32` into a local account.
 	AccountId32Aliases<ThisNetwork, AccountId>,
-	// We can derive a local account from a Tinkernet XCMultisig MultiLocation.
-	TinkernetMultisigAsAccountId<AccountId>,
 );
 
 /// Our asset transactor. This is what allows us to interest with the runtime facilities from the point of
@@ -102,8 +99,6 @@ type LocalOriginConverter = (
 	SignedAccountId32AsNative<ThisNetwork, RuntimeOrigin>,
 	// A system child parachain, expressed as a Superuser, converts to the `Root` origin.
 	ChildSystemParachainAsSuperuser<ParaId, RuntimeOrigin>,
-	// Converts a Tinkernet XCMultisig MultiLocation into a `Signed` origin.
-	TinkernetMultisigAsNative<RuntimeOrigin>,
 );
 
 parameter_types! {

--- a/runtime/rococo/src/xcm_config.rs
+++ b/runtime/rococo/src/xcm_config.rs
@@ -40,8 +40,8 @@ use xcm_builder::{
 	ChildParachainAsNative, ChildParachainConvertsVia, ChildSystemParachainAsSuperuser,
 	CurrencyAdapter as XcmCurrencyAdapter, FixedWeightBounds, IsChildSystemParachain, IsConcrete,
 	MintLocation, SignedAccountId32AsNative, SignedToAccountId32, SovereignSignedViaLocation,
-	TakeWeightCredit, TinkernetMultisigAsAccountId, TinkernetMultisigAsNative,
-	TrailingSetTopicAsId, UsingComponents, WeightInfoBounds, WithComputedOrigin, WithUniqueTopic,
+	TakeWeightCredit, TrailingSetTopicAsId, UsingComponents, WeightInfoBounds, WithComputedOrigin,
+	WithUniqueTopic,
 };
 use xcm_executor::{traits::WithOriginFilter, XcmExecutor};
 
@@ -53,12 +53,8 @@ parameter_types! {
 	pub LocalCheckAccount: (AccountId, MintLocation) = (CheckAccount::get(), MintLocation::Local);
 }
 
-pub type LocationConverter = (
-	ChildParachainConvertsVia<ParaId, AccountId>,
-	AccountId32Aliases<ThisNetwork, AccountId>,
-	// We can derive a local account from a Tinkernet XCMultisig MultiLocation.
-	TinkernetMultisigAsAccountId<AccountId>,
-);
+pub type LocationConverter =
+	(ChildParachainConvertsVia<ParaId, AccountId>, AccountId32Aliases<ThisNetwork, AccountId>);
 
 /// Our asset transactor. This is what allows us to interest with the runtime facilities from the point of
 /// view of XCM-only concepts like `MultiLocation` and `MultiAsset`.
@@ -87,8 +83,6 @@ type LocalOriginConverter = (
 	SignedAccountId32AsNative<ThisNetwork, RuntimeOrigin>,
 	// A system child parachain, expressed as a Superuser, converts to the `Root` origin.
 	ChildSystemParachainAsSuperuser<ParaId, RuntimeOrigin>,
-	// Converts a Tinkernet XCMultisig MultiLocation into a `Signed` origin.
-	TinkernetMultisigAsNative<RuntimeOrigin>,
 );
 
 parameter_types! {

--- a/xcm/xcm-builder/Cargo.toml
+++ b/xcm/xcm-builder/Cargo.toml
@@ -15,7 +15,6 @@ sp-std = { git = "https://github.com/paritytech/substrate", branch = "master", d
 sp-arithmetic = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 sp-io = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 sp-weights = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 frame-support = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 frame-system = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
@@ -50,7 +49,6 @@ std = [
 	"sp-arithmetic/std",
 	"sp-io/std",
 	"sp-runtime/std",
-	"sp-core/std",
 	"sp-weights/std",
 	"frame-support/std",
 	"frame-system/std",

--- a/xcm/xcm-builder/src/lib.rs
+++ b/xcm/xcm-builder/src/lib.rs
@@ -34,7 +34,7 @@ pub use location_conversion::{
 	ChildParachainConvertsVia, DescribeAccountId32Terminal, DescribeAccountIdTerminal,
 	DescribeAccountKey20Terminal, DescribeAllTerminal, DescribeFamily, DescribeLocation,
 	DescribePalletTerminal, DescribeTerminus, GlobalConsensusParachainConvertsFor,
-	HashedDescription, ParentIsPreset, SiblingParachainConvertsVia, TinkernetMultisigAsAccountId,
+	HashedDescription, ParentIsPreset, SiblingParachainConvertsVia,
 };
 
 mod origin_conversion;
@@ -42,7 +42,7 @@ pub use origin_conversion::{
 	BackingToPlurality, ChildParachainAsNative, ChildSystemParachainAsSuperuser, EnsureXcmOrigin,
 	OriginToPluralityVoice, ParentAsSuperuser, RelayChainAsNative, SiblingParachainAsNative,
 	SiblingSystemParachainAsSuperuser, SignedAccountId32AsNative, SignedAccountKey20AsNative,
-	SignedToAccountId32, SovereignSignedViaLocation, TinkernetMultisigAsNative,
+	SignedToAccountId32, SovereignSignedViaLocation,
 };
 
 mod asset_conversion;

--- a/xcm/xcm-builder/src/location_conversion.rs
+++ b/xcm/xcm-builder/src/location_conversion.rs
@@ -17,7 +17,6 @@
 use crate::universal_exports::ensure_is_remote;
 use frame_support::traits::Get;
 use parity_scale_codec::{Compact, Decode, Encode};
-use sp_core::H256;
 use sp_io::hashing::blake2_256;
 use sp_runtime::traits::{AccountIdConversion, Convert, TrailingZeroInput};
 use sp_std::{marker::PhantomData, prelude::*};
@@ -343,52 +342,6 @@ impl<Network: Get<Option<NetworkId>>, AccountId: From<[u8; 20]> + Into<[u8; 20]>
 			_ => return None,
 		};
 		Some(key.into())
-	}
-}
-
-/// Tinkernet ParaId used when matching Multisig MultiLocations.
-pub const KUSAMA_TINKERNET_PARA_ID: u32 = 2125;
-
-/// Tinkernet Multisig pallet instance used when matching Multisig MultiLocations.
-pub const KUSAMA_TINKERNET_MULTISIG_PALLET: u8 = 71;
-
-/// Constant derivation function for Tinkernet Multisigs.
-/// Uses the Tinkernet genesis hash as a salt.
-pub fn derive_tinkernet_multisig<AccountId: Decode>(id: u128) -> Result<AccountId, ()> {
-	AccountId::decode(&mut TrailingZeroInput::new(
-		&(
-			// The constant salt used to derive Tinkernet Multisigs, this is Tinkernet's genesis hash.
-			H256([
-				212, 46, 150, 6, 169, 149, 223, 228, 51, 220, 121, 85, 220, 42, 112, 244, 149, 243,
-				80, 243, 115, 218, 162, 0, 9, 138, 232, 68, 55, 129, 106, 210,
-			]),
-			// The actual multisig integer id.
-			u32::try_from(id).map_err(|_| ())?,
-		)
-			.using_encoded(blake2_256),
-	))
-	.map_err(|_| ())
-}
-
-/// Convert a Tinkernet Multisig `MultiLocation` value into a local `AccountId`.
-pub struct TinkernetMultisigAsAccountId<AccountId>(PhantomData<AccountId>);
-impl<AccountId: Decode + Clone> ConvertLocation<AccountId>
-	for TinkernetMultisigAsAccountId<AccountId>
-{
-	fn convert_location(location: &MultiLocation) -> Option<AccountId> {
-		match location {
-			MultiLocation {
-				parents: _,
-				interior:
-					X3(
-						Parachain(KUSAMA_TINKERNET_PARA_ID),
-						PalletInstance(KUSAMA_TINKERNET_MULTISIG_PALLET),
-						// Index from which the multisig account is derived.
-						GeneralIndex(id),
-					),
-			} => derive_tinkernet_multisig(*id).ok(),
-			_ => None,
-		}
 	}
 }
 
@@ -835,25 +788,5 @@ mod tests {
 			interior: X1(AccountKey20 { network: None, key: [0u8; 20] }),
 		};
 		assert!(ForeignChainAliasAccount::<[u8; 32]>::convert_location(&mul).is_none());
-	}
-
-	#[test]
-	fn remote_tinkernet_multisig_convert_to_account() {
-		let mul = MultiLocation {
-			parents: 0,
-			interior: X3(
-				Parachain(KUSAMA_TINKERNET_PARA_ID),
-				PalletInstance(KUSAMA_TINKERNET_MULTISIG_PALLET),
-				GeneralIndex(0),
-			),
-		};
-
-		assert_eq!(
-			[
-				97, 160, 244, 60, 133, 145, 170, 26, 202, 108, 203, 156, 114, 116, 175, 30, 156,
-				195, 43, 101, 243, 51, 193, 162, 152, 188, 30, 165, 244, 81, 70, 90
-			],
-			TinkernetMultisigAsAccountId::<[u8; 32]>::convert_location(&mul).unwrap()
-		);
 	}
 }

--- a/xcm/xcm-builder/src/origin_conversion.rs
+++ b/xcm/xcm-builder/src/origin_conversion.rs
@@ -16,12 +16,8 @@
 
 //! Various implementations for `ConvertOrigin`.
 
-use crate::location_conversion::{
-	derive_tinkernet_multisig, KUSAMA_TINKERNET_MULTISIG_PALLET, KUSAMA_TINKERNET_PARA_ID,
-};
 use frame_support::traits::{EnsureOrigin, Get, GetBacking, OriginTrait};
 use frame_system::RawOrigin as SystemRawOrigin;
-use parity_scale_codec::Decode;
 use polkadot_parachain::primitives::IsSystem;
 use sp_runtime::traits::TryConvert;
 use sp_std::marker::PhantomData;
@@ -240,37 +236,6 @@ where
 				MultiLocation { parents: 0, interior: X1(Junction::AccountKey20 { key, network }) },
 			) if (matches!(network, None) || network == Network::get()) =>
 				Ok(RuntimeOrigin::signed(key.into())),
-			(_, origin) => Err(origin),
-		}
-	}
-}
-
-/// Convert a Tinkernet Multisig `MultiLocation` value into a `Signed` origin.
-pub struct TinkernetMultisigAsNative<RuntimeOrigin>(PhantomData<RuntimeOrigin>);
-impl<RuntimeOrigin: OriginTrait> ConvertOrigin<RuntimeOrigin>
-	for TinkernetMultisigAsNative<RuntimeOrigin>
-where
-	RuntimeOrigin::AccountId: Decode,
-{
-	fn convert_origin(
-		origin: impl Into<MultiLocation>,
-		kind: OriginKind,
-	) -> Result<RuntimeOrigin, MultiLocation> {
-		let origin = origin.into();
-		match (kind, origin) {
-			(
-				OriginKind::Native,
-				MultiLocation {
-					parents: _,
-					interior:
-						X3(
-							Junction::Parachain(KUSAMA_TINKERNET_PARA_ID),
-							Junction::PalletInstance(KUSAMA_TINKERNET_MULTISIG_PALLET),
-							// Index from which the multisig account is derived.
-							Junction::GeneralIndex(id),
-						),
-				},
-			) => Ok(RuntimeOrigin::signed(derive_tinkernet_multisig(id).map_err(|_| origin)?)),
 			(_, origin) => Err(origin),
 		}
 	}


### PR DESCRIPTION
Reverts paritytech/polkadot#7165

Items specific to Kusama which go into common crates like `xcm-builder` should:

a) be placed in a Kusama-specific path or have "Kusama" clearly placed in its name; and
b) convert the `MultiLocation` value to be universal and then that used for matching.

This code makes little sense outside of the very specific context it is designed for. In particular, matching code like `parents: _` is not tight enough, especially when combined with a non-consensus-specific `Parachain` junction matcher. First converting into a universal location and then matching on that would alleviate these issues.

Once the runtimes are moved out into the Fellowship repo, this code should be, too. For now it can reasonably live next to the runtime, but it's just too inherently opinionated to be placed in `xcm-builder`.