### PR TITLE
Document non-uniqueness of SetTopic IDs

### DIFF
--- a/xcm/src/v3/mod.rs
+++ b/xcm/src/v3/mod.rs
@@ -981,6 +981,10 @@ pub enum Instruction<Call> {
 
 	/// Set the Topic Register.
 	///
+	/// The 32-byte array identifier in the parameter is not guaranteed to be
+	/// unique; if such a property is desired, it is up to the code author to
+	/// enforce uniqueness.
+	///
 	/// Safety: No concerns.
 	///
 	/// Kind: *Instruction*

--- a/xcm/xcm-builder/src/barriers.rs
+++ b/xcm/xcm-builder/src/barriers.rs
@@ -207,6 +207,9 @@ impl<
 
 /// Sets the message ID to `t` using a `SetTopic(t)` in the last position if present.
 ///
+/// Note that the message ID does not necessarily have to be unique; it is the
+/// sender's responsibility to ensure uniqueness.
+///
 /// Requires some inner barrier to pass on the rest of the message.
 pub struct TrailingSetTopicAsId<InnerBarrier>(PhantomData<InnerBarrier>);
 impl<InnerBarrier: ShouldExecute> ShouldExecute for TrailingSetTopicAsId<InnerBarrier> {


### PR DESCRIPTION
This PR documents that the parameter to `SetTopic` are not guaranteed to be unique, and hence the code author is responsible to maintain uniqueness if so desired.