### PR TITLE
revert to old `handle_new_activations` logic in some cases

### DIFF
--- a/node/collation-generation/src/lib.rs
+++ b/node/collation-generation/src/lib.rs
@@ -215,15 +215,14 @@ async fn handle_new_activations<Context>(
 			let (scheduled_core, assumption) = match core {
 				CoreState::Scheduled(scheduled_core) =>
 					(scheduled_core, OccupiedCoreAssumption::Free),
-				CoreState::Occupied(occupied_core) => {
-					// TODO [now]: this assumes that next up == current.
-					// in practice we should only set `OccupiedCoreAssumption::Included`
-					// when the candidate occupying the core is also of the same para.
-					if let Some(scheduled) = occupied_core.next_up_on_available {
-						(scheduled, OccupiedCoreAssumption::Included)
-					} else {
-						continue
-					}
+				CoreState::Occupied(_occupied_core) => {
+					gum::trace!(
+						target: LOG_TARGET,
+						core_idx = %core_idx,
+						relay_parent = ?relay_parent,
+						"core is occupied. Keep going.",
+					);
+					continue
 				},
 				CoreState::Free => {
 					gum::trace!(

--- a/node/collation-generation/src/lib.rs
+++ b/node/collation-generation/src/lib.rs
@@ -41,8 +41,9 @@ use polkadot_node_subsystem::{
 	SubsystemContext, SubsystemError, SubsystemResult,
 };
 use polkadot_node_subsystem_util::{
-	request_availability_cores, request_persisted_validation_data, request_validation_code,
-	request_validation_code_hash, request_validators, request_staging_async_backing_params,
+	request_availability_cores, request_persisted_validation_data,
+	request_staging_async_backing_params, request_validation_code, request_validation_code_hash,
+	request_validators,
 };
 use polkadot_primitives::{
 	collator_signature_payload, CandidateCommitments, CandidateDescriptor, CandidateReceipt,
@@ -231,7 +232,7 @@ async fn handle_new_activations<Context>(
 						} else {
 							continue
 						}
-					}
+					},
 					_ => {
 						gum::trace!(
 							target: LOG_TARGET,
@@ -240,7 +241,7 @@ async fn handle_new_activations<Context>(
 							"core is occupied. Keep going.",
 						);
 						continue
-					}
+					},
 				},
 				CoreState::Free => {
 					gum::trace!(

--- a/node/collation-generation/src/lib.rs
+++ b/node/collation-generation/src/lib.rs
@@ -219,10 +219,10 @@ async fn handle_new_activations<Context>(
 				CoreState::Scheduled(scheduled_core) =>
 					(scheduled_core, OccupiedCoreAssumption::Free),
 				CoreState::Occupied(occupied_core) => match async_backing_params {
-					Some(params) if params.max_candidate_depth >= 2 => {
+					Some(params) if params.max_candidate_depth >= 1 => {
 						// maximum candidate depth when building on top of a block
-						// pending availability is necessarily 2 - the depth of the
-						// pending block is 1, so the child has depth 2.
+						// pending availability is necessarily 1 - the depth of the
+						// pending block is 0 so the child has depth 1.
 
 						// TODO [now]: this assumes that next up == current.
 						// in practice we should only set `OccupiedCoreAssumption::Included`

--- a/node/collation-generation/src/tests.rs
+++ b/node/collation-generation/src/tests.rs
@@ -235,11 +235,12 @@ fn requests_validation_data_for_scheduled_matches() {
 				},
 				Some(AllMessages::RuntimeApi(RuntimeApiMessage::Request(
 					_hash,
-					RuntimeApiRequest::StagingAsyncBackingParams(
-						tx,
-					),
+					RuntimeApiRequest::StagingAsyncBackingParams(tx),
 				))) => {
-					tx.send(Err(RuntimeApiError::NotSupported { runtime_api_name: "doesnt_matter" })).unwrap();
+					tx.send(Err(RuntimeApiError::NotSupported {
+						runtime_api_name: "doesnt_matter",
+					}))
+					.unwrap();
 				},
 				Some(msg) => {
 					panic!("didn't expect any other overseer requests; got {:?}", msg)
@@ -331,11 +332,12 @@ fn sends_distribute_collation_message() {
 				},
 				Some(AllMessages::RuntimeApi(RuntimeApiMessage::Request(
 					_hash,
-					RuntimeApiRequest::StagingAsyncBackingParams(
-						tx,
-					),
+					RuntimeApiRequest::StagingAsyncBackingParams(tx),
 				))) => {
-					tx.send(Err(RuntimeApiError::NotSupported { runtime_api_name: "doesnt_matter" })).unwrap();
+					tx.send(Err(RuntimeApiError::NotSupported {
+						runtime_api_name: "doesnt_matter",
+					}))
+					.unwrap();
 				},
 				Some(msg @ AllMessages::CollatorProtocol(_)) => {
 					inner_to_collator_protocol.lock().await.push(msg);
@@ -492,11 +494,12 @@ fn fallback_when_no_validation_code_hash_api() {
 				},
 				Some(AllMessages::RuntimeApi(RuntimeApiMessage::Request(
 					_hash,
-					RuntimeApiRequest::StagingAsyncBackingParams(
-						tx,
-					),
+					RuntimeApiRequest::StagingAsyncBackingParams(tx),
 				))) => {
-					tx.send(Err(RuntimeApiError::NotSupported { runtime_api_name: "doesnt_matter" })).unwrap();
+					tx.send(Err(RuntimeApiError::NotSupported {
+						runtime_api_name: "doesnt_matter",
+					}))
+					.unwrap();
 				},
 				Some(msg @ AllMessages::CollatorProtocol(_)) => {
 					inner_to_collator_protocol.lock().await.push(msg);

--- a/node/collation-generation/src/tests.rs
+++ b/node/collation-generation/src/tests.rs
@@ -151,6 +151,14 @@ fn requests_availability_per_relay_parent() {
 				Some(AllMessages::RuntimeApi(RuntimeApiMessage::Request(_hash, RuntimeApiRequest::Validators(tx)))) => {
 					tx.send(Ok(vec![dummy_validator(); 3])).unwrap();
 				}
+				Some(AllMessages::RuntimeApi(RuntimeApiMessage::Request(
+					_hash,
+					RuntimeApiRequest::StagingAsyncBackingParams(
+						tx,
+					),
+				))) => {
+					tx.send(Err(RuntimeApiError::NotSupported { runtime_api_name: "doesnt_matter" })).unwrap();
+				},
 				Some(msg) => panic!("didn't expect any other overseer requests given no availability cores; got {:?}", msg),
 			}
 		}
@@ -224,6 +232,14 @@ fn requests_validation_data_for_scheduled_matches() {
 					RuntimeApiRequest::Validators(tx),
 				))) => {
 					tx.send(Ok(vec![dummy_validator(); 3])).unwrap();
+				},
+				Some(AllMessages::RuntimeApi(RuntimeApiMessage::Request(
+					_hash,
+					RuntimeApiRequest::StagingAsyncBackingParams(
+						tx,
+					),
+				))) => {
+					tx.send(Err(RuntimeApiError::NotSupported { runtime_api_name: "doesnt_matter" })).unwrap();
 				},
 				Some(msg) => {
 					panic!("didn't expect any other overseer requests; got {:?}", msg)
@@ -312,6 +328,14 @@ fn sends_distribute_collation_message() {
 					),
 				))) => {
 					tx.send(Ok(Some(ValidationCode(vec![1, 2, 3]).hash()))).unwrap();
+				},
+				Some(AllMessages::RuntimeApi(RuntimeApiMessage::Request(
+					_hash,
+					RuntimeApiRequest::StagingAsyncBackingParams(
+						tx,
+					),
+				))) => {
+					tx.send(Err(RuntimeApiError::NotSupported { runtime_api_name: "doesnt_matter" })).unwrap();
 				},
 				Some(msg @ AllMessages::CollatorProtocol(_)) => {
 					inner_to_collator_protocol.lock().await.push(msg);
@@ -465,6 +489,14 @@ fn fallback_when_no_validation_code_hash_api() {
 					RuntimeApiRequest::ValidationCode(_para_id, OccupiedCoreAssumption::Free, tx),
 				))) => {
 					tx.send(Ok(Some(ValidationCode(vec![1, 2, 3])))).unwrap();
+				},
+				Some(AllMessages::RuntimeApi(RuntimeApiMessage::Request(
+					_hash,
+					RuntimeApiRequest::StagingAsyncBackingParams(
+						tx,
+					),
+				))) => {
+					tx.send(Err(RuntimeApiError::NotSupported { runtime_api_name: "doesnt_matter" })).unwrap();
 				},
 				Some(msg @ AllMessages::CollatorProtocol(_)) => {
 					inner_to_collator_protocol.lock().await.push(msg);


### PR DESCRIPTION
As currently implemented, this would ask collators to build blocks where the parachain has a block pending availability. We should not do this unless the allowed maximum depth on the relay chain is >= 2. Presumably, this wouldn't be enabled before collators have some time to adjust.

Parachains not equipped for asynchronous backing should only author blocks when the parent has been included. This is enforced on the parachain runtime, usually with a `ConsensusHook`: https://github.com/paritytech/cumulus/pull/2501 . When the unincluded segment length is limited to 1, this leads to panics in the runtime implementation of naive collators when authoring blocks.