### PR TITLE
allow governance body on parachain to have sovereign account on Polkadot

### DIFF
--- a/runtime/polkadot/src/xcm_config.rs
+++ b/runtime/polkadot/src/xcm_config.rs
@@ -42,9 +42,9 @@ use xcm_builder::{
 	AccountId32Aliases, AllowExplicitUnpaidExecutionFrom, AllowKnownQueryResponses,
 	AllowSubscriptionsFrom, AllowTopLevelPaidExecutionFrom, BackingToPlurality,
 	ChildParachainAsNative, ChildParachainConvertsVia, CurrencyAdapter as XcmCurrencyAdapter,
-	FixedWeightBounds, IsConcrete, MintLocation, OriginToPluralityVoice, SignedAccountId32AsNative,
-	SignedToAccountId32, SovereignSignedViaLocation, TakeWeightCredit, UsingComponents,
-	WithComputedOrigin,
+	DescribeBodyTerminal, DescribeFamily, FixedWeightBounds, HashedDescription, IsConcrete,
+	MintLocation, OriginToPluralityVoice, SignedAccountId32AsNative, SignedToAccountId32,
+	SovereignSignedViaLocation, TakeWeightCredit, UsingComponents, WithComputedOrigin,
 };
 use xcm_executor::traits::WithOriginFilter;
 
@@ -70,6 +70,8 @@ pub type SovereignAccountOf = (
 	ChildParachainConvertsVia<ParaId, AccountId>,
 	// We can directly alias an `AccountId32` into a local account.
 	AccountId32Aliases<ThisNetwork, AccountId>,
+	// Allow governance body to be used as a sovereign account.
+	HashedDescription<AccountId, DescribeFamily<DescribeBodyTerminal>>,
 );
 
 /// Our asset transactor. This is what allows us to interact with the runtime assets from the point of

--- a/xcm/xcm-builder/src/lib.rs
+++ b/xcm/xcm-builder/src/lib.rs
@@ -32,9 +32,10 @@ pub use location_conversion::ForeignChainAliasAccount;
 pub use location_conversion::{
 	Account32Hash, AccountId32Aliases, AccountKey20Aliases, AliasesIntoAccountId32,
 	ChildParachainConvertsVia, DescribeAccountId32Terminal, DescribeAccountIdTerminal,
-	DescribeAccountKey20Terminal, DescribeAllTerminal, DescribeFamily, DescribeLocation,
-	DescribePalletTerminal, DescribeTerminus, GlobalConsensusParachainConvertsFor,
-	HashedDescription, ParentIsPreset, SiblingParachainConvertsVia,
+	DescribeAccountKey20Terminal, DescribeAllTerminal, DescribeBodyTerminal, DescribeFamily,
+	DescribeLocation, DescribePalletTerminal, DescribeTerminus,
+	GlobalConsensusParachainConvertsFor, HashedDescription, ParentIsPreset,
+	SiblingParachainConvertsVia,
 };
 
 mod origin_conversion;

--- a/xcm/xcm-builder/src/location_conversion.rs
+++ b/xcm/xcm-builder/src/location_conversion.rs
@@ -86,11 +86,22 @@ impl DescribeLocation for DescribeAccountKey20Terminal {
 
 pub type DescribeAccountIdTerminal = (DescribeAccountId32Terminal, DescribeAccountKey20Terminal);
 
+pub struct DescribeBodyTerminal;
+impl DescribeLocation for DescribeBodyTerminal {
+	fn describe_location(l: &MultiLocation) -> Option<Vec<u8>> {
+		match (l.parents, &l.interior) {
+			(0, X1(Plurality { id, part })) => Some((b"Body", id, part).encode()),
+			_ => return None,
+		}
+	}
+}
+
 pub type DescribeAllTerminal = (
 	DescribeTerminus,
 	DescribePalletTerminal,
 	DescribeAccountId32Terminal,
 	DescribeAccountKey20Terminal,
+	DescribeBodyTerminal,
 );
 
 pub struct DescribeFamily<DescribeInterior>(PhantomData<DescribeInterior>);


### PR DESCRIPTION
The goal is to allow Fellowship on Collective chain to have a sovereign account on Polkadot so that we can add it as an identity registrar. This will allow Fellows origin to be able to provide judgements for Fellowship members.