### PR TITLE
misc async backing improvements for allowed ancestry blocks

### DIFF
--- a/runtime/parachains/src/shared.rs
+++ b/runtime/parachains/src/shared.rs
@@ -98,7 +98,7 @@ impl<Hash: PartialEq + Copy, BlockNumber: AtLeast32BitUnsigned + Copy>
 		let number = self.latest_number - BlockNumber::from(age as u32);
 
 		if let Some(prev) = prev {
-			if prev >= number {
+			if prev > number {
 				return None
 			}
 		}

--- a/runtime/parachains/src/shared.rs
+++ b/runtime/parachains/src/shared.rs
@@ -94,15 +94,14 @@ impl<Hash: PartialEq + Copy, BlockNumber: AtLeast32BitUnsigned + Copy>
 		prev: Option<BlockNumber>,
 	) -> Option<(Hash, BlockNumber)> {
 		let pos = self.buffer.iter().position(|(rp, _)| rp == &relay_parent)?;
+		let age = (self.buffer.len() - 1) - pos;
+		let number = self.latest_number - BlockNumber::from(age as u32);
 
 		if let Some(prev) = prev {
-			if prev >= self.latest_number {
+			if prev >= number {
 				return None
 			}
 		}
-
-		let age = (self.buffer.len() - 1) - pos;
-		let number = self.latest_number - BlockNumber::from(age as u32);
 
 		Some((self.buffer[pos].1, number))
 	}

--- a/runtime/parachains/src/shared/tests.rs
+++ b/runtime/parachains/src/shared/tests.rs
@@ -77,13 +77,13 @@ fn tracker_acquire_info() {
 	tracker.update(relay_parent, state_root, 1u32, max_ancestry_len);
 	let (relay_parent, state_root) = blocks[2];
 	tracker.update(relay_parent, state_root, 2u32, max_ancestry_len);
-	for (block_num, (rp, state_root)) in blocks.iter().enumerate() {
+	for (block_num, (rp, state_root)) in blocks.iter().enumerate().take(2) {
 		assert_matches!(
 			tracker.acquire_info(*rp, None),
 			Some((s, b)) if &s == state_root && b == block_num as u32
 		);
 
-		assert!(tracker.acquire_info(*rp, Some(block_num as u32)).is_none());
+		assert!(tracker.acquire_info(*rp, Some(2)).is_none());
 	}
 
 	for (block_num, (rp, state_root)) in blocks.iter().enumerate().skip(1) {

--- a/runtime/parachains/src/shared/tests.rs
+++ b/runtime/parachains/src/shared/tests.rs
@@ -19,6 +19,7 @@ use crate::{
 	configuration::HostConfiguration,
 	mock::{new_test_ext, MockGenesisConfig, ParasShared},
 };
+use assert_matches::assert_matches;
 use keyring::Sr25519Keyring;
 use primitives::Hash;
 
@@ -51,6 +52,46 @@ fn tracker_earliest_block_number() {
 	// Capacity exceeded.
 	tracker.update(Hash::zero(), Hash::zero(), now, max_ancestry_len);
 	assert_eq!(tracker.hypothetical_earliest_block_number(now + 1, max_ancestry_len), 1);
+}
+
+#[test]
+fn tracker_acquire_info() {
+	let mut tracker = AllowedRelayParentsTracker::<Hash, u32>::default();
+	let max_ancestry_len = 2;
+
+	// (relay_parent, state_root) pairs.
+	let blocks = &[
+		(Hash::repeat_byte(0), Hash::repeat_byte(10)),
+		(Hash::repeat_byte(1), Hash::repeat_byte(11)),
+		(Hash::repeat_byte(2), Hash::repeat_byte(12)),
+	];
+
+	let (relay_parent, state_root) = blocks[0];
+	tracker.update(relay_parent, state_root, 0, max_ancestry_len);
+	assert_matches!(
+		tracker.acquire_info(relay_parent, None),
+		Some((s, b)) if s == state_root && b == 0
+	);
+
+	let (relay_parent, state_root) = blocks[1];
+	tracker.update(relay_parent, state_root, 1u32, max_ancestry_len);
+	let (relay_parent, state_root) = blocks[2];
+	tracker.update(relay_parent, state_root, 2u32, max_ancestry_len);
+	for (block_num, (rp, state_root)) in blocks.iter().enumerate() {
+		assert_matches!(
+			tracker.acquire_info(*rp, None),
+			Some((s, b)) if &s == state_root && b == block_num as u32
+		);
+
+		assert!(tracker.acquire_info(*rp, Some(block_num as u32)).is_none());
+	}
+
+	for (block_num, (rp, state_root)) in blocks.iter().enumerate().skip(1) {
+		assert_matches!(
+			tracker.acquire_info(*rp, Some(block_num as u32 - 1)),
+			Some((s, b)) if &s == state_root && b == block_num as u32
+		);
+	}
 }
 
 #[test]


### PR DESCRIPTION
Fixes `acquire_info` (`runtime::shared::AllowedRelayParentsTracker`) behavior and adds backwards compatibility test for prospective parachains with default zeroed parameters