### PR TITLE
add missing syscalls

### DIFF
--- a/scripts/packaging/polkadot.service
+++ b/scripts/packaging/polkadot.service
@@ -29,6 +29,7 @@ RestrictNamespaces=true
 RestrictSUIDSGID=true
 SystemCallArchitectures=native
 SystemCallFilter=@system-service
+SystemCallFilter=landlock_add_rule landlock_create_ruleset landlock_restrict_self seccomp
 SystemCallFilter=~@clock @module @mount @reboot @swap @privileged
 UMask=0027
 


### PR DESCRIPTION
With version 1.0.0 and landlock this systemd service will fail.

It will exit with `polkadot.service: Main process exited, code=killed, status=31/SYS`

`journalctl _AUDIT_TYPE_NAME=SECCOMP` shows that it's because it can't do landlock related syscalls.