### PR TITLE
Add type aliases for XCM Assets and Locations

### DIFF
--- a/xcm/src/v3/multiasset.rs
+++ b/xcm/src/v3/multiasset.rs
@@ -38,7 +38,8 @@ use core::{
 use parity_scale_codec::{self as codec, Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 
-// Type aliases to simplify
+// Type aliases to simplify,
+// TODO: Will be the real names in v4
 pub type Asset = MultiAsset;
 pub type Assets = MultiAssets;
 pub type AssetFilter = MultiAssetFilter;

--- a/xcm/src/v3/multiasset.rs
+++ b/xcm/src/v3/multiasset.rs
@@ -38,6 +38,11 @@ use core::{
 use parity_scale_codec::{self as codec, Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 
+// Type aliases to simplify
+pub type Asset = MultiAsset;
+pub type Assets = MultiAssets;
+pub type AssetFilter = MultiAssetFilter;
+
 /// A general identifier for an instance of a non-fungible asset class.
 #[derive(
 	Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, Debug, TypeInfo, MaxEncodedLen,

--- a/xcm/src/v3/multilocation.rs
+++ b/xcm/src/v3/multilocation.rs
@@ -25,6 +25,8 @@ use core::{
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 
+// Type aliases to simplify
+// TODO: Will be the real names in v4
 pub type Location = MultiLocation;
 pub type InteriorLocation = InteriorMultiLocation;
 

--- a/xcm/src/v3/multilocation.rs
+++ b/xcm/src/v3/multilocation.rs
@@ -25,6 +25,9 @@ use core::{
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 
+pub type Location = MultiLocation;
+pub type InteriorLocation = InteriorMultiLocation;
+
 /// A relative path between state-bearing consensus systems.
 ///
 /// A location in a consensus system is defined as an *isolatable state machine* held within global


### PR DESCRIPTION
The `Multi` prefix was originally thought to mean "future-proof" as in the [multiformats](https://multiformats.io/) used by [IPFS](https://ipfs.tech/).

The actual future-proof types are the `Versioned` types: `VersionedMultiAsset`, `VersionedMultiLocation`, etc.
In XCMv4, we'll rename the versioned types to multi types. Because this is a breaking change, for now we'll just have the aliases. The actual types are still exported from the `xcm` crate, for compatibility.

## TODO:
- [x] Add type aliases
- [x] Use aliases in instructions
