### PR TITLE
Add Rotko Networks relay chain bootnodes

### DIFF
--- a/node/service/chain-specs/kusama.json
+++ b/node/service/chain-specs/kusama.json
@@ -42,7 +42,9 @@
     "/dns/kusama-bootnode.radiumblock.com/tcp/30333/p2p/12D3KooWGzKffWe7JSXeKMQeSQC5xfBafZtgBDCuBVxmwe2TJRuc",
     "/dns/ksm-bootnode.stakeworld.io/tcp/30300/p2p/12D3KooWFRin7WWVS6RgUsSpkfUHSv4tfGKnr2zJPmf1pbMv118H",
     "/dns/ksm-bootnode.stakeworld.io/tcp/30301/ws/p2p/12D3KooWFRin7WWVS6RgUsSpkfUHSv4tfGKnr2zJPmf1pbMv118H",
-    "/dns/ksm-bootnode.stakeworld.io/tcp/30302/wss/p2p/12D3KooWFRin7WWVS6RgUsSpkfUHSv4tfGKnr2zJPmf1pbMv118H"
+    "/dns/ksm-bootnode.stakeworld.io/tcp/30302/wss/p2p/12D3KooWFRin7WWVS6RgUsSpkfUHSv4tfGKnr2zJPmf1pbMv118H",
+    "/dns/ksm14.rotko.net/tcp/35224/wss/p2p/12D3KooWAa5THTw8HPfnhEei23HdL8P9McBXdozG2oTtMMksjZkK",
+    "/dns/ksm14.rotko.net/tcp/33224/p2p/12D3KooWAa5THTw8HPfnhEei23HdL8P9McBXdozG2oTtMMksjZkK"
   ],
   "telemetryEndpoints": [
     [

--- a/node/service/chain-specs/westend.json
+++ b/node/service/chain-specs/westend.json
@@ -33,7 +33,9 @@
     "/dns/westend-bootnode.radiumblock.com/tcp/30333/p2p/12D3KooWJBowJuX1TaWNWHt8Dz8z44BoCZunLCfFqxA2rLTn6TBD",
     "/dns/wnd-bootnode.stakeworld.io/tcp/30320/p2p/12D3KooWBYdKipcNbrV5rCbgT5hco8HMLME7cE9hHC3ckqCKDuzP",
     "/dns/wnd-bootnode.stakeworld.io/tcp/30321/ws/p2p/12D3KooWBYdKipcNbrV5rCbgT5hco8HMLME7cE9hHC3ckqCKDuzP",
-    "/dns/wnd-bootnode.stakeworld.io/tcp/30322/wss/p2p/12D3KooWBYdKipcNbrV5rCbgT5hco8HMLME7cE9hHC3ckqCKDuzP"
+    "/dns/wnd-bootnode.stakeworld.io/tcp/30322/wss/p2p/12D3KooWBYdKipcNbrV5rCbgT5hco8HMLME7cE9hHC3ckqCKDuzP",
+    "/dns/wnd14.rotko.net/tcp/35234/wss/p2p/12D3KooWQoYaxSm8wPCpKbjXB3esnMrqZmwjXsQbBAKdgyoYSG2J",
+    "/dns/wnd14.rotko.net/tcp/33234/p2p/12D3KooWQoYaxSm8wPCpKbjXB3esnMrqZmwjXsQbBAKdgyoYSG2J"
   ],
   "telemetryEndpoints": [
     [


### PR DESCRIPTION
Consider adding following relay chain bootnodes [running](https://eupnea.rotko.net/) [on bare metal](https://rotko.net/docs/bkk04.html) at Bangkok.

```
polkadot --chain polkadot --reserved-only --reserved-nodes "/dns/dot14.rotko.net/tcp/33214/p2p/12D3KooWPyEvPEXghnMC67Gff6PuZiSvfx3fmziKiPZcGStZ5xff"
polkadot --chain polkadot --reserved-only --reserved-nodes "/dns/dot14.rotko.net/tcp/35214/wss/p2p/12D3KooWPyEvPEXghnMC67Gff6PuZiSvfx3fmziKiPZcGStZ5xff"
polkadot --chain kusama --reserved-only --reserved-nodes "/dns/ksm14.rotko.net/tcp/33224/p2p/12D3KooWAa5THTw8HPfnhEei23HdL8P9McBXdozG2oTtMMksjZkK"
polkadot --chain kusama --reserved-only --reserved-nodes "/dns/ksm14.rotko.net/tcp/35224/wss/p2p/12D3KooWAa5THTw8HPfnhEei23HdL8P9McBXdozG2oTtMMksjZkK"
polkadot --chain westend --reserved-only --reserved-nodes "/dns/wnd14.rotko.net/tcp/33234/p2p/12D3KooWQoYaxSm8wPCpKbjXB3esnMrqZmwjXsQbBAKdgyoYSG2J"
polkadot --chain westend --reserved-only --reserved-nodes "/dns/wnd14.rotko.net/tcp/35234/wss/p2p/12D3KooWQoYaxSm8wPCpKbjXB3esnMrqZmwjXsQbBAKdgyoYSG2J"
```