### PR TITLE
Unify assignment provider parameters into one call

### DIFF
--- a/runtime/parachains/src/assigner.rs
+++ b/runtime/parachains/src/assigner.rs
@@ -19,7 +19,10 @@
 use frame_system::pallet_prelude::BlockNumberFor;
 use primitives::{v5::Assignment, CoreIndex, Id as ParaId};
 
-use crate::{configuration, paras, scheduler_common::AssignmentProvider};
+use crate::{
+	configuration, paras,
+	scheduler_common::{AssignmentProvider, AssignmentProviderConfig},
+};
 
 pub use pallet::*;
 
@@ -93,25 +96,13 @@ impl<T: Config> AssignmentProvider<BlockNumberFor<T>> for Pallet<T> {
 		}
 	}
 
-	fn get_availability_period(core_idx: CoreIndex) -> BlockNumberFor<T> {
+	fn get_provider_config(core_idx: CoreIndex) -> AssignmentProviderConfig<BlockNumberFor<T>> {
 		if Pallet::<T>::is_bulk_core(&core_idx) {
-			<ParachainAssigner<T> as AssignmentProvider<BlockNumberFor<T>>>::get_availability_period(
+			<ParachainAssigner<T> as AssignmentProvider<BlockNumberFor<T>>>::get_provider_config(
 				core_idx,
 			)
 		} else {
-			<OnDemandAssigner<T> as AssignmentProvider<BlockNumberFor<T>>>::get_availability_period(
-				core_idx,
-			)
-		}
-	}
-
-	fn get_max_retries(core_idx: CoreIndex) -> u32 {
-		if Pallet::<T>::is_bulk_core(&core_idx) {
-			<ParachainAssigner<T> as AssignmentProvider<BlockNumberFor<T>>>::get_max_retries(
-				core_idx,
-			)
-		} else {
-			<OnDemandAssigner<T> as AssignmentProvider<BlockNumberFor<T>>>::get_max_retries(
+			<OnDemandAssigner<T> as AssignmentProvider<BlockNumberFor<T>>>::get_provider_config(
 				core_idx,
 			)
 		}

--- a/runtime/parachains/src/assigner.rs
+++ b/runtime/parachains/src/assigner.rs
@@ -21,7 +21,7 @@ use primitives::{v5::Assignment, CoreIndex, Id as ParaId};
 
 use crate::{
 	configuration, paras,
-	scheduler_common::{AssignmentProvider, AssignmentProviderConfig},
+	scheduler::common::{AssignmentProvider, AssignmentProviderConfig},
 };
 
 pub use pallet::*;

--- a/runtime/parachains/src/assigner_on_demand/mod.rs
+++ b/runtime/parachains/src/assigner_on_demand/mod.rs
@@ -34,7 +34,7 @@ mod tests;
 
 use crate::{
 	configuration, paras,
-	scheduler_common::{AssignmentProvider, AssignmentProviderConfig},
+	scheduler::common::{AssignmentProvider, AssignmentProviderConfig},
 };
 
 use frame_support::{

--- a/runtime/parachains/src/assigner_on_demand/mod.rs
+++ b/runtime/parachains/src/assigner_on_demand/mod.rs
@@ -32,7 +32,10 @@ mod mock_helpers;
 #[cfg(test)]
 mod tests;
 
-use crate::{configuration, paras, scheduler_common::AssignmentProvider};
+use crate::{
+	configuration, paras,
+	scheduler_common::{AssignmentProvider, AssignmentProviderConfig},
+};
 
 use frame_support::{
 	pallet_prelude::*,
@@ -585,13 +588,12 @@ impl<T: Config> AssignmentProvider<BlockNumberFor<T>> for Pallet<T> {
 		}
 	}
 
-	fn get_availability_period(_core_index: CoreIndex) -> BlockNumberFor<T> {
+	fn get_provider_config(_core_idx: CoreIndex) -> AssignmentProviderConfig<BlockNumberFor<T>> {
 		let config = <configuration::Pallet<T>>::config();
-		config.paras_availability_period
-	}
-
-	fn get_max_retries(_core_idx: CoreIndex) -> u32 {
-		let config = <configuration::Pallet<T>>::config();
-		config.on_demand_retries
+		AssignmentProviderConfig {
+			availability_period: config.paras_availability_period,
+			max_availability_timeouts: config.on_demand_retries,
+			ttl: config.on_demand_ttl,
+		}
 	}
 }

--- a/runtime/parachains/src/assigner_parachains.rs
+++ b/runtime/parachains/src/assigner_parachains.rs
@@ -19,7 +19,7 @@
 
 use crate::{
 	configuration, paras,
-	scheduler_common::{AssignmentProvider, AssignmentProviderConfig},
+	scheduler::common::{AssignmentProvider, AssignmentProviderConfig},
 };
 use frame_system::pallet_prelude::BlockNumberFor;
 pub use pallet::*;

--- a/runtime/parachains/src/inclusion/mod.rs
+++ b/runtime/parachains/src/inclusion/mod.rs
@@ -23,7 +23,7 @@
 use crate::{
 	configuration::{self, HostConfiguration},
 	disputes, dmp, hrmp, paras,
-	scheduler_common::CoreAssignment,
+	scheduler::common::CoreAssignment,
 	shared,
 };
 use bitvec::{order::Lsb0 as BitOrderLsb0, vec::BitVec};

--- a/runtime/parachains/src/lib.rs
+++ b/runtime/parachains/src/lib.rs
@@ -38,7 +38,6 @@ pub mod paras;
 pub mod paras_inherent;
 pub mod reward_points;
 pub mod scheduler;
-pub mod scheduler_common;
 pub mod session_info;
 pub mod shared;
 

--- a/runtime/parachains/src/paras_inherent/mod.rs
+++ b/runtime/parachains/src/paras_inherent/mod.rs
@@ -29,7 +29,7 @@ use crate::{
 	initializer,
 	metrics::METRICS,
 	scheduler,
-	scheduler_common::{CoreAssignment, FreedReason},
+	scheduler::common::{CoreAssignment, FreedReason},
 	shared, ParaId,
 };
 use bitvec::prelude::BitVec;

--- a/runtime/parachains/src/scheduler.rs
+++ b/runtime/parachains/src/scheduler.rs
@@ -35,6 +35,7 @@
 //! number of groups as availability cores. Validator groups will be assigned to different availability cores
 //! over time.
 
+use crate::{configuration, initializer::SessionChangeNotification, paras};
 use frame_support::pallet_prelude::*;
 use frame_system::pallet_prelude::BlockNumberFor;
 use primitives::{
@@ -47,12 +48,9 @@ use sp_std::{
 	prelude::*,
 };
 
-use crate::{
-	configuration,
-	initializer::SessionChangeNotification,
-	paras,
-	scheduler_common::{AssignmentProvider, AssignmentProviderConfig, CoreAssignment, FreedReason},
-};
+pub mod common;
+
+use common::{AssignmentProvider, AssignmentProviderConfig, CoreAssignment, FreedReason};
 
 pub use pallet::*;
 

--- a/runtime/parachains/src/scheduler.rs
+++ b/runtime/parachains/src/scheduler.rs
@@ -51,7 +51,7 @@ use crate::{
 	configuration,
 	initializer::SessionChangeNotification,
 	paras,
-	scheduler_common::{AssignmentProvider, CoreAssignment, FreedReason},
+	scheduler_common::{AssignmentProvider, AssignmentProviderConfig, CoreAssignment, FreedReason},
 };
 
 pub use pallet::*;
@@ -65,7 +65,6 @@ pub mod migration;
 #[frame_support::pallet]
 pub mod pallet {
 	use super::*;
-	use crate::scheduler_common::AssignmentProvider;
 
 	const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
 
@@ -304,7 +303,8 @@ impl<T: Config> Pallet<T> {
 					for drop in dropped_claims {
 						match T::AssignmentProvider::pop_assignment_for_core(core_idx, drop) {
 							Some(assignment) => {
-								let ttl = <configuration::Pallet<T>>::config().on_demand_ttl;
+								let AssignmentProviderConfig { ttl, .. } =
+									T::AssignmentProvider::get_provider_config(core_idx);
 								core_claimqueue.push_back(Some(ParasEntry::new(
 									assignment.clone(),
 									now + ttl,
@@ -397,8 +397,8 @@ impl<T: Config> Pallet<T> {
 		} else {
 			Some(|core_index: CoreIndex, pending_since| {
 				let availability_cores = AvailabilityCores::<T>::get();
-				let availability_period =
-					T::AssignmentProvider::get_availability_period(core_index);
+				let AssignmentProviderConfig { availability_period, .. } =
+					T::AssignmentProvider::get_provider_config(core_index);
 				let now = <frame_system::Pallet<T>>::block_number();
 				match availability_cores.get(core_index.0 as usize) {
 					None => true, // out-of-bounds, doesn't really matter what is returned.
@@ -445,7 +445,10 @@ impl<T: Config> Pallet<T> {
 			cores.get(core.0 as usize).and_then(|c| match c {
 				CoreOccupied::Free => None,
 				CoreOccupied::Paras(pe) => {
-					if pe.availability_timeouts < T::AssignmentProvider::get_max_retries(core) {
+					let AssignmentProviderConfig { max_availability_timeouts, .. } =
+						T::AssignmentProvider::get_provider_config(core);
+
+					if pe.availability_timeouts < max_availability_timeouts {
 						Some(Self::paras_entry_to_scheduled_core(pe))
 					} else {
 						None
@@ -545,9 +548,9 @@ impl<T: Config> Pallet<T> {
 
 				// add previously timedout paras back into the queue
 				if let Some(mut entry) = timedout_paras.remove(&core_idx) {
-					if entry.availability_timeouts <
-						T::AssignmentProvider::get_max_retries(core_idx)
-					{
+					let AssignmentProviderConfig { max_availability_timeouts, .. } =
+						T::AssignmentProvider::get_provider_config(core_idx);
+					if entry.availability_timeouts < max_availability_timeouts {
 						// Increment the timeout counter.
 						entry.availability_timeouts += 1;
 						// Reset the ttl so that a timed out assignment.

--- a/runtime/parachains/src/scheduler/common.rs
+++ b/runtime/parachains/src/scheduler/common.rs
@@ -14,26 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
-//! The scheduler module for parachains and parathreads.
-//!
-//! This module is responsible for two main tasks:
-//!   - Partitioning validators into groups and assigning groups to parachains and parathreads
-//!   - Scheduling parachains and parathreads
-//!
-//! It aims to achieve these tasks with these goals in mind:
-//! - It should be possible to know at least a block ahead-of-time, ideally more,
-//!   which validators are going to be assigned to which parachains.
-//! - Parachains that have a candidate pending availability in this fork of the chain
-//!   should not be assigned.
-//! - Validator assignments should not be gameable. Malicious cartels should not be able to
-//!   manipulate the scheduler to assign themselves as desired.
-//! - High or close to optimal throughput of parachains and parathreads. Work among validator groups should be balanced.
-//!
-//! The Scheduler manages resource allocation using the concept of "Availability Cores".
-//! There will be one availability core for each parachain, and a fixed number of cores
-//! used for multiplexing parathreads. Validators will be partitioned into groups, with the same
-//! number of groups as availability cores. Validator groups will be assigned to different availability cores
-//! over time.
+//! Common traits and types used by the scheduler and assignment providers.
 
 use frame_support::pallet_prelude::*;
 use primitives::{

--- a/runtime/parachains/src/scheduler_common/mod.rs
+++ b/runtime/parachains/src/scheduler_common/mod.rs
@@ -56,6 +56,20 @@ pub enum FreedReason {
 	TimedOut,
 }
 
+/// A set of variables required by the scheduler in order to operate.
+pub struct AssignmentProviderConfig<BlockNumber> {
+	/// The availability period specified by the implementation.
+	/// See [`HostConfiguration::paras_availability_period`] for more information.
+	pub availability_period: BlockNumber,
+
+	/// How many times a collation can time out on availability.
+	/// Zero timeouts still means that a collation can be provided as per the slot auction assignment provider.
+	pub max_availability_timeouts: u32,
+
+	/// How long the collator has to provide a collation to the backing group before being dropped.
+	pub ttl: BlockNumber,
+}
+
 pub trait AssignmentProvider<BlockNumber> {
 	/// How many cores are allocated to this provider.
 	fn session_core_count() -> u32;
@@ -73,15 +87,8 @@ pub trait AssignmentProvider<BlockNumber> {
 	/// such as the on demand assignment provider.
 	fn push_assignment_for_core(core_idx: CoreIndex, assignment: Assignment);
 
-	/// Returns the availability period specified by the implementation.
-	/// See
-	/// [`HostConfiguration::paras_availability_period`]
-	/// for more information.
-	fn get_availability_period(core_idx: CoreIndex) -> BlockNumber;
-
-	/// How many times a collation can time out on availability.
-	/// Zero retries still means that a collation can be provided as per the slot auction assignment provider.
-	fn get_max_retries(core_idx: CoreIndex) -> u32;
+	/// Returns a set of variables needed by the scheduler
+	fn get_provider_config(core_idx: CoreIndex) -> AssignmentProviderConfig<BlockNumber>;
 }
 
 /// How a core is mapped to a backing group and a `ParaId`


### PR DESCRIPTION
* Unifies all `get_*` methods of `AssignmentProvider` to a `get_provider_config` method that returns an `AssignmentProviderConfig` struct that can be destructured into the config items needed. i.e.
```rust
let AssignmentProviderConfig{ ttl, ..} = T::AssignmentProvider::get_provider_config(core_index);
do_something(ttl);
```
* Fixes an error where the scheduler was using the on demand ttl to set ttl for all providers.
* Moves the `scheduler_common` module into `scheduler::common`, a submodule of `scheduler`. 