### PR TITLE
Omnibus asynchronous backing bugfix PR

### DIFF
--- a/node/core/backing/src/lib.rs
+++ b/node/core/backing/src/lib.rs
@@ -789,9 +789,15 @@ async fn handle_active_leaves_update<Context>(
 	// as a result.
 	//
 	// when prospective parachains are disabled, the implicit view is empty,
-	// which means we'll clean up everything. This is correct.
+	// which means we'll clean up everything that's not a leaf - the expected behavior
+	// for pre-asynchronous backing.
 	{
-		let remaining: HashSet<_> = state.implicit_view.all_allowed_relay_parents().collect();
+		let remaining: HashSet<_> = state
+			.per_leaf
+			.keys()
+			.chain(state.implicit_view.all_allowed_relay_parents())
+			.collect();
+
 		state.per_relay_parent.retain(|r, _| remaining.contains(&r));
 	}
 

--- a/node/network/statement-distribution/src/vstaging/grid.rs
+++ b/node/network/statement-distribution/src/vstaging/grid.rs
@@ -429,6 +429,13 @@ impl GridTracker {
 		// and receiving groups, we may overwrite a `Full` manifest with a `Acknowledgement`
 		// one.
 		for (v, manifest_mode) in sending_group_manifests.chain(receiving_group_manifests) {
+			gum::trace!(
+				target: LOG_TARGET,
+				validator_index = ?v,
+				?manifest_mode,
+				"Preparing to send manifest/acknowledgement"
+			);
+
 			self.pending_manifests
 				.entry(v)
 				.or_default()


### PR DESCRIPTION
This is a collection of bugfixes found while testing asynchronous backing.

1. We weren't accounting for activated leaves properly in backing backcompat logic.
2. Prospective parachains wasn't accounting for session boundaries in ancestry.