### PR TITLE
Disable `spellcheck` CI job

### DIFF
--- a/scripts/ci/gitlab/pipeline/check.yml
+++ b/scripts/ci/gitlab/pipeline/check.yml
@@ -25,7 +25,7 @@ cargo-fmt:
     - cargo +nightly fmt --all -- --check
   allow_failure: true
 
-spellcheck:
+.spellcheck_disabled:
   stage: check
   extends:
     - .docker-env

--- a/scripts/ci/gitlab/pipeline/check.yml
+++ b/scripts/ci/gitlab/pipeline/check.yml
@@ -25,6 +25,7 @@ cargo-fmt:
     - cargo +nightly fmt --all -- --check
   allow_failure: true
 
+# Disabled in https://github.com/paritytech/polkadot/pull/7512
 .spellcheck_disabled:
   stage: check
   extends:


### PR DESCRIPTION
The mentioned test fails for a quite some time and introduces unnecessary misunderstandings. Disabling.