### PR TITLE
Fix xcm-builder mock

### DIFF
--- a/xcm/xcm-builder/Cargo.toml
+++ b/xcm/xcm-builder/Cargo.toml
@@ -43,9 +43,6 @@ runtime-benchmarks = [
 	"frame-system/runtime-benchmarks",
 	"xcm-executor/runtime-benchmarks",
 	"pallet-assets/runtime-benchmarks",
-	"pallet-balances/runtime-benchmarks",
-	"pallet-salary/runtime-benchmarks",
-	"pallet-xcm/runtime-benchmarks",
 ]
 std = [
 	"log/std",

--- a/xcm/xcm-builder/Cargo.toml
+++ b/xcm/xcm-builder/Cargo.toml
@@ -42,6 +42,10 @@ runtime-benchmarks = [
 	"frame-support/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
 	"xcm-executor/runtime-benchmarks",
+	"pallet-assets/runtime-benchmarks",
+	"pallet-balances/runtime-benchmarks",
+	"pallet-salary/runtime-benchmarks",
+	"pallet-xcm/runtime-benchmarks",
 ]
 std = [
 	"log/std",

--- a/xcm/xcm-builder/src/tests/pay/mock.rs
+++ b/xcm/xcm-builder/src/tests/pay/mock.rs
@@ -119,6 +119,8 @@ impl pallet_assets::Config for Test {
 	type RemoveItemsLimit = RemoveItemsLimit;
 	type AssetIdParameter = AssetIdForAssets;
 	type CallbackHandle = ();
+	#[cfg(feature = "runtime-benchmarks")]
+	type BenchmarkHelper = ();
 }
 
 parameter_types! {


### PR DESCRIPTION
(preparation for the monorepo)

The CI fails here when the runtime-benchmarks feature is enabled in the workspace.