### PR TITLE
scheduler migration minor fixes

### DIFF
--- a/runtime/parachains/src/scheduler/migration.rs
+++ b/runtime/parachains/src/scheduler/migration.rs
@@ -109,10 +109,6 @@ pub mod v1 {
 				"Scheduled before migration: {}",
 				v0::Scheduled::<T>::get().len()
 			);
-			ensure!(
-				StorageVersion::get::<Pallet<T>>() == 0,
-				"Storage version should be less than `1` before the migration",
-			);
 
 			let bytes = u32::to_be_bytes(v0::Scheduled::<T>::get().len() as u32);
 
@@ -123,8 +119,8 @@ pub mod v1 {
 		fn post_upgrade(state: Vec<u8>) -> Result<(), sp_runtime::DispatchError> {
 			log::trace!(target: crate::scheduler::LOG_TARGET, "Running post_upgrade()");
 			ensure!(
-				StorageVersion::get::<Pallet<T>>() == 1,
-				"Storage version should be `1` after the migration"
+				StorageVersion::get::<Pallet<T>>() >= 1,
+				"Storage version should be at least `1` after the migration"
 			);
 			ensure!(
 				v0::Scheduled::<T>::get().len() == 0,


### PR DESCRIPTION
Existing scheduler pre/post hooks contain unnecessarily strict checks which will begin failing after the migration is applied, breaking our runtime migration CI checks.

I could have used `VersionedRuntimeUpgrade` here, but it seemed overkill and I didn't want to break the API and cause unnecessary merge conflicts in Rob's async backing PR. 

### `pre_upgrade` change

Removed check ensuring on-chain version is 0.

This check is unnecessary as it is already checked in `on_runtime_upgrade`, which skips the migration and warns the developer if the migration can be removed.

### `post_upgrade` change:

Changed check ensuring the post-upgrade version == 1 to checking it is >= 1.

This check is unnecessary because all pallet `post_upgrade` hooks already check that the on-chain version matches the pallet version post-upgrade.