### PR TITLE
Publish docker image description

### DIFF
--- a/scripts/ci/dockerfiles/polkadot_Dockerfile.README.md
+++ b/scripts/ci/dockerfiles/polkadot_Dockerfile.README.md
@@ -1,0 +1,7 @@
+# Polkadot official Docker image
+
+[Polkadot](https://polkadot.network/)
+
+[GitHub](https://github.com/paritytech/polkadot)
+
+[Polkadot Wiki](https://wiki.polkadot.network/)

--- a/scripts/ci/dockerfiles/staking-miner/staking-miner_Dockerfile.README.md
+++ b/scripts/ci/dockerfiles/staking-miner/staking-miner_Dockerfile.README.md
@@ -1,0 +1,3 @@
+# Staking-miner Docker image
+
+[GitHub](https://github.com/paritytech/polkadot/tree/master/utils/staking-miner)

--- a/scripts/ci/gitlab/pipeline/publish.yml
+++ b/scripts/ci/gitlab/pipeline/publish.yml
@@ -114,6 +114,44 @@ publish-staking-miner-image:
     - job: build-staking-miner
       artifacts: true
 
+publish-polkadot-image-description:
+  stage: publish
+  variables:
+    CI_IMAGE: paritytech/dockerhub-description
+    DOCKER_USER: ${Docker_Hub_User_Parity}
+    DOCKER_PASS: ${Docker_Hub_Pass_Parity}
+    SHORT_DESCRIPTION: "Polkadot Official Docker Image"
+    README_FILEPATH: $CI_PROJECT_DIR/scripts/ci/dockerfiles/polkadot.Dockerfile.README.md
+  rules:
+    - if: $CI_COMMIT_REF_NAME == "master"
+      changes:
+        - scripts/ci/dockerfiles/staking-miner/polkadot_Dockerfile.README.md
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+      when: never
+  script:
+    - cd / && sh entrypoint.sh
+  tags:
+    - kubernetes-parity-build
+
+publish-staking-miner-image-description:
+  stage: publish
+  variables:
+    CI_IMAGE: paritytech/dockerhub-description
+    DOCKER_USER: ${Docker_Hub_User_Parity}
+    DOCKER_PASS: ${Docker_Hub_Pass_Parity}
+    SHORT_DESCRIPTION: "Staking-miner Docker Image"
+    README_FILEPATH: $CI_PROJECT_DIR/scripts/ci/dockerfiles/staking-miner/staking-miner_Dockerfile.README.md
+  rules:
+    - if: $CI_COMMIT_REF_NAME == "master"
+      changes:
+        - scripts/ci/dockerfiles/staking-miner/staking-miner.Dockerfile.README.md
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+      when: never
+  script:
+    - cd / && sh entrypoint.sh
+  tags:
+    - kubernetes-parity-build
+
 publish-s3-release:
   stage: publish
   extends:

--- a/scripts/ci/gitlab/pipeline/publish.yml
+++ b/scripts/ci/gitlab/pipeline/publish.yml
@@ -120,8 +120,9 @@ publish-polkadot-image-description:
     CI_IMAGE: paritytech/dockerhub-description
     DOCKER_USER: ${Docker_Hub_User_Parity}
     DOCKER_PASS: ${Docker_Hub_Pass_Parity}
+    DOCKERHUB_REPOSITORY: parity/polkadot
     SHORT_DESCRIPTION: "Polkadot Official Docker Image"
-    README_FILEPATH: $CI_PROJECT_DIR/scripts/ci/dockerfiles/polkadot.Dockerfile.README.md
+    README_FILEPATH: $CI_PROJECT_DIR/scripts/ci/dockerfiles/polkadot_Dockerfile.README.md
   rules:
     - if: $CI_COMMIT_REF_NAME == "master"
       changes:
@@ -139,6 +140,7 @@ publish-staking-miner-image-description:
     CI_IMAGE: paritytech/dockerhub-description
     DOCKER_USER: ${Docker_Hub_User_Parity}
     DOCKER_PASS: ${Docker_Hub_Pass_Parity}
+    DOCKERHUB_REPOSITORY: paritytech/staking-miner
     SHORT_DESCRIPTION: "Staking-miner Docker Image"
     README_FILEPATH: $CI_PROJECT_DIR/scripts/ci/dockerfiles/staking-miner/staking-miner_Dockerfile.README.md
   rules:


### PR DESCRIPTION
Added CI job to publish Docker image description to hub.docker.com for [Polkadot](https://hub.docker.com/r/parity/polkadot) and [staking-miner](https://hub.docker.com/repository/docker/paritytech/staking-miner)


Related https://github.com/paritytech/ci_cd/issues/741