### PR TITLE
add missing feature flag

### DIFF
--- a/xcm/xcm-executor/Cargo.toml
+++ b/xcm/xcm-executor/Cargo.toml
@@ -36,4 +36,5 @@ std = [
 	"sp-weights/std",
 	"frame-support/std",
 	"log/std",
+	"frame-benchmarking/std",
 ]


### PR DESCRIPTION
Without this, `cargo check -p xcm-executor --features runtime-benchmarks` isn't building.

This issue broke our build and we need [this](https://github.com/AcalaNetwork/Acala/pull/2577/commits/27983b1d0db40d4bd9090731e07ed0281bde4a64) workaround.