### PR TITLE
send network messages on main protocol name

### DIFF
--- a/node/network/bridge/src/network.rs
+++ b/node/network/bridge/src/network.rs
@@ -68,8 +68,11 @@ pub(crate) fn send_message<M>(
 	// list. The message payload can be quite large. If the underlying
 	// network used `Bytes` this would not be necessary.
 	let last_peer = peers.pop();
-	// optimization: generate the protocol name once.
-	let protocol_name = protocol_names.get_name(peer_set, version);
+
+	// We always send messages on the "main" name even when a negotiated
+	// fallback is used. The libp2p implementation handles the fallback
+	// under the hood.
+	let protocol_name = protocol_names.get_main_name(peer_set);
 	peers.into_iter().for_each(|peer| {
 		net.write_notification(peer, protocol_name.clone(), message.clone());
 	});


### PR DESCRIPTION
libp2p expects you to send on the "main" protocol name, even when a fallback has been negotiated. This was raised by @sandreim earlier