### PR TITLE
[Do not merge] migration to ci-unified image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,7 +33,7 @@ variables:
   GIT_STRATEGY: fetch
   GIT_DEPTH: 100
   CI_SERVER_NAME: "GitLab CI"
-  CI_IMAGE: "paritytech/ci-linux:production"
+  CI_IMAGE: "paritytech/ci-unified:bullseye-1.70.0-2023-05-23"
   BUILDAH_IMAGE: "quay.io/buildah/stable:v1.29"
   BUILDAH_COMMAND: "buildah --storage-driver overlay2"
   DOCKER_OS: "debian:stretch"


### PR DESCRIPTION
New [ci-unified](https://github.com/paritytech/scripts/tree/master/dockerfiles/ci-unified) image for pipelines ($CI_IMAGE)
Replaces base-ci-linux and derived
Relates to https://github.com/paritytech/ci_cd/issues/821