### PR TITLE
async-backing: Optimize collator-protocol validator-side request fetching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7020,7 +7020,6 @@ dependencies = [
 name = "polkadot-collator-protocol"
 version = "0.9.43"
 dependencies = [
- "always-assert",
  "assert_matches",
  "bitvec 1.0.1",
  "env_logger 0.9.0",
@@ -7043,6 +7042,7 @@ dependencies = [
  "sp-keystore",
  "sp-runtime",
  "thiserror",
+ "tokio-util",
  "tracing-gum",
 ]
 

--- a/node/network/collator-protocol/Cargo.toml
+++ b/node/network/collator-protocol/Cargo.toml
@@ -5,7 +5,6 @@ authors.workspace = true
 edition.workspace = true
 
 [dependencies]
-always-assert = "0.1.2"
 bitvec = { version = "1.0.1", default-features = false, features = ["alloc"] }
 futures = "0.3.21"
 futures-timer = "3"
@@ -22,6 +21,7 @@ polkadot-node-subsystem-util = { path = "../../subsystem-util" }
 polkadot-node-subsystem = {path = "../../subsystem" }
 fatality = "0.0.6"
 thiserror = "1.0.31"
+tokio-util = "0.7.1"
 
 [dev-dependencies]
 log = "0.4.17"

--- a/node/network/collator-protocol/src/error.rs
+++ b/node/network/collator-protocol/src/error.rs
@@ -69,9 +69,6 @@ pub enum Error {
 /// to start seconding a candidate.
 #[derive(Debug, thiserror::Error)]
 pub enum SecondingError {
-	#[error("Failed to fetch a collation")]
-	FailedToFetch(#[from] oneshot::Canceled),
-
 	#[error("Error while accessing Runtime API")]
 	RuntimeApi(#[from] RuntimeApiError),
 

--- a/node/network/collator-protocol/src/validator_side/collation.rs
+++ b/node/network/collator-protocol/src/validator_side/collation.rs
@@ -27,7 +27,6 @@
 //!    ┌──────────────────────────────────────────┐
 //!    └─▶Advertised ─▶ Pending ─▶ Fetched ─▶ Validated
 
-use futures::channel::oneshot;
 use std::collections::VecDeque;
 
 use polkadot_node_network_protocol::PeerId;
@@ -150,8 +149,7 @@ pub fn fetched_collation_sanity_check(
 
 pub type CollationEvent = (CollatorId, PendingCollation);
 
-pub type PendingCollationFetch =
-	(CollationEvent, std::result::Result<(CandidateReceipt, PoV), oneshot::Canceled>);
+pub type PendingCollationFetch = (CollationEvent, (CandidateReceipt, PoV));
 
 /// The status of the collations in [`CollationsPerRelayParent`].
 #[derive(Debug, Clone, Copy)]

--- a/node/network/collator-protocol/src/validator_side/metrics.rs
+++ b/node/network/collator-protocol/src/validator_side/metrics.rs
@@ -50,7 +50,7 @@ impl Metrics {
 			.map(|metrics| metrics.collator_peer_count.set(collator_peers as u64));
 	}
 
-	/// Provide a timer for `PerRequest` structure which observes on drop.
+	/// Provide a timer for `CollationFetchRequest` structure which observes on drop.
 	pub fn time_collation_request_duration(
 		&self,
 	) -> Option<metrics::prometheus::prometheus::HistogramTimer> {
@@ -121,7 +121,7 @@ impl metrics::Metrics for Metrics {
 				prometheus::Histogram::with_opts(
 					prometheus::HistogramOpts::new(
 						"polkadot_parachain_collator_protocol_validator_collation_request_duration",
-						"Lifetime of the `PerRequest` structure",
+						"Lifetime of the `CollationFetchRequest` structure",
 					).buckets(vec![0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.75, 0.9, 1.0, 1.2, 1.5, 1.75]),
 				)?,
 				registry,

--- a/node/network/collator-protocol/src/validator_side/tests/mod.rs
+++ b/node/network/collator-protocol/src/validator_side/tests/mod.rs
@@ -28,7 +28,7 @@ use polkadot_node_network_protocol::{
 	request_response::{Requests, ResponseSender},
 	ObservedRole,
 };
-use polkadot_node_primitives::BlockData;
+use polkadot_node_primitives::{BlockData, PoV};
 use polkadot_node_subsystem::{
 	errors::RuntimeApiError,
 	messages::{AllMessages, ReportPeerMessage, RuntimeApiMessage, RuntimeApiRequest},
@@ -36,8 +36,8 @@ use polkadot_node_subsystem::{
 use polkadot_node_subsystem_test_helpers as test_helpers;
 use polkadot_node_subsystem_util::{reputation::add_reputation, TimeoutExt};
 use polkadot_primitives::{
-	CollatorPair, CoreState, GroupIndex, GroupRotationInfo, HeadData, OccupiedCore,
-	PersistedValidationData, ScheduledCore, ValidatorId, ValidatorIndex,
+	CandidateReceipt, CollatorPair, CoreState, GroupIndex, GroupRotationInfo, HeadData,
+	OccupiedCore, PersistedValidationData, ScheduledCore, ValidatorId, ValidatorIndex,
 };
 use polkadot_primitives_test_helpers::{
 	dummy_candidate_descriptor, dummy_candidate_receipt_bad_sig, dummy_hash,


### PR DESCRIPTION
**Reopening https://github.com/paritytech/polkadot/pull/7440, on the async backing feature branch**

1. Refactors the collation fetching code to use `FuturesUnordered` instead of a `HashMap` of futures.
This enables us to remove the 5 ms `CHECK_COLLATIONS_POLL` interval future. Prior to this, we were constantly breaking out of the main select! in order to check if any collators sent us the requested collation, which is inefficient.
We are now polling the NetworkBridge response channel instead and only break out of the `select!` once we know for sure that a collation response was received.
As a side effect, since we're no longer using a `HashMap`, we rely on [`CancellationToken`](https://docs.rs/tokio-util/latest/tokio_util/sync/struct.CancellationToken.html)s to cancel requests (for example when relay parents are removed).

2. Removes the intermediate `collation_fetches` oneshot channels. This was a needless indirection that forced the code to enter the `select!` loop twice before a response was fully handled.

Closes https://github.com/paritytech/polkadot/issues/4182