### PR TITLE
Add publish = false to test-parachains and staking-miner

### DIFF
--- a/parachain/test-parachains/Cargo.toml
+++ b/parachain/test-parachains/Cargo.toml
@@ -4,6 +4,7 @@ description = "Integration tests using the test-parachains"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+publish = false
 
 [dependencies]
 tiny-keccak = { version = "2.0.2", features = ["keccak"] }

--- a/utils/staking-miner/Cargo.toml
+++ b/utils/staking-miner/Cargo.toml
@@ -7,6 +7,7 @@ name = "staking-miner"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+publish = false
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1" }


### PR DESCRIPTION
These crates should not be pushed.
See: https://forum.parity.io/t/renaming-squated-crates-in-substrate-polkadot-cumulus/1964