### PR TITLE
PVF workers: some fixes for cargo run and cargo install

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,11 @@ cargo build --release
 
 **Note:** compilation is a memory intensive process. We recommend having 4 GiB of physical RAM or swap available (keep in mind that if a build hits swap it tends to be very slow).
 
-**Note:** if you want to move the built `polkadot` binary somewhere (e.g. into $PATH) you will also need to move `polkadot-execute-worker` and `polkadot-prepare-worker`. You can let cargo do all this for you by running `cargo install --path .`.
+**Note:** if you want to move the built `polkadot` binary somewhere (e.g. into $PATH) you will also need to move `polkadot-execute-worker` and `polkadot-prepare-worker`. You can let cargo do all this for you by running:
+
+```sh
+cargo install --path . --locked
+```
 
 #### Build from Source with Docker
 
@@ -193,6 +197,7 @@ cargo test --workspace --release
 You can start a development chain with:
 
 ```bash
+cargo build
 cargo run -- --dev
 ```
 

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -243,7 +243,7 @@ pub enum Error {
 	InvalidWorkerBinaries { prep_worker_path: PathBuf, exec_worker_path: PathBuf },
 
 	#[cfg(feature = "full-node")]
-	#[error("Worker binaries could not be found, make sure polkadot was built/installed correctly. Searched given workers path ({given_workers_path:?}), polkadot binary path ({current_exe_path:?}), and lib path (/usr/lib/polkadot), workers names: {workers_names:?}")]
+	#[error("Worker binaries could not be found, make sure polkadot was built/installed correctly. If you ran with `cargo run`, please run `cargo build` first. Searched given workers path ({given_workers_path:?}), polkadot binary path ({current_exe_path:?}), and lib path (/usr/lib/polkadot), workers names: {workers_names:?}")]
 	MissingWorkerBinaries {
 		given_workers_path: Option<PathBuf>,
 		current_exe_path: PathBuf,
@@ -251,7 +251,7 @@ pub enum Error {
 	},
 
 	#[cfg(feature = "full-node")]
-	#[error("Version of worker binary ({worker_version}) is different from node version ({node_version}), worker_path: {worker_path}. TESTING ONLY: this check can be disabled with --disable-worker-version-check")]
+	#[error("Version of worker binary ({worker_version}) is different from node version ({node_version}), worker_path: {worker_path}. If you ran with `cargo run`, please run `cargo build` first, otherwise try to `cargo clean`. TESTING ONLY: this check can be disabled with --disable-worker-version-check")]
 	WorkerBinaryVersionMismatch {
 		worker_version: String,
 		node_version: String,

--- a/parachain/test-parachains/adder/collator/README.md
+++ b/parachain/test-parachains/adder/collator/README.md
@@ -1,6 +1,12 @@
 # How to run this collator
 
-First start two validators that will run for the relay chain:
+First, build Polkadot:
+
+```sh
+cargo build --release
+```
+
+Then start two validators that will run for the relay chain:
 
 ```sh
 cargo run --release -- -d alice --chain rococo-local --validator --alice --port 50551

--- a/utils/staking-miner/README.md
+++ b/utils/staking-miner/README.md
@@ -64,5 +64,7 @@ docker run --rm -i \
 
 ### Test locally
 
+Make sure you've built Polkadot, then:
+
 1. `cargo run -p polkadot --features fast-runtime -- --chain polkadot-dev --tmp --alice -lruntime=debug`
 2. `cargo run -p staking-miner -- --uri ws://localhost:9944 monitor --seed-or-path //Alice phrag-mms`


### PR DESCRIPTION
- Update some places where `cargo run` was used
- Add note to error messages about `cargo build` before `cargo run`
- Fix call to `cargo install` in readme

## Related

Closes https://github.com/paritytech/polkadot/issues/7602