### PR TITLE
[Polkadot] 28 days as conviction voting period

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,7 +166,6 @@ crossbeam-deque = { opt-level = 3 }
 crypto-mac = { opt-level = 3 }
 curve25519-dalek = { opt-level = 3 }
 ed25519-dalek = { opt-level = 3 }
-flate2 = { opt-level = 3 }
 futures-channel = { opt-level = 3 }
 hash-db = { opt-level = 3 }
 hashbrown = { opt-level = 3 }

--- a/runtime/polkadot/src/governance/mod.rs
+++ b/runtime/polkadot/src/governance/mod.rs
@@ -35,7 +35,7 @@ mod tracks;
 pub use tracks::TracksInfo;
 
 parameter_types! {
-	pub const VoteLockingPeriod: BlockNumber = 7 * DAYS;
+	pub const VoteLockingPeriod: BlockNumber = prod_or_fast!(28 * DAYS, 1);
 }
 
 impl pallet_conviction_voting::Config for Runtime {


### PR DESCRIPTION
Changes:
- Used 28 days as conviction voting period in the Polkadot runtime
- Removed unused dependency profile