### PR TITLE
Use cached session index to obtain executor params

### DIFF
--- a/node/core/approval-voting/src/lib.rs
+++ b/node/core/approval-voting/src/lib.rs
@@ -50,8 +50,8 @@ use polkadot_node_subsystem_util::{
 };
 use polkadot_primitives::{
 	ApprovalVote, BlockNumber, CandidateHash, CandidateIndex, CandidateReceipt, DisputeStatement,
-	GroupIndex, Hash, PvfExecTimeoutKind, SessionIndex, SessionInfo, ValidDisputeStatementKind,
-	ValidatorId, ValidatorIndex, ValidatorPair, ValidatorSignature,
+	ExecutorParams, GroupIndex, Hash, PvfExecTimeoutKind, SessionIndex, SessionInfo,
+	ValidDisputeStatementKind, ValidatorId, ValidatorIndex, ValidatorPair, ValidatorSignature,
 };
 use sc_keystore::LocalKeystore;
 use sp_application_crypto::Pair;
@@ -1009,6 +1009,15 @@ async fn handle_actions<Context>(
 					},
 					None => {
 						let ctx = &mut *ctx;
+						// FIXME: Should we request at `block_hash` or `relay_block_hash`?
+						let executor_params = match session_info_provider
+							.get_session_info_by_index(ctx.sender(), block_hash, session)
+							.await
+						{
+							Err(_) => None,
+							Ok(extended_session_info) =>
+								Some(extended_session_info.executor_params.clone()),
+						};
 						currently_checking_set
 							.insert_relay_block_hash(
 								candidate_hash,
@@ -1023,6 +1032,7 @@ async fn handle_actions<Context>(
 										validator_index,
 										block_hash,
 										backing_group,
+										executor_params,
 										&launch_approval_span,
 									)
 									.await
@@ -2462,6 +2472,7 @@ async fn launch_approval<Context>(
 	validator_index: ValidatorIndex,
 	block_hash: Hash,
 	backing_group: GroupIndex,
+	executor_params: Option<ExecutorParams>,
 	span: &jaeger::Span,
 ) -> SubsystemResult<RemoteHandle<ApprovalState>> {
 	let (a_tx, a_rx) = oneshot::channel();
@@ -2531,6 +2542,11 @@ async fn launch_approval<Context>(
 	let background = async move {
 		// Force the move of the timer into the background task.
 		let _timer = timer;
+
+		let executor_params = match executor_params {
+			Some(ep) => ep,
+			None => return ApprovalState::failed(validator_index, candidate_hash),
+		};
 
 		let available_data = match a_rx.await {
 			Err(_) => return ApprovalState::failed(validator_index, candidate_hash),
@@ -2607,6 +2623,7 @@ async fn launch_approval<Context>(
 				validation_code,
 				candidate.clone(),
 				available_data.pov,
+				executor_params,
 				PvfExecTimeoutKind::Approval,
 				val_tx,
 			))

--- a/node/core/approval-voting/src/tests.rs
+++ b/node/core/approval-voting/src/tests.rs
@@ -2376,7 +2376,7 @@ async fn handle_double_assignment_import(
 
 	assert_matches!(
 		overseer_recv(virtual_overseer).await,
-		AllMessages::CandidateValidation(CandidateValidationMessage::ValidateFromExhaustive(_, _, _, _, timeout, tx)) if timeout == PvfExecTimeoutKind::Approval => {
+		AllMessages::CandidateValidation(CandidateValidationMessage::ValidateFromExhaustive(_, _, _, _, _, timeout, tx)) if timeout == PvfExecTimeoutKind::Approval => {
 			tx.send(Ok(ValidationResult::Valid(Default::default(), Default::default())))
 				.unwrap();
 		}

--- a/node/core/backing/src/tests.rs
+++ b/node/core/backing/src/tests.rs
@@ -300,6 +300,7 @@ fn backing_second_works() {
 				CandidateValidationMessage::ValidateFromChainState(
 					candidate_receipt,
 					pov,
+					_,
 					timeout,
 					tx,
 				)
@@ -442,6 +443,7 @@ fn backing_works() {
 				CandidateValidationMessage::ValidateFromChainState(
 					c,
 					pov,
+					_,
 					timeout,
 					tx,
 				)
@@ -608,6 +610,7 @@ fn backing_works_while_validation_ongoing() {
 				CandidateValidationMessage::ValidateFromChainState(
 					c,
 					pov,
+					_,
 					timeout,
 					tx,
 				)
@@ -757,6 +760,7 @@ fn backing_misbehavior_works() {
 				CandidateValidationMessage::ValidateFromChainState(
 					c,
 					pov,
+					_,
 					timeout,
 					tx,
 				)
@@ -901,6 +905,7 @@ fn backing_dont_second_invalid() {
 				CandidateValidationMessage::ValidateFromChainState(
 					c,
 					pov,
+					_,
 					timeout,
 					tx,
 				)
@@ -930,6 +935,7 @@ fn backing_dont_second_invalid() {
 				CandidateValidationMessage::ValidateFromChainState(
 					c,
 					pov,
+					_,
 					timeout,
 					tx,
 				)
@@ -1043,6 +1049,7 @@ fn backing_second_after_first_fails_works() {
 				CandidateValidationMessage::ValidateFromChainState(
 					c,
 					pov,
+					_,
 					timeout,
 					tx,
 				)
@@ -1091,6 +1098,7 @@ fn backing_second_after_first_fails_works() {
 				CandidateValidationMessage::ValidateFromChainState(
 					_,
 					pov,
+					_,
 					_,
 					_,
 				)
@@ -1167,6 +1175,7 @@ fn backing_works_after_failed_validation() {
 				CandidateValidationMessage::ValidateFromChainState(
 					c,
 					pov,
+					_,
 					timeout,
 					tx,
 				)
@@ -1512,6 +1521,7 @@ fn retry_works() {
 				CandidateValidationMessage::ValidateFromChainState(
 					c,
 					pov,
+					_,
 					timeout,
 					_tx,
 				)

--- a/node/core/candidate-validation/src/tests.rs
+++ b/node/core/candidate-validation/src/tests.rs
@@ -461,18 +461,17 @@ fn candidate_validation_ok_is_ok() {
 	let candidate_receipt = CandidateReceipt { descriptor, commitments_hash: commitments.hash() };
 
 	let pool = TaskExecutor::new();
-	let (mut ctx, ctx_handle) =
-		test_helpers::make_subsystem_context::<AllMessages, _>(pool.clone());
+	let (_ctx, ctx_handle) = test_helpers::make_subsystem_context::<AllMessages, _>(pool.clone());
 	let metrics = Metrics::default();
 
 	let v = test_with_executor_params(ctx_handle, || {
 		validate_candidate_exhaustive(
-			ctx.sender(),
 			MockValidateCandidateBackend::with_hardcoded_result(Ok(validation_result)),
 			validation_data.clone(),
 			validation_code,
 			candidate_receipt,
 			Arc::new(pov),
+			ExecutorParams::default(),
 			PvfExecTimeoutKind::Backing,
 			&metrics,
 		)
@@ -518,13 +517,11 @@ fn candidate_validation_bad_return_is_invalid() {
 	let candidate_receipt = CandidateReceipt { descriptor, commitments_hash: Hash::zero() };
 
 	let pool = TaskExecutor::new();
-	let (mut ctx, ctx_handle) =
-		test_helpers::make_subsystem_context::<AllMessages, _>(pool.clone());
+	let (_ctx, ctx_handle) = test_helpers::make_subsystem_context::<AllMessages, _>(pool.clone());
 	let metrics = Metrics::default();
 
 	let v = test_with_executor_params(ctx_handle, || {
 		validate_candidate_exhaustive(
-			ctx.sender(),
 			MockValidateCandidateBackend::with_hardcoded_result(Err(
 				ValidationError::InvalidCandidate(WasmInvalidCandidate::HardTimeout),
 			)),
@@ -532,6 +529,7 @@ fn candidate_validation_bad_return_is_invalid() {
 			validation_code,
 			candidate_receipt,
 			Arc::new(pov),
+			ExecutorParams::default(),
 			PvfExecTimeoutKind::Backing,
 			&metrics,
 		)
@@ -589,13 +587,11 @@ fn candidate_validation_one_ambiguous_error_is_valid() {
 	let candidate_receipt = CandidateReceipt { descriptor, commitments_hash: commitments.hash() };
 
 	let pool = TaskExecutor::new();
-	let (mut ctx, ctx_handle) =
-		test_helpers::make_subsystem_context::<AllMessages, _>(pool.clone());
+	let (_ctx, ctx_handle) = test_helpers::make_subsystem_context::<AllMessages, _>(pool.clone());
 	let metrics = Metrics::default();
 
 	let v = test_with_executor_params(ctx_handle, || {
 		validate_candidate_exhaustive(
-			ctx.sender(),
 			MockValidateCandidateBackend::with_hardcoded_result_list(vec![
 				Err(ValidationError::InvalidCandidate(WasmInvalidCandidate::AmbiguousWorkerDeath)),
 				Ok(validation_result),
@@ -604,6 +600,7 @@ fn candidate_validation_one_ambiguous_error_is_valid() {
 			validation_code,
 			candidate_receipt,
 			Arc::new(pov),
+			ExecutorParams::default(),
 			PvfExecTimeoutKind::Backing,
 			&metrics,
 		)
@@ -649,13 +646,11 @@ fn candidate_validation_multiple_ambiguous_errors_is_invalid() {
 	let candidate_receipt = CandidateReceipt { descriptor, commitments_hash: Hash::zero() };
 
 	let pool = TaskExecutor::new();
-	let (mut ctx, ctx_handle) =
-		test_helpers::make_subsystem_context::<AllMessages, _>(pool.clone());
+	let (_ctx, ctx_handle) = test_helpers::make_subsystem_context::<AllMessages, _>(pool.clone());
 	let metrics = Metrics::default();
 
 	let v = test_with_executor_params(ctx_handle, || {
 		validate_candidate_exhaustive(
-			ctx.sender(),
 			MockValidateCandidateBackend::with_hardcoded_result_list(vec![
 				Err(ValidationError::InvalidCandidate(WasmInvalidCandidate::AmbiguousWorkerDeath)),
 				Err(ValidationError::InvalidCandidate(WasmInvalidCandidate::AmbiguousWorkerDeath)),
@@ -664,6 +659,7 @@ fn candidate_validation_multiple_ambiguous_errors_is_invalid() {
 			validation_code,
 			candidate_receipt,
 			Arc::new(pov),
+			ExecutorParams::default(),
 			PvfExecTimeoutKind::Backing,
 			&metrics,
 		)
@@ -703,13 +699,11 @@ fn candidate_validation_retry_internal_errors() {
 	let candidate_receipt = CandidateReceipt { descriptor, commitments_hash: Hash::zero() };
 
 	let pool = TaskExecutor::new();
-	let (mut ctx, ctx_handle) =
-		test_helpers::make_subsystem_context::<AllMessages, _>(pool.clone());
+	let (_ctx, ctx_handle) = test_helpers::make_subsystem_context::<AllMessages, _>(pool.clone());
 	let metrics = Metrics::default();
 
 	let v = test_with_executor_params(ctx_handle, || {
 		validate_candidate_exhaustive(
-			ctx.sender(),
 			MockValidateCandidateBackend::with_hardcoded_result_list(vec![
 				Err(InternalValidationError::HostCommunication("foo".into()).into()),
 				// Throw an AWD error, we should still retry again.
@@ -721,6 +715,7 @@ fn candidate_validation_retry_internal_errors() {
 			validation_code,
 			candidate_receipt,
 			Arc::new(pov),
+			ExecutorParams::default(),
 			PvfExecTimeoutKind::Backing,
 			&metrics,
 		)
@@ -759,13 +754,11 @@ fn candidate_validation_retry_panic_errors() {
 	let candidate_receipt = CandidateReceipt { descriptor, commitments_hash: Hash::zero() };
 
 	let pool = TaskExecutor::new();
-	let (mut ctx, ctx_handle) =
-		test_helpers::make_subsystem_context::<AllMessages, _>(pool.clone());
+	let (_ctx, ctx_handle) = test_helpers::make_subsystem_context::<AllMessages, _>(pool.clone());
 	let metrics = Metrics::default();
 
 	let v = test_with_executor_params(ctx_handle, || {
 		validate_candidate_exhaustive(
-			ctx.sender(),
 			MockValidateCandidateBackend::with_hardcoded_result_list(vec![
 				Err(ValidationError::InvalidCandidate(WasmInvalidCandidate::Panic("foo".into()))),
 				// Throw an AWD error, we should still retry again.
@@ -777,6 +770,7 @@ fn candidate_validation_retry_panic_errors() {
 			validation_code,
 			candidate_receipt,
 			Arc::new(pov),
+			ExecutorParams::default(),
 			PvfExecTimeoutKind::Backing,
 			&metrics,
 		)
@@ -814,13 +808,11 @@ fn candidate_validation_timeout_is_internal_error() {
 	let candidate_receipt = CandidateReceipt { descriptor, commitments_hash: Hash::zero() };
 
 	let pool = TaskExecutor::new();
-	let (mut ctx, ctx_handle) =
-		test_helpers::make_subsystem_context::<AllMessages, _>(pool.clone());
+	let (_ctx, ctx_handle) = test_helpers::make_subsystem_context::<AllMessages, _>(pool.clone());
 	let metrics = Metrics::default();
 
 	let v = test_with_executor_params(ctx_handle, || {
 		validate_candidate_exhaustive(
-			ctx.sender(),
 			MockValidateCandidateBackend::with_hardcoded_result(Err(
 				ValidationError::InvalidCandidate(WasmInvalidCandidate::HardTimeout),
 			)),
@@ -828,6 +820,7 @@ fn candidate_validation_timeout_is_internal_error() {
 			validation_code,
 			candidate_receipt,
 			Arc::new(pov),
+			ExecutorParams::default(),
 			PvfExecTimeoutKind::Backing,
 			&metrics,
 		)
@@ -868,18 +861,17 @@ fn candidate_validation_commitment_hash_mismatch_is_invalid() {
 	};
 
 	let pool = TaskExecutor::new();
-	let (mut ctx, ctx_handle) =
-		test_helpers::make_subsystem_context::<AllMessages, _>(pool.clone());
+	let (_ctx, ctx_handle) = test_helpers::make_subsystem_context::<AllMessages, _>(pool.clone());
 	let metrics = Metrics::default();
 
 	let result = test_with_executor_params(ctx_handle, || {
 		validate_candidate_exhaustive(
-			ctx.sender(),
 			MockValidateCandidateBackend::with_hardcoded_result(Ok(validation_result)),
 			validation_data,
 			validation_code,
 			candidate_receipt,
 			Arc::new(pov),
+			ExecutorParams::default(),
 			PvfExecTimeoutKind::Backing,
 			&metrics,
 		)
@@ -919,11 +911,9 @@ fn candidate_validation_code_mismatch_is_invalid() {
 	let candidate_receipt = CandidateReceipt { descriptor, commitments_hash: Hash::zero() };
 
 	let pool = TaskExecutor::new();
-	let (mut ctx, _ctx_handle) =
-		test_helpers::make_subsystem_context::<AllMessages, _>(pool.clone());
+	let (_ctx, _ctx_handle) = test_helpers::make_subsystem_context::<AllMessages, _>(pool.clone());
 
 	let v = executor::block_on(validate_candidate_exhaustive(
-		ctx.sender(),
 		MockValidateCandidateBackend::with_hardcoded_result(Err(
 			ValidationError::InvalidCandidate(WasmInvalidCandidate::HardTimeout),
 		)),
@@ -931,6 +921,7 @@ fn candidate_validation_code_mismatch_is_invalid() {
 		validation_code,
 		candidate_receipt,
 		Arc::new(pov),
+		ExecutorParams::default(),
 		PvfExecTimeoutKind::Backing,
 		&Default::default(),
 	))
@@ -982,18 +973,17 @@ fn compressed_code_works() {
 	let candidate_receipt = CandidateReceipt { descriptor, commitments_hash: commitments.hash() };
 
 	let pool = TaskExecutor::new();
-	let (mut ctx, ctx_handle) =
-		test_helpers::make_subsystem_context::<AllMessages, _>(pool.clone());
+	let (_ctx, ctx_handle) = test_helpers::make_subsystem_context::<AllMessages, _>(pool.clone());
 	let metrics = Metrics::default();
 
 	let v = test_with_executor_params(ctx_handle, || {
 		validate_candidate_exhaustive(
-			ctx.sender(),
 			MockValidateCandidateBackend::with_hardcoded_result(Ok(validation_result)),
 			validation_data,
 			validation_code,
 			candidate_receipt,
 			Arc::new(pov),
+			ExecutorParams::default(),
 			PvfExecTimeoutKind::Backing,
 			&metrics,
 		)
@@ -1037,16 +1027,15 @@ fn code_decompression_failure_is_error() {
 	let candidate_receipt = CandidateReceipt { descriptor, commitments_hash: Hash::zero() };
 
 	let pool = TaskExecutor::new();
-	let (mut ctx, _ctx_handle) =
-		test_helpers::make_subsystem_context::<AllMessages, _>(pool.clone());
+	let (_ctx, _ctx_handle) = test_helpers::make_subsystem_context::<AllMessages, _>(pool.clone());
 
 	let v = executor::block_on(validate_candidate_exhaustive(
-		ctx.sender(),
 		MockValidateCandidateBackend::with_hardcoded_result(Ok(validation_result)),
 		validation_data,
 		validation_code,
 		candidate_receipt,
 		Arc::new(pov),
+		ExecutorParams::default(),
 		PvfExecTimeoutKind::Backing,
 		&Default::default(),
 	));
@@ -1090,16 +1079,15 @@ fn pov_decompression_failure_is_invalid() {
 	let candidate_receipt = CandidateReceipt { descriptor, commitments_hash: Hash::zero() };
 
 	let pool = TaskExecutor::new();
-	let (mut ctx, _ctx_handle) =
-		test_helpers::make_subsystem_context::<AllMessages, _>(pool.clone());
+	let (_ctx, _ctx_handle) = test_helpers::make_subsystem_context::<AllMessages, _>(pool.clone());
 
 	let v = executor::block_on(validate_candidate_exhaustive(
-		ctx.sender(),
 		MockValidateCandidateBackend::with_hardcoded_result(Ok(validation_result)),
 		validation_data,
 		validation_code,
 		candidate_receipt,
 		Arc::new(pov),
+		ExecutorParams::default(),
 		PvfExecTimeoutKind::Backing,
 		&Default::default(),
 	));

--- a/node/core/dispute-coordinator/src/initialized.rs
+++ b/node/core/dispute-coordinator/src/initialized.rs
@@ -1160,6 +1160,7 @@ impl Initialized {
 					ParticipationRequest::new(
 						new_state.candidate_receipt().clone(),
 						session,
+						env.executor_params().clone(),
 						request_timer,
 					),
 				)

--- a/node/core/dispute-coordinator/src/lib.rs
+++ b/node/core/dispute-coordinator/src/lib.rs
@@ -398,6 +398,7 @@ impl DisputeCoordinatorSubsystem {
 						ParticipationRequest::new(
 							vote_state.votes().candidate_receipt.clone(),
 							session,
+							env.executor_params().clone(),
 							request_timer,
 						),
 					));

--- a/node/core/dispute-coordinator/src/participation/mod.rs
+++ b/node/core/dispute-coordinator/src/participation/mod.rs
@@ -366,6 +366,7 @@ async fn participate(
 			validation_code,
 			req.candidate_receipt().clone(),
 			available_data.pov,
+			req.executor_params(),
 			PvfExecTimeoutKind::Approval,
 			validation_tx,
 		))

--- a/node/core/dispute-coordinator/src/participation/queues/tests.rs
+++ b/node/core/dispute-coordinator/src/participation/queues/tests.rs
@@ -27,7 +27,7 @@ fn make_participation_request(hash: Hash) -> ParticipationRequest {
 	// make it differ:
 	receipt.commitments_hash = hash;
 	let request_timer = Metrics::default().time_participation_pipeline();
-	ParticipationRequest::new(receipt, 1, request_timer)
+	ParticipationRequest::new(receipt, 1, Default::default(), request_timer)
 }
 
 /// Make dummy comparator for request, based on the given block number.
@@ -46,6 +46,7 @@ fn clone_request(request: &ParticipationRequest) -> ParticipationRequest {
 		candidate_receipt: request.candidate_receipt.clone(),
 		candidate_hash: request.candidate_hash.clone(),
 		session: request.session,
+		executor_params: request.executor_params.clone(),
 		request_timer: None,
 	}
 }

--- a/node/core/dispute-coordinator/src/participation/tests.rs
+++ b/node/core/dispute-coordinator/src/participation/tests.rs
@@ -73,7 +73,8 @@ async fn participate_with_commitments_hash<Context>(
 	let session = 1;
 
 	let request_timer = participation.metrics.time_participation_pipeline();
-	let req = ParticipationRequest::new(candidate_receipt, session, request_timer);
+	let req =
+		ParticipationRequest::new(candidate_receipt, session, Default::default(), request_timer);
 
 	participation
 		.queue_participation(ctx, ParticipationPriority::BestEffort, req)
@@ -120,7 +121,7 @@ pub async fn participation_full_happy_path(
 	assert_matches!(
 	ctx_handle.recv().await,
 	AllMessages::CandidateValidation(
-		CandidateValidationMessage::ValidateFromExhaustive(_, _, candidate_receipt, _, timeout, tx)
+		CandidateValidationMessage::ValidateFromExhaustive(_, _, candidate_receipt, _, _, timeout, tx)
 		) if timeout == PvfExecTimeoutKind::Approval => {
 			if expected_commitments_hash != candidate_receipt.commitments_hash {
 				tx.send(Ok(ValidationResult::Invalid(InvalidCandidate::CommitmentsHashMismatch))).unwrap();
@@ -454,7 +455,7 @@ fn cast_invalid_vote_if_validation_fails_or_is_invalid() {
 		assert_matches!(
 			ctx_handle.recv().await,
 			AllMessages::CandidateValidation(
-				CandidateValidationMessage::ValidateFromExhaustive(_, _, _, _, timeout, tx)
+				CandidateValidationMessage::ValidateFromExhaustive(_, _, _, _, _, timeout, tx)
 			) if timeout == PvfExecTimeoutKind::Approval => {
 				tx.send(Ok(ValidationResult::Invalid(InvalidCandidate::Timeout))).unwrap();
 			},
@@ -491,7 +492,7 @@ fn cast_invalid_vote_if_commitments_dont_match() {
 		assert_matches!(
 			ctx_handle.recv().await,
 			AllMessages::CandidateValidation(
-				CandidateValidationMessage::ValidateFromExhaustive(_, _, _, _, timeout, tx)
+				CandidateValidationMessage::ValidateFromExhaustive(_, _, _, _, _, timeout, tx)
 			) if timeout == PvfExecTimeoutKind::Approval => {
 				tx.send(Ok(ValidationResult::Invalid(InvalidCandidate::CommitmentsHashMismatch))).unwrap();
 			},
@@ -528,7 +529,7 @@ fn cast_valid_vote_if_validation_passes() {
 		assert_matches!(
 			ctx_handle.recv().await,
 			AllMessages::CandidateValidation(
-				CandidateValidationMessage::ValidateFromExhaustive(_, _, _, _, timeout, tx)
+				CandidateValidationMessage::ValidateFromExhaustive(_, _, _, _, _, timeout, tx)
 			) if timeout == PvfExecTimeoutKind::Approval => {
 				tx.send(Ok(ValidationResult::Valid(dummy_candidate_commitments(None), PersistedValidationData::default()))).unwrap();
 			},

--- a/node/subsystem-types/src/messages.rs
+++ b/node/subsystem-types/src/messages.rs
@@ -118,6 +118,7 @@ pub enum CandidateValidationMessage {
 	ValidateFromChainState(
 		CandidateReceipt,
 		Arc<PoV>,
+		ExecutorParams,
 		/// Execution timeout
 		PvfExecTimeoutKind,
 		oneshot::Sender<Result<ValidationResult, ValidationFailed>>,
@@ -136,6 +137,7 @@ pub enum CandidateValidationMessage {
 		ValidationCode,
 		CandidateReceipt,
 		Arc<PoV>,
+		ExecutorParams,
 		/// Execution timeout
 		PvfExecTimeoutKind,
 		oneshot::Sender<Result<ValidationResult, ValidationFailed>>,

--- a/node/subsystem-util/src/runtime/error.rs
+++ b/node/subsystem-util/src/runtime/error.rs
@@ -38,6 +38,10 @@ pub enum Error {
 	/// We tried fetching a session info which was not available.
 	#[error("There was no session with the given index {0}")]
 	NoSuchSession(SessionIndex),
+
+	/// We tried fetching executor params for a session which were not available.
+	#[error("There was no executor parameters for session with the given index {0}")]
+	NoExecutorParams(SessionIndex),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/node/subsystem-util/src/runtime/mod.rs
+++ b/node/subsystem-util/src/runtime/mod.rs
@@ -27,17 +27,17 @@ use sp_keystore::{Keystore, KeystorePtr};
 
 use polkadot_node_subsystem::{messages::RuntimeApiMessage, overseer, SubsystemSender};
 use polkadot_primitives::{
-	vstaging, CandidateEvent, CandidateHash, CoreState, EncodeAs, GroupIndex, GroupRotationInfo,
-	Hash, IndexedVec, OccupiedCore, ScrapedOnChainVotes, SessionIndex, SessionInfo, Signed,
-	SigningContext, UncheckedSigned, ValidationCode, ValidationCodeHash, ValidatorId,
-	ValidatorIndex,
+	vstaging, CandidateEvent, CandidateHash, CoreState, EncodeAs, ExecutorParams, GroupIndex,
+	GroupRotationInfo, Hash, IndexedVec, OccupiedCore, ScrapedOnChainVotes, SessionIndex,
+	SessionInfo, Signed, SigningContext, UncheckedSigned, ValidationCode, ValidationCodeHash,
+	ValidatorId, ValidatorIndex,
 };
 
 use crate::{
 	request_availability_cores, request_candidate_events, request_key_ownership_proof,
-	request_on_chain_votes, request_session_index_for_child, request_session_info,
-	request_submit_report_dispute_lost, request_unapplied_slashes, request_validation_code_by_hash,
-	request_validator_groups,
+	request_on_chain_votes, request_session_executor_params, request_session_index_for_child,
+	request_session_info, request_submit_report_dispute_lost, request_unapplied_slashes,
+	request_validation_code_by_hash, request_validator_groups,
 };
 
 /// Errors that can happen on runtime fetches.
@@ -80,6 +80,8 @@ pub struct ExtendedSessionInfo {
 	pub session_info: SessionInfo,
 	/// Contains useful information about ourselves, in case this node is a validator.
 	pub validator_info: ValidatorInfo,
+	/// Session executor parameters
+	pub executor_params: ExecutorParams,
 }
 
 /// Information about ourselves, in case we are an `Authority`.
@@ -173,9 +175,15 @@ impl RuntimeInfo {
 				recv_runtime(request_session_info(parent, session_index, sender).await)
 					.await?
 					.ok_or(JfyiError::NoSuchSession(session_index))?;
+
+			let executor_params =
+				recv_runtime(request_session_executor_params(parent, session_index, sender).await)
+					.await?
+					.ok_or(JfyiError::NoExecutorParams(session_index))?;
+
 			let validator_info = self.get_validator_info(&session_info)?;
 
-			let full_info = ExtendedSessionInfo { session_info, validator_info };
+			let full_info = ExtendedSessionInfo { session_info, validator_info, executor_params };
 
 			self.session_info_cache.put(session_index, full_info);
 		}


### PR DESCRIPTION
Closes #7604 

To validate a candidate, approval voting and dispute coordinator subsystems currently rely on the candidate validation subsystem, which requests executor parameters at a session determined by the candidate's relay parent. This is unreliable, as the state at that relay parent may already be pruned. Still, we want to be able to apply slashes in that case.

This PR makes use of the internal cache maintained by approval voting and dispute distribution subsystems to reliably obtain session index even if the state in question has already been pruned. Then the execution parameters are requested and provided to the candidate validation subsystem, which doesn't have to request them on its own anymore.

The positive side effect is that the candidate validation subsystem is returning to its pre-#6161 state, that is, it expects the exhaustive validation data from a requesting subsystem instead of doing its own data collection.

The backing subsystem, also affected by the change, does not maintain any cache of session indexes as it doesn't need it, as the state at that stage is guaranteed to be alive. A session index is always known when a backing job is created. Executor parameters are requested before performing the actual validation using that session index.