### PR TITLE
Xcm-Builder: PayOverXcm - pass `Beneficiary` as value to infallible `Convert`

### DIFF
--- a/xcm/xcm-builder/src/location_conversion.rs
+++ b/xcm/xcm-builder/src/location_conversion.rs
@@ -321,11 +321,11 @@ impl<Network: Get<Option<NetworkId>>, AccountId: From<[u8; 32]> + Into<[u8; 32]>
 /// `MultiLocation` consisting solely of a `AccountId32` junction with a fixed value for its
 /// network (provided by `Network`) and the `AccountId`'s `[u8; 32]` datum for the `id`.
 pub struct AliasesIntoAccountId32<Network, AccountId>(PhantomData<(Network, AccountId)>);
-impl<'a, Network: Get<Option<NetworkId>>, AccountId: Clone + Into<[u8; 32]> + Clone>
-	Convert<&'a AccountId, MultiLocation> for AliasesIntoAccountId32<Network, AccountId>
+impl<Network: Get<Option<NetworkId>>, AccountId: Into<[u8; 32]>> Convert<AccountId, MultiLocation>
+	for AliasesIntoAccountId32<Network, AccountId>
 {
-	fn convert(who: &AccountId) -> MultiLocation {
-		AccountId32 { network: Network::get(), id: who.clone().into() }.into()
+	fn convert(who: AccountId) -> MultiLocation {
+		AccountId32 { network: Network::get(), id: who.into() }.into()
 	}
 }
 

--- a/xcm/xcm-builder/src/pay.rs
+++ b/xcm/xcm-builder/src/pay.rs
@@ -51,7 +51,7 @@ pub struct PayOverXcm<
 	Beneficiary,
 	AssetKind,
 	AssetKindToLocatableAsset,
-	BeneficiaryRefToLocation,
+	BeneficiaryToLocation,
 >(
 	PhantomData<(
 		Interior,
@@ -61,7 +61,7 @@ pub struct PayOverXcm<
 		Beneficiary,
 		AssetKind,
 		AssetKindToLocatableAsset,
-		BeneficiaryRefToLocation,
+		BeneficiaryToLocation,
 	)>,
 );
 impl<
@@ -72,7 +72,7 @@ impl<
 		Beneficiary: Clone,
 		AssetKind,
 		AssetKindToLocatableAsset: Convert<AssetKind, LocatableAssetId>,
-		BeneficiaryRefToLocation: for<'a> Convert<&'a Beneficiary, MultiLocation>,
+		BeneficiaryToLocation: Convert<Beneficiary, MultiLocation>,
 	> Pay
 	for PayOverXcm<
 		Interior,
@@ -82,7 +82,7 @@ impl<
 		Beneficiary,
 		AssetKind,
 		AssetKindToLocatableAsset,
-		BeneficiaryRefToLocation,
+		BeneficiaryToLocation,
 	>
 {
 	type Beneficiary = Beneficiary;
@@ -101,7 +101,7 @@ impl<
 		let destination = Querier::UniversalLocation::get()
 			.invert_target(&asset_location)
 			.map_err(|()| Self::Error::LocationNotInvertible)?;
-		let beneficiary = BeneficiaryRefToLocation::convert(&who);
+		let beneficiary = BeneficiaryToLocation::convert(who.clone());
 
 		let query_id = Querier::new_query(asset_location, Timeout::get(), Interior::get());
 


### PR DESCRIPTION
In this update, the `Beneficiary` is passed as a value to the infallible `Convert` bound in the Xcm-Builder's `PayOverXcm` type.

The modification enables the utilization of the `Identity` type.