### PR TITLE
Fix clippy warnings

### DIFF
--- a/node/collation-generation/src/tests.rs
+++ b/node/collation-generation/src/tests.rs
@@ -353,7 +353,7 @@ mod handle_new_activations {
 				let expect_descriptor = {
 					let mut expect_descriptor = expect_descriptor;
 					expect_descriptor.signature = descriptor.signature.clone();
-					expect_descriptor.erasure_root = descriptor.erasure_root.clone();
+					expect_descriptor.erasure_root = descriptor.erasure_root;
 					expect_descriptor
 				};
 				assert_eq!(descriptor, expect_descriptor);

--- a/node/core/av-store/src/tests.rs
+++ b/node/core/av-store/src/tests.rs
@@ -53,7 +53,7 @@ struct TestClock {
 
 impl TestClock {
 	fn now(&self) -> Duration {
-		self.inner.lock().clone()
+		*self.inner.lock()
 	}
 
 	fn inc(&self, by: Duration) {

--- a/node/core/backing/src/tests.rs
+++ b/node/core/backing/src/tests.rs
@@ -696,7 +696,6 @@ fn backing_misbehavior_works() {
 			pov_hash,
 			erasure_root: make_erasure_root(&test_state, pov.clone()),
 			head_data: expected_head_data.clone(),
-			..Default::default()
 		}
 		.build();
 
@@ -881,7 +880,6 @@ fn backing_dont_second_invalid() {
 			pov_hash: pov_hash_b,
 			erasure_root: make_erasure_root(&test_state, pov_block_b.clone()),
 			head_data: expected_head_data.clone(),
-			..Default::default()
 		}
 		.build();
 
@@ -1263,7 +1261,6 @@ fn validation_work_ignores_wrong_collator() {
 			pov_hash,
 			head_data: expected_head_data.clone(),
 			erasure_root: make_erasure_root(&test_state, pov.clone()),
-			..Default::default()
 		}
 		.build();
 

--- a/node/core/backing/src/tests.rs
+++ b/node/core/backing/src/tests.rs
@@ -283,7 +283,6 @@ fn backing_second_works() {
 			pov_hash,
 			head_data: expected_head_data.clone(),
 			erasure_root: make_erasure_root(&test_state, pov.clone()),
-			..Default::default()
 		}
 		.build();
 
@@ -373,7 +372,6 @@ fn backing_works() {
 			pov_hash,
 			head_data: expected_head_data.clone(),
 			erasure_root: make_erasure_root(&test_state, pov.clone()),
-			..Default::default()
 		}
 		.build();
 
@@ -522,7 +520,6 @@ fn backing_works_while_validation_ongoing() {
 			pov_hash,
 			head_data: expected_head_data.clone(),
 			erasure_root: make_erasure_root(&test_state, pov.clone()),
-			..Default::default()
 		}
 		.build();
 
@@ -1215,7 +1212,6 @@ fn backing_doesnt_second_wrong_collator() {
 			pov_hash,
 			head_data: expected_head_data.clone(),
 			erasure_root: make_erasure_root(&test_state, pov.clone()),
-			..Default::default()
 		}
 		.build();
 
@@ -1541,7 +1537,6 @@ fn observes_backing_even_if_not_validator() {
 			pov_hash,
 			head_data: expected_head_data.clone(),
 			erasure_root: make_erasure_root(&test_state, pov.clone()),
-			..Default::default()
 		}
 		.build();
 

--- a/node/core/chain-selection/src/tests.rs
+++ b/node/core/chain-selection/src/tests.rs
@@ -568,7 +568,7 @@ fn assert_backend_contains<'a>(
 
 fn assert_backend_contains_chains(backend: &TestBackend, chains: Vec<Vec<(Header, BlockWeight)>>) {
 	for chain in chains {
-		assert_backend_contains(backend, chain.iter().map(|&(ref hdr, _)| hdr))
+		assert_backend_contains(backend, chain.iter().map(|(hdr, _)| hdr))
 	}
 }
 
@@ -688,7 +688,7 @@ fn import_chain_on_finalized_incrementally() {
 		.await;
 
 		assert_eq!(backend.load_first_block_number().unwrap().unwrap(), 1);
-		assert_backend_contains(&backend, chain.iter().map(|&(ref h, _)| h));
+		assert_backend_contains(&backend, chain.iter().map(|(h, _)| h));
 		assert_leaves(&backend, vec![head_hash]);
 		assert_leaves_query(&mut virtual_overseer, vec![head_hash]).await;
 
@@ -721,8 +721,8 @@ fn import_two_subtrees_on_finalized() {
 		import_blocks_into(&mut virtual_overseer, &backend, None, chain_b.clone()).await;
 
 		assert_eq!(backend.load_first_block_number().unwrap().unwrap(), 1);
-		assert_backend_contains(&backend, chain_a.iter().map(|&(ref h, _)| h));
-		assert_backend_contains(&backend, chain_b.iter().map(|&(ref h, _)| h));
+		assert_backend_contains(&backend, chain_a.iter().map(|(h, _)| h));
+		assert_backend_contains(&backend, chain_b.iter().map(|(h, _)| h));
 		assert_leaves(&backend, vec![b_hash, a_hash]);
 		assert_leaves_query(&mut virtual_overseer, vec![b_hash, a_hash]).await;
 
@@ -755,8 +755,8 @@ fn import_two_subtrees_on_nonzero_finalized() {
 		import_blocks_into(&mut virtual_overseer, &backend, None, chain_b.clone()).await;
 
 		assert_eq!(backend.load_first_block_number().unwrap().unwrap(), 101);
-		assert_backend_contains(&backend, chain_a.iter().map(|&(ref h, _)| h));
-		assert_backend_contains(&backend, chain_b.iter().map(|&(ref h, _)| h));
+		assert_backend_contains(&backend, chain_a.iter().map(|(h, _)| h));
+		assert_backend_contains(&backend, chain_b.iter().map(|(h, _)| h));
 		assert_leaves(&backend, vec![b_hash, a_hash]);
 		assert_leaves_query(&mut virtual_overseer, vec![b_hash, a_hash]).await;
 
@@ -799,9 +799,9 @@ fn leaves_ordered_by_weight_and_then_number() {
 		.await;
 
 		assert_eq!(backend.load_first_block_number().unwrap().unwrap(), 1);
-		assert_backend_contains(&backend, chain_a.iter().map(|&(ref h, _)| h));
-		assert_backend_contains(&backend, chain_b.iter().map(|&(ref h, _)| h));
-		assert_backend_contains(&backend, chain_c.iter().map(|&(ref h, _)| h));
+		assert_backend_contains(&backend, chain_a.iter().map(|(h, _)| h));
+		assert_backend_contains(&backend, chain_b.iter().map(|(h, _)| h));
+		assert_backend_contains(&backend, chain_c.iter().map(|(h, _)| h));
 		assert_leaves(&backend, vec![c2_hash, a3_hash, b2_hash]);
 		assert_leaves_query(&mut virtual_overseer, vec![c2_hash, a3_hash, b2_hash]).await;
 		virtual_overseer
@@ -844,8 +844,8 @@ fn subtrees_imported_even_with_gaps() {
 		.await;
 
 		assert_eq!(backend.load_first_block_number().unwrap().unwrap(), 1);
-		assert_backend_contains(&backend, chain_a.iter().map(|&(ref h, _)| h));
-		assert_backend_contains(&backend, chain_b.iter().map(|&(ref h, _)| h));
+		assert_backend_contains(&backend, chain_a.iter().map(|(h, _)| h));
+		assert_backend_contains(&backend, chain_b.iter().map(|(h, _)| h));
 		assert_leaves(&backend, vec![b5_hash, a3_hash]);
 		assert_leaves_query(&mut virtual_overseer, vec![b5_hash, a3_hash]).await;
 
@@ -878,7 +878,7 @@ fn reversion_removes_viability_of_chain() {
 		)
 		.await;
 
-		assert_backend_contains(&backend, chain_a.iter().map(|&(ref h, _)| h));
+		assert_backend_contains(&backend, chain_a.iter().map(|(h, _)| h));
 		assert_leaves(&backend, vec![]);
 		assert_finalized_leaves_query(&mut virtual_overseer, finalized_number, finalized_hash)
 			.await;
@@ -914,7 +914,7 @@ fn reversion_removes_viability_and_finds_ancestor_as_leaf() {
 		)
 		.await;
 
-		assert_backend_contains(&backend, chain_a.iter().map(|&(ref h, _)| h));
+		assert_backend_contains(&backend, chain_a.iter().map(|(h, _)| h));
 		assert_leaves(&backend, vec![a1_hash]);
 		assert_leaves_query(&mut virtual_overseer, vec![a1_hash]).await;
 
@@ -954,15 +954,15 @@ fn ancestor_of_unviable_is_not_leaf_if_has_children() {
 
 		import_blocks_into(&mut virtual_overseer, &backend, None, chain_b.clone()).await;
 
-		assert_backend_contains(&backend, chain_a.iter().map(|&(ref h, _)| h));
-		assert_backend_contains(&backend, chain_b.iter().map(|&(ref h, _)| h));
+		assert_backend_contains(&backend, chain_a.iter().map(|(h, _)| h));
+		assert_backend_contains(&backend, chain_b.iter().map(|(h, _)| h));
 		assert_leaves(&backend, vec![a2_hash, b2_hash]);
 
 		import_blocks_into(&mut virtual_overseer, &backend, None, chain_a_ext.clone()).await;
 
-		assert_backend_contains(&backend, chain_a.iter().map(|&(ref h, _)| h));
-		assert_backend_contains(&backend, chain_a_ext.iter().map(|&(ref h, _)| h));
-		assert_backend_contains(&backend, chain_b.iter().map(|&(ref h, _)| h));
+		assert_backend_contains(&backend, chain_a.iter().map(|(h, _)| h));
+		assert_backend_contains(&backend, chain_a_ext.iter().map(|(h, _)| h));
+		assert_backend_contains(&backend, chain_b.iter().map(|(h, _)| h));
 		assert_leaves(&backend, vec![b2_hash]);
 		assert_leaves_query(&mut virtual_overseer, vec![b2_hash]).await;
 
@@ -995,7 +995,7 @@ fn self_and_future_reversions_are_ignored() {
 		)
 		.await;
 
-		assert_backend_contains(&backend, chain_a.iter().map(|&(ref h, _)| h));
+		assert_backend_contains(&backend, chain_a.iter().map(|(h, _)| h));
 		assert_leaves(&backend, vec![a3_hash]);
 		assert_leaves_query(&mut virtual_overseer, vec![a3_hash]).await;
 
@@ -1028,7 +1028,7 @@ fn revert_finalized_is_ignored() {
 		)
 		.await;
 
-		assert_backend_contains(&backend, chain_a.iter().map(|&(ref h, _)| h));
+		assert_backend_contains(&backend, chain_a.iter().map(|(h, _)| h));
 		assert_leaves(&backend, vec![a3_hash]);
 		assert_leaves_query(&mut virtual_overseer, vec![a3_hash]).await;
 
@@ -1072,8 +1072,8 @@ fn reversion_affects_viability_of_all_subtrees() {
 
 		import_blocks_into(&mut virtual_overseer, &backend, None, chain_b.clone()).await;
 
-		assert_backend_contains(&backend, chain_a.iter().map(|&(ref h, _)| h));
-		assert_backend_contains(&backend, chain_b.iter().map(|&(ref h, _)| h));
+		assert_backend_contains(&backend, chain_a.iter().map(|(h, _)| h));
+		assert_backend_contains(&backend, chain_b.iter().map(|(h, _)| h));
 		assert_leaves(&backend, vec![a1_hash]);
 		assert_leaves_query(&mut virtual_overseer, vec![a1_hash]).await;
 
@@ -2034,12 +2034,12 @@ fn revert_blocks_message_triggers_proper_reversion() {
 		.await;
 
 		// Checking mini chain
-		assert_backend_contains(&backend, built_chain.iter().map(|&(ref h, _)| h));
+		assert_backend_contains(&backend, built_chain.iter().map(|(h, _)| h));
 		assert_leaves(&backend, vec![head_hash]);
 		assert_leaves_query(&mut virtual_overseer, vec![head_hash]).await;
 
-		let block_1_hash = backend.load_blocks_by_number(1).unwrap().get(0).unwrap().clone();
-		let block_2_hash = backend.load_blocks_by_number(2).unwrap().get(0).unwrap().clone();
+		let block_1_hash = *backend.load_blocks_by_number(1).unwrap().get(0).unwrap();
+		let block_2_hash = *backend.load_blocks_by_number(2).unwrap().get(0).unwrap();
 
 		// Sending revert blocks message
 		let (_, write_rx) = backend.await_next_write();
@@ -2098,7 +2098,7 @@ fn revert_blocks_against_finalized_is_ignored() {
 		.await;
 
 		// Checking mini chain
-		assert_backend_contains(&backend, built_chain.iter().map(|&(ref h, _)| h));
+		assert_backend_contains(&backend, built_chain.iter().map(|(h, _)| h));
 
 		// Sending dispute concluded against message
 		virtual_overseer

--- a/node/core/dispute-coordinator/src/participation/queues/tests.rs
+++ b/node/core/dispute-coordinator/src/participation/queues/tests.rs
@@ -44,7 +44,7 @@ fn make_dummy_comparator(
 fn clone_request(request: &ParticipationRequest) -> ParticipationRequest {
 	ParticipationRequest {
 		candidate_receipt: request.candidate_receipt.clone(),
-		candidate_hash: request.candidate_hash.clone(),
+		candidate_hash: request.candidate_hash,
 		session: request.session,
 		request_timer: None,
 	}

--- a/node/core/dispute-coordinator/src/tests.rs
+++ b/node/core/dispute-coordinator/src/tests.rs
@@ -399,7 +399,8 @@ impl TestState {
 					let mut response = Vec::new();
 					for i in target_header.number.saturating_sub(k as u32)..target_header.number {
 						response.push(
-							*self.block_num_to_header
+							*self
+								.block_num_to_header
 								.get(&i)
 								.expect("headers and block_num_to_header should always be in sync"),
 						);

--- a/node/core/dispute-coordinator/src/tests.rs
+++ b/node/core/dispute-coordinator/src/tests.rs
@@ -399,10 +399,9 @@ impl TestState {
 					let mut response = Vec::new();
 					for i in target_header.number.saturating_sub(k as u32)..target_header.number {
 						response.push(
-							self.block_num_to_header
+							*self.block_num_to_header
 								.get(&i)
-								.expect("headers and block_num_to_header should always be in sync")
-								.clone(),
+								.expect("headers and block_num_to_header should always be in sync"),
 						);
 					}
 					let _ = response_channel.send(Ok(response));
@@ -552,7 +551,7 @@ impl TestState {
 		let (ctx, ctx_handle) = make_buffered_subsystem_context(TaskExecutor::new(), 1);
 		let subsystem = DisputeCoordinatorSubsystem::new(
 			self.db.clone(),
-			self.config.clone(),
+			self.config,
 			self.subsystem_keystore.clone(),
 			Metrics::default(),
 		);
@@ -574,27 +573,27 @@ where
 
 	// Add two more blocks after the genesis (which is created in `default()`)
 	let h1 = Header {
-		parent_hash: test_state.last_block.clone(),
+		parent_hash: test_state.last_block,
 		number: 1,
 		digest: dummy_digest(),
 		state_root: dummy_hash(),
 		extrinsics_root: dummy_hash(),
 	};
 	let h1_hash = h1.hash();
-	test_state.headers.insert(h1_hash.clone(), h1);
-	test_state.block_num_to_header.insert(1, h1_hash.clone());
+	test_state.headers.insert(h1_hash, h1);
+	test_state.block_num_to_header.insert(1, h1_hash);
 	test_state.last_block = h1_hash;
 
 	let h2 = Header {
-		parent_hash: test_state.last_block.clone(),
+		parent_hash: test_state.last_block,
 		number: 2,
 		digest: dummy_digest(),
 		state_root: dummy_hash(),
 		extrinsics_root: dummy_hash(),
 	};
 	let h2_hash = h2.hash();
-	test_state.headers.insert(h2_hash.clone(), h2);
-	test_state.block_num_to_header.insert(2, h2_hash.clone());
+	test_state.headers.insert(h2_hash, h2);
+	test_state.block_num_to_header.insert(2, h2_hash);
 	test_state.last_block = h2_hash;
 
 	test_state.resume(test)
@@ -3133,7 +3132,7 @@ fn participation_requests_reprioritized_for_newly_included() {
 				// participation.
 				let parent_block_num: BlockNumber = repetition as BlockNumber - 1;
 				candidate_receipt.descriptor.relay_parent =
-					test_state.block_num_to_header.get(&parent_block_num).unwrap().clone();
+					*test_state.block_num_to_header.get(&parent_block_num).unwrap();
 				receipts.push(candidate_receipt.clone());
 			}
 

--- a/node/core/provisioner/src/disputes/prioritized_selection/tests.rs
+++ b/node/core/provisioner/src/disputes/prioritized_selection/tests.rs
@@ -136,16 +136,16 @@ fn partitioning_happy_case() {
 		CandidateHash(Hash::random()),
 		DisputeStatus::ConcludedFor(time_now - ACTIVE_DURATION_SECS * 2),
 	);
-	input.push(inactive_unknown_onchain.clone());
+	input.push(inactive_unknown_onchain);
 
 	let inactive_unconcluded_onchain = (
 		1,
 		CandidateHash(Hash::random()),
 		DisputeStatus::ConcludedFor(time_now - ACTIVE_DURATION_SECS * 2),
 	);
-	input.push(inactive_unconcluded_onchain.clone());
+	input.push(inactive_unconcluded_onchain);
 	onchain.insert(
-		(inactive_unconcluded_onchain.0, inactive_unconcluded_onchain.1.clone()),
+		(inactive_unconcluded_onchain.0, inactive_unconcluded_onchain.1),
 		DisputeState {
 			validators_for: bitvec![u8, Lsb0; 1, 1, 1, 0, 0, 0, 0, 0, 0],
 			validators_against: bitvec![u8, Lsb0; 0, 0, 0, 0, 0, 0, 0, 0, 0],
@@ -155,12 +155,12 @@ fn partitioning_happy_case() {
 	);
 
 	let active_unknown_onchain = (2, CandidateHash(Hash::random()), DisputeStatus::Active);
-	input.push(active_unknown_onchain.clone());
+	input.push(active_unknown_onchain);
 
 	let active_unconcluded_onchain = (3, CandidateHash(Hash::random()), DisputeStatus::Active);
-	input.push(active_unconcluded_onchain.clone());
+	input.push(active_unconcluded_onchain);
 	onchain.insert(
-		(active_unconcluded_onchain.0, active_unconcluded_onchain.1.clone()),
+		(active_unconcluded_onchain.0, active_unconcluded_onchain.1),
 		DisputeState {
 			validators_for: bitvec![u8, Lsb0; 1, 1, 1, 0, 0, 0, 0, 0, 0],
 			validators_against: bitvec![u8, Lsb0; 0, 0, 0, 0, 0, 0, 0, 0, 0],
@@ -170,9 +170,9 @@ fn partitioning_happy_case() {
 	);
 
 	let active_concluded_onchain = (4, CandidateHash(Hash::random()), DisputeStatus::Active);
-	input.push(active_concluded_onchain.clone());
+	input.push(active_concluded_onchain);
 	onchain.insert(
-		(active_concluded_onchain.0, active_concluded_onchain.1.clone()),
+		(active_concluded_onchain.0, active_concluded_onchain.1),
 		DisputeState {
 			validators_for: bitvec![u8, Lsb0; 1, 1, 1, 1, 1, 1, 1, 1, 0],
 			validators_against: bitvec![u8, Lsb0; 0, 0, 0, 0, 0, 0, 0, 0, 0],
@@ -186,9 +186,9 @@ fn partitioning_happy_case() {
 		CandidateHash(Hash::random()),
 		DisputeStatus::ConcludedFor(time_now - ACTIVE_DURATION_SECS * 2),
 	);
-	input.push(inactive_concluded_onchain.clone());
+	input.push(inactive_concluded_onchain);
 	onchain.insert(
-		(inactive_concluded_onchain.0, inactive_concluded_onchain.1.clone()),
+		(inactive_concluded_onchain.0, inactive_concluded_onchain.1),
 		DisputeState {
 			validators_for: bitvec![u8, Lsb0; 1, 1, 1, 1, 1, 1, 1, 0, 0],
 			validators_against: bitvec![u8, Lsb0; 0, 0, 0, 0, 0, 0, 0, 0, 0],
@@ -254,10 +254,10 @@ fn partitioning_doubled_onchain_vote() {
 	// Dispute B has supermajority + 1 votes, so the doubled onchain vote doesn't affect it. It
 	// should be considered as 'can conclude onchain'.
 	let dispute_b = (4, CandidateHash(Hash::random()), DisputeStatus::Active);
-	input.push(dispute_a.clone());
-	input.push(dispute_b.clone());
+	input.push(dispute_a);
+	input.push(dispute_b);
 	onchain.insert(
-		(dispute_a.0, dispute_a.1.clone()),
+		(dispute_a.0, dispute_a.1),
 		DisputeState {
 			validators_for: bitvec![u8, Lsb0; 1, 1, 1, 1, 1, 1, 1, 0, 0],
 			validators_against: bitvec![u8, Lsb0; 1, 0, 0, 0, 0, 0, 0, 0, 0],
@@ -266,7 +266,7 @@ fn partitioning_doubled_onchain_vote() {
 		},
 	);
 	onchain.insert(
-		(dispute_b.0, dispute_b.1.clone()),
+		(dispute_b.0, dispute_b.1),
 		DisputeState {
 			validators_for: bitvec![u8, Lsb0; 1, 1, 1, 1, 1, 1, 1, 1, 0],
 			validators_against: bitvec![u8, Lsb0; 1, 0, 0, 0, 0, 0, 0, 0, 0],
@@ -287,10 +287,10 @@ fn partitioning_duplicated_dispute() {
 	let mut onchain = HashMap::<(u32, CandidateHash), DisputeState>::new();
 
 	let some_dispute = (3, CandidateHash(Hash::random()), DisputeStatus::Active);
-	input.push(some_dispute.clone());
-	input.push(some_dispute.clone());
+	input.push(some_dispute);
+	input.push(some_dispute);
 	onchain.insert(
-		(some_dispute.0, some_dispute.1.clone()),
+		(some_dispute.0, some_dispute.1),
 		DisputeState {
 			validators_for: bitvec![u8, Lsb0; 1, 1, 1, 0, 0, 0, 0, 0, 0],
 			validators_against: bitvec![u8, Lsb0; 0, 0, 0, 0, 0, 0, 0, 0, 0],
@@ -385,7 +385,7 @@ impl TestDisputes {
 		local_votes_count: usize,
 		dummy_receipt: CandidateReceipt,
 	) {
-		self.local_disputes.push(dispute.clone());
+		self.local_disputes.push(dispute);
 		self.votes_db.insert(
 			(dispute.0, dispute.1),
 			CandidateVotes {
@@ -412,7 +412,7 @@ impl TestDisputes {
 			DisputeStatus::ConcludedAgainst(_) | DisputeStatus::ConcludedFor(_) => Some(1),
 		};
 		self.onchain_disputes.insert(
-			(dispute.0, dispute.1.clone()),
+			(dispute.0, dispute.1),
 			DisputeState {
 				validators_for: TestDisputes::generate_bitvec(
 					self.validators_count,
@@ -434,10 +434,10 @@ impl TestDisputes {
 		let onchain_votes_count = self.validators_count * 80 / 100;
 		let session_idx = 0;
 		let lf = leaf();
-		let dummy_receipt = test_helpers::dummy_candidate_receipt(lf.hash.clone());
+		let dummy_receipt = test_helpers::dummy_candidate_receipt(lf.hash);
 		for _ in 0..dispute_count {
 			let d = (session_idx, CandidateHash(Hash::random()), DisputeStatus::Active);
-			self.add_offchain_dispute(d.clone(), local_votes_count, dummy_receipt.clone());
+			self.add_offchain_dispute(d, local_votes_count, dummy_receipt.clone());
 			self.add_onchain_dispute(d, onchain_votes_count);
 		}
 
@@ -452,10 +452,10 @@ impl TestDisputes {
 		let onchain_votes_count = self.validators_count * 40 / 100;
 		let session_idx = 1;
 		let lf = leaf();
-		let dummy_receipt = test_helpers::dummy_candidate_receipt(lf.hash.clone());
+		let dummy_receipt = test_helpers::dummy_candidate_receipt(lf.hash);
 		for _ in 0..dispute_count {
 			let d = (session_idx, CandidateHash(Hash::random()), DisputeStatus::Active);
-			self.add_offchain_dispute(d.clone(), local_votes_count, dummy_receipt.clone());
+			self.add_offchain_dispute(d, local_votes_count, dummy_receipt.clone());
 			self.add_onchain_dispute(d, onchain_votes_count);
 		}
 
@@ -469,10 +469,10 @@ impl TestDisputes {
 		let local_votes_count = self.validators_count * 90 / 100;
 		let session_idx = 2;
 		let lf = leaf();
-		let dummy_receipt = test_helpers::dummy_candidate_receipt(lf.hash.clone());
+		let dummy_receipt = test_helpers::dummy_candidate_receipt(lf.hash);
 		for _ in 0..dispute_count {
 			let d = (session_idx, CandidateHash(Hash::random()), DisputeStatus::Confirmed);
-			self.add_offchain_dispute(d.clone(), local_votes_count, dummy_receipt.clone());
+			self.add_offchain_dispute(d, local_votes_count, dummy_receipt.clone());
 		}
 		(session_idx, local_votes_count * dispute_count)
 	}
@@ -485,10 +485,10 @@ impl TestDisputes {
 		let onchain_votes_count = self.validators_count * 75 / 100;
 		let session_idx = 3;
 		let lf = leaf();
-		let dummy_receipt = test_helpers::dummy_candidate_receipt(lf.hash.clone());
+		let dummy_receipt = test_helpers::dummy_candidate_receipt(lf.hash);
 		for _ in 0..dispute_count {
 			let d = (session_idx, CandidateHash(Hash::random()), DisputeStatus::ConcludedFor(0));
-			self.add_offchain_dispute(d.clone(), local_votes_count, dummy_receipt.clone());
+			self.add_offchain_dispute(d, local_votes_count, dummy_receipt.clone());
 			self.add_onchain_dispute(d, onchain_votes_count);
 		}
 		(session_idx, (local_votes_count - onchain_votes_count) * dispute_count)
@@ -501,10 +501,10 @@ impl TestDisputes {
 		let local_votes_count = self.validators_count * 90 / 100;
 		let session_idx = 4;
 		let lf = leaf();
-		let dummy_receipt = test_helpers::dummy_candidate_receipt(lf.hash.clone());
+		let dummy_receipt = test_helpers::dummy_candidate_receipt(lf.hash);
 		for _ in 0..dispute_count {
 			let d = (session_idx, CandidateHash(Hash::random()), DisputeStatus::ConcludedFor(0));
-			self.add_offchain_dispute(d.clone(), local_votes_count, dummy_receipt.clone());
+			self.add_offchain_dispute(d, local_votes_count, dummy_receipt.clone());
 		}
 		(session_idx, local_votes_count * dispute_count)
 	}
@@ -517,10 +517,10 @@ impl TestDisputes {
 		let onchain_votes_count = self.validators_count * 10 / 100;
 		let session_idx = 5;
 		let lf = leaf();
-		let dummy_receipt = test_helpers::dummy_candidate_receipt(lf.hash.clone());
+		let dummy_receipt = test_helpers::dummy_candidate_receipt(lf.hash);
 		for _ in 0..dispute_count {
 			let d = (session_idx, CandidateHash(Hash::random()), DisputeStatus::Active);
-			self.add_offchain_dispute(d.clone(), local_votes_count, dummy_receipt.clone());
+			self.add_offchain_dispute(d, local_votes_count, dummy_receipt.clone());
 			self.add_onchain_dispute(d, onchain_votes_count);
 		}
 
@@ -534,10 +534,10 @@ impl TestDisputes {
 		let local_votes_count = self.validators_count * 10 / 100;
 		let session_idx = 6;
 		let lf = leaf();
-		let dummy_receipt = test_helpers::dummy_candidate_receipt(lf.hash.clone());
+		let dummy_receipt = test_helpers::dummy_candidate_receipt(lf.hash);
 		for _ in 0..dispute_count {
 			let d = (session_idx, CandidateHash(Hash::random()), DisputeStatus::Active);
-			self.add_offchain_dispute(d.clone(), local_votes_count, dummy_receipt.clone());
+			self.add_offchain_dispute(d, local_votes_count, dummy_receipt.clone());
 		}
 
 		(session_idx, local_votes_count * dispute_count)

--- a/node/core/pvf-checker/src/tests.rs
+++ b/node/core/pvf-checker/src/tests.rs
@@ -188,7 +188,7 @@ impl TestState {
 
 		let activated = if let Some(activated_leaf) = fake_leaf {
 			self.leaves.insert(
-				activated_leaf.block_hash.clone(),
+				activated_leaf.block_hash,
 				LeafState {
 					session_index: self.last_session_index,
 					pvfs: activated_leaf.pvfs.clone(),
@@ -497,9 +497,9 @@ fn reactivating_pvf_leads_to_second_check() {
 	test_harness(|mut test_state, mut handle| {
 		async move {
 			let pvf = dummy_validation_code_hash(1);
-			let block_1 = FakeLeaf::new(dummy_hash(), 1, vec![pvf.clone()]);
+			let block_1 = FakeLeaf::new(dummy_hash(), 1, vec![pvf]);
 			let block_2 = block_1.descendant(vec![]);
-			let block_3 = block_2.descendant(vec![pvf.clone()]);
+			let block_3 = block_2.descendant(vec![pvf]);
 
 			test_state
 				.activate_leaf_with_session(
@@ -552,9 +552,9 @@ fn dont_double_vote_for_pvfs_in_view() {
 	test_harness(|mut test_state, mut handle| {
 		async move {
 			let pvf = dummy_validation_code_hash(1);
-			let block_1_1 = FakeLeaf::new([1; 32].into(), 1, vec![pvf.clone()]);
-			let block_2_1 = FakeLeaf::new([2; 32].into(), 1, vec![pvf.clone()]);
-			let block_1_2 = block_1_1.descendant(vec![pvf.clone()]);
+			let block_1_1 = FakeLeaf::new([1; 32].into(), 1, vec![pvf]);
+			let block_2_1 = FakeLeaf::new([2; 32].into(), 1, vec![pvf]);
+			let block_1_2 = block_1_1.descendant(vec![pvf]);
 
 			test_state
 				.activate_leaf_with_session(
@@ -605,8 +605,8 @@ fn judgements_come_out_of_order() {
 			let pvf_1 = dummy_validation_code_hash(1);
 			let pvf_2 = dummy_validation_code_hash(2);
 
-			let block_1 = FakeLeaf::new([1; 32].into(), 1, vec![pvf_1.clone()]);
-			let block_2 = FakeLeaf::new([2; 32].into(), 1, vec![pvf_2.clone()]);
+			let block_1 = FakeLeaf::new([1; 32].into(), 1, vec![pvf_1]);
+			let block_2 = FakeLeaf::new([2; 32].into(), 1, vec![pvf_2]);
 
 			test_state
 				.activate_leaf_with_session(

--- a/node/core/pvf/tests/it/adder.rs
+++ b/node/core/pvf/tests/it/adder.rs
@@ -53,14 +53,13 @@ async fn execute_good_block_on_parent() {
 
 #[tokio::test]
 async fn execute_good_chain_on_parent() {
-	let mut number = 0;
 	let mut parent_hash = [0; 32];
 	let mut last_state = 0;
 
 	let host = TestHost::new();
 
-	for add in 0..10 {
-		let parent_head = HeadData { number, parent_hash, post_state: hash_state(last_state) };
+	for (number, add) in (0..10).enumerate() {
+		let parent_head = HeadData { number: number as u64, parent_hash, post_state: hash_state(last_state) };
 
 		let block_data = BlockData { state: last_state, add };
 
@@ -80,11 +79,10 @@ async fn execute_good_chain_on_parent() {
 
 		let new_head = HeadData::decode(&mut &ret.head_data.0[..]).unwrap();
 
-		assert_eq!(new_head.number, number + 1);
+		assert_eq!(new_head.number, number as u64 + 1);
 		assert_eq!(new_head.parent_hash, parent_head.hash());
 		assert_eq!(new_head.post_state, hash_state(last_state + add));
 
-		number += 1;
 		parent_hash = new_head.hash();
 		last_state += add;
 	}

--- a/node/core/pvf/tests/it/adder.rs
+++ b/node/core/pvf/tests/it/adder.rs
@@ -59,7 +59,8 @@ async fn execute_good_chain_on_parent() {
 	let host = TestHost::new();
 
 	for (number, add) in (0..10).enumerate() {
-		let parent_head = HeadData { number: number as u64, parent_hash, post_state: hash_state(last_state) };
+		let parent_head =
+			HeadData { number: number as u64, parent_hash, post_state: hash_state(last_state) };
 
 		let block_data = BlockData { state: last_state, add };
 

--- a/node/core/runtime-api/src/tests.rs
+++ b/node/core/runtime-api/src/tests.rs
@@ -1063,7 +1063,7 @@ fn requests_validation_code_hash() {
 	let mut subsystem_client = MockSubsystemClient::default();
 	subsystem_client
 		.validation_code_hash
-		.insert(para_a, validation_code_hash.clone());
+		.insert(para_a, validation_code_hash);
 	let subsystem_client = Arc::new(subsystem_client);
 
 	let subsystem =

--- a/node/core/runtime-api/src/tests.rs
+++ b/node/core/runtime-api/src/tests.rs
@@ -984,7 +984,7 @@ fn requests_submit_pvf_check_statement() {
 				),
 			})
 			.await;
-		assert_eq!(rx.await.unwrap().unwrap(), ());
+		let _ = rx.await.unwrap().unwrap();
 		let (tx, rx) = oneshot::channel();
 		ctx_handle
 			.send(FromOrchestra::Communication {
@@ -994,7 +994,7 @@ fn requests_submit_pvf_check_statement() {
 				),
 			})
 			.await;
-		assert_eq!(rx.await.unwrap().unwrap(), ());
+		let _ = rx.await.unwrap().unwrap();
 
 		assert_eq!(
 			&*subsystem_client.submitted_pvf_check_statement.lock().expect("poisened mutex"),

--- a/node/core/runtime-api/src/tests.rs
+++ b/node/core/runtime-api/src/tests.rs
@@ -1061,9 +1061,7 @@ fn requests_validation_code_hash() {
 	let validation_code_hash = dummy_validation_code().hash();
 
 	let mut subsystem_client = MockSubsystemClient::default();
-	subsystem_client
-		.validation_code_hash
-		.insert(para_a, validation_code_hash);
+	subsystem_client.validation_code_hash.insert(para_a, validation_code_hash);
 	let subsystem_client = Arc::new(subsystem_client);
 
 	let subsystem =

--- a/node/malus/src/variants/back_garbage_candidate.rs
+++ b/node/malus/src/variants/back_garbage_candidate.rs
@@ -59,10 +59,10 @@ pub(crate) struct BackGarbageCandidates {
 }
 
 impl OverseerGen for BackGarbageCandidates {
-	fn generate<'a, Spawner, RuntimeClient>(
+	fn generate<Spawner, RuntimeClient>(
 		&self,
 		connector: OverseerConnector,
-		args: OverseerGenArgs<'a, Spawner, RuntimeClient>,
+		args: OverseerGenArgs<'_, Spawner, RuntimeClient>,
 	) -> Result<
 		(Overseer<SpawnGlue<Spawner>, Arc<DefaultSubsystemClient<RuntimeClient>>>, OverseerHandle),
 		Error,

--- a/node/malus/src/variants/common.rs
+++ b/node/malus/src/variants/common.rs
@@ -392,9 +392,8 @@ where
 						let behave_maliciously = self.distribution.sample(&mut rand::thread_rng());
 						match behave_maliciously {
 							true => {
-								let validation_result = ValidationResult::Invalid(
-									self.fake_validation_error.into(),
-								);
+								let validation_result =
+									ValidationResult::Invalid(self.fake_validation_error.into());
 								gum::info!(
 									target: MALUS,
 									para_id = ?candidate_receipt.descriptor.para_id,

--- a/node/malus/src/variants/common.rs
+++ b/node/malus/src/variants/common.rs
@@ -393,7 +393,7 @@ where
 						match behave_maliciously {
 							true => {
 								let validation_result = ValidationResult::Invalid(
-									self.fake_validation_error.clone().into(),
+									self.fake_validation_error.into(),
 								);
 								gum::info!(
 									target: MALUS,

--- a/node/malus/src/variants/dispute_valid_candidates.rs
+++ b/node/malus/src/variants/dispute_valid_candidates.rs
@@ -76,10 +76,10 @@ pub(crate) struct DisputeValidCandidates {
 }
 
 impl OverseerGen for DisputeValidCandidates {
-	fn generate<'a, Spawner, RuntimeClient>(
+	fn generate<Spawner, RuntimeClient>(
 		&self,
 		connector: OverseerConnector,
-		args: OverseerGenArgs<'a, Spawner, RuntimeClient>,
+		args: OverseerGenArgs<'_, Spawner, RuntimeClient>,
 	) -> Result<
 		(Overseer<SpawnGlue<Spawner>, Arc<DefaultSubsystemClient<RuntimeClient>>>, OverseerHandle),
 		Error,

--- a/node/malus/src/variants/suggest_garbage_candidate.rs
+++ b/node/malus/src/variants/suggest_garbage_candidate.rs
@@ -99,7 +99,7 @@ where
 				// equal to `p`. We use `rand::thread_rng` as the source of randomness.
 				let generate_malicious_candidate = distribution.sample(&mut rand::thread_rng());
 
-				if generate_malicious_candidate == true {
+				if generate_malicious_candidate {
 					gum::debug!(target: MALUS, "😈 Suggesting malicious candidate.",);
 
 					let pov = PoV { block_data: BlockData(MALICIOUS_POV.into()) };
@@ -253,10 +253,10 @@ pub(crate) struct SuggestGarbageCandidates {
 }
 
 impl OverseerGen for SuggestGarbageCandidates {
-	fn generate<'a, Spawner, RuntimeClient>(
+	fn generate<Spawner, RuntimeClient>(
 		&self,
 		connector: OverseerConnector,
-		args: OverseerGenArgs<'a, Spawner, RuntimeClient>,
+		args: OverseerGenArgs<'_, Spawner, RuntimeClient>,
 	) -> Result<
 		(Overseer<SpawnGlue<Spawner>, Arc<DefaultSubsystemClient<RuntimeClient>>>, OverseerHandle),
 		Error,

--- a/node/network/approval-distribution/src/tests.rs
+++ b/node/network/approval-distribution/src/tests.rs
@@ -234,8 +234,7 @@ async fn setup_peer_with_view(
 	overseer_send(
 		virtual_overseer,
 		ApprovalDistributionMessage::NetworkBridgeUpdate(NetworkBridgeEvent::PeerViewChange(
-			*peer_id,
-			view,
+			*peer_id, view,
 		)),
 	)
 	.await;

--- a/node/network/approval-distribution/src/tests.rs
+++ b/node/network/approval-distribution/src/tests.rs
@@ -148,7 +148,7 @@ fn make_gossip_topology(
 	assert!(all_peers.len() >= grid_size);
 
 	let peer_info = |i: usize| TopologyPeerInfo {
-		peer_ids: vec![all_peers[i].0.clone()],
+		peer_ids: vec![all_peers[i].0],
 		validator_index: ValidatorIndex::from(i as u32),
 		discovery_id: all_peers[i].1.clone(),
 	};
@@ -224,7 +224,7 @@ async fn setup_peer_with_view(
 	overseer_send(
 		virtual_overseer,
 		ApprovalDistributionMessage::NetworkBridgeUpdate(NetworkBridgeEvent::PeerConnected(
-			peer_id.clone(),
+			*peer_id,
 			ObservedRole::Full,
 			ValidationVersion::V1.into(),
 			None,
@@ -234,7 +234,7 @@ async fn setup_peer_with_view(
 	overseer_send(
 		virtual_overseer,
 		ApprovalDistributionMessage::NetworkBridgeUpdate(NetworkBridgeEvent::PeerViewChange(
-			peer_id.clone(),
+			*peer_id,
 			view,
 		)),
 	)
@@ -249,7 +249,7 @@ async fn send_message_from_peer(
 	overseer_send(
 		virtual_overseer,
 		ApprovalDistributionMessage::NetworkBridgeUpdate(NetworkBridgeEvent::PeerMessage(
-			peer_id.clone(),
+			*peer_id,
 			Versioned::V1(msg),
 		)),
 	)
@@ -480,7 +480,7 @@ fn spam_attack_results_in_negative_reputation_change() {
 		// new block `hash_b` with 20 candidates
 		let candidates_count = 20;
 		let meta = BlockApprovalMeta {
-			hash: hash_b.clone(),
+			hash: hash_b,
 			parent_hash,
 			number: 2,
 			candidates: vec![Default::default(); candidates_count],
@@ -527,7 +527,7 @@ fn spam_attack_results_in_negative_reputation_change() {
 		overseer_send(
 			overseer,
 			ApprovalDistributionMessage::NetworkBridgeUpdate(NetworkBridgeEvent::PeerViewChange(
-				peer.clone(),
+				*peer,
 				View::with_finalized(2),
 			)),
 		)
@@ -587,7 +587,7 @@ fn peer_sending_us_the_same_we_just_sent_them_is_ok() {
 		overseer_send(
 			overseer,
 			ApprovalDistributionMessage::NetworkBridgeUpdate(NetworkBridgeEvent::PeerViewChange(
-				peer.clone(),
+				*peer,
 				view![hash],
 			)),
 		)
@@ -956,7 +956,7 @@ fn update_peer_view() {
 		overseer_send(
 			overseer,
 			ApprovalDistributionMessage::NetworkBridgeUpdate(NetworkBridgeEvent::PeerViewChange(
-				peer.clone(),
+				*peer,
 				View::new(vec![hash_b, hash_c, hash_d], 2),
 			)),
 		)
@@ -1009,7 +1009,7 @@ fn update_peer_view() {
 		overseer_send(
 			overseer,
 			ApprovalDistributionMessage::NetworkBridgeUpdate(NetworkBridgeEvent::PeerViewChange(
-				peer.clone(),
+				*peer,
 				View::with_finalized(finalized_number),
 			)),
 		)
@@ -1166,7 +1166,7 @@ fn sends_assignments_even_when_state_is_approved() {
 					protocol_v1::ApprovalDistributionMessage::Assignments(sent_assignments)
 				))
 			)) => {
-				assert_eq!(peers, vec![peer.clone()]);
+				assert_eq!(peers, vec![*peer]);
 				assert_eq!(sent_assignments, assignments);
 			}
 		);
@@ -1179,7 +1179,7 @@ fn sends_assignments_even_when_state_is_approved() {
 					protocol_v1::ApprovalDistributionMessage::Approvals(sent_approvals)
 				))
 			)) => {
-				assert_eq!(peers, vec![peer.clone()]);
+				assert_eq!(peers, vec![*peer]);
 				assert_eq!(sent_approvals, approvals);
 			}
 		);
@@ -1208,7 +1208,7 @@ fn race_condition_in_local_vs_remote_view_update() {
 		// Test a small number of candidates
 		let candidates_count = 1;
 		let meta = BlockApprovalMeta {
-			hash: hash_b.clone(),
+			hash: hash_b,
 			parent_hash,
 			number: 2,
 			candidates: vec![Default::default(); candidates_count],
@@ -1811,7 +1811,7 @@ fn originator_aggression_l1() {
 
 	let mut state = State::default();
 	state.aggression_config.resend_unfinalized_period = None;
-	let aggression_l1_threshold = state.aggression_config.l1_threshold.clone().unwrap();
+	let aggression_l1_threshold = state.aggression_config.l1_threshold.unwrap();
 
 	let _ = test_harness(state, |mut virtual_overseer| async move {
 		let overseer = &mut virtual_overseer;
@@ -1931,8 +1931,7 @@ fn originator_aggression_l1() {
 					assert_eq!(sent_assignments, assignments);
 
 					assert!(unsent_indices.iter()
-						.find(|i| &peers[**i].0 == &sent_peers[0])
-						.is_some());
+						.any(|i| &peers[*i].0 == &sent_peers[0]));
 				}
 			);
 		}
@@ -1951,8 +1950,7 @@ fn originator_aggression_l1() {
 					assert_eq!(sent_approvals, approvals);
 
 					assert!(unsent_indices.iter()
-						.find(|i| &peers[**i].0 == &sent_peers[0])
-						.is_some());
+						.any(|i| &peers[*i].0 == &sent_peers[0]));
 				}
 			);
 		}
@@ -1972,7 +1970,7 @@ fn non_originator_aggression_l1() {
 
 	let mut state = state_without_reputation_delay();
 	state.aggression_config.resend_unfinalized_period = None;
-	let aggression_l1_threshold = state.aggression_config.l1_threshold.clone().unwrap();
+	let aggression_l1_threshold = state.aggression_config.l1_threshold.unwrap();
 
 	let _ = test_harness(state, |mut virtual_overseer| async move {
 		let overseer = &mut virtual_overseer;
@@ -2077,8 +2075,8 @@ fn non_originator_aggression_l2() {
 	let mut state = state_without_reputation_delay();
 	state.aggression_config.resend_unfinalized_period = None;
 
-	let aggression_l1_threshold = state.aggression_config.l1_threshold.clone().unwrap();
-	let aggression_l2_threshold = state.aggression_config.l2_threshold.clone().unwrap();
+	let aggression_l1_threshold = state.aggression_config.l1_threshold.unwrap();
+	let aggression_l2_threshold = state.aggression_config.l2_threshold.unwrap();
 	let _ = test_harness(state, |mut virtual_overseer| async move {
 		let overseer = &mut virtual_overseer;
 
@@ -2222,8 +2220,7 @@ fn non_originator_aggression_l2() {
 					assert_eq!(sent_assignments, assignments);
 
 					assert!(unsent_indices.iter()
-						.find(|i| &peers[**i].0 == &sent_peers[0])
-						.is_some());
+						.any(|i| &peers[*i].0 == &sent_peers[0]));
 				}
 			);
 		}

--- a/node/network/availability-distribution/src/tests/state.rs
+++ b/node/network/availability-distribution/src/tests/state.rs
@@ -123,13 +123,13 @@ impl Default for TestState {
 						let (core, chunk) = OccupiedCoreBuilder {
 							group_responsible: GroupIndex(i as _),
 							para_id: *para_id,
-							relay_parent: relay_parent.clone(),
+							relay_parent: *relay_parent,
 						}
 						.build();
 						(CoreState::Occupied(core), chunk)
 					})
 					.unzip();
-				cores.insert(relay_child.clone(), p_cores);
+				cores.insert(*relay_child, p_cores);
 				// Skip chunks for our own group (won't get fetched):
 				let mut chunks_other_groups = p_chunks.into_iter();
 				chunks_other_groups.next();
@@ -176,12 +176,12 @@ impl TestState {
 				.zip(advanced)
 				.map(|(old, new)| ActiveLeavesUpdate {
 					activated: Some(ActivatedLeaf {
-						hash: new.clone(),
+						hash: *new,
 						number: 1,
 						status: LeafStatus::Fresh,
 						span: Arc::new(jaeger::Span::Disabled),
 					}),
-					deactivated: vec![old.clone()].into(),
+					deactivated: vec![*old].into(),
 				})
 				.collect::<Vec<_>>()
 		};
@@ -239,8 +239,7 @@ impl TestState {
 					let chunk = self
 						.chunks
 						.get_mut(&(candidate_hash, validator_index))
-						.map(Vec::pop)
-						.flatten()
+						.and_then(Vec::pop)
 						.flatten();
 					tx.send(chunk).expect("Receiver is expected to be alive");
 				},

--- a/node/network/availability-recovery/src/tests.rs
+++ b/node/network/availability-recovery/src/tests.rs
@@ -562,7 +562,7 @@ fn availability_is_recovered_from_chunks_if_no_group_provided() {
 		overseer_signal(
 			&mut virtual_overseer,
 			OverseerSignal::ActiveLeaves(ActiveLeavesUpdate::start_work(ActivatedLeaf {
-				hash: test_state.current.clone(),
+				hash: test_state.current,
 				number: 1,
 				status: LeafStatus::Fresh,
 				span: Arc::new(jaeger::Span::Disabled),
@@ -648,7 +648,7 @@ fn availability_is_recovered_from_chunks_even_if_backing_group_supplied_if_chunk
 		overseer_signal(
 			&mut virtual_overseer,
 			OverseerSignal::ActiveLeaves(ActiveLeavesUpdate::start_work(ActivatedLeaf {
-				hash: test_state.current.clone(),
+				hash: test_state.current,
 				number: 1,
 				status: LeafStatus::Fresh,
 				span: Arc::new(jaeger::Span::Disabled),
@@ -734,7 +734,7 @@ fn bad_merkle_path_leads_to_recovery_error() {
 		overseer_signal(
 			&mut virtual_overseer,
 			OverseerSignal::ActiveLeaves(ActiveLeavesUpdate::start_work(ActivatedLeaf {
-				hash: test_state.current.clone(),
+				hash: test_state.current,
 				number: 1,
 				status: LeafStatus::Fresh,
 				span: Arc::new(jaeger::Span::Disabled),
@@ -792,7 +792,7 @@ fn wrong_chunk_index_leads_to_recovery_error() {
 		overseer_signal(
 			&mut virtual_overseer,
 			OverseerSignal::ActiveLeaves(ActiveLeavesUpdate::start_work(ActivatedLeaf {
-				hash: test_state.current.clone(),
+				hash: test_state.current,
 				number: 1,
 				status: LeafStatus::Fresh,
 				span: Arc::new(jaeger::Span::Disabled),
@@ -866,7 +866,7 @@ fn invalid_erasure_coding_leads_to_invalid_error() {
 		overseer_signal(
 			&mut virtual_overseer,
 			OverseerSignal::ActiveLeaves(ActiveLeavesUpdate::start_work(ActivatedLeaf {
-				hash: test_state.current.clone(),
+				hash: test_state.current,
 				number: 1,
 				status: LeafStatus::Fresh,
 				span: Arc::new(jaeger::Span::Disabled),
@@ -915,7 +915,7 @@ fn fast_path_backing_group_recovers() {
 		overseer_signal(
 			&mut virtual_overseer,
 			OverseerSignal::ActiveLeaves(ActiveLeavesUpdate::start_work(ActivatedLeaf {
-				hash: test_state.current.clone(),
+				hash: test_state.current,
 				number: 1,
 				status: LeafStatus::Fresh,
 				span: Arc::new(jaeger::Span::Disabled),
@@ -965,7 +965,7 @@ fn recovers_from_only_chunks_if_pov_large() {
 		overseer_signal(
 			&mut virtual_overseer,
 			OverseerSignal::ActiveLeaves(ActiveLeavesUpdate::start_work(ActivatedLeaf {
-				hash: test_state.current.clone(),
+				hash: test_state.current,
 				number: 1,
 				status: LeafStatus::Fresh,
 				span: Arc::new(jaeger::Span::Disabled),
@@ -1069,7 +1069,7 @@ fn fast_path_backing_group_recovers_if_pov_small() {
 		overseer_signal(
 			&mut virtual_overseer,
 			OverseerSignal::ActiveLeaves(ActiveLeavesUpdate::start_work(ActivatedLeaf {
-				hash: test_state.current.clone(),
+				hash: test_state.current,
 				number: 1,
 				status: LeafStatus::Fresh,
 				span: Arc::new(jaeger::Span::Disabled),
@@ -1128,7 +1128,7 @@ fn no_answers_in_fast_path_causes_chunk_requests() {
 		overseer_signal(
 			&mut virtual_overseer,
 			OverseerSignal::ActiveLeaves(ActiveLeavesUpdate::start_work(ActivatedLeaf {
-				hash: test_state.current.clone(),
+				hash: test_state.current,
 				number: 1,
 				status: LeafStatus::Fresh,
 				span: Arc::new(jaeger::Span::Disabled),
@@ -1190,7 +1190,7 @@ fn task_canceled_when_receivers_dropped() {
 		overseer_signal(
 			&mut virtual_overseer,
 			OverseerSignal::ActiveLeaves(ActiveLeavesUpdate::start_work(ActivatedLeaf {
-				hash: test_state.current.clone(),
+				hash: test_state.current,
 				number: 1,
 				status: LeafStatus::Fresh,
 				span: Arc::new(jaeger::Span::Disabled),
@@ -1232,7 +1232,7 @@ fn chunks_retry_until_all_nodes_respond() {
 		overseer_signal(
 			&mut virtual_overseer,
 			OverseerSignal::ActiveLeaves(ActiveLeavesUpdate::start_work(ActivatedLeaf {
-				hash: test_state.current.clone(),
+				hash: test_state.current,
 				number: 1,
 				status: LeafStatus::Fresh,
 				span: Arc::new(jaeger::Span::Disabled),
@@ -1293,7 +1293,7 @@ fn not_returning_requests_wont_stall_retrieval() {
 		overseer_signal(
 			&mut virtual_overseer,
 			OverseerSignal::ActiveLeaves(ActiveLeavesUpdate::start_work(ActivatedLeaf {
-				hash: test_state.current.clone(),
+				hash: test_state.current,
 				number: 1,
 				status: LeafStatus::Fresh,
 				span: Arc::new(jaeger::Span::Disabled),
@@ -1365,7 +1365,7 @@ fn all_not_returning_requests_still_recovers_on_return() {
 		overseer_signal(
 			&mut virtual_overseer,
 			OverseerSignal::ActiveLeaves(ActiveLeavesUpdate::start_work(ActivatedLeaf {
-				hash: test_state.current.clone(),
+				hash: test_state.current,
 				number: 1,
 				status: LeafStatus::Fresh,
 				span: Arc::new(jaeger::Span::Disabled),
@@ -1442,7 +1442,7 @@ fn returns_early_if_we_have_the_data() {
 		overseer_signal(
 			&mut virtual_overseer,
 			OverseerSignal::ActiveLeaves(ActiveLeavesUpdate::start_work(ActivatedLeaf {
-				hash: test_state.current.clone(),
+				hash: test_state.current,
 				number: 1,
 				status: LeafStatus::Fresh,
 				span: Arc::new(jaeger::Span::Disabled),
@@ -1479,7 +1479,7 @@ fn does_not_query_local_validator() {
 		overseer_signal(
 			&mut virtual_overseer,
 			OverseerSignal::ActiveLeaves(ActiveLeavesUpdate::start_work(ActivatedLeaf {
-				hash: test_state.current.clone(),
+				hash: test_state.current,
 				number: 1,
 				status: LeafStatus::Fresh,
 				span: Arc::new(jaeger::Span::Disabled),
@@ -1538,7 +1538,7 @@ fn invalid_local_chunk_is_ignored() {
 		overseer_signal(
 			&mut virtual_overseer,
 			OverseerSignal::ActiveLeaves(ActiveLeavesUpdate::start_work(ActivatedLeaf {
-				hash: test_state.current.clone(),
+				hash: test_state.current,
 				number: 1,
 				status: LeafStatus::Fresh,
 				span: Arc::new(jaeger::Span::Disabled),

--- a/node/network/bitfield-distribution/src/tests.rs
+++ b/node/network/bitfield-distribution/src/tests.rs
@@ -184,28 +184,20 @@ fn receive_invalid_signature() {
 	.flatten()
 	.expect("should be signed");
 
-	let invalid_msg = BitfieldGossipMessage {
-		relay_parent: hash_a,
-		signed_availability: invalid_signed.clone(),
-	};
+	let invalid_msg =
+		BitfieldGossipMessage { relay_parent: hash_a, signed_availability: invalid_signed.clone() };
 	let invalid_msg_2 = BitfieldGossipMessage {
 		relay_parent: hash_a,
 		signed_availability: invalid_signed_2.clone(),
 	};
-	let valid_msg = BitfieldGossipMessage {
-		relay_parent: hash_a,
-		signed_availability: valid_signed.clone(),
-	};
+	let valid_msg =
+		BitfieldGossipMessage { relay_parent: hash_a, signed_availability: valid_signed.clone() };
 
 	let pool = sp_core::testing::TaskExecutor::new();
 	let (mut ctx, mut handle) = make_subsystem_context::<BitfieldDistributionMessage, _>(pool);
 
-	let mut state = prewarmed_state(
-		validator_0.into(),
-		signing_context.clone(),
-		valid_msg,
-		vec![peer_b],
-	);
+	let mut state =
+		prewarmed_state(validator_0.into(), signing_context.clone(), valid_msg, vec![peer_b]);
 	state
 		.per_relay_parent
 		.get_mut(&hash_a)
@@ -261,11 +253,8 @@ fn receive_invalid_validator_index() {
 	assert_ne!(peer_a, peer_b);
 
 	// validator 0 key pair
-	let (mut state, signing_context, keystore, validator) = state_with_view(
-		our_view![hash_a, hash_b],
-		hash_a,
-		ReputationAggregator::new(|_| true),
-	);
+	let (mut state, signing_context, keystore, validator) =
+		state_with_view(our_view![hash_a, hash_b], hash_a, ReputationAggregator::new(|_| true));
 
 	state.peer_views.insert(peer_b, view![hash_a]);
 
@@ -281,8 +270,7 @@ fn receive_invalid_validator_index() {
 	.flatten()
 	.expect("should be signed");
 
-	let msg =
-		BitfieldGossipMessage { relay_parent: hash_a, signed_availability: signed.clone() };
+	let msg = BitfieldGossipMessage { relay_parent: hash_a, signed_availability: signed.clone() };
 
 	let pool = sp_core::testing::TaskExecutor::new();
 	let (mut ctx, mut handle) = make_subsystem_context::<BitfieldDistributionMessage, _>(pool);
@@ -325,11 +313,8 @@ fn receive_duplicate_messages() {
 	assert_ne!(peer_a, peer_b);
 
 	// validator 0 key pair
-	let (mut state, signing_context, keystore, validator) = state_with_view(
-		our_view![hash_a, hash_b],
-		hash_a,
-		ReputationAggregator::new(|_| true),
-	);
+	let (mut state, signing_context, keystore, validator) =
+		state_with_view(our_view![hash_a, hash_b], hash_a, ReputationAggregator::new(|_| true));
 
 	// create a signed message by validator 0
 	let payload = AvailabilityBitfield(bitvec![u8, bitvec::order::Lsb0; 1u8; 32]);
@@ -442,11 +427,8 @@ fn delay_reputation_change() {
 	let peer = PeerId::random();
 
 	// validator 0 key pair
-	let (mut state, signing_context, keystore, validator) = state_with_view(
-		our_view![hash_a, hash_b],
-		hash_a,
-		ReputationAggregator::new(|_| false),
-	);
+	let (mut state, signing_context, keystore, validator) =
+		state_with_view(our_view![hash_a, hash_b], hash_a, ReputationAggregator::new(|_| false));
 
 	// create a signed message by validator 0
 	let payload = AvailabilityBitfield(bitvec![u8, bitvec::order::Lsb0; 1u8; 32]);
@@ -481,10 +463,7 @@ fn delay_reputation_change() {
 		handle
 			.send(FromOrchestra::Communication {
 				msg: BitfieldDistributionMessage::NetworkBridgeUpdate(
-					NetworkBridgeEvent::PeerMessage(
-						peer,
-						msg.clone().into_network_message(),
-					),
+					NetworkBridgeEvent::PeerMessage(peer, msg.clone().into_network_message()),
 				),
 			})
 			.await;
@@ -507,10 +486,7 @@ fn delay_reputation_change() {
 		handle
 			.send(FromOrchestra::Communication {
 				msg: BitfieldDistributionMessage::NetworkBridgeUpdate(
-					NetworkBridgeEvent::PeerMessage(
-						peer,
-						msg.clone().into_network_message(),
-					),
+					NetworkBridgeEvent::PeerMessage(peer, msg.clone().into_network_message()),
 				),
 			})
 			.await;
@@ -573,10 +549,8 @@ fn do_not_relay_message_twice() {
 	state.peer_views.insert(peer_b, view![hash]);
 	state.peer_views.insert(peer_a, view![hash]);
 
-	let msg = BitfieldGossipMessage {
-		relay_parent: hash,
-		signed_availability: signed_bitfield.clone(),
-	};
+	let msg =
+		BitfieldGossipMessage { relay_parent: hash, signed_availability: signed_bitfield.clone() };
 
 	let pool = sp_core::testing::TaskExecutor::new();
 	let (mut ctx, mut handle) = make_subsystem_context::<BitfieldDistributionMessage, _>(pool);
@@ -665,11 +639,8 @@ fn changing_view() {
 	assert_ne!(peer_a, peer_b);
 
 	// validator 0 key pair
-	let (mut state, signing_context, keystore, validator) = state_with_view(
-		our_view![hash_a, hash_b],
-		hash_a,
-		ReputationAggregator::new(|_| true),
-	);
+	let (mut state, signing_context, keystore, validator) =
+		state_with_view(our_view![hash_a, hash_b], hash_a, ReputationAggregator::new(|_| true));
 
 	// create a signed message by validator 0
 	let payload = AvailabilityBitfield(bitvec![u8, bitvec::order::Lsb0; 1u8; 32]);
@@ -849,10 +820,8 @@ fn do_not_send_message_back_to_origin() {
 	state.peer_views.insert(peer_b, view![hash]);
 	state.peer_views.insert(peer_a, view![hash]);
 
-	let msg = BitfieldGossipMessage {
-		relay_parent: hash,
-		signed_availability: signed_bitfield.clone(),
-	};
+	let msg =
+		BitfieldGossipMessage { relay_parent: hash, signed_availability: signed_bitfield.clone() };
 
 	let pool = sp_core::testing::TaskExecutor::new();
 	let (mut ctx, mut handle) = make_subsystem_context::<BitfieldDistributionMessage, _>(pool);
@@ -966,10 +935,8 @@ fn topology_test() {
 		state.peer_views.insert(*peer, view![hash]);
 	});
 
-	let msg = BitfieldGossipMessage {
-		relay_parent: hash,
-		signed_availability: signed_bitfield.clone(),
-	};
+	let msg =
+		BitfieldGossipMessage { relay_parent: hash, signed_availability: signed_bitfield.clone() };
 
 	let pool = sp_core::testing::TaskExecutor::new();
 	let (mut ctx, mut handle) = make_subsystem_context::<BitfieldDistributionMessage, _>(pool);

--- a/node/network/bitfield-distribution/src/tests.rs
+++ b/node/network/bitfield-distribution/src/tests.rs
@@ -65,7 +65,7 @@ fn prewarmed_state(
 	known_message: BitfieldGossipMessage,
 	peers: Vec<PeerId>,
 ) -> ProtocolState {
-	let relay_parent = known_message.relay_parent.clone();
+	let relay_parent = known_message.relay_parent;
 	let mut topologies = SessionBoundGridTopologyStorage::default();
 	topologies.update_topology(0_u32, SessionGridTopology::new(Vec::new(), Vec::new()), None);
 	topologies.get_current_topology_mut().local_grid_neighbors_mut().peers_x =
@@ -73,7 +73,7 @@ fn prewarmed_state(
 
 	ProtocolState {
 		per_relay_parent: hashmap! {
-			relay_parent.clone() =>
+			relay_parent =>
 				PerRelayParentData {
 					signing_context,
 					validator_set: vec![validator.clone()],
@@ -99,7 +99,7 @@ fn state_with_view(
 ) -> (ProtocolState, SigningContext, KeystorePtr, ValidatorId) {
 	let mut state = ProtocolState { reputation, ..Default::default() };
 
-	let signing_context = SigningContext { session_index: 1, parent_hash: relay_parent.clone() };
+	let signing_context = SigningContext { session_index: 1, parent_hash: relay_parent };
 
 	let keystore: KeystorePtr = Arc::new(MemoryKeystore::new());
 	let validator = Keystore::sr25519_generate_new(&*keystore, ValidatorId::ID, None)
@@ -109,10 +109,10 @@ fn state_with_view(
 		.iter()
 		.map(|relay_parent| {
 			(
-				relay_parent.clone(),
+				*relay_parent,
 				PerRelayParentData {
 					signing_context: signing_context.clone(),
-					validator_set: vec![validator.clone().into()],
+					validator_set: vec![validator.into()],
 					one_per_validator: hashmap! {},
 					message_received_from_peer: hashmap! {},
 					message_sent_to_peer: hashmap! {},
@@ -140,7 +140,7 @@ fn receive_invalid_signature() {
 	let peer_b = PeerId::random();
 	assert_ne!(peer_a, peer_b);
 
-	let signing_context = SigningContext { session_index: 1, parent_hash: hash_a.clone() };
+	let signing_context = SigningContext { session_index: 1, parent_hash: hash_a };
 
 	// another validator not part of the validatorset
 	let keystore: KeystorePtr = Arc::new(MemoryKeystore::new());
@@ -185,15 +185,15 @@ fn receive_invalid_signature() {
 	.expect("should be signed");
 
 	let invalid_msg = BitfieldGossipMessage {
-		relay_parent: hash_a.clone(),
+		relay_parent: hash_a,
 		signed_availability: invalid_signed.clone(),
 	};
 	let invalid_msg_2 = BitfieldGossipMessage {
-		relay_parent: hash_a.clone(),
+		relay_parent: hash_a,
 		signed_availability: invalid_signed_2.clone(),
 	};
 	let valid_msg = BitfieldGossipMessage {
-		relay_parent: hash_a.clone(),
+		relay_parent: hash_a,
 		signed_availability: valid_signed.clone(),
 	};
 
@@ -204,7 +204,7 @@ fn receive_invalid_signature() {
 		validator_0.into(),
 		signing_context.clone(),
 		valid_msg,
-		vec![peer_b.clone()],
+		vec![peer_b],
 	);
 	state
 		.per_relay_parent
@@ -219,7 +219,7 @@ fn receive_invalid_signature() {
 			&mut ctx,
 			&mut state,
 			&Default::default(),
-			NetworkBridgeEvent::PeerMessage(peer_b.clone(), invalid_msg.into_network_message()),
+			NetworkBridgeEvent::PeerMessage(peer_b, invalid_msg.into_network_message()),
 			&mut rng,
 		));
 
@@ -230,7 +230,7 @@ fn receive_invalid_signature() {
 			&mut ctx,
 			&mut state,
 			&Default::default(),
-			NetworkBridgeEvent::PeerMessage(peer_b.clone(), invalid_msg_2.into_network_message()),
+			NetworkBridgeEvent::PeerMessage(peer_b, invalid_msg_2.into_network_message()),
 			&mut rng,
 		));
 		// reputation change due to invalid signature
@@ -263,11 +263,11 @@ fn receive_invalid_validator_index() {
 	// validator 0 key pair
 	let (mut state, signing_context, keystore, validator) = state_with_view(
 		our_view![hash_a, hash_b],
-		hash_a.clone(),
+		hash_a,
 		ReputationAggregator::new(|_| true),
 	);
 
-	state.peer_views.insert(peer_b.clone(), view![hash_a]);
+	state.peer_views.insert(peer_b, view![hash_a]);
 
 	let payload = AvailabilityBitfield(bitvec![u8, bitvec::order::Lsb0; 1u8; 32]);
 	let signed = Signed::<AvailabilityBitfield>::sign(
@@ -282,7 +282,7 @@ fn receive_invalid_validator_index() {
 	.expect("should be signed");
 
 	let msg =
-		BitfieldGossipMessage { relay_parent: hash_a.clone(), signed_availability: signed.clone() };
+		BitfieldGossipMessage { relay_parent: hash_a, signed_availability: signed.clone() };
 
 	let pool = sp_core::testing::TaskExecutor::new();
 	let (mut ctx, mut handle) = make_subsystem_context::<BitfieldDistributionMessage, _>(pool);
@@ -293,7 +293,7 @@ fn receive_invalid_validator_index() {
 			&mut ctx,
 			&mut state,
 			&Default::default(),
-			NetworkBridgeEvent::PeerMessage(peer_b.clone(), msg.into_network_message()),
+			NetworkBridgeEvent::PeerMessage(peer_b, msg.into_network_message()),
 			&mut rng,
 		));
 
@@ -327,7 +327,7 @@ fn receive_duplicate_messages() {
 	// validator 0 key pair
 	let (mut state, signing_context, keystore, validator) = state_with_view(
 		our_view![hash_a, hash_b],
-		hash_a.clone(),
+		hash_a,
 		ReputationAggregator::new(|_| true),
 	);
 
@@ -345,7 +345,7 @@ fn receive_duplicate_messages() {
 	.expect("should be signed");
 
 	let msg = BitfieldGossipMessage {
-		relay_parent: hash_a.clone(),
+		relay_parent: hash_a,
 		signed_availability: signed_bitfield.clone(),
 	};
 
@@ -359,7 +359,7 @@ fn receive_duplicate_messages() {
 			&mut ctx,
 			&mut state,
 			&Default::default(),
-			NetworkBridgeEvent::PeerMessage(peer_b.clone(), msg.clone().into_network_message(),),
+			NetworkBridgeEvent::PeerMessage(peer_b, msg.clone().into_network_message(),),
 			&mut rng,
 		));
 
@@ -392,7 +392,7 @@ fn receive_duplicate_messages() {
 			&mut ctx,
 			&mut state,
 			&Default::default(),
-			NetworkBridgeEvent::PeerMessage(peer_a.clone(), msg.clone().into_network_message(),),
+			NetworkBridgeEvent::PeerMessage(peer_a, msg.clone().into_network_message(),),
 			&mut rng,
 		));
 
@@ -411,7 +411,7 @@ fn receive_duplicate_messages() {
 			&mut ctx,
 			&mut state,
 			&Default::default(),
-			NetworkBridgeEvent::PeerMessage(peer_b.clone(), msg.clone().into_network_message(),),
+			NetworkBridgeEvent::PeerMessage(peer_b, msg.clone().into_network_message(),),
 			&mut rng,
 		));
 
@@ -444,7 +444,7 @@ fn delay_reputation_change() {
 	// validator 0 key pair
 	let (mut state, signing_context, keystore, validator) = state_with_view(
 		our_view![hash_a, hash_b],
-		hash_a.clone(),
+		hash_a,
 		ReputationAggregator::new(|_| false),
 	);
 
@@ -462,7 +462,7 @@ fn delay_reputation_change() {
 	.expect("should be signed");
 
 	let msg = BitfieldGossipMessage {
-		relay_parent: hash_a.clone(),
+		relay_parent: hash_a,
 		signed_availability: signed_bitfield.clone(),
 	};
 
@@ -482,7 +482,7 @@ fn delay_reputation_change() {
 			.send(FromOrchestra::Communication {
 				msg: BitfieldDistributionMessage::NetworkBridgeUpdate(
 					NetworkBridgeEvent::PeerMessage(
-						peer.clone(),
+						peer,
 						msg.clone().into_network_message(),
 					),
 				),
@@ -508,7 +508,7 @@ fn delay_reputation_change() {
 			.send(FromOrchestra::Communication {
 				msg: BitfieldDistributionMessage::NetworkBridgeUpdate(
 					NetworkBridgeEvent::PeerMessage(
-						peer.clone(),
+						peer,
 						msg.clone().into_network_message(),
 					),
 				),
@@ -555,7 +555,7 @@ fn do_not_relay_message_twice() {
 
 	// validator 0 key pair
 	let (mut state, signing_context, keystore, validator) =
-		state_with_view(our_view![hash], hash.clone(), ReputationAggregator::new(|_| true));
+		state_with_view(our_view![hash], hash, ReputationAggregator::new(|_| true));
 
 	// create a signed message by validator 0
 	let payload = AvailabilityBitfield(bitvec![u8, bitvec::order::Lsb0; 1u8; 32]);
@@ -570,11 +570,11 @@ fn do_not_relay_message_twice() {
 	.flatten()
 	.expect("should be signed");
 
-	state.peer_views.insert(peer_b.clone(), view![hash]);
-	state.peer_views.insert(peer_a.clone(), view![hash]);
+	state.peer_views.insert(peer_b, view![hash]);
+	state.peer_views.insert(peer_a, view![hash]);
 
 	let msg = BitfieldGossipMessage {
-		relay_parent: hash.clone(),
+		relay_parent: hash,
 		signed_availability: signed_bitfield.clone(),
 	};
 
@@ -584,7 +584,7 @@ fn do_not_relay_message_twice() {
 
 	executor::block_on(async move {
 		let mut gossip_peers = GridNeighbors::empty();
-		gossip_peers.peers_x = HashSet::from_iter(vec![peer_a.clone(), peer_b.clone()].into_iter());
+		gossip_peers.peers_x = HashSet::from_iter(vec![peer_a, peer_b].into_iter());
 
 		relay_message(
 			&mut ctx,
@@ -667,7 +667,7 @@ fn changing_view() {
 	// validator 0 key pair
 	let (mut state, signing_context, keystore, validator) = state_with_view(
 		our_view![hash_a, hash_b],
-		hash_a.clone(),
+		hash_a,
 		ReputationAggregator::new(|_| true),
 	);
 
@@ -685,7 +685,7 @@ fn changing_view() {
 	.expect("should be signed");
 
 	let msg = BitfieldGossipMessage {
-		relay_parent: hash_a.clone(),
+		relay_parent: hash_a,
 		signed_availability: signed_bitfield.clone(),
 	};
 
@@ -699,7 +699,7 @@ fn changing_view() {
 			&mut state,
 			&Default::default(),
 			NetworkBridgeEvent::PeerConnected(
-				peer_b.clone(),
+				peer_b,
 				ObservedRole::Full,
 				ValidationVersion::V1.into(),
 				None
@@ -712,7 +712,7 @@ fn changing_view() {
 			&mut ctx,
 			&mut state,
 			&Default::default(),
-			NetworkBridgeEvent::PeerViewChange(peer_b.clone(), view![hash_a, hash_b]),
+			NetworkBridgeEvent::PeerViewChange(peer_b, view![hash_a, hash_b]),
 			&mut rng,
 		));
 
@@ -723,7 +723,7 @@ fn changing_view() {
 			&mut ctx,
 			&mut state,
 			&Default::default(),
-			NetworkBridgeEvent::PeerMessage(peer_b.clone(), msg.clone().into_network_message(),),
+			NetworkBridgeEvent::PeerMessage(peer_b, msg.clone().into_network_message(),),
 			&mut rng,
 		));
 
@@ -754,7 +754,7 @@ fn changing_view() {
 			&mut ctx,
 			&mut state,
 			&Default::default(),
-			NetworkBridgeEvent::PeerViewChange(peer_b.clone(), view![]),
+			NetworkBridgeEvent::PeerViewChange(peer_b, view![]),
 			&mut rng,
 		));
 
@@ -767,7 +767,7 @@ fn changing_view() {
 			&mut ctx,
 			&mut state,
 			&Default::default(),
-			NetworkBridgeEvent::PeerMessage(peer_b.clone(), msg.clone().into_network_message(),),
+			NetworkBridgeEvent::PeerMessage(peer_b, msg.clone().into_network_message(),),
 			&mut rng,
 		));
 
@@ -786,7 +786,7 @@ fn changing_view() {
 			&mut ctx,
 			&mut state,
 			&Default::default(),
-			NetworkBridgeEvent::PeerDisconnected(peer_b.clone()),
+			NetworkBridgeEvent::PeerDisconnected(peer_b),
 			&mut rng,
 		));
 
@@ -799,7 +799,7 @@ fn changing_view() {
 			&mut ctx,
 			&mut state,
 			&Default::default(),
-			NetworkBridgeEvent::PeerMessage(peer_a.clone(), msg.clone().into_network_message(),),
+			NetworkBridgeEvent::PeerMessage(peer_a, msg.clone().into_network_message(),),
 			&mut rng,
 		));
 
@@ -846,11 +846,11 @@ fn do_not_send_message_back_to_origin() {
 	.flatten()
 	.expect("should be signed");
 
-	state.peer_views.insert(peer_b.clone(), view![hash]);
-	state.peer_views.insert(peer_a.clone(), view![hash]);
+	state.peer_views.insert(peer_b, view![hash]);
+	state.peer_views.insert(peer_a, view![hash]);
 
 	let msg = BitfieldGossipMessage {
-		relay_parent: hash.clone(),
+		relay_parent: hash,
 		signed_availability: signed_bitfield.clone(),
 	};
 
@@ -864,7 +864,7 @@ fn do_not_send_message_back_to_origin() {
 			&mut ctx,
 			&mut state,
 			&Default::default(),
-			NetworkBridgeEvent::PeerMessage(peer_b.clone(), msg.clone().into_network_message(),),
+			NetworkBridgeEvent::PeerMessage(peer_b, msg.clone().into_network_message(),),
 			&mut rng,
 		));
 
@@ -930,13 +930,13 @@ fn topology_test() {
 	let peers_x: Vec<_> = [0, 2, 3, 4, 5, 6]
 		.iter()
 		.cloned()
-		.map(|i| topology_peer_info[i].peer_ids[0].clone())
+		.map(|i| topology_peer_info[i].peer_ids[0])
 		.collect();
 
 	let peers_y: Vec<_> = [8, 15, 22, 29, 36, 43]
 		.iter()
 		.cloned()
-		.map(|i| topology_peer_info[i].peer_ids[0].clone())
+		.map(|i| topology_peer_info[i].peer_ids[0])
 		.collect();
 
 	{
@@ -963,11 +963,11 @@ fn topology_test() {
 	.expect("should be signed");
 
 	peers_x.iter().chain(peers_y.iter()).for_each(|peer| {
-		state.peer_views.insert(peer.clone(), view![hash]);
+		state.peer_views.insert(*peer, view![hash]);
 	});
 
 	let msg = BitfieldGossipMessage {
-		relay_parent: hash.clone(),
+		relay_parent: hash,
 		signed_availability: signed_bitfield.clone(),
 	};
 
@@ -981,7 +981,7 @@ fn topology_test() {
 			&mut ctx,
 			&mut state,
 			&Default::default(),
-			NetworkBridgeEvent::PeerMessage(peers_x[0].clone(), msg.clone().into_network_message(),),
+			NetworkBridgeEvent::PeerMessage(peers_x[0], msg.clone().into_network_message(),),
 			&mut rng,
 		));
 
@@ -1064,22 +1064,22 @@ fn need_message_works() {
 				.insert(signed_by.clone());
 		};
 
-	assert!(true == pretend_send(&mut state, peer_a, &validator_set[0]));
-	assert!(true == pretend_send(&mut state, peer_b, &validator_set[1]));
+	assert!(pretend_send(&mut state, peer_a, &validator_set[0]));
+	assert!(pretend_send(&mut state, peer_b, &validator_set[1]));
 	// sending the same thing must not be allowed
-	assert!(false == pretend_send(&mut state, peer_a, &validator_set[0]));
+	assert!(!pretend_send(&mut state, peer_a, &validator_set[0]));
 
 	// receive by Alice
 	pretend_receive(&mut state, peer_a, &validator_set[0]);
 	// must be marked as not needed by Alice, so attempt to send to Alice must be false
-	assert!(false == pretend_send(&mut state, peer_a, &validator_set[0]));
+	assert!(!pretend_send(&mut state, peer_a, &validator_set[0]));
 	// but ok for Bob
-	assert!(false == pretend_send(&mut state, peer_b, &validator_set[1]));
+	assert!(!pretend_send(&mut state, peer_b, &validator_set[1]));
 
 	// receive by Bob
 	pretend_receive(&mut state, peer_a, &validator_set[0]);
 	// not ok for Alice
-	assert!(false == pretend_send(&mut state, peer_a, &validator_set[0]));
+	assert!(!pretend_send(&mut state, peer_a, &validator_set[0]));
 	// also not ok for Bob
-	assert!(false == pretend_send(&mut state, peer_b, &validator_set[1]));
+	assert!(!pretend_send(&mut state, peer_b, &validator_set[1]));
 }

--- a/node/network/bridge/src/rx/tests.rs
+++ b/node/network/bridge/src/rx/tests.rs
@@ -433,10 +433,10 @@ fn send_our_view_upon_connection() {
 		handle.await_mode_switch().await;
 
 		network_handle
-			.connect_peer(peer.clone(), PeerSet::Validation, ObservedRole::Full)
+			.connect_peer(peer, PeerSet::Validation, ObservedRole::Full)
 			.await;
 		network_handle
-			.connect_peer(peer.clone(), PeerSet::Collation, ObservedRole::Full)
+			.connect_peer(peer, PeerSet::Collation, ObservedRole::Full)
 			.await;
 
 		await_peer_connections(&shared, 1, 1).await;
@@ -446,7 +446,7 @@ fn send_our_view_upon_connection() {
 		assert_network_actions_contains(
 			&actions,
 			&NetworkAction::WriteNotification(
-				peer.clone(),
+				peer,
 				PeerSet::Validation,
 				WireMessage::<protocol_v1::ValidationProtocol>::ViewUpdate(view.clone()).encode(),
 			),
@@ -454,7 +454,7 @@ fn send_our_view_upon_connection() {
 		assert_network_actions_contains(
 			&actions,
 			&NetworkAction::WriteNotification(
-				peer.clone(),
+				peer,
 				PeerSet::Collation,
 				WireMessage::<protocol_v1::CollationProtocol>::ViewUpdate(view.clone()).encode(),
 			),
@@ -482,10 +482,10 @@ fn sends_view_updates_to_peers() {
 		handle.await_mode_switch().await;
 
 		network_handle
-			.connect_peer(peer_a.clone(), PeerSet::Validation, ObservedRole::Full)
+			.connect_peer(peer_a, PeerSet::Validation, ObservedRole::Full)
 			.await;
 		network_handle
-			.connect_peer(peer_b.clone(), PeerSet::Collation, ObservedRole::Full)
+			.connect_peer(peer_b, PeerSet::Collation, ObservedRole::Full)
 			.await;
 
 		await_peer_connections(&shared, 1, 1).await;
@@ -545,10 +545,10 @@ fn do_not_send_view_update_until_synced() {
 		assert_ne!(peer_a, peer_b);
 
 		network_handle
-			.connect_peer(peer_a.clone(), PeerSet::Validation, ObservedRole::Full)
+			.connect_peer(peer_a, PeerSet::Validation, ObservedRole::Full)
 			.await;
 		network_handle
-			.connect_peer(peer_b.clone(), PeerSet::Collation, ObservedRole::Full)
+			.connect_peer(peer_b, PeerSet::Collation, ObservedRole::Full)
 			.await;
 
 		await_peer_connections(&shared, 1, 1).await;
@@ -640,10 +640,10 @@ fn do_not_send_view_update_when_only_finalized_block_changed() {
 		let peer_b = PeerId::random();
 
 		network_handle
-			.connect_peer(peer_a.clone(), PeerSet::Validation, ObservedRole::Full)
+			.connect_peer(peer_a, PeerSet::Validation, ObservedRole::Full)
 			.await;
 		network_handle
-			.connect_peer(peer_b.clone(), PeerSet::Validation, ObservedRole::Full)
+			.connect_peer(peer_b, PeerSet::Validation, ObservedRole::Full)
 			.await;
 
 		await_peer_connections(&shared, 2, 0).await;
@@ -701,7 +701,7 @@ fn peer_view_updates_sent_via_overseer() {
 		let peer = PeerId::random();
 
 		network_handle
-			.connect_peer(peer.clone(), PeerSet::Validation, ObservedRole::Full)
+			.connect_peer(peer, PeerSet::Validation, ObservedRole::Full)
 			.await;
 
 		await_peer_connections(&shared, 1, 0).await;
@@ -712,7 +712,7 @@ fn peer_view_updates_sent_via_overseer() {
 		{
 			assert_sends_validation_event_to_all(
 				NetworkBridgeEvent::PeerConnected(
-					peer.clone(),
+					peer,
 					ObservedRole::Full,
 					ValidationVersion::V1.into(),
 					None,
@@ -722,7 +722,7 @@ fn peer_view_updates_sent_via_overseer() {
 			.await;
 
 			assert_sends_validation_event_to_all(
-				NetworkBridgeEvent::PeerViewChange(peer.clone(), View::default()),
+				NetworkBridgeEvent::PeerViewChange(peer, View::default()),
 				&mut virtual_overseer,
 			)
 			.await;
@@ -730,14 +730,14 @@ fn peer_view_updates_sent_via_overseer() {
 
 		network_handle
 			.peer_message(
-				peer.clone(),
+				peer,
 				PeerSet::Validation,
 				WireMessage::<protocol_v1::ValidationProtocol>::ViewUpdate(view.clone()).encode(),
 			)
 			.await;
 
 		assert_sends_validation_event_to_all(
-			NetworkBridgeEvent::PeerViewChange(peer.clone(), view),
+			NetworkBridgeEvent::PeerViewChange(peer, view),
 			&mut virtual_overseer,
 		)
 		.await;
@@ -753,7 +753,7 @@ fn peer_messages_sent_via_overseer() {
 		let peer = PeerId::random();
 
 		network_handle
-			.connect_peer(peer.clone(), PeerSet::Validation, ObservedRole::Full)
+			.connect_peer(peer, PeerSet::Validation, ObservedRole::Full)
 			.await;
 
 		await_peer_connections(&shared, 1, 0).await;
@@ -762,7 +762,7 @@ fn peer_messages_sent_via_overseer() {
 		{
 			assert_sends_validation_event_to_all(
 				NetworkBridgeEvent::PeerConnected(
-					peer.clone(),
+					peer,
 					ObservedRole::Full,
 					ValidationVersion::V1.into(),
 					None,
@@ -772,7 +772,7 @@ fn peer_messages_sent_via_overseer() {
 			.await;
 
 			assert_sends_validation_event_to_all(
-				NetworkBridgeEvent::PeerViewChange(peer.clone(), View::default()),
+				NetworkBridgeEvent::PeerViewChange(peer, View::default()),
 				&mut virtual_overseer,
 			)
 			.await;
@@ -787,13 +787,13 @@ fn peer_messages_sent_via_overseer() {
 
 		network_handle
 			.peer_message(
-				peer.clone(),
+				peer,
 				PeerSet::Validation,
 				WireMessage::ProtocolMessage(message_v1.clone()).encode(),
 			)
 			.await;
 
-		network_handle.disconnect_peer(peer.clone(), PeerSet::Validation).await;
+		network_handle.disconnect_peer(peer, PeerSet::Validation).await;
 
 		// Approval distribution message comes first, and the message is only sent to that
 		// subsystem. then a disconnection event arises that is sent to all validation networking
@@ -828,10 +828,10 @@ fn peer_disconnect_from_just_one_peerset() {
 		let peer = PeerId::random();
 
 		network_handle
-			.connect_peer(peer.clone(), PeerSet::Validation, ObservedRole::Full)
+			.connect_peer(peer, PeerSet::Validation, ObservedRole::Full)
 			.await;
 		network_handle
-			.connect_peer(peer.clone(), PeerSet::Collation, ObservedRole::Full)
+			.connect_peer(peer, PeerSet::Collation, ObservedRole::Full)
 			.await;
 
 		await_peer_connections(&shared, 1, 1).await;
@@ -840,7 +840,7 @@ fn peer_disconnect_from_just_one_peerset() {
 		{
 			assert_sends_validation_event_to_all(
 				NetworkBridgeEvent::PeerConnected(
-					peer.clone(),
+					peer,
 					ObservedRole::Full,
 					ValidationVersion::V1.into(),
 					None,
@@ -850,7 +850,7 @@ fn peer_disconnect_from_just_one_peerset() {
 			.await;
 
 			assert_sends_validation_event_to_all(
-				NetworkBridgeEvent::PeerViewChange(peer.clone(), View::default()),
+				NetworkBridgeEvent::PeerViewChange(peer, View::default()),
 				&mut virtual_overseer,
 			)
 			.await;
@@ -859,7 +859,7 @@ fn peer_disconnect_from_just_one_peerset() {
 		{
 			assert_sends_collation_event_to_all(
 				NetworkBridgeEvent::PeerConnected(
-					peer.clone(),
+					peer,
 					ObservedRole::Full,
 					ValidationVersion::V1.into(),
 					None,
@@ -869,16 +869,16 @@ fn peer_disconnect_from_just_one_peerset() {
 			.await;
 
 			assert_sends_collation_event_to_all(
-				NetworkBridgeEvent::PeerViewChange(peer.clone(), View::default()),
+				NetworkBridgeEvent::PeerViewChange(peer, View::default()),
 				&mut virtual_overseer,
 			)
 			.await;
 		}
 
-		network_handle.disconnect_peer(peer.clone(), PeerSet::Validation).await;
+		network_handle.disconnect_peer(peer, PeerSet::Validation).await;
 
 		assert_sends_validation_event_to_all(
-			NetworkBridgeEvent::PeerDisconnected(peer.clone()),
+			NetworkBridgeEvent::PeerDisconnected(peer),
 			&mut virtual_overseer,
 		)
 		.await;
@@ -905,7 +905,7 @@ fn peer_disconnect_from_just_one_peerset() {
 		assert_network_actions_contains(
 			&actions,
 			&NetworkAction::WriteNotification(
-				peer.clone(),
+				peer,
 				PeerSet::Collation,
 				wire_message.clone(),
 			),
@@ -923,10 +923,10 @@ fn relays_collation_protocol_messages() {
 		let peer_b = PeerId::random();
 
 		network_handle
-			.connect_peer(peer_a.clone(), PeerSet::Validation, ObservedRole::Full)
+			.connect_peer(peer_a, PeerSet::Validation, ObservedRole::Full)
 			.await;
 		network_handle
-			.connect_peer(peer_b.clone(), PeerSet::Collation, ObservedRole::Full)
+			.connect_peer(peer_b, PeerSet::Collation, ObservedRole::Full)
 			.await;
 
 		await_peer_connections(&shared, 1, 1).await;
@@ -935,7 +935,7 @@ fn relays_collation_protocol_messages() {
 		{
 			assert_sends_validation_event_to_all(
 				NetworkBridgeEvent::PeerConnected(
-					peer_a.clone(),
+					peer_a,
 					ObservedRole::Full,
 					ValidationVersion::V1.into(),
 					None,
@@ -945,7 +945,7 @@ fn relays_collation_protocol_messages() {
 			.await;
 
 			assert_sends_validation_event_to_all(
-				NetworkBridgeEvent::PeerViewChange(peer_a.clone(), View::default()),
+				NetworkBridgeEvent::PeerViewChange(peer_a, View::default()),
 				&mut virtual_overseer,
 			)
 			.await;
@@ -954,7 +954,7 @@ fn relays_collation_protocol_messages() {
 		{
 			assert_sends_collation_event_to_all(
 				NetworkBridgeEvent::PeerConnected(
-					peer_b.clone(),
+					peer_b,
 					ObservedRole::Full,
 					ValidationVersion::V1.into(),
 					None,
@@ -964,7 +964,7 @@ fn relays_collation_protocol_messages() {
 			.await;
 
 			assert_sends_collation_event_to_all(
-				NetworkBridgeEvent::PeerViewChange(peer_b.clone(), View::default()),
+				NetworkBridgeEvent::PeerViewChange(peer_b, View::default()),
 				&mut virtual_overseer,
 			)
 			.await;
@@ -983,7 +983,7 @@ fn relays_collation_protocol_messages() {
 
 		network_handle
 			.peer_message(
-				peer_a.clone(),
+				peer_a,
 				PeerSet::Collation,
 				WireMessage::ProtocolMessage(message_v1.clone()).encode(),
 			)
@@ -992,14 +992,14 @@ fn relays_collation_protocol_messages() {
 		let actions = network_handle.next_network_actions(3).await;
 		assert_network_actions_contains(
 			&actions,
-			&NetworkAction::ReputationChange(peer_a.clone(), UNCONNECTED_PEERSET_COST.into()),
+			&NetworkAction::ReputationChange(peer_a, UNCONNECTED_PEERSET_COST.into()),
 		);
 
 		// peer B has the message relayed.
 
 		network_handle
 			.peer_message(
-				peer_b.clone(),
+				peer_b,
 				PeerSet::Collation,
 				WireMessage::ProtocolMessage(message_v1.clone()).encode(),
 			)
@@ -1028,10 +1028,10 @@ fn different_views_on_different_peer_sets() {
 		let peer = PeerId::random();
 
 		network_handle
-			.connect_peer(peer.clone(), PeerSet::Validation, ObservedRole::Full)
+			.connect_peer(peer, PeerSet::Validation, ObservedRole::Full)
 			.await;
 		network_handle
-			.connect_peer(peer.clone(), PeerSet::Collation, ObservedRole::Full)
+			.connect_peer(peer, PeerSet::Collation, ObservedRole::Full)
 			.await;
 
 		await_peer_connections(&shared, 1, 1).await;
@@ -1040,7 +1040,7 @@ fn different_views_on_different_peer_sets() {
 		{
 			assert_sends_validation_event_to_all(
 				NetworkBridgeEvent::PeerConnected(
-					peer.clone(),
+					peer,
 					ObservedRole::Full,
 					ValidationVersion::V1.into(),
 					None,
@@ -1050,7 +1050,7 @@ fn different_views_on_different_peer_sets() {
 			.await;
 
 			assert_sends_validation_event_to_all(
-				NetworkBridgeEvent::PeerViewChange(peer.clone(), View::default()),
+				NetworkBridgeEvent::PeerViewChange(peer, View::default()),
 				&mut virtual_overseer,
 			)
 			.await;
@@ -1059,7 +1059,7 @@ fn different_views_on_different_peer_sets() {
 		{
 			assert_sends_collation_event_to_all(
 				NetworkBridgeEvent::PeerConnected(
-					peer.clone(),
+					peer,
 					ObservedRole::Full,
 					ValidationVersion::V1.into(),
 					None,
@@ -1069,7 +1069,7 @@ fn different_views_on_different_peer_sets() {
 			.await;
 
 			assert_sends_collation_event_to_all(
-				NetworkBridgeEvent::PeerViewChange(peer.clone(), View::default()),
+				NetworkBridgeEvent::PeerViewChange(peer, View::default()),
 				&mut virtual_overseer,
 			)
 			.await;
@@ -1080,7 +1080,7 @@ fn different_views_on_different_peer_sets() {
 
 		network_handle
 			.peer_message(
-				peer.clone(),
+				peer,
 				PeerSet::Validation,
 				WireMessage::<protocol_v1::ValidationProtocol>::ViewUpdate(view_a.clone()).encode(),
 			)
@@ -1088,20 +1088,20 @@ fn different_views_on_different_peer_sets() {
 
 		network_handle
 			.peer_message(
-				peer.clone(),
+				peer,
 				PeerSet::Collation,
 				WireMessage::<protocol_v1::CollationProtocol>::ViewUpdate(view_b.clone()).encode(),
 			)
 			.await;
 
 		assert_sends_validation_event_to_all(
-			NetworkBridgeEvent::PeerViewChange(peer.clone(), view_a.clone()),
+			NetworkBridgeEvent::PeerViewChange(peer, view_a.clone()),
 			&mut virtual_overseer,
 		)
 		.await;
 
 		assert_sends_collation_event_to_all(
-			NetworkBridgeEvent::PeerViewChange(peer.clone(), view_b.clone()),
+			NetworkBridgeEvent::PeerViewChange(peer, view_b.clone()),
 			&mut virtual_overseer,
 		)
 		.await;
@@ -1117,7 +1117,7 @@ fn sent_views_include_finalized_number_update() {
 		let peer_a = PeerId::random();
 
 		network_handle
-			.connect_peer(peer_a.clone(), PeerSet::Validation, ObservedRole::Full)
+			.connect_peer(peer_a, PeerSet::Validation, ObservedRole::Full)
 			.await;
 
 		await_peer_connections(&shared, 1, 0).await;
@@ -1147,7 +1147,7 @@ fn sent_views_include_finalized_number_update() {
 		assert_network_actions_contains(
 			&actions,
 			&NetworkAction::WriteNotification(
-				peer_a.clone(),
+				peer_a,
 				PeerSet::Validation,
 				wire_message.clone(),
 			),
@@ -1164,14 +1164,14 @@ fn view_finalized_number_can_not_go_down() {
 		let peer_a = PeerId::random();
 
 		network_handle
-			.connect_peer(peer_a.clone(), PeerSet::Validation, ObservedRole::Full)
+			.connect_peer(peer_a, PeerSet::Validation, ObservedRole::Full)
 			.await;
 
 		await_peer_connections(&shared, 1, 0).await;
 
 		network_handle
 			.peer_message(
-				peer_a.clone(),
+				peer_a,
 				PeerSet::Validation,
 				WireMessage::<protocol_v1::ValidationProtocol>::ViewUpdate(View::new(
 					vec![Hash::repeat_byte(0x01)],
@@ -1183,7 +1183,7 @@ fn view_finalized_number_can_not_go_down() {
 
 		network_handle
 			.peer_message(
-				peer_a.clone(),
+				peer_a,
 				PeerSet::Validation,
 				WireMessage::<protocol_v1::ValidationProtocol>::ViewUpdate(View::new(vec![], 0))
 					.encode(),
@@ -1193,7 +1193,7 @@ fn view_finalized_number_can_not_go_down() {
 		let actions = network_handle.next_network_actions(2).await;
 		assert_network_actions_contains(
 			&actions,
-			&NetworkAction::ReputationChange(peer_a.clone(), MALFORMED_VIEW_COST.into()),
+			&NetworkAction::ReputationChange(peer_a, MALFORMED_VIEW_COST.into()),
 		);
 		virtual_overseer
 	});

--- a/node/network/bridge/src/rx/tests.rs
+++ b/node/network/bridge/src/rx/tests.rs
@@ -432,12 +432,8 @@ fn send_our_view_upon_connection() {
 
 		handle.await_mode_switch().await;
 
-		network_handle
-			.connect_peer(peer, PeerSet::Validation, ObservedRole::Full)
-			.await;
-		network_handle
-			.connect_peer(peer, PeerSet::Collation, ObservedRole::Full)
-			.await;
+		network_handle.connect_peer(peer, PeerSet::Validation, ObservedRole::Full).await;
+		network_handle.connect_peer(peer, PeerSet::Collation, ObservedRole::Full).await;
 
 		await_peer_connections(&shared, 1, 1).await;
 
@@ -700,9 +696,7 @@ fn peer_view_updates_sent_via_overseer() {
 
 		let peer = PeerId::random();
 
-		network_handle
-			.connect_peer(peer, PeerSet::Validation, ObservedRole::Full)
-			.await;
+		network_handle.connect_peer(peer, PeerSet::Validation, ObservedRole::Full).await;
 
 		await_peer_connections(&shared, 1, 0).await;
 
@@ -752,9 +746,7 @@ fn peer_messages_sent_via_overseer() {
 
 		let peer = PeerId::random();
 
-		network_handle
-			.connect_peer(peer, PeerSet::Validation, ObservedRole::Full)
-			.await;
+		network_handle.connect_peer(peer, PeerSet::Validation, ObservedRole::Full).await;
 
 		await_peer_connections(&shared, 1, 0).await;
 
@@ -827,12 +819,8 @@ fn peer_disconnect_from_just_one_peerset() {
 
 		let peer = PeerId::random();
 
-		network_handle
-			.connect_peer(peer, PeerSet::Validation, ObservedRole::Full)
-			.await;
-		network_handle
-			.connect_peer(peer, PeerSet::Collation, ObservedRole::Full)
-			.await;
+		network_handle.connect_peer(peer, PeerSet::Validation, ObservedRole::Full).await;
+		network_handle.connect_peer(peer, PeerSet::Collation, ObservedRole::Full).await;
 
 		await_peer_connections(&shared, 1, 1).await;
 
@@ -904,11 +892,7 @@ fn peer_disconnect_from_just_one_peerset() {
 
 		assert_network_actions_contains(
 			&actions,
-			&NetworkAction::WriteNotification(
-				peer,
-				PeerSet::Collation,
-				wire_message.clone(),
-			),
+			&NetworkAction::WriteNotification(peer, PeerSet::Collation, wire_message.clone()),
 		);
 		virtual_overseer
 	});
@@ -1027,12 +1011,8 @@ fn different_views_on_different_peer_sets() {
 
 		let peer = PeerId::random();
 
-		network_handle
-			.connect_peer(peer, PeerSet::Validation, ObservedRole::Full)
-			.await;
-		network_handle
-			.connect_peer(peer, PeerSet::Collation, ObservedRole::Full)
-			.await;
+		network_handle.connect_peer(peer, PeerSet::Validation, ObservedRole::Full).await;
+		network_handle.connect_peer(peer, PeerSet::Collation, ObservedRole::Full).await;
 
 		await_peer_connections(&shared, 1, 1).await;
 
@@ -1146,11 +1126,7 @@ fn sent_views_include_finalized_number_update() {
 
 		assert_network_actions_contains(
 			&actions,
-			&NetworkAction::WriteNotification(
-				peer_a,
-				PeerSet::Validation,
-				wire_message.clone(),
-			),
+			&NetworkAction::WriteNotification(peer_a, PeerSet::Validation, wire_message.clone()),
 		);
 		virtual_overseer
 	});

--- a/node/network/bridge/src/tx/tests.rs
+++ b/node/network/bridge/src/tx/tests.rs
@@ -242,7 +242,7 @@ fn send_messages_to_peers() {
 		let peer = PeerId::random();
 
 		network_handle
-			.connect_peer(peer.clone(), PeerSet::Validation, ObservedRole::Full)
+			.connect_peer(peer, PeerSet::Validation, ObservedRole::Full)
 			.timeout(TIMEOUT)
 			.await
 			.expect("Timeout does not occur");
@@ -251,7 +251,7 @@ fn send_messages_to_peers() {
 		// so the single item sink has to be free explicitly
 
 		network_handle
-			.connect_peer(peer.clone(), PeerSet::Collation, ObservedRole::Full)
+			.connect_peer(peer, PeerSet::Collation, ObservedRole::Full)
 			.timeout(TIMEOUT)
 			.await
 			.expect("Timeout does not occur");
@@ -269,7 +269,7 @@ fn send_messages_to_peers() {
 			virtual_overseer
 				.send(FromOrchestra::Communication {
 					msg: NetworkBridgeTxMessage::SendValidationMessage(
-						vec![peer.clone()],
+						vec![peer],
 						Versioned::V1(message_v1.clone()),
 					),
 				})
@@ -284,7 +284,7 @@ fn send_messages_to_peers() {
 					.await
 					.expect("Timeout does not occur"),
 				NetworkAction::WriteNotification(
-					peer.clone(),
+					peer,
 					PeerSet::Validation,
 					WireMessage::ProtocolMessage(message_v1).encode(),
 				)
@@ -306,7 +306,7 @@ fn send_messages_to_peers() {
 			virtual_overseer
 				.send(FromOrchestra::Communication {
 					msg: NetworkBridgeTxMessage::SendCollationMessage(
-						vec![peer.clone()],
+						vec![peer],
 						Versioned::V1(message_v1.clone()),
 					),
 				})
@@ -319,7 +319,7 @@ fn send_messages_to_peers() {
 					.await
 					.expect("Timeout does not occur"),
 				NetworkAction::WriteNotification(
-					peer.clone(),
+					peer,
 					PeerSet::Collation,
 					WireMessage::ProtocolMessage(message_v1).encode(),
 				)

--- a/node/network/bridge/src/validator_discovery.rs
+++ b/node/network/bridge/src/validator_discovery.rs
@@ -311,7 +311,7 @@ mod tests {
 		let (ns, ads) = new_network();
 
 		let authority_ids: Vec<_> =
-			ads.by_peer_id.values().map(|v| v.iter()).flatten().cloned().collect();
+			ads.by_peer_id.values().flat_map(|v| v.iter()).cloned().collect();
 
 		futures::executor::block_on(async move {
 			let (failed, _) = oneshot::channel();
@@ -344,7 +344,7 @@ mod tests {
 		let (ns, ads) = new_network();
 
 		let authority_ids: Vec<_> =
-			ads.by_peer_id.values().map(|v| v.iter()).flatten().cloned().collect();
+			ads.by_peer_id.values().flat_map(|v| v.iter()).cloned().collect();
 
 		futures::executor::block_on(async move {
 			let (failed, failed_rx) = oneshot::channel();

--- a/node/network/collator-protocol/src/collator_side/tests.rs
+++ b/node/network/collator-protocol/src/collator_side/tests.rs
@@ -773,6 +773,7 @@ fn delay_reputation_change() {
 }
 
 #[test]
+#[allow(clippy::async_yields_async)]
 fn send_only_one_collation_per_relay_parent_at_a_time() {
 	test_validator_send_sequence(|mut second_response_receiver, feedback_first_tx| async move {
 		Delay::new(Duration::from_millis(100)).await;
@@ -788,6 +789,7 @@ fn send_only_one_collation_per_relay_parent_at_a_time() {
 }
 
 #[test]
+#[allow(clippy::async_yields_async)]
 fn send_next_collation_after_max_unshared_upload_time() {
 	test_validator_send_sequence(|second_response_receiver, _| async move {
 		Delay::new(MAX_UNSHARED_UPLOAD_TIME + Duration::from_millis(50)).await;

--- a/node/network/collator-protocol/src/collator_side/tests.rs
+++ b/node/network/collator-protocol/src/collator_side/tests.rs
@@ -147,7 +147,7 @@ impl TestState {
 	fn current_group_validator_peer_ids(&self) -> Vec<PeerId> {
 		self.current_group_validator_indices()
 			.iter()
-			.map(|i| self.validator_peer_id[i.0 as usize].clone())
+			.map(|i| self.validator_peer_id[i.0 as usize])
 			.collect()
 	}
 
@@ -412,7 +412,7 @@ async fn connect_peer(
 	overseer_send(
 		virtual_overseer,
 		CollatorProtocolMessage::NetworkBridgeUpdate(NetworkBridgeEvent::PeerConnected(
-			peer.clone(),
+			peer,
 			polkadot_node_network_protocol::ObservedRole::Authority,
 			CollationVersion::V1.into(),
 			authority_id.map(|v| HashSet::from([v])),
@@ -509,7 +509,7 @@ async fn send_peer_view_change(
 	overseer_send(
 		virtual_overseer,
 		CollatorProtocolMessage::NetworkBridgeUpdate(NetworkBridgeEvent::PeerViewChange(
-			peer.clone(),
+			*peer,
 			View::new(hashes, 0),
 		)),
 	)
@@ -519,7 +519,7 @@ async fn send_peer_view_change(
 #[test]
 fn advertise_and_send_collation() {
 	let mut test_state = TestState::default();
-	let local_peer_id = test_state.local_peer_id.clone();
+	let local_peer_id = test_state.local_peer_id;
 	let collator_pair = test_state.collator_pair.clone();
 
 	test_harness(
@@ -540,7 +540,7 @@ fn advertise_and_send_collation() {
 				.into_iter()
 				.zip(test_state.current_group_validator_peer_ids())
 			{
-				connect_peer(&mut virtual_overseer, peer.clone(), Some(val.clone())).await;
+				connect_peer(&mut virtual_overseer, peer, Some(val.clone())).await;
 			}
 
 			// We declare to the connected validators that we are a collator.
@@ -550,7 +550,7 @@ fn advertise_and_send_collation() {
 				expect_declare_msg(&mut virtual_overseer, &test_state, &peer_id).await;
 			}
 
-			let peer = test_state.current_group_validator_peer_ids()[0].clone();
+			let peer = test_state.current_group_validator_peer_ids()[0];
 
 			// Send info about peer's view.
 			send_peer_view_change(&mut virtual_overseer, &peer, vec![test_state.relay_parent])
@@ -627,7 +627,7 @@ fn advertise_and_send_collation() {
 			let old_relay_parent = test_state.relay_parent;
 			test_state.advance_to_new_round(&mut virtual_overseer, false).await;
 
-			let peer = test_state.validator_peer_id[2].clone();
+			let peer = test_state.validator_peer_id[2];
 
 			// Re-request a collation.
 			let (pending_response, rx) = oneshot::channel();
@@ -658,7 +658,7 @@ fn advertise_and_send_collation() {
 			overseer_send(
 				&mut virtual_overseer,
 				CollatorProtocolMessage::NetworkBridgeUpdate(NetworkBridgeEvent::PeerViewChange(
-					peer.clone(),
+					peer,
 					view![test_state.relay_parent],
 				)),
 			)
@@ -674,7 +674,7 @@ fn advertise_and_send_collation() {
 #[test]
 fn delay_reputation_change() {
 	let test_state = TestState::default();
-	let local_peer_id = test_state.local_peer_id.clone();
+	let local_peer_id = test_state.local_peer_id;
 	let collator_pair = test_state.collator_pair.clone();
 
 	test_harness(
@@ -694,7 +694,7 @@ fn delay_reputation_change() {
 				.into_iter()
 				.zip(test_state.current_group_validator_peer_ids())
 			{
-				connect_peer(&mut virtual_overseer, peer.clone(), Some(val.clone())).await;
+				connect_peer(&mut virtual_overseer, peer, Some(val.clone())).await;
 			}
 
 			// We declare to the connected validators that we are a collator.
@@ -704,7 +704,7 @@ fn delay_reputation_change() {
 				expect_declare_msg(&mut virtual_overseer, &test_state, &peer_id).await;
 			}
 
-			let peer = test_state.current_group_validator_peer_ids()[0].clone();
+			let peer = test_state.current_group_validator_peer_ids()[0];
 
 			// Send info about peer's view.
 			send_peer_view_change(&mut virtual_overseer, &peer, vec![test_state.relay_parent])
@@ -798,7 +798,7 @@ fn send_next_collation_after_max_unshared_upload_time() {
 #[test]
 fn collators_declare_to_connected_peers() {
 	let test_state = TestState::default();
-	let local_peer_id = test_state.local_peer_id.clone();
+	let local_peer_id = test_state.local_peer_id;
 	let collator_pair = test_state.collator_pair.clone();
 
 	test_harness(
@@ -806,13 +806,13 @@ fn collators_declare_to_connected_peers() {
 		collator_pair,
 		ReputationAggregator::new(|_| true),
 		|mut test_harness| async move {
-			let peer = test_state.validator_peer_id[0].clone();
+			let peer = test_state.validator_peer_id[0];
 			let validator_id = test_state.current_group_validator_authority_ids()[0].clone();
 
 			setup_system(&mut test_harness.virtual_overseer, &test_state).await;
 
 			// A validator connected to us
-			connect_peer(&mut test_harness.virtual_overseer, peer.clone(), Some(validator_id))
+			connect_peer(&mut test_harness.virtual_overseer, peer, Some(validator_id))
 				.await;
 			expect_declare_msg(&mut test_harness.virtual_overseer, &test_state, &peer).await;
 			test_harness
@@ -823,7 +823,7 @@ fn collators_declare_to_connected_peers() {
 #[test]
 fn collations_are_only_advertised_to_validators_with_correct_view() {
 	let test_state = TestState::default();
-	let local_peer_id = test_state.local_peer_id.clone();
+	let local_peer_id = test_state.local_peer_id;
 	let collator_pair = test_state.collator_pair.clone();
 
 	test_harness(
@@ -833,19 +833,19 @@ fn collations_are_only_advertised_to_validators_with_correct_view() {
 		|mut test_harness| async move {
 			let virtual_overseer = &mut test_harness.virtual_overseer;
 
-			let peer = test_state.current_group_validator_peer_ids()[0].clone();
+			let peer = test_state.current_group_validator_peer_ids()[0];
 			let validator_id = test_state.current_group_validator_authority_ids()[0].clone();
 
-			let peer2 = test_state.current_group_validator_peer_ids()[1].clone();
+			let peer2 = test_state.current_group_validator_peer_ids()[1];
 			let validator_id2 = test_state.current_group_validator_authority_ids()[1].clone();
 
 			setup_system(virtual_overseer, &test_state).await;
 
 			// A validator connected to us
-			connect_peer(virtual_overseer, peer.clone(), Some(validator_id)).await;
+			connect_peer(virtual_overseer, peer, Some(validator_id)).await;
 
 			// Connect the second validator
-			connect_peer(virtual_overseer, peer2.clone(), Some(validator_id2)).await;
+			connect_peer(virtual_overseer, peer2, Some(validator_id2)).await;
 
 			expect_declare_msg(virtual_overseer, &test_state, &peer).await;
 			expect_declare_msg(virtual_overseer, &test_state, &peer2).await;
@@ -870,7 +870,7 @@ fn collations_are_only_advertised_to_validators_with_correct_view() {
 #[test]
 fn collate_on_two_different_relay_chain_blocks() {
 	let mut test_state = TestState::default();
-	let local_peer_id = test_state.local_peer_id.clone();
+	let local_peer_id = test_state.local_peer_id;
 	let collator_pair = test_state.collator_pair.clone();
 
 	test_harness(
@@ -880,19 +880,19 @@ fn collate_on_two_different_relay_chain_blocks() {
 		|mut test_harness| async move {
 			let virtual_overseer = &mut test_harness.virtual_overseer;
 
-			let peer = test_state.current_group_validator_peer_ids()[0].clone();
+			let peer = test_state.current_group_validator_peer_ids()[0];
 			let validator_id = test_state.current_group_validator_authority_ids()[0].clone();
 
-			let peer2 = test_state.current_group_validator_peer_ids()[1].clone();
+			let peer2 = test_state.current_group_validator_peer_ids()[1];
 			let validator_id2 = test_state.current_group_validator_authority_ids()[1].clone();
 
 			setup_system(virtual_overseer, &test_state).await;
 
 			// A validator connected to us
-			connect_peer(virtual_overseer, peer.clone(), Some(validator_id)).await;
+			connect_peer(virtual_overseer, peer, Some(validator_id)).await;
 
 			// Connect the second validator
-			connect_peer(virtual_overseer, peer2.clone(), Some(validator_id2)).await;
+			connect_peer(virtual_overseer, peer2, Some(validator_id2)).await;
 
 			expect_declare_msg(virtual_overseer, &test_state, &peer).await;
 			expect_declare_msg(virtual_overseer, &test_state, &peer2).await;
@@ -921,7 +921,7 @@ fn collate_on_two_different_relay_chain_blocks() {
 #[test]
 fn validator_reconnect_does_not_advertise_a_second_time() {
 	let test_state = TestState::default();
-	let local_peer_id = test_state.local_peer_id.clone();
+	let local_peer_id = test_state.local_peer_id;
 	let collator_pair = test_state.collator_pair.clone();
 
 	test_harness(
@@ -931,13 +931,13 @@ fn validator_reconnect_does_not_advertise_a_second_time() {
 		|mut test_harness| async move {
 			let virtual_overseer = &mut test_harness.virtual_overseer;
 
-			let peer = test_state.current_group_validator_peer_ids()[0].clone();
+			let peer = test_state.current_group_validator_peer_ids()[0];
 			let validator_id = test_state.current_group_validator_authority_ids()[0].clone();
 
 			setup_system(virtual_overseer, &test_state).await;
 
 			// A validator connected to us
-			connect_peer(virtual_overseer, peer.clone(), Some(validator_id.clone())).await;
+			connect_peer(virtual_overseer, peer, Some(validator_id.clone())).await;
 			expect_declare_msg(virtual_overseer, &test_state, &peer).await;
 
 			distribute_collation(virtual_overseer, &test_state, true).await;
@@ -946,8 +946,8 @@ fn validator_reconnect_does_not_advertise_a_second_time() {
 			expect_advertise_collation_msg(virtual_overseer, &peer, test_state.relay_parent).await;
 
 			// Disconnect and reconnect directly
-			disconnect_peer(virtual_overseer, peer.clone()).await;
-			connect_peer(virtual_overseer, peer.clone(), Some(validator_id)).await;
+			disconnect_peer(virtual_overseer, peer).await;
+			connect_peer(virtual_overseer, peer, Some(validator_id)).await;
 			expect_declare_msg(virtual_overseer, &test_state, &peer).await;
 
 			send_peer_view_change(virtual_overseer, &peer, vec![test_state.relay_parent]).await;
@@ -961,7 +961,7 @@ fn validator_reconnect_does_not_advertise_a_second_time() {
 #[test]
 fn collators_reject_declare_messages() {
 	let test_state = TestState::default();
-	let local_peer_id = test_state.local_peer_id.clone();
+	let local_peer_id = test_state.local_peer_id;
 	let collator_pair = test_state.collator_pair.clone();
 	let collator_pair2 = CollatorPair::generate().0;
 
@@ -972,19 +972,19 @@ fn collators_reject_declare_messages() {
 		|mut test_harness| async move {
 			let virtual_overseer = &mut test_harness.virtual_overseer;
 
-			let peer = test_state.current_group_validator_peer_ids()[0].clone();
+			let peer = test_state.current_group_validator_peer_ids()[0];
 			let validator_id = test_state.current_group_validator_authority_ids()[0].clone();
 
 			setup_system(virtual_overseer, &test_state).await;
 
 			// A validator connected to us
-			connect_peer(virtual_overseer, peer.clone(), Some(validator_id)).await;
+			connect_peer(virtual_overseer, peer, Some(validator_id)).await;
 			expect_declare_msg(virtual_overseer, &test_state, &peer).await;
 
 			overseer_send(
 				virtual_overseer,
 				CollatorProtocolMessage::NetworkBridgeUpdate(NetworkBridgeEvent::PeerMessage(
-					peer.clone(),
+					peer,
 					Versioned::V1(protocol_v1::CollatorProtocolMessage::Declare(
 						collator_pair2.public(),
 						ParaId::from(5),
@@ -1021,7 +1021,7 @@ where
 	F: Future<Output = oneshot::Receiver<sc_network::config::OutgoingResponse>>,
 {
 	let test_state = TestState::default();
-	let local_peer_id = test_state.local_peer_id.clone();
+	let local_peer_id = test_state.local_peer_id;
 	let collator_pair = test_state.collator_pair.clone();
 
 	test_harness(
@@ -1042,7 +1042,7 @@ where
 				.into_iter()
 				.zip(test_state.current_group_validator_peer_ids())
 			{
-				connect_peer(virtual_overseer, peer.clone(), Some(val.clone())).await;
+				connect_peer(virtual_overseer, peer, Some(val.clone())).await;
 			}
 
 			// We declare to the connected validators that we are a collator.
@@ -1052,8 +1052,8 @@ where
 				expect_declare_msg(virtual_overseer, &test_state, &peer_id).await;
 			}
 
-			let validator_0 = test_state.current_group_validator_peer_ids()[0].clone();
-			let validator_1 = test_state.current_group_validator_peer_ids()[1].clone();
+			let validator_0 = test_state.current_group_validator_peer_ids()[0];
+			let validator_1 = test_state.current_group_validator_peer_ids()[1];
 
 			// Send info about peer's view.
 			send_peer_view_change(virtual_overseer, &validator_0, vec![test_state.relay_parent])
@@ -1149,7 +1149,7 @@ where
 #[test]
 fn connect_to_buffered_groups() {
 	let mut test_state = TestState::default();
-	let local_peer_id = test_state.local_peer_id.clone();
+	let local_peer_id = test_state.local_peer_id;
 	let collator_pair = test_state.collator_pair.clone();
 
 	test_harness(
@@ -1180,7 +1180,7 @@ fn connect_to_buffered_groups() {
 			let head_a = test_state.relay_parent;
 
 			for (val, peer) in group_a.iter().zip(&peers_a) {
-				connect_peer(&mut virtual_overseer, peer.clone(), Some(val.clone())).await;
+				connect_peer(&mut virtual_overseer, *peer, Some(val.clone())).await;
 			}
 
 			for peer_id in &peers_a {

--- a/node/network/collator-protocol/src/collator_side/tests.rs
+++ b/node/network/collator-protocol/src/collator_side/tests.rs
@@ -812,8 +812,7 @@ fn collators_declare_to_connected_peers() {
 			setup_system(&mut test_harness.virtual_overseer, &test_state).await;
 
 			// A validator connected to us
-			connect_peer(&mut test_harness.virtual_overseer, peer, Some(validator_id))
-				.await;
+			connect_peer(&mut test_harness.virtual_overseer, peer, Some(validator_id)).await;
 			expect_declare_msg(&mut test_harness.virtual_overseer, &test_state, &peer).await;
 			test_harness
 		},

--- a/node/network/collator-protocol/src/validator_side/tests.rs
+++ b/node/network/collator-protocol/src/validator_side/tests.rs
@@ -313,7 +313,7 @@ async fn connect_and_declare_collator(
 	overseer_send(
 		virtual_overseer,
 		CollatorProtocolMessage::NetworkBridgeUpdate(NetworkBridgeEvent::PeerConnected(
-			peer.clone(),
+			peer,
 			ObservedRole::Full,
 			CollationVersion::V1.into(),
 			None,
@@ -324,7 +324,7 @@ async fn connect_and_declare_collator(
 	overseer_send(
 		virtual_overseer,
 		CollatorProtocolMessage::NetworkBridgeUpdate(NetworkBridgeEvent::PeerMessage(
-			peer.clone(),
+			peer,
 			Versioned::V1(protocol_v1::CollatorProtocolMessage::Declare(
 				collator.public(),
 				para_id,
@@ -376,13 +376,13 @@ fn act_on_advertisement() {
 
 		connect_and_declare_collator(
 			&mut virtual_overseer,
-			peer_b.clone(),
+			peer_b,
 			pair.clone(),
 			test_state.chain_ids[0],
 		)
 		.await;
 
-		advertise_collation(&mut virtual_overseer, peer_b.clone(), test_state.relay_parent).await;
+		advertise_collation(&mut virtual_overseer, peer_b, test_state.relay_parent).await;
 
 		assert_fetch_collation_request(
 			&mut virtual_overseer,
@@ -418,17 +418,17 @@ fn collator_reporting_works() {
 
 		connect_and_declare_collator(
 			&mut virtual_overseer,
-			peer_b.clone(),
+			peer_b,
 			test_state.collators[0].clone(),
-			test_state.chain_ids[0].clone(),
+			test_state.chain_ids[0],
 		)
 		.await;
 
 		connect_and_declare_collator(
 			&mut virtual_overseer,
-			peer_c.clone(),
+			peer_c,
 			test_state.collators[1].clone(),
-			test_state.chain_ids[0].clone(),
+			test_state.chain_ids[0],
 		)
 		.await;
 
@@ -477,7 +477,7 @@ fn collator_authentication_verification_works() {
 		overseer_send(
 			&mut virtual_overseer,
 			CollatorProtocolMessage::NetworkBridgeUpdate(NetworkBridgeEvent::PeerMessage(
-				peer_b.clone(),
+				peer_b,
 				Versioned::V1(protocol_v1::CollatorProtocolMessage::Declare(
 					test_state.collators[0].public(),
 					test_state.chain_ids[0],
@@ -529,22 +529,22 @@ fn fetch_one_collation_at_a_time() {
 
 		connect_and_declare_collator(
 			&mut virtual_overseer,
-			peer_b.clone(),
+			peer_b,
 			test_state.collators[0].clone(),
-			test_state.chain_ids[0].clone(),
+			test_state.chain_ids[0],
 		)
 		.await;
 
 		connect_and_declare_collator(
 			&mut virtual_overseer,
-			peer_c.clone(),
+			peer_c,
 			test_state.collators[1].clone(),
-			test_state.chain_ids[0].clone(),
+			test_state.chain_ids[0],
 		)
 		.await;
 
-		advertise_collation(&mut virtual_overseer, peer_b.clone(), test_state.relay_parent).await;
-		advertise_collation(&mut virtual_overseer, peer_c.clone(), test_state.relay_parent).await;
+		advertise_collation(&mut virtual_overseer, peer_b, test_state.relay_parent).await;
+		advertise_collation(&mut virtual_overseer, peer_c, test_state.relay_parent).await;
 
 		let response_channel = assert_fetch_collation_request(
 			&mut virtual_overseer,
@@ -615,31 +615,31 @@ fn fetches_next_collation() {
 
 		connect_and_declare_collator(
 			&mut virtual_overseer,
-			peer_b.clone(),
+			peer_b,
 			test_state.collators[2].clone(),
-			test_state.chain_ids[0].clone(),
+			test_state.chain_ids[0],
 		)
 		.await;
 
 		connect_and_declare_collator(
 			&mut virtual_overseer,
-			peer_c.clone(),
+			peer_c,
 			test_state.collators[3].clone(),
-			test_state.chain_ids[0].clone(),
+			test_state.chain_ids[0],
 		)
 		.await;
 
 		connect_and_declare_collator(
 			&mut virtual_overseer,
-			peer_d.clone(),
+			peer_d,
 			test_state.collators[4].clone(),
-			test_state.chain_ids[0].clone(),
+			test_state.chain_ids[0],
 		)
 		.await;
 
-		advertise_collation(&mut virtual_overseer, peer_b.clone(), second).await;
-		advertise_collation(&mut virtual_overseer, peer_c.clone(), second).await;
-		advertise_collation(&mut virtual_overseer, peer_d.clone(), second).await;
+		advertise_collation(&mut virtual_overseer, peer_b, second).await;
+		advertise_collation(&mut virtual_overseer, peer_c, second).await;
+		advertise_collation(&mut virtual_overseer, peer_d, second).await;
 
 		// Dropping the response channel should lead to fetching the second collation.
 		assert_fetch_collation_request(&mut virtual_overseer, second, test_state.chain_ids[0])
@@ -708,9 +708,9 @@ fn reject_connection_to_next_group() {
 
 		connect_and_declare_collator(
 			&mut virtual_overseer,
-			peer_b.clone(),
+			peer_b,
 			test_state.collators[0].clone(),
-			test_state.chain_ids[1].clone(), // next, not current `para_id`
+			test_state.chain_ids[1], // next, not current `para_id`
 		)
 		.await;
 
@@ -757,22 +757,22 @@ fn fetch_next_collation_on_invalid_collation() {
 
 		connect_and_declare_collator(
 			&mut virtual_overseer,
-			peer_b.clone(),
+			peer_b,
 			test_state.collators[0].clone(),
-			test_state.chain_ids[0].clone(),
+			test_state.chain_ids[0],
 		)
 		.await;
 
 		connect_and_declare_collator(
 			&mut virtual_overseer,
-			peer_c.clone(),
+			peer_c,
 			test_state.collators[1].clone(),
-			test_state.chain_ids[0].clone(),
+			test_state.chain_ids[0],
 		)
 		.await;
 
-		advertise_collation(&mut virtual_overseer, peer_b.clone(), test_state.relay_parent).await;
-		advertise_collation(&mut virtual_overseer, peer_c.clone(), test_state.relay_parent).await;
+		advertise_collation(&mut virtual_overseer, peer_b, test_state.relay_parent).await;
+		advertise_collation(&mut virtual_overseer, peer_c, test_state.relay_parent).await;
 
 		let response_channel = assert_fetch_collation_request(
 			&mut virtual_overseer,
@@ -854,12 +854,12 @@ fn inactive_disconnected() {
 
 		connect_and_declare_collator(
 			&mut virtual_overseer,
-			peer_b.clone(),
+			peer_b,
 			pair.clone(),
 			test_state.chain_ids[0],
 		)
 		.await;
-		advertise_collation(&mut virtual_overseer, peer_b.clone(), test_state.relay_parent).await;
+		advertise_collation(&mut virtual_overseer, peer_b, test_state.relay_parent).await;
 
 		assert_fetch_collation_request(
 			&mut virtual_overseer,
@@ -870,7 +870,7 @@ fn inactive_disconnected() {
 
 		Delay::new(ACTIVITY_TIMEOUT * 3).await;
 
-		assert_collator_disconnect(&mut virtual_overseer, peer_b.clone()).await;
+		assert_collator_disconnect(&mut virtual_overseer, peer_b).await;
 		virtual_overseer
 	});
 }
@@ -905,7 +905,7 @@ fn activity_extends_life() {
 
 		connect_and_declare_collator(
 			&mut virtual_overseer,
-			peer_b.clone(),
+			peer_b,
 			pair.clone(),
 			test_state.chain_ids[0],
 		)
@@ -913,28 +913,28 @@ fn activity_extends_life() {
 
 		Delay::new(ACTIVITY_TIMEOUT * 2 / 3).await;
 
-		advertise_collation(&mut virtual_overseer, peer_b.clone(), hash_a).await;
+		advertise_collation(&mut virtual_overseer, peer_b, hash_a).await;
 
 		assert_fetch_collation_request(&mut virtual_overseer, hash_a, test_state.chain_ids[0])
 			.await;
 
 		Delay::new(ACTIVITY_TIMEOUT * 2 / 3).await;
 
-		advertise_collation(&mut virtual_overseer, peer_b.clone(), hash_b).await;
+		advertise_collation(&mut virtual_overseer, peer_b, hash_b).await;
 
 		assert_fetch_collation_request(&mut virtual_overseer, hash_b, test_state.chain_ids[0])
 			.await;
 
 		Delay::new(ACTIVITY_TIMEOUT * 2 / 3).await;
 
-		advertise_collation(&mut virtual_overseer, peer_b.clone(), hash_c).await;
+		advertise_collation(&mut virtual_overseer, peer_b, hash_c).await;
 
 		assert_fetch_collation_request(&mut virtual_overseer, hash_c, test_state.chain_ids[0])
 			.await;
 
 		Delay::new(ACTIVITY_TIMEOUT * 3 / 2).await;
 
-		assert_collator_disconnect(&mut virtual_overseer, peer_b.clone()).await;
+		assert_collator_disconnect(&mut virtual_overseer, peer_b).await;
 
 		virtual_overseer
 	});
@@ -962,7 +962,7 @@ fn disconnect_if_no_declare() {
 		overseer_send(
 			&mut virtual_overseer,
 			CollatorProtocolMessage::NetworkBridgeUpdate(NetworkBridgeEvent::PeerConnected(
-				peer_b.clone(),
+				peer_b,
 				ObservedRole::Full,
 				CollationVersion::V1.into(),
 				None,
@@ -970,7 +970,7 @@ fn disconnect_if_no_declare() {
 		)
 		.await;
 
-		assert_collator_disconnect(&mut virtual_overseer, peer_b.clone()).await;
+		assert_collator_disconnect(&mut virtual_overseer, peer_b).await;
 
 		virtual_overseer
 	})
@@ -1000,7 +1000,7 @@ fn disconnect_if_wrong_declare() {
 		overseer_send(
 			&mut virtual_overseer,
 			CollatorProtocolMessage::NetworkBridgeUpdate(NetworkBridgeEvent::PeerConnected(
-				peer_b.clone(),
+				peer_b,
 				ObservedRole::Full,
 				CollationVersion::V1.into(),
 				None,
@@ -1011,7 +1011,7 @@ fn disconnect_if_wrong_declare() {
 		overseer_send(
 			&mut virtual_overseer,
 			CollatorProtocolMessage::NetworkBridgeUpdate(NetworkBridgeEvent::PeerMessage(
-				peer_b.clone(),
+				peer_b,
 				Versioned::V1(protocol_v1::CollatorProtocolMessage::Declare(
 					pair.public(),
 					ParaId::from(69),
@@ -1031,7 +1031,7 @@ fn disconnect_if_wrong_declare() {
 			}
 		);
 
-		assert_collator_disconnect(&mut virtual_overseer, peer_b.clone()).await;
+		assert_collator_disconnect(&mut virtual_overseer, peer_b).await;
 
 		virtual_overseer
 	})
@@ -1061,7 +1061,7 @@ fn delay_reputation_change() {
 		overseer_send(
 			&mut virtual_overseer,
 			CollatorProtocolMessage::NetworkBridgeUpdate(NetworkBridgeEvent::PeerConnected(
-				peer_b.clone(),
+				peer_b,
 				ObservedRole::Full,
 				CollationVersion::V1.into(),
 				None,
@@ -1072,7 +1072,7 @@ fn delay_reputation_change() {
 		overseer_send(
 			&mut virtual_overseer,
 			CollatorProtocolMessage::NetworkBridgeUpdate(NetworkBridgeEvent::PeerMessage(
-				peer_b.clone(),
+				peer_b,
 				Versioned::V1(protocol_v1::CollatorProtocolMessage::Declare(
 					pair.public(),
 					ParaId::from(69),
@@ -1085,7 +1085,7 @@ fn delay_reputation_change() {
 		overseer_send(
 			&mut virtual_overseer,
 			CollatorProtocolMessage::NetworkBridgeUpdate(NetworkBridgeEvent::PeerMessage(
-				peer_b.clone(),
+				peer_b,
 				Versioned::V1(protocol_v1::CollatorProtocolMessage::Declare(
 					pair.public(),
 					ParaId::from(69),
@@ -1145,7 +1145,7 @@ fn view_change_clears_old_collators() {
 
 		connect_and_declare_collator(
 			&mut virtual_overseer,
-			peer_b.clone(),
+			peer_b,
 			pair.clone(),
 			test_state.chain_ids[0],
 		)
@@ -1164,7 +1164,7 @@ fn view_change_clears_old_collators() {
 		test_state.group_rotation_info = test_state.group_rotation_info.bump_rotation();
 		respond_to_core_info_queries(&mut virtual_overseer, &test_state).await;
 
-		assert_collator_disconnect(&mut virtual_overseer, peer_b.clone()).await;
+		assert_collator_disconnect(&mut virtual_overseer, peer_b).await;
 
 		virtual_overseer
 	})

--- a/node/network/dispute-distribution/src/tests/mock.rs
+++ b/node/network/dispute-distribution/src/tests/mock.rs
@@ -70,7 +70,7 @@ pub static ref MOCK_VALIDATORS_DISCOVERY_KEYS: HashMap<Sr25519Keyring, Authority
 	MOCK_VALIDATORS
 	.iter()
 	.chain(MOCK_AUTHORITIES_NEXT_SESSION.iter())
-	.map(|v| (v.clone(), v.public().into()))
+	.map(|v| (*v, v.public().into()))
 	.collect()
 ;
 pub static ref FERDIE_DISCOVERY_KEY: AuthorityDiscoveryId =

--- a/node/network/gossip-support/src/tests.rs
+++ b/node/network/gossip-support/src/tests.rs
@@ -643,8 +643,8 @@ fn issues_a_connection_request_when_last_request_was_mostly_unresolved() {
 					let mut expected = get_address_map(AUTHORITIES_WITHOUT_US.clone()).await;
 					expected.remove(&alice);
 					expected.remove(&bob);
-					let expected: HashSet<Multiaddr> = expected.into_iter().map(|(_,v)| v.into_iter()).flatten().collect();
-					assert_eq!(validator_addrs.into_iter().map(|v| v.into_iter()).flatten().collect::<HashSet<_>>(), expected);
+					let expected: HashSet<Multiaddr> = expected.into_values().flat_map(|v| v.into_iter()).collect();
+					assert_eq!(validator_addrs.into_iter().flat_map(|v| v.into_iter()).collect::<HashSet<_>>(), expected);
 					assert_eq!(peer_set, PeerSet::Validation);
 				}
 			);
@@ -707,8 +707,8 @@ fn issues_a_connection_request_when_last_request_was_mostly_unresolved() {
 			}) => {
 				let mut expected = get_address_map(AUTHORITIES_WITHOUT_US.clone()).await;
 				expected.remove(&bob);
-				let expected: HashSet<Multiaddr> = expected.into_iter().map(|(_,v)| v.into_iter()).flatten().collect();
-				assert_eq!(validator_addrs.into_iter().map(|v| v.into_iter()).flatten().collect::<HashSet<_>>(), expected);
+				let expected: HashSet<Multiaddr> = expected.into_values().flat_map(|v| v.into_iter()).collect();
+				assert_eq!(validator_addrs.into_iter().flat_map(|v| v.into_iter()).collect::<HashSet<_>>(), expected);
 				assert_eq!(peer_set, PeerSet::Validation);
 			}
 		);

--- a/node/network/statement-distribution/src/tests.rs
+++ b/node/network/statement-distribution/src/tests.rs
@@ -210,8 +210,8 @@ fn note_local_works() {
 	let hash_b = CandidateHash([2; 32].into());
 
 	let mut per_peer_tracker = VcPerPeerTracker::default();
-	per_peer_tracker.note_local(hash_a.clone());
-	per_peer_tracker.note_local(hash_b.clone());
+	per_peer_tracker.note_local(hash_a);
+	per_peer_tracker.note_local(hash_b);
 
 	assert!(per_peer_tracker.local_observed.contains(&hash_a));
 	assert!(per_peer_tracker.local_observed.contains(&hash_b));
@@ -227,9 +227,9 @@ fn note_remote_works() {
 	let hash_c = CandidateHash([3; 32].into());
 
 	let mut per_peer_tracker = VcPerPeerTracker::default();
-	assert!(per_peer_tracker.note_remote(hash_a.clone()));
-	assert!(per_peer_tracker.note_remote(hash_b.clone()));
-	assert!(!per_peer_tracker.note_remote(hash_c.clone()));
+	assert!(per_peer_tracker.note_remote(hash_a));
+	assert!(per_peer_tracker.note_remote(hash_b));
+	assert!(!per_peer_tracker.note_remote(hash_c));
 
 	assert!(per_peer_tracker.remote_observed.contains(&hash_a));
 	assert!(per_peer_tracker.remote_observed.contains(&hash_b));
@@ -516,9 +516,9 @@ fn peer_view_update_sends_messages() {
 
 	executor::block_on(async move {
 		let mut topology = GridNeighbors::empty();
-		topology.peers_x = HashSet::from_iter(vec![peer.clone()].into_iter());
+		topology.peers_x = HashSet::from_iter(vec![peer].into_iter());
 		update_peer_view_and_maybe_send_unlocked(
-			peer.clone(),
+			peer,
 			&topology,
 			&mut peer_data,
 			&mut ctx,
@@ -553,7 +553,7 @@ fn peer_view_update_sends_messages() {
 		// it will not change between runs of the program.
 		for statement in active_head.statements_about(candidate_hash) {
 			let message = handle.recv().await;
-			let expected_to = vec![peer.clone()];
+			let expected_to = vec![peer];
 			let expected_payload =
 				statement_message(hash_c, statement.statement.clone(), &Metrics::default());
 
@@ -596,14 +596,14 @@ fn circulated_statement_goes_to_all_peers_with_view() {
 
 	let peer_data_from_view = |view: View| PeerData {
 		view: view.clone(),
-		view_knowledge: view.iter().map(|v| (v.clone(), Default::default())).collect(),
+		view_knowledge: view.iter().map(|v| (*v, Default::default())).collect(),
 		maybe_authority: None,
 	};
 
 	let mut peer_data: HashMap<_, _> = vec![
-		(peer_a.clone(), peer_data_from_view(peer_a_view)),
-		(peer_b.clone(), peer_data_from_view(peer_b_view)),
-		(peer_c.clone(), peer_data_from_view(peer_c_view)),
+		(peer_a, peer_data_from_view(peer_a_view)),
+		(peer_b, peer_data_from_view(peer_b_view)),
+		(peer_c, peer_data_from_view(peer_c_view)),
 	]
 	.into_iter()
 	.collect();
@@ -645,7 +645,7 @@ fn circulated_statement_goes_to_all_peers_with_view() {
 
 		let mut topology = GridNeighbors::empty();
 		topology.peers_x =
-			HashSet::from_iter(vec![peer_a.clone(), peer_b.clone(), peer_c.clone()].into_iter());
+			HashSet::from_iter(vec![peer_a, peer_b, peer_c].into_iter());
 		let needs_dependents = circulate_statement(
 			RequiredRouting::GridXY,
 			&topology,
@@ -786,7 +786,7 @@ fn receiving_from_one_sends_to_another_and_to_candidate_backing() {
 			.send(FromOrchestra::Communication {
 				msg: StatementDistributionMessage::NetworkBridgeUpdate(
 					NetworkBridgeEvent::PeerConnected(
-						peer_a.clone(),
+						peer_a,
 						ObservedRole::Full,
 						ValidationVersion::V1.into(),
 						None,
@@ -799,7 +799,7 @@ fn receiving_from_one_sends_to_another_and_to_candidate_backing() {
 			.send(FromOrchestra::Communication {
 				msg: StatementDistributionMessage::NetworkBridgeUpdate(
 					NetworkBridgeEvent::PeerConnected(
-						peer_b.clone(),
+						peer_b,
 						ObservedRole::Full,
 						ValidationVersion::V1.into(),
 						None,
@@ -811,7 +811,7 @@ fn receiving_from_one_sends_to_another_and_to_candidate_backing() {
 		handle
 			.send(FromOrchestra::Communication {
 				msg: StatementDistributionMessage::NetworkBridgeUpdate(
-					NetworkBridgeEvent::PeerViewChange(peer_a.clone(), view![hash_a]),
+					NetworkBridgeEvent::PeerViewChange(peer_a, view![hash_a]),
 				),
 			})
 			.await;
@@ -819,7 +819,7 @@ fn receiving_from_one_sends_to_another_and_to_candidate_backing() {
 		handle
 			.send(FromOrchestra::Communication {
 				msg: StatementDistributionMessage::NetworkBridgeUpdate(
-					NetworkBridgeEvent::PeerViewChange(peer_b.clone(), view![hash_a]),
+					NetworkBridgeEvent::PeerViewChange(peer_b, view![hash_a]),
 				),
 			})
 			.await;
@@ -853,7 +853,7 @@ fn receiving_from_one_sends_to_another_and_to_candidate_backing() {
 			.send(FromOrchestra::Communication {
 				msg: StatementDistributionMessage::NetworkBridgeUpdate(
 					NetworkBridgeEvent::PeerMessage(
-						peer_a.clone(),
+						peer_a,
 						Versioned::V1(protocol_v1::StatementDistributionMessage::Statement(
 							hash_a,
 							statement.clone().into(),
@@ -887,7 +887,7 @@ fn receiving_from_one_sends_to_another_and_to_candidate_backing() {
 					)),
 				)
 			) => {
-				assert_eq!(recipients, vec![peer_b.clone()]);
+				assert_eq!(recipients, vec![peer_b]);
 				assert_eq!(r, hash_a);
 				assert_eq!(s, statement.into());
 			}
@@ -990,7 +990,7 @@ fn receiving_large_statement_from_one_sends_to_another_and_to_candidate_backing(
 			.send(FromOrchestra::Communication {
 				msg: StatementDistributionMessage::NetworkBridgeUpdate(
 					NetworkBridgeEvent::PeerConnected(
-						peer_a.clone(),
+						peer_a,
 						ObservedRole::Full,
 						ValidationVersion::V1.into(),
 						Some(HashSet::from([Sr25519Keyring::Alice.public().into()])),
@@ -1003,7 +1003,7 @@ fn receiving_large_statement_from_one_sends_to_another_and_to_candidate_backing(
 			.send(FromOrchestra::Communication {
 				msg: StatementDistributionMessage::NetworkBridgeUpdate(
 					NetworkBridgeEvent::PeerConnected(
-						peer_b.clone(),
+						peer_b,
 						ObservedRole::Full,
 						ValidationVersion::V1.into(),
 						Some(HashSet::from([Sr25519Keyring::Bob.public().into()])),
@@ -1015,7 +1015,7 @@ fn receiving_large_statement_from_one_sends_to_another_and_to_candidate_backing(
 			.send(FromOrchestra::Communication {
 				msg: StatementDistributionMessage::NetworkBridgeUpdate(
 					NetworkBridgeEvent::PeerConnected(
-						peer_c.clone(),
+						peer_c,
 						ObservedRole::Full,
 						ValidationVersion::V1.into(),
 						Some(HashSet::from([Sr25519Keyring::Charlie.public().into()])),
@@ -1027,7 +1027,7 @@ fn receiving_large_statement_from_one_sends_to_another_and_to_candidate_backing(
 			.send(FromOrchestra::Communication {
 				msg: StatementDistributionMessage::NetworkBridgeUpdate(
 					NetworkBridgeEvent::PeerConnected(
-						peer_bad.clone(),
+						peer_bad,
 						ObservedRole::Full,
 						ValidationVersion::V1.into(),
 						None,
@@ -1039,7 +1039,7 @@ fn receiving_large_statement_from_one_sends_to_another_and_to_candidate_backing(
 		handle
 			.send(FromOrchestra::Communication {
 				msg: StatementDistributionMessage::NetworkBridgeUpdate(
-					NetworkBridgeEvent::PeerViewChange(peer_a.clone(), view![hash_a]),
+					NetworkBridgeEvent::PeerViewChange(peer_a, view![hash_a]),
 				),
 			})
 			.await;
@@ -1047,21 +1047,21 @@ fn receiving_large_statement_from_one_sends_to_another_and_to_candidate_backing(
 		handle
 			.send(FromOrchestra::Communication {
 				msg: StatementDistributionMessage::NetworkBridgeUpdate(
-					NetworkBridgeEvent::PeerViewChange(peer_b.clone(), view![hash_a]),
+					NetworkBridgeEvent::PeerViewChange(peer_b, view![hash_a]),
 				),
 			})
 			.await;
 		handle
 			.send(FromOrchestra::Communication {
 				msg: StatementDistributionMessage::NetworkBridgeUpdate(
-					NetworkBridgeEvent::PeerViewChange(peer_c.clone(), view![hash_a]),
+					NetworkBridgeEvent::PeerViewChange(peer_c, view![hash_a]),
 				),
 			})
 			.await;
 		handle
 			.send(FromOrchestra::Communication {
 				msg: StatementDistributionMessage::NetworkBridgeUpdate(
-					NetworkBridgeEvent::PeerViewChange(peer_bad.clone(), view![hash_a]),
+					NetworkBridgeEvent::PeerViewChange(peer_bad, view![hash_a]),
 				),
 			})
 			.await;
@@ -1098,7 +1098,7 @@ fn receiving_large_statement_from_one_sends_to_another_and_to_candidate_backing(
 			.send(FromOrchestra::Communication {
 				msg: StatementDistributionMessage::NetworkBridgeUpdate(
 					NetworkBridgeEvent::PeerMessage(
-						peer_a.clone(),
+						peer_a,
 						Versioned::V1(protocol_v1::StatementDistributionMessage::LargeStatement(
 							metadata.clone(),
 						)),
@@ -1136,7 +1136,7 @@ fn receiving_large_statement_from_one_sends_to_another_and_to_candidate_backing(
 			.send(FromOrchestra::Communication {
 				msg: StatementDistributionMessage::NetworkBridgeUpdate(
 					NetworkBridgeEvent::PeerMessage(
-						peer_c.clone(),
+						peer_c,
 						Versioned::V1(protocol_v1::StatementDistributionMessage::LargeStatement(
 							metadata.clone(),
 						)),
@@ -1150,7 +1150,7 @@ fn receiving_large_statement_from_one_sends_to_another_and_to_candidate_backing(
 			.send(FromOrchestra::Communication {
 				msg: StatementDistributionMessage::NetworkBridgeUpdate(
 					NetworkBridgeEvent::PeerMessage(
-						peer_bad.clone(),
+						peer_bad,
 						Versioned::V1(protocol_v1::StatementDistributionMessage::LargeStatement(
 							metadata.clone(),
 						)),
@@ -1486,7 +1486,7 @@ fn delay_reputation_changes() {
 			.send(FromOrchestra::Communication {
 				msg: StatementDistributionMessage::NetworkBridgeUpdate(
 					NetworkBridgeEvent::PeerConnected(
-						peer_a.clone(),
+						peer_a,
 						ObservedRole::Full,
 						ValidationVersion::V1.into(),
 						Some(HashSet::from([Sr25519Keyring::Alice.public().into()])),
@@ -1499,7 +1499,7 @@ fn delay_reputation_changes() {
 			.send(FromOrchestra::Communication {
 				msg: StatementDistributionMessage::NetworkBridgeUpdate(
 					NetworkBridgeEvent::PeerConnected(
-						peer_b.clone(),
+						peer_b,
 						ObservedRole::Full,
 						ValidationVersion::V1.into(),
 						Some(HashSet::from([Sr25519Keyring::Bob.public().into()])),
@@ -1511,7 +1511,7 @@ fn delay_reputation_changes() {
 			.send(FromOrchestra::Communication {
 				msg: StatementDistributionMessage::NetworkBridgeUpdate(
 					NetworkBridgeEvent::PeerConnected(
-						peer_c.clone(),
+						peer_c,
 						ObservedRole::Full,
 						ValidationVersion::V1.into(),
 						Some(HashSet::from([Sr25519Keyring::Charlie.public().into()])),
@@ -1523,7 +1523,7 @@ fn delay_reputation_changes() {
 			.send(FromOrchestra::Communication {
 				msg: StatementDistributionMessage::NetworkBridgeUpdate(
 					NetworkBridgeEvent::PeerConnected(
-						peer_bad.clone(),
+						peer_bad,
 						ObservedRole::Full,
 						ValidationVersion::V1.into(),
 						None,
@@ -1535,7 +1535,7 @@ fn delay_reputation_changes() {
 		handle
 			.send(FromOrchestra::Communication {
 				msg: StatementDistributionMessage::NetworkBridgeUpdate(
-					NetworkBridgeEvent::PeerViewChange(peer_a.clone(), view![hash_a]),
+					NetworkBridgeEvent::PeerViewChange(peer_a, view![hash_a]),
 				),
 			})
 			.await;
@@ -1543,21 +1543,21 @@ fn delay_reputation_changes() {
 		handle
 			.send(FromOrchestra::Communication {
 				msg: StatementDistributionMessage::NetworkBridgeUpdate(
-					NetworkBridgeEvent::PeerViewChange(peer_b.clone(), view![hash_a]),
+					NetworkBridgeEvent::PeerViewChange(peer_b, view![hash_a]),
 				),
 			})
 			.await;
 		handle
 			.send(FromOrchestra::Communication {
 				msg: StatementDistributionMessage::NetworkBridgeUpdate(
-					NetworkBridgeEvent::PeerViewChange(peer_c.clone(), view![hash_a]),
+					NetworkBridgeEvent::PeerViewChange(peer_c, view![hash_a]),
 				),
 			})
 			.await;
 		handle
 			.send(FromOrchestra::Communication {
 				msg: StatementDistributionMessage::NetworkBridgeUpdate(
-					NetworkBridgeEvent::PeerViewChange(peer_bad.clone(), view![hash_a]),
+					NetworkBridgeEvent::PeerViewChange(peer_bad, view![hash_a]),
 				),
 			})
 			.await;
@@ -1594,7 +1594,7 @@ fn delay_reputation_changes() {
 			.send(FromOrchestra::Communication {
 				msg: StatementDistributionMessage::NetworkBridgeUpdate(
 					NetworkBridgeEvent::PeerMessage(
-						peer_a.clone(),
+						peer_a,
 						Versioned::V1(protocol_v1::StatementDistributionMessage::LargeStatement(
 							metadata.clone(),
 						)),
@@ -1632,7 +1632,7 @@ fn delay_reputation_changes() {
 			.send(FromOrchestra::Communication {
 				msg: StatementDistributionMessage::NetworkBridgeUpdate(
 					NetworkBridgeEvent::PeerMessage(
-						peer_c.clone(),
+						peer_c,
 						Versioned::V1(protocol_v1::StatementDistributionMessage::LargeStatement(
 							metadata.clone(),
 						)),
@@ -1646,7 +1646,7 @@ fn delay_reputation_changes() {
 			.send(FromOrchestra::Communication {
 				msg: StatementDistributionMessage::NetworkBridgeUpdate(
 					NetworkBridgeEvent::PeerMessage(
-						peer_bad.clone(),
+						peer_bad,
 						Versioned::V1(protocol_v1::StatementDistributionMessage::LargeStatement(
 							metadata.clone(),
 						)),
@@ -1962,7 +1962,7 @@ fn share_prioritizes_backing_group() {
 			.send(FromOrchestra::Communication {
 				msg: StatementDistributionMessage::NetworkBridgeUpdate(
 					NetworkBridgeEvent::PeerConnected(
-						peer_a.clone(),
+						peer_a,
 						ObservedRole::Full,
 						ValidationVersion::V1.into(),
 						Some(HashSet::from([Sr25519Keyring::Alice.public().into()])),
@@ -1974,7 +1974,7 @@ fn share_prioritizes_backing_group() {
 			.send(FromOrchestra::Communication {
 				msg: StatementDistributionMessage::NetworkBridgeUpdate(
 					NetworkBridgeEvent::PeerConnected(
-						peer_b.clone(),
+						peer_b,
 						ObservedRole::Full,
 						ValidationVersion::V1.into(),
 						Some(HashSet::from([Sr25519Keyring::Bob.public().into()])),
@@ -1986,7 +1986,7 @@ fn share_prioritizes_backing_group() {
 			.send(FromOrchestra::Communication {
 				msg: StatementDistributionMessage::NetworkBridgeUpdate(
 					NetworkBridgeEvent::PeerConnected(
-						peer_c.clone(),
+						peer_c,
 						ObservedRole::Full,
 						ValidationVersion::V1.into(),
 						Some(HashSet::from([Sr25519Keyring::Charlie.public().into()])),
@@ -1998,7 +1998,7 @@ fn share_prioritizes_backing_group() {
 			.send(FromOrchestra::Communication {
 				msg: StatementDistributionMessage::NetworkBridgeUpdate(
 					NetworkBridgeEvent::PeerConnected(
-						peer_bad.clone(),
+						peer_bad,
 						ObservedRole::Full,
 						ValidationVersion::V1.into(),
 						None,
@@ -2010,7 +2010,7 @@ fn share_prioritizes_backing_group() {
 			.send(FromOrchestra::Communication {
 				msg: StatementDistributionMessage::NetworkBridgeUpdate(
 					NetworkBridgeEvent::PeerConnected(
-						peer_other_group.clone(),
+						peer_other_group,
 						ObservedRole::Full,
 						ValidationVersion::V1.into(),
 						Some(HashSet::from([Sr25519Keyring::Dave.public().into()])),
@@ -2022,7 +2022,7 @@ fn share_prioritizes_backing_group() {
 		handle
 			.send(FromOrchestra::Communication {
 				msg: StatementDistributionMessage::NetworkBridgeUpdate(
-					NetworkBridgeEvent::PeerViewChange(peer_a.clone(), view![hash_a]),
+					NetworkBridgeEvent::PeerViewChange(peer_a, view![hash_a]),
 				),
 			})
 			.await;
@@ -2030,28 +2030,28 @@ fn share_prioritizes_backing_group() {
 		handle
 			.send(FromOrchestra::Communication {
 				msg: StatementDistributionMessage::NetworkBridgeUpdate(
-					NetworkBridgeEvent::PeerViewChange(peer_b.clone(), view![hash_a]),
+					NetworkBridgeEvent::PeerViewChange(peer_b, view![hash_a]),
 				),
 			})
 			.await;
 		handle
 			.send(FromOrchestra::Communication {
 				msg: StatementDistributionMessage::NetworkBridgeUpdate(
-					NetworkBridgeEvent::PeerViewChange(peer_c.clone(), view![hash_a]),
+					NetworkBridgeEvent::PeerViewChange(peer_c, view![hash_a]),
 				),
 			})
 			.await;
 		handle
 			.send(FromOrchestra::Communication {
 				msg: StatementDistributionMessage::NetworkBridgeUpdate(
-					NetworkBridgeEvent::PeerViewChange(peer_bad.clone(), view![hash_a]),
+					NetworkBridgeEvent::PeerViewChange(peer_bad, view![hash_a]),
 				),
 			})
 			.await;
 		handle
 			.send(FromOrchestra::Communication {
 				msg: StatementDistributionMessage::NetworkBridgeUpdate(
-					NetworkBridgeEvent::PeerViewChange(peer_other_group.clone(), view![hash_a]),
+					NetworkBridgeEvent::PeerViewChange(peer_other_group, view![hash_a]),
 				),
 			})
 			.await;
@@ -2232,7 +2232,7 @@ fn peer_cant_flood_with_large_statements() {
 			.send(FromOrchestra::Communication {
 				msg: StatementDistributionMessage::NetworkBridgeUpdate(
 					NetworkBridgeEvent::PeerConnected(
-						peer_a.clone(),
+						peer_a,
 						ObservedRole::Full,
 						ValidationVersion::V1.into(),
 						Some(HashSet::from([Sr25519Keyring::Alice.public().into()])),
@@ -2244,7 +2244,7 @@ fn peer_cant_flood_with_large_statements() {
 		handle
 			.send(FromOrchestra::Communication {
 				msg: StatementDistributionMessage::NetworkBridgeUpdate(
-					NetworkBridgeEvent::PeerViewChange(peer_a.clone(), view![hash_a]),
+					NetworkBridgeEvent::PeerViewChange(peer_a, view![hash_a]),
 				),
 			})
 			.await;
@@ -2280,7 +2280,7 @@ fn peer_cant_flood_with_large_statements() {
 				.send(FromOrchestra::Communication {
 					msg: StatementDistributionMessage::NetworkBridgeUpdate(
 						NetworkBridgeEvent::PeerMessage(
-							peer_a.clone(),
+							peer_a,
 							Versioned::V1(
 								protocol_v1::StatementDistributionMessage::LargeStatement(
 									metadata.clone(),
@@ -2355,8 +2355,8 @@ fn handle_multiple_seconded_statements() {
 	for _ in 0..MIN_GOSSIP_PEERS + 2 {
 		all_peers.push(PeerId::random());
 	}
-	all_peers.push(peer_a.clone());
-	all_peers.push(peer_b.clone());
+	all_peers.push(peer_a);
+	all_peers.push(peer_b);
 
 	let mut lucky_peers = all_peers.clone();
 	util::choose_random_subset_with_rng(
@@ -2438,7 +2438,7 @@ fn handle_multiple_seconded_statements() {
 				.send(FromOrchestra::Communication {
 					msg: StatementDistributionMessage::NetworkBridgeUpdate(
 						NetworkBridgeEvent::PeerConnected(
-							peer.clone(),
+							*peer,
 							ObservedRole::Full,
 							ValidationVersion::V1.into(),
 							None,
@@ -2449,7 +2449,7 @@ fn handle_multiple_seconded_statements() {
 			handle
 				.send(FromOrchestra::Communication {
 					msg: StatementDistributionMessage::NetworkBridgeUpdate(
-						NetworkBridgeEvent::PeerViewChange(peer.clone(), view![relay_parent_hash]),
+						NetworkBridgeEvent::PeerViewChange(*peer, view![relay_parent_hash]),
 					),
 				})
 				.await;
@@ -2470,13 +2470,13 @@ fn handle_multiple_seconded_statements() {
 				.map(|i| {
 					if i == 0 {
 						TopologyPeerInfo {
-							peer_ids: vec![peer_a.clone()],
+							peer_ids: vec![peer_a],
 							validator_index: ValidatorIndex(0),
 							discovery_id: AuthorityPair::generate().0.public(),
 						}
 					} else if i == 1 {
 						TopologyPeerInfo {
-							peer_ids: vec![peer_b.clone()],
+							peer_ids: vec![peer_b],
 							validator_index: ValidatorIndex(1),
 							discovery_id: AuthorityPair::generate().0.public(),
 						}
@@ -2489,7 +2489,7 @@ fn handle_multiple_seconded_statements() {
 					} else if (i - 2) % dim == 0 {
 						let lucky_index = ((i - 2) / dim) - 1;
 						TopologyPeerInfo {
-							peer_ids: vec![lucky_peers[lucky_index].clone()],
+							peer_ids: vec![lucky_peers[lucky_index]],
 							validator_index: ValidatorIndex(i as _),
 							discovery_id: AuthorityPair::generate().0.public(),
 						}
@@ -2566,7 +2566,7 @@ fn handle_multiple_seconded_statements() {
 			.send(FromOrchestra::Communication {
 				msg: StatementDistributionMessage::NetworkBridgeUpdate(
 					NetworkBridgeEvent::PeerMessage(
-						peer_a.clone(),
+						peer_a,
 						Versioned::V1(protocol_v1::StatementDistributionMessage::Statement(
 							relay_parent_hash,
 							statement.clone().into(),
@@ -2618,7 +2618,7 @@ fn handle_multiple_seconded_statements() {
 			.send(FromOrchestra::Communication {
 				msg: StatementDistributionMessage::NetworkBridgeUpdate(
 					NetworkBridgeEvent::PeerMessage(
-						peer_b.clone(),
+						peer_b,
 						Versioned::V1(protocol_v1::StatementDistributionMessage::Statement(
 							relay_parent_hash,
 							statement.clone().into(),
@@ -2667,7 +2667,7 @@ fn handle_multiple_seconded_statements() {
 			.send(FromOrchestra::Communication {
 				msg: StatementDistributionMessage::NetworkBridgeUpdate(
 					NetworkBridgeEvent::PeerMessage(
-						peer_a.clone(),
+						peer_a,
 						Versioned::V1(protocol_v1::StatementDistributionMessage::Statement(
 							relay_parent_hash,
 							statement.clone().into(),
@@ -2718,7 +2718,7 @@ fn handle_multiple_seconded_statements() {
 			.send(FromOrchestra::Communication {
 				msg: StatementDistributionMessage::NetworkBridgeUpdate(
 					NetworkBridgeEvent::PeerMessage(
-						peer_b.clone(),
+						peer_b,
 						Versioned::V1(protocol_v1::StatementDistributionMessage::Statement(
 							relay_parent_hash,
 							statement.clone().into(),

--- a/node/network/statement-distribution/src/tests.rs
+++ b/node/network/statement-distribution/src/tests.rs
@@ -644,8 +644,7 @@ fn circulated_statement_goes_to_all_peers_with_view() {
 		let statement = StoredStatement { comparator: &comparator, statement: &statement };
 
 		let mut topology = GridNeighbors::empty();
-		topology.peers_x =
-			HashSet::from_iter(vec![peer_a, peer_b, peer_c].into_iter());
+		topology.peers_x = HashSet::from_iter(vec![peer_a, peer_b, peer_c].into_iter());
 		let needs_dependents = circulate_statement(
 			RequiredRouting::GridXY,
 			&topology,

--- a/node/service/src/tests.rs
+++ b/node/service/src/tests.rs
@@ -251,12 +251,7 @@ impl ChainBuilder {
 		self.add_block_inner(hash, parent_hash, number)
 	}
 
-	fn add_block_inner(
-		&mut self,
-		hash: Hash,
-		parent_hash: Hash,
-		number: u32,
-	) -> &mut Self {
+	fn add_block_inner(&mut self, hash: Hash, parent_hash: Hash, number: u32) -> &mut Self {
 		let header = ChainBuilder::make_header(parent_hash, number);
 		assert!(
 			self.0.blocks_by_hash.insert(hash, header).is_none(),

--- a/node/service/src/tests.rs
+++ b/node/service/src/tests.rs
@@ -87,7 +87,7 @@ fn test_harness<T: Future<Output = VirtualOverseer>>(
 		None,
 	);
 
-	let target_hash = case_vars.target_block.clone();
+	let target_hash = case_vars.target_block;
 	let selection_process = async move {
 		let best = select_relay_chain
 			.finality_target_with_longest_chain(target_hash, None)
@@ -106,8 +106,7 @@ fn test_harness<T: Future<Output = VirtualOverseer>>(
 			let _overseer = test_fut.await;
 		},
 		selection_process,
-	))
-	.1;
+	));
 }
 
 async fn overseer_recv(overseer: &mut VirtualOverseer) -> AllMessages {
@@ -241,7 +240,7 @@ impl ChainBuilder {
 		builder
 	}
 
-	pub fn add_block<'a>(&'a mut self, hash: Hash, parent_hash: Hash, number: u32) -> &'a mut Self {
+	pub fn add_block(&mut self, hash: Hash, parent_hash: Hash, number: u32) -> &mut Self {
 		assert!(number != 0, "cannot add duplicate genesis block");
 		assert!(hash != Self::GENESIS_HASH, "cannot add block with genesis hash");
 		assert!(
@@ -252,12 +251,12 @@ impl ChainBuilder {
 		self.add_block_inner(hash, parent_hash, number)
 	}
 
-	fn add_block_inner<'a>(
-		&'a mut self,
+	fn add_block_inner(
+		&mut self,
 		hash: Hash,
 		parent_hash: Hash,
 		number: u32,
-	) -> &'a mut Self {
+	) -> &mut Self {
 		let header = ChainBuilder::make_header(parent_hash, number);
 		assert!(
 			self.0.blocks_by_hash.insert(hash, header).is_none(),
@@ -360,7 +359,7 @@ async fn test_skeleton(
 		))
 		=> {
 			assert_eq!(target_block_hash, target_hash, "TestIntegrity: target hashes always match. qed");
-			tx.send(best_chain_containing_block.clone()).unwrap();
+			tx.send(best_chain_containing_block).unwrap();
 		}
 	);
 

--- a/node/test/service/src/lib.rs
+++ b/node/test/service/src/lib.rs
@@ -210,7 +210,7 @@ pub fn run_validator_node(
 			.expect("could not create Polkadot test service");
 
 	let overseer_handle = overseer_handle.expect("test node must have an overseer handle");
-	let peer_id = network.local_peer_id().clone();
+	let peer_id = network.local_peer_id();
 	let addr = MultiaddrWithPeerId { multiaddr, peer_id };
 
 	PolkadotTestNode { task_manager, client, overseer_handle, addr, rpc_handlers }
@@ -242,7 +242,7 @@ pub fn run_collator_node(
 			.expect("could not create Polkadot test service");
 
 	let overseer_handle = overseer_handle.expect("test node must have an overseer handle");
-	let peer_id = network.local_peer_id().clone();
+	let peer_id = network.local_peer_id();
 	let addr = MultiaddrWithPeerId { multiaddr, peer_id };
 
 	PolkadotTestNode { task_manager, client, overseer_handle, addr, rpc_handlers }
@@ -273,7 +273,7 @@ impl PolkadotTestNode {
 	) -> Result<(), RpcTransactionError> {
 		let sudo = SudoCall::sudo { call: Box::new(call.into()) };
 
-		let extrinsic = construct_extrinsic(&*self.client, sudo, caller, nonce);
+		let extrinsic = construct_extrinsic(&self.client, sudo, caller, nonce);
 		self.rpc_handlers.send_transaction(extrinsic.into()).await.map(drop)
 	}
 
@@ -283,7 +283,7 @@ impl PolkadotTestNode {
 		function: impl Into<polkadot_test_runtime::RuntimeCall>,
 		caller: Sr25519Keyring,
 	) -> Result<RpcTransactionOutput, RpcTransactionError> {
-		let extrinsic = construct_extrinsic(&*self.client, function, caller, 0);
+		let extrinsic = construct_extrinsic(&self.client, function, caller, 0);
 
 		self.rpc_handlers.send_transaction(extrinsic.into()).await
 	}

--- a/runtime/common/src/auctions.rs
+++ b/runtime/common/src/auctions.rs
@@ -793,7 +793,7 @@ mod tests {
 					if leases.contains_key(&(para, period)) {
 						return Err(LeaseError::AlreadyLeased)
 					}
-					leases.insert((para, period), LeaseData { leaser: leaser.clone(), amount });
+					leases.insert((para, period), LeaseData { leaser: *leaser, amount });
 				}
 				Ok(())
 			})
@@ -1391,7 +1391,7 @@ mod tests {
 			(1, 2.into(), 53, SlotRange::TwoTwo),
 			(5, 3.into(), 1, SlotRange::ThreeThree),
 		];
-		assert_eq!(Auctions::calculate_winners(winning.clone()), winners);
+		assert_eq!(Auctions::calculate_winners(winning), winners);
 
 		winning[SlotRange::ZeroOne as u8 as usize] = Some((4, 10.into(), 3));
 		let winners = vec![
@@ -1399,11 +1399,11 @@ mod tests {
 			(1, 2.into(), 53, SlotRange::TwoTwo),
 			(5, 3.into(), 1, SlotRange::ThreeThree),
 		];
-		assert_eq!(Auctions::calculate_winners(winning.clone()), winners);
+		assert_eq!(Auctions::calculate_winners(winning), winners);
 
 		winning[SlotRange::ZeroThree as u8 as usize] = Some((1, 100.into(), 100));
 		let winners = vec![(1, 100.into(), 100, SlotRange::ZeroThree)];
-		assert_eq!(Auctions::calculate_winners(winning.clone()), winners);
+		assert_eq!(Auctions::calculate_winners(winning), winners);
 	}
 
 	#[test]

--- a/runtime/common/src/crowdloan/mod.rs
+++ b/runtime/common/src/crowdloan/mod.rs
@@ -970,16 +970,16 @@ mod tests {
 		ENDING_PERIOD.with(|p| *p.borrow_mut() = ending_period);
 	}
 	fn auction() -> Option<(u64, u64)> {
-		AUCTION.with(|p| p.borrow().clone())
+		AUCTION.with(|p| *p.borrow())
 	}
 	fn ending_period() -> u64 {
-		ENDING_PERIOD.with(|p| p.borrow().clone())
+		ENDING_PERIOD.with(|p| *p.borrow())
 	}
 	fn bids() -> Vec<BidPlaced> {
 		BIDS_PLACED.with(|p| p.borrow().clone())
 	}
 	fn vrf_delay() -> u64 {
-		VRF_DELAY.with(|p| p.borrow().clone())
+		VRF_DELAY.with(|p| *p.borrow())
 	}
 	fn set_vrf_delay(delay: u64) {
 		VRF_DELAY.with(|p| *p.borrow_mut() = delay);

--- a/runtime/common/src/xcm_sender.rs
+++ b/runtime/common/src/xcm_sender.rs
@@ -147,16 +147,14 @@ mod tests {
 		);
 
 		// message size = 2
-		let result: u128 =
-			TestFeeTracker::get_fee_factor(id).saturating_mul_int(b + (2 * m));
+		let result: u128 = TestFeeTracker::get_fee_factor(id).saturating_mul_int(b + (2 * m));
 		assert_eq!(
 			TestExponentialPrice::price_for_parachain_delivery(id, &Xcm(vec![ClearOrigin])),
 			(FeeAssetId::get(), result).into()
 		);
 
 		// message size = 4
-		let result: u128 =
-			TestFeeTracker::get_fee_factor(id).saturating_mul_int(b + (4 * m));
+		let result: u128 = TestFeeTracker::get_fee_factor(id).saturating_mul_int(b + (4 * m));
 		assert_eq!(
 			TestExponentialPrice::price_for_parachain_delivery(
 				id,

--- a/runtime/common/src/xcm_sender.rs
+++ b/runtime/common/src/xcm_sender.rs
@@ -140,26 +140,26 @@ mod tests {
 
 		// F * (B + msg_length * M)
 		// message_length = 1
-		let result: u128 = TestFeeTracker::get_fee_factor(id.clone()).saturating_mul_int(b + m);
+		let result: u128 = TestFeeTracker::get_fee_factor(id).saturating_mul_int(b + m);
 		assert_eq!(
-			TestExponentialPrice::price_for_parachain_delivery(id.clone(), &Xcm(vec![])),
+			TestExponentialPrice::price_for_parachain_delivery(id, &Xcm(vec![])),
 			(FeeAssetId::get(), result).into()
 		);
 
 		// message size = 2
 		let result: u128 =
-			TestFeeTracker::get_fee_factor(id.clone()).saturating_mul_int(b + (2 * m));
+			TestFeeTracker::get_fee_factor(id).saturating_mul_int(b + (2 * m));
 		assert_eq!(
-			TestExponentialPrice::price_for_parachain_delivery(id.clone(), &Xcm(vec![ClearOrigin])),
+			TestExponentialPrice::price_for_parachain_delivery(id, &Xcm(vec![ClearOrigin])),
 			(FeeAssetId::get(), result).into()
 		);
 
 		// message size = 4
 		let result: u128 =
-			TestFeeTracker::get_fee_factor(id.clone()).saturating_mul_int(b + (4 * m));
+			TestFeeTracker::get_fee_factor(id).saturating_mul_int(b + (4 * m));
 		assert_eq!(
 			TestExponentialPrice::price_for_parachain_delivery(
-				id.clone(),
+				id,
 				&Xcm(vec![SetAppendix(Xcm(vec![ClearOrigin]))])
 			),
 			(FeeAssetId::get(), result).into()

--- a/runtime/parachains/src/builder.rs
+++ b/runtime/parachains/src/builder.rs
@@ -377,8 +377,8 @@ impl<T: paras_inherent::Config> BenchBuilder<T> {
 
 	fn signing_context(&self) -> SigningContext<T::Hash> {
 		SigningContext {
-			parent_hash: Self::header(self.block_number.clone()).hash(),
-			session_index: self.session.clone(),
+			parent_hash: Self::header(self.block_number).hash(),
+			session_index: self.session,
 		}
 	}
 
@@ -408,7 +408,7 @@ impl<T: paras_inherent::Config> BenchBuilder<T> {
 		}
 
 		let block_number = BlockNumberFor::<T>::from(block);
-		let header = Self::header(block_number.clone());
+		let header = Self::header(block_number);
 
 		frame_system::Pallet::<T>::reset_events();
 		frame_system::Pallet::<T>::initialize(
@@ -464,13 +464,13 @@ impl<T: paras_inherent::Config> BenchBuilder<T> {
 
 		for (seed, _) in concluding_cores.iter() {
 			// make sure the candidates that will be concluding are marked as pending availability.
-			let (para_id, core_idx, group_idx) = self.create_indexes(seed.clone());
+			let (para_id, core_idx, group_idx) = self.create_indexes(*seed);
 			Self::add_availability(
 				para_id,
 				core_idx,
 				group_idx,
 				Self::validator_availability_votes_yes(validators.len()),
-				CandidateHash(H256::from(byte32_slice_from(seed.clone()))),
+				CandidateHash(H256::from(byte32_slice_from(*seed))),
 			);
 		}
 
@@ -496,11 +496,11 @@ impl<T: paras_inherent::Config> BenchBuilder<T> {
 			.iter()
 			.map(|(seed, num_votes)| {
 				assert!(*num_votes <= validators.len() as u32);
-				let (para_id, _core_idx, group_idx) = self.create_indexes(seed.clone());
+				let (para_id, _core_idx, group_idx) = self.create_indexes(*seed);
 
 				// This generates a pair and adds it to the keystore, returning just the public.
 				let collator_public = CollatorId::generate_pair(None);
-				let header = Self::header(self.block_number.clone());
+				let header = Self::header(self.block_number);
 				let relay_parent = header.hash();
 				let head_data = Self::mock_head_data();
 				let persisted_validation_data_hash = PersistedValidationData::<H256> {
@@ -563,7 +563,7 @@ impl<T: paras_inherent::Config> BenchBuilder<T> {
 						let public = validators.get(*val_idx).unwrap();
 						let sig = UncheckedSigned::<CompactStatement>::benchmark_sign(
 							public,
-							CompactStatement::Valid(candidate_hash.clone()),
+							CompactStatement::Valid(candidate_hash),
 							&self.signing_context(),
 							*val_idx,
 						)
@@ -632,14 +632,14 @@ impl<T: paras_inherent::Config> BenchBuilder<T> {
 						} else {
 							DisputeStatement::Valid(ValidDisputeStatementKind::Explicit)
 						};
-						let data = dispute_statement.payload_data(candidate_hash.clone(), session);
+						let data = dispute_statement.payload_data(candidate_hash, session);
 						let statement_sig = validator_public.sign(&data).unwrap();
 
 						(dispute_statement, ValidatorIndex(validator_index), statement_sig)
 					})
 					.collect();
 
-				DisputeStatementSet { candidate_hash: candidate_hash.clone(), session, statements }
+				DisputeStatementSet { candidate_hash: candidate_hash, session, statements }
 			})
 			.collect()
 	}
@@ -702,7 +702,7 @@ impl<T: paras_inherent::Config> BenchBuilder<T> {
 				bitfields,
 				backed_candidates,
 				disputes,
-				parent_header: Self::header(builder.block_number.clone()),
+				parent_header: Self::header(builder.block_number),
 			},
 			_session: target_session,
 			_block_number: builder.block_number,

--- a/runtime/parachains/src/disputes/tests.rs
+++ b/runtime/parachains/src/disputes/tests.rs
@@ -377,7 +377,6 @@ fn test_initializer_on_new_session() {
 	let mock_genesis_config = MockGenesisConfig {
 		configuration: crate::configuration::GenesisConfig {
 			config: HostConfiguration { dispute_period, ..Default::default() },
-			..Default::default()
 		},
 		..Default::default()
 	};
@@ -2297,7 +2296,6 @@ fn filter_removes_concluded_ancient() {
 				dispute_post_conclusion_acceptance_period,
 				..Default::default()
 			},
-			..Default::default()
 		},
 		..Default::default()
 	};

--- a/runtime/parachains/src/disputes/tests.rs
+++ b/runtime/parachains/src/disputes/tests.rs
@@ -386,13 +386,13 @@ fn test_initializer_on_new_session() {
 		let v0 = <ValidatorId as CryptoType>::Pair::generate().0;
 
 		let candidate_hash = CandidateHash(sp_core::H256::repeat_byte(1));
-		Pallet::<Test>::note_included(0, candidate_hash.clone(), 0);
-		Pallet::<Test>::note_included(1, candidate_hash.clone(), 1);
-		Pallet::<Test>::note_included(2, candidate_hash.clone(), 2);
-		Pallet::<Test>::note_included(3, candidate_hash.clone(), 3);
-		Pallet::<Test>::note_included(4, candidate_hash.clone(), 4);
-		Pallet::<Test>::note_included(5, candidate_hash.clone(), 5);
-		Pallet::<Test>::note_included(6, candidate_hash.clone(), 5);
+		Pallet::<Test>::note_included(0, candidate_hash, 0);
+		Pallet::<Test>::note_included(1, candidate_hash, 1);
+		Pallet::<Test>::note_included(2, candidate_hash, 2);
+		Pallet::<Test>::note_included(3, candidate_hash, 3);
+		Pallet::<Test>::note_included(4, candidate_hash, 4);
+		Pallet::<Test>::note_included(5, candidate_hash, 5);
+		Pallet::<Test>::note_included(6, candidate_hash, 5);
 
 		run_to_block(7, |b| {
 			// a new session at each block
@@ -465,7 +465,7 @@ fn test_provide_multi_dispute_is_providing() {
 		let inclusion_parent = sp_core::H256::repeat_byte(0xff);
 		let session = 1;
 		let stmts = vec![DisputeStatementSet {
-			candidate_hash: candidate_hash.clone(),
+			candidate_hash: candidate_hash,
 			session,
 			statements: vec![
 				(
@@ -483,7 +483,7 @@ fn test_provide_multi_dispute_is_providing() {
 					v1.sign(
 						&ExplicitDisputeStatement {
 							valid: false,
-							candidate_hash: candidate_hash.clone(),
+							candidate_hash: candidate_hash,
 							session,
 						}
 						.signing_payload(),
@@ -499,7 +499,7 @@ fn test_provide_multi_dispute_is_providing() {
 					.map(CheckedDisputeStatementSet::unchecked_from_unchecked)
 					.collect()
 			),
-			vec![(1, candidate_hash.clone())],
+			vec![(1, candidate_hash)],
 		);
 	})
 }
@@ -528,7 +528,7 @@ fn test_disputes_with_missing_backing_votes_are_rejected() {
 		let session = 1;
 
 		let stmts = vec![DisputeStatementSet {
-			candidate_hash: candidate_hash.clone(),
+			candidate_hash: candidate_hash,
 			session,
 			statements: vec![
 				(
@@ -537,7 +537,7 @@ fn test_disputes_with_missing_backing_votes_are_rejected() {
 					v0.sign(
 						&ExplicitDisputeStatement {
 							valid: true,
-							candidate_hash: candidate_hash.clone(),
+							candidate_hash: candidate_hash,
 							session,
 						}
 						.signing_payload(),
@@ -549,7 +549,7 @@ fn test_disputes_with_missing_backing_votes_are_rejected() {
 					v1.sign(
 						&ExplicitDisputeStatement {
 							valid: false,
-							candidate_hash: candidate_hash.clone(),
+							candidate_hash: candidate_hash,
 							session,
 						}
 						.signing_payload(),
@@ -590,7 +590,7 @@ fn test_freeze_on_note_included() {
 
 		// v0 votes for 3
 		let stmts = vec![DisputeStatementSet {
-			candidate_hash: candidate_hash.clone(),
+			candidate_hash: candidate_hash,
 			session: 3,
 			statements: vec![
 				(
@@ -599,7 +599,7 @@ fn test_freeze_on_note_included() {
 					v0.sign(
 						&ExplicitDisputeStatement {
 							valid: false,
-							candidate_hash: candidate_hash.clone(),
+							candidate_hash: candidate_hash,
 							session: 3,
 						}
 						.signing_payload(),
@@ -611,7 +611,7 @@ fn test_freeze_on_note_included() {
 					v1.sign(
 						&ExplicitDisputeStatement {
 							valid: false,
-							candidate_hash: candidate_hash.clone(),
+							candidate_hash: candidate_hash,
 							session: 3,
 						}
 						.signing_payload(),
@@ -636,7 +636,7 @@ fn test_freeze_on_note_included() {
 		)
 		.is_ok());
 
-		Pallet::<Test>::note_included(3, candidate_hash.clone(), 3);
+		Pallet::<Test>::note_included(3, candidate_hash, 3);
 		assert_eq!(Frozen::<Test>::get(), Some(2));
 	});
 }
@@ -663,7 +663,7 @@ fn test_freeze_provided_against_supermajority_for_included() {
 
 		// v0 votes for 3
 		let stmts = vec![DisputeStatementSet {
-			candidate_hash: candidate_hash.clone(),
+			candidate_hash: candidate_hash,
 			session,
 			statements: vec![
 				(
@@ -672,7 +672,7 @@ fn test_freeze_provided_against_supermajority_for_included() {
 					v0.sign(
 						&ExplicitDisputeStatement {
 							valid: false,
-							candidate_hash: candidate_hash.clone(),
+							candidate_hash: candidate_hash,
 							session,
 						}
 						.signing_payload(),
@@ -684,7 +684,7 @@ fn test_freeze_provided_against_supermajority_for_included() {
 					v1.sign(
 						&ExplicitDisputeStatement {
 							valid: false,
-							candidate_hash: candidate_hash.clone(),
+							candidate_hash: candidate_hash,
 							session,
 						}
 						.signing_payload(),
@@ -702,7 +702,7 @@ fn test_freeze_provided_against_supermajority_for_included() {
 			],
 		}];
 
-		Pallet::<Test>::note_included(3, candidate_hash.clone(), 3);
+		Pallet::<Test>::note_included(3, candidate_hash, 3);
 		assert!(Pallet::<Test>::process_checked_multi_dispute_data(
 			&stmts
 				.into_iter()
@@ -744,7 +744,7 @@ fn test_freeze_provided_against_byzantine_threshold_for_included() {
 
 		// A byzantine threshold of INVALID
 		let stmts = vec![DisputeStatementSet {
-			candidate_hash: candidate_hash.clone(),
+			candidate_hash: candidate_hash,
 			session,
 			statements: vec![
 				(
@@ -753,7 +753,7 @@ fn test_freeze_provided_against_byzantine_threshold_for_included() {
 					v0.sign(
 						&ExplicitDisputeStatement {
 							valid: false,
-							candidate_hash: candidate_hash.clone(),
+							candidate_hash: candidate_hash,
 							session,
 						}
 						.signing_payload(),
@@ -765,7 +765,7 @@ fn test_freeze_provided_against_byzantine_threshold_for_included() {
 					v1.sign(
 						&ExplicitDisputeStatement {
 							valid: false,
-							candidate_hash: candidate_hash.clone(),
+							candidate_hash: candidate_hash,
 							session,
 						}
 						.signing_payload(),
@@ -777,7 +777,7 @@ fn test_freeze_provided_against_byzantine_threshold_for_included() {
 					v2.sign(
 						&ExplicitDisputeStatement {
 							valid: false,
-							candidate_hash: candidate_hash.clone(),
+							candidate_hash: candidate_hash,
 							session,
 						}
 						.signing_payload(),
@@ -796,7 +796,7 @@ fn test_freeze_provided_against_byzantine_threshold_for_included() {
 		}];
 
 		// Include the candidate and import the votes
-		Pallet::<Test>::note_included(3, candidate_hash.clone(), 3);
+		Pallet::<Test>::note_included(3, candidate_hash, 3);
 		assert!(Pallet::<Test>::process_checked_multi_dispute_data(
 			&stmts
 				.into_iter()
@@ -813,7 +813,7 @@ fn test_freeze_provided_against_byzantine_threshold_for_included() {
 
 		// And generate enough votes to reach supermajority of invalid votes
 		let stmts = vec![DisputeStatementSet {
-			candidate_hash: candidate_hash.clone(),
+			candidate_hash: candidate_hash,
 			session,
 			statements: vec![
 				(
@@ -822,7 +822,7 @@ fn test_freeze_provided_against_byzantine_threshold_for_included() {
 					v3.sign(
 						&ExplicitDisputeStatement {
 							valid: false,
-							candidate_hash: candidate_hash.clone(),
+							candidate_hash: candidate_hash,
 							session,
 						}
 						.signing_payload(),
@@ -834,7 +834,7 @@ fn test_freeze_provided_against_byzantine_threshold_for_included() {
 					v4.sign(
 						&ExplicitDisputeStatement {
 							valid: false,
-							candidate_hash: candidate_hash.clone(),
+							candidate_hash: candidate_hash,
 							session,
 						}
 						.signing_payload(),
@@ -846,7 +846,7 @@ fn test_freeze_provided_against_byzantine_threshold_for_included() {
 					v5.sign(
 						&ExplicitDisputeStatement {
 							valid: false,
-							candidate_hash: candidate_hash.clone(),
+							candidate_hash: candidate_hash,
 							session,
 						}
 						.signing_payload(),
@@ -922,7 +922,7 @@ mod unconfirmed_disputes {
 
 		// v0 votes for 4, v1 votes against 4.
 		DisputeStatementSet {
-			candidate_hash: candidate_hash.clone(),
+			candidate_hash: candidate_hash,
 			session: 4,
 			statements: vec![
 				(
@@ -931,7 +931,7 @@ mod unconfirmed_disputes {
 					v0.sign(
 						&ExplicitDisputeStatement {
 							valid: true,
-							candidate_hash: candidate_hash.clone(),
+							candidate_hash: candidate_hash,
 							session: 4,
 						}
 						.signing_payload(),
@@ -943,7 +943,7 @@ mod unconfirmed_disputes {
 					v1.sign(
 						&ExplicitDisputeStatement {
 							valid: false,
-							candidate_hash: candidate_hash.clone(),
+							candidate_hash: candidate_hash,
 							session: 4,
 						}
 						.signing_payload(),
@@ -1037,7 +1037,7 @@ fn test_provide_multi_dispute_success_and_other() {
 
 		// v0 and v1 vote for 3, v6 votes against
 		let stmts = vec![DisputeStatementSet {
-			candidate_hash: candidate_hash.clone(),
+			candidate_hash: candidate_hash,
 			session,
 			statements: vec![
 				(
@@ -1055,7 +1055,7 @@ fn test_provide_multi_dispute_success_and_other() {
 					v6.sign(
 						&ExplicitDisputeStatement {
 							valid: false,
-							candidate_hash: candidate_hash.clone(),
+							candidate_hash: candidate_hash,
 							session,
 						}
 						.signing_payload(),
@@ -1067,7 +1067,7 @@ fn test_provide_multi_dispute_success_and_other() {
 					v1.sign(
 						&ExplicitDisputeStatement {
 							valid: true,
-							candidate_hash: candidate_hash.clone(),
+							candidate_hash: candidate_hash,
 							session: 3,
 						}
 						.signing_payload(),
@@ -1080,13 +1080,13 @@ fn test_provide_multi_dispute_success_and_other() {
 
 		assert_ok!(
 			Pallet::<Test>::process_checked_multi_dispute_data(&stmts),
-			vec![(3, candidate_hash.clone())],
+			vec![(3, candidate_hash)],
 		);
 
 		// v3 votes against 3 and for 5, v2 and v6 vote against 5.
 		let stmts = vec![
 			DisputeStatementSet {
-				candidate_hash: candidate_hash.clone(),
+				candidate_hash: candidate_hash,
 				session: 3,
 				statements: vec![(
 					DisputeStatement::Invalid(InvalidDisputeStatementKind::Explicit),
@@ -1094,7 +1094,7 @@ fn test_provide_multi_dispute_success_and_other() {
 					v3.sign(
 						&ExplicitDisputeStatement {
 							valid: false,
-							candidate_hash: candidate_hash.clone(),
+							candidate_hash: candidate_hash,
 							session: 3,
 						}
 						.signing_payload(),
@@ -1102,7 +1102,7 @@ fn test_provide_multi_dispute_success_and_other() {
 				)],
 			},
 			DisputeStatementSet {
-				candidate_hash: candidate_hash.clone(),
+				candidate_hash: candidate_hash,
 				session: 5,
 				statements: vec![
 					(
@@ -1120,7 +1120,7 @@ fn test_provide_multi_dispute_success_and_other() {
 						v2.sign(
 							&ExplicitDisputeStatement {
 								valid: false,
-								candidate_hash: candidate_hash.clone(),
+								candidate_hash: candidate_hash,
 								session: 5,
 							}
 							.signing_payload(),
@@ -1132,7 +1132,7 @@ fn test_provide_multi_dispute_success_and_other() {
 						v6.sign(
 							&ExplicitDisputeStatement {
 								valid: false,
-								candidate_hash: candidate_hash.clone(),
+								candidate_hash: candidate_hash,
 								session: 5,
 							}
 							.signing_payload(),
@@ -1145,12 +1145,12 @@ fn test_provide_multi_dispute_success_and_other() {
 		let stmts = filter_dispute_set(stmts);
 		assert_ok!(
 			Pallet::<Test>::process_checked_multi_dispute_data(&stmts),
-			vec![(5, candidate_hash.clone())],
+			vec![(5, candidate_hash)],
 		);
 
 		// v2 votes for 3
 		let stmts = vec![DisputeStatementSet {
-			candidate_hash: candidate_hash.clone(),
+			candidate_hash: candidate_hash,
 			session: 3,
 			statements: vec![(
 				DisputeStatement::Valid(ValidDisputeStatementKind::Explicit),
@@ -1158,7 +1158,7 @@ fn test_provide_multi_dispute_success_and_other() {
 				v2.sign(
 					&ExplicitDisputeStatement {
 						valid: true,
-						candidate_hash: candidate_hash.clone(),
+						candidate_hash: candidate_hash,
 						session: 3,
 					}
 					.signing_payload(),
@@ -1171,7 +1171,7 @@ fn test_provide_multi_dispute_success_and_other() {
 		let stmts = vec![
 			// 0, 4, and 5 vote against 5
 			DisputeStatementSet {
-				candidate_hash: candidate_hash.clone(),
+				candidate_hash: candidate_hash,
 				session: 5,
 				statements: vec![
 					(
@@ -1180,7 +1180,7 @@ fn test_provide_multi_dispute_success_and_other() {
 						v0.sign(
 							&ExplicitDisputeStatement {
 								valid: false,
-								candidate_hash: candidate_hash.clone(),
+								candidate_hash: candidate_hash,
 								session: 5,
 							}
 							.signing_payload(),
@@ -1192,7 +1192,7 @@ fn test_provide_multi_dispute_success_and_other() {
 						v4.sign(
 							&ExplicitDisputeStatement {
 								valid: false,
-								candidate_hash: candidate_hash.clone(),
+								candidate_hash: candidate_hash,
 								session: 5,
 							}
 							.signing_payload(),
@@ -1204,7 +1204,7 @@ fn test_provide_multi_dispute_success_and_other() {
 						v5.sign(
 							&ExplicitDisputeStatement {
 								valid: false,
-								candidate_hash: candidate_hash.clone(),
+								candidate_hash: candidate_hash,
 								session: 5,
 							}
 							.signing_payload(),
@@ -1214,7 +1214,7 @@ fn test_provide_multi_dispute_success_and_other() {
 			},
 			// 4 and 5 vote for 3
 			DisputeStatementSet {
-				candidate_hash: candidate_hash.clone(),
+				candidate_hash: candidate_hash,
 				session: 3,
 				statements: vec![
 					(
@@ -1223,7 +1223,7 @@ fn test_provide_multi_dispute_success_and_other() {
 						v4.sign(
 							&ExplicitDisputeStatement {
 								valid: true,
-								candidate_hash: candidate_hash.clone(),
+								candidate_hash: candidate_hash,
 								session: 3,
 							}
 							.signing_payload(),
@@ -1235,7 +1235,7 @@ fn test_provide_multi_dispute_success_and_other() {
 						v5.sign(
 							&ExplicitDisputeStatement {
 								valid: true,
-								candidate_hash: candidate_hash.clone(),
+								candidate_hash: candidate_hash,
 								session: 3,
 							}
 							.signing_payload(),
@@ -1252,7 +1252,7 @@ fn test_provide_multi_dispute_success_and_other() {
 			vec![
 				(
 					5,
-					candidate_hash.clone(),
+					candidate_hash,
 					DisputeState {
 						validators_for: bitvec![u8, BitOrderLsb0; 0, 0, 0, 0, 0, 1, 0],
 						validators_against: bitvec![u8, BitOrderLsb0; 1, 1, 1, 0, 1, 0, 1],
@@ -1262,7 +1262,7 @@ fn test_provide_multi_dispute_success_and_other() {
 				),
 				(
 					3,
-					candidate_hash.clone(),
+					candidate_hash,
 					DisputeState {
 						validators_for: bitvec![u8, BitOrderLsb0; 1, 1, 0, 1, 1, 0, 1],
 						validators_against: bitvec![u8, BitOrderLsb0; 0, 0, 1, 0, 0, 1, 0],
@@ -1273,9 +1273,9 @@ fn test_provide_multi_dispute_success_and_other() {
 			]
 		);
 
-		assert!(!Pallet::<Test>::concluded_invalid(3, candidate_hash.clone()));
-		assert!(!Pallet::<Test>::concluded_invalid(4, candidate_hash.clone()));
-		assert!(Pallet::<Test>::concluded_invalid(5, candidate_hash.clone()));
+		assert!(!Pallet::<Test>::concluded_invalid(3, candidate_hash));
+		assert!(!Pallet::<Test>::concluded_invalid(4, candidate_hash));
+		assert!(Pallet::<Test>::concluded_invalid(5, candidate_hash));
 
 		// Ensure the `reward_validator` function was correctly called
 		assert_eq!(
@@ -1372,7 +1372,7 @@ fn test_punish_post_conclusion() {
 		let session = 3;
 
 		let stmts = vec![DisputeStatementSet {
-			candidate_hash: candidate_hash.clone(),
+			candidate_hash: candidate_hash,
 			session,
 			statements: vec![
 				(
@@ -1390,7 +1390,7 @@ fn test_punish_post_conclusion() {
 					v4.sign(
 						&ExplicitDisputeStatement {
 							valid: false,
-							candidate_hash: candidate_hash.clone(),
+							candidate_hash: candidate_hash,
 							session,
 						}
 						.signing_payload(),
@@ -1402,7 +1402,7 @@ fn test_punish_post_conclusion() {
 					v6.sign(
 						&ExplicitDisputeStatement {
 							valid: false,
-							candidate_hash: candidate_hash.clone(),
+							candidate_hash: candidate_hash,
 							session,
 						}
 						.signing_payload(),
@@ -1414,7 +1414,7 @@ fn test_punish_post_conclusion() {
 					v2.sign(
 						&ExplicitDisputeStatement {
 							valid: false,
-							candidate_hash: candidate_hash.clone(),
+							candidate_hash: candidate_hash,
 							session,
 						}
 						.signing_payload(),
@@ -1426,7 +1426,7 @@ fn test_punish_post_conclusion() {
 					v5.sign(
 						&ExplicitDisputeStatement {
 							valid: false,
-							candidate_hash: candidate_hash.clone(),
+							candidate_hash: candidate_hash,
 							session,
 						}
 						.signing_payload(),
@@ -1438,7 +1438,7 @@ fn test_punish_post_conclusion() {
 					v3.sign(
 						&ExplicitDisputeStatement {
 							valid: false,
-							candidate_hash: candidate_hash.clone(),
+							candidate_hash: candidate_hash,
 							session,
 						}
 						.signing_payload(),
@@ -1469,7 +1469,7 @@ fn test_punish_post_conclusion() {
 
 		// someone reveals 3 backing vote, 6 votes against
 		let stmts = vec![DisputeStatementSet {
-			candidate_hash: candidate_hash.clone(),
+			candidate_hash: candidate_hash,
 			session,
 			statements: vec![
 				(
@@ -1487,7 +1487,7 @@ fn test_punish_post_conclusion() {
 					v2.sign(
 						&ExplicitDisputeStatement {
 							valid: false,
-							candidate_hash: candidate_hash.clone(),
+							candidate_hash: candidate_hash,
 							session,
 						}
 						.signing_payload(),
@@ -1601,35 +1601,35 @@ fn test_check_signature() {
 
 	let statement_1 = DisputeStatement::Valid(ValidDisputeStatementKind::Explicit);
 	let statement_2 = DisputeStatement::Valid(ValidDisputeStatementKind::BackingSeconded(
-		inclusion_parent.clone(),
+		inclusion_parent,
 	));
 	let wrong_statement_2 = DisputeStatement::Valid(ValidDisputeStatementKind::BackingSeconded(
-		wrong_inclusion_parent.clone(),
+		wrong_inclusion_parent,
 	));
 	let statement_3 =
-		DisputeStatement::Valid(ValidDisputeStatementKind::BackingValid(inclusion_parent.clone()));
+		DisputeStatement::Valid(ValidDisputeStatementKind::BackingValid(inclusion_parent));
 	let wrong_statement_3 = DisputeStatement::Valid(ValidDisputeStatementKind::BackingValid(
-		wrong_inclusion_parent.clone(),
+		wrong_inclusion_parent,
 	));
 	let statement_4 = DisputeStatement::Valid(ValidDisputeStatementKind::ApprovalChecking);
 	let statement_5 = DisputeStatement::Invalid(InvalidDisputeStatementKind::Explicit);
 
 	let signed_1 = validator_id.sign(
-		&ExplicitDisputeStatement { valid: true, candidate_hash: candidate_hash.clone(), session }
+		&ExplicitDisputeStatement { valid: true, candidate_hash: candidate_hash, session }
 			.signing_payload(),
 	);
 	let signed_2 =
-		validator_id.sign(&CompactStatement::Seconded(candidate_hash.clone()).signing_payload(
-			&SigningContext { session_index: session, parent_hash: inclusion_parent.clone() },
+		validator_id.sign(&CompactStatement::Seconded(candidate_hash).signing_payload(
+			&SigningContext { session_index: session, parent_hash: inclusion_parent },
 		));
 	let signed_3 =
-		validator_id.sign(&CompactStatement::Valid(candidate_hash.clone()).signing_payload(
-			&SigningContext { session_index: session, parent_hash: inclusion_parent.clone() },
+		validator_id.sign(&CompactStatement::Valid(candidate_hash).signing_payload(
+			&SigningContext { session_index: session, parent_hash: inclusion_parent },
 		));
 	let signed_4 =
-		validator_id.sign(&ApprovalVote(candidate_hash.clone()).signing_payload(session));
+		validator_id.sign(&ApprovalVote(candidate_hash).signing_payload(session));
 	let signed_5 = validator_id.sign(
-		&ExplicitDisputeStatement { valid: false, candidate_hash: candidate_hash.clone(), session }
+		&ExplicitDisputeStatement { valid: false, candidate_hash: candidate_hash, session }
 			.signing_payload(),
 	);
 
@@ -2008,7 +2008,7 @@ fn deduplication_and_sorting_works() {
 		                                 valid,
 		                                 session| {
 			let payload =
-				ExplicitDisputeStatement { valid, candidate_hash: c_hash.clone(), session }
+				ExplicitDisputeStatement { valid, candidate_hash: *c_hash, session }
 					.signing_payload();
 			let sig = validator.sign(&payload);
 			(DisputeStatement::Valid(ValidDisputeStatementKind::Explicit), vidx, sig.clone())
@@ -2031,24 +2031,24 @@ fn deduplication_and_sorting_works() {
 
 		let mut disputes = vec![
 			DisputeStatementSet {
-				candidate_hash: candidate_hash_b.clone(),
+				candidate_hash: candidate_hash_b,
 				session: 2,
 				statements: vec![explicit_triple_b.clone(), explicit_triple_b_bad.clone()],
 			},
 			// same session as above
 			DisputeStatementSet {
-				candidate_hash: candidate_hash_c.clone(),
+				candidate_hash: candidate_hash_c,
 				session: 2,
 				statements: vec![explicit_triple_c, explicit_triple_c_bad],
 			},
 			// the duplicate set
 			DisputeStatementSet {
-				candidate_hash: candidate_hash_b.clone(),
+				candidate_hash: candidate_hash_b,
 				session: 2,
 				statements: vec![explicit_triple_b.clone(), explicit_triple_b_bad.clone()],
 			},
 			DisputeStatementSet {
-				candidate_hash: candidate_hash_a.clone(),
+				candidate_hash: candidate_hash_a,
 				session: 1,
 				statements: vec![explicit_triple_a, explicit_triple_a_bad],
 			},
@@ -2118,14 +2118,14 @@ fn filter_removes_duplicates_within_set() {
 
 		let payload = ExplicitDisputeStatement {
 			valid: true,
-			candidate_hash: candidate_hash.clone(),
+			candidate_hash: candidate_hash,
 			session: 1,
 		}
 		.signing_payload();
 
 		let payload_against = ExplicitDisputeStatement {
 			valid: false,
-			candidate_hash: candidate_hash.clone(),
+			candidate_hash: candidate_hash,
 			session: 1,
 		}
 		.signing_payload();
@@ -2136,7 +2136,7 @@ fn filter_removes_duplicates_within_set() {
 		let sig_d = v1.sign(&payload_against);
 
 		let statements = DisputeStatementSet {
-			candidate_hash: candidate_hash.clone(),
+			candidate_hash: candidate_hash,
 			session: 1,
 			statements: vec![
 				(
@@ -2172,7 +2172,7 @@ fn filter_removes_duplicates_within_set() {
 		assert_eq!(
 			statements,
 			Some(CheckedDisputeStatementSet::unchecked_from_unchecked(DisputeStatementSet {
-				candidate_hash: candidate_hash.clone(),
+				candidate_hash: candidate_hash,
 				session: 1,
 				statements: vec![
 					(
@@ -2217,7 +2217,7 @@ fn filter_bad_signatures_correctly_detects_single_sided() {
 		let candidate_hash_a = CandidateHash(sp_core::H256::repeat_byte(1));
 
 		let payload = |c_hash: &CandidateHash, valid| {
-			ExplicitDisputeStatement { valid, candidate_hash: c_hash.clone(), session: 1 }
+			ExplicitDisputeStatement { valid, candidate_hash: *c_hash, session: 1 }
 				.signing_payload()
 		};
 
@@ -2228,7 +2228,7 @@ fn filter_bad_signatures_correctly_detects_single_sided() {
 		let sig_1 = v1.sign(&payload_a_bad);
 
 		let statements = vec![DisputeStatementSet {
-			candidate_hash: candidate_hash_a.clone(),
+			candidate_hash: candidate_hash_a,
 			session: 1,
 			statements: vec![
 				(
@@ -2264,7 +2264,7 @@ fn filter_removes_session_out_of_bounds() {
 
 		let payload = ExplicitDisputeStatement {
 			valid: true,
-			candidate_hash: candidate_hash.clone(),
+			candidate_hash: candidate_hash,
 			session: 1,
 		}
 		.signing_payload();
@@ -2272,7 +2272,7 @@ fn filter_removes_session_out_of_bounds() {
 		let sig_a = v0.sign(&payload);
 
 		let statements = vec![DisputeStatementSet {
-			candidate_hash: candidate_hash.clone(),
+			candidate_hash: candidate_hash,
 			session: 100,
 			statements: vec![(
 				DisputeStatement::Valid(ValidDisputeStatementKind::Explicit),
@@ -2337,14 +2337,14 @@ fn filter_removes_concluded_ancient() {
 
 		let payload_a = ExplicitDisputeStatement {
 			valid: true,
-			candidate_hash: candidate_hash_a.clone(),
+			candidate_hash: candidate_hash_a,
 			session: 1,
 		}
 		.signing_payload();
 
 		let payload_b = ExplicitDisputeStatement {
 			valid: true,
-			candidate_hash: candidate_hash_b.clone(),
+			candidate_hash: candidate_hash_b,
 			session: 1,
 		}
 		.signing_payload();
@@ -2354,7 +2354,7 @@ fn filter_removes_concluded_ancient() {
 
 		let statements = vec![
 			DisputeStatementSet {
-				candidate_hash: candidate_hash_a.clone(),
+				candidate_hash: candidate_hash_a,
 				session: 1,
 				statements: vec![(
 					DisputeStatement::Valid(ValidDisputeStatementKind::Explicit),
@@ -2363,7 +2363,7 @@ fn filter_removes_concluded_ancient() {
 				)],
 			},
 			DisputeStatementSet {
-				candidate_hash: candidate_hash_b.clone(),
+				candidate_hash: candidate_hash_b,
 				session: 1,
 				statements: vec![(
 					DisputeStatement::Valid(ValidDisputeStatementKind::Explicit),
@@ -2378,7 +2378,7 @@ fn filter_removes_concluded_ancient() {
 		assert_eq!(
 			statements,
 			vec![CheckedDisputeStatementSet::unchecked_from_unchecked(DisputeStatementSet {
-				candidate_hash: candidate_hash_b.clone(),
+				candidate_hash: candidate_hash_b,
 				session: 1,
 				statements: vec![(
 					DisputeStatement::Valid(ValidDisputeStatementKind::Explicit),
@@ -2410,14 +2410,14 @@ fn filter_removes_duplicate_statements_sets() {
 
 		let payload = ExplicitDisputeStatement {
 			valid: true,
-			candidate_hash: candidate_hash_a.clone(),
+			candidate_hash: candidate_hash_a,
 			session: 1,
 		}
 		.signing_payload();
 
 		let payload_against = ExplicitDisputeStatement {
 			valid: false,
-			candidate_hash: candidate_hash_a.clone(),
+			candidate_hash: candidate_hash_a,
 			session: 1,
 		}
 		.signing_payload();
@@ -2440,12 +2440,12 @@ fn filter_removes_duplicate_statements_sets() {
 
 		let mut sets = vec![
 			DisputeStatementSet {
-				candidate_hash: candidate_hash_a.clone(),
+				candidate_hash: candidate_hash_a,
 				session: 1,
 				statements: statements.clone(),
 			},
 			DisputeStatementSet {
-				candidate_hash: candidate_hash_a.clone(),
+				candidate_hash: candidate_hash_a,
 				session: 1,
 				statements: statements.clone(),
 			},
@@ -2460,7 +2460,7 @@ fn filter_removes_duplicate_statements_sets() {
 		assert_eq!(
 			sets,
 			vec![DisputeStatementSet {
-				candidate_hash: candidate_hash_a.clone(),
+				candidate_hash: candidate_hash_a,
 				session: 1,
 				statements,
 			}]
@@ -2482,7 +2482,7 @@ fn filter_ignores_single_sided() {
 
 		let payload = ExplicitDisputeStatement {
 			valid: true,
-			candidate_hash: candidate_hash_a.clone(),
+			candidate_hash: candidate_hash_a,
 			session: 1,
 		}
 		.signing_payload();
@@ -2490,7 +2490,7 @@ fn filter_ignores_single_sided() {
 		let sig_a = v0.sign(&payload);
 
 		let statements = vec![DisputeStatementSet {
-			candidate_hash: candidate_hash_a.clone(),
+			candidate_hash: candidate_hash_a,
 			session: 1,
 			statements: vec![(
 				DisputeStatement::Valid(ValidDisputeStatementKind::Explicit),
@@ -2519,7 +2519,7 @@ fn import_ignores_single_sided() {
 
 		let payload = ExplicitDisputeStatement {
 			valid: true,
-			candidate_hash: candidate_hash_a.clone(),
+			candidate_hash: candidate_hash_a,
 			session: 1,
 		}
 		.signing_payload();
@@ -2527,7 +2527,7 @@ fn import_ignores_single_sided() {
 		let sig_a = v0.sign(&payload);
 
 		let statements = vec![DisputeStatementSet {
-			candidate_hash: candidate_hash_a.clone(),
+			candidate_hash: candidate_hash_a,
 			session: 1,
 			statements: vec![(
 				DisputeStatement::Valid(ValidDisputeStatementKind::Explicit),

--- a/runtime/parachains/src/disputes/tests.rs
+++ b/runtime/parachains/src/disputes/tests.rs
@@ -464,7 +464,7 @@ fn test_provide_multi_dispute_is_providing() {
 		let inclusion_parent = sp_core::H256::repeat_byte(0xff);
 		let session = 1;
 		let stmts = vec![DisputeStatementSet {
-			candidate_hash: candidate_hash,
+			candidate_hash,
 			session,
 			statements: vec![
 				(
@@ -480,12 +480,8 @@ fn test_provide_multi_dispute_is_providing() {
 					DisputeStatement::Invalid(InvalidDisputeStatementKind::Explicit),
 					ValidatorIndex(1),
 					v1.sign(
-						&ExplicitDisputeStatement {
-							valid: false,
-							candidate_hash: candidate_hash,
-							session,
-						}
-						.signing_payload(),
+						&ExplicitDisputeStatement { valid: false, candidate_hash, session }
+							.signing_payload(),
 					),
 				),
 			],
@@ -527,31 +523,23 @@ fn test_disputes_with_missing_backing_votes_are_rejected() {
 		let session = 1;
 
 		let stmts = vec![DisputeStatementSet {
-			candidate_hash: candidate_hash,
+			candidate_hash,
 			session,
 			statements: vec![
 				(
 					DisputeStatement::Valid(ValidDisputeStatementKind::Explicit),
 					ValidatorIndex(0),
 					v0.sign(
-						&ExplicitDisputeStatement {
-							valid: true,
-							candidate_hash: candidate_hash,
-							session,
-						}
-						.signing_payload(),
+						&ExplicitDisputeStatement { valid: true, candidate_hash, session }
+							.signing_payload(),
 					),
 				),
 				(
 					DisputeStatement::Invalid(InvalidDisputeStatementKind::Explicit),
 					ValidatorIndex(1),
 					v1.sign(
-						&ExplicitDisputeStatement {
-							valid: false,
-							candidate_hash: candidate_hash,
-							session,
-						}
-						.signing_payload(),
+						&ExplicitDisputeStatement { valid: false, candidate_hash, session }
+							.signing_payload(),
 					),
 				),
 			],
@@ -589,31 +577,23 @@ fn test_freeze_on_note_included() {
 
 		// v0 votes for 3
 		let stmts = vec![DisputeStatementSet {
-			candidate_hash: candidate_hash,
+			candidate_hash,
 			session: 3,
 			statements: vec![
 				(
 					DisputeStatement::Invalid(InvalidDisputeStatementKind::Explicit),
 					ValidatorIndex(0),
 					v0.sign(
-						&ExplicitDisputeStatement {
-							valid: false,
-							candidate_hash: candidate_hash,
-							session: 3,
-						}
-						.signing_payload(),
+						&ExplicitDisputeStatement { valid: false, candidate_hash, session: 3 }
+							.signing_payload(),
 					),
 				),
 				(
 					DisputeStatement::Invalid(InvalidDisputeStatementKind::Explicit),
 					ValidatorIndex(1),
 					v1.sign(
-						&ExplicitDisputeStatement {
-							valid: false,
-							candidate_hash: candidate_hash,
-							session: 3,
-						}
-						.signing_payload(),
+						&ExplicitDisputeStatement { valid: false, candidate_hash, session: 3 }
+							.signing_payload(),
 					),
 				),
 				(
@@ -662,31 +642,23 @@ fn test_freeze_provided_against_supermajority_for_included() {
 
 		// v0 votes for 3
 		let stmts = vec![DisputeStatementSet {
-			candidate_hash: candidate_hash,
+			candidate_hash,
 			session,
 			statements: vec![
 				(
 					DisputeStatement::Invalid(InvalidDisputeStatementKind::Explicit),
 					ValidatorIndex(0),
 					v0.sign(
-						&ExplicitDisputeStatement {
-							valid: false,
-							candidate_hash: candidate_hash,
-							session,
-						}
-						.signing_payload(),
+						&ExplicitDisputeStatement { valid: false, candidate_hash, session }
+							.signing_payload(),
 					),
 				),
 				(
 					DisputeStatement::Invalid(InvalidDisputeStatementKind::Explicit),
 					ValidatorIndex(1),
 					v1.sign(
-						&ExplicitDisputeStatement {
-							valid: false,
-							candidate_hash: candidate_hash,
-							session,
-						}
-						.signing_payload(),
+						&ExplicitDisputeStatement { valid: false, candidate_hash, session }
+							.signing_payload(),
 					),
 				),
 				(
@@ -743,43 +715,31 @@ fn test_freeze_provided_against_byzantine_threshold_for_included() {
 
 		// A byzantine threshold of INVALID
 		let stmts = vec![DisputeStatementSet {
-			candidate_hash: candidate_hash,
+			candidate_hash,
 			session,
 			statements: vec![
 				(
 					DisputeStatement::Invalid(InvalidDisputeStatementKind::Explicit),
 					ValidatorIndex(0),
 					v0.sign(
-						&ExplicitDisputeStatement {
-							valid: false,
-							candidate_hash: candidate_hash,
-							session,
-						}
-						.signing_payload(),
+						&ExplicitDisputeStatement { valid: false, candidate_hash, session }
+							.signing_payload(),
 					),
 				),
 				(
 					DisputeStatement::Invalid(InvalidDisputeStatementKind::Explicit),
 					ValidatorIndex(1),
 					v1.sign(
-						&ExplicitDisputeStatement {
-							valid: false,
-							candidate_hash: candidate_hash,
-							session,
-						}
-						.signing_payload(),
+						&ExplicitDisputeStatement { valid: false, candidate_hash, session }
+							.signing_payload(),
 					),
 				),
 				(
 					DisputeStatement::Invalid(InvalidDisputeStatementKind::Explicit),
 					ValidatorIndex(2),
 					v2.sign(
-						&ExplicitDisputeStatement {
-							valid: false,
-							candidate_hash: candidate_hash,
-							session,
-						}
-						.signing_payload(),
+						&ExplicitDisputeStatement { valid: false, candidate_hash, session }
+							.signing_payload(),
 					),
 				),
 				(
@@ -812,43 +772,31 @@ fn test_freeze_provided_against_byzantine_threshold_for_included() {
 
 		// And generate enough votes to reach supermajority of invalid votes
 		let stmts = vec![DisputeStatementSet {
-			candidate_hash: candidate_hash,
+			candidate_hash,
 			session,
 			statements: vec![
 				(
 					DisputeStatement::Invalid(InvalidDisputeStatementKind::Explicit),
 					ValidatorIndex(3),
 					v3.sign(
-						&ExplicitDisputeStatement {
-							valid: false,
-							candidate_hash: candidate_hash,
-							session,
-						}
-						.signing_payload(),
+						&ExplicitDisputeStatement { valid: false, candidate_hash, session }
+							.signing_payload(),
 					),
 				),
 				(
 					DisputeStatement::Invalid(InvalidDisputeStatementKind::Explicit),
 					ValidatorIndex(4),
 					v4.sign(
-						&ExplicitDisputeStatement {
-							valid: false,
-							candidate_hash: candidate_hash,
-							session,
-						}
-						.signing_payload(),
+						&ExplicitDisputeStatement { valid: false, candidate_hash, session }
+							.signing_payload(),
 					),
 				),
 				(
 					DisputeStatement::Invalid(InvalidDisputeStatementKind::Explicit),
 					ValidatorIndex(5),
 					v5.sign(
-						&ExplicitDisputeStatement {
-							valid: false,
-							candidate_hash: candidate_hash,
-							session,
-						}
-						.signing_payload(),
+						&ExplicitDisputeStatement { valid: false, candidate_hash, session }
+							.signing_payload(),
 					),
 				),
 			],
@@ -921,31 +869,23 @@ mod unconfirmed_disputes {
 
 		// v0 votes for 4, v1 votes against 4.
 		DisputeStatementSet {
-			candidate_hash: candidate_hash,
+			candidate_hash,
 			session: 4,
 			statements: vec![
 				(
 					DisputeStatement::Valid(ValidDisputeStatementKind::Explicit),
 					ValidatorIndex(0),
 					v0.sign(
-						&ExplicitDisputeStatement {
-							valid: true,
-							candidate_hash: candidate_hash,
-							session: 4,
-						}
-						.signing_payload(),
+						&ExplicitDisputeStatement { valid: true, candidate_hash, session: 4 }
+							.signing_payload(),
 					),
 				),
 				(
 					DisputeStatement::Invalid(InvalidDisputeStatementKind::Explicit),
 					ValidatorIndex(3),
 					v1.sign(
-						&ExplicitDisputeStatement {
-							valid: false,
-							candidate_hash: candidate_hash,
-							session: 4,
-						}
-						.signing_payload(),
+						&ExplicitDisputeStatement { valid: false, candidate_hash, session: 4 }
+							.signing_payload(),
 					),
 				),
 			],
@@ -1036,7 +976,7 @@ fn test_provide_multi_dispute_success_and_other() {
 
 		// v0 and v1 vote for 3, v6 votes against
 		let stmts = vec![DisputeStatementSet {
-			candidate_hash: candidate_hash,
+			candidate_hash,
 			session,
 			statements: vec![
 				(
@@ -1052,24 +992,16 @@ fn test_provide_multi_dispute_success_and_other() {
 					DisputeStatement::Invalid(InvalidDisputeStatementKind::Explicit),
 					ValidatorIndex(2),
 					v6.sign(
-						&ExplicitDisputeStatement {
-							valid: false,
-							candidate_hash: candidate_hash,
-							session,
-						}
-						.signing_payload(),
+						&ExplicitDisputeStatement { valid: false, candidate_hash, session }
+							.signing_payload(),
 					),
 				),
 				(
 					DisputeStatement::Valid(ValidDisputeStatementKind::Explicit),
 					ValidatorIndex(3),
 					v1.sign(
-						&ExplicitDisputeStatement {
-							valid: true,
-							candidate_hash: candidate_hash,
-							session: 3,
-						}
-						.signing_payload(),
+						&ExplicitDisputeStatement { valid: true, candidate_hash, session: 3 }
+							.signing_payload(),
 					),
 				),
 			],
@@ -1085,23 +1017,19 @@ fn test_provide_multi_dispute_success_and_other() {
 		// v3 votes against 3 and for 5, v2 and v6 vote against 5.
 		let stmts = vec![
 			DisputeStatementSet {
-				candidate_hash: candidate_hash,
+				candidate_hash,
 				session: 3,
 				statements: vec![(
 					DisputeStatement::Invalid(InvalidDisputeStatementKind::Explicit),
 					ValidatorIndex(5),
 					v3.sign(
-						&ExplicitDisputeStatement {
-							valid: false,
-							candidate_hash: candidate_hash,
-							session: 3,
-						}
-						.signing_payload(),
+						&ExplicitDisputeStatement { valid: false, candidate_hash, session: 3 }
+							.signing_payload(),
 					),
 				)],
 			},
 			DisputeStatementSet {
-				candidate_hash: candidate_hash,
+				candidate_hash,
 				session: 5,
 				statements: vec![
 					(
@@ -1117,24 +1045,16 @@ fn test_provide_multi_dispute_success_and_other() {
 						DisputeStatement::Invalid(InvalidDisputeStatementKind::Explicit),
 						ValidatorIndex(6),
 						v2.sign(
-							&ExplicitDisputeStatement {
-								valid: false,
-								candidate_hash: candidate_hash,
-								session: 5,
-							}
-							.signing_payload(),
+							&ExplicitDisputeStatement { valid: false, candidate_hash, session: 5 }
+								.signing_payload(),
 						),
 					),
 					(
 						DisputeStatement::Invalid(InvalidDisputeStatementKind::Explicit),
 						ValidatorIndex(2),
 						v6.sign(
-							&ExplicitDisputeStatement {
-								valid: false,
-								candidate_hash: candidate_hash,
-								session: 5,
-							}
-							.signing_payload(),
+							&ExplicitDisputeStatement { valid: false, candidate_hash, session: 5 }
+								.signing_payload(),
 						),
 					),
 				],
@@ -1149,18 +1069,14 @@ fn test_provide_multi_dispute_success_and_other() {
 
 		// v2 votes for 3
 		let stmts = vec![DisputeStatementSet {
-			candidate_hash: candidate_hash,
+			candidate_hash,
 			session: 3,
 			statements: vec![(
 				DisputeStatement::Valid(ValidDisputeStatementKind::Explicit),
 				ValidatorIndex(6),
 				v2.sign(
-					&ExplicitDisputeStatement {
-						valid: true,
-						candidate_hash: candidate_hash,
-						session: 3,
-					}
-					.signing_payload(),
+					&ExplicitDisputeStatement { valid: true, candidate_hash, session: 3 }
+						.signing_payload(),
 				),
 			)],
 		}];
@@ -1170,74 +1086,54 @@ fn test_provide_multi_dispute_success_and_other() {
 		let stmts = vec![
 			// 0, 4, and 5 vote against 5
 			DisputeStatementSet {
-				candidate_hash: candidate_hash,
+				candidate_hash,
 				session: 5,
 				statements: vec![
 					(
 						DisputeStatement::Invalid(InvalidDisputeStatementKind::Explicit),
 						ValidatorIndex(0),
 						v0.sign(
-							&ExplicitDisputeStatement {
-								valid: false,
-								candidate_hash: candidate_hash,
-								session: 5,
-							}
-							.signing_payload(),
+							&ExplicitDisputeStatement { valid: false, candidate_hash, session: 5 }
+								.signing_payload(),
 						),
 					),
 					(
 						DisputeStatement::Invalid(InvalidDisputeStatementKind::Explicit),
 						ValidatorIndex(1),
 						v4.sign(
-							&ExplicitDisputeStatement {
-								valid: false,
-								candidate_hash: candidate_hash,
-								session: 5,
-							}
-							.signing_payload(),
+							&ExplicitDisputeStatement { valid: false, candidate_hash, session: 5 }
+								.signing_payload(),
 						),
 					),
 					(
 						DisputeStatement::Invalid(InvalidDisputeStatementKind::Explicit),
 						ValidatorIndex(4),
 						v5.sign(
-							&ExplicitDisputeStatement {
-								valid: false,
-								candidate_hash: candidate_hash,
-								session: 5,
-							}
-							.signing_payload(),
+							&ExplicitDisputeStatement { valid: false, candidate_hash, session: 5 }
+								.signing_payload(),
 						),
 					),
 				],
 			},
 			// 4 and 5 vote for 3
 			DisputeStatementSet {
-				candidate_hash: candidate_hash,
+				candidate_hash,
 				session: 3,
 				statements: vec![
 					(
 						DisputeStatement::Valid(ValidDisputeStatementKind::Explicit),
 						ValidatorIndex(1),
 						v4.sign(
-							&ExplicitDisputeStatement {
-								valid: true,
-								candidate_hash: candidate_hash,
-								session: 3,
-							}
-							.signing_payload(),
+							&ExplicitDisputeStatement { valid: true, candidate_hash, session: 3 }
+								.signing_payload(),
 						),
 					),
 					(
 						DisputeStatement::Valid(ValidDisputeStatementKind::Explicit),
 						ValidatorIndex(4),
 						v5.sign(
-							&ExplicitDisputeStatement {
-								valid: true,
-								candidate_hash: candidate_hash,
-								session: 3,
-							}
-							.signing_payload(),
+							&ExplicitDisputeStatement { valid: true, candidate_hash, session: 3 }
+								.signing_payload(),
 						),
 					),
 				],
@@ -1371,7 +1267,7 @@ fn test_punish_post_conclusion() {
 		let session = 3;
 
 		let stmts = vec![DisputeStatementSet {
-			candidate_hash: candidate_hash,
+			candidate_hash,
 			session,
 			statements: vec![
 				(
@@ -1387,60 +1283,40 @@ fn test_punish_post_conclusion() {
 					DisputeStatement::Invalid(InvalidDisputeStatementKind::Explicit),
 					ValidatorIndex(1),
 					v4.sign(
-						&ExplicitDisputeStatement {
-							valid: false,
-							candidate_hash: candidate_hash,
-							session,
-						}
-						.signing_payload(),
+						&ExplicitDisputeStatement { valid: false, candidate_hash, session }
+							.signing_payload(),
 					),
 				),
 				(
 					DisputeStatement::Invalid(InvalidDisputeStatementKind::Explicit),
 					ValidatorIndex(2),
 					v6.sign(
-						&ExplicitDisputeStatement {
-							valid: false,
-							candidate_hash: candidate_hash,
-							session,
-						}
-						.signing_payload(),
+						&ExplicitDisputeStatement { valid: false, candidate_hash, session }
+							.signing_payload(),
 					),
 				),
 				(
 					DisputeStatement::Invalid(InvalidDisputeStatementKind::Explicit),
 					ValidatorIndex(6),
 					v2.sign(
-						&ExplicitDisputeStatement {
-							valid: false,
-							candidate_hash: candidate_hash,
-							session,
-						}
-						.signing_payload(),
+						&ExplicitDisputeStatement { valid: false, candidate_hash, session }
+							.signing_payload(),
 					),
 				),
 				(
 					DisputeStatement::Invalid(InvalidDisputeStatementKind::Explicit),
 					ValidatorIndex(4),
 					v5.sign(
-						&ExplicitDisputeStatement {
-							valid: false,
-							candidate_hash: candidate_hash,
-							session,
-						}
-						.signing_payload(),
+						&ExplicitDisputeStatement { valid: false, candidate_hash, session }
+							.signing_payload(),
 					),
 				),
 				(
 					DisputeStatement::Invalid(InvalidDisputeStatementKind::Explicit),
 					ValidatorIndex(5),
 					v3.sign(
-						&ExplicitDisputeStatement {
-							valid: false,
-							candidate_hash: candidate_hash,
-							session,
-						}
-						.signing_payload(),
+						&ExplicitDisputeStatement { valid: false, candidate_hash, session }
+							.signing_payload(),
 					),
 				),
 				(
@@ -1468,7 +1344,7 @@ fn test_punish_post_conclusion() {
 
 		// someone reveals 3 backing vote, 6 votes against
 		let stmts = vec![DisputeStatementSet {
-			candidate_hash: candidate_hash,
+			candidate_hash,
 			session,
 			statements: vec![
 				(
@@ -1484,12 +1360,8 @@ fn test_punish_post_conclusion() {
 					DisputeStatement::Invalid(InvalidDisputeStatementKind::Explicit),
 					ValidatorIndex(6),
 					v2.sign(
-						&ExplicitDisputeStatement {
-							valid: false,
-							candidate_hash: candidate_hash,
-							session,
-						}
-						.signing_payload(),
+						&ExplicitDisputeStatement { valid: false, candidate_hash, session }
+							.signing_payload(),
 					),
 				),
 			],
@@ -1599,37 +1471,28 @@ fn test_check_signature() {
 	let wrong_inclusion_parent = sp_core::H256::repeat_byte(4);
 
 	let statement_1 = DisputeStatement::Valid(ValidDisputeStatementKind::Explicit);
-	let statement_2 = DisputeStatement::Valid(ValidDisputeStatementKind::BackingSeconded(
-		inclusion_parent,
-	));
-	let wrong_statement_2 = DisputeStatement::Valid(ValidDisputeStatementKind::BackingSeconded(
-		wrong_inclusion_parent,
-	));
+	let statement_2 =
+		DisputeStatement::Valid(ValidDisputeStatementKind::BackingSeconded(inclusion_parent));
+	let wrong_statement_2 =
+		DisputeStatement::Valid(ValidDisputeStatementKind::BackingSeconded(wrong_inclusion_parent));
 	let statement_3 =
 		DisputeStatement::Valid(ValidDisputeStatementKind::BackingValid(inclusion_parent));
-	let wrong_statement_3 = DisputeStatement::Valid(ValidDisputeStatementKind::BackingValid(
-		wrong_inclusion_parent,
-	));
+	let wrong_statement_3 =
+		DisputeStatement::Valid(ValidDisputeStatementKind::BackingValid(wrong_inclusion_parent));
 	let statement_4 = DisputeStatement::Valid(ValidDisputeStatementKind::ApprovalChecking);
 	let statement_5 = DisputeStatement::Invalid(InvalidDisputeStatementKind::Explicit);
 
-	let signed_1 = validator_id.sign(
-		&ExplicitDisputeStatement { valid: true, candidate_hash: candidate_hash, session }
-			.signing_payload(),
-	);
-	let signed_2 =
-		validator_id.sign(&CompactStatement::Seconded(candidate_hash).signing_payload(
-			&SigningContext { session_index: session, parent_hash: inclusion_parent },
-		));
-	let signed_3 =
-		validator_id.sign(&CompactStatement::Valid(candidate_hash).signing_payload(
-			&SigningContext { session_index: session, parent_hash: inclusion_parent },
-		));
-	let signed_4 =
-		validator_id.sign(&ApprovalVote(candidate_hash).signing_payload(session));
+	let signed_1 = validator_id
+		.sign(&ExplicitDisputeStatement { valid: true, candidate_hash, session }.signing_payload());
+	let signed_2 = validator_id.sign(&CompactStatement::Seconded(candidate_hash).signing_payload(
+		&SigningContext { session_index: session, parent_hash: inclusion_parent },
+	));
+	let signed_3 = validator_id.sign(&CompactStatement::Valid(candidate_hash).signing_payload(
+		&SigningContext { session_index: session, parent_hash: inclusion_parent },
+	));
+	let signed_4 = validator_id.sign(&ApprovalVote(candidate_hash).signing_payload(session));
 	let signed_5 = validator_id.sign(
-		&ExplicitDisputeStatement { valid: false, candidate_hash: candidate_hash, session }
-			.signing_payload(),
+		&ExplicitDisputeStatement { valid: false, candidate_hash, session }.signing_payload(),
 	);
 
 	assert!(check_signature(
@@ -2006,9 +1869,8 @@ fn deduplication_and_sorting_works() {
 		                                 c_hash: &CandidateHash,
 		                                 valid,
 		                                 session| {
-			let payload =
-				ExplicitDisputeStatement { valid, candidate_hash: *c_hash, session }
-					.signing_payload();
+			let payload = ExplicitDisputeStatement { valid, candidate_hash: *c_hash, session }
+				.signing_payload();
 			let sig = validator.sign(&payload);
 			(DisputeStatement::Valid(ValidDisputeStatementKind::Explicit), vidx, sig.clone())
 		};
@@ -2115,19 +1977,11 @@ fn filter_removes_duplicates_within_set() {
 
 		let candidate_hash = CandidateHash(sp_core::H256::repeat_byte(1));
 
-		let payload = ExplicitDisputeStatement {
-			valid: true,
-			candidate_hash: candidate_hash,
-			session: 1,
-		}
-		.signing_payload();
+		let payload =
+			ExplicitDisputeStatement { valid: true, candidate_hash, session: 1 }.signing_payload();
 
-		let payload_against = ExplicitDisputeStatement {
-			valid: false,
-			candidate_hash: candidate_hash,
-			session: 1,
-		}
-		.signing_payload();
+		let payload_against =
+			ExplicitDisputeStatement { valid: false, candidate_hash, session: 1 }.signing_payload();
 
 		let sig_a = v0.sign(&payload);
 		let sig_b = v0.sign(&payload);
@@ -2135,7 +1989,7 @@ fn filter_removes_duplicates_within_set() {
 		let sig_d = v1.sign(&payload_against);
 
 		let statements = DisputeStatementSet {
-			candidate_hash: candidate_hash,
+			candidate_hash,
 			session: 1,
 			statements: vec![
 				(
@@ -2171,7 +2025,7 @@ fn filter_removes_duplicates_within_set() {
 		assert_eq!(
 			statements,
 			Some(CheckedDisputeStatementSet::unchecked_from_unchecked(DisputeStatementSet {
-				candidate_hash: candidate_hash,
+				candidate_hash,
 				session: 1,
 				statements: vec![
 					(
@@ -2261,17 +2115,13 @@ fn filter_removes_session_out_of_bounds() {
 
 		let candidate_hash = CandidateHash(sp_core::H256::repeat_byte(1));
 
-		let payload = ExplicitDisputeStatement {
-			valid: true,
-			candidate_hash: candidate_hash,
-			session: 1,
-		}
-		.signing_payload();
+		let payload =
+			ExplicitDisputeStatement { valid: true, candidate_hash, session: 1 }.signing_payload();
 
 		let sig_a = v0.sign(&payload);
 
 		let statements = vec![DisputeStatementSet {
-			candidate_hash: candidate_hash,
+			candidate_hash,
 			session: 100,
 			statements: vec![(
 				DisputeStatement::Valid(ValidDisputeStatementKind::Explicit),
@@ -2333,19 +2183,13 @@ fn filter_removes_concluded_ancient() {
 			},
 		);
 
-		let payload_a = ExplicitDisputeStatement {
-			valid: true,
-			candidate_hash: candidate_hash_a,
-			session: 1,
-		}
-		.signing_payload();
+		let payload_a =
+			ExplicitDisputeStatement { valid: true, candidate_hash: candidate_hash_a, session: 1 }
+				.signing_payload();
 
-		let payload_b = ExplicitDisputeStatement {
-			valid: true,
-			candidate_hash: candidate_hash_b,
-			session: 1,
-		}
-		.signing_payload();
+		let payload_b =
+			ExplicitDisputeStatement { valid: true, candidate_hash: candidate_hash_b, session: 1 }
+				.signing_payload();
 
 		let sig_a = v0.sign(&payload_a);
 		let sig_b = v0.sign(&payload_b);
@@ -2406,19 +2250,13 @@ fn filter_removes_duplicate_statements_sets() {
 
 		let candidate_hash_a = CandidateHash(sp_core::H256::repeat_byte(1));
 
-		let payload = ExplicitDisputeStatement {
-			valid: true,
-			candidate_hash: candidate_hash_a,
-			session: 1,
-		}
-		.signing_payload();
+		let payload =
+			ExplicitDisputeStatement { valid: true, candidate_hash: candidate_hash_a, session: 1 }
+				.signing_payload();
 
-		let payload_against = ExplicitDisputeStatement {
-			valid: false,
-			candidate_hash: candidate_hash_a,
-			session: 1,
-		}
-		.signing_payload();
+		let payload_against =
+			ExplicitDisputeStatement { valid: false, candidate_hash: candidate_hash_a, session: 1 }
+				.signing_payload();
 
 		let sig_a = v0.sign(&payload);
 		let sig_a_against = v1.sign(&payload_against);
@@ -2457,11 +2295,7 @@ fn filter_removes_duplicate_statements_sets() {
 
 		assert_eq!(
 			sets,
-			vec![DisputeStatementSet {
-				candidate_hash: candidate_hash_a,
-				session: 1,
-				statements,
-			}]
+			vec![DisputeStatementSet { candidate_hash: candidate_hash_a, session: 1, statements }]
 		);
 	})
 }
@@ -2478,12 +2312,9 @@ fn filter_ignores_single_sided() {
 
 		let candidate_hash_a = CandidateHash(sp_core::H256::repeat_byte(1));
 
-		let payload = ExplicitDisputeStatement {
-			valid: true,
-			candidate_hash: candidate_hash_a,
-			session: 1,
-		}
-		.signing_payload();
+		let payload =
+			ExplicitDisputeStatement { valid: true, candidate_hash: candidate_hash_a, session: 1 }
+				.signing_payload();
 
 		let sig_a = v0.sign(&payload);
 
@@ -2515,12 +2346,9 @@ fn import_ignores_single_sided() {
 
 		let candidate_hash_a = CandidateHash(sp_core::H256::repeat_byte(1));
 
-		let payload = ExplicitDisputeStatement {
-			valid: true,
-			candidate_hash: candidate_hash_a,
-			session: 1,
-		}
-		.signing_payload();
+		let payload =
+			ExplicitDisputeStatement { valid: true, candidate_hash: candidate_hash_a, session: 1 }
+				.signing_payload();
 
 		let sig_a = v0.sign(&payload);
 

--- a/runtime/parachains/src/inclusion/tests.rs
+++ b/runtime/parachains/src/inclusion/tests.rs
@@ -68,9 +68,7 @@ pub(crate) fn genesis_config(paras: Vec<(ParaId, ParaKind)>) -> MockGenesisConfi
 				.collect(),
 			..Default::default()
 		},
-		configuration: configuration::GenesisConfig {
-			config: default_config(),
-		},
+		configuration: configuration::GenesisConfig { config: default_config() },
 		..Default::default()
 	}
 }

--- a/runtime/parachains/src/inclusion/tests.rs
+++ b/runtime/parachains/src/inclusion/tests.rs
@@ -70,7 +70,6 @@ pub(crate) fn genesis_config(paras: Vec<(ParaId, ParaKind)>) -> MockGenesisConfi
 		},
 		configuration: configuration::GenesisConfig {
 			config: default_config(),
-			..Default::default()
 		},
 		..Default::default()
 	}

--- a/runtime/parachains/src/paras/mod.rs
+++ b/runtime/parachains/src/paras/mod.rs
@@ -259,7 +259,7 @@ impl<N: Ord + Copy + PartialEq> ParaPastCodeMeta<N> {
 	// of the para.
 	#[cfg(test)]
 	fn most_recent_change(&self) -> Option<N> {
-		self.upgrade_times.last().map(|x| x.expected_at.clone())
+		self.upgrade_times.last().map(|x| x.expected_at)
 	}
 
 	// prunes all code upgrade logs occurring at or before `max`.

--- a/runtime/parachains/src/paras/tests.rs
+++ b/runtime/parachains/src/paras/tests.rs
@@ -280,7 +280,6 @@ fn para_past_code_pruning_in_initialize() {
 		paras: GenesisConfig { paras, ..Default::default() },
 		configuration: crate::configuration::GenesisConfig {
 			config: HostConfiguration { code_retention_period, ..Default::default() },
-			..Default::default()
 		},
 		..Default::default()
 	};
@@ -333,7 +332,6 @@ fn note_new_head_sets_head() {
 		paras: GenesisConfig { paras, ..Default::default() },
 		configuration: crate::configuration::GenesisConfig {
 			config: HostConfiguration { code_retention_period, ..Default::default() },
-			..Default::default()
 		},
 		..Default::default()
 	};
@@ -375,7 +373,6 @@ fn note_past_code_sets_up_pruning_correctly() {
 		paras: GenesisConfig { paras, ..Default::default() },
 		configuration: crate::configuration::GenesisConfig {
 			config: HostConfiguration { code_retention_period, ..Default::default() },
-			..Default::default()
 		},
 		..Default::default()
 	};
@@ -424,7 +421,6 @@ fn code_upgrade_applied_after_delay() {
 				validation_upgrade_cooldown,
 				..Default::default()
 			},
-			..Default::default()
 		},
 		..Default::default()
 	};
@@ -537,7 +533,6 @@ fn code_upgrade_applied_after_delay_even_when_late() {
 				validation_upgrade_cooldown,
 				..Default::default()
 			},
-			..Default::default()
 		},
 		..Default::default()
 	};
@@ -620,7 +615,6 @@ fn submit_code_change_when_not_allowed_is_err() {
 				validation_upgrade_cooldown,
 				..Default::default()
 			},
-			..Default::default()
 		},
 		..Default::default()
 	};
@@ -691,7 +685,6 @@ fn upgrade_restriction_elapsed_doesnt_mean_can_upgrade() {
 				validation_upgrade_cooldown,
 				..Default::default()
 			},
-			..Default::default()
 		},
 		..Default::default()
 	};
@@ -757,7 +750,6 @@ fn full_parachain_cleanup_storage() {
 				thread_availability_period: 1,
 				..Default::default()
 			},
-			..Default::default()
 		},
 		..Default::default()
 	};
@@ -1013,7 +1005,6 @@ fn code_hash_at_returns_up_to_end_of_code_retention_period() {
 				validation_upgrade_delay,
 				..Default::default()
 			},
-			..Default::default()
 		},
 		..Default::default()
 	};
@@ -1104,7 +1095,6 @@ fn pvf_check_coalescing_onboarding_and_upgrade() {
 		paras: GenesisConfig { paras, ..Default::default() },
 		configuration: crate::configuration::GenesisConfig {
 			config: HostConfiguration { validation_upgrade_delay, ..Default::default() },
-			..Default::default()
 		},
 		..Default::default()
 	};
@@ -1169,7 +1159,6 @@ fn pvf_check_onboarding_reject_on_expiry() {
 	let genesis_config = MockGenesisConfig {
 		configuration: crate::configuration::GenesisConfig {
 			config: HostConfiguration { pvf_voting_ttl, ..Default::default() },
-			..Default::default()
 		},
 		..Default::default()
 	};
@@ -1569,7 +1558,6 @@ fn add_trusted_validation_code_insta_approval() {
 				minimum_validation_upgrade_delay,
 				..Default::default()
 			},
-			..Default::default()
 		},
 		..Default::default()
 	};
@@ -1611,7 +1599,6 @@ fn add_trusted_validation_code_enacts_existing_pvf_vote() {
 				minimum_validation_upgrade_delay,
 				..Default::default()
 			},
-			..Default::default()
 		},
 		..Default::default()
 	};

--- a/runtime/parachains/src/paras_inherent/tests.rs
+++ b/runtime/parachains/src/paras_inherent/tests.rs
@@ -155,43 +155,31 @@ mod enter {
 			let generate_votes = |session: u32, candidate_hash: CandidateHash| {
 				// v0 votes for 3
 				vec![DisputeStatementSet {
-					candidate_hash: candidate_hash,
+					candidate_hash,
 					session,
 					statements: vec![
 						(
 							DisputeStatement::Invalid(InvalidDisputeStatementKind::Explicit),
 							ValidatorIndex(0),
 							v0.sign(
-								&ExplicitDisputeStatement {
-									valid: false,
-									candidate_hash: candidate_hash,
-									session,
-								}
-								.signing_payload(),
+								&ExplicitDisputeStatement { valid: false, candidate_hash, session }
+									.signing_payload(),
 							),
 						),
 						(
 							DisputeStatement::Invalid(InvalidDisputeStatementKind::Explicit),
 							ValidatorIndex(1),
 							v1.sign(
-								&ExplicitDisputeStatement {
-									valid: false,
-									candidate_hash: candidate_hash,
-									session,
-								}
-								.signing_payload(),
+								&ExplicitDisputeStatement { valid: false, candidate_hash, session }
+									.signing_payload(),
 							),
 						),
 						(
 							DisputeStatement::Valid(ValidDisputeStatementKind::Explicit),
 							ValidatorIndex(1),
 							v1.sign(
-								&ExplicitDisputeStatement {
-									valid: true,
-									candidate_hash: candidate_hash,
-									session,
-								}
-								.signing_payload(),
+								&ExplicitDisputeStatement { valid: true, candidate_hash, session }
+									.signing_payload(),
 							),
 						),
 					],

--- a/runtime/parachains/src/paras_inherent/tests.rs
+++ b/runtime/parachains/src/paras_inherent/tests.rs
@@ -155,7 +155,7 @@ mod enter {
 			let generate_votes = |session: u32, candidate_hash: CandidateHash| {
 				// v0 votes for 3
 				vec![DisputeStatementSet {
-					candidate_hash: candidate_hash.clone(),
+					candidate_hash: candidate_hash,
 					session,
 					statements: vec![
 						(
@@ -164,7 +164,7 @@ mod enter {
 							v0.sign(
 								&ExplicitDisputeStatement {
 									valid: false,
-									candidate_hash: candidate_hash.clone(),
+									candidate_hash: candidate_hash,
 									session,
 								}
 								.signing_payload(),
@@ -176,7 +176,7 @@ mod enter {
 							v1.sign(
 								&ExplicitDisputeStatement {
 									valid: false,
-									candidate_hash: candidate_hash.clone(),
+									candidate_hash: candidate_hash,
 									session,
 								}
 								.signing_payload(),
@@ -188,7 +188,7 @@ mod enter {
 							v1.sign(
 								&ExplicitDisputeStatement {
 									valid: true,
-									candidate_hash: candidate_hash.clone(),
+									candidate_hash: candidate_hash,
 									session,
 								}
 								.signing_payload(),
@@ -202,7 +202,7 @@ mod enter {
 			};
 
 			let candidate_hash = CandidateHash(sp_core::H256::repeat_byte(1));
-			let statements = generate_votes(3, candidate_hash.clone());
+			let statements = generate_votes(3, candidate_hash);
 			set_scrapable_on_chain_disputes::<Test>(3, statements);
 			assert_matches!(pallet::Pallet::<Test>::on_chain_votes(), Some(ScrapedOnChainVotes {
 				session,
@@ -221,7 +221,7 @@ mod enter {
 			});
 
 			let candidate_hash = CandidateHash(sp_core::H256::repeat_byte(2));
-			let statements = generate_votes(7, candidate_hash.clone());
+			let statements = generate_votes(7, candidate_hash);
 			set_scrapable_on_chain_disputes::<Test>(7, statements);
 			assert_matches!(pallet::Pallet::<Test>::on_chain_votes(), Some(ScrapedOnChainVotes {
 				session,
@@ -1330,7 +1330,7 @@ mod sanitizers {
 				let mut set = std::collections::HashSet::new();
 				for (idx, backed_candidate) in backed_candidates.iter().enumerate() {
 					if idx & 0x01 == 0 {
-						set.insert(backed_candidate.hash().clone());
+						set.insert(backed_candidate.hash());
 					}
 				}
 				set

--- a/runtime/parachains/src/scheduler/tests.rs
+++ b/runtime/parachains/src/scheduler/tests.rs
@@ -116,9 +116,7 @@ fn default_config() -> HostConfiguration<BlockNumber> {
 #[test]
 fn add_parathread_claim_works() {
 	let genesis_config = MockGenesisConfig {
-		configuration: crate::configuration::GenesisConfig {
-				config: default_config(),
-		},
+		configuration: crate::configuration::GenesisConfig { config: default_config() },
 		..Default::default()
 	};
 
@@ -223,9 +221,7 @@ fn cannot_add_claim_when_no_parathread_cores() {
 #[test]
 fn session_change_prunes_cores_beyond_retries_and_those_from_non_live_parathreads() {
 	let genesis_config = MockGenesisConfig {
-		configuration: crate::configuration::GenesisConfig {
-				config: default_config(),
-		},
+		configuration: crate::configuration::GenesisConfig { config: default_config() },
 		..Default::default()
 	};
 	let max_parathread_retries = default_config().parathread_retries;
@@ -324,9 +320,7 @@ fn session_change_prunes_cores_beyond_retries_and_those_from_non_live_parathread
 #[test]
 fn session_change_shuffles_validators() {
 	let genesis_config = MockGenesisConfig {
-		configuration: crate::configuration::GenesisConfig {
-				config: default_config(),
-		},
+		configuration: crate::configuration::GenesisConfig { config: default_config() },
 		..Default::default()
 	};
 
@@ -381,9 +375,7 @@ fn session_change_takes_only_max_per_core() {
 	};
 
 	let genesis_config = MockGenesisConfig {
-		configuration: crate::configuration::GenesisConfig {
-			config: config.clone(),
-		},
+		configuration: crate::configuration::GenesisConfig { config: config.clone() },
 		..Default::default()
 	};
 
@@ -428,9 +420,7 @@ fn session_change_takes_only_max_per_core() {
 #[test]
 fn schedule_schedules() {
 	let genesis_config = MockGenesisConfig {
-		configuration: crate::configuration::GenesisConfig {
-				config: default_config(),
-		},
+		configuration: crate::configuration::GenesisConfig { config: default_config() },
 		..Default::default()
 	};
 
@@ -552,9 +542,7 @@ fn schedule_schedules() {
 #[test]
 fn schedule_schedules_including_just_freed() {
 	let genesis_config = MockGenesisConfig {
-		configuration: crate::configuration::GenesisConfig {
-				config: default_config(),
-		},
+		configuration: crate::configuration::GenesisConfig { config: default_config() },
 		..Default::default()
 	};
 
@@ -727,9 +715,7 @@ fn schedule_schedules_including_just_freed() {
 #[test]
 fn schedule_clears_availability_cores() {
 	let genesis_config = MockGenesisConfig {
-		configuration: crate::configuration::GenesisConfig {
-				config: default_config(),
-		},
+		configuration: crate::configuration::GenesisConfig { config: default_config() },
 		..Default::default()
 	};
 
@@ -832,9 +818,7 @@ fn schedule_rotates_groups() {
 	let parathread_cores = config.parathread_cores;
 
 	let genesis_config = MockGenesisConfig {
-		configuration: crate::configuration::GenesisConfig {
-			config: config.clone(),
-		},
+		configuration: crate::configuration::GenesisConfig { config: config.clone() },
 		..Default::default()
 	};
 
@@ -903,9 +887,7 @@ fn parathread_claims_are_pruned_after_retries() {
 	let max_retries = default_config().parathread_retries;
 
 	let genesis_config = MockGenesisConfig {
-		configuration: crate::configuration::GenesisConfig {
-				config: default_config(),
-		},
+		configuration: crate::configuration::GenesisConfig { config: default_config() },
 		..Default::default()
 	};
 
@@ -950,9 +932,7 @@ fn parathread_claims_are_pruned_after_retries() {
 #[test]
 fn availability_predicate_works() {
 	let genesis_config = MockGenesisConfig {
-		configuration: crate::configuration::GenesisConfig {
-			config: default_config(),
-		},
+		configuration: crate::configuration::GenesisConfig { config: default_config() },
 		..Default::default()
 	};
 
@@ -1057,9 +1037,7 @@ fn next_up_on_available_uses_next_scheduled_or_none_for_thread() {
 	config.parathread_cores = 1;
 
 	let genesis_config = MockGenesisConfig {
-		configuration: crate::configuration::GenesisConfig {
-			config: config.clone(),
-		},
+		configuration: crate::configuration::GenesisConfig { config: config.clone() },
 		..Default::default()
 	};
 
@@ -1128,9 +1106,7 @@ fn next_up_on_time_out_reuses_claim_if_nothing_queued() {
 	config.parathread_cores = 1;
 
 	let genesis_config = MockGenesisConfig {
-		configuration: crate::configuration::GenesisConfig {
-			config: config.clone(),
-		},
+		configuration: crate::configuration::GenesisConfig { config: config.clone() },
 		..Default::default()
 	};
 
@@ -1205,9 +1181,7 @@ fn next_up_on_available_is_parachain_always() {
 	config.parathread_cores = 0;
 
 	let genesis_config = MockGenesisConfig {
-		configuration: crate::configuration::GenesisConfig {
-			config: config.clone(),
-		},
+		configuration: crate::configuration::GenesisConfig { config: config.clone() },
 		..Default::default()
 	};
 
@@ -1258,9 +1232,7 @@ fn next_up_on_time_out_is_parachain_always() {
 	config.parathread_cores = 0;
 
 	let genesis_config = MockGenesisConfig {
-		configuration: crate::configuration::GenesisConfig {
-			config: config.clone(),
-		},
+		configuration: crate::configuration::GenesisConfig { config: config.clone() },
 		..Default::default()
 	};
 
@@ -1308,9 +1280,7 @@ fn next_up_on_time_out_is_parachain_always() {
 #[test]
 fn session_change_requires_reschedule_dropping_removed_paras() {
 	let genesis_config = MockGenesisConfig {
-		configuration: crate::configuration::GenesisConfig {
-			config: default_config(),
-		},
+		configuration: crate::configuration::GenesisConfig { config: default_config() },
 		..Default::default()
 	};
 
@@ -1384,9 +1354,7 @@ fn session_change_requires_reschedule_dropping_removed_paras() {
 #[test]
 fn parathread_claims_are_pruned_after_deregistration() {
 	let genesis_config = MockGenesisConfig {
-		configuration: crate::configuration::GenesisConfig {
-			config: default_config(),
-		},
+		configuration: crate::configuration::GenesisConfig { config: default_config() },
 		..Default::default()
 	};
 

--- a/runtime/parachains/src/scheduler/tests.rs
+++ b/runtime/parachains/src/scheduler/tests.rs
@@ -117,8 +117,7 @@ fn default_config() -> HostConfiguration<BlockNumber> {
 fn add_parathread_claim_works() {
 	let genesis_config = MockGenesisConfig {
 		configuration: crate::configuration::GenesisConfig {
-			config: default_config(),
-			..Default::default()
+				config: default_config(),
 		},
 		..Default::default()
 	};
@@ -200,7 +199,7 @@ fn cannot_add_claim_when_no_parathread_cores() {
 		config
 	};
 	let genesis_config = MockGenesisConfig {
-		configuration: crate::configuration::GenesisConfig { config, ..Default::default() },
+		configuration: crate::configuration::GenesisConfig { config },
 		..Default::default()
 	};
 
@@ -225,8 +224,7 @@ fn cannot_add_claim_when_no_parathread_cores() {
 fn session_change_prunes_cores_beyond_retries_and_those_from_non_live_parathreads() {
 	let genesis_config = MockGenesisConfig {
 		configuration: crate::configuration::GenesisConfig {
-			config: default_config(),
-			..Default::default()
+				config: default_config(),
 		},
 		..Default::default()
 	};
@@ -327,8 +325,7 @@ fn session_change_prunes_cores_beyond_retries_and_those_from_non_live_parathread
 fn session_change_shuffles_validators() {
 	let genesis_config = MockGenesisConfig {
 		configuration: crate::configuration::GenesisConfig {
-			config: default_config(),
-			..Default::default()
+				config: default_config(),
 		},
 		..Default::default()
 	};
@@ -386,7 +383,6 @@ fn session_change_takes_only_max_per_core() {
 	let genesis_config = MockGenesisConfig {
 		configuration: crate::configuration::GenesisConfig {
 			config: config.clone(),
-			..Default::default()
 		},
 		..Default::default()
 	};
@@ -433,8 +429,7 @@ fn session_change_takes_only_max_per_core() {
 fn schedule_schedules() {
 	let genesis_config = MockGenesisConfig {
 		configuration: crate::configuration::GenesisConfig {
-			config: default_config(),
-			..Default::default()
+				config: default_config(),
 		},
 		..Default::default()
 	};
@@ -558,8 +553,7 @@ fn schedule_schedules() {
 fn schedule_schedules_including_just_freed() {
 	let genesis_config = MockGenesisConfig {
 		configuration: crate::configuration::GenesisConfig {
-			config: default_config(),
-			..Default::default()
+				config: default_config(),
 		},
 		..Default::default()
 	};
@@ -734,8 +728,7 @@ fn schedule_schedules_including_just_freed() {
 fn schedule_clears_availability_cores() {
 	let genesis_config = MockGenesisConfig {
 		configuration: crate::configuration::GenesisConfig {
-			config: default_config(),
-			..Default::default()
+				config: default_config(),
 		},
 		..Default::default()
 	};
@@ -841,7 +834,6 @@ fn schedule_rotates_groups() {
 	let genesis_config = MockGenesisConfig {
 		configuration: crate::configuration::GenesisConfig {
 			config: config.clone(),
-			..Default::default()
 		},
 		..Default::default()
 	};
@@ -912,8 +904,7 @@ fn parathread_claims_are_pruned_after_retries() {
 
 	let genesis_config = MockGenesisConfig {
 		configuration: crate::configuration::GenesisConfig {
-			config: default_config(),
-			..Default::default()
+				config: default_config(),
 		},
 		..Default::default()
 	};
@@ -961,7 +952,6 @@ fn availability_predicate_works() {
 	let genesis_config = MockGenesisConfig {
 		configuration: crate::configuration::GenesisConfig {
 			config: default_config(),
-			..Default::default()
 		},
 		..Default::default()
 	};
@@ -1069,7 +1059,6 @@ fn next_up_on_available_uses_next_scheduled_or_none_for_thread() {
 	let genesis_config = MockGenesisConfig {
 		configuration: crate::configuration::GenesisConfig {
 			config: config.clone(),
-			..Default::default()
 		},
 		..Default::default()
 	};
@@ -1141,7 +1130,6 @@ fn next_up_on_time_out_reuses_claim_if_nothing_queued() {
 	let genesis_config = MockGenesisConfig {
 		configuration: crate::configuration::GenesisConfig {
 			config: config.clone(),
-			..Default::default()
 		},
 		..Default::default()
 	};
@@ -1219,7 +1207,6 @@ fn next_up_on_available_is_parachain_always() {
 	let genesis_config = MockGenesisConfig {
 		configuration: crate::configuration::GenesisConfig {
 			config: config.clone(),
-			..Default::default()
 		},
 		..Default::default()
 	};
@@ -1273,7 +1260,6 @@ fn next_up_on_time_out_is_parachain_always() {
 	let genesis_config = MockGenesisConfig {
 		configuration: crate::configuration::GenesisConfig {
 			config: config.clone(),
-			..Default::default()
 		},
 		..Default::default()
 	};
@@ -1324,7 +1310,6 @@ fn session_change_requires_reschedule_dropping_removed_paras() {
 	let genesis_config = MockGenesisConfig {
 		configuration: crate::configuration::GenesisConfig {
 			config: default_config(),
-			..Default::default()
 		},
 		..Default::default()
 	};
@@ -1401,7 +1386,6 @@ fn parathread_claims_are_pruned_after_deregistration() {
 	let genesis_config = MockGenesisConfig {
 		configuration: crate::configuration::GenesisConfig {
 			config: default_config(),
-			..Default::default()
 		},
 		..Default::default()
 	};

--- a/runtime/parachains/src/session_info/tests.rs
+++ b/runtime/parachains/src/session_info/tests.rs
@@ -73,7 +73,6 @@ fn genesis_config() -> MockGenesisConfig {
 	MockGenesisConfig {
 		configuration: configuration::GenesisConfig {
 			config: default_config(),
-			..Default::default()
 		},
 		..Default::default()
 	}

--- a/runtime/parachains/src/session_info/tests.rs
+++ b/runtime/parachains/src/session_info/tests.rs
@@ -71,9 +71,7 @@ fn default_config() -> HostConfiguration<BlockNumber> {
 
 fn genesis_config() -> MockGenesisConfig {
 	MockGenesisConfig {
-		configuration: configuration::GenesisConfig {
-			config: default_config(),
-		},
+		configuration: configuration::GenesisConfig { config: default_config() },
 		..Default::default()
 	}
 }

--- a/runtime/parachains/src/ump_tests.rs
+++ b/runtime/parachains/src/ump_tests.rs
@@ -523,21 +523,21 @@ fn overweight_queue_works() {
 		assert_last_events(
 			[
 				pallet_message_queue::Event::<Test>::Processed {
-					id: hash_1.clone(),
+					id: hash_1,
 					origin: Ump(UmpQueueId::Para(para_a)),
 					weight_used: Weight::from_parts(301, 301),
 					success: true,
 				}
 				.into(),
 				pallet_message_queue::Event::<Test>::OverweightEnqueued {
-					id: hash_2.clone(),
+					id: hash_2,
 					origin: Ump(UmpQueueId::Para(para_a)),
 					page_index: 0,
 					message_index: 1,
 				}
 				.into(),
 				pallet_message_queue::Event::<Test>::OverweightEnqueued {
-					id: hash_3.clone(),
+					id: hash_3,
 					origin: Ump(UmpQueueId::Para(para_a)),
 					page_index: 0,
 					message_index: 2,

--- a/scripts/ci/gitlab/pipeline/test.yml
+++ b/scripts/ci/gitlab/pipeline/test.yml
@@ -116,4 +116,4 @@ cargo-clippy:
   script:
     - echo $RUSTFLAGS
     - cargo version && cargo clippy --version
-    - SKIP_WASM_BUILD=1 env -u RUSTFLAGS cargo clippy --locked --all-targets --workspace
+    - SKIP_WASM_BUILD=1 env -u RUSTFLAGS cargo clippy -q --locked --all-targets --workspace

--- a/scripts/ci/gitlab/pipeline/test.yml
+++ b/scripts/ci/gitlab/pipeline/test.yml
@@ -114,5 +114,6 @@ cargo-clippy:
     - .docker-env
     - .test-refs
   script:
+    - echo $RUSTFLAGS
     - cargo version && cargo clippy --version
-    - SKIP_WASM_BUILD=1 env -u RUSTFLAGS cargo clippy --locked --all-targets
+    - SKIP_WASM_BUILD=1 env -u RUSTFLAGS cargo clippy --locked --all-targets --workspace

--- a/statement-table/src/generic.rs
+++ b/statement-table/src/generic.rs
@@ -723,7 +723,7 @@ mod tests {
 
 		// authority 2 votes for validity on 1's candidate.
 		let bad_validity_vote = SignedStatement {
-			statement: Statement::Valid(candidate_a_digest.clone()),
+			statement: Statement::Valid(candidate_a_digest),
 			signature: Signature(2),
 			sender: AuthorityId(2),
 		};
@@ -794,7 +794,7 @@ mod tests {
 		assert!(!table.detected_misbehavior.contains_key(&AuthorityId(1)));
 
 		let extra_vote = SignedStatement {
-			statement: Statement::Valid(candidate_digest.clone()),
+			statement: Statement::Valid(candidate_digest),
 			signature: Signature(1),
 			sender: AuthorityId(1),
 		};
@@ -864,7 +864,7 @@ mod tests {
 		assert!(table.attested_candidate(&candidate_digest, &context).is_none());
 
 		let vote = SignedStatement {
-			statement: Statement::Valid(candidate_digest.clone()),
+			statement: Statement::Valid(candidate_digest),
 			signature: Signature(2),
 			sender: AuthorityId(2),
 		};
@@ -923,7 +923,7 @@ mod tests {
 		assert!(!table.detected_misbehavior.contains_key(&AuthorityId(1)));
 
 		let vote = SignedStatement {
-			statement: Statement::Valid(candidate_digest.clone()),
+			statement: Statement::Valid(candidate_digest),
 			signature: Signature(2),
 			sender: AuthorityId(2),
 		};

--- a/xcm/pallet-xcm/src/tests.rs
+++ b/xcm/pallet-xcm/src/tests.rs
@@ -46,10 +46,8 @@ fn report_outcome_notify_works() {
 		(ParaId::from(PARA_ID).into_account_truncating(), INITIAL_BALANCE),
 	];
 	let sender: MultiLocation = AccountId32 { network: None, id: ALICE.into() }.into();
-	let mut message = Xcm(vec![TransferAsset {
-		assets: (Here, SEND_AMOUNT).into(),
-		beneficiary: sender,
-	}]);
+	let mut message =
+		Xcm(vec![TransferAsset { assets: (Here, SEND_AMOUNT).into(), beneficiary: sender }]);
 	let call = pallet_test_notifier::Call::notification_received {
 		query_id: 0,
 		response: Default::default(),
@@ -123,10 +121,8 @@ fn report_outcome_works() {
 		(ParaId::from(PARA_ID).into_account_truncating(), INITIAL_BALANCE),
 	];
 	let sender: MultiLocation = AccountId32 { network: None, id: ALICE.into() }.into();
-	let mut message = Xcm(vec![TransferAsset {
-		assets: (Here, SEND_AMOUNT).into(),
-		beneficiary: sender,
-	}]);
+	let mut message =
+		Xcm(vec![TransferAsset { assets: (Here, SEND_AMOUNT).into(), beneficiary: sender }]);
 	new_test_ext_with_balances(balances).execute_with(|| {
 		XcmPallet::report_outcome(&mut message, Parachain(PARA_ID).into_location(), 100).unwrap();
 		assert_eq!(
@@ -683,7 +679,7 @@ fn trapped_assets_can_be_claimed() {
 			last_events(2),
 			vec![
 				RuntimeEvent::XcmPallet(crate::Event::AssetsTrapped {
-					hash: hash,
+					hash,
 					origin: source,
 					assets: vma
 				}),
@@ -747,10 +743,7 @@ fn basic_subscription_works() {
 
 		assert_eq!(
 			Queries::<Test>::iter().collect::<Vec<_>>(),
-			vec![(
-				0,
-				QueryStatus::VersionNotifier { origin: remote.into(), is_active: false }
-			)]
+			vec![(0, QueryStatus::VersionNotifier { origin: remote.into(), is_active: false })]
 		);
 		assert_eq!(
 			VersionNotifiers::<Test>::iter().collect::<Vec<_>>(),

--- a/xcm/xcm-builder/src/asset_conversion.rs
+++ b/xcm/xcm-builder/src/asset_conversion.rs
@@ -286,11 +286,11 @@ mod tests {
 		struct ClassInstanceIdConverter;
 		impl MaybeEquivalence<AssetInstance, ClassInstanceId> for ClassInstanceIdConverter {
 			fn convert(value: &AssetInstance) -> Option<ClassInstanceId> {
-				value.clone().try_into().ok()
+				(*value).try_into().ok()
 			}
 
 			fn convert_back(value: &ClassInstanceId) -> Option<AssetInstance> {
-				Some(AssetInstance::from(value.clone()))
+				Some(AssetInstance::from(*value))
 			}
 		}
 

--- a/xcm/xcm-builder/src/tests/assets.rs
+++ b/xcm/xcm-builder/src/tests/assets.rs
@@ -149,7 +149,7 @@ fn reserve_transfer_should_work() {
 		dest: Parachain(2).into(),
 		xcm: Xcm::<()>(vec![DepositAsset {
 			assets: AllCounted(1).into(),
-			beneficiary: three.clone(),
+			beneficiary: three,
 		}]),
 	}]);
 	let hash = fake_message_hash(&message);

--- a/xcm/xcm-builder/src/tests/assets.rs
+++ b/xcm/xcm-builder/src/tests/assets.rs
@@ -147,10 +147,7 @@ fn reserve_transfer_should_work() {
 	let message = Xcm(vec![TransferReserveAsset {
 		assets: (Here, 100u128).into(),
 		dest: Parachain(2).into(),
-		xcm: Xcm::<()>(vec![DepositAsset {
-			assets: AllCounted(1).into(),
-			beneficiary: three,
-		}]),
+		xcm: Xcm::<()>(vec![DepositAsset { assets: AllCounted(1).into(), beneficiary: three }]),
 	}]);
 	let hash = fake_message_hash(&message);
 	let r = XcmExecutor::<TestConfig>::execute_xcm(

--- a/xcm/xcm-builder/src/tests/bridging/mod.rs
+++ b/xcm/xcm-builder/src/tests/bridging/mod.rs
@@ -155,7 +155,7 @@ fn price<RemoteExporter: ExportXcm>(
 	d: &InteriorMultiLocation,
 	m: &Xcm<()>,
 ) -> Result<MultiAssets, SendError> {
-	Ok(validate_export::<RemoteExporter>(n, c, s.clone(), d.clone(), m.clone())?.1)
+	Ok(validate_export::<RemoteExporter>(n, c, *s, *d, m.clone())?.1)
 }
 
 fn deliver<RemoteExporter: ExportXcm>(
@@ -205,7 +205,7 @@ impl<Local: Get<Junctions>, Remote: Get<Junctions>, RemoteExporter: ExportXcm> S
 		// though it is `Remote`.
 		ExecutorUniversalLocation::set(Remote::get());
 		let origin = Local::get().relative_to(&Remote::get());
-		AllowUnpaidFrom::set(vec![origin.clone()]);
+		AllowUnpaidFrom::set(vec![origin]);
 		set_exporter_override(price::<RemoteExporter>, deliver::<RemoteExporter>);
 		// The we execute it:
 		let mut id = fake_id();
@@ -255,7 +255,7 @@ impl<Local: Get<Junctions>, Remote: Get<Junctions>, RemoteExporter: ExportXcm> S
 		// though it is `Remote`.
 		ExecutorUniversalLocation::set(Remote::get());
 		let origin = Local::get().relative_to(&Remote::get());
-		AllowPaidFrom::set(vec![origin.clone()]);
+		AllowPaidFrom::set(vec![origin]);
 		set_exporter_override(price::<RemoteExporter>, deliver::<RemoteExporter>);
 		// Then we execute it:
 		let mut id = fake_id();

--- a/xcm/xcm-builder/src/tests/bridging/paid_remote_relay_relay.rs
+++ b/xcm/xcm-builder/src/tests/bridging/paid_remote_relay_relay.rs
@@ -113,7 +113,7 @@ fn sending_to_bridged_chain_without_funds_fails() {
 	let dest: MultiLocation = (Parent, Parent, Remote::get()).into();
 	// Routing won't work if we don't have enough funds.
 	assert_eq!(
-		send_xcm::<LocalRouter>(dest.clone(), Xcm(vec![Trap(1)])),
+		send_xcm::<LocalRouter>(dest, Xcm(vec![Trap(1)])),
 		Err(SendError::Transport("Error executing")),
 	);
 }
@@ -188,7 +188,7 @@ fn sending_to_parachain_of_bridged_chain_without_funds_fails() {
 	let dest: MultiLocation = (Parent, Parent, Remote::get(), Parachain(100)).into();
 	// Routing won't work if we don't have enough funds.
 	assert_eq!(
-		send_xcm::<LocalRouter>(dest.clone(), Xcm(vec![Trap(1)])),
+		send_xcm::<LocalRouter>(dest, Xcm(vec![Trap(1)])),
 		Err(SendError::Transport("Error executing")),
 	);
 }

--- a/xcm/xcm-builder/src/tests/mock.rs
+++ b/xcm/xcm-builder/src/tests/mock.rs
@@ -254,7 +254,7 @@ impl TransactAsset for TestAssetTransactor {
 		who: &MultiLocation,
 		_context: &XcmContext,
 	) -> Result<(), XcmError> {
-		add_asset(who.clone(), what.clone());
+		add_asset(*who, what.clone());
 		Ok(())
 	}
 
@@ -515,7 +515,7 @@ pub fn disallow_unlock(
 pub fn unlock_allowed(unlocker: &MultiLocation, asset: &MultiAsset, owner: &MultiLocation) -> bool {
 	ALLOWED_UNLOCKS.with(|l| {
 		l.borrow_mut()
-			.get(&(owner.clone(), unlocker.clone()))
+			.get(&(*owner, *unlocker))
 			.map_or(false, |x| x.contains_asset(asset))
 	})
 }
@@ -550,7 +550,7 @@ pub fn request_unlock_allowed(
 ) -> bool {
 	ALLOWED_REQUEST_UNLOCKS.with(|l| {
 		l.borrow_mut()
-			.get(&(owner.clone(), locker.clone()))
+			.get(&(*owner, *locker))
 			.map_or(false, |x| x.contains_asset(asset))
 	})
 }
@@ -560,11 +560,11 @@ impl Enact for TestTicket {
 	fn enact(self) -> Result<(), LockError> {
 		match &self.0 {
 			LockTraceItem::Lock { unlocker, asset, owner } =>
-				allow_unlock(unlocker.clone(), asset.clone(), owner.clone()),
+				allow_unlock(*unlocker, asset.clone(), *owner),
 			LockTraceItem::Unlock { unlocker, asset, owner } =>
-				disallow_unlock(unlocker.clone(), asset.clone(), owner.clone()),
+				disallow_unlock(*unlocker, asset.clone(), *owner),
 			LockTraceItem::Reduce { locker, asset, owner } =>
-				disallow_request_unlock(locker.clone(), asset.clone(), owner.clone()),
+				disallow_request_unlock(*locker, asset.clone(), *owner),
 			_ => {},
 		}
 		LOCK_TRACE.with(move |l| l.borrow_mut().push(self.0));
@@ -583,7 +583,7 @@ impl AssetLock for TestAssetLock {
 		asset: MultiAsset,
 		owner: MultiLocation,
 	) -> Result<Self::LockTicket, LockError> {
-		ensure!(assets(owner.clone()).contains_asset(&asset), LockError::AssetNotOwned);
+		ensure!(assets(owner).contains_asset(&asset), LockError::AssetNotOwned);
 		Ok(TestTicket(LockTraceItem::Lock { unlocker, asset, owner }))
 	}
 
@@ -601,7 +601,7 @@ impl AssetLock for TestAssetLock {
 		asset: MultiAsset,
 		owner: MultiLocation,
 	) -> Result<(), LockError> {
-		allow_request_unlock(locker.clone(), asset.clone(), owner.clone());
+		allow_request_unlock(locker, asset.clone(), owner);
 		let item = LockTraceItem::Note { locker, asset, owner };
 		LOCK_TRACE.with(move |l| l.borrow_mut().push(item));
 		Ok(())

--- a/xcm/xcm-builder/src/tests/transacting.rs
+++ b/xcm/xcm-builder/src/tests/transacting.rs
@@ -66,11 +66,11 @@ fn transacting_should_refund_weight() {
 #[test]
 fn paid_transacting_should_refund_payment_for_unused_weight() {
 	let one: MultiLocation = AccountIndex64 { index: 1, network: None }.into();
-	AllowPaidFrom::set(vec![one.clone()]);
+	AllowPaidFrom::set(vec![one]);
 	add_asset(AccountIndex64 { index: 1, network: None }, (Parent, 200u128));
 	WeightPrice::set((Parent.into(), 1_000_000_000_000, 1024 * 1024));
 
-	let origin = one.clone();
+	let origin = one;
 	let fees = (Parent, 200u128).into();
 	let message = Xcm::<TestCall>(vec![
 		WithdrawAsset((Parent, 200u128).into()), // enough for 200 units of weight.
@@ -84,7 +84,7 @@ fn paid_transacting_should_refund_payment_for_unused_weight() {
 				.into(),
 		},
 		RefundSurplus,
-		DepositAsset { assets: AllCounted(1).into(), beneficiary: one.clone() },
+		DepositAsset { assets: AllCounted(1).into(), beneficiary: one },
 	]);
 	let hash = fake_message_hash(&message);
 	let weight_limit = Weight::from_parts(100, 100);

--- a/xcm/xcm-builder/src/tests/version_subscriptions.rs
+++ b/xcm/xcm-builder/src/tests/version_subscriptions.rs
@@ -59,7 +59,7 @@ fn version_subscription_instruction_should_work() {
 	let hash = fake_message_hash(&message);
 	let weight_limit = Weight::from_parts(20, 20);
 	let r = XcmExecutor::<TestConfig>::execute_xcm_in_credit(
-		origin.clone(),
+		origin,
 		message,
 		hash,
 		weight_limit,
@@ -124,7 +124,7 @@ fn version_unsubscription_instruction_should_work() {
 	let hash = fake_message_hash(&message);
 	let weight_limit = Weight::from_parts(20, 20);
 	let r = XcmExecutor::<TestConfig>::execute_xcm_in_credit(
-		origin.clone(),
+		origin,
 		message,
 		hash,
 		weight_limit,

--- a/xcm/xcm-simulator/fuzzer/src/parachain.rs
+++ b/xcm/xcm-simulator/fuzzer/src/parachain.rs
@@ -238,7 +238,7 @@ pub mod mock_msg_queue {
 				Ok(xcm) => {
 					let location = MultiLocation::new(1, X1(Parachain(sender.into())));
 					match T::XcmExecutor::execute_xcm(location, xcm, message_hash, max_weight) {
-						Outcome::Error(e) => (Err(e.clone()), Event::Fail(Some(hash), e)),
+						Outcome::Error(e) => (Err(e), Event::Fail(Some(hash), e)),
 						Outcome::Complete(w) => (Ok(w), Event::Success(Some(hash))),
 						// As far as the caller is concerned, this was dispatched without error, so
 						// we just report the weight used.
@@ -262,7 +262,7 @@ pub mod mock_msg_queue {
 				let _ = XcmpMessageFormat::decode(&mut data_ref)
 					.expect("Simulator encodes with versioned xcm format; qed");
 
-				let mut remaining_fragments = &data_ref[..];
+				let mut remaining_fragments = data_ref;
 				while !remaining_fragments.is_empty() {
 					if let Ok(xcm) =
 						VersionedXcm::<T::RuntimeCall>::decode(&mut remaining_fragments)


### PR DESCRIPTION
(preparation for monorepo)

Turns out clippy does not run everywhere without the `--workspace` flag :upside_down_face:. Now adding it and fixing the warnings.