### PR TITLE
Fix publish dockerhub description ci jobs

### DIFF
--- a/scripts/ci/dockerfiles/polkadot_Dockerfile.README.md
+++ b/scripts/ci/dockerfiles/polkadot_Dockerfile.README.md
@@ -5,4 +5,3 @@
 ## [GitHub](https://github.com/paritytech/polkadot)
 
 ## [Polkadot Wiki](https://wiki.polkadot.network/)
-

--- a/scripts/ci/dockerfiles/staking-miner/staking-miner_Dockerfile.README.md
+++ b/scripts/ci/dockerfiles/staking-miner/staking-miner_Dockerfile.README.md
@@ -1,4 +1,3 @@
 # Staking-miner Docker image
 
 ## [GitHub](https://github.com/paritytech/polkadot/tree/master/utils/staking-miner)
-

--- a/scripts/ci/gitlab/pipeline/publish.yml
+++ b/scripts/ci/gitlab/pipeline/publish.yml
@@ -118,8 +118,8 @@ publish-polkadot-image-description:
   stage: publish
   image: paritytech/dockerhub-description
   variables:
-    DOCKER_USER: ${Docker_Hub_User_Parity}
-    DOCKER_PASS: ${Docker_Hub_Pass_Parity}
+    DOCKER_USERNAME: ${Docker_Hub_User_Parity}
+    DOCKER_PASSWORD: ${Docker_Hub_Pass_Parity}
     DOCKERHUB_REPOSITORY: parity/polkadot
     SHORT_DESCRIPTION: "Polkadot Official Docker Image"
     README_FILEPATH: $CI_PROJECT_DIR/scripts/ci/dockerfiles/polkadot_Dockerfile.README.md
@@ -138,8 +138,8 @@ publish-staking-miner-image-description:
   stage: publish
   image: paritytech/dockerhub-description
   variables:
-    DOCKER_USER: ${Docker_Hub_User_Parity}
-    DOCKER_PASS: ${Docker_Hub_Pass_Parity}
+    DOCKER_USERNAME: ${Docker_Hub_User_Parity}
+    DOCKER_PASSWORD: ${Docker_Hub_Pass_Parity}
     DOCKERHUB_REPOSITORY: paritytech/staking-miner
     SHORT_DESCRIPTION: "Staking-miner Docker Image"
     README_FILEPATH: $CI_PROJECT_DIR/scripts/ci/dockerfiles/staking-miner/staking-miner_Dockerfile.README.md


### PR DESCRIPTION
Final fix to https://github.com/paritytech/polkadot/pull/7551 - was not using `paritytech/docker-description` for a while and completely forgot that it will not accept shortened var names.
