### PR TITLE
bump zombienet to `v1.3.65`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,12 +33,12 @@ variables:
   GIT_STRATEGY: fetch
   GIT_DEPTH: 100
   CI_SERVER_NAME: "GitLab CI"
-  CI_IMAGE: !reference [.ci-unified, variables, CI_IMAGE] 
+  CI_IMAGE: !reference [.ci-unified, variables, CI_IMAGE]
   BUILDAH_IMAGE: "quay.io/buildah/stable:v1.29"
   BUILDAH_COMMAND: "buildah --storage-driver overlay2"
   DOCKER_OS: "debian:stretch"
   ARCH: "x86_64"
-  ZOMBIENET_IMAGE: "docker.io/paritytech/zombienet:v1.3.55"
+  ZOMBIENET_IMAGE: "docker.io/paritytech/zombienet:v1.3.65"
 
 default:
   cache: {}
@@ -233,7 +233,7 @@ include:
     file: /common/timestamp.yml
   - project: parity/infrastructure/ci_cd/shared
     ref: main
-    file: /common/ci-unified.yml   
+    file: /common/ci-unified.yml
 
 
 #### stage:                        .post

--- a/parachain/test-parachains/adder/collator/src/main.rs
+++ b/parachain/test-parachains/adder/collator/src/main.rs
@@ -21,7 +21,6 @@ use polkadot_node_primitives::CollationGenerationConfig;
 use polkadot_node_subsystem::messages::{CollationGenerationMessage, CollatorProtocolMessage};
 use polkadot_primitives::Id as ParaId;
 use sc_cli::{Error as SubstrateCliError, SubstrateCli};
-use sc_service::Role;
 use sp_core::hexdisplay::HexDisplay;
 use test_parachain_adder_collator::Collator;
 
@@ -54,12 +53,9 @@ fn main() -> Result<()> {
 				)
 			})?;
 
-			runner.run_node_until_exit(|mut config| async move {
+			runner.run_node_until_exit(|config| async move {
 				let collator = Collator::new();
 
-				// Zombienet is spawning all collators currently with the same CLI, this means it
-				// sets `--validator` and this is wrong here.
-				config.role = Role::Full;
 				let full_node = polkadot_service::build_full(
 					config,
 					polkadot_service::NewFullParams {

--- a/parachain/test-parachains/undying/collator/src/main.rs
+++ b/parachain/test-parachains/undying/collator/src/main.rs
@@ -21,7 +21,6 @@ use polkadot_node_primitives::CollationGenerationConfig;
 use polkadot_node_subsystem::messages::{CollationGenerationMessage, CollatorProtocolMessage};
 use polkadot_primitives::Id as ParaId;
 use sc_cli::{Error as SubstrateCliError, SubstrateCli};
-use sc_service::Role;
 use sp_core::hexdisplay::HexDisplay;
 use test_parachain_undying_collator::Collator;
 
@@ -54,12 +53,9 @@ fn main() -> Result<()> {
 				)
 			})?;
 
-			runner.run_node_until_exit(|mut config| async move {
+			runner.run_node_until_exit(|config| async move {
 				let collator = Collator::new(cli.run.pov_size, cli.run.pvf_complexity);
 
-				// Zombienet is spawning all collators currently with the same CLI, this means it
-				// sets `--validator` and this is wrong here.
-				config.role = Role::Full;
 				let full_node = polkadot_service::build_full(
 					config,
 					polkadot_service::NewFullParams {

--- a/scripts/ci/gitlab/pipeline/zombienet.yml
+++ b/scripts/ci/gitlab/pipeline/zombienet.yml
@@ -1,9 +1,5 @@
 # This file is part of .gitlab-ci.yml
 # Here are all jobs that are executed during "zombienet" stage
-.zombienet-common:
-  variables:
-    RUN_IN_CONTAINER: "1"
-
 
 zombienet-tests-parachains-smoke-test:
   stage: zombienet
@@ -11,12 +7,12 @@ zombienet-tests-parachains-smoke-test:
   extends:
     - .kubernetes-env
     - .zombienet-refs
-    - .zombienet-common
   needs:
     - job: publish-polkadot-debug-image
     - job: publish-malus-image
     - job: publish-test-collators-image
   variables:
+    RUN_IN_CONTAINER: "1"
     GH_DIR: "https://github.com/paritytech/polkadot/tree/${CI_COMMIT_SHORT_SHA}/zombienet_tests/smoke"
   before_script:
     - echo "Zombie-net Tests Config"
@@ -43,11 +39,11 @@ zombienet-tests-parachains-pvf:
   extends:
     - .kubernetes-env
     - .zombienet-refs
-    - .zombienet-common
   needs:
     - job: publish-polkadot-debug-image
     - job: publish-test-collators-image
   variables:
+    RUN_IN_CONTAINER: "1"
     GH_DIR: "https://github.com/paritytech/polkadot/tree/${CI_COMMIT_SHORT_SHA}/zombienet_tests/functional"
   before_script:
     - echo "Zombie-net Tests Config"
@@ -74,12 +70,12 @@ zombienet-tests-parachains-disputes:
   extends:
     - .kubernetes-env
     - .zombienet-refs
-    - .zombienet-common
   needs:
     - job: publish-polkadot-debug-image
     - job: publish-test-collators-image
     - job: publish-malus-image
   variables:
+    RUN_IN_CONTAINER: "1"
     GH_DIR: "https://github.com/paritytech/polkadot/tree/${CI_COMMIT_SHORT_SHA}/zombienet_tests/functional"
   before_script:
     - echo "Zombie-net Tests Config"
@@ -106,12 +102,12 @@ zombienet-tests-parachains-disputes-garbage-candidate:
   extends:
     - .kubernetes-env
     - .zombienet-refs
-    - .zombienet-common
   needs:
     - job: publish-polkadot-debug-image
     - job: publish-test-collators-image
     - job: publish-malus-image
   variables:
+    RUN_IN_CONTAINER: "1"
     GH_DIR: "https://github.com/paritytech/polkadot/tree/${CI_COMMIT_SHORT_SHA}/zombienet_tests/functional"
   before_script:
     - echo "Zombie-net Tests Config"
@@ -138,12 +134,12 @@ zombienet-tests-parachains-disputes-past-session:
   extends:
     - .kubernetes-env
     - .zombienet-refs
-    - .zombienet-common
   needs:
     - job: publish-polkadot-debug-image
     - job: publish-test-collators-image
     - job: publish-malus-image
   variables:
+    RUN_IN_CONTAINER: "1"
     GH_DIR: "https://github.com/paritytech/polkadot/tree/${CI_COMMIT_SHORT_SHA}/zombienet_tests/functional"
   before_script:
     - echo "Zombie-net Tests Config"
@@ -171,12 +167,12 @@ zombienet-test-parachains-upgrade-smoke-test:
   extends:
     - .kubernetes-env
     - .zombienet-refs
-    - .zombienet-common
   needs:
     - job: publish-polkadot-debug-image
     - job: publish-malus-image
     - job: publish-test-collators-image
   variables:
+    RUN_IN_CONTAINER: "1"
     GH_DIR: "https://github.com/paritytech/polkadot/tree/${CI_COMMIT_SHORT_SHA}/zombienet_tests/smoke"
   before_script:
     - echo "ZombieNet Tests Config"
@@ -202,12 +198,12 @@ zombienet-tests-misc-paritydb:
   extends:
     - .kubernetes-env
     - .zombienet-refs
-    - .zombienet-common
   needs:
     - job: publish-polkadot-debug-image
     - job: publish-test-collators-image
       artifacts: true
   variables:
+    RUN_IN_CONTAINER: "1"
     GH_DIR: "https://github.com/paritytech/polkadot/tree/${CI_COMMIT_SHORT_SHA}/zombienet_tests/misc"
   before_script:
     - echo "Zombie-net Tests Config"
@@ -232,14 +228,14 @@ zombienet-tests-misc-upgrade-node:
    extends:
      - .kubernetes-env
      - .zombienet-refs
-    - .zombienet-common
    needs:
      - job: publish-polkadot-debug-image
      - job: publish-test-collators-image
      - job: build-linux-stable
        artifacts: true
    variables:
-     GH_DIR: "https://github.com/paritytech/polkadot/tree/${CI_COMMIT_SHORT_SHA}/zombienet_tests/misc"
+    RUN_IN_CONTAINER: "1"
+    GH_DIR: "https://github.com/paritytech/polkadot/tree/${CI_COMMIT_SHORT_SHA}/zombienet_tests/misc"
    before_script:
      - echo "Zombie-net Tests Config"
      - echo "${ZOMBIENET_IMAGE_NAME}"
@@ -265,12 +261,12 @@ zombienet-tests-malus-dispute-valid:
   extends:
     - .kubernetes-env
     - .zombienet-refs
-    - .zombienet-common
   needs:
     - job: publish-polkadot-debug-image
     - job: publish-malus-image
     - job: publish-test-collators-image
   variables:
+    RUN_IN_CONTAINER: "1"
     GH_DIR: "https://github.com/paritytech/polkadot/tree/${CI_COMMIT_SHORT_SHA}/node/malus/integrationtests"
   before_script:
     - echo "Zombie-net Tests Config"
@@ -297,11 +293,11 @@ zombienet-tests-deregister-register-validator:
   extends:
     - .kubernetes-env
     - .zombienet-refs
-    - .zombienet-common
   needs:
     - job: publish-polkadot-debug-image
       artifacts: true
   variables:
+    RUN_IN_CONTAINER: "1"
     GH_DIR: "https://github.com/paritytech/polkadot/tree/${CI_COMMIT_SHORT_SHA}/zombienet_tests/smoke"
   before_script:
     - echo "Zombie-net Tests Config"
@@ -326,10 +322,10 @@ zombienet-tests-beefy-and-mmr:
   extends:
     - .kubernetes-env
     - .zombienet-refs
-    - .zombienet-common
   needs:
     - job: publish-polkadot-debug-image
   variables:
+    RUN_IN_CONTAINER: "1"
     GH_DIR: "https://github.com/paritytech/polkadot/tree/${CI_COMMIT_SHORT_SHA}/zombienet_tests/functional"
   before_script:
     - echo "Zombie-net Tests Config"

--- a/scripts/ci/gitlab/pipeline/zombienet.yml
+++ b/scripts/ci/gitlab/pipeline/zombienet.yml
@@ -1,5 +1,9 @@
 # This file is part of .gitlab-ci.yml
 # Here are all jobs that are executed during "zombienet" stage
+.zombienet-common:
+  variables:
+    RUN_IN_CONTAINER: "1"
+
 
 zombienet-tests-parachains-smoke-test:
   stage: zombienet
@@ -7,6 +11,7 @@ zombienet-tests-parachains-smoke-test:
   extends:
     - .kubernetes-env
     - .zombienet-refs
+    - .zombienet-common
   needs:
     - job: publish-polkadot-debug-image
     - job: publish-malus-image
@@ -38,6 +43,7 @@ zombienet-tests-parachains-pvf:
   extends:
     - .kubernetes-env
     - .zombienet-refs
+    - .zombienet-common
   needs:
     - job: publish-polkadot-debug-image
     - job: publish-test-collators-image
@@ -68,6 +74,7 @@ zombienet-tests-parachains-disputes:
   extends:
     - .kubernetes-env
     - .zombienet-refs
+    - .zombienet-common
   needs:
     - job: publish-polkadot-debug-image
     - job: publish-test-collators-image
@@ -99,6 +106,7 @@ zombienet-tests-parachains-disputes-garbage-candidate:
   extends:
     - .kubernetes-env
     - .zombienet-refs
+    - .zombienet-common
   needs:
     - job: publish-polkadot-debug-image
     - job: publish-test-collators-image
@@ -130,6 +138,7 @@ zombienet-tests-parachains-disputes-past-session:
   extends:
     - .kubernetes-env
     - .zombienet-refs
+    - .zombienet-common
   needs:
     - job: publish-polkadot-debug-image
     - job: publish-test-collators-image
@@ -162,6 +171,7 @@ zombienet-test-parachains-upgrade-smoke-test:
   extends:
     - .kubernetes-env
     - .zombienet-refs
+    - .zombienet-common
   needs:
     - job: publish-polkadot-debug-image
     - job: publish-malus-image
@@ -192,6 +202,7 @@ zombienet-tests-misc-paritydb:
   extends:
     - .kubernetes-env
     - .zombienet-refs
+    - .zombienet-common
   needs:
     - job: publish-polkadot-debug-image
     - job: publish-test-collators-image
@@ -221,6 +232,7 @@ zombienet-tests-misc-upgrade-node:
    extends:
      - .kubernetes-env
      - .zombienet-refs
+    - .zombienet-common
    needs:
      - job: publish-polkadot-debug-image
      - job: publish-test-collators-image
@@ -253,6 +265,7 @@ zombienet-tests-malus-dispute-valid:
   extends:
     - .kubernetes-env
     - .zombienet-refs
+    - .zombienet-common
   needs:
     - job: publish-polkadot-debug-image
     - job: publish-malus-image
@@ -284,6 +297,7 @@ zombienet-tests-deregister-register-validator:
   extends:
     - .kubernetes-env
     - .zombienet-refs
+    - .zombienet-common
   needs:
     - job: publish-polkadot-debug-image
       artifacts: true
@@ -312,6 +326,7 @@ zombienet-tests-beefy-and-mmr:
   extends:
     - .kubernetes-env
     - .zombienet-refs
+    - .zombienet-common
   needs:
     - job: publish-polkadot-debug-image
   variables:


### PR DESCRIPTION
The latest version of zombienet includes the fix for undying/adder collators args. (https://github.com/paritytech/zombienet/issues/1245).

Remove workaround introduced [here](https://github.com/paritytech/polkadot/pull/7617) because of this bug.

Thanks!