### PR TITLE
Validator disabling - node side changes

### DIFF
--- a/node/core/runtime-api/src/cache.rs
+++ b/node/core/runtime-api/src/cache.rs
@@ -68,6 +68,7 @@ pub(crate) struct RequestResultCache {
 		LruCache<Hash, Vec<(SessionIndex, CandidateHash, vstaging::slashing::PendingSlashes)>>,
 	key_ownership_proof:
 		LruCache<(Hash, ValidatorId), Option<vstaging::slashing::OpaqueKeyOwnershipProof>>,
+	disabled_validators: LruCache<Hash, Vec<ValidatorIndex>>,
 
 	staging_para_backing_state: LruCache<(Hash, ParaId), Option<vstaging::BackingState>>,
 	staging_async_backing_params: LruCache<Hash, vstaging::AsyncBackingParams>,
@@ -100,6 +101,7 @@ impl Default for RequestResultCache {
 			disputes: LruCache::new(DEFAULT_CACHE_CAP),
 			unapplied_slashes: LruCache::new(DEFAULT_CACHE_CAP),
 			key_ownership_proof: LruCache::new(DEFAULT_CACHE_CAP),
+			disabled_validators: LruCache::new(DEFAULT_CACHE_CAP),
 
 			staging_para_backing_state: LruCache::new(DEFAULT_CACHE_CAP),
 			staging_async_backing_params: LruCache::new(DEFAULT_CACHE_CAP),
@@ -437,6 +439,21 @@ impl RequestResultCache {
 		None
 	}
 
+	pub(crate) fn disabled_validators(
+		&mut self,
+		relay_parent: &Hash,
+	) -> Option<&Vec<ValidatorIndex>> {
+		self.disabled_validators.get(relay_parent)
+	}
+
+	pub(crate) fn cache_disabled_validators(
+		&mut self,
+		relay_parent: Hash,
+		disabled_validators: Vec<ValidatorIndex>,
+	) {
+		self.disabled_validators.put(relay_parent, disabled_validators);
+	}
+
 	pub(crate) fn staging_para_backing_state(
 		&mut self,
 		key: (Hash, ParaId),
@@ -512,6 +529,7 @@ pub(crate) enum RequestResult {
 		vstaging::slashing::OpaqueKeyOwnershipProof,
 		Option<()>,
 	),
+	DisabledValidators(Hash, Vec<ValidatorIndex>),
 
 	StagingParaBackingState(Hash, ParaId, Option<vstaging::BackingState>),
 	StagingAsyncBackingParams(Hash, vstaging::AsyncBackingParams),

--- a/node/core/runtime-api/src/lib.rs
+++ b/node/core/runtime-api/src/lib.rs
@@ -163,6 +163,8 @@ where
 				.requests_cache
 				.cache_key_ownership_proof((relay_parent, validator_id), key_ownership_proof),
 			SubmitReportDisputeLost(_, _, _, _) => {},
+			DisabledValidators(relay_parent, disabled_validators) =>
+				self.requests_cache.cache_disabled_validators(relay_parent, disabled_validators),
 
 			StagingParaBackingState(relay_parent, para_id, constraints) => self
 				.requests_cache
@@ -294,6 +296,8 @@ where
 						Request::SubmitReportDisputeLost(dispute_proof, key_ownership_proof, sender)
 					},
 				),
+			Request::DisabledValidators(sender) => query!(disabled_validators(), sender)
+				.map(|sender| Request::DisabledValidators(sender)),
 
 			Request::StagingParaBackingState(para, sender) =>
 				query!(staging_para_backing_state(para), sender)
@@ -549,6 +553,12 @@ where
 			SubmitReportDisputeLost,
 			submit_report_dispute_lost(dispute_proof, key_ownership_proof),
 			ver = Request::SUBMIT_REPORT_DISPUTE_LOST_RUNTIME_REQUIREMENT,
+			sender
+		),
+		Request::DisabledValidators(sender) => query!(
+			DisabledValidators,
+			disabled_validators(),
+			ver = Request::DISABLED_VALIDATORS_RUNTIME_REQUIREMENT,
 			sender
 		),
 

--- a/node/subsystem-types/src/messages.rs
+++ b/node/subsystem-types/src/messages.rs
@@ -691,6 +691,9 @@ pub enum RuntimeApiRequest {
 		slashing::OpaqueKeyOwnershipProof,
 		RuntimeApiSender<Option<()>>,
 	),
+	/// Returns all disabled validators at a given block height.
+	/// `V6`
+	DisabledValidators(RuntimeApiSender<Vec<ValidatorIndex>>),
 
 	/// Get the backing state of the given para.
 	/// This is a staging API that will not be available on production runtimes.
@@ -718,6 +721,9 @@ impl RuntimeApiRequest {
 
 	/// `SubmitReportDisputeLost`
 	pub const SUBMIT_REPORT_DISPUTE_LOST_RUNTIME_REQUIREMENT: u32 = 5;
+
+	/// `DisabledValidators`
+	pub const DISABLED_VALIDATORS_RUNTIME_REQUIREMENT: u32 = 6;
 
 	/// Minimum version for backing state, required for async backing.
 	///

--- a/node/subsystem-types/src/runtime_client.rs
+++ b/node/subsystem-types/src/runtime_client.rs
@@ -232,6 +232,9 @@ pub trait RuntimeApiSubsystemClient {
 		session_index: SessionIndex,
 	) -> Result<Option<ExecutorParams>, ApiError>;
 
+	/// Gets the disabled validators at a specific block height
+	async fn disabled_validators(&self, at: Hash) -> Result<Vec<ValidatorIndex>, ApiError>;
+
 	// === Asynchronous backing API ===
 
 	/// Returns candidate's acceptance limitations for asynchronous backing for a relay parent.
@@ -471,6 +474,10 @@ where
 		);
 
 		runtime_api.submit_report_dispute_lost(at, dispute_proof, key_ownership_proof)
+	}
+
+	async fn disabled_validators(&self, at: Hash) -> Result<Vec<ValidatorIndex>, ApiError> {
+		self.client.runtime_api().disabled_validators(at)
 	}
 
 	async fn staging_para_backing_state(

--- a/primitives/src/runtime_api.rs
+++ b/primitives/src/runtime_api.rs
@@ -240,6 +240,12 @@ sp_api::decl_runtime_apis! {
 			key_ownership_proof: vstaging::slashing::OpaqueKeyOwnershipProof,
 		) -> Option<()>;
 
+		/* Staging APIs */
+
+		/// Returns a sorted Vec with the `ValidatorIndex` of all disabled validators.
+		#[api_version(6)]
+		fn disabled_validators() -> Vec<ValidatorIndex>;
+
 		/***** Asynchronous backing *****/
 
 		/// Returns the state of parachain backing for a given para.

--- a/runtime/parachains/src/runtime_api_impl/vstaging.rs
+++ b/runtime/parachains/src/runtime_api_impl/vstaging.rs
@@ -23,7 +23,7 @@ use primitives::{
 		AsyncBackingParams, BackingState, CandidatePendingAvailability, Constraints,
 		InboundHrmpLimitations, OutboundHrmpChannelLimitations,
 	},
-	Id as ParaId,
+	Id as ParaId, ValidatorIndex,
 };
 use sp_std::prelude::*;
 
@@ -117,4 +117,13 @@ pub fn backing_state<T: initializer::Config>(
 /// Implementation for `StagingAsyncBackingParams` function from the runtime API
 pub fn async_backing_params<T: configuration::Config>() -> AsyncBackingParams {
 	<configuration::Pallet<T>>::config().async_backing_params
+}
+
+/// Implementation for `DisabledValidators`
+pub fn disabled_validators<T: pallet_session::Config>() -> Vec<ValidatorIndex> {
+	<pallet_session::Pallet<T>>::disabled_validators()
+		.iter()
+		.cloned()
+		.map(|v| ValidatorIndex(v))
+		.collect()
 }

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -46,7 +46,9 @@ use runtime_parachains::{
 	inclusion::{AggregateMessageOrigin, UmpQueueId},
 	initializer as parachains_initializer, origin as parachains_origin, paras as parachains_paras,
 	paras_inherent as parachains_paras_inherent,
-	runtime_api_impl::v5 as parachains_runtime_api_impl,
+	runtime_api_impl::{
+		v5 as parachains_runtime_api_impl, vstaging as parachains_staging_runtime_api_impl,
+	},
 	scheduler as parachains_scheduler, session_info as parachains_session_info,
 	shared as parachains_shared,
 };
@@ -1715,6 +1717,7 @@ sp_api::impl_runtime_apis! {
 		}
 	}
 
+	#[api_version(6)]
 	impl primitives::runtime_api::ParachainHost<Block, Hash, BlockNumber> for Runtime {
 		fn validators() -> Vec<ValidatorId> {
 			parachains_runtime_api_impl::validators::<Runtime>()
@@ -1844,6 +1847,10 @@ sp_api::impl_runtime_apis! {
 				dispute_proof,
 				key_ownership_proof,
 			)
+		}
+
+		fn disabled_validators() -> Vec<ValidatorIndex> {
+			parachains_staging_runtime_api_impl::disabled_validators::<Runtime>()
 		}
 	}
 


### PR DESCRIPTION
This PR will serve as a base for any node side validator disabling changes. 

Included changes:
* `disabled_validators` runtime API (this PR)

