### PR TITLE
Revert "companion for 14754: cli: move no-beefy flag to sc-cli (#7600)"

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -99,6 +99,11 @@ pub struct RunCmd {
 	#[arg(long = "grandpa-pause", num_args = 2)]
 	pub grandpa_pause: Vec<u32>,
 
+	/// Disable the BEEFY gadget
+	/// (currently enabled by default on Rococo, Wococo and Versi).
+	#[arg(long)]
+	pub no_beefy: bool,
+
 	/// Add the destination address to the jaeger agent.
 	///
 	/// Must be valid socket address, of format `IP:Port`

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -629,6 +629,7 @@ where
 pub struct NewFullParams<OverseerGenerator: OverseerGen> {
 	pub is_collator: IsCollator,
 	pub grandpa_pause: Option<(u32, u32)>,
+	pub enable_beefy: bool,
 	pub jaeger_agent: Option<std::net::SocketAddr>,
 	pub telemetry_worker_handle: Option<TelemetryWorkerHandle>,
 	/// The version of the node. TESTING ONLY: `None` can be passed to skip the node/worker version
@@ -711,6 +712,7 @@ pub fn new_full<OverseerGenerator: OverseerGen>(
 	NewFullParams {
 		is_collator,
 		grandpa_pause,
+		enable_beefy,
 		jaeger_agent,
 		telemetry_worker_handle,
 		node_version,
@@ -745,7 +747,6 @@ pub fn new_full<OverseerGenerator: OverseerGen>(
 		Some(backoff)
 	};
 
-	let enable_beefy = !config.disable_beefy;
 	// If not on a known test network, warn the user that BEEFY is still experimental.
 	if enable_beefy &&
 		!config.chain_spec.is_rococo() &&

--- a/node/test/service/src/lib.rs
+++ b/node/test/service/src/lib.rs
@@ -81,6 +81,7 @@ pub fn new_full(
 		polkadot_service::NewFullParams {
 			is_collator,
 			grandpa_pause: None,
+			enable_beefy: true,
 			jaeger_agent: None,
 			telemetry_worker_handle: None,
 			node_version: None,
@@ -187,7 +188,6 @@ pub fn node_config(
 		offchain_worker: Default::default(),
 		force_authoring: false,
 		disable_grandpa: false,
-		disable_beefy: false,
 		dev_key_seed: Some(key_seed),
 		tracing_targets: None,
 		tracing_receiver: Default::default(),

--- a/parachain/test-parachains/adder/collator/src/main.rs
+++ b/parachain/test-parachains/adder/collator/src/main.rs
@@ -53,15 +53,15 @@ fn main() -> Result<()> {
 				)
 			})?;
 
-			runner.run_node_until_exit(|mut config| async move {
+			runner.run_node_until_exit(|config| async move {
 				let collator = Collator::new();
 
-				config.disable_beefy = true;
 				let full_node = polkadot_service::build_full(
 					config,
 					polkadot_service::NewFullParams {
 						is_collator: polkadot_service::IsCollator::Yes(collator.collator_key()),
 						grandpa_pause: None,
+						enable_beefy: false,
 						jaeger_agent: None,
 						telemetry_worker_handle: None,
 

--- a/parachain/test-parachains/undying/collator/src/main.rs
+++ b/parachain/test-parachains/undying/collator/src/main.rs
@@ -53,15 +53,15 @@ fn main() -> Result<()> {
 				)
 			})?;
 
-			runner.run_node_until_exit(|mut config| async move {
+			runner.run_node_until_exit(|config| async move {
 				let collator = Collator::new(cli.run.pov_size, cli.run.pvf_complexity);
 
-				config.disable_beefy = true;
 				let full_node = polkadot_service::build_full(
 					config,
 					polkadot_service::NewFullParams {
 						is_collator: polkadot_service::IsCollator::Yes(collator.collator_key()),
 						grandpa_pause: None,
+						enable_beefy: false,
 						jaeger_agent: None,
 						telemetry_worker_handle: None,
 


### PR DESCRIPTION
This reverts commit 8f05479e4bd61341af69f0721e617f01cbad8bb2.

Based on https://github.com/paritytech/substrate/pull/14754#issuecomment-1677208626

companion for: https://github.com/paritytech/substrate/pull/14766