### PR TITLE
remove staging APIs from Rococo & Westend

### DIFF
--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -1805,7 +1805,6 @@ sp_api::impl_runtime_apis! {
 		}
 	}
 
-	#[api_version(99)]
 	impl primitives::runtime_api::ParachainHost<Block, Hash, BlockNumber> for Runtime {
 		fn validators() -> Vec<ValidatorId> {
 			parachains_runtime_api_impl::validators::<Runtime>()
@@ -1935,14 +1934,6 @@ sp_api::impl_runtime_apis! {
 				dispute_proof,
 				key_ownership_proof,
 			)
-		}
-
-		fn staging_para_backing_state(para_id: ParaId) -> Option<primitives::vstaging::BackingState> {
-			runtime_parachains::runtime_api_impl::vstaging::backing_state::<Runtime>(para_id)
-		}
-
-		fn staging_async_backing_params() -> primitives::vstaging::AsyncBackingParams {
-			runtime_parachains::runtime_api_impl::vstaging::async_backing_params::<Runtime>()
 		}
 	}
 

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -1481,7 +1481,6 @@ sp_api::impl_runtime_apis! {
 		}
 	}
 
-	#[api_version(99)]
 	impl primitives::runtime_api::ParachainHost<Block, Hash, BlockNumber> for Runtime {
 		fn validators() -> Vec<ValidatorId> {
 			parachains_runtime_api_impl::validators::<Runtime>()
@@ -1611,14 +1610,6 @@ sp_api::impl_runtime_apis! {
 				dispute_proof,
 				key_ownership_proof,
 			)
-		}
-
-		fn staging_para_backing_state(para_id: ParaId) -> Option<primitives::vstaging::BackingState> {
-			runtime_parachains::runtime_api_impl::vstaging::backing_state::<Runtime>(para_id)
-		}
-
-		fn staging_async_backing_params() -> primitives::vstaging::AsyncBackingParams {
-			runtime_parachains::runtime_api_impl::vstaging::async_backing_params::<Runtime>()
 		}
 	}
 


### PR DESCRIPTION
The default should be for them to be off. We can enable in a branch or with feature flags (though that poses some implementation details to push off to #7499 )