### PR TITLE
Update pr-custom-review.yml 3 Core-devs to approve

### DIFF
--- a/.github/pr-custom-review.yml
+++ b/.github/pr-custom-review.yml
@@ -23,7 +23,7 @@ rules:
       include: .*
       # excluding files from 'Runtime files' and 'CI files' rules
       exclude: ^runtime/(kusama|polkadot)/src/[^/]+\.rs$|^\.gitlab-ci\.yml|^(?!.*\.dic$|.*spellcheck\.toml$)scripts/ci/.*|^\.github/.*
-    min_approvals: 2
+    min_approvals: 3
     teams:
       - core-devs
 


### PR DESCRIPTION
Context: 
Until last week we always had to have minimum 2 approvals from core-devs to merge PR, regardless if you're core-dev or external contributor
Due to https://github.com/paritytech/pr-custom-review/issues/104 we've started count the contributor (PR author) as one of the "knower-of-code", so now, if we keep `min_approvals: 2`, for core-dev author PRs - it's only 1 approval needed to merge, (example https://github.com/paritytech/polkadot/pull/7451), thus we need to bump min_approvals to match a criteria in https://github.com/paritytech/pr-custom-review/issues/104
Read more:
- https://github.com/paritytech/pr-custom-review/issues/104#issuecomment-1604609376
- https://github.com/paritytech/pr-custom-review/issues/104#issuecomment-1614723949

After this change, core-dev authors will remain to have 2 reviews to be made by other core-devs, 
while external developers would require 3 core-dev approvals
