### PR TITLE
Add xcm context to weight trader

### DIFF
--- a/runtime/test-runtime/src/xcm_config.rs
+++ b/runtime/test-runtime/src/xcm_config.rs
@@ -80,7 +80,7 @@ impl WeightTrader for DummyWeightTrader {
 		DummyWeightTrader
 	}
 
-	fn buy_weight(&mut self, _weight: Weight, _payment: Assets) -> Result<Assets, XcmError> {
+	fn buy_weight(&mut self, _ctx: &XcmContext, _weight: Weight, _payment: Assets) -> Result<Assets, XcmError> {
 		Ok(Assets::default())
 	}
 }

--- a/runtime/test-runtime/src/xcm_config.rs
+++ b/runtime/test-runtime/src/xcm_config.rs
@@ -80,7 +80,12 @@ impl WeightTrader for DummyWeightTrader {
 		DummyWeightTrader
 	}
 
-	fn buy_weight(&mut self, _ctx: &XcmContext, _weight: Weight, _payment: Assets) -> Result<Assets, XcmError> {
+	fn buy_weight(
+		&mut self,
+		_ctx: &XcmContext,
+		_weight: Weight,
+		_payment: Assets,
+	) -> Result<Assets, XcmError> {
 		Ok(Assets::default())
 	}
 }

--- a/runtime/test-runtime/src/xcm_config.rs
+++ b/runtime/test-runtime/src/xcm_config.rs
@@ -82,7 +82,7 @@ impl WeightTrader for DummyWeightTrader {
 
 	fn buy_weight(
 		&mut self,
-		_ctx: &XcmContext,
+		_ctx: Option<&XcmContext>,
 		_weight: Weight,
 		_payment: Assets,
 	) -> Result<Assets, XcmError> {

--- a/xcm/xcm-builder/src/tests/weight.rs
+++ b/xcm/xcm-builder/src/tests/weight.rs
@@ -24,25 +24,31 @@ fn fixed_rate_of_fungible_should_work() {
 	}
 
 	let mut trader = FixedRateOfFungible::<WeightPrice, ()>::new();
+	let ctx = XcmContext {
+		origin: None,
+		message_id: XcmHash::default(),
+		topic: None,
+	};
+
 	// supplies 100 unit of asset, 80 still remains after purchasing weight
 	assert_eq!(
 		trader
-			.buy_weight(Weight::from_parts(10, 10), fungible_multi_asset(Here.into(), 100).into()),
+			.buy_weight(&ctx, Weight::from_parts(10, 10), fungible_multi_asset(Here.into(), 100).into()),
 		Ok(fungible_multi_asset(Here.into(), 80).into()),
 	);
 	// should have nothing left, as 5 + 5 = 10, and we supplied 10 units of asset.
 	assert_eq!(
-		trader.buy_weight(Weight::from_parts(5, 5), fungible_multi_asset(Here.into(), 10).into()),
+		trader.buy_weight(&ctx, Weight::from_parts(5, 5), fungible_multi_asset(Here.into(), 10).into()),
 		Ok(vec![].into()),
 	);
 	// should have 5 left, as there are no proof size components
 	assert_eq!(
-		trader.buy_weight(Weight::from_parts(5, 0), fungible_multi_asset(Here.into(), 10).into()),
+		trader.buy_weight(&ctx, Weight::from_parts(5, 0), fungible_multi_asset(Here.into(), 10).into()),
 		Ok(fungible_multi_asset(Here.into(), 5).into()),
 	);
 	// not enough to purchase the combined weights
 	assert_err!(
-		trader.buy_weight(Weight::from_parts(5, 5), fungible_multi_asset(Here.into(), 5).into()),
+		trader.buy_weight(&ctx, Weight::from_parts(5, 5), fungible_multi_asset(Here.into(), 5).into()),
 		XcmError::TooExpensive,
 	);
 }

--- a/xcm/xcm-builder/src/tests/weight.rs
+++ b/xcm/xcm-builder/src/tests/weight.rs
@@ -24,31 +24,42 @@ fn fixed_rate_of_fungible_should_work() {
 	}
 
 	let mut trader = FixedRateOfFungible::<WeightPrice, ()>::new();
-	let ctx = XcmContext {
-		origin: None,
-		message_id: XcmHash::default(),
-		topic: None,
-	};
+	let ctx = XcmContext { origin: None, message_id: XcmHash::default(), topic: None };
 
 	// supplies 100 unit of asset, 80 still remains after purchasing weight
 	assert_eq!(
-		trader
-			.buy_weight(&ctx, Weight::from_parts(10, 10), fungible_multi_asset(Here.into(), 100).into()),
+		trader.buy_weight(
+			&ctx,
+			Weight::from_parts(10, 10),
+			fungible_multi_asset(Here.into(), 100).into()
+		),
 		Ok(fungible_multi_asset(Here.into(), 80).into()),
 	);
 	// should have nothing left, as 5 + 5 = 10, and we supplied 10 units of asset.
 	assert_eq!(
-		trader.buy_weight(&ctx, Weight::from_parts(5, 5), fungible_multi_asset(Here.into(), 10).into()),
+		trader.buy_weight(
+			&ctx,
+			Weight::from_parts(5, 5),
+			fungible_multi_asset(Here.into(), 10).into()
+		),
 		Ok(vec![].into()),
 	);
 	// should have 5 left, as there are no proof size components
 	assert_eq!(
-		trader.buy_weight(&ctx, Weight::from_parts(5, 0), fungible_multi_asset(Here.into(), 10).into()),
+		trader.buy_weight(
+			&ctx,
+			Weight::from_parts(5, 0),
+			fungible_multi_asset(Here.into(), 10).into()
+		),
 		Ok(fungible_multi_asset(Here.into(), 5).into()),
 	);
 	// not enough to purchase the combined weights
 	assert_err!(
-		trader.buy_weight(&ctx, Weight::from_parts(5, 5), fungible_multi_asset(Here.into(), 5).into()),
+		trader.buy_weight(
+			&ctx,
+			Weight::from_parts(5, 5),
+			fungible_multi_asset(Here.into(), 5).into()
+		),
 		XcmError::TooExpensive,
 	);
 }

--- a/xcm/xcm-builder/src/tests/weight.rs
+++ b/xcm/xcm-builder/src/tests/weight.rs
@@ -168,7 +168,11 @@ fn weight_trader_tuple_should_work() {
 	let mut traders = Traders::new();
 	// trader one buys weight
 	assert_eq!(
-		traders.buy_weight(None, Weight::from_parts(5, 5), fungible_multi_asset(Here.into(), 10).into()),
+		traders.buy_weight(
+			None,
+			Weight::from_parts(5, 5),
+			fungible_multi_asset(Here.into(), 10).into()
+		),
 		Ok(vec![].into()),
 	);
 	// trader one refunds

--- a/xcm/xcm-builder/src/tests/weight.rs
+++ b/xcm/xcm-builder/src/tests/weight.rs
@@ -29,7 +29,7 @@ fn fixed_rate_of_fungible_should_work() {
 	// supplies 100 unit of asset, 80 still remains after purchasing weight
 	assert_eq!(
 		trader.buy_weight(
-			&ctx,
+			Some(&ctx),
 			Weight::from_parts(10, 10),
 			fungible_multi_asset(Here.into(), 100).into()
 		),
@@ -38,7 +38,7 @@ fn fixed_rate_of_fungible_should_work() {
 	// should have nothing left, as 5 + 5 = 10, and we supplied 10 units of asset.
 	assert_eq!(
 		trader.buy_weight(
-			&ctx,
+			Some(&ctx),
 			Weight::from_parts(5, 5),
 			fungible_multi_asset(Here.into(), 10).into()
 		),
@@ -47,7 +47,7 @@ fn fixed_rate_of_fungible_should_work() {
 	// should have 5 left, as there are no proof size components
 	assert_eq!(
 		trader.buy_weight(
-			&ctx,
+			Some(&ctx),
 			Weight::from_parts(5, 0),
 			fungible_multi_asset(Here.into(), 10).into()
 		),
@@ -56,7 +56,7 @@ fn fixed_rate_of_fungible_should_work() {
 	// not enough to purchase the combined weights
 	assert_err!(
 		trader.buy_weight(
-			&ctx,
+			Some(&ctx),
 			Weight::from_parts(5, 5),
 			fungible_multi_asset(Here.into(), 5).into()
 		),
@@ -168,33 +168,33 @@ fn weight_trader_tuple_should_work() {
 	let mut traders = Traders::new();
 	// trader one buys weight
 	assert_eq!(
-		traders.buy_weight(Weight::from_parts(5, 5), fungible_multi_asset(Here.into(), 10).into()),
+		traders.buy_weight(None, Weight::from_parts(5, 5), fungible_multi_asset(Here.into(), 10).into()),
 		Ok(vec![].into()),
 	);
 	// trader one refunds
 	assert_eq!(
-		traders.refund_weight(Weight::from_parts(2, 2)),
+		traders.refund_weight(None, Weight::from_parts(2, 2)),
 		Some(fungible_multi_asset(Here.into(), 4))
 	);
 
 	let mut traders = Traders::new();
 	// trader one failed; trader two buys weight
 	assert_eq!(
-		traders.buy_weight(Weight::from_parts(5, 5), fungible_multi_asset(para_1, 10).into()),
+		traders.buy_weight(None, Weight::from_parts(5, 5), fungible_multi_asset(para_1, 10).into()),
 		Ok(vec![].into()),
 	);
 	// trader two refunds
 	assert_eq!(
-		traders.refund_weight(Weight::from_parts(2, 2)),
+		traders.refund_weight(None, Weight::from_parts(2, 2)),
 		Some(fungible_multi_asset(para_1, 4))
 	);
 
 	let mut traders = Traders::new();
 	// all traders fails
 	assert_err!(
-		traders.buy_weight(Weight::from_parts(5, 5), fungible_multi_asset(para_2, 10).into()),
+		traders.buy_weight(None, Weight::from_parts(5, 5), fungible_multi_asset(para_2, 10).into()),
 		XcmError::TooExpensive,
 	);
 	// and no refund
-	assert_eq!(traders.refund_weight(Weight::from_parts(2, 2)), None);
+	assert_eq!(traders.refund_weight(None, Weight::from_parts(2, 2)), None);
 }

--- a/xcm/xcm-builder/src/weight.rs
+++ b/xcm/xcm-builder/src/weight.rs
@@ -140,7 +140,7 @@ impl<T: Get<(AssetId, u128, u128)>, R: TakeRevenue> WeightTrader for FixedRateOf
 		Self(Weight::zero(), 0, PhantomData)
 	}
 
-	fn buy_weight(&mut self, weight: Weight, payment: Assets) -> Result<Assets, XcmError> {
+	fn buy_weight(&mut self, _ctx: &XcmContext, weight: Weight, payment: Assets) -> Result<Assets, XcmError> {
 		log::trace!(
 			target: "xcm::weight",
 			"FixedRateOfFungible::buy_weight weight: {:?}, payment: {:?}",
@@ -160,7 +160,7 @@ impl<T: Get<(AssetId, u128, u128)>, R: TakeRevenue> WeightTrader for FixedRateOf
 		Ok(unused)
 	}
 
-	fn refund_weight(&mut self, weight: Weight) -> Option<MultiAsset> {
+	fn refund_weight(&mut self, _ctx: &XcmContext, weight: Weight) -> Option<MultiAsset> {
 		log::trace!(target: "xcm::weight", "FixedRateOfFungible::refund_weight weight: {:?}", weight);
 		let (id, units_per_second, units_per_mb) = T::get();
 		let weight = weight.min(self.0);
@@ -210,7 +210,7 @@ impl<
 		Self(Weight::zero(), Zero::zero(), PhantomData)
 	}
 
-	fn buy_weight(&mut self, weight: Weight, payment: Assets) -> Result<Assets, XcmError> {
+	fn buy_weight(&mut self, _ctx: &XcmContext, weight: Weight, payment: Assets) -> Result<Assets, XcmError> {
 		log::trace!(target: "xcm::weight", "UsingComponents::buy_weight weight: {:?}, payment: {:?}", weight, payment);
 		let amount = WeightToFee::weight_to_fee(&weight);
 		let u128_amount: u128 = amount.try_into().map_err(|_| XcmError::Overflow)?;
@@ -221,7 +221,7 @@ impl<
 		Ok(unused)
 	}
 
-	fn refund_weight(&mut self, weight: Weight) -> Option<MultiAsset> {
+	fn refund_weight(&mut self, _ctx: &XcmContext, weight: Weight) -> Option<MultiAsset> {
 		log::trace!(target: "xcm::weight", "UsingComponents::refund_weight weight: {:?}", weight);
 		let weight = weight.min(self.0);
 		let amount = WeightToFee::weight_to_fee(&weight);

--- a/xcm/xcm-builder/src/weight.rs
+++ b/xcm/xcm-builder/src/weight.rs
@@ -142,7 +142,7 @@ impl<T: Get<(AssetId, u128, u128)>, R: TakeRevenue> WeightTrader for FixedRateOf
 
 	fn buy_weight(
 		&mut self,
-		_ctx: &XcmContext,
+		_ctx: Option<&XcmContext>,
 		weight: Weight,
 		payment: Assets,
 	) -> Result<Assets, XcmError> {
@@ -165,7 +165,7 @@ impl<T: Get<(AssetId, u128, u128)>, R: TakeRevenue> WeightTrader for FixedRateOf
 		Ok(unused)
 	}
 
-	fn refund_weight(&mut self, _ctx: &XcmContext, weight: Weight) -> Option<MultiAsset> {
+	fn refund_weight(&mut self, _ctx: Option<&XcmContext>, weight: Weight) -> Option<MultiAsset> {
 		log::trace!(target: "xcm::weight", "FixedRateOfFungible::refund_weight weight: {:?}", weight);
 		let (id, units_per_second, units_per_mb) = T::get();
 		let weight = weight.min(self.0);
@@ -217,7 +217,7 @@ impl<
 
 	fn buy_weight(
 		&mut self,
-		_ctx: &XcmContext,
+		_ctx: Option<&XcmContext>,
 		weight: Weight,
 		payment: Assets,
 	) -> Result<Assets, XcmError> {
@@ -231,7 +231,7 @@ impl<
 		Ok(unused)
 	}
 
-	fn refund_weight(&mut self, _ctx: &XcmContext, weight: Weight) -> Option<MultiAsset> {
+	fn refund_weight(&mut self, _ctx: Option<&XcmContext>, weight: Weight) -> Option<MultiAsset> {
 		log::trace!(target: "xcm::weight", "UsingComponents::refund_weight weight: {:?}", weight);
 		let weight = weight.min(self.0);
 		let amount = WeightToFee::weight_to_fee(&weight);

--- a/xcm/xcm-builder/src/weight.rs
+++ b/xcm/xcm-builder/src/weight.rs
@@ -140,7 +140,12 @@ impl<T: Get<(AssetId, u128, u128)>, R: TakeRevenue> WeightTrader for FixedRateOf
 		Self(Weight::zero(), 0, PhantomData)
 	}
 
-	fn buy_weight(&mut self, _ctx: &XcmContext, weight: Weight, payment: Assets) -> Result<Assets, XcmError> {
+	fn buy_weight(
+		&mut self,
+		_ctx: &XcmContext,
+		weight: Weight,
+		payment: Assets,
+	) -> Result<Assets, XcmError> {
 		log::trace!(
 			target: "xcm::weight",
 			"FixedRateOfFungible::buy_weight weight: {:?}, payment: {:?}",
@@ -210,7 +215,12 @@ impl<
 		Self(Weight::zero(), Zero::zero(), PhantomData)
 	}
 
-	fn buy_weight(&mut self, _ctx: &XcmContext, weight: Weight, payment: Assets) -> Result<Assets, XcmError> {
+	fn buy_weight(
+		&mut self,
+		_ctx: &XcmContext,
+		weight: Weight,
+		payment: Assets,
+	) -> Result<Assets, XcmError> {
 		log::trace!(target: "xcm::weight", "UsingComponents::buy_weight weight: {:?}, payment: {:?}", weight, payment);
 		let amount = WeightToFee::weight_to_fee(&weight);
 		let u128_amount: u128 = amount.try_into().map_err(|_| XcmError::Overflow)?;

--- a/xcm/xcm-executor/src/lib.rs
+++ b/xcm/xcm-executor/src/lib.rs
@@ -457,7 +457,7 @@ impl<Config: config::Config> XcmExecutor<Config> {
 		let current_surplus = self.total_surplus.saturating_sub(self.total_refunded);
 		if current_surplus.any_gt(Weight::zero()) {
 			self.total_refunded.saturating_accrue(current_surplus);
-			if let Some(w) = self.trader.refund_weight(current_surplus) {
+			if let Some(w) = self.trader.refund_weight(&self.context, current_surplus) {
 				self.subsume_asset(w)?;
 			}
 		}
@@ -689,7 +689,7 @@ impl<Config: config::Config> XcmExecutor<Config> {
 					// pay for `weight` using up to `fees` of the holding register.
 					let max_fee =
 						self.holding.try_take(fees.into()).map_err(|_| XcmError::NotHoldingFees)?;
-					let unspent = self.trader.buy_weight(weight, max_fee)?;
+					let unspent = self.trader.buy_weight(&self.context, weight, max_fee)?;
 					self.subsume_assets(unspent)?;
 				}
 				Ok(())

--- a/xcm/xcm-executor/src/lib.rs
+++ b/xcm/xcm-executor/src/lib.rs
@@ -457,7 +457,7 @@ impl<Config: config::Config> XcmExecutor<Config> {
 		let current_surplus = self.total_surplus.saturating_sub(self.total_refunded);
 		if current_surplus.any_gt(Weight::zero()) {
 			self.total_refunded.saturating_accrue(current_surplus);
-			if let Some(w) = self.trader.refund_weight(&self.context, current_surplus) {
+			if let Some(w) = self.trader.refund_weight(Some(&self.context), current_surplus) {
 				self.subsume_asset(w)?;
 			}
 		}
@@ -689,7 +689,7 @@ impl<Config: config::Config> XcmExecutor<Config> {
 					// pay for `weight` using up to `fees` of the holding register.
 					let max_fee =
 						self.holding.try_take(fees.into()).map_err(|_| XcmError::NotHoldingFees)?;
-					let unspent = self.trader.buy_weight(&self.context, weight, max_fee)?;
+					let unspent = self.trader.buy_weight(Some(&self.context), weight, max_fee)?;
 					self.subsume_assets(unspent)?;
 				}
 				Ok(())

--- a/xcm/xcm-executor/src/traits/weight.rs
+++ b/xcm/xcm-executor/src/traits/weight.rs
@@ -49,13 +49,13 @@ pub trait WeightTrader: Sized {
 	/// Purchase execution weight credit in return for up to a given `payment`. If less of the
 	/// payment is required then the surplus is returned. If the `payment` cannot be used to pay
 	/// for the `weight`, then an error is returned.
-	fn buy_weight(&mut self, weight: Weight, payment: Assets) -> Result<Assets, XcmError>;
+	fn buy_weight(&mut self, ctx: &XcmContext, weight: Weight, payment: Assets) -> Result<Assets, XcmError>;
 
 	/// Attempt a refund of `weight` into some asset. The caller does not guarantee that the weight was
 	/// purchased using `buy_weight`.
 	///
 	/// Default implementation refunds nothing.
-	fn refund_weight(&mut self, _weight: Weight) -> Option<MultiAsset> {
+	fn refund_weight(&mut self, _ctx: &XcmContext, _weight: Weight) -> Option<MultiAsset> {
 		None
 	}
 }
@@ -66,11 +66,11 @@ impl WeightTrader for Tuple {
 		for_tuples!( ( #( Tuple::new() ),* ) )
 	}
 
-	fn buy_weight(&mut self, weight: Weight, payment: Assets) -> Result<Assets, XcmError> {
+	fn buy_weight(&mut self, ctx: &XcmContext, weight: Weight, payment: Assets) -> Result<Assets, XcmError> {
 		let mut too_expensive_error_found = false;
 		let mut last_error = None;
 		for_tuples!( #(
-			match Tuple.buy_weight(weight, payment.clone()) {
+			match Tuple.buy_weight(ctx, weight, payment.clone()) {
 				Ok(assets) => return Ok(assets),
 				Err(e) => {
 					if let XcmError::TooExpensive = e {
@@ -92,9 +92,9 @@ impl WeightTrader for Tuple {
 		})
 	}
 
-	fn refund_weight(&mut self, weight: Weight) -> Option<MultiAsset> {
+	fn refund_weight(&mut self, ctx: &XcmContext, weight: Weight) -> Option<MultiAsset> {
 		for_tuples!( #(
-			if let Some(asset) = Tuple.refund_weight(weight) {
+			if let Some(asset) = Tuple.refund_weight(ctx, weight) {
 				return Some(asset);
 			}
 		)* );

--- a/xcm/xcm-executor/src/traits/weight.rs
+++ b/xcm/xcm-executor/src/traits/weight.rs
@@ -49,7 +49,12 @@ pub trait WeightTrader: Sized {
 	/// Purchase execution weight credit in return for up to a given `payment`. If less of the
 	/// payment is required then the surplus is returned. If the `payment` cannot be used to pay
 	/// for the `weight`, then an error is returned.
-	fn buy_weight(&mut self, ctx: &XcmContext, weight: Weight, payment: Assets) -> Result<Assets, XcmError>;
+	fn buy_weight(
+		&mut self,
+		ctx: &XcmContext,
+		weight: Weight,
+		payment: Assets,
+	) -> Result<Assets, XcmError>;
 
 	/// Attempt a refund of `weight` into some asset. The caller does not guarantee that the weight was
 	/// purchased using `buy_weight`.
@@ -66,7 +71,12 @@ impl WeightTrader for Tuple {
 		for_tuples!( ( #( Tuple::new() ),* ) )
 	}
 
-	fn buy_weight(&mut self, ctx: &XcmContext, weight: Weight, payment: Assets) -> Result<Assets, XcmError> {
+	fn buy_weight(
+		&mut self,
+		ctx: &XcmContext,
+		weight: Weight,
+		payment: Assets,
+	) -> Result<Assets, XcmError> {
 		let mut too_expensive_error_found = false;
 		let mut last_error = None;
 		for_tuples!( #(

--- a/xcm/xcm-executor/src/traits/weight.rs
+++ b/xcm/xcm-executor/src/traits/weight.rs
@@ -51,7 +51,7 @@ pub trait WeightTrader: Sized {
 	/// for the `weight`, then an error is returned.
 	fn buy_weight(
 		&mut self,
-		ctx: &XcmContext,
+		ctx: Option<&XcmContext>,
 		weight: Weight,
 		payment: Assets,
 	) -> Result<Assets, XcmError>;
@@ -60,7 +60,7 @@ pub trait WeightTrader: Sized {
 	/// purchased using `buy_weight`.
 	///
 	/// Default implementation refunds nothing.
-	fn refund_weight(&mut self, _ctx: &XcmContext, _weight: Weight) -> Option<MultiAsset> {
+	fn refund_weight(&mut self, _ctx: Option<&XcmContext>, _weight: Weight) -> Option<MultiAsset> {
 		None
 	}
 }
@@ -73,7 +73,7 @@ impl WeightTrader for Tuple {
 
 	fn buy_weight(
 		&mut self,
-		ctx: &XcmContext,
+		ctx: Option<&XcmContext>,
 		weight: Weight,
 		payment: Assets,
 	) -> Result<Assets, XcmError> {
@@ -102,7 +102,7 @@ impl WeightTrader for Tuple {
 		})
 	}
 
-	fn refund_weight(&mut self, ctx: &XcmContext, weight: Weight) -> Option<MultiAsset> {
+	fn refund_weight(&mut self, ctx: Option<&XcmContext>, weight: Weight) -> Option<MultiAsset> {
 		for_tuples!( #(
 			if let Some(asset) = Tuple.refund_weight(ctx, weight) {
 				return Some(asset);


### PR DESCRIPTION
(This is needed for paying xcm fees via asset conversion)

Cumulus companion: https://github.com/paritytech/cumulus/pull/2954