### PR TITLE
Setting ProspectiveParachainsMode::Disabled

### DIFF
--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -1805,7 +1805,7 @@ sp_api::impl_runtime_apis! {
 		}
 	}
 
-	#[api_version(99)]
+	#[api_version(98)]
 	impl primitives::runtime_api::ParachainHost<Block, Hash, BlockNumber> for Runtime {
 		fn validators() -> Vec<ValidatorId> {
 			parachains_runtime_api_impl::validators::<Runtime>()

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -1481,7 +1481,7 @@ sp_api::impl_runtime_apis! {
 		}
 	}
 
-	#[api_version(99)]
+	#[api_version(98)]
 	impl primitives::runtime_api::ParachainHost<Block, Hash, BlockNumber> for Runtime {
 		fn validators() -> Vec<ValidatorId> {
 			parachains_runtime_api_impl::validators::<Runtime>()


### PR DESCRIPTION
It appears that with api version < 99 async backing is disabled. I'm not entirely sure that this is the right place to change the API number to make this happen.

 We want this to test the network state (collators: unupgraded, validators: upgraded, async backing: disabled)