### PR TITLE
backing: move the min votes threshold to the runtime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,7 +165,6 @@ crossbeam-deque = { opt-level = 3 }
 crypto-mac = { opt-level = 3 }
 curve25519-dalek = { opt-level = 3 }
 ed25519-dalek = { opt-level = 3 }
-flate2 = { opt-level = 3 }
 futures-channel = { opt-level = 3 }
 hash-db = { opt-level = 3 }
 hashbrown = { opt-level = 3 }

--- a/node/core/backing/src/tests.rs
+++ b/node/core/backing/src/tests.rs
@@ -64,6 +64,7 @@ struct TestState {
 	head_data: HashMap<ParaId, HeadData>,
 	signing_context: SigningContext,
 	relay_parent: Hash,
+	minimum_backing_votes: u32,
 }
 
 impl Default for TestState {
@@ -132,6 +133,7 @@ impl Default for TestState {
 			validation_data,
 			signing_context,
 			relay_parent,
+			minimum_backing_votes: 2,
 		}
 	}
 }
@@ -259,6 +261,16 @@ async fn test_startup(virtual_overseer: &mut VirtualOverseer, test_state: &TestS
 			RuntimeApiMessage::Request(parent, RuntimeApiRequest::AvailabilityCores(tx))
 		) if parent == test_state.relay_parent => {
 			tx.send(Ok(test_state.availability_cores.clone())).unwrap();
+		}
+	);
+
+	// Check that subsystem job issues a request for the minimum backing votes.
+	assert_matches!(
+		virtual_overseer.recv().await,
+		AllMessages::RuntimeApi(
+			RuntimeApiMessage::Request(parent, RuntimeApiRequest::MinimumBackingVotes(tx))
+		) if parent == test_state.relay_parent => {
+			tx.send(Ok(test_state.minimum_backing_votes)).unwrap();
 		}
 	);
 }

--- a/node/core/runtime-api/src/cache.rs
+++ b/node/core/runtime-api/src/cache.rs
@@ -40,6 +40,7 @@ const DEFAULT_CACHE_CAP: NonZeroUsize = match NonZeroUsize::new(128) {
 pub(crate) struct RequestResultCache {
 	authorities: LruCache<Hash, Vec<AuthorityDiscoveryId>>,
 	validators: LruCache<Hash, Vec<ValidatorId>>,
+	minimum_backing_votes: LruCache<Hash, u32>,
 	validator_groups: LruCache<Hash, (Vec<Vec<ValidatorIndex>>, GroupRotationInfo)>,
 	availability_cores: LruCache<Hash, Vec<CoreState>>,
 	persisted_validation_data:
@@ -75,6 +76,7 @@ impl Default for RequestResultCache {
 		Self {
 			authorities: LruCache::new(DEFAULT_CACHE_CAP),
 			validators: LruCache::new(DEFAULT_CACHE_CAP),
+			minimum_backing_votes: LruCache::new(DEFAULT_CACHE_CAP),
 			validator_groups: LruCache::new(DEFAULT_CACHE_CAP),
 			availability_cores: LruCache::new(DEFAULT_CACHE_CAP),
 			persisted_validation_data: LruCache::new(DEFAULT_CACHE_CAP),
@@ -123,6 +125,18 @@ impl RequestResultCache {
 
 	pub(crate) fn cache_validators(&mut self, relay_parent: Hash, validators: Vec<ValidatorId>) {
 		self.validators.put(relay_parent, validators);
+	}
+
+	pub(crate) fn minimum_backing_votes(&mut self, relay_parent: &Hash) -> Option<u32> {
+		self.minimum_backing_votes.get(relay_parent).copied()
+	}
+
+	pub(crate) fn cache_minimum_backing_votes(
+		&mut self,
+		relay_parent: Hash,
+		minimum_backing_votes: u32,
+	) {
+		self.minimum_backing_votes.put(relay_parent, minimum_backing_votes);
 	}
 
 	pub(crate) fn validator_groups(
@@ -436,6 +450,7 @@ pub(crate) enum RequestResult {
 	// The structure of each variant is (relay_parent, [params,]*, result)
 	Authorities(Hash, Vec<AuthorityDiscoveryId>),
 	Validators(Hash, Vec<ValidatorId>),
+	MinimumBackingVotes(Hash, u32),
 	ValidatorGroups(Hash, (Vec<Vec<ValidatorIndex>>, GroupRotationInfo)),
 	AvailabilityCores(Hash, Vec<CoreState>),
 	PersistedValidationData(Hash, ParaId, OccupiedCoreAssumption, Option<PersistedValidationData>),

--- a/node/core/runtime-api/src/lib.rs
+++ b/node/core/runtime-api/src/lib.rs
@@ -101,6 +101,9 @@ where
 				self.requests_cache.cache_authorities(relay_parent, authorities),
 			Validators(relay_parent, validators) =>
 				self.requests_cache.cache_validators(relay_parent, validators),
+			MinimumBackingVotes(relay_parent, minimum_backing_votes) => self
+				.requests_cache
+				.cache_minimum_backing_votes(relay_parent, minimum_backing_votes),
 			ValidatorGroups(relay_parent, groups) =>
 				self.requests_cache.cache_validator_groups(relay_parent, groups),
 			AvailabilityCores(relay_parent, cores) =>
@@ -288,6 +291,8 @@ where
 						Request::SubmitReportDisputeLost(dispute_proof, key_ownership_proof, sender)
 					},
 				),
+			Request::MinimumBackingVotes(sender) => query!(minimum_backing_votes(), sender)
+				.map(|sender| Request::MinimumBackingVotes(sender)),
 		}
 	}
 
@@ -436,6 +441,9 @@ where
 
 		Request::Authorities(sender) => query!(Authorities, authorities(), ver = 1, sender),
 		Request::Validators(sender) => query!(Validators, validators(), ver = 1, sender),
+		Request::MinimumBackingVotes(sender) =>
+			query!(MinimumBackingVotes, minimum_backing_votes(), ver = 1, sender),
+
 		Request::ValidatorGroups(sender) => {
 			query!(ValidatorGroups, validator_groups(), ver = 1, sender)
 		},

--- a/node/service/src/fake_runtime_api.rs
+++ b/node/service/src/fake_runtime_api.rs
@@ -120,6 +120,10 @@ sp_api::impl_runtime_apis! {
 			unimplemented!()
 		}
 
+		fn minimum_backing_votes() -> u32 {
+			unimplemented!()
+		}
+
 		fn validator_groups() -> (Vec<Vec<ValidatorIndex>>, GroupRotationInfo<BlockNumber>) {
 			unimplemented!()
 		}

--- a/node/subsystem-types/src/messages.rs
+++ b/node/subsystem-types/src/messages.rs
@@ -564,6 +564,8 @@ pub enum RuntimeApiRequest {
 	Authorities(RuntimeApiSender<Vec<AuthorityDiscoveryId>>),
 	/// Get the current validator set.
 	Validators(RuntimeApiSender<Vec<ValidatorId>>),
+	/// Get the minimum required backing votes.
+	MinimumBackingVotes(RuntimeApiSender<u32>),
 	/// Get the validator groups and group rotation info.
 	ValidatorGroups(RuntimeApiSender<(Vec<Vec<ValidatorIndex>>, GroupRotationInfo)>),
 	/// Get information on all availability cores.

--- a/node/subsystem-types/src/runtime_client.rs
+++ b/node/subsystem-types/src/runtime_client.rs
@@ -40,6 +40,9 @@ pub trait RuntimeApiSubsystemClient {
 	/// Get the current validators.
 	async fn validators(&self, at: Hash) -> Result<Vec<ValidatorId>, ApiError>;
 
+	/// Get the minimum number of backing votes.
+	async fn minimum_backing_votes(&self, at: Hash) -> Result<u32, ApiError>;
+
 	/// Returns the validator groups and rotation info localized based on the hypothetical child
 	///  of a block whose state  this is invoked on. Note that `now` in the `GroupRotationInfo`
 	/// should be the successor of the number of the block.
@@ -256,6 +259,10 @@ where
 {
 	async fn validators(&self, at: Hash) -> Result<Vec<ValidatorId>, ApiError> {
 		self.client.runtime_api().validators(at)
+	}
+
+	async fn minimum_backing_votes(&self, at: Hash) -> Result<u32, ApiError> {
+		self.client.runtime_api().minimum_backing_votes(at)
 	}
 
 	async fn validator_groups(

--- a/primitives/src/runtime_api.rs
+++ b/primitives/src/runtime_api.rs
@@ -132,6 +132,9 @@ sp_api::decl_runtime_apis! {
 		/// Get the current validators.
 		fn validators() -> Vec<ValidatorId>;
 
+		/// Get the minimum number of backing votes for a parachain candidate.
+		fn minimum_backing_votes() -> u32;
+
 		/// Returns the validator groups and rotation info localized based on the hypothetical child
 		///  of a block whose state  this is invoked on. Note that `now` in the `GroupRotationInfo`
 		/// should be the successor of the number of the block.

--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -1689,6 +1689,10 @@ sp_api::impl_runtime_apis! {
 			parachains_runtime_api_impl::validators::<Runtime>()
 		}
 
+		fn minimum_backing_votes() -> u32 {
+			parachains_runtime_api_impl::minimum_backing_votes::<Runtime>()
+		}
+
 		fn validator_groups() -> (Vec<Vec<ValidatorIndex>>, GroupRotationInfo<BlockNumber>) {
 			parachains_runtime_api_impl::validator_groups::<Runtime>()
 		}

--- a/runtime/parachains/src/configuration.rs
+++ b/runtime/parachains/src/configuration.rs
@@ -239,6 +239,8 @@ pub struct HostConfiguration<BlockNumber> {
 	/// This value should be greater than [`chain_availability_period`] and
 	/// [`thread_availability_period`].
 	pub minimum_validation_upgrade_delay: BlockNumber,
+	/// The minimum number of valid backing statements required to consider a parachain candidate backable.
+	pub minimum_backing_votes: u32,
 }
 
 impl<BlockNumber: Default + From<u32>> Default for HostConfiguration<BlockNumber> {
@@ -287,6 +289,7 @@ impl<BlockNumber: Default + From<u32>> Default for HostConfiguration<BlockNumber
 			pvf_voting_ttl: 2u32.into(),
 			minimum_validation_upgrade_delay: 2.into(),
 			executor_params: Default::default(),
+			minimum_backing_votes: Default::default(),
 		}
 	}
 }

--- a/runtime/parachains/src/configuration/migration/v7.rs
+++ b/runtime/parachains/src/configuration/migration/v7.rs
@@ -147,6 +147,7 @@ pvf_voting_ttl                           : pre.pvf_voting_ttl,
 minimum_validation_upgrade_delay         : pre.minimum_validation_upgrade_delay,
 async_backing_params                     : pre.async_backing_params,
 executor_params                          : pre.executor_params,
+minimum_backing_votes                    : 2
 		}
 	};
 

--- a/runtime/parachains/src/inclusion/mod.rs
+++ b/runtime/parachains/src/inclusion/mod.rs
@@ -192,18 +192,6 @@ impl<H> Default for ProcessedCandidates<H> {
 	}
 }
 
-/// Number of backing votes we need for a valid backing.
-///
-/// WARNING: This check has to be kept in sync with the node side check in the backing
-/// subsystem.
-pub fn minimum_backing_votes(n_validators: usize) -> usize {
-	// For considerations on this value see:
-	// https://github.com/paritytech/polkadot/pull/1656#issuecomment-999734650
-	// and
-	// https://github.com/paritytech/polkadot/issues/4386
-	sp_std::cmp::min(n_validators, 2)
-}
-
 /// Reads the footprint of queues for a specific origin type.
 pub trait QueueFootprinter {
 	type Origin;
@@ -611,6 +599,7 @@ impl<T: Config> Pallet<T> {
 			return Ok(ProcessedCandidates::default())
 		}
 
+		let minimum_backing_votes = configuration::Pallet::<T>::config().minimum_backing_votes;
 		let validators = shared::Pallet::<T>::active_validator_keys();
 		let parent_hash = <frame_system::Pallet<T>>::parent_hash();
 
@@ -719,7 +708,11 @@ impl<T: Config> Pallet<T> {
 
 							match maybe_amount_validated {
 								Ok(amount_validated) => ensure!(
-									amount_validated >= minimum_backing_votes(group_vals.len()),
+									amount_validated >=
+										sp_std::cmp::min(
+											group_vals.len(),
+											minimum_backing_votes as usize
+										),
 									Error::<T>::InsufficientBacking,
 								),
 								Err(()) => {

--- a/runtime/parachains/src/runtime_api_impl/v5.rs
+++ b/runtime/parachains/src/runtime_api_impl/v5.rs
@@ -38,6 +38,12 @@ pub fn validators<T: initializer::Config>() -> Vec<ValidatorId> {
 	<shared::Pallet<T>>::active_validator_keys()
 }
 
+/// Implementation of the `minimum_backing_votes` function of the runtime API.
+pub fn minimum_backing_votes<T: initializer::Config>() -> u32 {
+	let config = <configuration::Pallet<T>>::config();
+	config.minimum_backing_votes
+}
+
 /// Implementation for the `validator_groups` function of the runtime API.
 pub fn validator_groups<T: initializer::Config>(
 ) -> (Vec<Vec<ValidatorIndex>>, GroupRotationInfo<BlockNumberFor<T>>) {

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -1692,6 +1692,10 @@ sp_api::impl_runtime_apis! {
 			parachains_runtime_api_impl::validators::<Runtime>()
 		}
 
+		fn minimum_backing_votes() -> u32 {
+			parachains_runtime_api_impl::minimum_backing_votes::<Runtime>()
+		}
+
 		fn validator_groups() -> (Vec<Vec<ValidatorIndex>>, GroupRotationInfo<BlockNumber>) {
 			parachains_runtime_api_impl::validator_groups::<Runtime>()
 		}

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -1692,6 +1692,10 @@ sp_api::impl_runtime_apis! {
 			parachains_runtime_api_impl::validators::<Runtime>()
 		}
 
+		fn minimum_backing_votes() -> u32 {
+			parachains_runtime_api_impl::minimum_backing_votes::<Runtime>()
+		}
+
 		fn validator_groups() -> (Vec<Vec<ValidatorIndex>>, GroupRotationInfo<BlockNumber>) {
 			parachains_runtime_api_impl::validator_groups::<Runtime>()
 		}

--- a/runtime/westend/src/lib.rs
+++ b/runtime/westend/src/lib.rs
@@ -1427,6 +1427,10 @@ sp_api::impl_runtime_apis! {
 			parachains_runtime_api_impl::validators::<Runtime>()
 		}
 
+		fn minimum_backing_votes() -> u32 {
+			parachains_runtime_api_impl::minimum_backing_votes::<Runtime>()
+		}
+
 		fn validator_groups() -> (Vec<Vec<ValidatorIndex>>, GroupRotationInfo<BlockNumber>) {
 			parachains_runtime_api_impl::validator_groups::<Runtime>()
 		}

--- a/statement-table/src/generic.rs
+++ b/statement-table/src/generic.rs
@@ -57,8 +57,8 @@ pub trait Context {
 	/// Members are meant to submit candidates and vote on validity.
 	fn is_member_of(&self, authority: &Self::AuthorityId, group: &Self::GroupId) -> bool;
 
-	/// requisite number of votes for validity from a group.
-	fn requisite_votes(&self, group: &Self::GroupId) -> usize;
+	/// Get a validator group size.
+	fn get_group_size(&self, group: &Self::GroupId) -> Option<usize>;
 }
 
 /// Statements circulated among peers.
@@ -310,9 +310,12 @@ impl<Ctx: Context> Table<Ctx> {
 		&self,
 		digest: &Ctx::Digest,
 		context: &Ctx,
+		minimum_backing_votes: u32,
 	) -> Option<AttestedCandidate<Ctx::GroupId, Ctx::Candidate, Ctx::AuthorityId, Ctx::Signature>> {
 		self.candidate_votes.get(digest).and_then(|data| {
-			let v_threshold = context.requisite_votes(&data.group_id);
+			let v_threshold = context
+				.get_group_size(&data.group_id)
+				.map_or(usize::MAX, |len| std::cmp::min(minimum_backing_votes as usize, len));
 			data.attested(v_threshold)
 		})
 	}
@@ -616,16 +619,13 @@ mod tests {
 			self.authorities.get(authority).map(|v| v == group).unwrap_or(false)
 		}
 
-		fn requisite_votes(&self, id: &GroupId) -> usize {
-			let mut total_validity = 0;
-
-			for validity in self.authorities.values() {
-				if validity == id {
-					total_validity += 1
-				}
+		fn get_group_size(&self, group: &Self::GroupId) -> Option<usize> {
+			let count = self.authorities.values().filter(|g| *g == group).count();
+			if count == 0 {
+				None
+			} else {
+				Some(count)
 			}
-
-			total_validity / 2 + 1
 		}
 	}
 
@@ -860,7 +860,7 @@ mod tests {
 		table.import_statement(&context, statement);
 
 		assert!(!table.detected_misbehavior.contains_key(&AuthorityId(1)));
-		assert!(table.attested_candidate(&candidate_digest, &context).is_none());
+		assert!(table.attested_candidate(&candidate_digest, &context, 2).is_none());
 
 		let vote = SignedStatement {
 			statement: Statement::Valid(candidate_digest.clone()),
@@ -870,7 +870,7 @@ mod tests {
 
 		table.import_statement(&context, vote);
 		assert!(!table.detected_misbehavior.contains_key(&AuthorityId(2)));
-		assert!(table.attested_candidate(&candidate_digest, &context).is_some());
+		assert!(table.attested_candidate(&candidate_digest, &context, 2).is_some());
 	}
 
 	#[test]


### PR DESCRIPTION
Need to sort out:
- runtime migration
- see if we can further cache the min_backing_votes on the SessionInfo (can we? do we guarantee that there'll be a session change if the `HostConfiguration` changes?)