### PR TITLE
backing: Remove redundant erasure encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7071,6 +7071,7 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "polkadot-erasure-coding",
+ "polkadot-node-jaeger",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-test-helpers",

--- a/node/core/av-store/Cargo.toml
+++ b/node/core/av-store/Cargo.toml
@@ -20,6 +20,7 @@ polkadot-overseer = { path = "../../overseer" }
 polkadot-primitives = { path = "../../../primitives" }
 polkadot-node-primitives = { path = "../../primitives" }
 sp-consensus = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+polkadot-node-jaeger = { path = "../../jaeger" }
 
 [dev-dependencies]
 log = "0.4.17"

--- a/node/core/av-store/src/lib.rs
+++ b/node/core/av-store/src/lib.rs
@@ -1212,10 +1212,10 @@ fn process_message(
 					return Err(Error::InvalidErasureRoot)
 				},
 				Err(e) => {
-					// We do not bubble up internal errors to caller caller subsystems, instead the
-					// tx channel is dropped and that error is caught in the subsystem.
+					// We do not bubble up internal errors to caller subsystems, instead the
+					// tx channel is dropped and that error is caught by the caller subsystem.
 					//
-					// We bubble up the specific error here so the logs still tell what happend.
+					// We bubble up the specific error here so `av-store` logs still tell what happend.
 					return Err(e.into())
 				},
 			}

--- a/node/core/av-store/src/tests.rs
+++ b/node/core/av-store/src/tests.rs
@@ -416,6 +416,45 @@ fn query_chunk_checks_meta() {
 }
 
 #[test]
+fn store_available_data_erasure_mismatch() {
+	let store = test_store();
+	let test_state = TestState::default();
+	test_harness(test_state.clone(), store.clone(), |mut virtual_overseer| async move {
+		let candidate_hash = CandidateHash(Hash::repeat_byte(1));
+		let validator_index = ValidatorIndex(5);
+		let n_validators = 10;
+
+		let pov = PoV { block_data: BlockData(vec![4, 5, 6]) };
+
+		let available_data = AvailableData {
+			pov: Arc::new(pov),
+			validation_data: test_state.persisted_validation_data.clone(),
+		};
+		let (tx, rx) = oneshot::channel();
+
+		let block_msg = AvailabilityStoreMessage::StoreAvailableData {
+			candidate_hash,
+			n_validators,
+			available_data: available_data.clone(),
+			tx,
+			// A dummy erasure root should lead to failure.
+			expected_erasure_root: Hash::default(),
+		};
+
+		virtual_overseer.send(FromOrchestra::Communication { msg: block_msg }).await;
+		assert_eq!(rx.await.unwrap(), Err(()));
+
+		assert!(query_available_data(&mut virtual_overseer, candidate_hash).await.is_none());
+
+		assert!(query_chunk(&mut virtual_overseer, candidate_hash, validator_index)
+			.await
+			.is_none());
+
+		virtual_overseer
+	});
+}
+
+#[test]
 fn store_block_works() {
 	let store = test_store();
 	let test_state = TestState::default();
@@ -430,13 +469,17 @@ fn store_block_works() {
 			pov: Arc::new(pov),
 			validation_data: test_state.persisted_validation_data.clone(),
 		};
-
 		let (tx, rx) = oneshot::channel();
+
+		let chunks = erasure::obtain_chunks_v1(10, &available_data).unwrap();
+		let mut branches = erasure::branches(chunks.as_ref());
+
 		let block_msg = AvailabilityStoreMessage::StoreAvailableData {
 			candidate_hash,
 			n_validators,
 			available_data: available_data.clone(),
 			tx,
+			expected_erasure_root: branches.root(),
 		};
 
 		virtual_overseer.send(FromOrchestra::Communication { msg: block_msg }).await;
@@ -448,10 +491,6 @@ fn store_block_works() {
 		let chunk = query_chunk(&mut virtual_overseer, candidate_hash, validator_index)
 			.await
 			.unwrap();
-
-		let chunks = erasure::obtain_chunks_v1(10, &available_data).unwrap();
-
-		let mut branches = erasure::branches(chunks.as_ref());
 
 		let branch = branches.nth(5).unwrap();
 		let expected_chunk = ErasureChunk {
@@ -483,6 +522,7 @@ fn store_pov_and_query_chunk_works() {
 
 		let chunks_expected =
 			erasure::obtain_chunks_v1(n_validators as _, &available_data).unwrap();
+		let branches = erasure::branches(chunks_expected.as_ref());
 
 		let (tx, rx) = oneshot::channel();
 		let block_msg = AvailabilityStoreMessage::StoreAvailableData {
@@ -490,6 +530,7 @@ fn store_pov_and_query_chunk_works() {
 			n_validators,
 			available_data,
 			tx,
+			expected_erasure_root: branches.root(),
 		};
 
 		virtual_overseer.send(FromOrchestra::Communication { msg: block_msg }).await;
@@ -530,12 +571,16 @@ fn query_all_chunks_works() {
 		};
 
 		{
+			let chunks_expected =
+				erasure::obtain_chunks_v1(n_validators as _, &available_data).unwrap();
+			let branches = erasure::branches(chunks_expected.as_ref());
 			let (tx, rx) = oneshot::channel();
 			let block_msg = AvailabilityStoreMessage::StoreAvailableData {
 				candidate_hash: candidate_hash_1,
 				n_validators,
 				available_data,
 				tx,
+				expected_erasure_root: branches.root(),
 			};
 
 			virtual_overseer.send(FromOrchestra::Communication { msg: block_msg }).await;
@@ -619,11 +664,15 @@ fn stored_but_not_included_data_is_pruned() {
 		};
 
 		let (tx, rx) = oneshot::channel();
+		let chunks = erasure::obtain_chunks_v1(n_validators as _, &available_data).unwrap();
+		let branches = erasure::branches(chunks.as_ref());
+
 		let block_msg = AvailabilityStoreMessage::StoreAvailableData {
 			candidate_hash,
 			n_validators,
 			available_data: available_data.clone(),
 			tx,
+			expected_erasure_root: branches.root(),
 		};
 
 		virtual_overseer.send(FromOrchestra::Communication { msg: block_msg }).await;
@@ -670,12 +719,16 @@ fn stored_data_kept_until_finalized() {
 		let parent = Hash::repeat_byte(2);
 		let block_number = 10;
 
+		let chunks = erasure::obtain_chunks_v1(n_validators as _, &available_data).unwrap();
+		let branches = erasure::branches(chunks.as_ref());
+
 		let (tx, rx) = oneshot::channel();
 		let block_msg = AvailabilityStoreMessage::StoreAvailableData {
 			candidate_hash,
 			n_validators,
 			available_data: available_data.clone(),
 			tx,
+			expected_erasure_root: branches.root(),
 		};
 
 		virtual_overseer.send(FromOrchestra::Communication { msg: block_msg }).await;
@@ -946,17 +999,24 @@ fn forkfullness_works() {
 			validation_data: test_state.persisted_validation_data.clone(),
 		};
 
+		let chunks = erasure::obtain_chunks_v1(n_validators as _, &available_data_1).unwrap();
+		let branches = erasure::branches(chunks.as_ref());
+
 		let (tx, rx) = oneshot::channel();
 		let msg = AvailabilityStoreMessage::StoreAvailableData {
 			candidate_hash: candidate_1_hash,
 			n_validators,
 			available_data: available_data_1.clone(),
 			tx,
+			expected_erasure_root: branches.root(),
 		};
 
 		virtual_overseer.send(FromOrchestra::Communication { msg }).await;
 
 		rx.await.unwrap().unwrap();
+
+		let chunks = erasure::obtain_chunks_v1(n_validators as _, &available_data_2).unwrap();
+		let branches = erasure::branches(chunks.as_ref());
 
 		let (tx, rx) = oneshot::channel();
 		let msg = AvailabilityStoreMessage::StoreAvailableData {
@@ -964,6 +1024,7 @@ fn forkfullness_works() {
 			n_validators,
 			available_data: available_data_2.clone(),
 			tx,
+			expected_erasure_root: branches.root(),
 		};
 
 		virtual_overseer.send(FromOrchestra::Communication { msg }).await;

--- a/node/core/av-store/src/tests.rs
+++ b/node/core/av-store/src/tests.rs
@@ -442,7 +442,7 @@ fn store_available_data_erasure_mismatch() {
 		};
 
 		virtual_overseer.send(FromOrchestra::Communication { msg: block_msg }).await;
-		assert_eq!(rx.await.unwrap(), Err(()));
+		assert_eq!(rx.await.unwrap(), Err(StoreAvailableDataError::InvalidErasureRoot));
 
 		assert!(query_available_data(&mut virtual_overseer, candidate_hash).await.is_none());
 

--- a/node/core/backing/src/error.rs
+++ b/node/core/backing/src/error.rs
@@ -17,7 +17,10 @@
 use fatality::Nested;
 use futures::channel::{mpsc, oneshot};
 
-use polkadot_node_subsystem::{messages::ValidationFailed, SubsystemError};
+use polkadot_node_subsystem::{
+	messages::{StoreAvailableDataError, ValidationFailed},
+	SubsystemError,
+};
 use polkadot_node_subsystem_util::Error as UtilError;
 use polkadot_primitives::BackedCandidate;
 
@@ -50,7 +53,7 @@ pub enum Error {
 	ValidateFromChainState(#[source] oneshot::Canceled),
 
 	#[error("StoreAvailableData channel closed before receipt")]
-	StoreAvailableData(#[source] oneshot::Canceled),
+	StoreAvailableDataChannel(#[source] oneshot::Canceled),
 
 	#[error("a channel was closed before receipt in try_join!")]
 	JoinMultiple(#[source] oneshot::Canceled),
@@ -74,6 +77,9 @@ pub enum Error {
 	#[fatal]
 	#[error(transparent)]
 	OverseerExited(SubsystemError),
+
+	#[error("Availability store error")]
+	StoreAvailableData(#[source] StoreAvailableDataError),
 }
 
 /// Utility for eating top level errors and log them.

--- a/node/subsystem-types/src/messages.rs
+++ b/node/subsystem-types/src/messages.rs
@@ -472,6 +472,8 @@ pub enum AvailabilityStoreMessage {
 		n_validators: u32,
 		/// The `AvailableData` itself.
 		available_data: AvailableData,
+		/// Erasure root we expect to get after chunking.
+		expected_erasure_root: Hash,
 		/// Sending side of the channel to send result to.
 		tx: oneshot::Sender<Result<(), ()>>,
 	},

--- a/node/subsystem-types/src/messages.rs
+++ b/node/subsystem-types/src/messages.rs
@@ -462,9 +462,10 @@ pub enum AvailabilityStoreMessage {
 		tx: oneshot::Sender<Result<(), ()>>,
 	},
 
-	/// Store a `AvailableData` and all of its chunks in the AV store.
+	/// Computes and checks the erasure root of `AvailableData` before storing all of its chunks in
+	/// the AV store.
 	///
-	/// Return `Ok(())` if the store operation succeeded, `Err(())` if it failed.
+	/// Return `Ok(())` if the store operation succeeded, `Err(StoreAvailableData)` if it failed.
 	StoreAvailableData {
 		/// A hash of the candidate this `available_data` belongs to.
 		candidate_hash: CandidateHash,
@@ -475,8 +476,16 @@ pub enum AvailabilityStoreMessage {
 		/// Erasure root we expect to get after chunking.
 		expected_erasure_root: Hash,
 		/// Sending side of the channel to send result to.
-		tx: oneshot::Sender<Result<(), ()>>,
+		tx: oneshot::Sender<Result<(), StoreAvailableDataError>>,
 	},
+}
+
+/// The error result type of a [`AvailabilityStoreMessage::StoreAvailableData`] request.
+#[derive(Error, Debug, Clone, PartialEq, Eq)]
+#[allow(missing_docs)]
+pub enum StoreAvailableDataError {
+	#[error("The computed erasure root did not match expected one")]
+	InvalidErasureRoot,
 }
 
 /// A response channel for the result of a chain API request.

--- a/roadmap/implementers-guide/src/node/utility/availability-store.md
+++ b/roadmap/implementers-guide/src/node/utility/availability-store.md
@@ -155,6 +155,7 @@ On `StoreChunk` message:
 
 On `StoreAvailableData` message:
 
+- Compute the erasure root of the available data and compare it with `expected_erasure_root`. Return `StoreAvailableDataError::InvalidErasureRoot` on mismatch.
 - If there is no `CandidateMeta` under the candidate hash, create it with `State::Unavailable(now)`. Load the `CandidateMeta` otherwise.
 - Store `data` under `("available", candidate_hash)` and set `data_available` to true.
 - Store each chunk under `("chunk", candidate_hash, index)` and set every bit in `chunks_stored` to `1`.


### PR DESCRIPTION
In candidate backing we are calling `erasure_coding::obtain_chunks_v1` to get the erasure root and check it vs the expected root, but we drop the result and do this again in `av store`. This PR moves the check in `av store` and removes the redundant one in backing.

