### PR TITLE
PVF worker: random fixes

### DIFF
--- a/node/core/pvf/common/src/worker/mod.rs
+++ b/node/core/pvf/common/src/worker/mod.rs
@@ -173,10 +173,10 @@ fn remove_env_vars(debug_id: &'static str) {
 			err_reasons.push("key contains '='");
 		}
 		if key_str.is_some_and(|s| s.contains('\0')) {
-			err_reasons.push("key contains '\0' (null character)");
+			err_reasons.push("key contains null character");
 		}
 		if value_str.is_some_and(|s| s.contains('\0')) {
-			err_reasons.push("value contains '\0' (null character)");
+			err_reasons.push("value contains null character");
 		}
 		if !err_reasons.is_empty() {
 			gum::warn!(

--- a/node/core/pvf/common/src/worker/mod.rs
+++ b/node/core/pvf/common/src/worker/mod.rs
@@ -127,7 +127,7 @@ pub fn worker_event_loop<F, Fut>(
 		}
 	}
 
-	remove_env_vars();
+	remove_env_vars(debug_id);
 
 	// Run the main worker loop.
 	let rt = Runtime::new().expect("Creates tokio runtime. If this panics the worker will die and the host will detect that and deal with it.");
@@ -152,7 +152,7 @@ pub fn worker_event_loop<F, Fut>(
 }
 
 /// Delete all env vars to prevent malicious code from accessing them.
-fn remove_env_vars() {
+fn remove_env_vars(debug_id: &'static str) {
 	for (key, value) in std::env::vars_os() {
 		// TODO: *theoretically* the value (or mere presence) of `RUST_LOG` can be a source of
 		// randomness for malicious code. In the future we can remove it also and log in the host;
@@ -181,9 +181,10 @@ fn remove_env_vars() {
 		if !err_reasons.is_empty() {
 			gum::warn!(
 				target: LOG_TARGET,
+				%debug_id,
 				?key,
 				?value,
-				"Attempting to remove env var may fail: {:?}",
+				"Attempting to remove badly-formatted env var, this may cause the PVF worker to crash. Please remove it yourself. Reasons: {:?}",
 				err_reasons
 			);
 		}

--- a/node/core/pvf/common/src/worker/mod.rs
+++ b/node/core/pvf/common/src/worker/mod.rs
@@ -132,7 +132,7 @@ pub fn worker_event_loop<F, Fut>(
 		// TODO: *theoretically* the value (or mere presence) of `RUST_LOG` can be a source of
 		// randomness for malicious code. In the future we can remove it also and log in the host;
 		// see <https://github.com/paritytech/polkadot/issues/7117>.
-		if key.to_str() != Some("RUST_LOG") {
+		if key != "RUST_LOG" {
 			std::env::remove_var(key);
 		}
 	}


### PR DESCRIPTION
- Fixes possible panic due to non-UTF-8 env vars (see [here](https://github.com/paritytech/polkadot/pull/7330#discussion_r1300101716))
- In case of a key or value that would cause [`env::remove_var` to panic](https://doc.rust-lang.org/std/env/fn.remove_var.html#panics), we first log a warning and then proceed to attempt to remove the env var.
  - ~Not needed on Unix according to @vstakhov~
- Very small refactor of some duplicated code

I didn't address [keeping `PATH`](https://github.com/paritytech/polkadot/pull/7330#discussion_r1300103960) as it's not needed for the workers to function. @vstakhov is there any reason to keep it?