### PR TITLE
license-scanner update

### DIFF
--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -11,16 +11,16 @@ jobs:
         uses: actions/checkout@v3.3.0
       - uses: actions/setup-node@v3.6.0
         with:
-          node-version: '16.19.0'
+          node-version: '18.x'
           registry-url: 'https://npm.pkg.github.com'
           scope: '@paritytech'
       - name: Check the licenses
         run: |
           shopt -s globstar
 
-          npx @paritytech/license-scanner@0.0.3 scan \
-            --ensure-licenses Apache-2.0 \
-            --ensure-licenses GPL-3.0-only \
+          npx @paritytech/license-scanner@0.0.5 scan \
+            --ensure-licenses=Apache-2.0 \
+            --ensure-licenses=GPL-3.0-only \
             ./**/*.rs
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
As Node@^16 reaches its end-of-life this October, we're upgrading to
Node@^18 everywhere
