### PR TITLE
`[pallet_xcm::reserve_transfer_assets]` `NotHoldingFees` issue in case of paid XcmRouter is used

### DIFF
--- a/xcm/pallet-xcm/src/tests.rs
+++ b/xcm/pallet-xcm/src/tests.rs
@@ -583,9 +583,9 @@ fn reserve_transfer_assets_with_paid_router_works() {
 			vec![(
 				Parachain(PARA_ID).into(),
 				Xcm(vec![
-					ReserveAssetDeposited((Parent, SEND_AMOUNT - xcm_router_fee_amount).into()),
+					ReserveAssetDeposited((Parent, SEND_AMOUNT).into()),
 					ClearOrigin,
-					buy_limited_execution((Parent, SEND_AMOUNT - xcm_router_fee_amount), Weight::from_parts(4000, 4000)),
+					buy_limited_execution((Parent, SEND_AMOUNT), Weight::from_parts(4000, 4000)),
 					DepositAsset { assets: AllCounted(1).into(), beneficiary: dest },
 				]),
 			)]

--- a/xcm/pallet-xcm/src/tests.rs
+++ b/xcm/pallet-xcm/src/tests.rs
@@ -525,6 +525,80 @@ fn reserve_transfer_assets_works() {
 	});
 }
 
+/// Test `reserve_transfer_assets_with_paid_router_works`
+///
+/// Asserts that the sender's balance is decreased and the beneficiary's balance
+/// is increased. Verifies the correct message is sent and event is emitted.
+/// Verifies that XCM router fees (`SendXcm::validate` -> `MultiAssets`) are withdrawn from correct user account
+/// and deposited to a correct target account (`XcmFeesTargetAccount`).
+#[test]
+fn reserve_transfer_assets_with_paid_router_works() {
+	// set up router fees for destination
+	let xcm_router_fee_amount = 1;
+	set_router_fee_for_destination(
+		Parachain(PARA_ID).into(),
+		Some(MultiAssets::from((Here, xcm_router_fee_amount))),
+	);
+
+	let user_account = AccountId::from(XCM_FEES_NOT_WAIVED_USER_ACCOUNT);
+
+	let balances = vec![
+		(user_account.clone(), INITIAL_BALANCE),
+		(ParaId::from(PARA_ID).into_account_truncating(), INITIAL_BALANCE),
+		(XcmFeesTargetAccount::get(), INITIAL_BALANCE),
+	];
+	new_test_ext_with_balances(balances).execute_with(|| {
+		let weight = BaseXcmWeight::get() * 2;
+		let dest: MultiLocation =
+			Junction::AccountId32 { network: None, id: user_account.clone().into() }.into();
+		assert_eq!(Balances::total_balance(&user_account), INITIAL_BALANCE);
+		assert_ok!(XcmPallet::reserve_transfer_assets(
+			RuntimeOrigin::signed(user_account.clone()),
+			Box::new(Parachain(PARA_ID).into()),
+			Box::new(dest.clone().into()),
+			Box::new((Here, SEND_AMOUNT).into()),
+			0,
+		));
+		// check event
+		assert_eq!(
+			last_event(),
+			RuntimeEvent::XcmPallet(crate::Event::Attempted { outcome: Outcome::Complete(weight) })
+		);
+
+		// XCM_FEES_NOT_WAIVED_USER_ACCOUNT spent amount
+		assert_eq!(
+			Balances::free_balance(user_account),
+			INITIAL_BALANCE - SEND_AMOUNT - xcm_router_fee_amount
+		);
+		// Destination account (parachain account) has amount
+		let para_acc: AccountId = ParaId::from(PARA_ID).into_account_truncating();
+		assert_eq!(Balances::free_balance(para_acc), INITIAL_BALANCE + SEND_AMOUNT);
+		// XcmFeesTargetAccount where should lend xcm_router_fee_amount
+		assert_eq!(
+			Balances::free_balance(XcmFeesTargetAccount::get()),
+			INITIAL_BALANCE + xcm_router_fee_amount
+		);
+		assert_eq!(
+			sent_xcm(),
+			vec![(
+				Parachain(PARA_ID).into(),
+				Xcm(vec![
+					ReserveAssetDeposited((Parent, SEND_AMOUNT).into()),
+					ClearOrigin,
+					buy_limited_execution((Parent, SEND_AMOUNT), Weight::from_parts(4000, 4000)),
+					DepositAsset { assets: AllCounted(1).into(), beneficiary: dest },
+				]),
+			)]
+		);
+		let versioned_sent = VersionedXcm::from(sent_xcm().into_iter().next().unwrap().1);
+		let _check_v2_ok: xcm::v2::Xcm<()> = versioned_sent.try_into().unwrap();
+		assert_eq!(
+			last_event(),
+			RuntimeEvent::XcmPallet(crate::Event::Attempted { outcome: Outcome::Complete(weight) })
+		);
+	});
+}
+
 /// Test `limited_reserve_transfer_assets`
 ///
 /// Asserts that the sender's balance is decreased and the beneficiary's balance

--- a/xcm/pallet-xcm/src/tests.rs
+++ b/xcm/pallet-xcm/src/tests.rs
@@ -583,9 +583,9 @@ fn reserve_transfer_assets_with_paid_router_works() {
 			vec![(
 				Parachain(PARA_ID).into(),
 				Xcm(vec![
-					ReserveAssetDeposited((Parent, SEND_AMOUNT).into()),
+					ReserveAssetDeposited((Parent, SEND_AMOUNT - xcm_router_fee_amount).into()),
 					ClearOrigin,
-					buy_limited_execution((Parent, SEND_AMOUNT), Weight::from_parts(4000, 4000)),
+					buy_limited_execution((Parent, SEND_AMOUNT - xcm_router_fee_amount), Weight::from_parts(4000, 4000)),
 					DepositAsset { assets: AllCounted(1).into(), beneficiary: dest },
 				]),
 			)]

--- a/xcm/xcm-executor/src/lib.rs
+++ b/xcm/xcm-executor/src/lib.rs
@@ -405,8 +405,7 @@ impl<Config: config::Config> XcmExecutor<Config> {
 	) -> Result<XcmHash, XcmError> {
 		let (ticket, fee) = validate_send::<Config::XcmSender>(dest, msg)?;
 		if !Config::FeeManager::is_waived(self.origin_ref(), reason) {
-			let paid = self.holding.try_take(fee.into()).map_err(|_| XcmError::NotHoldingFees)?;
-			Config::FeeManager::handle_fee(paid.into(), Some(&self.context));
+			self.take_fee(fee, reason)?;
 		}
 		Config::XcmSender::deliver(ticket).map_err(Into::into)
 	}


### PR DESCRIPTION
Based on PR: https://github.com/paritytech/polkadot/pull/7005

on AssetHubs we plan to set FeeManager and waive unpaid only for system parachains or relay chain
https://github.com/paritytech/cumulus/pull/2433/files#diff-9a51956f7781a349d207a9d5f54ea0061666a856fb108d1a1190bd5178eaac50R432-R437
so it means, that any user/origin will be charged for delivery, from [holding register](https://github.com/paritytech/polkadot/blob/6f4a8bb0063c91fe869b94196ead5717950b9f23/xcm/xcm-executor/src/lib.rs#L399-L412):
```
                let (ticket, fee) = validate_send::<Config::XcmSender>(dest, msg)?;
		if !Config::FeeManager::is_waived(self.origin_ref(), reason) {
			let paid = self.holding.try_take(fee.into()).map_err(|_| XcmError::NotHoldingFees)?;
			Config::FeeManager::handle_fee(paid.into(), Some(&self.context));
		}
		Config::XcmSender::deliver(ticket).map_err(Into::into)
```
which seems ok, but there are several cases, when this `holding` register is not filled and is empty,
for example `pallet_xcm::reserve_transfer_assets` generates instructions:
```
SetFeesMode { jit_withdraw: true },
TransferReserveAsset { assets, ...}
```

`SetFeesMode` -> does nothing, because it affects only `sef.take_fee(` which is used only for `ExportMessage / LockAsset / RequestUnlock` 
`TransferReserveAsset` - does reserve transfer of assets and then `self.send(ReserveAssetDeposited(assets))` to destination

**and here are problems with this `self.send`:**

---
1. there is nothing in `holding` so this `self.send` for regular user fails on `NotHoldingFees` - see test bellow without fix
---
2. Should we withdraw `fee from validate_send`  from user account directly or from holding register?
maybe here in `fn send` is missing `IF` based on `jit_withdraw: true`, which is the same code as `fn take_fee` does?

so maybe solution is to use here `self.take_fee(` - which is working for test :)
```
/// Send an XCM, charging fees from Holding as needed.
	fn send(
		&mut self,
		dest: MultiLocation,
		msg: Xcm<()>,
		reason: FeeReason,
	) -> Result<XcmHash, XcmError> {
		let (ticket, fee) = validate_send::<Config::XcmSender>(dest, msg)?;
		if !Config::FeeManager::is_waived(self.origin_ref(), reason) {
			self.take_fee(fee, reason)?;
		}
		Config::XcmSender::deliver(ticket).map_err(Into::into)
	}
```





---
**Test fails withtout changing:**

orginal:
```
		if !Config::FeeManager::is_waived(self.origin_ref(), reason) {
			let paid = self.holding.try_take(fee.into()).map_err(|_| XcmError::NotHoldingFees)?;
			Config::FeeManager::handle_fee(paid.into(), Some(&self.context));
		}
```

fixed to:
```
		if !Config::FeeManager::is_waived(self.origin_ref(), reason) {
			self.take_fee(fee, reason)?;
		}
```





```
cargo test --package pallet-xcm --lib tests::reserve_transfer_assets_with_paid_router_works -- --exact

Left:  RuntimeEvent::XcmPallet(Event::Attempted { outcome: Incomplete(Weight { ref_time: 2000, proof_size: 2000 }, NotHoldingFees) })
Right: RuntimeEvent::XcmPallet(Event::Attempted { outcome: Complete(Weight { ref_time: 2000, proof_size: 2000 }) })
<Click to see difference>

thread 'tests::reserve_transfer_assets_with_paid_router_works' panicked at 'assertion failed: `(left == right)`
  left: `RuntimeEvent::XcmPallet(Event::Attempted { outcome: Incomplete(Weight { ref_time: 2000, proof_size: 2000 }, NotHoldingFees) })`,
 right: `RuntimeEvent::XcmPallet(Event::Attempted { outcome: Complete(Weight { ref_time: 2000, proof_size: 2000 }) })`', xcm/pallet-xcm/src/tests.rs:563:9
```





