### PR TITLE
Enforce max length for MultiAssets for some instructions

### DIFF
--- a/xcm/src/v3/mod.rs
+++ b/xcm/src/v3/mod.rs
@@ -42,7 +42,7 @@ pub use junction::{BodyId, BodyPart, Junction, NetworkId};
 pub use junctions::Junctions;
 pub use multiasset::{
 	AssetId, AssetInstance, Fungibility, MultiAsset, MultiAssetFilter, MultiAssets,
-	WildFungibility, WildMultiAsset,
+	WildFungibility, WildMultiAsset, MAX_ITEMS_IN_MULTIASSETS,
 };
 pub use multilocation::{
 	Ancestor, AncestorThen, InteriorMultiLocation, MultiLocation, Parent, ParentThen,
@@ -188,7 +188,7 @@ pub mod prelude {
 			WeightLimit::{self, *},
 			WildFungibility::{self, Fungible as WildFungible, NonFungible as WildNonFungible},
 			WildMultiAsset::{self, *},
-			XcmContext, XcmHash, XcmWeightInfo, VERSION as XCM_VERSION,
+			XcmContext, XcmHash, XcmWeightInfo, MAX_ITEMS_IN_MULTIASSETS, VERSION as XCM_VERSION,
 		};
 	}
 	pub use super::{Instruction, Xcm};

--- a/xcm/src/v3/multiasset.rs
+++ b/xcm/src/v3/multiasset.rs
@@ -508,7 +508,7 @@ pub struct MultiAssets(Vec<MultiAsset>);
 
 /// Maximum number of items we expect in a single `MultiAssets` value. Note this is not (yet)
 /// enforced, and just serves to provide a sensible `max_encoded_len` for `MultiAssets`.
-const MAX_ITEMS_IN_MULTIASSETS: usize = 20;
+pub const MAX_ITEMS_IN_MULTIASSETS: usize = 20;
 
 impl MaxEncodedLen for MultiAssets {
 	fn max_encoded_len() -> usize {

--- a/xcm/src/v3/traits.rs
+++ b/xcm/src/v3/traits.rs
@@ -157,6 +157,9 @@ pub enum Error {
 	WeightNotComputable,
 	/// Recursion stack limit reached
 	ExceedsStackLimit,
+	/// Assets exceeded maximum
+	// TODO (XCMv4): Add to spec
+	TooManyAssets,
 }
 
 impl MaxEncodedLen for Error {

--- a/xcm/xcm-executor/src/lib.rs
+++ b/xcm/xcm-executor/src/lib.rs
@@ -479,6 +479,9 @@ impl<Config: config::Config> XcmExecutor<Config> {
 			WithdrawAsset(assets) => {
 				// Take `assets` from the origin account (on-chain) and place in holding.
 				let origin = *self.origin_ref().ok_or(XcmError::BadOrigin)?;
+				if assets.len() > MAX_ITEMS_IN_MULTIASSETS {
+					return Err(XcmError::TooManyAssets)
+				}
 				for asset in assets.into_inner().into_iter() {
 					Config::AssetTransactor::withdraw_asset(&asset, &origin, Some(&self.context))?;
 					self.subsume_asset(asset)?;
@@ -488,6 +491,9 @@ impl<Config: config::Config> XcmExecutor<Config> {
 			ReserveAssetDeposited(assets) => {
 				// check whether we trust origin to be our reserve location for this asset.
 				let origin = *self.origin_ref().ok_or(XcmError::BadOrigin)?;
+				if assets.len() > MAX_ITEMS_IN_MULTIASSETS {
+					return Err(XcmError::TooManyAssets)
+				}
 				for asset in assets.into_inner().into_iter() {
 					// Must ensure that we recognise the asset as being managed by the origin.
 					ensure!(
@@ -526,6 +532,9 @@ impl<Config: config::Config> XcmExecutor<Config> {
 			},
 			ReceiveTeleportedAsset(assets) => {
 				let origin = *self.origin_ref().ok_or(XcmError::BadOrigin)?;
+				if assets.len() > MAX_ITEMS_IN_MULTIASSETS {
+					return Err(XcmError::TooManyAssets)
+				}
 				// check whether we trust origin to teleport this asset to us via config trait.
 				for asset in assets.inner() {
 					// We only trust the origin to send us assets that they identify as their
@@ -719,6 +728,9 @@ impl<Config: config::Config> XcmExecutor<Config> {
 			},
 			ClaimAsset { assets, ticket } => {
 				let origin = self.origin_ref().ok_or(XcmError::BadOrigin)?;
+				if assets.len() > MAX_ITEMS_IN_MULTIASSETS {
+					return Err(XcmError::TooManyAssets)
+				}
 				let ok = Config::AssetClaims::claim_assets(origin, &ticket, &assets, &self.context);
 				ensure!(ok, XcmError::UnknownClaim);
 				for asset in assets.into_inner().into_iter() {


### PR DESCRIPTION
`MultiAssets` had a recommended `MAX_ITEMS_IN_MULTIASSETS` set to 20 but it was not being enforced.

This PR enforces this check on the following instructions:
- `WithdrawAsset`
- `ClaimAsset`
- `ReserveAssetDeposited`
- `ReceiveTeleportedAsset`