### PR TITLE
Cleaning "common good" vs "system"

### DIFF
--- a/parachain/src/primitives.rs
+++ b/parachain/src/primitives.rs
@@ -198,7 +198,7 @@ impl From<i32> for Id {
 	}
 }
 
-const USER_INDEX_START: u32 = 1000;
+const USER_INDEX_START: u32 = 2000;
 const PUBLIC_INDEX_START: u32 = 2000;
 
 /// The ID of the first user (non-system) parachain.

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -523,7 +523,7 @@ impl pallet_staking::EraPayout<Balance> for EraPayout {
 		// all para-ids that are currently active.
 		let auctioned_slots = Paras::parachains()
 			.into_iter()
-			// all active para-ids that do not belong to a system or common good chain is the number
+			// all active para-ids that do not belong to a system chain is the number
 			// of parachains that we should take into account for inflation.
 			.filter(|i| *i >= LOWEST_PUBLIC_ID)
 			.count() as u64;

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -553,7 +553,7 @@ impl pallet_staking::EraPayout<Balance> for EraPayout {
 		// all para-ids that are not active.
 		let auctioned_slots = Paras::parachains()
 			.into_iter()
-			// all active para-ids that do not belong to a system or common good chain is the number
+			// all active para-ids that do not belong to a system chain is the number
 			// of parachains that we should take into account for inflation.
 			.filter(|i| *i >= LOWEST_PUBLIC_ID)
 			.count() as u64;


### PR DESCRIPTION
Everything with `paraId<2000` should be considered as system parachain.
(Here where also introduced `system_parachain` constants: https://github.com/paritytech/polkadot/pull/7005)


There are 3 possible places that are effected by change `para<1000` -> `para<2000`. 
So the main question is where to use **"explicit paraIds"** or **relaxed `para<2000`**?



### **How to setup:**

--- 
### **Polkadot:**

**AllowExplicitUnpaidExecutionFrom**
- actual: `AllowExplicitUnpaidExecutionFrom<CollectivesOrFellows>`
- update:
  - [ ] no change 
  - `AllowExplicitUnpaidExecutionFrom<SystemParachainsOrFellows>`
    - [ ] SystemParachains -> `paraId<2000`
    - [ ] SystemParachains -> explicitly say which one (using [constants](https://github.com/paritytech/polkadot/pull/7005))


**ChildSystemParachainAsSuperuser**
- actual: does not use for `LocalOriginConverter`
- update:
  - [ ] no change 
  - add `ChildSystemParachainAsSuperuser<SystemParachains>`
    - [ ] SystemParachains -> `paraId<2000`
    - [ ] SystemParachains -> explicitly say which one (using [constants](https://github.com/paritytech/polkadot/pull/7005))

**TrustedTeleporters**
- actual: (DotForAssetHub, DotForCollectives) (explicit)
- update:
  - [ ] no change (stay explicit - BH is comming [here](https://github.com/paritytech/polkadot/pull/7005))
  - [ ] `DotForSystemParachain` based on `paraId<2000` e.g. https://github.com/paritytech/cumulus/pull/2842/files#diff-53073f451405f5fdf3a02c595270a9fce3b0d5951122e0ad26f482a073019ad1R68-R79


--- 

### **Kusama:**

**AllowExplicitUnpaidExecutionFrom**
- actual: `AllowExplicitUnpaidExecutionFrom<IsChildSystemParachain<ParaId>`  (effected bychange in PR `paraId<1000` -> `paraId<2000`)
- update:
  - [ ] no change (with this PR this will automatically include AssetHub, BridgeHub, Collectives, Encointer)
  - [ ] `AllowExplicitUnpaidExecutionFrom<SystemParachains>` -> explicitly say which one (using [constants](https://github.com/paritytech/polkadot/pull/7005))

**ChildSystemParachainAsSuperuser**
- actual: `ChildSystemParachainAsSuperuser<ParaId>` (effected by change in PR `paraId<1000` -> `paraId<2000`)
- update:
  - [ ] no change (with this PR this will automatically include AssetHub, BridgeHub, Collectives, Encointer)
  - [ ] `ChildSystemParachainAsSuperuser<SystemParachains>` -> explicitly say which one (using [constants](https://github.com/paritytech/polkadot/pull/7005))

**TrustedTeleporters**
- actual: (KsmForAssetHub, KsmForEncointer) (explicit)
- update:
  - [ ] no change (stay explicit - BH is comming [here](https://github.com/paritytech/polkadot/pull/7005))
  - [ ] `KsmForSystemParachain` based on `paraId<2000` e.g. https://github.com/paritytech/cumulus/pull/2842/files#diff-53073f451405f5fdf3a02c595270a9fce3b0d5951122e0ad26f482a073019ad1R68-R79

--- 

### **Westend/Rococo:**
the same as Kusama or relaxed more

---
- [ ] `SiblingSystemParachainAsSuperuser` - never used in Cumulus (effected by change in PR `paraId<1000` -> `paraId<2000`) 
--- 

- [ ] move `NativeAssetFromSiblingSystemParachain` to xcm-builder from [here](https://github.com/paritytech/cumulus/pull/2842/files#diff-53073f451405f5fdf3a02c595270a9fce3b0d5951122e0ad26f482a073019ad1R68-R79)


