### PR TITLE
Fix flaky reputation change test

### DIFF
--- a/node/network/bitfield-distribution/src/tests.rs
+++ b/node/network/bitfield-distribution/src/tests.rs
@@ -429,7 +429,6 @@ fn receive_duplicate_messages() {
 
 #[test]
 // FIXME <https://github.com/paritytech/polkadot/issues/7407>
-#[cfg(feature = "enable-flaky")]
 fn delay_reputation_change() {
 	use polkadot_node_subsystem_util::reputation::add_reputation;
 
@@ -471,7 +470,7 @@ fn delay_reputation_change() {
 	let pool = sp_core::testing::TaskExecutor::new();
 	let (ctx, mut handle) = make_subsystem_context::<BitfieldDistributionMessage, _>(pool);
 	let mut rng = dummy_rng();
-	let reputation_interval = Duration::from_millis(1);
+	let reputation_interval = Duration::from_millis(100);
 
 	let bg = async move {
 		let subsystem = BitfieldDistribution::new(Default::default());

--- a/node/network/bitfield-distribution/src/tests.rs
+++ b/node/network/bitfield-distribution/src/tests.rs
@@ -428,7 +428,6 @@ fn receive_duplicate_messages() {
 }
 
 #[test]
-// FIXME <https://github.com/paritytech/polkadot/issues/7407>
 fn delay_reputation_change() {
 	use polkadot_node_subsystem_util::reputation::add_reputation;
 


### PR DESCRIPTION
Fixes https://github.com/paritytech/polkadot/issues/7407

That job requires more than 1ms to complete on cold cache, so reputation change triggers twice. I changed the interval significantly, same as in other test uses reputation change. 

Could you please check if this works? 