### PR TITLE
primitives: make async backing params accessible for parachains

### DIFF
--- a/primitives/src/v5/mod.rs
+++ b/primitives/src/v5/mod.rs
@@ -1165,6 +1165,8 @@ pub struct AbridgedHostConfiguration {
 	pub validation_upgrade_cooldown: BlockNumber,
 	/// The delay, in blocks, before a validation upgrade is applied.
 	pub validation_upgrade_delay: BlockNumber,
+	/// Asynchronous backing parameters.
+	pub async_backing_params: super::vstaging::AsyncBackingParams,
 }
 
 /// Abridged version of `HrmpChannel` (from the `Hrmp` parachains host runtime module) meant to be

--- a/runtime/parachains/src/configuration.rs
+++ b/runtime/parachains/src/configuration.rs
@@ -124,13 +124,13 @@ pub struct HostConfiguration<BlockNumber> {
 	///
 	/// [#4601]: https://github.com/paritytech/polkadot/issues/4601
 	pub validation_upgrade_delay: BlockNumber,
+	/// Asynchronous backing parameters.
+	pub async_backing_params: AsyncBackingParams,
 
 	/**
 	 * The parameters that are not essential, but still may be of interest for parachains.
 	 */
 
-	/// Asynchronous backing parameters.
-	pub async_backing_params: AsyncBackingParams,
 	/// The maximum POV block size, in bytes.
 	pub max_pov_size: u32,
 	/// The maximum size of a message that can be put in a downward message queue.

--- a/runtime/parachains/src/configuration/tests.rs
+++ b/runtime/parachains/src/configuration/tests.rs
@@ -487,7 +487,9 @@ fn verify_externally_accessible() {
 	use primitives::{well_known_keys, AbridgedHostConfiguration};
 
 	new_test_ext(Default::default()).execute_with(|| {
-		let ground_truth = HostConfiguration::default();
+		let mut ground_truth = HostConfiguration::default();
+		ground_truth.async_backing_params =
+			AsyncBackingParams { allowed_ancestry_len: 111, max_candidate_depth: 222 };
 
 		// Make sure that the configuration is stored in the storage.
 		ActiveConfig::<Test>::put(ground_truth.clone());
@@ -511,6 +513,7 @@ fn verify_externally_accessible() {
 				hrmp_max_message_num_per_candidate: ground_truth.hrmp_max_message_num_per_candidate,
 				validation_upgrade_cooldown: ground_truth.validation_upgrade_cooldown,
 				validation_upgrade_delay: ground_truth.validation_upgrade_delay,
+				async_backing_params: ground_truth.async_backing_params,
 			},
 		);
 	});


### PR DESCRIPTION
Extends `AbridgedHostConfiguration` with asynchronous backing parameters, which were added directly under the abridged part. The migration adding this field has been executed on all chains, thus it's safe to decode new type.

Needed for https://github.com/paritytech/cumulus/issues/2706

cumulus companion: https://github.com/paritytech/cumulus/pull/3055