### PR TITLE
[DNM] approval-voting: approvals gossip and lazy signature checks optimizations

### DIFF
--- a/node/core/approval-voting/src/tests.rs
+++ b/node/core/approval-voting/src/tests.rs
@@ -590,6 +590,7 @@ async fn check_and_import_approval(
 			msg: ApprovalVotingMessage::CheckAndImportApproval(
 				IndirectSignedApprovalVote { block_hash, candidate_index, validator, signature },
 				tx,
+				false,
 			),
 		},
 	)

--- a/node/network/approval-distribution/src/lib.rs
+++ b/node/network/approval-distribution/src/lib.rs
@@ -210,34 +210,30 @@ struct Knowledge {
 	// When there is no entry, this means the message is unknown
 	// When there is an entry with `MessageKind::Assignment`, the assignment is known.
 	// When there is an entry with `MessageKind::Approval`, the assignment and approval are known.
-	known_messages: HashMap<MessageSubject, MessageKind>,
+	known_messages: HashMap<MessageSubject, Vec<MessageKind>>,
 }
 
 impl Knowledge {
 	fn contains(&self, message: &MessageSubject, kind: MessageKind) -> bool {
-		match (kind, self.known_messages.get(message)) {
-			(_, None) => false,
-			(MessageKind::Assignment, Some(_)) => true,
-			(MessageKind::Approval, Some(MessageKind::Assignment)) => false,
-			(MessageKind::Approval, Some(MessageKind::Approval)) => true,
-		}
+		self.known_messages
+			.get(message)
+			.map(|messages| messages.contains(&kind))
+			.unwrap_or(false)
 	}
 
 	fn insert(&mut self, message: MessageSubject, kind: MessageKind) -> bool {
 		match self.known_messages.entry(message) {
 			hash_map::Entry::Vacant(vacant) => {
-				vacant.insert(kind);
+				vacant.insert(vec![kind]);
 				true
 			},
-			hash_map::Entry::Occupied(mut occupied) => match (*occupied.get(), kind) {
-				(MessageKind::Assignment, MessageKind::Assignment) => false,
-				(MessageKind::Approval, MessageKind::Approval) => false,
-				(MessageKind::Approval, MessageKind::Assignment) => false,
-				(MessageKind::Assignment, MessageKind::Approval) => {
-					*occupied.get_mut() = MessageKind::Approval;
+			hash_map::Entry::Occupied(mut occupied) =>
+				if !occupied.get().contains(&kind) {
+					occupied.get_mut().push(kind);
 					true
+				} else {
+					false
 				},
-			},
 		}
 	}
 }
@@ -278,13 +274,15 @@ struct BlockEntry {
 enum ApprovalState {
 	Assigned(AssignmentCert),
 	Approved(AssignmentCert, ValidatorSignature),
+	UnassignedApproval(IndirectSignedApprovalVote, MessageSource),
 }
 
 impl ApprovalState {
-	fn assignment_cert(&self) -> &AssignmentCert {
+	fn assignment_cert(&self) -> Option<&AssignmentCert> {
 		match *self {
-			ApprovalState::Assigned(ref cert) => cert,
-			ApprovalState::Approved(ref cert, _) => cert,
+			ApprovalState::Assigned(ref cert) => Some(cert),
+			ApprovalState::Approved(ref cert, _) => Some(cert),
+			ApprovalState::UnassignedApproval(_, _) => None,
 		}
 	}
 
@@ -292,6 +290,7 @@ impl ApprovalState {
 		match *self {
 			ApprovalState::Assigned(_) => None,
 			ApprovalState::Approved(_, ref sig) => Some(sig.clone()),
+			ApprovalState::UnassignedApproval(_, _) => None,
 		}
 	}
 }
@@ -301,7 +300,10 @@ impl ApprovalState {
 // assignments preceding approvals in all cases.
 #[derive(Debug)]
 struct MessageState {
-	required_routing: RequiredRouting,
+	// Required routing for an approval
+	required_routing_assignment: RequiredRouting,
+	// Require routing for an assignment
+	required_routing_approval: RequiredRouting,
 	local: bool,
 	random_routing: RandomRouting,
 	approval_state: ApprovalState,
@@ -451,6 +453,8 @@ impl State {
 			for (peer_id, view) in self.peer_views.iter() {
 				let intersection = view.iter().filter(|h| new_hashes.contains(h));
 				let view_intersection = View::new(intersection.cloned(), view.finalized_number);
+				let should_trigger_aggression =
+					self.aggression_config.should_trigger_aggression(self.approval_checking_lag);
 				Self::unify_with_peer(
 					sender,
 					metrics,
@@ -460,6 +464,7 @@ impl State {
 					*peer_id,
 					view_intersection,
 					rng,
+					should_trigger_aggression,
 				)
 				.await;
 			}
@@ -678,7 +683,8 @@ impl State {
 					}
 				});
 		}
-
+		let should_trigger_aggression =
+			self.aggression_config.should_trigger_aggression(self.approval_checking_lag);
 		Self::unify_with_peer(
 			ctx.sender(),
 			metrics,
@@ -688,6 +694,7 @@ impl State {
 			peer_id,
 			view,
 			rng,
+			should_trigger_aggression,
 		)
 		.await;
 	}
@@ -774,7 +781,6 @@ impl State {
 				return
 			},
 		};
-
 		// compute metadata on the assignment.
 		let message_subject = MessageSubject(block_hash, claimed_candidate_index, validator_index);
 		let message_kind = MessageKind::Assignment;
@@ -872,7 +878,7 @@ impl State {
 						BENEFIT_VALID_MESSAGE_FIRST,
 					)
 					.await;
-					entry.knowledge.known_messages.insert(message_subject.clone(), message_kind);
+					entry.knowledge.insert(message_subject.clone(), message_kind);
 					if let Some(peer_knowledge) = entry.known_by.get_mut(&peer_id) {
 						peer_knowledge.received.insert(message_subject.clone(), message_kind);
 					}
@@ -950,32 +956,44 @@ impl State {
 		let topology = self.topologies.get_topology(entry.session);
 		let local = source == MessageSource::Local;
 
-		let required_routing = topology.map_or(RequiredRouting::PendingTopology, |t| {
+		let required_routing_assignment = topology.map_or(RequiredRouting::PendingTopology, |t| {
 			t.local_grid_neighbors().required_routing_by_index(validator_index, local)
 		});
 
-		let message_state = match entry.candidates.get_mut(claimed_candidate_index as usize) {
-			Some(candidate_entry) => {
-				// set the approval state for validator_index to Assigned
-				// unless the approval state is set already
-				candidate_entry.messages.entry(validator_index).or_insert_with(|| MessageState {
-					required_routing,
-					local,
-					random_routing: Default::default(),
-					approval_state: ApprovalState::Assigned(assignment.cert.clone()),
-				})
-			},
-			None => {
-				gum::warn!(
-					target: LOG_TARGET,
-					hash = ?block_hash,
-					?claimed_candidate_index,
-					"Expected a candidate entry on import_and_circulate_assignment",
-				);
+		let (message_state, cached_approval_vote) =
+			match entry.candidates.get_mut(claimed_candidate_index as usize) {
+				Some(candidate_entry) => {
+					// We might have received the approval before the assignment, so save it for processing after the assignment
+					let cached_approval_vote = candidate_entry.messages.remove(&validator_index);
+					metrics.on_delayed_approval_processed();
+					(
+						candidate_entry.messages.entry(validator_index).or_insert_with(|| {
+							MessageState {
+								required_routing_assignment,
+								required_routing_approval: if local {
+									RequiredRouting::All
+								} else {
+									RequiredRouting::None
+								},
+								local,
+								random_routing: Default::default(),
+								approval_state: ApprovalState::Assigned(assignment.cert.clone()),
+							}
+						}),
+						cached_approval_vote,
+					)
+				},
+				None => {
+					gum::warn!(
+						target: LOG_TARGET,
+						hash = ?block_hash,
+						?claimed_candidate_index,
+						"Expected a candidate entry on import_and_circulate_assignment",
+					);
 
-				return
-			},
-		};
+					return
+				},
+			};
 
 		// Dispatch the message to all peers in the routing set which
 		// know the block.
@@ -994,7 +1012,7 @@ impl State {
 
 			if let Some(true) = topology
 				.as_ref()
-				.map(|t| t.local_grid_neighbors().route_to_peer(required_routing, peer))
+				.map(|t| t.local_grid_neighbors().route_to_peer(required_routing_assignment, peer))
 			{
 				return true
 			}
@@ -1038,6 +1056,19 @@ impl State {
 				)),
 			))
 			.await;
+		}
+
+		if let Some(MessageState {
+			approval_state: ApprovalState::UnassignedApproval(vote, source),
+			..
+		}) = cached_approval_vote
+		{
+			gum::info!(
+				target: LOG_TARGET,
+				?message_subject,
+				"Delayed approval processed"
+			);
+			self.import_and_circulate_approval(ctx, metrics, source, vote).await
 		}
 	}
 
@@ -1090,7 +1121,48 @@ impl State {
 		let message_kind = MessageKind::Approval;
 
 		if let Some(peer_id) = source.peer_id() {
+			let sender_matches_validator_index = self
+				.topologies
+				.get_topology(entry.session)
+				.map(|topology| {
+					topology.get().peer_id_matches_validator_index(validator_index, peer_id)
+				})
+				.unwrap_or(false);
+
 			if !entry.knowledge.contains(&message_subject, MessageKind::Assignment) {
+				metrics.on_unassigned_approval();
+
+				match entry.candidates.get_mut(candidate_index as usize) {
+					// Approvals might arrive sooner than their corresponding assignment because we are sending them directly
+					// to all peers instead of relaying on them being gossiped, so we need to save them untill the assignment
+					// arrives.
+					// We could also receive gossiped assignments in the case when aggression is triggered, but in that
+					// case we do not care about saving them because they should arrive before their corresponding assignments,
+					// since they are sent on the same route.
+					Some(candidate_entry)
+						if sender_matches_validator_index &&
+							!candidate_entry.messages.contains_key(&validator_index) =>
+					{
+						candidate_entry.messages.entry(validator_index).or_insert_with(|| {
+							MessageState {
+								required_routing_assignment: RequiredRouting::None,
+								required_routing_approval: RequiredRouting::None,
+								local: false,
+								random_routing: Default::default(),
+								approval_state: ApprovalState::UnassignedApproval(vote, source),
+							}
+						});
+						gum::info!(
+							target: LOG_TARGET,
+							?peer_id,
+							?message_subject,
+							"Saving approval to process later on",
+						);
+						return
+					},
+					_ => {},
+				};
+
 				gum::debug!(
 					target: LOG_TARGET,
 					?peer_id,
@@ -1165,9 +1237,19 @@ impl State {
 			}
 
 			let (tx, rx) = oneshot::channel();
+			if !sender_matches_validator_index {
+				gum::info!(
+					target: LOG_TARGET,
+					"Received gossiped approval"
+				)
+			}
 
-			ctx.send_message(ApprovalVotingMessage::CheckAndImportApproval(vote.clone(), tx))
-				.await;
+			ctx.send_message(ApprovalVotingMessage::CheckAndImportApproval(
+				vote.clone(),
+				tx,
+				sender_matches_validator_index,
+			))
+			.await;
 
 			let timer = metrics.time_awaiting_approval_voting();
 			let result = match rx.await {
@@ -1238,17 +1320,19 @@ impl State {
 
 		// Invariant: to our knowledge, none of the peers except for the `source` know about the approval.
 		metrics.on_approval_imported();
-
-		let required_routing = match entry.candidates.get_mut(candidate_index as usize) {
+		let should_trigger_aggression =
+			self.aggression_config.should_trigger_aggression(self.approval_checking_lag);
+		let required_routing_approval = match entry.candidates.get_mut(candidate_index as usize) {
 			Some(candidate_entry) => {
 				// set the approval state for validator_index to Approved
 				// it should be in assigned state already
 				match candidate_entry.messages.remove(&validator_index) {
 					Some(MessageState {
 						approval_state: ApprovalState::Assigned(cert),
-						required_routing,
+						required_routing_assignment,
 						local,
 						random_routing,
+						required_routing_approval,
 					}) => {
 						candidate_entry.messages.insert(
 							validator_index,
@@ -1257,13 +1341,28 @@ impl State {
 									cert,
 									vote.signature.clone(),
 								),
-								required_routing,
+								required_routing_assignment,
 								local,
 								random_routing,
+								required_routing_approval,
 							},
 						);
-
-						required_routing
+						// When aggression is enabled gossip the approvals we received from peers, so that we reach finality.
+						if required_routing_approval == RequiredRouting::None &&
+							should_trigger_aggression
+						{
+							self.topologies
+								.get_topology(entry.session)
+								.zip(source.peer_id())
+								.map(|(topology, peer_id)| {
+									topology
+										.local_grid_neighbors()
+										.required_routing_by_peer_id(peer_id, local)
+								})
+								.unwrap_or(RequiredRouting::None)
+						} else {
+							required_routing_approval
+						}
 					},
 					Some(_) => {
 						unreachable!(
@@ -1309,7 +1408,8 @@ impl State {
 				return false
 			}
 
-			// Here we're leaning on a few behaviors of assignment propagation:
+			// When approvals are gossiped(l1 agression enabled) we are leaning on a few behaviors of
+			// assignment propagation:
 			//   1. At this point, the only peer we're aware of which has the approval
 			//      message is the source peer.
 			//   2. We have sent the assignment message to every peer in the required routing
@@ -1318,9 +1418,12 @@ impl State {
 			//      the assignment to all aware peers in the required routing _except_ the original
 			//      source of the assignment. Hence the `in_topology_check`.
 			//   3. Any randomly selected peers have been sent the assignment already.
-			let in_topology = topology
-				.map_or(false, |t| t.local_grid_neighbors().route_to_peer(required_routing, peer));
-			in_topology || knowledge.sent.contains(message_subject, MessageKind::Assignment)
+			let in_topology = topology.map_or(false, |t| {
+				t.local_grid_neighbors().route_to_peer(required_routing_approval, peer)
+			});
+			in_topology ||
+				(knowledge.sent.contains(message_subject, MessageKind::Assignment) &&
+					should_trigger_aggression)
 		};
 
 		let peers = entry
@@ -1403,7 +1506,8 @@ impl State {
 				candidate_entry.messages.iter().filter_map(|(validator_index, message_state)| {
 					match &message_state.approval_state {
 						ApprovalState::Approved(_, sig) => Some((*validator_index, sig.clone())),
-						ApprovalState::Assigned(_) => None,
+						ApprovalState::Assigned(_) | ApprovalState::UnassignedApproval(_, _) =>
+							None,
 					}
 				});
 			all_sigs.extend(sigs);
@@ -1420,6 +1524,7 @@ impl State {
 		peer_id: PeerId,
 		view: View,
 		rng: &mut (impl CryptoRng + Rng),
+		should_trigger_aggression: bool,
 	) {
 		metrics.on_unify_with_peer();
 		let _timer = metrics.time_unify_with_peer();
@@ -1454,39 +1559,36 @@ impl State {
 					}) {
 					// Propagate the message to all peers in the required routing set OR
 					// randomly sample peers.
-					{
-						let random_routing = &mut message_state.random_routing;
-						let required_routing = message_state.required_routing;
-						let rng = &mut *rng;
-						let mut peer_filter = move |peer_id| {
-							let in_topology = topology.as_ref().map_or(false, |t| {
-								t.local_grid_neighbors().route_to_peer(required_routing, peer_id)
-							});
-							in_topology || {
-								let route_random = random_routing.sample(total_peers, rng);
-								if route_random {
-									random_routing.inc_sent();
-								}
-
-								route_random
+					let random_routing = &mut message_state.random_routing;
+					let required_routing_assignment = message_state.required_routing_assignment;
+					let rng = &mut *rng;
+					let mut peer_filter_assignment = move |peer_id| {
+						let in_topology = topology.as_ref().map_or(false, |t| {
+							t.local_grid_neighbors()
+								.route_to_peer(required_routing_assignment, peer_id)
+						});
+						in_topology || {
+							let route_random = random_routing.sample(total_peers, rng);
+							if route_random {
+								random_routing.inc_sent();
 							}
-						};
-
-						if !peer_filter(&peer_id) {
-							continue
+							route_random
 						}
-					}
+					};
 
 					let message_subject = MessageSubject(block, candidate_index, *validator);
 
-					let assignment_message = (
-						IndirectAssignmentCert {
-							block_hash: block,
-							validator: *validator,
-							cert: message_state.approval_state.assignment_cert().clone(),
-						},
-						candidate_index,
-					);
+					let assignment_message =
+						message_state.approval_state.assignment_cert().map(|assignmentcert| {
+							(
+								IndirectAssignmentCert {
+									block_hash: block,
+									validator: *validator,
+									cert: assignmentcert.clone(),
+								},
+								candidate_index,
+							)
+						});
 
 					let approval_message =
 						message_state.approval_state.approval_signature().map(|signature| {
@@ -1498,19 +1600,39 @@ impl State {
 							}
 						});
 
-					if !peer_knowledge.contains(&message_subject, MessageKind::Assignment) {
-						peer_knowledge
-							.sent
-							.insert(message_subject.clone(), MessageKind::Assignment);
-						assignments_to_send.push(assignment_message);
+					let mut assignment_sent = false;
+					if peer_filter_assignment(&peer_id) {
+						if let Some(assignment_message) = assignment_message {
+							if !peer_knowledge.contains(&message_subject, MessageKind::Assignment) {
+								peer_knowledge
+									.sent
+									.insert(message_subject.clone(), MessageKind::Assignment);
+								assignments_to_send.push(assignment_message);
+								assignment_sent = true;
+							}
+						}
 					}
 
-					if let Some(approval_message) = approval_message {
-						if !peer_knowledge.contains(&message_subject, MessageKind::Approval) {
-							peer_knowledge
-								.sent
-								.insert(message_subject.clone(), MessageKind::Approval);
-							approvals_to_send.push(approval_message);
+					let peer_filter_approval = move |peer_id, required_routing, local| {
+						let in_topology = topology.as_ref().map_or(false, |t| {
+							t.local_grid_neighbors().route_to_peer(required_routing, peer_id)
+						});
+
+						in_topology || local || (should_trigger_aggression && assignment_sent)
+					};
+
+					if peer_filter_approval(
+						&peer_id,
+						message_state.required_routing_approval,
+						message_state.local,
+					) {
+						if let Some(approval_message) = approval_message {
+							if !peer_knowledge.contains(&message_subject, MessageKind::Approval) {
+								peer_knowledge
+									.sent
+									.insert(message_subject.clone(), MessageKind::Approval);
+								approvals_to_send.push(approval_message);
+							}
 						}
 					}
 				}
@@ -1685,9 +1807,15 @@ async fn adjust_required_routing_and_propagate<Context, BlockFilter, RoutingModi
 			.enumerate()
 			.flat_map(|(c_i, c)| c.messages.iter_mut().map(move |(k, v)| (c_i as _, k, v)))
 		{
-			routing_modifier(&mut message_state.required_routing, message_state.local, validator);
+			routing_modifier(
+				&mut message_state.required_routing_assignment,
+				message_state.local,
+				validator,
+			);
 
-			if message_state.required_routing.is_empty() {
+			if message_state.required_routing_assignment.is_empty() &&
+				message_state.required_routing_approval.is_empty()
+			{
 				continue
 			}
 
@@ -1699,14 +1827,17 @@ async fn adjust_required_routing_and_propagate<Context, BlockFilter, RoutingModi
 			// Propagate the message to all peers in the required routing set.
 			let message_subject = MessageSubject(*block_hash, candidate_index, *validator);
 
-			let assignment_message = (
-				IndirectAssignmentCert {
-					block_hash: *block_hash,
-					validator: *validator,
-					cert: message_state.approval_state.assignment_cert().clone(),
-				},
-				candidate_index,
-			);
+			let assignment_message = message_state.approval_state.assignment_cert().map(|cert| {
+				(
+					IndirectAssignmentCert {
+						block_hash: *block_hash,
+						validator: *validator,
+						cert: cert.clone(),
+					},
+					candidate_index,
+				)
+			});
+
 			let approval_message =
 				message_state.approval_state.approval_signature().map(|signature| {
 					IndirectSignedApprovalVote {
@@ -1718,28 +1849,37 @@ async fn adjust_required_routing_and_propagate<Context, BlockFilter, RoutingModi
 				});
 
 			for (peer, peer_knowledge) in &mut block_entry.known_by {
-				if !topology
+				if topology
 					.local_grid_neighbors()
-					.route_to_peer(message_state.required_routing, peer)
+					.route_to_peer(message_state.required_routing_assignment, peer)
 				{
-					continue
+					if let Some(assignment_message) = assignment_message.as_ref() {
+						if !peer_knowledge.contains(&message_subject, MessageKind::Assignment) {
+							peer_knowledge
+								.sent
+								.insert(message_subject.clone(), MessageKind::Assignment);
+							peer_assignments
+								.entry(*peer)
+								.or_insert_with(Vec::new)
+								.push(assignment_message.clone());
+						}
+					}
 				}
 
-				if !peer_knowledge.contains(&message_subject, MessageKind::Assignment) {
-					peer_knowledge.sent.insert(message_subject.clone(), MessageKind::Assignment);
-					peer_assignments
-						.entry(*peer)
-						.or_insert_with(Vec::new)
-						.push(assignment_message.clone());
-				}
-
-				if let Some(approval_message) = approval_message.as_ref() {
-					if !peer_knowledge.contains(&message_subject, MessageKind::Approval) {
-						peer_knowledge.sent.insert(message_subject.clone(), MessageKind::Approval);
-						peer_approvals
-							.entry(*peer)
-							.or_insert_with(Vec::new)
-							.push(approval_message.clone());
+				if topology
+					.local_grid_neighbors()
+					.route_to_peer(message_state.required_routing_approval, peer)
+				{
+					if let Some(approval_message) = approval_message.as_ref() {
+						if !peer_knowledge.contains(&message_subject, MessageKind::Approval) {
+							peer_knowledge
+								.sent
+								.insert(message_subject.clone(), MessageKind::Approval);
+							peer_approvals
+								.entry(*peer)
+								.or_insert_with(Vec::new)
+								.push(approval_message.clone());
+						}
 					}
 				}
 			}

--- a/node/network/approval-distribution/src/metrics.rs
+++ b/node/network/approval-distribution/src/metrics.rs
@@ -24,6 +24,8 @@ pub struct Metrics(Option<MetricsInner>);
 struct MetricsInner {
 	assignments_imported_total: prometheus::Counter<prometheus::U64>,
 	approvals_imported_total: prometheus::Counter<prometheus::U64>,
+	unassigned_approval_total: prometheus::Counter<prometheus::U64>,
+	delayed_approvals_processed_total: prometheus::Counter<prometheus::U64>,
 	unified_with_peer_total: prometheus::Counter<prometheus::U64>,
 	aggression_l1_messages_total: prometheus::Counter<prometheus::U64>,
 	aggression_l2_messages_total: prometheus::Counter<prometheus::U64>,
@@ -43,6 +45,18 @@ impl Metrics {
 	pub(crate) fn on_approval_imported(&self) {
 		if let Some(metrics) = &self.0 {
 			metrics.approvals_imported_total.inc();
+		}
+	}
+
+	pub(crate) fn on_unassigned_approval(&self) {
+		if let Some(metrics) = &self.0 {
+			metrics.unassigned_approval_total.inc();
+		}
+	}
+
+	pub(crate) fn on_delayed_approval_processed(&self) {
+		if let Some(metrics) = &self.0 {
+			metrics.delayed_approvals_processed_total.inc();
 		}
 	}
 
@@ -92,6 +106,20 @@ impl MetricsTrait for Metrics {
 				prometheus::Counter::new(
 					"polkadot_parachain_assignments_imported_total",
 					"Number of valid assignments imported locally or from other peers.",
+				)?,
+				registry,
+			)?,
+			unassigned_approval_total: prometheus::register(
+				prometheus::Counter::new(
+					"polkadot_parachain_unassigned_approval_total",
+					"Number of approvals received for which we didn't received the approval yet.",
+				)?,
+				registry,
+			)?,
+			delayed_approvals_processed_total: prometheus::register(
+				prometheus::Counter::new(
+					"polkadot_parachain_delayed_approvals_processedtotal",
+					"Number of approvals processed with delay after we received the assignment.",
 				)?,
 				registry,
 			)?,

--- a/node/network/approval-distribution/src/tests.rs
+++ b/node/network/approval-distribution/src/tests.rs
@@ -689,26 +689,15 @@ fn import_approval_happy_path() {
 			AllMessages::ApprovalVoting(ApprovalVotingMessage::CheckAndImportApproval(
 				vote,
 				tx,
+				_,
 			)) => {
 				assert_eq!(vote, approval);
 				tx.send(ApprovalCheckResult::Accepted).unwrap();
 			}
 		);
-
+		// We expect only reputation changes, because approvals from peers are not gossiped unless agression is enabled.
 		expect_reputation_change(overseer, &peer_b, BENEFIT_VALID_MESSAGE_FIRST).await;
 
-		assert_matches!(
-			overseer_recv(overseer).await,
-			AllMessages::NetworkBridgeTx(NetworkBridgeTxMessage::SendValidationMessage(
-				peers,
-				Versioned::V1(protocol_v1::ValidationProtocol::ApprovalDistribution(
-					protocol_v1::ApprovalDistributionMessage::Approvals(approvals)
-				))
-			)) => {
-				assert_eq!(peers.len(), 1);
-				assert_eq!(approvals.len(), 1);
-			}
-		);
 		virtual_overseer
 	});
 }
@@ -783,6 +772,7 @@ fn import_approval_bad() {
 			AllMessages::ApprovalVoting(ApprovalVotingMessage::CheckAndImportApproval(
 				vote,
 				tx,
+				false,
 			)) => {
 				assert_eq!(vote, approval);
 				tx.send(ApprovalCheckResult::Bad(ApprovalCheckError::UnknownBlock(hash))).unwrap();
@@ -1094,6 +1084,7 @@ fn import_remotely_then_locally() {
 			AllMessages::ApprovalVoting(ApprovalVotingMessage::CheckAndImportApproval(
 				vote,
 				tx,
+				false
 			)) => {
 				assert_eq!(vote, approval);
 				tx.send(ApprovalCheckResult::Accepted).unwrap();
@@ -1363,7 +1354,10 @@ fn propagates_locally_generated_assignment_to_both_dimensions() {
 				))
 			)) => {
 				// Random sampling is reused from the assignment.
-				assert_eq!(sent_peers, assignment_sent_peers);
+				for peer in &peers {
+					assert!(sent_peers.contains(&peer.0));
+				}
+				assert_eq!(sent_peers.len(), peers.len());
 				assert_eq!(sent_approvals, approvals);
 			}
 		);
@@ -1519,11 +1513,10 @@ fn propagates_to_required_after_connect() {
 	let hash = Hash::repeat_byte(0xAA);
 
 	let peers = make_peers_and_authority_ids(100);
+	let omitted = [0, 10, 50, 51];
 
 	let _ = test_harness(State::default(), |mut virtual_overseer| async move {
 		let overseer = &mut virtual_overseer;
-
-		let omitted = [0, 10, 50, 51];
 
 		// Connect all peers except omitted.
 		for (i, (peer, _)) in peers.iter().enumerate() {
@@ -1610,8 +1603,10 @@ fn propagates_to_required_after_connect() {
 					protocol_v1::ApprovalDistributionMessage::Approvals(sent_approvals)
 				))
 			)) => {
-				// Random sampling is reused from the assignment.
-				assert_eq!(sent_peers, assignment_sent_peers);
+				// Approvals should be sent to all peers.
+				for (index, peer) in  peers.iter().enumerate().filter(|(index, _)| !omitted.contains(index)){
+					assert!(sent_peers.contains(&peer.0));
+				}
 				assert_eq!(sent_approvals, approvals);
 			}
 		);
@@ -1706,7 +1701,12 @@ fn sends_to_more_peers_after_getting_topology() {
 		let assignments = vec![(cert.clone(), candidate_index)];
 		let approvals = vec![approval.clone()];
 
-		let mut expected_indices = vec![0, 10, 20, 30, 50, 51, 52, 53];
+		let mut expected_indices_assignments = vec![0, 10, 20, 30, 50, 51, 52, 53];
+
+		// Approvals are sent to all peers
+		let mut expected_indices_approvals: Vec<usize> = (0..peers.len()).collect();
+
+		// We sent only assignment when we don't a topology set yet.
 		let assignment_sent_peers = assert_matches!(
 			overseer_recv(overseer).await,
 			AllMessages::NetworkBridgeTx(NetworkBridgeTxMessage::SendValidationMessage(
@@ -1722,24 +1722,11 @@ fn sends_to_more_peers_after_getting_topology() {
 					// Random gossip before topology can send to topology-targeted peers.
 					// Remove them from the expected indices so we don't expect
 					// them to get the messages again after the assignment.
-					expected_indices.retain(|&i2| i2 != i);
+					expected_indices_assignments.retain(|&i2| i2 != i);
+
 				}
 				assert_eq!(sent_assignments, assignments);
 				sent_peers
-			}
-		);
-
-		assert_matches!(
-			overseer_recv(overseer).await,
-			AllMessages::NetworkBridgeTx(NetworkBridgeTxMessage::SendValidationMessage(
-				sent_peers,
-				Versioned::V1(protocol_v1::ValidationProtocol::ApprovalDistribution(
-					protocol_v1::ApprovalDistributionMessage::Approvals(sent_approvals)
-				))
-			)) => {
-				// Random sampling is reused from the assignment.
-				assert_eq!(sent_peers, assignment_sent_peers);
-				assert_eq!(sent_approvals, approvals);
 			}
 		);
 
@@ -1750,8 +1737,7 @@ fn sends_to_more_peers_after_getting_topology() {
 		)
 		.await;
 
-		let mut expected_indices_assignments = expected_indices.clone();
-		let mut expected_indices_approvals = expected_indices.clone();
+		let mut expected_indices_assignments = expected_indices_assignments.clone();
 
 		for _ in 0..expected_indices_assignments.len() {
 			assert_matches!(
@@ -1790,7 +1776,6 @@ fn sends_to_more_peers_after_getting_topology() {
 					let pos = expected_indices_approvals.iter()
 						.position(|i| &peers[*i].0 == &sent_peers[0])
 						.unwrap();
-
 					expected_indices_approvals.remove(pos);
 				}
 			);
@@ -1879,14 +1864,18 @@ fn originator_aggression_l1() {
 			}
 		);
 
-		assert_matches!(
+		let prev_sent_approvals = assert_matches!(
 			overseer_recv(overseer).await,
 			AllMessages::NetworkBridgeTx(NetworkBridgeTxMessage::SendValidationMessage(
-				_,
+				sent_peers,
 				Versioned::V1(protocol_v1::ValidationProtocol::ApprovalDistribution(
 					protocol_v1::ApprovalDistributionMessage::Approvals(_)
 				))
-			)) => { }
+			)) => {
+				sent_peers.into_iter()
+				.filter_map(|sp| peers.iter().position(|p| &p.0 == &sp))
+				.collect::<Vec<_>>()
+			 }
 		);
 
 		// Add blocks until aggression L1 is triggered.
@@ -1917,6 +1906,10 @@ fn originator_aggression_l1() {
 		let unsent_indices =
 			(0..peers.len()).filter(|i| !prev_sent_indices.contains(&i)).collect::<Vec<_>>();
 
+		let unsent_indices_approvals = (0..peers.len())
+			.filter(|i| !prev_sent_approvals.contains(&i))
+			.collect::<Vec<_>>();
+
 		for _ in 0..unsent_indices.len() {
 			assert_matches!(
 				overseer_recv(overseer).await,
@@ -1937,7 +1930,7 @@ fn originator_aggression_l1() {
 			);
 		}
 
-		for _ in 0..unsent_indices.len() {
+		for _ in 0..unsent_indices_approvals.len() {
 			assert_matches!(
 				overseer_recv(overseer).await,
 				AllMessages::NetworkBridgeTx(NetworkBridgeTxMessage::SendValidationMessage(

--- a/node/network/protocol/src/grid_topology.rs
+++ b/node/network/protocol/src/grid_topology.rs
@@ -108,6 +108,33 @@ impl SessionGridTopology {
 
 		Some(grid_subset)
 	}
+
+	/// Gets the list of known peer Ids for a given validator index
+	///
+	/// Returns `None` if the validator index is out of bound
+	pub fn get_known_peer_ids_by_validator_index(
+		&self,
+		validator_index: ValidatorIndex,
+	) -> Option<&Vec<PeerId>> {
+		let peer_index = self.shuffled_indices.get(validator_index.0 as usize)?;
+
+		self.canonical_shuffling
+			.get(*peer_index)
+			.map(|topology_peer_info| &topology_peer_info.peer_ids)
+	}
+
+	/// Checks if the passed validator_index matches the peer_id
+	///
+	/// Returns true if they match and false otherwise
+	pub fn peer_id_matches_validator_index(
+		&self,
+		validator_index: ValidatorIndex,
+		peer_id: PeerId,
+	) -> bool {
+		self.get_known_peer_ids_by_validator_index(validator_index)
+			.map(|known_peer_ids| known_peer_ids.contains(&peer_id))
+			.unwrap_or(false)
+	}
 }
 
 struct MatrixNeighbors<R, C> {

--- a/node/subsystem-types/src/messages.rs
+++ b/node/subsystem-types/src/messages.rs
@@ -827,8 +827,13 @@ pub enum ApprovalVotingMessage {
 	/// Check if the approval vote is valid and can be accepted by our view of the
 	/// protocol.
 	///
+	/// * `IndirectSignedApprovalVote` - The vote to be imported
+	/// * `oneshot::Sender<ApprovalCheckResult>` - The channel used for sending the reply back
+	/// * `bool` - If the sender of the messages is the originator of it, when false it means
+	/// the message has been gossipped.
+	///
 	/// Should not be sent unless the block hash within the indirect vote is known.
-	CheckAndImportApproval(IndirectSignedApprovalVote, oneshot::Sender<ApprovalCheckResult>),
+	CheckAndImportApproval(IndirectSignedApprovalVote, oneshot::Sender<ApprovalCheckResult>, bool),
 	/// Returns the highest possible ancestor hash of the provided block hash which is
 	/// acceptable to vote on finality for.
 	/// The `BlockNumber` provided is the number of the block's ancestor which is the


### PR DESCRIPTION
## Overview

This implements the lazy signatures checks solution proposed here: approval-voting: approvals gossip and lazy signature checks optimizations proposed here: https://github.com/paritytech/polkadot/issues/7458

## Problem

While profiling `versi` for https://github.com/paritytech/polkadot/issues/6608#issuecomment-1590822854, the conclusions are that during peak time  with 250 validator, `approval-distribution and approval-voting` need to process between 10k-15k messages per second, a rough breakdown on where the time is spent looks like this
- 38% of the time is used by `approval-voting` to check the `assignment certificate` ( This will be dramatically improved by https://github.com/paritytech/polkadot/pull/6782 )
- 37% of the time is used by `approval-voting` to check the signature of an approval vote.
- 25% of the time is used doing book-keeping and to deal with tremendous amount of duplicate messages.

## Proposed Solution

The amount of work for assignments is already being addressed by https://github.com/paritytech/polkadot/pull/6782,  so this PR is trying to address and reduce the amount of work we have to do when processing an approval and it is achieved by implementing a fast path for processing approval-votes, consisting of the following steps:
1. Disable gossiping of approval-votes on the fast path.
2. Make each validator send their approval votes to all of its peers.
3. Do not check the signature of an approval vote if the peer_id that sent us the message is the originator of the message.
4. In case finality is lagging use enable_aggression thresholds to fallback on gossiping the approvals(The slow_path).

## FAQ

### Why is it ok to not check approval votes signatures ?
If we received the message directly from the originator we can trust that the vote is legit, the signature will be later on checked just in the cases when we are dealing with a dispute and we have to import the votes on chain. The validators are incentivised to correctly sign their votes because otherwise their votes won't be imported on chain and they will miss on disputes.

### Wouldn't this make it risk-free for attackers to try to approve invalid blocks ?
This is already possible in our current implementation because we do not punish in any way validators that try to approve invalid blocks and we allow them to change their votes during disputes.However, that is already included in our threat model, see https://github.com/paritytech/polkadot/issues/7229 on why it is alright(we do slash the backers).

### What happens if network is segmented and peers can not reach each other directly ?
Finality will be lagging and when the configured threshold will be passed we will enable the aggression which falls back on gossiping approvals.

### Does this increases the risks of malicious nodes attacking honest nodes without the network observing ?
No, we are still gossiping assignments, so they will spread-out much faster and randomly than the approvals,  so if honest nodes get DoS-ed before sending all of their approvals, they will be marked as no-show and a new tranche would kick-in

### Can approvals arrive before their corresponding assignments
Yes, and to deal with this case we will have to store the approval and process it later on when an assignment is received. The buffer for storing this approval would have to be reasonably bounded, but given that we already store all the assignments and approvals we received in `approval-distribution` this shouldn't affect our memory profile too much. All validators get just one slot per candidate per un-finalized block.

## Alternative solutions paths
There are two other paths that I explored for optimization:

### Coalescing approvals https://github.com/paritytech/polkadot/issues/6831
This is an alternative optimization that we can go instead of this MR, which should give us major gains, but I would estimate would be lower than the ones in this MR and it will also increase the size of the votes we have to import on chain for disputes/slashing, see: https://github.com/paritytech/polkadot/issues/6831#issuecomment-1588945746 

### Parallelization  of processing `approval-distribution/approval-voting` 
The measurements I did here: https://github.com/paritytech/polkadot/pull/7393#issuecomment-1619780933, suggests that this should give us some gains, but they won't be enough for our goal of 1k validators, so we would still need either this MR or the coalescing of approvals describe above. However, the good part is that the parallelization could be stacked on top of optimisations we do for reducing the amount of work. So, once we reached consensus which of the two options(lazy checking/approval coalescing) we want to implement, I think we should see  some benefit  from parallelising the work done in `approval-distribution and approval-voting`


### TODOs
- [ ] More tests to confirm everything is correctly.
- [ ] Test in versi.
- [ ] Rebased on top of https://github.com/paritytech/polkadot/pull/6782 and test in versi. This should give us the maximum benefit.
- [ ] Decide and implement how would this be enabled on our networks 

