### PR TITLE
companion for 14754: cli: move no-beefy flag to sc-cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -617,7 +617,7 @@ dependencies = [
 [[package]]
 name = "binary-merkle-tree"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "hash-db",
  "log",
@@ -2446,7 +2446,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -2469,7 +2469,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 [[package]]
 name = "frame-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -2494,7 +2494,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "Inflector",
  "array-bytes",
@@ -2542,7 +2542,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2553,7 +2553,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -2570,7 +2570,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2599,7 +2599,7 @@ dependencies = [
 [[package]]
 name = "frame-remote-externalities"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "async-recursion",
  "futures",
@@ -2620,7 +2620,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "aquamarine",
  "bitflags",
@@ -2657,7 +2657,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -2675,7 +2675,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -2687,7 +2687,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2697,7 +2697,7 @@ dependencies = [
 [[package]]
 name = "frame-support-test"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "frame-benchmarking",
  "frame-executive",
@@ -2724,7 +2724,7 @@ dependencies = [
 [[package]]
 name = "frame-support-test-pallet"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2737,7 +2737,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "cfg-if",
  "frame-support",
@@ -2756,7 +2756,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2771,7 +2771,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -2780,7 +2780,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -2962,7 +2962,7 @@ dependencies = [
 [[package]]
 name = "generate-bags"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "chrono",
  "frame-election-provider-support",
@@ -4829,7 +4829,7 @@ dependencies = [
 [[package]]
 name = "mmr-gadget"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "futures",
  "log",
@@ -4848,7 +4848,7 @@ dependencies = [
 [[package]]
 name = "mmr-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "anyhow",
  "jsonrpsee",
@@ -5374,7 +5374,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5389,7 +5389,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5405,7 +5405,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5419,7 +5419,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5443,7 +5443,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5463,7 +5463,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list-remote-tests"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "frame-election-provider-support",
  "frame-remote-externalities",
@@ -5482,7 +5482,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5497,7 +5497,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5516,7 +5516,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "array-bytes",
  "binary-merkle-tree",
@@ -5540,7 +5540,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5558,7 +5558,7 @@ dependencies = [
 [[package]]
 name = "pallet-child-bounties"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5577,7 +5577,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5594,7 +5594,7 @@ dependencies = [
 [[package]]
 name = "pallet-conviction-voting"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -5611,7 +5611,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5629,7 +5629,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5652,7 +5652,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5665,7 +5665,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "5.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5684,7 +5684,7 @@ dependencies = [
 [[package]]
 name = "pallet-fast-unstake"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -5703,7 +5703,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5726,7 +5726,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -5742,7 +5742,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5762,7 +5762,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5779,7 +5779,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5796,7 +5796,7 @@ dependencies = [
 [[package]]
 name = "pallet-message-queue"
 version = "7.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5815,7 +5815,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5832,7 +5832,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5848,7 +5848,7 @@ dependencies = [
 [[package]]
 name = "pallet-nis"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5864,7 +5864,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5883,7 +5883,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5903,7 +5903,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
 version = "1.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
@@ -5914,7 +5914,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5931,7 +5931,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5955,7 +5955,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5972,7 +5972,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5987,7 +5987,7 @@ dependencies = [
 [[package]]
 name = "pallet-ranked-collective"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6005,7 +6005,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6020,7 +6020,7 @@ dependencies = [
 [[package]]
 name = "pallet-referenda"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -6039,7 +6039,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6056,7 +6056,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6077,7 +6077,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6093,7 +6093,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6111,7 +6111,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6134,7 +6134,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -6145,7 +6145,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -6154,7 +6154,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6163,7 +6163,7 @@ dependencies = [
 [[package]]
 name = "pallet-state-trie-migration"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6180,7 +6180,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6195,7 +6195,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6213,7 +6213,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6232,7 +6232,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6248,7 +6248,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -6264,7 +6264,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -6276,7 +6276,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6293,7 +6293,7 @@ dependencies = [
 [[package]]
 name = "pallet-uniques"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6308,7 +6308,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6324,7 +6324,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6339,7 +6339,7 @@ dependencies = [
 [[package]]
 name = "pallet-whitelist"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9360,7 +9360,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "4.1.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "log",
  "sp-core",
@@ -9371,7 +9371,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "async-trait",
  "futures",
@@ -9399,7 +9399,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "futures",
  "futures-timer",
@@ -9422,7 +9422,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -9437,7 +9437,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "memmap2",
  "sc-chain-spec-derive",
@@ -9456,7 +9456,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -9467,7 +9467,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "array-bytes",
  "chrono",
@@ -9506,7 +9506,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "fnv",
  "futures",
@@ -9532,7 +9532,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -9558,7 +9558,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "async-trait",
  "futures",
@@ -9583,7 +9583,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -9619,7 +9619,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -9641,7 +9641,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "array-bytes",
  "async-channel",
@@ -9675,7 +9675,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -9694,7 +9694,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -9707,7 +9707,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "ahash 0.8.2",
  "array-bytes",
@@ -9748,7 +9748,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "finality-grandpa",
  "futures",
@@ -9768,7 +9768,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "async-trait",
  "futures",
@@ -9791,7 +9791,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.1",
@@ -9813,7 +9813,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "sc-allocator",
  "sp-maybe-compressed-blob",
@@ -9825,7 +9825,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -9842,7 +9842,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "ansi_term",
  "futures",
@@ -9858,7 +9858,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "array-bytes",
  "parking_lot 0.12.1",
@@ -9872,7 +9872,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "array-bytes",
  "async-channel",
@@ -9915,7 +9915,7 @@ dependencies = [
 [[package]]
 name = "sc-network-bitswap"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "async-channel",
  "cid",
@@ -9935,7 +9935,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "async-trait",
  "bitflags",
@@ -9952,7 +9952,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "ahash 0.8.2",
  "futures",
@@ -9971,7 +9971,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "array-bytes",
  "async-channel",
@@ -9992,7 +9992,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "array-bytes",
  "async-channel",
@@ -10026,7 +10026,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "array-bytes",
  "futures",
@@ -10044,7 +10044,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "array-bytes",
  "bytes",
@@ -10078,7 +10078,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -10087,7 +10087,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -10118,7 +10118,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -10137,7 +10137,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "http",
  "jsonrpsee",
@@ -10152,7 +10152,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "array-bytes",
  "futures",
@@ -10179,7 +10179,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "async-trait",
  "directories",
@@ -10243,7 +10243,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -10254,7 +10254,7 @@ dependencies = [
 [[package]]
 name = "sc-storage-monitor"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "clap 4.2.5",
  "fs4",
@@ -10268,7 +10268,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -10287,7 +10287,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "6.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "futures",
  "libc",
@@ -10306,7 +10306,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "chrono",
  "futures",
@@ -10325,7 +10325,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "ansi_term",
  "atty",
@@ -10354,7 +10354,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -10365,7 +10365,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "async-trait",
  "futures",
@@ -10391,7 +10391,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "async-trait",
  "futures",
@@ -10407,7 +10407,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "async-channel",
  "futures",
@@ -10955,7 +10955,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "hash-db",
  "log",
@@ -10976,7 +10976,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "Inflector",
  "blake2",
@@ -10990,7 +10990,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11003,7 +11003,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -11017,7 +11017,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11030,7 +11030,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -11041,7 +11041,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "futures",
  "log",
@@ -11059,7 +11059,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "async-trait",
  "futures",
@@ -11074,7 +11074,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -11091,7 +11091,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -11110,7 +11110,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-beefy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "lazy_static",
  "parity-scale-codec",
@@ -11129,7 +11129,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -11147,7 +11147,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11159,7 +11159,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "array-bytes",
  "arrayvec 0.7.4",
@@ -11206,7 +11206,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing"
 version = "9.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -11219,7 +11219,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing-proc-macro"
 version = "9.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "quote",
  "sp-core-hashing",
@@ -11229,7 +11229,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.1",
@@ -11238,7 +11238,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "8.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11248,7 +11248,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.19.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -11259,7 +11259,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "serde_json",
  "sp-api",
@@ -11270,7 +11270,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -11284,7 +11284,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "bytes",
  "ed25519",
@@ -11309,7 +11309,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -11320,7 +11320,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.27.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.1",
@@ -11332,7 +11332,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "4.1.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "thiserror",
  "zstd 0.12.3+zstd.1.5.2",
@@ -11341,7 +11341,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",
@@ -11352,7 +11352,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "ckb-merkle-mountain-range",
  "log",
@@ -11370,7 +11370,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11384,7 +11384,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -11394,7 +11394,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "8.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -11404,7 +11404,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -11414,7 +11414,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -11436,7 +11436,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -11454,7 +11454,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -11466,7 +11466,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11481,7 +11481,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -11495,7 +11495,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.28.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "hash-db",
  "log",
@@ -11516,7 +11516,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "aes-gcm 0.10.2",
  "curve25519-dalek 3.2.0",
@@ -11540,12 +11540,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "8.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 
 [[package]]
 name = "sp-storage"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -11558,7 +11558,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -11571,7 +11571,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "parity-scale-codec",
  "sp-std",
@@ -11583,7 +11583,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -11592,7 +11592,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -11607,7 +11607,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "ahash 0.8.2",
  "hash-db",
@@ -11630,7 +11630,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -11647,7 +11647,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "8.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -11658,7 +11658,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -11671,7 +11671,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11896,12 +11896,12 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures",
@@ -11920,7 +11920,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "hyper",
  "log",
@@ -11932,7 +11932,7 @@ dependencies = [
 [[package]]
 name = "substrate-rpc-client"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "async-trait",
  "jsonrpsee",
@@ -11945,7 +11945,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-trie-migration-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -11962,7 +11962,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -11988,7 +11988,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-utils"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "futures",
  "substrate-test-utils-derive",
@@ -11998,7 +11998,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-utils-derive"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -12009,7 +12009,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "5.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "ansi_term",
  "build-helper",
@@ -12879,7 +12879,7 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 [[package]]
 name = "try-runtime-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#57d2e53b6afefc079cec3b507710970ccd4a5aae"
+source = "git+https://github.com/paritytech/substrate?branch=master#2060c366fb1402deab188911551a43c3c41b36c0"
 dependencies = [
  "async-trait",
  "clap 4.2.5",

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -99,11 +99,6 @@ pub struct RunCmd {
 	#[arg(long = "grandpa-pause", num_args = 2)]
 	pub grandpa_pause: Vec<u32>,
 
-	/// Disable the BEEFY gadget
-	/// (currently enabled by default on Rococo, Wococo and Versi).
-	#[arg(long)]
-	pub no_beefy: bool,
-
 	/// Add the destination address to the jaeger agent.
 	///
 	/// Must be valid socket address, of format `IP:Port`

--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -235,14 +235,10 @@ fn run_node_inner<F>(
 where
 	F: FnOnce(&mut sc_cli::LoggerBuilder, &sc_service::Configuration),
 {
-	let runner = cli
+	let mut runner = cli
 		.create_runner_with_logger_hook::<sc_cli::RunCmd, F>(&cli.run.base, logger_hook)
 		.map_err(Error::from)?;
 	let chain_spec = &runner.config().chain_spec;
-
-	// By default, enable BEEFY on test networks.
-	let enable_beefy = (chain_spec.is_rococo() || chain_spec.is_wococo() || chain_spec.is_versi()) &&
-		!cli.run.no_beefy;
 
 	set_default_ss58_version(chain_spec);
 
@@ -258,6 +254,10 @@ where
 		info!("      endorsed by the       ");
 		info!("     KUSAMA FOUNDATION      ");
 		info!("----------------------------");
+	}
+	// BEEFY allowed only on test networks.
+	if !(chain_spec.is_rococo() || chain_spec.is_wococo() || chain_spec.is_versi()) {
+		runner.config_mut().disable_beefy = true;
 	}
 
 	let jaeger_agent = if let Some(ref jaeger_agent) = cli.run.jaeger_agent {
@@ -289,7 +289,6 @@ where
 			service::NewFullParams {
 				is_collator: service::IsCollator::No,
 				grandpa_pause,
-				enable_beefy,
 				jaeger_agent,
 				telemetry_worker_handle: None,
 				node_version,

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -629,7 +629,6 @@ where
 pub struct NewFullParams<OverseerGenerator: OverseerGen> {
 	pub is_collator: IsCollator,
 	pub grandpa_pause: Option<(u32, u32)>,
-	pub enable_beefy: bool,
 	pub jaeger_agent: Option<std::net::SocketAddr>,
 	pub telemetry_worker_handle: Option<TelemetryWorkerHandle>,
 	/// The version of the node. TESTING ONLY: `None` can be passed to skip the node/worker version
@@ -711,7 +710,6 @@ pub fn new_full<OverseerGenerator: OverseerGen>(
 	NewFullParams {
 		is_collator,
 		grandpa_pause,
-		enable_beefy,
 		jaeger_agent,
 		telemetry_worker_handle,
 		node_version,
@@ -746,6 +744,7 @@ pub fn new_full<OverseerGenerator: OverseerGen>(
 		Some(backoff)
 	};
 
+	let enable_beefy = !config.disable_beefy;
 	// If not on a known test network, warn the user that BEEFY is still experimental.
 	if enable_beefy &&
 		!config.chain_spec.is_rococo() &&

--- a/node/test/service/src/lib.rs
+++ b/node/test/service/src/lib.rs
@@ -81,7 +81,6 @@ pub fn new_full(
 		polkadot_service::NewFullParams {
 			is_collator,
 			grandpa_pause: None,
-			enable_beefy: true,
 			jaeger_agent: None,
 			telemetry_worker_handle: None,
 			node_version: None,
@@ -188,6 +187,7 @@ pub fn node_config(
 		offchain_worker: Default::default(),
 		force_authoring: false,
 		disable_grandpa: false,
+		disable_beefy: false,
 		dev_key_seed: Some(key_seed),
 		tracing_targets: None,
 		tracing_receiver: Default::default(),

--- a/parachain/test-parachains/adder/collator/src/main.rs
+++ b/parachain/test-parachains/adder/collator/src/main.rs
@@ -53,15 +53,15 @@ fn main() -> Result<()> {
 				)
 			})?;
 
-			runner.run_node_until_exit(|config| async move {
+			runner.run_node_until_exit(|mut config| async move {
 				let collator = Collator::new();
 
+				config.disable_beefy = true;
 				let full_node = polkadot_service::build_full(
 					config,
 					polkadot_service::NewFullParams {
 						is_collator: polkadot_service::IsCollator::Yes(collator.collator_key()),
 						grandpa_pause: None,
-						enable_beefy: false,
 						jaeger_agent: None,
 						telemetry_worker_handle: None,
 

--- a/parachain/test-parachains/undying/collator/src/main.rs
+++ b/parachain/test-parachains/undying/collator/src/main.rs
@@ -53,15 +53,15 @@ fn main() -> Result<()> {
 				)
 			})?;
 
-			runner.run_node_until_exit(|config| async move {
+			runner.run_node_until_exit(|mut config| async move {
 				let collator = Collator::new(cli.run.pov_size, cli.run.pvf_complexity);
 
+				config.disable_beefy = true;
 				let full_node = polkadot_service::build_full(
 					config,
 					polkadot_service::NewFullParams {
 						is_collator: polkadot_service::IsCollator::Yes(collator.collator_key()),
 						grandpa_pause: None,
-						enable_beefy: false,
 						jaeger_agent: None,
 						telemetry_worker_handle: None,
 


### PR DESCRIPTION
BEEFY is soon expected to run on all substrate-based chains.

Move `--no-beefy` flag from polkadot specific cli to `sc-cli`.

Companion for https://github.com/paritytech/substrate/pull/14754