### PR TITLE
paras: Prune upgrade cooldowns

### DIFF
--- a/runtime/parachains/src/paras/mod.rs
+++ b/runtime/parachains/src/paras/mod.rs
@@ -1262,7 +1262,7 @@ impl<T: Config> Pallet<T> {
 		// Persist parachains into the storage explicitly.
 		drop(parachains);
 
-		return outgoing
+		outgoing
 	}
 
 	// note replacement of the code of para with given `id`, which occured in the
@@ -1389,9 +1389,15 @@ impl<T: Config> Pallet<T> {
 	/// See `process_scheduled_upgrade_changes` for more details.
 	fn process_scheduled_upgrade_cooldowns(now: T::BlockNumber) {
 		UpgradeCooldowns::<T>::mutate(|upgrade_cooldowns: &mut Vec<(ParaId, T::BlockNumber)>| {
-			for &(para, _) in upgrade_cooldowns.iter().take_while(|&(_, at)| at <= &now) {
-				UpgradeRestrictionSignal::<T>::remove(&para);
-			}
+			// Remove all expired signals and also prune the cooldowns.
+			upgrade_cooldowns.retain(|(para, at)| {
+				if at <= &now {
+					UpgradeRestrictionSignal::<T>::remove(&para);
+					false
+				} else {
+					true
+				}
+			});
 		});
 	}
 


### PR DESCRIPTION
After an upgrade cooldown triggered to remove a signal we also need to prune it from the list.