### PR TITLE
[async backing branch] fix zombienet tests

### DIFF
--- a/zombienet_tests/async_backing/002-async-backing-runtime-upgrade.toml
+++ b/zombienet_tests/async_backing/002-async-backing-runtime-upgrade.toml
@@ -47,3 +47,8 @@ addToGenesis = true
   image = "{{COL_IMAGE}}"
   command = "undying-collator"
   args = ["-lparachain=debug"]
+
+[types.Header]
+number = "u64"
+parent_hash = "Hash"
+post_state = "Hash"

--- a/zombienet_tests/async_backing/003-async-backing-collator-mix.zndsl
+++ b/zombienet_tests/async_backing/003-async-backing-collator-mix.zndsl
@@ -5,8 +5,6 @@ Creds: config
 # General
 alice: is up
 bob: is up
-charlie: is up
-dave: is up
 
 # Check peers
 alice: reports peers count is at least 3 within 20 seconds


### PR DESCRIPTION
This should make `async-backing-runtime-upgrade` and `async-backing-collator-mix` zomebienet tests pass in https://github.com/paritytech/polkadot/pull/5022