### PR TITLE
Reconfigure spending tracks on Kusama

### DIFF
--- a/runtime/kusama/src/governance/origins.rs
+++ b/runtime/kusama/src/governance/origins.rs
@@ -20,7 +20,7 @@ pub use pallet_custom_origins::*;
 
 #[frame_support::pallet]
 pub mod pallet_custom_origins {
-	use crate::{Balance, GRAND, QUID};
+	use crate::{Balance, GRAND, QUID, UNITS};
 	use frame_support::pallet_prelude::*;
 
 	#[pallet::config]
@@ -48,15 +48,15 @@ pub mod pallet_custom_origins {
 		ReferendumCanceller,
 		/// Origin able to kill referenda.
 		ReferendumKiller,
-		/// Origin able to spend up to 1 KSM from the treasury at once.
+		/// Origin able to spend up to 8.333 KSM from the treasury at once.
 		SmallTipper,
-		/// Origin able to spend up to 5 KSM from the treasury at once.
+		/// Origin able to spend up to 33.33 KSM from the treasury at once.
 		BigTipper,
-		/// Origin able to spend up to 50 KSM from the treasury at once.
+		/// Origin able to spend up to 100.0 KSM from the treasury at once.
 		SmallSpender,
-		/// Origin able to spend up to 500 KSM from the treasury at once.
+		/// Origin able to spend up to 1,250 KSM from the treasury at once.
 		MediumSpender,
-		/// Origin able to spend up to 5,000 KSM from the treasury at once.
+		/// Origin able to spend up to 2,500 KSM from the treasury at once.
 		BigSpender,
 		/// Origin able to dispatch a whitelisted call.
 		WhitelistedCaller,
@@ -171,9 +171,9 @@ pub mod pallet_custom_origins {
 		pub type Spender: EnsureOrigin<Success = Balance> {
 			SmallTipper = 250 * QUID,
 			BigTipper = 1 * GRAND,
-			SmallSpender = 10 * GRAND,
-			MediumSpender = 100 * GRAND,
-			BigSpender = 1_000 * GRAND,
+			SmallSpender = 100 * UNITS,
+			MediumSpender = 1_250 * UNITS,
+			BigSpender = 2_500 * UNITS,
 			Treasurer = 10_000 * GRAND,
 		}
 	}

--- a/runtime/kusama/src/governance/tracks.rs
+++ b/runtime/kusama/src/governance/tracks.rs
@@ -22,14 +22,20 @@ const fn percent(x: i32) -> sp_arithmetic::FixedI64 {
 	sp_arithmetic::FixedI64::from_rational(x as u128, 100)
 }
 use pallet_referenda::Curve;
-const APP_ROOT: Curve = Curve::make_reciprocal(4, 28, percent(80), percent(50), percent(100));
-const SUP_ROOT: Curve = Curve::make_linear(28, 28, percent(0), percent(50));
-const APP_STAKING_ADMIN: Curve = Curve::make_linear(17, 28, percent(50), percent(100));
+const APP_ROOT: Curve =
+	Curve::make_reciprocal(4, 28, percent(80), percent(50), percent(100));
+const SUP_ROOT: Curve =
+	Curve::make_linear(28, 28, percent(0), percent(50));
+const APP_STAKING_ADMIN: Curve =
+	Curve::make_linear(17, 28, percent(50), percent(100));
 const SUP_STAKING_ADMIN: Curve =
 	Curve::make_reciprocal(12, 28, percent(1), percent(0), percent(50));
-const APP_TREASURER: Curve = Curve::make_reciprocal(4, 28, percent(80), percent(50), percent(100));
-const SUP_TREASURER: Curve = Curve::make_linear(28, 28, percent(0), percent(50));
-const APP_FELLOWSHIP_ADMIN: Curve = Curve::make_linear(17, 28, percent(50), percent(100));
+const APP_TREASURER: Curve =
+	Curve::make_reciprocal(4, 28, percent(80), percent(66), percent(100));
+const SUP_TREASURER: Curve =
+	Curve::make_linear(28, 28, percent(0), percent(50));
+const APP_FELLOWSHIP_ADMIN: Curve =
+	Curve::make_linear(17, 28, percent(50), percent(100));
 const SUP_FELLOWSHIP_ADMIN: Curve =
 	Curve::make_reciprocal(12, 28, percent(1), percent(0), percent(50));
 const APP_GENERAL_ADMIN: Curve =
@@ -40,26 +46,38 @@ const APP_AUCTION_ADMIN: Curve =
 	Curve::make_reciprocal(4, 28, percent(80), percent(50), percent(100));
 const SUP_AUCTION_ADMIN: Curve =
 	Curve::make_reciprocal(7, 28, percent(10), percent(0), percent(50));
-const APP_LEASE_ADMIN: Curve = Curve::make_linear(17, 28, percent(50), percent(100));
-const SUP_LEASE_ADMIN: Curve = Curve::make_reciprocal(12, 28, percent(1), percent(0), percent(50));
-const APP_REFERENDUM_CANCELLER: Curve = Curve::make_linear(17, 28, percent(50), percent(100));
+const APP_LEASE_ADMIN: Curve =
+	Curve::make_linear(17, 28, percent(50), percent(100));
+const SUP_LEASE_ADMIN: Curve =
+	Curve::make_reciprocal(12, 28, percent(1), percent(0), percent(50));
+const APP_REFERENDUM_CANCELLER: Curve =
+	Curve::make_linear(17, 28, percent(50), percent(100));
 const SUP_REFERENDUM_CANCELLER: Curve =
 	Curve::make_reciprocal(12, 28, percent(1), percent(0), percent(50));
-const APP_REFERENDUM_KILLER: Curve = Curve::make_linear(17, 28, percent(50), percent(100));
+const APP_REFERENDUM_KILLER: Curve =
+	Curve::make_linear(17, 28, percent(50), percent(100));
 const SUP_REFERENDUM_KILLER: Curve =
 	Curve::make_reciprocal(12, 28, percent(1), percent(0), percent(50));
-const APP_SMALL_TIPPER: Curve = Curve::make_linear(10, 28, percent(50), percent(100));
-const SUP_SMALL_TIPPER: Curve = Curve::make_reciprocal(1, 28, percent(4), percent(0), percent(50));
-const APP_BIG_TIPPER: Curve = Curve::make_linear(10, 28, percent(50), percent(100));
-const SUP_BIG_TIPPER: Curve = Curve::make_reciprocal(8, 28, percent(1), percent(0), percent(50));
-const APP_SMALL_SPENDER: Curve = Curve::make_linear(17, 28, percent(50), percent(100));
+const APP_SMALL_TIPPER: Curve =
+	Curve::make_linear(10, 28, percent(50), percent(100));
+const SUP_SMALL_TIPPER: Curve =
+	Curve::make_reciprocal(1, 28, percent(4), percent(0), percent(50));
+const APP_BIG_TIPPER: Curve =
+	Curve::make_linear(10, 28, percent(50), percent(100));
+const SUP_BIG_TIPPER: Curve =
+	Curve::make_reciprocal(8, 28, percent(1), percent(0), percent(50));
+const APP_SMALL_SPENDER: Curve =
+	Curve::make_linear(17, 28, percent(50), percent(100));
 const SUP_SMALL_SPENDER: Curve =
 	Curve::make_reciprocal(12, 28, percent(1), percent(0), percent(50));
-const APP_MEDIUM_SPENDER: Curve = Curve::make_linear(23, 28, percent(50), percent(100));
+const APP_MEDIUM_SPENDER: Curve =
+	Curve::make_linear(23, 28, percent(50), percent(100));
 const SUP_MEDIUM_SPENDER: Curve =
 	Curve::make_reciprocal(16, 28, percent(1), percent(0), percent(50));
-const APP_BIG_SPENDER: Curve = Curve::make_linear(28, 28, percent(50), percent(100));
-const SUP_BIG_SPENDER: Curve = Curve::make_reciprocal(20, 28, percent(1), percent(0), percent(50));
+const APP_BIG_SPENDER: Curve =
+	Curve::make_linear(28, 28, percent(66), percent(100));
+const SUP_BIG_SPENDER: Curve =
+	Curve::make_reciprocal(20, 28, percent(1), percent(0), percent(50));
 const APP_WHITELISTED_CALLER: Curve =
 	Curve::make_reciprocal(16, 28 * 24, percent(96), percent(50), percent(100));
 const SUP_WHITELISTED_CALLER: Curve =
@@ -114,9 +132,9 @@ const TRACKS_DATA: [(u16, pallet_referenda::TrackInfo<Balance, BlockNumber>); 15
 			name: "treasurer",
 			max_deciding: 10,
 			decision_deposit: 1 * GRAND,
-			prepare_period: 2 * HOURS,
-			decision_period: 14 * DAYS,
-			confirm_period: 3 * HOURS,
+			prepare_period: 48 * HOURS,
+			decision_period: 28 * DAYS,
+			confirm_period: 48 * HOURS,
 			min_enactment_period: 24 * HOURS,
 			min_approval: APP_TREASURER,
 			min_support: SUP_TREASURER,
@@ -210,9 +228,9 @@ const TRACKS_DATA: [(u16, pallet_referenda::TrackInfo<Balance, BlockNumber>); 15
 		30,
 		pallet_referenda::TrackInfo {
 			name: "small_tipper",
-			max_deciding: 200,
+			max_deciding: 6,
 			decision_deposit: 1 * QUID,
-			prepare_period: 1 * MINUTES,
+			prepare_period: 3 * HOURS,
 			decision_period: 7 * DAYS,
 			confirm_period: 10 * MINUTES,
 			min_enactment_period: 1 * MINUTES,
@@ -224,9 +242,9 @@ const TRACKS_DATA: [(u16, pallet_referenda::TrackInfo<Balance, BlockNumber>); 15
 		31,
 		pallet_referenda::TrackInfo {
 			name: "big_tipper",
-			max_deciding: 100,
+			max_deciding: 3,
 			decision_deposit: 10 * QUID,
-			prepare_period: 10 * MINUTES,
+			prepare_period: 6 * HOURS,
 			decision_period: 7 * DAYS,
 			confirm_period: 1 * HOURS,
 			min_enactment_period: 10 * MINUTES,
@@ -238,9 +256,9 @@ const TRACKS_DATA: [(u16, pallet_referenda::TrackInfo<Balance, BlockNumber>); 15
 		32,
 		pallet_referenda::TrackInfo {
 			name: "small_spender",
-			max_deciding: 50,
+			max_deciding: 7,
 			decision_deposit: 100 * QUID,
-			prepare_period: 4 * HOURS,
+			prepare_period: 24 * HOURS,
 			decision_period: 14 * DAYS,
 			confirm_period: 12 * HOURS,
 			min_enactment_period: 24 * HOURS,
@@ -252,9 +270,9 @@ const TRACKS_DATA: [(u16, pallet_referenda::TrackInfo<Balance, BlockNumber>); 15
 		33,
 		pallet_referenda::TrackInfo {
 			name: "medium_spender",
-			max_deciding: 50,
+			max_deciding: 2,
 			decision_deposit: 200 * QUID,
-			prepare_period: 4 * HOURS,
+			prepare_period: 24 * HOURS,
 			decision_period: 14 * DAYS,
 			confirm_period: 24 * HOURS,
 			min_enactment_period: 24 * HOURS,
@@ -266,11 +284,11 @@ const TRACKS_DATA: [(u16, pallet_referenda::TrackInfo<Balance, BlockNumber>); 15
 		34,
 		pallet_referenda::TrackInfo {
 			name: "big_spender",
-			max_deciding: 50,
+			max_deciding: 1,
 			decision_deposit: 400 * QUID,
-			prepare_period: 4 * HOURS,
+			prepare_period: 24 * HOURS,
 			decision_period: 14 * DAYS,
-			confirm_period: 48 * HOURS,
+			confirm_period: 24 * HOURS,
 			min_enactment_period: 24 * HOURS,
 			min_approval: APP_BIG_SPENDER,
 			min_support: SUP_BIG_SPENDER,

--- a/runtime/kusama/src/governance/tracks.rs
+++ b/runtime/kusama/src/governance/tracks.rs
@@ -22,20 +22,14 @@ const fn percent(x: i32) -> sp_arithmetic::FixedI64 {
 	sp_arithmetic::FixedI64::from_rational(x as u128, 100)
 }
 use pallet_referenda::Curve;
-const APP_ROOT: Curve =
-	Curve::make_reciprocal(4, 28, percent(80), percent(50), percent(100));
-const SUP_ROOT: Curve =
-	Curve::make_linear(28, 28, percent(0), percent(50));
-const APP_STAKING_ADMIN: Curve =
-	Curve::make_linear(17, 28, percent(50), percent(100));
+const APP_ROOT: Curve = Curve::make_reciprocal(4, 28, percent(80), percent(50), percent(100));
+const SUP_ROOT: Curve = Curve::make_linear(28, 28, percent(0), percent(50));
+const APP_STAKING_ADMIN: Curve = Curve::make_linear(17, 28, percent(50), percent(100));
 const SUP_STAKING_ADMIN: Curve =
 	Curve::make_reciprocal(12, 28, percent(1), percent(0), percent(50));
-const APP_TREASURER: Curve =
-	Curve::make_reciprocal(4, 28, percent(80), percent(66), percent(100));
-const SUP_TREASURER: Curve =
-	Curve::make_linear(28, 28, percent(0), percent(50));
-const APP_FELLOWSHIP_ADMIN: Curve =
-	Curve::make_linear(17, 28, percent(50), percent(100));
+const APP_TREASURER: Curve = Curve::make_reciprocal(4, 28, percent(80), percent(66), percent(100));
+const SUP_TREASURER: Curve = Curve::make_linear(28, 28, percent(0), percent(50));
+const APP_FELLOWSHIP_ADMIN: Curve = Curve::make_linear(17, 28, percent(50), percent(100));
 const SUP_FELLOWSHIP_ADMIN: Curve =
 	Curve::make_reciprocal(12, 28, percent(1), percent(0), percent(50));
 const APP_GENERAL_ADMIN: Curve =
@@ -46,38 +40,26 @@ const APP_AUCTION_ADMIN: Curve =
 	Curve::make_reciprocal(4, 28, percent(80), percent(50), percent(100));
 const SUP_AUCTION_ADMIN: Curve =
 	Curve::make_reciprocal(7, 28, percent(10), percent(0), percent(50));
-const APP_LEASE_ADMIN: Curve =
-	Curve::make_linear(17, 28, percent(50), percent(100));
-const SUP_LEASE_ADMIN: Curve =
-	Curve::make_reciprocal(12, 28, percent(1), percent(0), percent(50));
-const APP_REFERENDUM_CANCELLER: Curve =
-	Curve::make_linear(17, 28, percent(50), percent(100));
+const APP_LEASE_ADMIN: Curve = Curve::make_linear(17, 28, percent(50), percent(100));
+const SUP_LEASE_ADMIN: Curve = Curve::make_reciprocal(12, 28, percent(1), percent(0), percent(50));
+const APP_REFERENDUM_CANCELLER: Curve = Curve::make_linear(17, 28, percent(50), percent(100));
 const SUP_REFERENDUM_CANCELLER: Curve =
 	Curve::make_reciprocal(12, 28, percent(1), percent(0), percent(50));
-const APP_REFERENDUM_KILLER: Curve =
-	Curve::make_linear(17, 28, percent(50), percent(100));
+const APP_REFERENDUM_KILLER: Curve = Curve::make_linear(17, 28, percent(50), percent(100));
 const SUP_REFERENDUM_KILLER: Curve =
 	Curve::make_reciprocal(12, 28, percent(1), percent(0), percent(50));
-const APP_SMALL_TIPPER: Curve =
-	Curve::make_linear(10, 28, percent(50), percent(100));
-const SUP_SMALL_TIPPER: Curve =
-	Curve::make_reciprocal(1, 28, percent(4), percent(0), percent(50));
-const APP_BIG_TIPPER: Curve =
-	Curve::make_linear(10, 28, percent(50), percent(100));
-const SUP_BIG_TIPPER: Curve =
-	Curve::make_reciprocal(8, 28, percent(1), percent(0), percent(50));
-const APP_SMALL_SPENDER: Curve =
-	Curve::make_linear(17, 28, percent(50), percent(100));
+const APP_SMALL_TIPPER: Curve = Curve::make_linear(10, 28, percent(50), percent(100));
+const SUP_SMALL_TIPPER: Curve = Curve::make_reciprocal(1, 28, percent(4), percent(0), percent(50));
+const APP_BIG_TIPPER: Curve = Curve::make_linear(10, 28, percent(50), percent(100));
+const SUP_BIG_TIPPER: Curve = Curve::make_reciprocal(8, 28, percent(1), percent(0), percent(50));
+const APP_SMALL_SPENDER: Curve = Curve::make_linear(17, 28, percent(50), percent(100));
 const SUP_SMALL_SPENDER: Curve =
 	Curve::make_reciprocal(12, 28, percent(1), percent(0), percent(50));
-const APP_MEDIUM_SPENDER: Curve =
-	Curve::make_linear(23, 28, percent(50), percent(100));
+const APP_MEDIUM_SPENDER: Curve = Curve::make_linear(23, 28, percent(50), percent(100));
 const SUP_MEDIUM_SPENDER: Curve =
 	Curve::make_reciprocal(16, 28, percent(1), percent(0), percent(50));
-const APP_BIG_SPENDER: Curve =
-	Curve::make_linear(28, 28, percent(66), percent(100));
-const SUP_BIG_SPENDER: Curve =
-	Curve::make_reciprocal(20, 28, percent(1), percent(0), percent(50));
+const APP_BIG_SPENDER: Curve = Curve::make_linear(28, 28, percent(66), percent(100));
+const SUP_BIG_SPENDER: Curve = Curve::make_reciprocal(20, 28, percent(1), percent(0), percent(50));
 const APP_WHITELISTED_CALLER: Curve =
 	Curve::make_reciprocal(16, 28 * 24, percent(96), percent(50), percent(100));
 const SUP_WHITELISTED_CALLER: Curve =


### PR DESCRIPTION
These reconfigurations are what many believe is the first step in changing the paradigm of Treasury spending. Discussion can be found here:  https://forum.polkadot.network/t/kusama-treasury-follow-up-analysis-continued-budgeting-incompetence.

This will change the following parameters:

| Track | Spend Limit| Max Deciding | Min Approval | Preparation Period | Confirmation Period | Decision Period |
|-------|--------------|----------------|-----------------|---------------------|------------------------|------------------|
|Small Tipper|No Change|200 -> 6|No Change|1 mins -> 3 hrs|No Change|No Change|
|Big Tipper|No Change|100 -> 3|No Change|10 mins -> 6 hrs|No Change|No Change|
|Small Spender|333 KSM -> 100 KSM|50 -> 7|No Change|4 hrs -> 24 hrs|No Change|No Change|
|Medium Spender|3,333 KSM -> 1,250 KSM|50 -> 2|No Change|4 hrs -> 24 hrs|No Change|No Change|
|Big Spender|33,333 KSM -> 2,500 KSM|50 -> 1|50% -> 66%|4 hrs -> 24 hrs|48 hrs -> 24 hrs|No Change|
|Treasurer|No Change|No Change|50% -> 66%|2 hrs -> 48 hrs|3 hrs -> 48 hrs|14 days -> 28 days|

This pull request coincides with [referendum 235](https://kusama.polkassembly.io/referenda/235) on Kusama which implements these changes in v9430. Should that referendum pass, this can be merged into v1.0.0 to ensure these changes persist.