### PR TITLE
Approve multiple candidates with a single signature

### DIFF
--- a/node/core/approval-voting/src/approval_db/v2/migration_helpers.rs
+++ b/node/core/approval-voting/src/approval_db/v2/migration_helpers.rs
@@ -51,6 +51,7 @@ fn make_block_entry(
 		approved_bitfield: make_bitvec(candidates.len()),
 		candidates,
 		children: Vec::new(),
+		candidates_pending_signature: Default::default(),
 	}
 }
 

--- a/node/core/approval-voting/src/approval_db/v2/mod.rs
+++ b/node/core/approval-voting/src/approval_db/v2/mod.rs
@@ -21,8 +21,8 @@ use polkadot_node_primitives::approval::{v1::DelayTranche, v2::AssignmentCertV2}
 use polkadot_node_subsystem::{SubsystemError, SubsystemResult};
 use polkadot_node_subsystem_util::database::{DBTransaction, Database};
 use polkadot_primitives::{
-	BlockNumber, CandidateHash, CandidateReceipt, CoreIndex, GroupIndex, Hash, SessionIndex,
-	ValidatorIndex, ValidatorSignature,
+	BlockNumber, CandidateHash, CandidateIndex, CandidateReceipt, CoreIndex, GroupIndex, Hash,
+	SessionIndex, ValidatorIndex, ValidatorSignature,
 };
 
 use sp_consensus_slots::Slot;
@@ -238,6 +238,16 @@ pub struct BlockEntry {
 	// block. The block can be considered approved if the bitfield has all bits set to `true`.
 	pub approved_bitfield: Bitfield,
 	pub children: Vec<Hash>,
+	// A list of candidates that has been approved, but we didn't not sign and
+	// advertise the vote yet.
+	pub candidates_pending_signature: BTreeMap<CandidateIndex, CandidateSigningContext>,
+}
+
+#[derive(Encode, Decode, Debug, Clone, PartialEq)]
+
+/// Context needed for creating an approval signature  for a given candidate.
+pub struct CandidateSigningContext {
+	pub candidate_hash: CandidateHash,
 }
 
 impl From<crate::Tick> for Tick {

--- a/node/core/approval-voting/src/approval_db/v2/tests.rs
+++ b/node/core/approval-voting/src/approval_db/v2/tests.rs
@@ -56,6 +56,7 @@ fn make_block_entry(
 		approved_bitfield: make_bitvec(candidates.len()),
 		candidates,
 		children: Vec::new(),
+		candidates_pending_signature: Default::default(),
 	}
 }
 

--- a/node/core/approval-voting/src/import.rs
+++ b/node/core/approval-voting/src/import.rs
@@ -511,6 +511,7 @@ pub(crate) async fn handle_new_head<Context, B: Backend>(
 				.collect(),
 			approved_bitfield,
 			children: Vec::new(),
+			candidates_pending_signature: Default::default(),
 		};
 
 		gum::trace!(
@@ -1264,6 +1265,7 @@ pub(crate) mod tests {
 				candidates: Vec::new(),
 				approved_bitfield: Default::default(),
 				children: Vec::new(),
+				candidates_pending_signature: Default::default(),
 			}
 			.into(),
 		);

--- a/node/core/dispute-coordinator/src/import.rs
+++ b/node/core/dispute-coordinator/src/import.rs
@@ -34,7 +34,7 @@ use polkadot_node_primitives::{
 use polkadot_node_subsystem::overseer;
 use polkadot_node_subsystem_util::runtime::RuntimeInfo;
 use polkadot_primitives::{
-	CandidateReceipt, DisputeStatement, Hash, IndexedVec, SessionIndex, SessionInfo,
+	CandidateHash, CandidateReceipt, DisputeStatement, Hash, IndexedVec, SessionIndex, SessionInfo,
 	ValidDisputeStatementKind, ValidatorId, ValidatorIndex, ValidatorPair, ValidatorSignature,
 };
 use sc_keystore::LocalKeystore;
@@ -118,7 +118,9 @@ impl OwnVoteState {
 		let our_valid_votes = controlled_indices
 			.iter()
 			.filter_map(|i| votes.valid.raw().get_key_value(i))
-			.map(|(index, (kind, sig))| (*index, (DisputeStatement::Valid(*kind), sig.clone())));
+			.map(|(index, (kind, sig))| {
+				(*index, (DisputeStatement::Valid(kind.clone()), sig.clone()))
+			});
 		let our_invalid_votes = controlled_indices
 			.iter()
 			.filter_map(|i| votes.invalid.get_key_value(i))
@@ -297,7 +299,7 @@ impl CandidateVoteState<CandidateVotes> {
 				DisputeStatement::Valid(valid_kind) => {
 					let fresh = votes.valid.insert_vote(
 						val_index,
-						*valid_kind,
+						valid_kind.clone(),
 						statement.into_validator_signature(),
 					);
 					if fresh {
@@ -503,7 +505,7 @@ impl ImportResult {
 	pub fn import_approval_votes(
 		self,
 		env: &CandidateEnvironment,
-		approval_votes: HashMap<ValidatorIndex, ValidatorSignature>,
+		approval_votes: HashMap<ValidatorIndex, (Vec<CandidateHash>, ValidatorSignature)>,
 		now: Timestamp,
 	) -> Self {
 		let Self {
@@ -517,14 +519,17 @@ impl ImportResult {
 
 		let (mut votes, _) = new_state.into_old_state();
 
-		for (index, sig) in approval_votes.into_iter() {
+		for (index, (candidate_hashes, sig)) in approval_votes.into_iter() {
+			gum::debug!(
+				target: LOG_TARGET,
+				"Imported votes for {:?}", candidate_hashes
+			);
 			debug_assert!(
 				{
 					let pub_key = &env.session_info().validators.get(index).expect("indices are validated by approval-voting subsystem; qed");
-					let candidate_hash = votes.candidate_receipt.hash();
 					let session_index = env.session_index();
-					DisputeStatement::Valid(ValidDisputeStatementKind::ApprovalChecking)
-						.check_signature(pub_key, candidate_hash, session_index, &sig)
+					candidate_hashes.contains(&votes.candidate_receipt.hash()) && DisputeStatement::Valid(ValidDisputeStatementKind::ApprovalCheckingV2(candidate_hashes.clone()))
+						.check_signature(pub_key, *candidate_hashes.first().expect("Valid votes have at least one candidate; qed"), session_index, &sig)
 						.is_ok()
 				},
 				"Signature check for imported approval votes failed! This is a serious bug. Session: {:?}, candidate hash: {:?}, validator index: {:?}", env.session_index(), votes.candidate_receipt.hash(), index

--- a/node/core/dispute-coordinator/src/initialized.rs
+++ b/node/core/dispute-coordinator/src/initialized.rs
@@ -633,7 +633,7 @@ impl Initialized {
 						};
 					debug_assert!(
 						SignedDisputeStatement::new_checked(
-							DisputeStatement::Valid(valid_statement_kind),
+							DisputeStatement::Valid(valid_statement_kind.clone()),
 							candidate_hash,
 							session,
 							validator_public.clone(),
@@ -647,7 +647,7 @@ impl Initialized {
 					);
 					let signed_dispute_statement =
 						SignedDisputeStatement::new_unchecked_from_trusted_source(
-							DisputeStatement::Valid(valid_statement_kind),
+							DisputeStatement::Valid(valid_statement_kind.clone()),
 							candidate_hash,
 							session,
 							validator_public,

--- a/node/core/dispute-coordinator/src/lib.rs
+++ b/node/core/dispute-coordinator/src/lib.rs
@@ -574,7 +574,7 @@ pub fn make_dispute_message(
 				.next()
 				.ok_or(DisputeMessageCreationError::NoOppositeVote)?;
 			let other_vote = SignedDisputeStatement::new_checked(
-				DisputeStatement::Valid(*statement_kind),
+				DisputeStatement::Valid(statement_kind.clone()),
 				*our_vote.candidate_hash(),
 				our_vote.session_index(),
 				validators

--- a/node/core/dispute-coordinator/src/tests.rs
+++ b/node/core/dispute-coordinator/src/tests.rs
@@ -651,7 +651,7 @@ fn make_candidate_included_event(candidate_receipt: CandidateReceipt) -> Candida
 pub async fn handle_approval_vote_request(
 	ctx_handle: &mut VirtualOverseer,
 	expected_hash: &CandidateHash,
-	votes_to_send: HashMap<ValidatorIndex, ValidatorSignature>,
+	votes_to_send: HashMap<ValidatorIndex, (Vec<CandidateHash>, ValidatorSignature)>,
 ) {
 	assert_matches!(
 		ctx_handle.recv().await,
@@ -857,9 +857,12 @@ fn approval_vote_import_works() {
 				.await;
 			gum::trace!("After sending `ImportStatements`");
 
-			let approval_votes = [(ValidatorIndex(4), approval_vote.into_validator_signature())]
-				.into_iter()
-				.collect();
+			let approval_votes = [(
+				ValidatorIndex(4),
+				(vec![candidate_receipt1.hash()], approval_vote.into_validator_signature()),
+			)]
+			.into_iter()
+			.collect();
 
 			handle_approval_vote_request(&mut virtual_overseer, &candidate_hash1, approval_votes)
 				.await;

--- a/node/core/provisioner/src/disputes/prioritized_selection/mod.rs
+++ b/node/core/provisioner/src/disputes/prioritized_selection/mod.rs
@@ -217,7 +217,7 @@ where
 				votes.valid.retain(|validator_idx, (statement_kind, _)| {
 					is_vote_worth_to_keep(
 						validator_idx,
-						DisputeStatement::Valid(*statement_kind),
+						DisputeStatement::Valid(statement_kind.clone()),
 						&onchain_state,
 					)
 				});

--- a/node/network/protocol/src/lib.rs
+++ b/node/network/protocol/src/lib.rs
@@ -427,9 +427,8 @@ impl_versioned_try_from!(
 /// - assignment cert type changed, see `IndirectAssignmentCertV2`.
 pub mod vstaging {
 	use parity_scale_codec::{Decode, Encode};
-	use polkadot_node_primitives::approval::{
-		v1::IndirectSignedApprovalVote,
-		v2::{CandidateBitfield, IndirectAssignmentCertV2},
+	use polkadot_node_primitives::approval::v2::{
+		CandidateBitfield, IndirectAssignmentCertV2, IndirectSignedApprovalVoteV2,
 	};
 
 	// Re-export stuff that has not changed since v1.
@@ -468,7 +467,7 @@ pub mod vstaging {
 		Assignments(Vec<(IndirectAssignmentCertV2, CandidateBitfield)>),
 		/// Approvals for candidates in some recent, unfinalized block.
 		#[codec(index = 1)]
-		Approvals(Vec<IndirectSignedApprovalVote>),
+		Approvals(Vec<IndirectSignedApprovalVoteV2>),
 	}
 }
 

--- a/node/primitives/src/approval.rs
+++ b/node/primitives/src/approval.rs
@@ -219,7 +219,9 @@ pub mod v2 {
 	use std::ops::BitOr;
 
 	use bitvec::{prelude::Lsb0, vec::BitVec};
-	use polkadot_primitives::{CandidateIndex, CoreIndex, Hash, ValidatorIndex};
+	use polkadot_primitives::{
+		CandidateIndex, CoreIndex, Hash, ValidatorIndex, ValidatorSignature,
+	};
 
 	/// A static context associated with producing randomness for a core.
 	pub const CORE_RANDOMNESS_CONTEXT: &[u8] = b"A&V CORE v2";
@@ -361,14 +363,16 @@ pub mod v2 {
 		/// candidates were included.
 		///
 		/// The context is [`v2::RELAY_VRF_MODULO_CONTEXT`]
+		#[codec(index = 0)]
 		RelayVRFModuloCompact {
 			/// A bitfield representing the core indices claimed by this assignment.
 			core_bitfield: CoreBitfield,
-		} = 0,
+		},
 		/// An assignment story based on the VRF that authorized the relay-chain block where the
 		/// candidate was included combined with the index of a particular core.
 		///
 		/// The context is [`v2::RELAY_VRF_DELAY_CONTEXT`]
+		#[codec(index = 1)]
 		RelayVRFDelay {
 			/// The core index chosen in this cert.
 			core_index: CoreIndex,
@@ -378,6 +382,7 @@ pub mod v2 {
 		/// candidate was included combined with a sample number.
 		///
 		/// The context used to produce bytes is [`v1::RELAY_VRF_MODULO_CONTEXT`]
+		#[codec(index = 2)]
 		RelayVRFModulo {
 			/// The sample number used in this cert.
 			sample: u32,
@@ -464,6 +469,59 @@ pub mod v2 {
 				cert: indirect_cert.cert.try_into()?,
 			})
 		}
+	}
+
+	impl From<super::v1::IndirectSignedApprovalVote> for IndirectSignedApprovalVoteV2 {
+		fn from(value: super::v1::IndirectSignedApprovalVote) -> Self {
+			Self {
+				block_hash: value.block_hash,
+				validator: value.validator,
+				candidate_indices: value.candidate_index.into(),
+				signature: value.signature,
+			}
+		}
+	}
+
+	/// Errors that can occur when trying to convert to/from approvals v1/v2
+	#[derive(Debug)]
+	pub enum ApprovalConversionError {
+		/// More than one candidate was signed.
+		MoreThanOneCandidate(usize),
+	}
+
+	impl TryFrom<IndirectSignedApprovalVoteV2> for super::v1::IndirectSignedApprovalVote {
+		type Error = ApprovalConversionError;
+
+		fn try_from(value: IndirectSignedApprovalVoteV2) -> Result<Self, Self::Error> {
+			if value.candidate_indices.count_ones() != 1 {
+				return Err(ApprovalConversionError::MoreThanOneCandidate(
+					value.candidate_indices.count_ones(),
+				))
+			}
+			Ok(Self {
+				block_hash: value.block_hash,
+				validator: value.validator,
+				candidate_index: value.candidate_indices.first_one().expect("Qed we checked above")
+					as u32,
+				signature: value.signature,
+			})
+		}
+	}
+
+	/// A signed approval vote which references the candidate indirectly via the block.
+	///
+	/// In practice, we have a look-up from block hash and candidate index to candidate hash,
+	/// so this can be transformed into a `SignedApprovalVote`.
+	#[derive(Debug, Clone, Encode, Decode, PartialEq, Eq)]
+	pub struct IndirectSignedApprovalVoteV2 {
+		/// A block hash where the candidate appears.
+		pub block_hash: Hash,
+		/// The index of the candidate in the list of candidates fully included as-of the block.
+		pub candidate_indices: CandidateBitfield,
+		/// The validator index.
+		pub validator: ValidatorIndex,
+		/// The signature by the validator.
+		pub signature: ValidatorSignature,
 	}
 }
 

--- a/node/primitives/src/disputes/message.rs
+++ b/node/primitives/src/disputes/message.rs
@@ -170,7 +170,7 @@ impl DisputeMessage {
 		let valid_vote = ValidDisputeVote {
 			validator_index: valid_index,
 			signature: valid_statement.validator_signature().clone(),
-			kind: *valid_kind,
+			kind: valid_kind.clone(),
 		};
 
 		let invalid_vote = InvalidDisputeVote {

--- a/node/primitives/src/disputes/mod.rs
+++ b/node/primitives/src/disputes/mod.rs
@@ -107,8 +107,9 @@ impl ValidCandidateVotes {
 				ValidDisputeStatementKind::BackingValid(_) |
 				ValidDisputeStatementKind::BackingSeconded(_) => false,
 				ValidDisputeStatementKind::Explicit |
-				ValidDisputeStatementKind::ApprovalChecking => {
-					occupied.insert((kind, sig));
+				ValidDisputeStatementKind::ApprovalChecking |
+				ValidDisputeStatementKind::ApprovalCheckingV2(_) => {
+					occupied.insert((kind.clone(), sig));
 					kind != occupied.get().0
 				},
 			},

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -55,8 +55,9 @@ pub use v5::{
 	UncheckedSignedAvailabilityBitfields, UncheckedSignedStatement, UpgradeGoAhead,
 	UpgradeRestriction, UpwardMessage, ValidDisputeStatementKind, ValidationCode,
 	ValidationCodeHash, ValidatorId, ValidatorIndex, ValidatorSignature, ValidityAttestation,
-	ValidityError, ASSIGNMENT_KEY_TYPE_ID, LOWEST_PUBLIC_ID, MAX_CODE_SIZE, MAX_HEAD_DATA_SIZE,
-	MAX_POV_SIZE, PARACHAINS_INHERENT_IDENTIFIER, PARACHAIN_KEY_TYPE_ID,
+	ValidityError, ASSIGNMENT_KEY_TYPE_ID, LOWEST_PUBLIC_ID, MAX_APPROVAL_COALESCE_COUNT,
+	MAX_APPROVAL_COALESCE_WAIT_MILLIS, MAX_CODE_SIZE, MAX_HEAD_DATA_SIZE, MAX_POV_SIZE,
+	PARACHAINS_INHERENT_IDENTIFIER, PARACHAIN_KEY_TYPE_ID,
 };
 
 #[cfg(feature = "std")]

--- a/primitives/src/v5/mod.rs
+++ b/primitives/src/v5/mod.rs
@@ -353,6 +353,13 @@ pub mod well_known_keys {
 /// Unique identifier for the Parachains Inherent
 pub const PARACHAINS_INHERENT_IDENTIFIER: InherentIdentifier = *b"parachn0";
 
+/// TODO: Make this two a parachain host configuration.
+/// Maximum allowed candidates to be signed withing a signle approval votes.
+pub const MAX_APPROVAL_COALESCE_COUNT: u64 = 6;
+/// The maximum time we await for an approval to be coalesced with other approvals
+/// before we sign it and distribute to our peers
+pub const MAX_APPROVAL_COALESCE_WAIT_MILLIS: u64 = 500;
+
 /// The key type ID for parachain assignment key.
 pub const ASSIGNMENT_KEY_TYPE_ID: KeyTypeId = KeyTypeId(*b"asgn");
 
@@ -1060,6 +1067,26 @@ impl ApprovalVote {
 	}
 }
 
+/// A vote of approvalf for multiple candidates.
+#[derive(Clone, RuntimeDebug)]
+pub struct ApprovalVoteMultipleCandidates(pub Vec<CandidateHash>);
+
+impl ApprovalVoteMultipleCandidates {
+	/// Yields the signing payload for this approval vote.
+	pub fn signing_payload(&self, session_index: SessionIndex) -> Vec<u8> {
+		const MAGIC: [u8; 4] = *b"APPR";
+		// Make this backwards compatible with `ApprovalVote` so if we have just on candidate the signature
+		// will look the same.
+		// This gives us the nice benefit that old nodes can still check signatures when len is 1 and the
+		// new node can check the signature coming from old nodes.
+		if self.0.len() == 1 {
+			(MAGIC, self.0.first().expect("QED: we just checked"), session_index).encode()
+		} else {
+			(MAGIC, &self.0, session_index).encode()
+		}
+	}
+}
+
 /// Custom validity errors used in Polkadot while validating transactions.
 #[repr(u8)]
 pub enum ValidityError {
@@ -1234,22 +1261,25 @@ pub enum DisputeStatement {
 impl DisputeStatement {
 	/// Get the payload data for this type of dispute statement.
 	pub fn payload_data(&self, candidate_hash: CandidateHash, session: SessionIndex) -> Vec<u8> {
-		match *self {
+		match self {
 			DisputeStatement::Valid(ValidDisputeStatementKind::Explicit) =>
 				ExplicitDisputeStatement { valid: true, candidate_hash, session }.signing_payload(),
 			DisputeStatement::Valid(ValidDisputeStatementKind::BackingSeconded(
 				inclusion_parent,
 			)) => CompactStatement::Seconded(candidate_hash).signing_payload(&SigningContext {
 				session_index: session,
-				parent_hash: inclusion_parent,
+				parent_hash: *inclusion_parent,
 			}),
 			DisputeStatement::Valid(ValidDisputeStatementKind::BackingValid(inclusion_parent)) =>
 				CompactStatement::Valid(candidate_hash).signing_payload(&SigningContext {
 					session_index: session,
-					parent_hash: inclusion_parent,
+					parent_hash: *inclusion_parent,
 				}),
 			DisputeStatement::Valid(ValidDisputeStatementKind::ApprovalChecking) =>
 				ApprovalVote(candidate_hash).signing_payload(session),
+			DisputeStatement::Valid(ValidDisputeStatementKind::ApprovalCheckingV2(
+				candidate_hashes,
+			)) => ApprovalVoteMultipleCandidates(candidate_hashes.clone()).signing_payload(session),
 			DisputeStatement::Invalid(InvalidDisputeStatementKind::Explicit) =>
 				ExplicitDisputeStatement { valid: false, candidate_hash, session }.signing_payload(),
 		}
@@ -1295,13 +1325,14 @@ impl DisputeStatement {
 			Self::Valid(ValidDisputeStatementKind::BackingValid(_)) => true,
 			Self::Valid(ValidDisputeStatementKind::Explicit) |
 			Self::Valid(ValidDisputeStatementKind::ApprovalChecking) |
+			Self::Valid(ValidDisputeStatementKind::ApprovalCheckingV2(_)) |
 			Self::Invalid(_) => false,
 		}
 	}
 }
 
 /// Different kinds of statements of validity on  a candidate.
-#[derive(Encode, Decode, Copy, Clone, PartialEq, RuntimeDebug, TypeInfo)]
+#[derive(Encode, Decode, Clone, PartialEq, RuntimeDebug, TypeInfo)]
 pub enum ValidDisputeStatementKind {
 	/// An explicit statement issued as part of a dispute.
 	#[codec(index = 0)]
@@ -1315,6 +1346,11 @@ pub enum ValidDisputeStatementKind {
 	/// An approval vote from the approval checking phase.
 	#[codec(index = 3)]
 	ApprovalChecking,
+	/// An approval vote from the new version.
+	/// TODO: Fixme this probably means we can't create this version
+	/// untill all nodes have been updated to support it.
+	#[codec(index = 4)]
+	ApprovalCheckingV2(Vec<CandidateHash>),
 }
 
 /// Different kinds of statements of invalidity on a candidate.

--- a/runtime/parachains/src/disputes.rs
+++ b/runtime/parachains/src/disputes.rs
@@ -25,11 +25,11 @@ use frame_system::pallet_prelude::*;
 use parity_scale_codec::{Decode, Encode};
 use polkadot_runtime_metrics::get_current_time;
 use primitives::{
-	byzantine_threshold, supermajority_threshold, ApprovalVote, CandidateHash,
-	CheckedDisputeStatementSet, CheckedMultiDisputeStatementSet, CompactStatement, ConsensusLog,
-	DisputeState, DisputeStatement, DisputeStatementSet, ExplicitDisputeStatement,
-	InvalidDisputeStatementKind, MultiDisputeStatementSet, SessionIndex, SigningContext,
-	ValidDisputeStatementKind, ValidatorId, ValidatorIndex, ValidatorSignature,
+	byzantine_threshold, supermajority_threshold, vstaging::ApprovalVoteMultipleCandidates,
+	ApprovalVote, CandidateHash, CheckedDisputeStatementSet, CheckedMultiDisputeStatementSet,
+	CompactStatement, ConsensusLog, DisputeState, DisputeStatement, DisputeStatementSet,
+	ExplicitDisputeStatement, InvalidDisputeStatementKind, MultiDisputeStatementSet, SessionIndex,
+	SigningContext, ValidDisputeStatementKind, ValidatorId, ValidatorIndex, ValidatorSignature,
 };
 use scale_info::TypeInfo;
 use sp_runtime::{
@@ -1345,6 +1345,9 @@ fn check_signature(
 			}),
 		DisputeStatement::Valid(ValidDisputeStatementKind::ApprovalChecking) =>
 			ApprovalVote(candidate_hash).signing_payload(session),
+		DisputeStatement::Valid(ValidDisputeStatementKind::ApprovalCheckingV2(_)) =>
+		// TODO: Fixme
+			ApprovalVoteMultipleCandidates(vec![candidate_hash]).signing_payload(session),
 		DisputeStatement::Invalid(InvalidDisputeStatementKind::Explicit) =>
 			ExplicitDisputeStatement { valid: false, candidate_hash, session }.signing_payload(),
 	};

--- a/zombienet_tests/functional/0001-parachains-pvf.zndsl
+++ b/zombienet_tests/functional/0001-parachains-pvf.zndsl
@@ -32,6 +32,8 @@ alice: parachain 2005 block height is at least 10 within 300 seconds
 alice: parachain 2006 block height is at least 10 within 300 seconds
 alice: parachain 2007 block height is at least 10 within 300 seconds
 
+alice: reports substrate_block_height{status="finalized"} is at least 30 within 400 seconds
+
 # Check preparation time is under 10s.
 # Check all buckets <= 10.
 alice: reports histogram polkadot_pvf_preparation_time has at least 1 samples in buckets ["0.1", "0.5", "1", "2", "3", "10"] within 10 seconds


### PR DESCRIPTION
Initial implementation for the plan discussed here: https://github.com/paritytech/polkadot/issues/6831#issuecomment-1649649600 on top of: https://github.com/paritytech/polkadot/pull/6782

Note! This is not yet ready to be merged, but should be in a good shape to get feedback if it is moving in the right direction.

## Overall idea
When approval-voting checks a candidate and is ready to advertise the approval, defer it in a per-relay chain block until we either have `MAX_APPROVAL_COALESCE_COUNT` candidates to sign or a candidate has stayed `MAX_APPROVAL_COALESCE_WAIT_MILLIS` in the queue, in both cases we sign what candidates we have available.

This should allow us to reduce the number of approvals messages we have to create/send/verify and the parameters are configurable, so we should find some values that balances:
- Security of the network: Delaying broadcasting of an approval shouldn't but the finality at risk.
- Scalability of the network:  MAX_APPROVAL_COALESCE_COUNT = 1 & MAX_APPROVAL_COALESCE_WAIT_MILLIS =0, is what we have now and we know from the measurements we did on versi, it bottlenecks approval-distribution/approval-voting when increase significantly the number of validators and parachains 
- Block storage: In case of disputes we have to import this votes on chain and that increase the necessary storage with MAX_APPROVAL_COALESCE_COUNT * CandidateHash per vote. Given that disputes are not the normal way of the network functioning and we will limit  MAX_APPROVAL_COALESCE_COUNT in the single digits numbers, this should be good enough. Alternatively, we could try to create a better way to store this on-chain through indirection, if that's needed.




### TODO:
[] Get feedback, that this is moving in the right direction. @ordian @sandreim @eskimor @burdges, let me know what you think.
[]  More and more testing. 
[] Test in versi.
[] Make MAX_APPROVAL_COALESCE_COUNT & MAX_APPROVAL_COALESCE_WAIT_MILLIS a parachain host configuration.
[] Make sure the backwards compatibility works correctly
[] Make sure this direction is compatible with other streams of work: https://github.com/paritytech/polkadot/issues/7229 &  https://github.com/paritytech/polkadot/issues/6510

